### PR TITLE
Trap warning when pytest runs

### DIFF
--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -425,7 +425,8 @@ class TestTaskRunner_get_run_state:
         assert state.cached is None
 
     def test_uses_cache_for_as_trigger_for_initializing_a_cache(self):
-        runner = TaskRunner(AddTask(cache_validator=duration_only))
+        with pytest.warns(UserWarning):
+            runner = TaskRunner(AddTask(cache_validator=duration_only))
         state = runner.get_run_state(state=Running(), inputs=dict(x=1, y=2))
         assert state.cached is None
 


### PR DESCRIPTION
Something in this test raised a warning, though the test appears to run fine -- it gives the impression of a test that had an issue. I added a trap for the warning so all tests pass.