### PR TITLE
Clarify process of PIN-1

### DIFF
--- a/docs/PINs/PIN-1-Introduce-PINs.md
+++ b/docs/PINs/PIN-1-Introduce-PINs.md
@@ -51,9 +51,11 @@ Each PIN has four important sections: Status, Context, Decision, and Consequence
 
 PINs are often the reflection of offline work and discussions, but we will attempt to integrate them in our online processes when possible.
 
-PINs will be submitted as issues on the appropriate forum. Issues are an appropriate, archivable forum for discussing the content and nature of the PIN. In addition, as an issue the PIN's content can easily be modified. Once some consensus is reached, the PIN will be submitted as a PR.
+PINs will be submitted as issues on the appropriate repo. Issues are an appropriate, archivable forum for discussing the content and nature of the PIN. In addition, as an issue the PIN's content can easily be modified. Once some consensus is reached, the PIN will be submitted as a PR.
 
-When a PIN is submitted as a PR, its proposed decision does NOT need to be accepted in order for the PR to be merged. The code maintainers should accept PRs for PINs that have yet to be accepted or even ones that have been rejected. In this way, the acceptance of a PIN PR should be judged similar to documentation: it helps explain how the software evolved to its current state. However, the maintainers may use editorial judgement for non-accepted PRs. A polluted narrative can be worse than no narrative at all.
+When a PIN is submitted as a PR, its proposed decision does NOT need to be accepted in order for the PR to be merged. The repo's maintainers may merge PRs for PINs that have yet to be accepted or even ones that have been rejected. The acceptance of a PIN PR should be judged similarly to one for documentation: it helps explain how the software evolved to its current state.
+
+Any PIN that generated sufficient discussion to affect the course of Prefect's software is worthwhile to include permanently, even if it, itself, remained pending or was rejected. These "negative decisions" are just as important. However, the maintainers may use editorial judgement for non-accepted PINs. A polluted narrative can be worse than no narrative at all.
 
 ## Consequences
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)



## What does this PR change?

Clarifies that PINs should be opened as issues, not PRs. This rapidly became evident with PIN2 (#570), where the PR format felt constrictive and required simultaneous updates of the file (via commit) and the PR body (via edit). 


## Why is this PR important?
Editing a PIN is, broadly speaking, bad. They should be superseded by other PINs instead. However, as we're still figuring this system out and since PIN-1 is an important description of the process, I thought it would be appropriate to update it in place with these new ideas.


