### PR TITLE
More static typing

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -121,7 +121,7 @@ class Flow(Serializable):
         self._cache = {}  # type: dict
 
         self._id = str(uuid.uuid4())
-        self.task_info = dict()  # type: Dict[Task, str]
+        self.task_info = dict()  # type: Dict[Task, dict]
 
         self.name = name or type(self).__name__
         self.version = version or prefect.config.flows.default_version  # type: ignore
@@ -295,7 +295,7 @@ class Flow(Serializable):
     def id(self) -> str:
         return self._id
 
-    @property
+    @property  # type: ignore
     @cache
     def task_ids(self) -> Dict[str, Task]:
         """
@@ -954,6 +954,8 @@ class Flow(Serializable):
             )
 
         try:
+            from IPython import get_ipython
+
             if get_ipython().config.get("IPKernelApp") is not None:
                 return graph
         except NameError:

--- a/src/prefect/engine/executors/base.py
+++ b/src/prefect/engine/executors/base.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Iterator
 
 import prefect
 from prefect.utilities.executors import multiprocessing_timeout
@@ -15,11 +15,11 @@ class Executor(Serializable):
 
     timeout_handler = staticmethod(multiprocessing_timeout)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.executor_id = type(self).__name__ + ": " + str(uuid.uuid4())
 
     @contextmanager
-    def start(self) -> Iterable[None]:
+    def start(self) -> Iterator[None]:
         """
         Context manager for initializing execution.
 
@@ -28,7 +28,9 @@ class Executor(Serializable):
         """
         yield
 
-    def map(self, fn: Callable, *args: Any, upstream_states=None, **kwargs: Any) -> Any:
+    def map(
+        self, fn: Callable, *args: Any, upstream_states: dict = None, **kwargs: Any
+    ) -> Any:
         """
         Submit a function to be mapped over.
 
@@ -74,7 +76,7 @@ class Executor(Serializable):
         """
         raise NotImplementedError()
 
-    def queue(self, maxsize=0):
+    def queue(self, maxsize: int = 0) -> Any:
         """
         Creates an executor-compatible Queue object which can share state across tasks.
 
@@ -102,7 +104,7 @@ class Executor(Serializable):
             - Any: a future-like object
         """
 
-        def run_fn_in_context(*args, context, **kwargs):
+        def run_fn_in_context(*args: Any, context: dict, **kwargs: Any) -> Any:
             with prefect.context(context):
                 return fn(*args, **kwargs)
 

--- a/src/prefect/engine/executors/local.py
+++ b/src/prefect/engine/executors/local.py
@@ -16,7 +16,7 @@ class LocalExecutor(Executor):
     timeout_handler = staticmethod(main_thread_timeout)
 
     def map(
-        self, fn: Callable, *args: Any, upstream_states=None, **kwargs: Any
+        self, fn: Callable, *args: Any, upstream_states: dict = None, **kwargs: Any
     ) -> Iterable[Any]:
 
         states = dict_to_list(upstream_states)
@@ -26,7 +26,7 @@ class LocalExecutor(Executor):
 
         return results
 
-    def submit(self, fn: Callable, *args: Any, **kwargs: Any):
+    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> Any:
         """
         Submit a function to the executor for execution. Returns the result of the computation.
 
@@ -40,7 +40,7 @@ class LocalExecutor(Executor):
         """
         return fn(*args, **kwargs)
 
-    def wait(self, futures: Any, timeout: datetime.timedelta = None):
+    def wait(self, futures: Any, timeout: datetime.timedelta = None) -> Any:
         """
         Args:
             - futures (Any): objects to wait on

--- a/src/prefect/engine/executors/sync.py
+++ b/src/prefect/engine/executors/sync.py
@@ -2,7 +2,7 @@
 
 import datetime
 from contextlib import contextmanager
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Iterator
 
 import dask
 import dask.bag
@@ -19,7 +19,7 @@ class SynchronousExecutor(Executor):
     """
 
     @contextmanager
-    def start(self) -> Iterable[None]:
+    def start(self) -> Iterator:
         """
         Context manager for initializing execution.
 
@@ -28,12 +28,12 @@ class SynchronousExecutor(Executor):
         with dask.config.set(scheduler="synchronous") as cfg:
             yield cfg
 
-    def queue(self, maxsize=0):
-        q = queue.Queue(maxsize=maxsize)
+    def queue(self, maxsize: int = 0):
+        q = queue.Queue(maxsize=maxsize)  # type: queue.Queue
         return q
 
     def map(
-        self, fn: Callable, *args: Any, upstream_states=None, **kwargs: Any
+        self, fn: Callable, *args: Any, upstream_states: dict = None, **kwargs: Any
     ) -> dask.bag:
         """
         Submit a function to be mapped over.
@@ -52,6 +52,7 @@ class SynchronousExecutor(Executor):
             - dask.bag: an `dask.bag` collection representing the computation of
                 ecah `fn(*args, **kwargs)` call
         """
+        assert upstream_states is not None
         # every task which is being mapped over needs its state represented as a
         # dask.bag; there are two situations: 1.) the task being mapped over is
         # itself a result of a mapped task, in which case it will already be a

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -20,7 +20,7 @@ class PrefectStateSignal(PrefectError):
     _state_cls = state.State
 
     def __init__(self, message=None, **kwargs) -> None:  # type: ignore
-        super().__init__(message, **kwargs)
+        super().__init__(message, **kwargs)  # type: ignore
         self.state = self._state_cls(message=self)
 
 

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -78,7 +78,7 @@ class IntervalSchedule(Schedule):
             for i in itertools.count(start=0, step=1)
         )
         # filter generator for only dates on or after the requested date
-        upcoming_dates = filter(lambda d: d >= on_or_after, all_dates)
+        upcoming_dates = filter(lambda d: d >= on_or_after, all_dates)  # type: ignore
         # get the next n items from the generator
         return list(itertools.islice(upcoming_dates, n))
 

--- a/src/prefect/tasks/core/constants.py
+++ b/src/prefect/tasks/core/constants.py
@@ -1,10 +1,12 @@
 # Licensed under LICENSE.md; also available at https://www.prefect.io/licenses/alpha-eula
 
+from typing import Any
+
 import prefect
 
 
 class Constant(prefect.Task):
-    def __init__(self, value, name=None, **kwargs):
+    def __init__(self, value: Any, name: str = None, **kwargs: Any) -> None:
 
         self.value = value
 
@@ -16,5 +18,5 @@ class Constant(prefect.Task):
 
         super().__init__(name=name, **kwargs)
 
-    def run(self):
+    def run(self):  # type: ignore
         return self.value

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -1,7 +1,7 @@
 # Licensed under LICENSE.md; also available at https://www.prefect.io/licenses/alpha-eula
 
 import inspect
-from typing import Callable
+from typing import Any, Callable
 
 import prefect
 
@@ -29,7 +29,7 @@ class FunctionTask(prefect.Task):
     ```
     """
 
-    def __init__(self, fn: Callable, name: str = None, **kwargs) -> None:
+    def __init__(self, fn: Callable, name: str = None, **kwargs: Any) -> None:
         if not callable(fn):
             raise TypeError("fn must be callable.")
 

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -18,14 +18,18 @@ class EmailTask(prefect.Task):
     This task sends an email.
     """
 
-    def __init__(self, username=None, password=None, **kwargs):
+    def __init__(
+        self, username: str = None, password: str = None, **kwargs: Any
+    ) -> None:
 
         self.username = username
         self.password = password
 
         super().__init__(**kwargs)
 
-    def run(self, subject=None, msg=None, email_from=None, email_to=None):
+    def run(
+        self, subject=None, msg=None, email_from=None, email_to=None
+    ):  # type: ignore
 
         message = EMAIL_TEMPLATE.format(
             email_from=email_from, email_to=email_to, subject=subject, msg=msg

--- a/src/prefect/utilities/datetimes.py
+++ b/src/prefect/utilities/datetimes.py
@@ -1,17 +1,17 @@
 # Licensed under LICENSE.md; also available at https://www.prefect.io/licenses/alpha-eula
 
 import datetime
-
 import dateutil
+from typing import Any, Callable, Union
 
 
 def retry_delay(
-    interval=None,
-    *,
-    exponential_backoff=False,
-    max_delay=datetime.timedelta(hours=2),
-    **kwargs
-):
+    interval: datetime.timedelta = None,
+    *args: Any,
+    exponential_backoff: bool = False,
+    max_delay: datetime.timedelta = datetime.timedelta(hours=2),
+    **kwargs: Any
+) -> Callable:
     """
     A helper function for generating task retry delays.
 
@@ -45,7 +45,7 @@ def retry_delay(
     elif kwargs:
         interval = datetime.timedelta(**kwargs)
 
-    def retry_delay(run_number):
+    def retry_delay(run_number: int) -> datetime.timedelta:
         if exponential_backoff:
             scale = 2 ** (max(0, run_number - 2))
         else:
@@ -58,13 +58,15 @@ def retry_delay(
     return retry_delay
 
 
-def parse_datetime(dt):
+def parse_datetime(
+    dt: Union[str, bytes, float, datetime.datetime]
+) -> datetime.datetime:
     """
     Parses a string, bytes, float, or datetime object and returns a
     corresponding datetime
     """
     if isinstance(dt, (str, bytes)):
-        return dateutil.parser.parse(dt)
+        return dateutil.parser.parse(dt)  # type: ignore
     elif isinstance(dt, float):
         return datetime.datetime.fromtimestamp(dt)
     elif isinstance(dt, (datetime.datetime)):

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -39,7 +39,7 @@ def tags(*tags: str) -> Iterator[None]:
         yield
 
 
-def as_task(x: Any) -> "prefect.core.Task":
+def as_task(x: Any) -> "prefect.Task":
     """
     Wraps a function, collection, or constant with the appropriate Task type.
 
@@ -76,7 +76,7 @@ def as_task(x: Any) -> "prefect.core.Task":
 
 @curry
 def task(
-    fn: Callable, **task_init_kwargs
+    fn: Callable, **task_init_kwargs: Any
 ) -> "prefect.tasks.core.function.FunctionTask":
     """
     A decorator for creating Tasks from functions.
@@ -155,5 +155,5 @@ class unmapped:
         ```
     """
 
-    def __init__(self, task):
+    def __init__(self, task: "prefect.Task") -> None:
         self.task = as_task(task)

--- a/src/prefect/utilities/tests.py
+++ b/src/prefect/utilities/tests.py
@@ -2,7 +2,7 @@
 
 import copy
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Iterator
 
 import prefect
 from prefect.configuration import Config
@@ -10,7 +10,7 @@ from prefect.engine.state import State
 
 
 @contextmanager
-def set_temporary_config(key: str, value: Any):
+def set_temporary_config(key: str, value: Any) -> Iterator:
     """
     Temporarily sets a configuration value for the duration of the context manager.
 
@@ -39,6 +39,6 @@ def set_temporary_config(key: str, value: Any):
 
 
 @contextmanager
-def raise_on_exception():
+def raise_on_exception() -> Iterator:
     with prefect.context(_raise_on_exception=True):
         yield

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -455,7 +455,7 @@ def test_task_map_doesnt_assume_purity_of_functions(executor):
 
     @prefect.task
     def zz(s):
-        return round(random.random(), 4)
+        return round(random.random(), 6)
 
     with Flow() as f:
         res = zz.map(ll)


### PR DESCRIPTION
Contributes toward #217 with additional headway on static typing.

As of this writing, there are 129 failures from `mypy` in `src/`, most of which come from `client.py` and the `cli/` folder.