### PR TITLE
Add missing `data` key for GQL result

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -359,7 +359,9 @@ class Client:
         if set_schedule_active:
             self.graphql(
                 schedule_mutation,
-                input=dict(flowId=res.createFlow.id, setActive=True),  # type: ignore
+                input=dict(
+                    flowId=res.data.createFlow.id, setActive=True
+                ),  # type: ignore
             )  # type: Any
 
         return res.data.createFlow.id


### PR DESCRIPTION
Quick fix that catches one `graphql` call that was missed in #642 