### PR TITLE
Allow engine configs to be objects in addition to strings

### DIFF
--- a/src/prefect/engine/__init__.py
+++ b/src/prefect/engine/__init__.py
@@ -11,61 +11,76 @@ from prefect.engine.task_runner import TaskRunner
 
 def get_default_executor_class() -> type:
     """
-    Returns the `Executor` class specified in `prefect.config.engine.executor`
+    Returns the `Executor` class specified in `prefect.config.engine.executor`. If the
+    value is a string, it will attempt to load the already-imported object. Otherwise, the
+    value is returned.
 
-    Defaults to `SynchronousExecutor` if the config value can not be loaded
+    Defaults to `SynchronousExecutor` if the string config value can not be loaded
     """
-    try:
-        return prefect.utilities.serialization.from_qualified_name(
-            prefect.config.engine.executor
-        )
-    except ValueError:
-        warn(
-            "Could not import {}; using "
-            "prefect.engine.executors.SynchronousExecutor instead.".format(
+    if isinstance(prefect.config.engine.executor, str):
+        try:
+            return prefect.utilities.serialization.from_qualified_name(
                 prefect.config.engine.executor
             )
-        )
-        return prefect.engine.executors.SynchronousExecutor
+        except ValueError:
+            warn(
+                "Could not import {}; using "
+                "prefect.engine.executors.SynchronousExecutor instead.".format(
+                    prefect.config.engine.executor
+                )
+            )
+            return prefect.engine.executors.SynchronousExecutor
+    else:
+        return prefect.config.engine.executor
 
 
 def get_default_flow_runner_class() -> type:
     """
-    Returns the `FlowRunner` class specified in `prefect.config.engine.flow_runner`
+    Returns the `FlowRunner` class specified in `prefect.config.engine.flow_runner` If the
+    value is a string, it will attempt to load the already-imported object. Otherwise, the
+    value is returned.
 
-    Defaults to `FlowRunner` if the config value can not be loaded
+    Defaults to `FlowRunner` if the string config value can not be loaded
     """
 
-    try:
-        return prefect.utilities.serialization.from_qualified_name(
-            prefect.config.engine.flow_runner
-        )
-    except ValueError:
-        warn(
-            "Could not import {}; using "
-            "prefect.engine.flow_runner.FlowRunner instead.".format(
+    if isinstance(prefect.config.engine.flow_runner, str):
+        try:
+            return prefect.utilities.serialization.from_qualified_name(
                 prefect.config.engine.flow_runner
             )
-        )
-        return prefect.engine.flow_runner.FlowRunner
+        except ValueError:
+            warn(
+                "Could not import {}; using "
+                "prefect.engine.flow_runner.FlowRunner instead.".format(
+                    prefect.config.engine.flow_runner
+                )
+            )
+            return prefect.engine.flow_runner.FlowRunner
+    else:
+        return prefect.config.engine.flow_runner
 
 
 def get_default_task_runner_class() -> type:
     """
-    Returns the `TaskRunner` class specified in `prefect.config.engine.task_runner`
+    Returns the `TaskRunner` class specified in `prefect.config.engine.task_runner` If the
+    value is a string, it will attempt to load the already-imported object. Otherwise, the
+    value is returned.
 
-    Defaults to `TaskRunner` if the config value can not be loaded
+    Defaults to `TaskRunner` if the string config value can not be loaded
     """
 
-    try:
-        return prefect.utilities.serialization.from_qualified_name(
-            prefect.config.engine.task_runner
-        )
-    except ValueError:
-        warn(
-            "Could not import {}; using "
-            "prefect.engine.task_runner.TaskRunner instead.".format(
+    if isinstance(prefect.config.engine.task_runner, str):
+        try:
+            return prefect.utilities.serialization.from_qualified_name(
                 prefect.config.engine.task_runner
             )
-        )
-        return prefect.engine.task_runner.TaskRunner
+        except ValueError:
+            warn(
+                "Could not import {}; using "
+                "prefect.engine.task_runner.TaskRunner instead.".format(
+                    prefect.config.engine.task_runner
+                )
+            )
+            return prefect.engine.task_runner.TaskRunner
+    else:
+        return prefect.config.engine.task_runner

--- a/tests/engine/test_defaults.py
+++ b/tests/engine/test_defaults.py
@@ -13,6 +13,13 @@ def test_default_executor_responds_to_config():
         assert engine.get_default_executor_class() is engine.executors.LocalExecutor
 
 
+def test_default_executor_responds_to_config_object():
+    with utilities.configuration.set_temporary_config(
+        {"engine.executor": engine.executors.LocalExecutor}
+    ):
+        assert engine.get_default_executor_class() is engine.executors.LocalExecutor
+
+
 def test_default_executor_with_bad_config():
     with utilities.configuration.set_temporary_config(
         {"engine.executor": "prefect.engine.bad import path"}
@@ -35,6 +42,13 @@ def test_default_flow_runner_responds_to_config():
         assert engine.get_default_flow_runner_class() is engine.cloud.CloudFlowRunner
 
 
+def test_default_flow_runner_responds_to_config_object():
+    with utilities.configuration.set_temporary_config(
+        {"engine.flow_runner": engine.cloud.CloudFlowRunner}
+    ):
+        assert engine.get_default_flow_runner_class() is engine.cloud.CloudFlowRunner
+
+
 def test_default_flow_runner_with_bad_config():
     with utilities.configuration.set_temporary_config(
         {"engine.flow_runner": "prefect.engine. bad import path"}
@@ -52,6 +66,13 @@ def test_default_task_runner():
 def test_default_task_runner_responds_to_config():
     with utilities.configuration.set_temporary_config(
         {"engine.task_runner": "prefect.engine.cloud.CloudTaskRunner"}
+    ):
+        assert engine.get_default_task_runner_class() is engine.cloud.CloudTaskRunner
+
+
+def test_default_task_runner_responds_to_config_object():
+    with utilities.configuration.set_temporary_config(
+        {"engine.task_runner": engine.cloud.CloudTaskRunner}
     ):
         assert engine.get_default_task_runner_class() is engine.cloud.CloudTaskRunner
 


### PR DESCRIPTION
In #477, introduced functions that parsed the config from a string and returned executor/flow_runner/task_runner classes.

This tweaks those functions to allow the config to be set as an object (instead of a string pointing to an object).

This is useful for runtime configuration switches. 