### PR TITLE
Checkpointing updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Set Parameter `checkpoint` to `False` by default - [#839](https://github.com/PrefectHQ/prefect/pull/839)
+- Only checkpoint tasks if running in cloud - [#839](https://github.com/PrefectHQ/prefect/pull/839), [#854](https://github.com/PrefectHQ/prefect/pull/854)
 - Adjusted small flake8 issues for names, imports, and comparisons - [#849](https://github.com/PrefectHQ/prefect/pull/849)
 
 ### Breaking Changes

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -974,7 +974,7 @@ class Parameter(Task):
             name=name,
             slug=name,
             tags=tags,
-            checkpoint=False,
+            checkpoint=True,
             result_handler=JSONResultHandler(),
         )
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -145,5 +145,6 @@ class CloudTaskRunner(TaskRunner):
 
         # we assign this so it can be shared with heartbeat thread
         self.task_run_id = context.get("task_run_id")  # type: ignore
+        context.update(cloud=True)
 
         return super().initialize_run(state=state, context=context)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -799,7 +799,12 @@ class TaskRunner(Runner):
         result = Result(value=result, result_handler=self.result_handler)
         state = Success(result=result, message="Task run succeeded.")
 
-        if state.is_successful() and self.task.checkpoint is True:
+        ## only checkpoint tasks if running in cloud
+        if (
+            state.is_successful()
+            and prefect.context.get("cloud") is True
+            and self.task.checkpoint is True
+        ):
             state._result.store_safe_value()
 
         return state

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -69,6 +69,17 @@ def client(monkeypatch):
     yield cloud_client
 
 
+def test_task_runner_puts_cloud_in_context(client):
+    @prefect.task
+    def whats_in_ctx():
+        return prefect.context.get("cloud")
+
+    res = CloudTaskRunner(task=whats_in_ctx).run()
+
+    assert res.is_successful()
+    assert res.result is True
+
+
 def test_task_runner_doesnt_call_client_if_map_index_is_none(client):
     task = Task(name="test")
 

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -915,9 +915,10 @@ class TestRunTaskStep:
         def fn(x):
             return x + 1
 
-        new_state = TaskRunner(task=fn).get_task_run_state(
-            state=Running(), inputs={"x": Result(1)}, timeout_handler=None
-        )
+        with prefect.context(cloud=True):
+            new_state = TaskRunner(task=fn).get_task_run_state(
+                state=Running(), inputs={"x": Result(1)}, timeout_handler=None
+            )
         assert new_state.is_successful()
         assert new_state._result.safe_value is NoResult
 
@@ -928,19 +929,20 @@ class TestRunTaskStep:
         def fn(x):
             return x + 1
 
-        new_state = TaskRunner(task=fn).get_task_run_state(
-            state=Running(), inputs={"x": Result(2)}, timeout_handler=None
-        )
+        with prefect.context(cloud=True):
+            new_state = TaskRunner(task=fn).get_task_run_state(
+                state=Running(), inputs={"x": Result(2)}, timeout_handler=None
+            )
         assert new_state.is_successful()
         assert new_state._result.safe_value == SafeResult("3", result_handler=handler)
 
-    @pytest.mark.xfail(reason="UX improvement for Core")
     def test_success_state_for_parameter(self):
         handler = JSONResultHandler()
         p = prefect.Parameter("p", default=2)
-        new_state = TaskRunner(task=p).get_task_run_state(
-            state=Running(), inputs={}, timeout_handler=None
-        )
+        with prefect.context(cloud=True):
+            new_state = TaskRunner(task=p).get_task_run_state(
+                state=Running(), inputs={}, timeout_handler=None
+            )
         assert new_state.is_successful()
         assert new_state._result.safe_value == SafeResult("2", result_handler=handler)
 
@@ -956,9 +958,10 @@ class TestRunTaskStep:
         def fn(x):
             return x + 1
 
-        new_state = TaskRunner(task=fn).get_task_run_state(
-            state=Running(), inputs={"x": Result(1)}, timeout_handler=None
-        )
+        with prefect.context(cloud=True):
+            new_state = TaskRunner(task=fn).get_task_run_state(
+                state=Running(), inputs={"x": Result(1)}, timeout_handler=None
+            )
         assert new_state.is_failed()
         assert "SyntaxError" in new_state.message
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR turns checkpointing back on after #839; however, to prevent local bugs such as #832 task checkpointing now only occurs if the flow is running in Cloud (detected via context).

## Why is this PR important?
Checkpointing of parameters is semi-important for UI visibility; however, the JSON requirement of cloud parameters shouldn't affect core users executing flows locally.