### PR TITLE
Remove example runs

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,9 +12,3 @@ examples_dir = str(Path(__file__).parents[1] / "examples")
 def test_examples_exist():
     assert os.path.exists(examples_dir)
     assert len(os.listdir(examples_dir)) > 0
-
-
-@pytest.mark.parametrize("f", os.listdir(examples_dir))
-def test_all_examples_run_without_error(f):
-    if "github" not in f:
-        subprocess.check_call(["python", os.path.join(examples_dir, f)])


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)



## What does this PR change?
Closes #811 by removing the tests which execute our examples directory.  The intent of this test is great, but ultimately it doesn't do more than make sure the flows _run_ (no assertions are made on flow / task state).  These examples will grow to include more tasks from the task library, which will make the dependency burden complex and excessive.  We want
```
pip install -e ".[dev]"
pytest .
```
to work cleanly.