### PR TITLE
Add optional build kwarg to client.deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 - Bump to latest version of `pytest` (4.3) - [#814](https://github.com/PrefectHQ/prefect/issues/814)
+- `Client.deploy` accepts optional `build` kwarg for avoiding building Flow environment - [#876](https://github.com/PrefectHQ/prefect/pull/876)
 
 ### Task Library
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -299,7 +299,11 @@ class Client:
         self.token = response.json().get("token")
 
     def deploy(
-        self, flow: "Flow", project_name: str, set_schedule_active: bool = False
+        self,
+        flow: "Flow",
+        project_name: str,
+        build: bool = True,
+        set_schedule_active: bool = False,
     ) -> str:
         """
         Push a new flow to Prefect Cloud
@@ -307,6 +311,8 @@ class Client:
         Args:
             - flow (Flow): a flow to deploy
             - project_name (str): the project that should contain this flow.
+            - build (bool, optional): if `True`, the flow's environment is built
+                prior to serialization; defaults to `True`
             - set_schedule_active (bool, optional): if `True`, will set the
                 schedule to active in the database and begin scheduling runs (if the Flow has a schedule).
                 Defaults to `False`. This can be changed later.
@@ -352,7 +358,7 @@ class Client:
         res = self.graphql(
             create_mutation,
             input=dict(
-                projectId=project[0].id, serializedFlow=flow.serialize(build=True)
+                projectId=project[0].id, serializedFlow=flow.serialize(build=build)
             ),
         )  # type: Any
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1364,12 +1364,16 @@ class Flow:
 
     # Deployment ------------------------------------------------------------------
 
-    def deploy(self, project_name: str, set_schedule_active: bool = False) -> str:
+    def deploy(
+        self, project_name: str, build: bool = True, set_schedule_active: bool = False
+    ) -> str:
         """
         Deploy the flow to Prefect Cloud
 
         Args:
             - project_name (str): the project that should contain this flow.
+            - build (bool, optional): if `True`, the flow's environment is built
+                prior to serialization; defaults to `True`
             - set_schedule_active (bool, optional): if `True`, will set the
                 schedule to active in the database and begin scheduling runs (if the Flow has a schedule).
                 Defaults to `False`. This can be changed later.
@@ -1380,6 +1384,7 @@ class Flow:
         client = prefect.Client()
         deployed_flow = client.deploy(
             flow=self,
+            build=build,
             project_name=project_name,
             set_schedule_active=set_schedule_active,
         )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)


## What does this PR change?
This PR adds an optional `build` kwarg to our deployment endpoints.  This makes it easier to build an environment manually and pass that to a Flow without having the Client attempt to rebuild it.  Probably makes #868 easier


## Why is this PR important?
This makes it easier for users to provide completely custom Docker images to their flow and avoid rebuilding the docker images.