### PR TITLE
Rename PrefectContext to Context

### DIFF
--- a/prefect/utilities/context.py
+++ b/prefect/utilities/context.py
@@ -27,9 +27,7 @@ class Context(DotDict):
         return "<Context>"
 
     @contextlib.contextmanager
-    def __call__(
-        self, *args: MutableMapping, **kwargs: Any
-    ) -> Iterator["Context"]:
+    def __call__(self, *args: MutableMapping, **kwargs: Any) -> Iterator["Context"]:
         """
         A context manager for setting / resetting the Prefect context
 


### PR DESCRIPTION
The `Context` is a very useful object, and I'm using it to solve some issues in other libraries. Propose renaming the class a more general `Context` instead of `PrefectContext`.