### PR TITLE
Allow for module-level docstrings

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1,5 +1,13 @@
 """Functionality for auto-generating markdown documentation.
 
+Each entry in `OUTLINE` is a dictionary with the following key/value pairs:
+    - "page" -> (str): relative path to the markdown file this page represents
+    - "classes" -> (list, optional): list of classes to document
+    - "functions" -> (list, optional): list of standalone functions to document
+    - "title" -> (str, optional): title of page
+    - "top-level-doc" -> (object, optional): module object which contains the
+        docstring which will be displayed at the top of the generated page
+
 On a development installation of Prefect, simply run `python generate_docs.py` from inside the `docs/` folder.
 """
 import inspect
@@ -33,6 +41,7 @@ OUTLINE = [
             prefect.triggers.any_failed,
         ],
         "title": "Triggers",
+        "top-level-doc": prefect.triggers,
     },
     {
         "page": "client.md",
@@ -368,6 +377,9 @@ if __name__ == "__main__":
             if title:  # this would be a good place to have assignments
                 f.write(f"# {title}\n---\n")
 
+            top_doc = page.get("top-level-doc")
+            if top_doc is not None:
+                f.write(inspect.getdoc(top_doc) + "\n<hr>\n")
             for obj in classes:
                 f.write(format_subheader(obj))
 


### PR DESCRIPTION
This is a minimal PR implementing module-level docstrings so that others can access this functionality sooner rather than later.  Uses `triggers.py` as an example.

It formats like this:
<img width="845" alt="screen shot 2018-08-13 at 8 22 14 am" src="https://user-images.githubusercontent.com/13255838/44041190-08b5542e-9ed2-11e8-8ad6-8031e2bfd054.png">
