### PR TITLE
Fixes for docker COPY in environments

### DIFF
--- a/src/prefect/environments.py
+++ b/src/prefect/environments.py
@@ -365,7 +365,7 @@ class ContainerEnvironment(Environment):
         In order for the docker python library to build a container it needs a
         Dockerfile that it can use to define the container. This function takes the
         image and python_dependencies then writes them to a file called Dockerfile.
-        
+
         *Note*: if `files` are added to this container, they will be copied to this directory as well.
 
         Args:
@@ -396,14 +396,18 @@ class ContainerEnvironment(Environment):
             if self.files:
                 for src, dest in self.files.items():
                     fname = os.path.basename(src)
-                    if os.path.exists(fname) and filecmp.cmp(src, fname) is False:
+                    full_fname = os.path.join(directory, fname)
+                    if (
+                        os.path.exists(full_fname)
+                        and filecmp.cmp(src, full_fname) is False
+                    ):
                         raise ValueError(
                             "File {fname} already exists in {directory}".format(
-                                fname=fname, directory=directory
+                                fname=full_fname, directory=directory
                             )
                         )
                     else:
-                        shutil.copy2(src, fname)
+                        shutil.copy2(src, full_fname)
                     copy_files += "COPY {fname} {dest}\n".format(fname=fname, dest=dest)
 
             # Create a LocalEnvironment to run the flow

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import shutil
 import tempfile
 
 import pytest
@@ -104,11 +105,54 @@ class TestContainerEnvironment:
 
             with tempfile.TemporaryDirectory(prefix="prefect-tests") as tmp:
                 container.create_dockerfile(Flow(), directory=tmp)
+
+                ## ensure create_dockerfile copied the files over
+                assert os.path.exists(os.path.join(tmp, base1))
+                assert os.path.exists(os.path.join(tmp, base2))
+
                 with open(os.path.join(tmp, "Dockerfile"), "r") as f:
                     dockerfile = f.read()
 
         assert "COPY {} /root/dockerconfig".format(base1) in dockerfile
         assert "COPY {} ./.secret_file".format(base2) in dockerfile
+
+    def test_create_dockerfile_with_copy_files_doesnt_raise_if_file_exists_and_is_same(
+        self
+    ):
+        with tempfile.NamedTemporaryFile() as t1, tempfile.NamedTemporaryFile() as t2:
+            container = ContainerEnvironment(
+                base_image="python:3.6",
+                registry_url="",
+                files={t1.name: "/root/dockerconfig", t2.name: "./.secret_file"},
+            )
+
+            base1, base2 = os.path.basename(t1.name), os.path.basename(t2.name)
+
+            with tempfile.TemporaryDirectory(prefix="prefect-tests") as tmp:
+                shutil.copy(t1.name, os.path.join(tmp, base1))
+                container.create_dockerfile(Flow(), directory=tmp)
+
+    def test_create_dockerfile_with_copy_files_raises_if_file_exists_and_different(
+        self
+    ):
+        with tempfile.NamedTemporaryFile() as t1, tempfile.NamedTemporaryFile() as t2:
+            container = ContainerEnvironment(
+                base_image="python:3.6",
+                registry_url="",
+                files={t1.name: "/root/dockerconfig", t2.name: "./.secret_file"},
+            )
+
+            base1, base2 = os.path.basename(t1.name), os.path.basename(t2.name)
+
+            with tempfile.TemporaryDirectory(prefix="prefect-tests") as tmp:
+                new_file = os.path.join(tmp, base1)
+                shutil.copy(t1.name, new_file)
+                with open(new_file, "w+") as f:
+                    f.write("a few lines\n")
+                with pytest.raises(ValueError) as exc:
+                    container.create_dockerfile(Flow(), directory=tmp)
+
+        assert "already exists" in str(exc.value)
 
     def test_init_with_copy_files_raises_informative_error_if_not_absolute(self):
         with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
Files weren't being appropriately copied to the temporary directory for placing into the containers, this PR fixes that