### PR TITLE
Allow OneOfSchema to load DotDicts

### DIFF
--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -1,9 +1,13 @@
 from typing import Any
 import marshmallow
 import prefect
-from marshmallow_oneofschema import OneOfSchema
 from marshmallow import fields
-from prefect.utilities.serialization import VersionedSchema, version, to_qualified_name
+from prefect.utilities.serialization import (
+    VersionedSchema,
+    version,
+    to_qualified_name,
+    OneOfSchema,
+)
 
 
 @version("0.3.3")

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -2,11 +2,16 @@ from marshmallow import fields, post_load, pre_dump
 
 import prefect
 from prefect.serialization.edge import EdgeSchema
-from prefect.serialization.schedule import ScheduleSchema
 from prefect.serialization.environment import EnvironmentSchema
+from prefect.serialization.schedule import ScheduleSchema
 from prefect.serialization.task import ParameterSchema, TaskSchema
-from prefect.utilities.serialization import VersionedSchema, version, to_qualified_name
-from prefect.utilities.serialization import JSONField, NestedField
+from prefect.utilities.serialization import (
+    JSONField,
+    NestedField,
+    VersionedSchema,
+    to_qualified_name,
+    version,
+)
 
 
 @version("0.3.3")

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -1,9 +1,15 @@
 from typing import Any
+
 import marshmallow
-import prefect
-from marshmallow_oneofschema import OneOfSchema
 from marshmallow import fields
-from prefect.utilities.serialization import VersionedSchema, version, to_qualified_name
+
+import prefect
+from prefect.utilities.serialization import (
+    OneOfSchema,
+    VersionedSchema,
+    to_qualified_name,
+    version,
+)
 
 
 @version("0.3.3")

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict
 import json
-from marshmallow_oneofschema import OneOfSchema
+from typing import Any, Dict
+
 from marshmallow import fields, post_load
-from prefect.utilities.serialization import VersionedSchema, version, to_qualified_name
+
 from prefect.engine import state
-from prefect.utilities.serialization import JSONField
+from prefect.utilities.serialization import (
+    JSONField,
+    OneOfSchema,
+    VersionedSchema,
+    to_qualified_name,
+    version,
+)
 
 
 @version("0.3.3")

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import marshmallow
 import prefect
-from marshmallow_oneofschema import OneOfSchema
 from marshmallow import (
     fields,
     pre_dump,

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -5,6 +5,9 @@ import sys
 from typing import Dict, Callable, Optional, Any, List
 import json
 from marshmallow import Schema, post_dump, post_load, SchemaOpts, pre_load, fields
+from prefect.utilities.collections import DotDict, as_nested_dict
+
+import marshmallow_oneofschema
 
 MAX_VERSION = "__MAX_VERSION__"
 VERSIONS = {}  # type: Dict[str, Dict[str, VersionedSchema]]
@@ -217,3 +220,14 @@ class NestedField(fields.Nested):
         if self.dump_fn is not None:
             value = self.dump_fn(obj, self.context)
         return super()._serialize(value, attr, obj, **kwargs)
+
+
+class OneOfSchema(marshmallow_oneofschema.OneOfSchema):
+    """
+    A subclass of marshmallow_oneofschema.OneOfSchema that can load DotDicts
+    """
+
+    def _load(self, data, partial=None, unknown=None):
+        if isinstance(data, DotDict):
+            data = as_nested_dict(data, dict)
+        return super()._load(data=data, partial=partial, unknown=unknown)

--- a/tests/serialization/test_versioned_schemas.py
+++ b/tests/serialization/test_versioned_schemas.py
@@ -1,14 +1,18 @@
 import datetime
-import pendulum
-import prefect
-import pytest
+
 import marshmallow
+import pendulum
+import pytest
+
+import prefect
+from prefect.utilities.collections import DotDict, as_nested_dict
 from prefect.utilities.serialization import (
-    VersionedSchema,
-    version,
     VERSIONS,
+    OneOfSchema,
+    VersionedSchema,
     get_versioned_schema,
     to_qualified_name,
+    version,
 )
 
 
@@ -313,3 +317,18 @@ def test_nested_schemas_pass_context_on_load():
             return obj
 
     assert Parent().load({"child": {"x": 1}})["child"]["x"] == 5
+
+
+def test_oneofschema_load_dotdict():
+    """
+    Tests that modified OneOfSchema can load data from a DotDict (standard can not)
+    """
+
+    class ChildSchema(marshmallow.Schema):
+        x = marshmallow.fields.Integer()
+
+    class ParentSchema(OneOfSchema):
+        type_schemas = {"Child": ChildSchema}
+
+    child = ParentSchema().load(DotDict(type="Child", x="5"))
+    assert child["x"] == 5


### PR DESCRIPTION
OneOfSchema-based serializers (which automatically load other schemas based on a `type` field) can't load `DotDicts` (or `GraphQLResults`) because of an explicit `isinstance(obj, dict)` check -- and `DotDicts` are not dict subclasses.

This modifies the load function to convert the incoming payload to a dict, in necessary.