### PR TITLE
Shutup vuepress

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -395,9 +395,9 @@ if __name__ == "__main__":
     GIT_SHA = os.getenv("GIT_SHA", "0000000")
     SHORT_SHA = GIT_SHA[:7]
     auto_generated_footer = (
-        "<hr>\n\n<sub>*This documentation was auto-generated from "
-        "[{short_sha}](https://github.com/PrefectHQ/prefect/commit/{git_sha})"
-        "*</sub>".format(short_sha=SHORT_SHA, git_sha=GIT_SHA)
+        "<hr>\n\n<p><small><i>This documentation was auto-generated from "
+        "<a href='https://github.com/PrefectHQ/prefect/commit/{git_sha}'>{short_sha}</a>"
+        "</i></small></p>".format(short_sha=SHORT_SHA, git_sha=GIT_SHA)
     )
 
     front_matter = textwrap.dedent(


### PR DESCRIPTION
Closes #148 

This might even be a `vuepress` bug; reproducible example:
```
mkdir vue-bug && cd vue-bug
cat << EOF > README.md
> # hello
> 
> <sub>hidden</sub>
> EOF
vuepress build .

 WAIT  Extracting site metadata...
<sub>hidden</sub>
[6:20:26 PM] Compiling Client
[6:20:26 PM] Compiling Server
(node:26359) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
<sub>hidden</sub>
[6:20:30 PM] Compiled Server in 4s
[6:20:32 PM] Compiled Client in 6s
 WAIT  Rendering static HTML...

 DONE  Success! Generated static files in .vuepress/dist.
```

Same happens with `<small>` tag and probably others as well; should we open an issue on the `vuepress` repo or should we wait for Dylan in case this is some obvious web dev thing?