### PR TITLE
Add logger to context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,6 @@ Please describe your work and make sure your PR:
 - [ ] updates `CHANGELOG.md` (if appropriate)
 - [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
 
-
-
 ## What does this PR change?
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - `Client.deploy` accepts optional `build` kwarg for avoiding building Flow environment - [#876](https://github.com/PrefectHQ/prefect/pull/876)
 - Bump `distributed` to 1.26.1 for enhanced security features - [#878](https://github.com/PrefectHQ/prefect/pull/878)
 - Local secrets automatically attempt to load secrets as JSON - [#883](https://github.com/PrefectHQ/prefect/pull/883)
+- Add task logger to context for easily creating custom logs during task runs - [#884](https://github.com/PrefectHQ/prefect/issues/884)
 
 ### Task Library
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -783,9 +783,10 @@ class TaskRunner(Runner):
             )
             timeout_handler = timeout_handler or main_thread_timeout
             raw_inputs = {k: r.value for k, r in inputs.items()}
-            result = timeout_handler(
-                self.task.run, timeout=self.task.timeout, **raw_inputs
-            )
+            with prefect.context(logger=self.task.logger):
+                result = timeout_handler(
+                    self.task.run, timeout=self.task.timeout, **raw_inputs
+                )
 
         # inform user of timeout
         except TimeoutError as exc:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -305,18 +305,6 @@ def test_task_runner_can_handle_timeouts_by_default():
     assert state.cached_inputs == dict(secs=Result(2))
 
 
-@pytest.mark.parametrize(
-    "executor", ["local", "sync", "mproc", "mthread"], indirect=True
-)
-def test_task_runner_handles_timeouts_correctly(executor):
-    sleeper = SlowTask(timeout=3)
-    upstream_state = Success(result=0)
-    state = TaskRunner(sleeper).run(
-        upstream_states={Edge(None, sleeper, key="secs"): upstream_state}
-    )
-    assert state.is_successful()
-
-
 def test_task_runner_handles_secrets():
     t = SecretTask()
     with set_temporary_config({"cloud.use_local_secrets": True}):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR adds Task loggers to context for easily creating custom logs during task runs.  This is easy enough when a custom Task class is created, but wasn't possible when using the `task` decorator.  Now a user simply has to pull the logger from context:
```python
@task
def my_logging_task():
    logger = prefect.context.get("logger")
    logger.info("Hey")
```

## Why is this PR important?
Closes #884 