### PR TITLE
Make google a base requirement for now

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-google-cloud-storage >= 1.13, < 2.0
 graphviz >= 0.8.3
 jinja2 >= 2.0, < 3.0
 nbformat >= 4.4.0, < 5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cryptography >= 2.2.2, < 3.0
 dask >= 0.18, < 2.0
 distributed >= 1.21.8, < 2.0
 docker >= 3.4.1, < 4.0
+google-cloud-storage >= 1.13, < 2.0
 idna < 2.8, >= 2.5
 marshmallow == 3.0.0b19
 marshmallow-oneofschema >= 2.0.0b2, < 3.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ dev_requires = open("dev-requirements.txt").read().strip().split("\n")
 
 extras = {
     "dev": dev_requires,
-    "google": ["google-cloud-storage >= 1.13, < 2.0"],
     "viz": ["graphviz >= 0.8.3"],
     "templates": ["jinja2 >= 2.0, < 3.0"],
 }


### PR DESCRIPTION
ContainerEnvironments install plain Prefect, and because of the way the imports are currently structured, `google` needs to be a requirement for now.