### PR TITLE
Add two tests for checkpointing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,5 @@ include LICENSE.md
 include src/prefect/config.toml
 include versioneer.py
 include src/prefect/_version.py
-
 include src/prefect/_siginfo.py
 include src/prefect/_sig29/*.txt


### PR DESCRIPTION
This PR adds two simple tests that ensures only `Success` states are checkpointed. This isn't an issue in the current implementation, but if we ever break out `checkpointing` into its own pipeline step, these tests will ensure that we cover edge cases (e.g., because `Skipped().is_successful() == True`).