### PR TITLE
Properly handle environment variables that contain newline characters

### DIFF
--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -266,8 +266,10 @@ def load_config_file(path: str, env_var_prefix: str = None, env: dict = None) ->
                 if "__" not in env_var:
                     continue
 
-                # make sure to handle newlines -- a "\n" in an env will be interpolated as "\\n"
-                value = env.get(env_var).replace("\\n", "\n")
+                # env vars with escaped characters are interpreted as literal "\", which
+                # Python helpfully escapes with a second "\". This step makes sure that
+                # escaped characters are properly interpreted.
+                value = env.get(env_var).encode().decode("unicode_escape")
 
                 # place the env var in the flat config as a compound key
                 config_option = collections.CompoundKey(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -117,7 +117,7 @@ def config(test_config_file_path):
     environ["PREFECT__ENV_VARS__NEGATIVE_INT"] = "-10"
     environ["PREFECT__ENV_VARS__FLOAT"] = "7.5"
     environ["PREFECT__ENV_VARS__NEGATIVE_FLOAT"] = "-7.5"
-    environ["PREFECT__ENV_VARS__NEW_LINE"] = r"line 1\nline 2"
+    environ["PREFECT__ENV_VARS__ESCAPED_CHARACTERS"] = r"line 1\nline 2\rand 3\tand 4"
     yield configuration.load_config_file(
         path=test_config_file_path, env_var_prefix="PREFECT", env=environ
     )
@@ -218,16 +218,16 @@ def test_env_var_creates_nested_keys(config):
     assert config.env_vars.twice.nested.new_key == "TEST"
 
 
-def test_env_var_newline(config):
-    assert config.env_vars.new_line == "line 1\nline 2"
+def test_env_var_escaped(config):
+    assert config.env_vars.escaped_characters == "line 1\nline 2\rand 3\tand 4"
 
 
 def test_env_var_newline_declared_inline(config):
     result = subprocess.check_output(
-        r'PREFECT__ENV_VARS__X="line 1\nline 2" python -c "import prefect; print(prefect.config.env_vars.x)"',
+        r'PREFECT__ENV_VARS__X="line 1\nline 2\rand 3\tand 4" python -c "import prefect; print(prefect.config.env_vars.x)"',
         shell=True,
     )
-    assert result.strip() == b"line 1\nline 2"
+    assert result.strip() == b"line 1\nline 2\rand 3\tand 4"
 
 
 def test_merge_configurations(test_config_file_path):


### PR DESCRIPTION
If an environment variable contains a newline character (`\n`), then it gets interpolated by `os.environ` as `\\n`. For example, `"line 1\nline 2"` becomes `"line 1\\nline 2"`. This means that Prefect configurations set by env var are modified unexpected.

This applies a small fix to correct that situation.