### PR TITLE
Mark test as xfail

### DIFF
--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -776,6 +776,9 @@ def test_flow_runner_allows_for_parallelism_with_prints(capsys, executor):
     assert captured.out != bob_first
 
 
+@pytest.mark.xfail(
+    reason="This test fails on CircleCI for Python 3.5+ if not enough cores/workers are available."
+)
 @pytest.mark.parametrize("executor", ["mproc", "mthread"], indirect=True)
 def test_flow_runner_allows_for_parallelism_with_times(executor):
 


### PR DESCRIPTION
Unfortunately I was a little too overeager in #490 and one of the tests still fails on occasion if it can't allocate enough workers to truly run in parallel.