### PR TITLE
Fix issue with serialization of cached_inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Older versions of Prefect will now ignore fields added by newer versions when deserializing objects - [#583](https://github.com/PrefectHQ/prefect/pull/583)
 - Result handler failures now result in clear task run failures - [#575](https://github.com/PrefectHQ/prefect/issues/575)
 - Fix issue deserializing old states with empty metadata - [#590](https://github.com/PrefectHQ/prefect/pull/590)
+- Fix issue serializing `cached_inputs` - [#594](https://github.com/PrefectHQ/prefect/pull/594)
 
 ### Breaking Changes
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -193,7 +193,6 @@ class CloudTaskRunner(TaskRunner):
                         input_handlers[edge.key] = upstream_state._metadata["result"][
                             "result_handler"
                         ]
-
                 state.handle_inputs(input_handlers)
             except Exception as exc:
                 self.logger.debug(

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -13,20 +13,29 @@ from prefect.utilities.serialization import (
 )
 
 
+def reset_value(value, is_raw):
+    if is_raw:
+        value = None
+    else:
+        try:
+            json.dumps(value)
+        except TypeError:
+            raise TypeError(
+                "The serialized result of a ResultHandler must be JSON-compatible."
+            )
+    return value
+
+
 class ResultHandlerField(fields.Field):
     def _serialize(self, value, attr, obj, **kwargs):
         if hasattr(obj, "_metadata"):
-            is_raw = obj._metadata[attr]["raw"]
-            # "raw" results are never serialized
-            if is_raw:
-                value = None
-            else:
-                try:
-                    json.dumps(value)
-                except TypeError:
-                    raise TypeError(
-                        "The serialized result of a ResultHandler must be JSON-compatible."
+            if attr == "cached_inputs":
+                for var in value or {}:
+                    value[var] = reset_value(
+                        value[var], obj._metadata[attr][var]["raw"]
                     )
+            else:
+                value = reset_value(value, obj._metadata[attr]["raw"])
         return super()._serialize(value, attr, obj, **kwargs)
 
 


### PR DESCRIPTION
Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR ensures that each individual variable of `cached_inputs` is considered when serializing state objects; this has the nice unintended side effect that the actual _keys_ of the `cached_inputs` dictionary are now preserved in serialization, even if the values are discarded!

## Why is this PR important?
This PR fixes a situation wherein `cached_inputs` were actually _not_ being serialized at all during task retries.
