### PR TITLE
Remove references to return_tasks in docs

### DIFF
--- a/docs/.vuepress/public/notebooks/advanced-mapping.ipynb
+++ b/docs/.vuepress/public/notebooks/advanced-mapping.ipynb
@@ -73,8 +73,7 @@
    "outputs": [],
    "source": [
     "episode_url = \"http://www.insidethex.co.uk/transcrp/scrp320.htm\"\n",
-    "outer_space = flow.run(parameters={\"url\": episode_url},\n",
-    "                       return_tasks=[dialogue])\n",
+    "outer_space = flow.run(parameters={\"url\": episode_url}\n",
     "\n",
     "state = outer_space.result[dialogue] # the `State` object for the dialogue task\n",
     "first_five_spoken_lines = state.result[1][:5] # state.result is a tuple (episode_name, [dialogue])\n",
@@ -130,8 +129,7 @@
    "source": [
     "episode_url = \"http://www.insidethex.co.uk/transcrp/scrp320.htm\"\n",
     "outer_space = flow.run(parameters={\"url\": episode_url, \"bypass\": True},\n",
-    "                       start_tasks=[bypass, episodes, url],\n",
-    "                       return_tasks=[dialogue])"
+    "                       start_tasks=[bypass, episodes, url])"
    ]
   },
   {
@@ -150,7 +148,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "scraped_state = flow.run(parameters={\"url\": \"http://www.insidethex.co.uk/\"}, return_tasks=[dialogue])\n",
+    "scraped_state = flow.run(parameters={\"url\": \"http://www.insidethex.co.uk/\"})\n",
     "#    CPU times: user 7.48 s, sys: 241 ms, total: 7.73 s\n",
     "#    Wall time: 4min 46s\n",
     "\n",
@@ -177,7 +175,6 @@
    "source": [
     "%%time\n",
     "scraped_state = flow.run(parameters={\"url\": \"http://www.insidethex.co.uk/\"},\n",
-    "               return_tasks=flow.tasks,\n",
     "               executor=executor)\n",
     "\n",
     "#    CPU times: user 9.7 s, sys: 1.67 s, total: 11.4 s\n",

--- a/docs/.vuepress/public/notebooks/airflow_migration.ipynb
+++ b/docs/.vuepress/public/notebooks/airflow_migration.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "from prefect.utilities.debug import raise_on_exception\n",
     "\n",
-    "flow_state = flow.run(execution_date='2018-09-20', return_tasks=flow.tasks)\n",
+    "flow_state = flow.run(execution_date='2018-09-20')\n",
     "#    branch_b\n",
     "#    None\n",
     "flow.visualize(flow_state=flow_state)\n"

--- a/docs/.vuepress/public/notebooks/calculator.ipynb
+++ b/docs/.vuepress/public/notebooks/calculator.ipynb
@@ -12,7 +12,7 @@
     "    runs the flow with the provided parameters and returns that task's result.\n",
     "    \"\"\"\n",
     "    task = list(flow.terminal_tasks())[0]\n",
-    "    state = flow.run(parameters=parameters, return_tasks=[task])\n",
+    "    state = flow.run(parameters=parameters)\n",
     "    return state.result[task].result\n"
    ]
   },

--- a/docs/.vuepress/public/notebooks/task-retries.ipynb
+++ b/docs/.vuepress/public/notebooks/task-retries.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "%%time\n",
     "with prefect.context(fail=True) as ctx:\n",
-    "    flow_state = f.run(return_tasks=f.tasks, context=ctx)\n",
+    "    flow_state = f.run(context=ctx)\n",
     "\n",
     "##    CPU times: user 5.65 ms, sys: 1.46 ms, total: 7.12 ms\n",
     "##    Wall time: 5.01 s\n"
@@ -82,8 +82,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "new_flow_state = f.run(return_tasks=[text],\n",
-    "                       task_states={text: flow_state.result[text]},\n",
+    "new_flow_state = f.run(task_states={text: flow_state.result[text]},\n",
     "                       start_tasks=[text])\n",
     "\n",
     "##    CPU times: user 15.5 ms, sys: 5.91 ms, total: 21.4 ms\n",

--- a/docs/.vuepress/public/notebooks/triggers-and-references.ipynb
+++ b/docs/.vuepress/public/notebooks/triggers-and-references.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_state = f.run(return_tasks=[report, board_email, complaint])\n",
+    "flow_state = f.run()\n",
     "\n",
     "print(\"Flow state: {}\\n\".format(flow_state))\n",
     "print(flow_state.result)\n",
@@ -70,7 +70,7 @@
     "    \n",
     "##    Flow results: {\n",
     "##     <Task: build_report>: Success(\"Task run succeeded.\"), \n",
-    "##     <Task: email_report_to_board>: Paused("Trigger function is "manual_only""), 
+    "##     <Task: email_report_to_board>: Paused("Trigger function is "manual_only""),
     "##     <Task: complain_to_data_analyst>: Pending()\n",
     "##     }\n"
    ]
@@ -92,8 +92,7 @@
    "outputs": [],
    "source": [
     "new_flow_state = f.run(task_states=flow_state.result, \n",
-    "                       start_tasks=[board_email], \n",
-    "                       return_tasks=[board_email, complaint])\n",
+    "                       start_tasks=[board_email])\n",
     "\n",
     "print(\"Flow state: {}\\n\".format(new_flow_state))\n",
     "print(new_flow_state.result)\n",

--- a/docs/.vuepress/public/notebooks/visualization.ipynb
+++ b/docs/.vuepress/public/notebooks/visualization.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_state = f.run(return_tasks=f.tasks) # ask for all tasks to be returned\n",
+    "flow_state = f.run()\n",
     "f.visualize(flow_state=flow_state)\n"
    ]
   },

--- a/docs/guide/PINs/PIN-4-Result-Objects.md
+++ b/docs/guide/PINs/PIN-4-Result-Objects.md
@@ -150,7 +150,7 @@ result = Result(value=value, serialized=False, serializer=task.serializer)
 Despite all of this, the FlowRunner would require no changes. It would return an object that could still be accessed in the exact same way we do today:
 
 ```python
-state = flow.run(return_tasks=flow.tasks)
+state = flow.run()
 
 # the value returned by task "x"
 state.result[x].result

--- a/docs/guide/core_concepts/engine.md
+++ b/docs/guide/core_concepts/engine.md
@@ -10,10 +10,6 @@ The flow runner takes a flow and attempts to run all of its tasks. It collects t
 
 Flow runners loop over all of the tasks one time. If tasks remain unfinished after that pass -- for example, if one of them needs to be retried -- then a second loop will be required to attempt to finish them. There is no limit to the number of attempts it may take to move all tasks (and therefore the flow itself) into a finished state.
 
-### Return tasks
-
-When a flow is run, users can set `return_tasks`. The runner will return states for all requested tasks; by default, it returns states for no tasks.
-
 ### Parameters
 
 Flows that have parameters may require parameter values (if those parameters have no defaults). Parameter values must be passed to the flow runner when it runs.

--- a/docs/guide/core_concepts/flows.md
+++ b/docs/guide/core_concepts/flows.md
@@ -100,16 +100,12 @@ with Flow() as flow:
 flow.run() # prints "Hello, world!"
 ```
 
-This will return a `State` object representing the outcome of the run. To receive task states as well, supply a `return_tasks` argument to `flow.run()`:
+This will return a `State` object representing the outcome of the run, including the `States` of all tasks.
 
 ```python
-state = flow.run(return_tasks=[h])
+state = flow.run()
 state.result[h] # the task state of the say_hello task
 ```
-
-:::tip Task classes vs Task instances
-Notice that we passed `return_tasks=[h]`, not `return_tasks=[say_hello]`. This is because `h` represents a specific instance of a task that is contained inside the flow, whereas `say_hello` is just a generator of such tasks. Similarly, with a custom subclass, we would pass the task instance rather than the subclass itself.
-:::
 
 ## Schedules
 

--- a/docs/guide/core_concepts/mapping.md
+++ b/docs/guide/core_concepts/mapping.md
@@ -45,7 +45,7 @@ with Flow() as flow:
     mapped_result = map_fn.map(numbers)
     reduced_result = reduce_fn(mapped_result)
 
-state = flow.run(return_tasks=[reduced_result])
+state = flow.run()
 assert state.result[reduced_result].result == 9
 ```
 

--- a/docs/guide/tutorials/advanced-mapping.md
+++ b/docs/guide/tutorials/advanced-mapping.md
@@ -110,14 +110,12 @@ flow.visualize()
 Awesome! We've constructed our flow and everything looks good; all that's left is to run it. When we call `flow.run()` we need to provide two keywords:
 
 - `parameters`: a dictionary of the required parameter values (in our case, `url`)
-- `return_tasks`: a list of the tasks we want returned in the flow's state; in this case we ask for the `dialogue` task so we can see if our scraping worked as intended
 
 We then print the first five spoken lines of the episode.
 
 ```python
 episode_url = "http://www.insidethex.co.uk/transcrp/scrp320.htm"
-outer_space = flow.run(parameters={"url": episode_url},
-                       return_tasks=[dialogue])
+outer_space = flow.run(parameters={"url": episode_url})
 
 state = outer_space.result[dialogue] # the `State` object for the dialogue task
 first_five_spoken_lines = state.result[1][:5] # state.result is a tuple (episode_name, [dialogue])
@@ -214,8 +212,7 @@ To reproduce [the first example](#setting-up-the-flow-for-a-single-episode) we r
 ```python
 episode_url = "http://www.insidethex.co.uk/transcrp/scrp320.htm"
 outer_space = flow.run(parameters={"url": episode_url, "bypass": True},
-                       start_tasks=[bypass, episodes, url],
-                       return_tasks=[dialogue])
+                       start_tasks=[bypass, episodes, url])
 ```
 
 In this case, we provide `bypass=True` so that the full episode list is not scraped; morever, we explicitly tell the flow to begin execution with the Parameters and the `create_episode_list` task, avoiding the task which would retrieve the homepage html. See the diagram above to better understand what is occuring here - we'll see this pattern again shortly.
@@ -237,7 +234,7 @@ Now let's run our flow, time its execution, and print the states for the first f
 
 ```python
 %%time
-scraped_state = flow.run(parameters={"url": "http://www.insidethex.co.uk/"}, return_tasks=[dialogue])
+scraped_state = flow.run(parameters={"url": "http://www.insidethex.co.uk/"})
 #    CPU times: user 7.48 s, sys: 241 ms, total: 7.73 s
 #    Wall time: 4min 46s
 
@@ -272,7 +269,6 @@ executor = DaskExecutor(local_processes=True)
 
 %%time
 scraped_state = flow.run(parameters={"url": "http://www.insidethex.co.uk/"},
-               return_tasks=flow.tasks,
                executor=executor)
 
 #    CPU times: user 9.7 s, sys: 1.67 s, total: 11.4 s

--- a/docs/guide/tutorials/airflow_migration.md
+++ b/docs/guide/tutorials/airflow_migration.md
@@ -166,7 +166,7 @@ When we execute this, we expect to see two print statements:
 ```python
 from prefect.utilities.debug import raise_on_exception
 
-flow_state = flow.run(execution_date='2018-09-20', return_tasks=flow.tasks)
+flow_state = flow.run(execution_date='2018-09-20')
 #    branch_b
 #    None
 flow.visualize(flow_state=flow_state)

--- a/docs/guide/tutorials/calculator.md
+++ b/docs/guide/tutorials/calculator.md
@@ -26,7 +26,7 @@ def run(flow, **parameters):
     that task's result.
     """
     task = list(flow.terminal_tasks())[0]
-    state = flow.run(parameters=parameters, return_tasks=[task])
+    state = flow.run(parameters=parameters)
     return state.result[task].result
 ```
 

--- a/docs/guide/tutorials/task-retries.md
+++ b/docs/guide/tutorials/task-retries.md
@@ -66,18 +66,18 @@ with Flow(name="retry example") as f:
 
 Now that we have created our flow `f`, we could continue to add tasks and dependencies to it through a variety of methods such as `add_task` and `set_dependencies`, or inspect its current state with methods such as `visualize` and `terminal_tasks`.
 
-To actually perform the computation, we call `f.run()` and specify which tasks we want returned for inspection. For the first run, we ensure that the request fails by artificially injecting a `"fail"` key into the `prefect.context` (see the docs for more information on context) which the task will look for. If you look back at the definition of the `ping_external_services` task, we explicitly look for this key to determine whether the task should fail or succeed.
+To actually perform the computation, we call `f.run()`. For the first run, we ensure that the request fails by artificially injecting a `"fail"` key into the `prefect.context` (see the docs for more information on context) which the task will look for. If you look back at the definition of the `ping_external_services` task, we explicitly look for this key to determine whether the task should fail or succeed.
 
 ```python
 %%time
 with prefect.context(fail=True) as ctx:
-    flow_state = f.run(return_tasks=f.tasks, context=ctx)
+    flow_state = f.run(context=ctx)
 
 ##    CPU times: user 5.65 ms, sys: 1.46 ms, total: 7.12 ms
 ##    Wall time: 5.01 s
 ```
 
-As expected, the flow run took 5 seconds due to the `create_payload` task. We can now inspect both the state of the flow as well as the state of the requested `return_tasks`.
+As expected, the flow run took 5 seconds due to the `create_payload` task. We can now inspect both the state of the flow as well as the state of its tasks.
 
 ```python
 print("Flow state: {}\n".format(flow_state))
@@ -104,8 +104,7 @@ Providing states to the `run` method will be handled by the server on the actual
 
 ```python
 %%time
-new_flow_state = f.run(return_tasks=[text],
-                       task_states={text: flow_state.result[text]},
+new_flow_state = f.run(task_states={text: flow_state.result[text]},
                        start_tasks=[text])
 
 ##    CPU times: user 15.5 ms, sys: 5.91 ms, total: 21.4 ms

--- a/docs/guide/tutorials/triggers-and-references.md
+++ b/docs/guide/tutorials/triggers-and-references.md
@@ -79,7 +79,7 @@ f.set_reference_tasks([board_email])
 We are now ready to run the flow:
 
 ```python
-flow_state = f.run(return_tasks=[report, board_email, complaint])
+flow_state = f.run()
 
 print("Flow state: {}\n".format(flow_state))
 print(flow_state.result)
@@ -111,8 +111,7 @@ Note that in this case, the tasks represented by `data` and `report` will _not_ 
 
 ```python
 new_flow_state = f.run(task_states=flow_state.result,
-                       start_tasks=[board_email],
-                       return_tasks=[board_email, complaint])
+                       start_tasks=[board_email])
 
 print("Flow state: {}\n".format(new_flow_state))
 print(new_flow_state.result)

--- a/docs/guide/tutorials/visualization.md
+++ b/docs/guide/tutorials/visualization.md
@@ -80,7 +80,7 @@ f.root_tasks()
 # {<Parameter: x>, <Parameter: y>, <Task: 6>}
 ```
 
-These are the tasks the flow will execute first (by default); consequently, the task "6" will be run _regardless_ of whether the `Div` task is skipped by the switch condition.  If, instead of merely returning the number 6, this task performed a lot of computation, we might want it executed _only if_ the switch condition passes; in this case we would need to rearrange our flow.  
+These are the tasks the flow will execute first (by default); consequently, the task "6" will be run _regardless_ of whether the `Div` task is skipped by the switch condition.  If, instead of merely returning the number 6, this task performed a lot of computation, we might want it executed _only if_ the switch condition passes; in this case we would need to rearrange our flow.
 
 ::: tip Note
 Notice that we have identified this situation and possibly remediated it _all without executing our code_!
@@ -91,7 +91,7 @@ Notice that we have identified this situation and possibly remediated it _all wi
 In addition to viewing the structure of our DAG, Prefect allows you to easily visualize the post-run states of your tasks as well. Using our flow from above, suppose we were curious about how states would propagate if we set `x=1` and `y=1` (a condition not handled by the `switch`).  In this case, we can first execute the flow, and then provide all the task states to the `flow.visualize` method to see how the states propagated!
 
 ```python
-flow_state = f.run(return_tasks=f.tasks) # ask for all tasks to be returned
+flow_state = f.run()
 f.visualize(flow_state=flow_state)
 ```
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -957,10 +957,14 @@ class Flow:
         Returns:
             - State: the state of the flow after its final run
         """
+        # protect against old behavior
         if "return_tasks" in kwargs:
             raise ValueError(
-                "The `return_tasks` keywords cannot be provided to `flow.run`; all task states are always returned.  If you wish to only work with a subset, use a FlowRunner directly."
+                "The `return_tasks` keyword cannot be provided to `flow.run()`; "
+                "all task states are always returned. If you want to receive a subset "
+                "of task states, use a FlowRunner directly."
             )
+
         if runner_cls is None:
             runner_cls = prefect.engine.get_default_flow_runner_class()
 

--- a/src/prefect/engine/cache_validators.py
+++ b/src/prefect/engine/cache_validators.py
@@ -164,13 +164,12 @@ def partial_parameters_only(
         runtime = Parameter("runtime")
         db_state = daily_db_refresh(nrows, runtime)
 
-    state1 = f.run(parameters=dict(nrows=1000, runtime=pendulum.now('utc')),
-                  return_tasks=[db_state])
+    state1 = f.run(parameters=dict(nrows=1000, runtime=pendulum.now('utc')))
 
     ## the second run will use the cache contained within state1.result[db_state]
     ## even though `runtime` has changed
     state2 = f.run(parameters=dict(nrows=1000, runtime=pendulum.now('utc')),
-                   return_tasks=[db_state], task_states={result: state1.result[db_state]})
+                   task_states={result: state1.result[db_state]})
     ```
     """
     parameters = parameters or {}
@@ -233,11 +232,10 @@ def partial_inputs_only(
     with Flow() as f:
         ans = add(1, 2, rand_bool())
 
-    state1 = f.run(return_tasks=[ans])
+    state1 = f.run()
     ## the second run will use the cache contained within state1.result[ans]
     ## even though `rand_bool` might change
-    state2 = f.run(return_tasks=[ans],
-                   task_states={result: state1.result[ans]})
+    state2 = f.run(task_states={result: state1.result[ans]})
     ```
     """
     inputs = inputs or {}

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -100,10 +100,10 @@ def pause_task(message: str = None):
         with Flow() as f:
             res = add(4, 4)
 
-        state = f.run(return_tasks=[res])
+        state = f.run()
         state.result[res] # a Paused state
 
-        state = f.run(return_tasks=[res], task_states={res: Resume()})
+        state = f.run(task_states={res: Resume()})
         state.result[res] # a Success state
         ```
     """

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1415,8 +1415,7 @@ def test_flow_run_raises_informative_error_for_certain_kwargs():
     f = Flow()
     with pytest.raises(ValueError) as exc:
         f.run(return_tasks=f.tasks)
-    assert "return_tasks" in str(exc.value)
-    assert "FlowRunner" in str(exc.value)
+    assert "`return_tasks` keyword cannot be provided" in str(exc.value)
 
 
 def test_flow_run_raises_if_no_more_scheduled_runs():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)



## What does this PR change?
Closes #718 by removing references to `return_tasks`