### PR TITLE
Bump click version cap

### DIFF
--- a/requirements.ini
+++ b/requirements.ini
@@ -1,11 +1,11 @@
 [base]
 click = >= 6.7, < 8.0
-cloudpickle = >= 0.6.0
+cloudpickle = >= 0.6.0, < 0.7
 croniter = >= 0.3.23, < 0.4
 cryptography = >= 2.2.2, < 3.0
 dask = >= 0.18, < 0.19
 distributed = >= 1.21.8, < 2.0
-docker = >= 3.4.1, < 3.5
+docker = >= 3.4.1, < 4.0
 marshmallow = == 3.0.0b19
 marshmallow-oneofschema = >= 2.0.0b2, < 3.0
 mypy = >= 0.600, < 0.700
@@ -20,17 +20,17 @@ xxhash = >= 1.2.0, < 2.0
 
 [dev]
 include = viz
-nbformat = >= 4.4.0, < 4.5.0
-pre-commit = >= 1.12.0, < 1.13.0
+nbformat = >= 4.4.0, < 5.0
+pre-commit = >= 1.12.0, < 2.0
 pytest = >= 3.8, < 4.0
-pytest-cov= >=2.6.0, < 2.7.0
+pytest-cov= >=2.6.0, < 3.0
 pytest-env = >=0.6.2, < 0.7.0
-pytest-xdist = >=1.23.2, < 1.24.0
+pytest-xdist = >=1.23.2, < 2.0
 Pygments = == 2.2.0
 
 [templates]
 jinja2 = >= 2.0, < 3.0
 
 [viz]
-bokeh = == 0.13.0
+bokeh = >= 0.13.0, < 0.14
 graphviz = >= 0.8.3


### PR DESCRIPTION
Click 7.0 is out, but is API-compatible with our current pin. Therefore, in the interest of creating as generous a requirements spread as possible, this bumps the pin ceiling without raising the minimum.

In addition, bumps a number of version caps that were way too restrictive (we can trust package maintainers to respect API compatibility for versions >= 1.0)