### PR TITLE
Cast env var configs as typed values

### DIFF
--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -194,7 +194,7 @@ def load_config_file(path: str, env_var_prefix: str = None) -> Config:
             # get the referenced key from the config value
             ref_key = collections.CompoundKey(matched_key.split("."))
             # get the value corresponding to the referenced key
-            ref_value = flat_config[ref_key]
+            ref_value = flat_config.get(ref_key, "")
 
             # if the matched was the entire value, replace it with the interpolated value
             if flat_config[k] == matched_string:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -128,6 +128,9 @@ def test_env_var_interpolation_doesnt_match_internal_dollar_sign(config):
     assert config.env_vars.not_interpolated_path == "xxx$PATHxxx"
 
 
+def test_env_var_interpolation_with_nonexistant_key(config):
+    assert config.interpolation.bad_value == ""
+
 
 def test_env_var_overrides_new_key(config):
     assert config.env_vars.new_key == "TEST"


### PR DESCRIPTION
One of the benefits of using TOML config files is that they're typed ("true" becomes `True`, numbers are numbers, etc.) However, it's often desirable to set configuration values from env vars, which are always strings. This adds a utility to cast values from env vars (or any interpolated value from elsewhere in the TOML file) as a non-string type.


Maps:     
- "true" or "True" to `True`
- "false" or "False" to `False`
- integers to `int`
- floats to `float`
