### PR TITLE
Use expanduser appropriately

### DIFF
--- a/src/prefect/client.py
+++ b/src/prefect/client.py
@@ -225,7 +225,7 @@ class Client:
         if self.token:
             creds_dir = Path("~/.prefect/.credentials").expanduser()
             if not creds_dir.exists():
-                os.makedirs(creds_dir)
+                creds_dir.mkdir()
             with open(creds_dir / "auth_token", "w+") as f:
                 f.write(self.token)
 
@@ -235,7 +235,7 @@ class Client:
         """
         token_path = Path("~/.prefect/.credentials/auth_token").expanduser()
         if token_path.exists():
-            os.remove(token_path)
+            os.remove(str(token_path))
         del self.token
 
     def refresh_token(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open
 


### PR DESCRIPTION
Closes #356 

All occurrences of `"~"` need to be properly expanded

