### PR TITLE
documentation styling updates

### DIFF
--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -199,13 +199,14 @@ i
 // footer
 .footer
     margin-top: 2.5em
-
+ 
 .page-edit, 
 .page-nav
     max-width: 55rem
 
 // badges
-badge = '.badge[data-v-23988dc6], .badge[data-v-099ab69c]'
+badge = 'span.badge'
+// badge = '.badge[data-v-23988dc6], .badge[data-v-099ab69c]'
 
 .content
     {badge}

--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -196,6 +196,10 @@ i
 .footer
     margin-top: 2.5em
 
+.page-edit, 
+.page-nav
+    max-width: 55rem
+
 // badges
 badge = '.badge[data-v-23988dc6], .badge[data-v-099ab69c]'
 

--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -177,6 +177,11 @@ i
             left: 50%
             top: .7rem
 
+    .site-name
+        font-family: font-secondary
+        font-size: 1.625em
+        line-height: 1.3
+
 // sidebar
 .sidebar
     &-link,
@@ -190,7 +195,6 @@ i
 
 .content:not(.custom)
     max-width: 55rem
-
 
 // footer
 .footer


### PR DESCRIPTION
- matched bottom footer divider width to content width
- changed top header navigation font to 'arboria' to match the rest of our documentation headers
- resolved #786 by targeting `span.badge` instead of `.badge[data-v-numbers]`