### PR TITLE
Add PIN 6 (and a utility for auto-generating docs sidebar)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,17 +2,17 @@ const sidebar = require('../api/0.5.0/sidebar')
 const glob = require('glob')
 
 // function for loading all MD files in a directory
-const getChildren = function(parent, path) {
+const getChildren = function(parent_path, dir) {
   return glob
-    .sync(parent + '/' + path + '/**/*.md')
-    .map(f => {
-      // remove "parent" and ".md"
-      f = f.slice(parent.length + 1, -3)
+    .sync(parent_path + '/' + dir + '/**/*.md')
+    .map(path => {
+      // remove "parent_path" and ".md"
+      path = path.slice(parent_path.length + 1, -3)
       // remove README
-      if (f.endsWith('README')) {
-        f = f.slice(0, -6)
+      if (path.endsWith('README')) {
+        path = path.slice(0, -6)
       }
-      return f
+      return path
     })
     .sort()
 }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,21 @@
-var sidebar = require('../api/0.5.0/sidebar')
+const sidebar = require('../api/0.5.0/sidebar')
+const glob = require('glob')
+
+// function for loading all MD files in a directory
+const getChildren = function(parent, path) {
+  return glob
+    .sync(parent + '/' + path + '/**/*.md')
+    .map(f => {
+      // remove "parent" and ".md"
+      f = f.slice(parent.length + 1, -3)
+      // remove README
+      if (f.endsWith('README')) {
+        f = f.slice(0, -6)
+      }
+      return f
+    })
+    .sort()
+}
 
 module.exports = {
   title: 'Prefect Docs',
@@ -24,8 +41,10 @@ module.exports = {
       },
       {
         text: 'API Reference',
-        items: [{ text: "Unreleased", link: '/api/unreleased/' },
-                { text: "0.5.0", link: '/api/0.5.0/' } ]
+        items: [
+          { text: 'Unreleased', link: '/api/unreleased/' },
+          { text: '0.5.0', link: '/api/0.5.0/' }
+        ]
       }
     ],
     sidebar: {
@@ -42,76 +61,32 @@ module.exports = {
         {
           title: 'prefect.client',
           collapsable: true,
-          children: ['client/client', 'client/secrets']
+          children: getChildren('docs/api/unreleased', 'client')
         },
         {
           title: 'prefect.core',
           collapsable: true,
-          children: ['core/task', 'core/flow', 'core/edge']
+          children: getChildren('docs/api/unreleased', 'core')
         },
         {
           title: 'prefect.engine',
           collapsable: true,
-          children: [
-            'engine/cloud',
-            'engine/cache_validators',
-            'engine/executors',
-            'engine/flow_runner',
-            'engine/result',
-            'engine/result_handlers',
-            'engine/signals',
-            'engine/state',
-            'engine/task_runner'
-          ]
+          children: getChildren('docs/api/unreleased', 'engine')
         },
         {
           title: 'prefect.environments',
           collapsable: true,
-          children: [
-            'environments/environment',
-            'environments/base_environment',
-            'environments/kubernetes/docker_on_kubernetes',
-            'environments/kubernetes/dask_on_kubernetes'
-          ]
+          children: getChildren('docs/api/unreleased', 'environments')
         },
         {
           title: 'prefect.tasks',
           collapsable: true,
-          children: [
-            'tasks/airflow',
-            'tasks/aws',
-            'tasks/collections',
-            'tasks/constants',
-            'tasks/control_flow',
-            'tasks/docker',
-            'tasks/function',
-            'tasks/github',
-            'tasks/google',
-            'tasks/kubernetes',
-            'tasks/notifications',
-            'tasks/operators',
-            'tasks/rss',
-            'tasks/shell',
-            'tasks/sqlite',
-            'tasks/strings'
-          ]
+          children: getChildren('docs/api/unreleased', 'tasks')
         },
         {
           title: 'prefect.utilities',
           collapsable: true,
-          children: [
-            'utilities/collections',
-            'utilities/configuration',
-            'utilities/context',
-            'utilities/debug',
-            'utilities/environments',
-            'utilities/executors',
-            'utilities/graphql',
-            'utilities/logging',
-            'utilities/notifications',
-            'utilities/serialization',
-            'utilities/tasks'
-          ]
+          children: getChildren('docs/api/unreleased', 'utilities')
         }
       ],
       '/guide/': [
@@ -138,46 +113,17 @@ module.exports = {
         {
           title: 'Tutorials',
           collapsable: true,
-          children: [
-            'tutorials/',
-            'tutorials/etl',
-            'tutorials/calculator',
-            'tutorials/local-debugging',
-            'tutorials/visualization',
-            'tutorials/advanced-mapping',
-            'tutorials/slack-notifications'
-          ]
+          children: getChildren('docs/guide', 'tutorials')
         },
         {
           title: 'Task Library',
           collapsable: true,
-          children: [
-            'task_library/',
-            'task_library/airflow',
-            'task_library/airtable',
-            'task_library/aws',
-            'task_library/collections',
-            'task_library/constants',
-            'task_library/control_flow',
-            'task_library/docker',
-            'task_library/function',
-            'task_library/github',
-            'task_library/google',
-            'task_library/kubernetes',
-            'task_library/notifications',
-            'task_library/operators',
-            'task_library/rss',
-            'task_library/shell',
-            'task_library/sqlite',
-            'task_library/strings',
-            'task_library/twitter'
-          ]
+          children: getChildren('docs/guide', 'task_library')
         },
         {
           title: 'Core Concepts',
           collapsable: true,
           children: [
-            // 'concepts/',
             'core_concepts/tasks',
             'core_concepts/flows',
             'core_concepts/parameters',
@@ -197,43 +143,17 @@ module.exports = {
         {
           title: 'Cloud Concepts',
           collapsable: true,
-          children: [
-            'cloud_concepts/auth',
-            'cloud_concepts/ui',
-            'cloud_concepts/graphql',
-            'cloud_concepts/projects',
-            'cloud_concepts/flows',
-            'cloud_concepts/flow_runs',
-            'cloud_concepts/scheduled-flows',
-            'cloud_concepts/secrets'
-          ]
+          children: getChildren('docs/guide', 'cloud_concepts')
         },
         {
           title: 'Examples',
           collapsable: true,
-          children: [
-            'examples/airflow_tutorial_dag',
-            'examples/cached_task',
-            'examples/etl',
-            'examples/github_release_cycle',
-            'examples/map_reduce',
-            'examples/parameterized_flow',
-            'examples/retries_with_mapping',
-            'examples/twitter_to_airtable',
-            'examples/daily_github_stats_to_airtable'
-          ]
+          children: getChildren('docs/guide', 'examples')
         },
         {
           title: 'PINs',
           collapsable: true,
-          children: [
-            'PINs/',
-            'PINs/PIN-1-Introduce-PINs',
-            'PINs/PIN-2-Result-Handlers',
-            'PINs/PIN-3-Agent-Environment',
-            'PINs/PIN-4-Result-Objects',
-            'PINs/PIN-5-Combining-Tasks'
-          ]
+          children: getChildren('docs/guide', 'PINs')
         },
         {
           title: 'Development',

--- a/docs/api/0.5.0/utilities/notifications.md
+++ b/docs/api/0.5.0/utilities/notifications.md
@@ -6,7 +6,7 @@ editLink: false
 ---
 Tools and utilities for notifications and callbacks.
 
-For an in-depth guide to setting up your system for using Slack notifications, [please see our tutorial](../../guide/tutorials/slack-notifications.html).
+For an in-depth guide to setting up your system for using Slack notifications, [please see our tutorial](/guide/tutorials/slack-notifications.html).
 
 ## Functions
 |top-level functions: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|

--- a/docs/guide/PINs/PIN-4-Result-Objects.md
+++ b/docs/guide/PINs/PIN-4-Result-Objects.md
@@ -3,7 +3,7 @@ title: 'PIN-4: Result Objects'
 sidebarDepth: 0
 ---
 
-# PIN-4 Result Objects for Tracking and Serializing Task Outputs
+# PIN-4: Result Objects for Tracking and Serializing Task Outputs
 
 2019-01-30
 Jeremiah Lowin

--- a/docs/guide/PINs/PIN-5-Combining-Tasks.md
+++ b/docs/guide/PINs/PIN-5-Combining-Tasks.md
@@ -3,7 +3,7 @@ title: 'PIN-5: Combining Tasks'
 sidebarDepth: 0
 ---
 
-# PIN-5 Ability to Combine Tasks
+# PIN-5: Combining Tasks
 
 Date: 2019-02-20
 Author: Chris White

--- a/docs/guide/PINs/PIN-5-Combining-Tasks.md
+++ b/docs/guide/PINs/PIN-5-Combining-Tasks.md
@@ -6,6 +6,7 @@ sidebarDepth: 0
 # PIN-5: Combining Tasks
 
 Date: 2019-02-20
+
 Author: Chris White
 
 ## Status

--- a/docs/guide/PINs/PIN-6-Remove-Constant-Tasks.md
+++ b/docs/guide/PINs/PIN-6-Remove-Constant-Tasks.md
@@ -1,0 +1,33 @@
+---
+sidebarDepth: 0
+---
+
+# PIN-6: Remove Constant Tasks
+
+Date: March 19, 2019
+
+Author: Jeremiah Lowin
+
+## Status
+
+Accepted
+
+## Context
+
+When a dependency is created between a task and any non-task value, Prefect automatically wraps the upstream value in a `Constant` Task and creates an appropriate edge. This "works" in the sense that it properly models a relationship between a computational node (the constant value) and a task that consumes it; but it adds noise to flow graphs that is confusing to users that don't expect it. Furthermore, it adds edge-case potential for error in some circumstance where the constant task fails (for any reason including a node crashing) and results in a difficult-to-diagnose flow failure. In addition, it creates difficulties with triggers, as the `Constant` task always succeeds.
+
+Simply put: `Constant` tasks are confusing and do not add helpful information for users.
+
+## Proposal
+
+`Constant` tasks will no longer be automatically created (though they can stay in the task library, as they may be useful for particularly large objects that users only want to reference once in their flow).
+
+Instead, if a task is attached to any constant (non-Task) value, that value is added to a new flow attribute, `flow.constant_values`. This attribute is a dictionary `Dict[Task, Dict[str, Any]]` that maps each task to a collection of input argument values. For example, if task `t` is called in the functional API as `t(x=1)`, then `flow.constants[t]` would be updated to `{t: {x: 1}}`. An additional "validation" step would ensure that the keys of `flow.constants` were always a strict subset of `flow.tasks`.
+
+In addition, the `TaskRunner.run()` method will accept a `constant_inputs` kwarg and `FlowRunner.run()` will read and provide the appropriate values for each task. The TaskRunner is responsible for combining those with the upstream state values in order to provide all input arguments for the task itself.
+
+## Consequences
+
+`Constant` tasks will no longer be created (though they can remain in existence in case users find them useful for encapsulating some piece of information). Constant values that are used in a flow will be stored in a nested dictionary attached to the flow itself.
+
+## Actions

--- a/docs/guide/development/documentation.md
+++ b/docs/guide/development/documentation.md
@@ -20,7 +20,7 @@ classes = ["Class"]
 functions = ["function"]
 ```
 
-If your module wasn't already in the reference docs, update `docs/.vuepress/config.js` to add it to the navigation sidebar. For example, the collections module from this example would be added to the "utilities" section:
+Most reference docs sections update their sidebars automatically by detecting the files generated from `outline.toml`. However, in some instances you may have include your file explicitly. To do so, update `docs/.vuepress/config.js` and add it to the appropriate "children" section. The actual `prefect.utilities` section *does* auto-update its sidebar, but for the sake of example, you would add the new file to the children array like so:
 
 ```javascript
 {

--- a/docs/guide/tutorials/visualization.md
+++ b/docs/guide/tutorials/visualization.md
@@ -86,7 +86,7 @@ Notice that we have identified this situation and possibly remediated it _all wi
 In addition to viewing the structure of our DAG, Prefect allows you to easily visualize the post-run states of your tasks as well. Using our flow from above, suppose we were curious about how states would propagate if we set `x=1` and `y=1` (a condition not handled by the `switch`).  In this case, we can first execute the flow, and then provide all the task states to the `flow.visualize` method to see how the states propagated!
 
 ::: tip State colors
-The colors of all states, along with their inheritance relationships can be found in [the API reference for states](../../api/unreleased/engine/state.html).
+The colors of all states, along with their inheritance relationships can be found in [the API reference for states](/api/unreleased/engine/state.html).
 :::
 
 ```python

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "prefect",
-    "version": "0.3.0",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.5.0",
   "license": "Apache-2.0",
   "dependencies": {
+    "glob": "^7.1.3",
     "markdown-it-attrs": "^2.3.1",
     "markdown-it-checkbox": "^1.1.0",
     "netlify-identity-widget": "^1.4.14",

--- a/src/prefect/utilities/notifications.py
+++ b/src/prefect/utilities/notifications.py
@@ -1,7 +1,7 @@
 """
 Tools and utilities for notifications and callbacks.
 
-For an in-depth guide to setting up your system for using Slack notifications, [please see our tutorial](../../guide/tutorials/slack-notifications.html).
+For an in-depth guide to setting up your system for using Slack notifications, [please see our tutorial](/guide/tutorials/slack-notifications.html).
 """
 import smtplib
 from email.header import Header


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
- Adds PIN 6, closes #748. Based on conversations, I marked it as "Accepted", but happy to revert to "Proposed" if I'm mistaken.
- Adds a utility for auto-generating sidebar children. It looks like VuePress has officially decided not to support this (https://github.com/vuejs/vuepress/issues/613). I've applied it to each section where alphabetical children are appropriate.


## Why is this PR important?


