### PR TITLE
Update config to point to apollo port number

### DIFF
--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -12,7 +12,7 @@ prefect_cloud = false
 [cloud]
 # the Prefect Server address
 api = "http://localhost:4202"
-graphql = "http://localhost:4300/graphql"
+graphql = "http://localhost:4300"
 log = "http://localhost:4202/log"
 use_local_secrets = true
 


### PR DESCRIPTION
Sends graphql requests to `4300` by default and removes unnecessary `/graphql` route