### PR TITLE
Base Task class can be run (instead of raising NotImplementedError)

### DIFF
--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -167,26 +167,28 @@ class Task(Serializable, metaclass=SignatureValidator):
         """
         return tuple(inspect.signature(self.run).parameters.keys())
 
-    def run(self):  # type: ignore
+    def run(self) -> None:  # type: ignore
         """
-        The main entrypoint for tasks.
+        The `run()` method is called (with arguments, if appropriate) to run a task.
 
         In addition to running arbitrary functions, tasks can interact with
         Prefect in a few ways:
             1. Return an optional result. When this function runs successfully,
-                the task is considered successful and the result (if any) is
-                made available to downstream edges.
+                the task is considered successful and the result (if any) can be
+                made available to downstream tasks.
             2. Raise an error. Errors are interpreted as failure.
-            3. Raise a signal. Signals can include `FAIL`, `SUCCESS`, `WAIT`, etc.
+            3. Raise a signal. Signals can include `FAIL`, `SUCCESS`, RETRY`, `SKIP`, etc.
                 and indicate that the task should be put in the indicated
                 state.
                 - `FAIL` will lead to retries if appropriate
-                - `WAIT` will end execution and skip all downstream tasks with
-                    state WAITING_FOR_UPSTREAM (unless appropriate triggers
-                    are set). The task can be run again and should check
-                    context.is_waiting to see if it was placed in a WAIT.
+                - `SUCCESS` will cause the task to be marked successful
+                - `RETRY` will cause the task to be marked for retry, even if `max_retries`
+                    has been exceeded
+                - `SKIP` will skip the task and possibly propogate the skip state through the
+                    flow, depending on whether downstream tasks have
+                    `skip_on_upstream_skip=True`.
         """
-        raise NotImplementedError()
+        pass
 
     # Dependencies -------------------------------------------------------------
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -103,6 +103,11 @@ class TestCreateTask:
             Task(cache_validator=all_inputs)
 
 
+def test_task_produces_no_result():
+    t = Task()
+    assert t.run() is None
+
+
 def test_task_is_not_iterable():
     t = Task()
     with pytest.raises(TypeError):

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -161,6 +161,17 @@ def test_flow_runner_runs_basic_flow_with_2_dependent_tasks():
     assert flow_state.result[task2] == Success(result=1)
 
 
+def test_flow_runner_runs_base_task_class():
+    flow = prefect.Flow()
+    task1 = Task()
+    task2 = Task()
+    flow.add_edge(task1, task2)
+    flow_state = FlowRunner(flow=flow).run(return_tasks=[task1, task2])
+    assert isinstance(flow_state, Success)
+    assert isinstance(flow_state.result[task1], Success)
+    assert isinstance(flow_state.result[task2], Success)
+
+
 def test_flow_runner_runs_basic_flow_with_2_dependent_tasks_and_first_task_fails():
     flow = prefect.Flow()
     task1 = ErrorTask()


### PR DESCRIPTION
Currently, the base Task class raises a NotImplementedError when run. This is unsatisfying for a few reasons:
- It's something users will only discover when they run their flow (which could be after submitting to server)
- There's not a clear reason for it other than to indicate that the method should be overridden -- but again, that doesn't become clear until runtime.
- It's actually useful to have a "no-op" task class, because that class can be used for purely state-manipulation control flow. For example, a `Task` could be used to bottleneck other tasks simply by introducing upstream/downstream dependencies, or it could be used purely to implement `trigger` logic at places where the logic may be difficult to implement or not easily accessible (if a task is generated by a non-user-configurable function, for example, but the user wants to place a `manual_only` trigger ahead of it).

Therefore, this PR simply changes the base Task so it will run (and return `None`) instead of raising an error