### PR TITLE
Add unit test to check that prefect version is updated in both places it appears

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+
+import prefect
+
+
+def test_prefect_version_is_updated_everywhere():
+    """
+    Tests that prefect.__version__ matches the version defined in setup.py
+    """
+    current_version = prefect.__version__
+
+    cwd = os.path.dirname(os.path.dirname(__file__))
+    cmd = ["python", "setup.py", "--version"]
+    setup_version = subprocess.check_output(cmd, cwd=cwd).strip().decode()
+
+    assert setup_version == current_version


### PR DESCRIPTION
Prefect's version is defined as a string in setup.py and also as `prefect.__version__`. In order to avoid a situation in which one would be updated but the other isn't, we add a unit test to make sure they're the same.