### PR TITLE
Container health check prior to push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Load `context` from Cloud when running flows - [#699](https://github.com/PrefectHQ/prefect/pull/699)
 - Add `Queued` state - [#705](https://github.com/PrefectHQ/prefect/issues/705)
 - `flow.serialize()` will always serialize its environment, regardless of `build` - [#696](https://github.com/PrefectHQ/prefect/issues/696)
+- `flow.deploy()` now raises an informative error if your container cannot deserialize the Flow - [#711](https://github.com/PrefectHQ/prefect/issues/711)
 
 ### Fixes
 

--- a/src/prefect/environments/docker.py
+++ b/src/prefect/environments/docker.py
@@ -15,6 +15,7 @@ import docker
 import prefect
 from prefect.environments import Environment
 from prefect.environments import LocalEnvironment
+from prefect.utilities.exceptions import SerializationError
 
 
 class DockerEnvironment(Environment):
@@ -133,6 +134,10 @@ class DockerEnvironment(Environment):
                 path=tempdir, tag="{}:{}".format(full_name, image_tag), forcerm=True
             )
             self._parse_generator_output(output)
+            if len(client.images(name=full_name)) == 0:
+                raise SerializationError(
+                    "Your flow failed to deserialize in the container; please ensure that all necessary files and dependencies have been included."
+                )
 
             if push:
                 self.push_image(full_name, image_tag)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR raises an informative error if your image failed to build in any way; 99% of the time, an image failing to build means that the container does not contain all necessary dependencies to deserialize the flow (although there are other, weirder serialization issues that can occur).


## Why is this PR important?
Closes #711 and helps users learn about serialization issues well before attempting to run their flow and not understanding why nothing is happening.