### PR TITLE
Properly render empty dict in GQL arguments

### DIFF
--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -179,6 +179,10 @@ def parse_graphql_arguments(arguments: Any) -> str:
 
 def _parse_arguments_inner(arguments: Any) -> str:
     if isinstance(arguments, (dict, DotDict)):
+        # empty dicts are valid GQL arguments
+        if len(arguments) == 0:
+            return "{}"
+
         formatted = []
         for key, value in arguments.items():
             formatted.append(

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -330,3 +330,7 @@ def test_pass_dotdicts_as_args():
             }
         """,
     )
+
+
+def test_empty_dict_in_arguments():
+    assert parse_graphql_arguments({"where": {}}) == "where: {}"


### PR DESCRIPTION
`{}` is valid in GQL arguments, but current code renders empty dicts as `{  }`.