### PR TITLE
Airflow tests weren't being skipped locally

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,6 @@ def pytest_runtest_setup(item):
     mark = item.get_marker("airflow")
     if mark is not None:
         if item.config.getoption("--airflow") is False:
-            pytest.mark.skip(
+            pytest.skip(
                 "Airflow tests skipped by default unless --airflow flag provided to pytest."
             )

--- a/tests/utilities/airflow/test_airflow.py
+++ b/tests/utilities/airflow/test_airflow.py
@@ -23,6 +23,7 @@ def airflow_settings():
         yield dict(db_file=tmp.name, dag_folder=dag_folder)
 
 
+@pytest.mark.airflow()
 def test_trigger_rules_dag(airflow_settings):
     flow = AirFlow(dag_id="trigger_rules", **airflow_settings)
     res = flow.run(execution_date="2018-09-20", return_tasks=flow.tasks)


### PR DESCRIPTION
Fixes the skip behavior **cc**: @joshmeek 