### PR TITLE
Set Parameter checkpoint to a False default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
+- Set Parameter `checkpoint` to `False` by default - [#839](https://github.com/PrefectHQ/prefect/pull/839)
+
 ### Breaking Changes
 
 ## 0.5.0 <Badge text="beta" type="success"/>

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -977,7 +977,7 @@ class Parameter(Task):
             name=name,
             slug=name,
             tags=tags,
-            checkpoint=True,
+            checkpoint=False,
             result_handler=JSONResultHandler(),
         )
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -945,9 +945,6 @@ class Parameter(Task):
     Flows enforce slug uniqueness across all tasks, so this ensures that the flow has
     no other parameters by the same name.
 
-    *Note*: Parameters should always be JSON-compatible objects, and will always be checkpointed
-    during execution using the `JSONResultHandler`.
-
     Args:
         - name (str): the Parameter name.
         - required (bool, optional): If True, the Parameter is required and the default

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -805,6 +805,16 @@ def test_flow_doesnt_raises_for_missing_nonrequired_parameters():
     assert flow_state.result[p].result == 1
 
 
+def test_flow_accepts_odd_parameters():
+    with Flow(name="test") as f:
+        p = Parameter("x")()
+
+    value = lambda a: a + 1
+
+    state = f.run(parameters={"x": value})
+    assert state.result[p].result is value
+
+
 def test_validate_cycles():
     f = Flow(name="test")
     t1 = Task()

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -805,7 +805,7 @@ def test_flow_doesnt_raises_for_missing_nonrequired_parameters():
     assert flow_state.result[p].result == 1
 
 
-def test_flow_accepts_odd_parameters():
+def test_flow_accepts_unserializeable_parameters():
     with Flow(name="test") as f:
         p = Parameter("x")()
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -236,6 +236,7 @@ class TestCreateTask:
             r = Task()
         assert r.checkpoint is True
 
+    @pytest.mark.xfail(reason="UX improvement for Core")
     def test_create_parameter_always_checkpoints(self):
         with set_temporary_config({"tasks.defaults.checkpoint": False}):
             p = Parameter("p")

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -934,6 +934,7 @@ class TestRunTaskStep:
         assert new_state.is_successful()
         assert new_state._result.safe_value == SafeResult("3", result_handler=handler)
 
+    @pytest.mark.xfail(reason="UX improvement for Core")
     def test_success_state_for_parameter(self):
         handler = JSONResultHandler()
         p = prefect.Parameter("p", default=2)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)



## What does this PR change?
Addresses an issue raise in #832 by automatically serializing non-serializeable parameters. Now the `Parameter` class will, by default, set `checkpoint` to False


## Why is this PR important?
This is feature more in tune with using Prefect Cloud (UI display) and is not needed for local development.

