### PR TITLE
Secrets upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Bump to latest version of `pytest` (4.3) - [#814](https://github.com/PrefectHQ/prefect/issues/814)
 - `Client.deploy` accepts optional `build` kwarg for avoiding building Flow environment - [#876](https://github.com/PrefectHQ/prefect/pull/876)
 - Bump `distributed` to 1.26.1 for enhanced security features - [#878](https://github.com/PrefectHQ/prefect/pull/878)
+- Local secrets automatically attempt to load secrets as JSON - [#883](https://github.com/PrefectHQ/prefect/pull/883)
 
 ### Task Library
 

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -17,6 +17,10 @@ class Secret:
     The value of the `Secret` is not set upon initialization and instead is set
     either in `prefect.context` or on the server, with behavior dependent on the value
     of the `use_local_secrets` flag in your Prefect configuration file.
+
+    If using local secrets, `Secret.get()` will attempt to call `json.loads` on the
+    value pulled from context.  For this reason it is recommended to store local secrets as
+    JSON documents to avoid ambiguous behavior (e.g., `"42"` being parsed as `42`).
     """
 
     def __init__(self, name: str):
@@ -24,9 +28,11 @@ class Secret:
 
     def get(self) -> Optional[Any]:
         """
-        Retrieve the secret value.
+        Retrieve the secret value.  If not found, returns `None`.
 
-        If not found, returns `None`.
+        If using local secrets, `Secret.get()` will attempt to call `json.loads` on the
+        value pulled from context.  For this reason it is recommended to store local secrets as
+        JSON documents to avoid ambiguous behavior.
 
         Returns:
             - Any: the value of the secret; if not found, returns `None`

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -36,7 +36,11 @@ class Secret:
         """
         if prefect.config.cloud.use_local_secrets is True:
             secrets = prefect.context.get("secrets", {})
-            return secrets.get(self.name)
+            value = secrets.get(self.name)
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return value
         else:
             client = Client()
             result = client.graphql(

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -51,3 +51,11 @@ def test_secrets_use_client(monkeypatch):
         my_secret = Secret(name="the-key")
         val = my_secret.get()
     assert val == "1234"
+
+
+def test_local_secrets_auto_load_json_strings():
+    secret = Secret(name="test")
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(test='{"x": 42}')):
+            assert secret.get() == {"x": 42}
+        assert secret.get() is None

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -9,6 +9,7 @@ import pytest
 import prefect
 from prefect.client.client import Client, FlowRunInfoResult, TaskRunInfoResult
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
+from prefect.engine.executors import LocalExecutor
 from prefect.engine.result_handlers import ResultHandler
 from prefect.engine.state import (
     Failed,
@@ -569,7 +570,7 @@ def test_deep_map_with_a_retry(monkeypatch):
     )
 
     with prefect.context(flow_run_id=flow_run_id):
-        CloudFlowRunner(flow=flow).run()
+        CloudFlowRunner(flow=flow).run(executor=LocalExecutor())
 
     assert client.flow_runs[flow_run_id].state.is_running()
     assert client.task_runs[task_run_id_1].state.is_mapped()
@@ -598,7 +599,7 @@ def test_deep_map_with_a_retry(monkeypatch):
 
     # RUN A SECOND TIME
     with prefect.context(flow_run_id=flow_run_id):
-        CloudFlowRunner(flow=flow).run()
+        CloudFlowRunner(flow=flow).run(executor=LocalExecutor())
 
     # t2's first child task should be successful
     t2_0 = next(

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -829,7 +829,7 @@ def test_flow_runner_allows_for_parallelism_with_times(executor):
     with Flow(name="test") as flow:
         a, b = record_times(), record_times()
 
-    state = flow.run(executor=executor, return_tasks=[a, b])
+    state = flow.run(executor=executor)
     assert state.is_successful()
 
     times = [("alice", t) for t in state.result[a].result] + [

--- a/tests/tasks/google/test_bigquery.py
+++ b/tests/tasks/google/test_bigquery.py
@@ -181,7 +181,7 @@ class TestBigQueryStreamingInsertCredentialsandProjects:
         )
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(TEST="42", RUN={})):
+            with prefect.context(secrets=dict(TEST='"42"', RUN={})):
                 task.run(records=[])
                 task.run(records=[], credentials_secret="RUN")
 

--- a/tests/tasks/google/test_storage.py
+++ b/tests/tasks/google/test_storage.py
@@ -84,7 +84,7 @@ class TestCredentialsandProjects:
         monkeypatch.setattr("prefect.tasks.google.storage.storage.Client", MagicMock())
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(TEST="42", RUN={})):
+            with prefect.context(secrets=dict(TEST='"42"', RUN={})):
                 task.run(**{run_arg: "empty"})
                 task.run(**{run_arg: "empty", "credentials_secret": "RUN"})
 
@@ -194,7 +194,9 @@ class TestBlob:
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
-                secrets=dict(encrypt="42", two="2", GOOGLE_APPLICATION_CREDENTIALS={})
+                secrets=dict(
+                    encrypt='"42"', two='"2"', GOOGLE_APPLICATION_CREDENTIALS={}
+                )
             ):
                 task.run(**{run_arg: "empty"})
                 task.run(**{run_arg: "empty", "encryption_key_secret": "two"})


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR adds some auto-formatting inside `Secret.get` for local secrets only; in particular, `json.loads` will now attempt to be called on the value pulled from context.  Any errors this raises are ignored and the underlying value is returned.

## Why is this PR important?
This PR makes it much easier to handle complex secrets locally (such as `GOOGLE_APPLICATION_CREDENTIALS`).