### PR TITLE
Clean up docs for auto-applied task classes

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -124,31 +124,6 @@ def format_lists(doc):
 @preprocess
 def format_doc(obj, in_table=False):
     doc = inspect.getdoc(obj)
-
-    # if the object is a Class and doesn't implement an __init__, then we want to
-    # "inherit" the doc of its immediate parent class.
-    if inspect.isclass(obj):
-        for parent in obj.mro()[1:]:  # first object in MRO is the class itself
-            if obj.__init__ is parent.__init__:
-
-                try:
-                    parent_name = create_absolute_path(parent)
-                except:
-                    parent_name = parent.__name__
-
-                doc = "\n\n".join(
-                    [
-                        doc,
-                        f"#### Parent Class Documentation (`{parent_name}`):",
-                        format_doc(parent, in_table=in_table),
-                    ]
-                )
-
-                # once we match, we can break the loop.
-                # avoids a situation where we match multiple parent classes that all have
-                # no __init__.
-                break
-
     body = doc or ""
     code_blocks = re.findall(r"```(.*?)```", body, re.DOTALL)
     for num, block in enumerate(code_blocks):

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 import sys
 from functools import partial, wraps
@@ -308,12 +309,6 @@ def test_format_doc_on_subclass_with_doc_but_inherited_init():
     expected = textwrap.dedent(
         """
         This is the child doc
-
-        #### Parent Class Documentation (`test_format_doc_on_subclass_with_doc_but_inherited_init.<locals>.Parent`):
-
-        This is the parent doc
-
-        **Args**:     <ul class="args"><li class="args">`x (int)`: a number</li></ul>
         """
     ).strip()
 
@@ -325,10 +320,6 @@ def test_format_doc_on_raw_exception():
     expected = textwrap.dedent(
         """
         Just a name, nothing more.
-
-        #### Parent Class Documentation (`Exception`):
-
-        Common base class for all non-exit exceptions.
         """
     ).strip()
     assert formatted == expected
@@ -467,8 +458,9 @@ def test_sections_have_formatted_headers_for_class_docs(obj):
     for section in ["Args", "Returns", "Raises", "Example"]:
         option1 = ">**{}**:".format(section)
         option2 = "\n**{}**:".format(section)
+        option3 = "**{}**:".format(section)
         assert (section in doc) is any(
-            [(o in doc) for o in (option1, option2)]
+            [(o in doc) for o in (option1, option2)] + [doc.startswith(option3)]
         ), "{obj.__module__}.{obj.__name__} has a poorly formatted {sec} header.".format(
             obj=obj, sec=section
         )

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -13,9 +13,9 @@ class PrefectStateSignal(PrefectError):
 
     Args:
         - message (Any, optional): Defaults to `None`. A message about the signal.
-        - args (Any, optional): additional arguments to pass to this Signal's
+        - *args (Any, optional): additional arguments to pass to this Signal's
             associated state constructor
-        - kwargs (Any, optional): additional keyword arguments to pass to this Signal's
+        - **kwargs (Any, optional): additional keyword arguments to pass to this Signal's
             associated state constructor
     """
 

--- a/src/prefect/tasks/core/collections.py
+++ b/src/prefect/tasks/core/collections.py
@@ -15,7 +15,14 @@ class VarArgsTask(Task):
     Most task classes do not support `*args` as an input.
 
     This task *does* accept `*args` and automatically transforms them into `**kwargs`.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def bind(
         self,
@@ -43,6 +50,17 @@ class VarArgsTask(Task):
 
 
 class List(VarArgsTask):
+    """
+    Collects task results into a list.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
     def run(self, **task_results: Any) -> list:  # type: ignore
         """
         Args:
@@ -55,6 +73,17 @@ class List(VarArgsTask):
 
 
 class Tuple(VarArgsTask):
+    """
+    Collects task results into a tuple.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
     def run(self, **task_results: Any) -> tuple:  # type: ignore
         """
         Args:
@@ -67,6 +96,17 @@ class Tuple(VarArgsTask):
 
 
 class Set(VarArgsTask):
+    """
+    Collects task results into a set.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
     def run(self, **task_results: Any) -> set:  # type: ignore
         """
         Args:
@@ -79,6 +119,17 @@ class Set(VarArgsTask):
 
 
 class Dict(Task):
+    """
+    Collects task results into a dict.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
     def run(self, **task_results: Any) -> dict:  # type: ignore
         """
         Args:

--- a/src/prefect/tasks/core/operators.py
+++ b/src/prefect/tasks/core/operators.py
@@ -14,7 +14,14 @@ from prefect import Task
 class GetItem(Task):
     """
     Helper task that retrieves a specific index of an upstream task's result.
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, task_result: Any, key: Any) -> Any:  # type: ignore
         """
@@ -31,7 +38,14 @@ class GetItem(Task):
 class Add(Task):
     """
     Evaluates `x + y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -48,7 +62,14 @@ class Add(Task):
 class Sub(Task):
     """
     Evaluates `x - y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -65,7 +86,14 @@ class Sub(Task):
 class Mul(Task):
     """
     Evaluates `x * y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -82,7 +110,14 @@ class Mul(Task):
 class Div(Task):
     """
     Evaluates `x / y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -99,7 +134,14 @@ class Div(Task):
 class FloorDiv(Task):
     """
     Evaluates `x // y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -116,7 +158,14 @@ class FloorDiv(Task):
 class Pow(Task):
     """
     Evaluates `x ** y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -133,7 +182,14 @@ class Pow(Task):
 class Mod(Task):
     """
     Evaluates `x % y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
@@ -153,7 +209,14 @@ class Mod(Task):
 class And(Task):
     """
     Evaluates `x and y.`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -170,7 +233,14 @@ class And(Task):
 class Or(Task):
     """
     Evaluates `x or y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -187,7 +257,14 @@ class Or(Task):
 class Not(Task):
     """
     Evaluates `not x`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any) -> bool:  # type: ignore
         """
@@ -203,7 +280,14 @@ class Not(Task):
 class Equal(Task):
     """
     Evaluates `x == y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -220,7 +304,14 @@ class Equal(Task):
 class NotEqual(Task):
     """
     Evaluates `x != y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -237,7 +328,14 @@ class NotEqual(Task):
 class GreaterThanOrEqual(Task):
     """
     Evaluates `x ≥ y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -254,7 +352,14 @@ class GreaterThanOrEqual(Task):
 class GreaterThan(Task):
     """
     Evaluates `x > y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -271,7 +376,14 @@ class GreaterThan(Task):
 class LessThanOrEqual(Task):
     """
     Evaluates `x ≤ y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """
@@ -288,7 +400,14 @@ class LessThanOrEqual(Task):
 class LessThan(Task):
     """
     Evaluates `x < y`
+
+    Args:
+        - *args (Any): positional arguments for the `Task` class
+        - **kwargs (Any): keyword arguments for the `Task` class
     """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
 
     def run(self, x: Any, y: Any) -> bool:  # type: ignore
         """


### PR DESCRIPTION
Reverses the change that automatically added "parent docs" to subclass documentation.