### PR TITLE
Add FunctionTaskGenerator to @task

### DIFF
--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -75,24 +75,17 @@ class FunctionTaskGenerator:
 
     def __call__(self, *args, **kwargs) -> "prefect.tasks.core.function.FunctionTask":
         task = self.as_task()
-
-        # if args / kwargs were provided, try to apply them or arise a helpful error.
-        if args or kwargs:
-            try:
-                return task(*args, **kwargs)
-            except ValueError as exc:
-                if "could not infer an active flow context" in str(exc).lower():
-                    raise ValueError(
-                        "This task generator must be called inside a `Flow` context in order "
-                        "to set up dependencies. To access the `Task` class without "
-                        "dependencies, call `task_generator.as_task()`."
-                    )
-                else:
-                    raise
-
-        # this will raise an error if args/kwargs were required but not provided
-        inspect.signature(self.fn).bind()
-        return task
+        try:
+            return task(*args, **kwargs)
+        except ValueError as exc:
+            if "could not infer an active flow context" in str(exc).lower():
+                raise ValueError(
+                    "This task generator must be called inside a `Flow` context in order "
+                    "to set up dependencies. To access the `Task` class without "
+                    "dependencies, call `task_generator.as_task()`."
+                )
+            else:
+                raise
 
 
 @curry
@@ -143,9 +136,6 @@ def task(fn: Callable, **task_init_kwargs) -> FunctionTaskGenerator:
     # both tasks can be accessed imperatively, without a flow context
     fn_without_args.as_task()
     fn_with_args.as_task()
-
-    # the function without args can be called functionally without a flow context
-    fn_without_args()
 
     ```
     """

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -30,22 +30,24 @@ class TestTaskDecorator:
             fn(1)
         assert "task generator must be called inside a `Flow` context" in str(exc.value)
 
-    def test_task_decorator_with_no_args_can_be_called_outside_flow_context(self):
+    def test_task_decorator_with_no_args_must_be_called_inside_flow_context(self):
         @tasks.task
         def fn():
             return 1
 
-        assert isinstance(fn(), Task)
+        with pytest.raises(ValueError):
+            fn()
 
         with Flow():
             assert isinstance(fn(), Task)
 
-    def test_task_decorator_with_default_args_can_be_called_outside_flow_context(self):
+    def test_task_decorator_with_default_args_must_be_called_inside_flow_context(self):
         @tasks.task
         def fn(x=1):
             return x
 
-        assert isinstance(fn(), Task)
+        with pytest.raises(ValueError):
+            fn()
 
         with Flow():
             assert isinstance(fn(), Task)


### PR DESCRIPTION
While writing tutorials, I realized that task's created with @task were ONLY compatible with the functional API (couldn't be called outside a Flow context). This formalizes their construction a bit with a proper `FunctionTaskGenerator` class that provides an `as_task()` method for accessing tasks imperatively.