### PR TITLE
Fix as_task bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Breaking Changes
 
-- None
+- Change the call signature of `Dict` task from `run(**task_results)` to `run(keys, values)` - [#894](https://github.com/PrefectHQ/prefect/issues/894)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix tempfile usage in `flow.visualize` so that it runs on Windows machines - [#858](https://github.com/PrefectHQ/prefect/issues/858)
 - Fix issue caused by Python 3.5.2 bug for Python 3.5.2 compatibility - [#857](https://github.com/PrefectHQ/prefect/issues/857)
 - Fix issue in which `GCSResultHandler` was not pickleable - [#879](https://github.com/PrefectHQ/prefect/pull/879)
+- Fix issue with automatically converting callables and dicts to tasks - [#894](https://github.com/PrefectHQ/prefect/issues/894)
 
 ### Breaking Changes
 

--- a/src/prefect/tasks/core/collections.py
+++ b/src/prefect/tasks/core/collections.py
@@ -131,12 +131,19 @@ class Dict(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, **task_results: Any) -> dict:  # type: ignore
+    def run(self, keys: Iterable[Any], values: Iterable[Any]) -> dict:  # type: ignore
         """
         Args:
-            - **task_results (Any): task result key / value pairs to collect into a dict
+            - keys (Iterable[Any]): a list of keys that will form the dictionary
+            - values (Iterable[Any]): a list of values for the dictionary
 
         Returns:
             - dict: a dict of task results
+
+        Raises:
+            - ValueError: if the number of keys and the number of values are different
         """
-        return task_results
+        if len(keys) != len(values):
+            raise ValueError("A different number of keys and values were provided!")
+
+        return {k: v for k, v in zip(keys, values)}

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -65,7 +65,11 @@ def as_task(x: Any) -> "prefect.Task":
     elif isinstance(x, set):
         return prefect.tasks.core.collections.Set().bind(*x)
     elif isinstance(x, dict):
-        return prefect.tasks.core.collections.Dict().bind(**x)
+        keys, values = [], []
+        for k, v in x.items():
+            keys.append(k)
+            values.append(v)
+        return prefect.tasks.core.collections.Dict().bind(keys=keys, values=values)
 
     # constants
     else:

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -67,10 +67,6 @@ def as_task(x: Any) -> "prefect.Task":
     elif isinstance(x, dict):
         return prefect.tasks.core.collections.Dict().bind(**x)
 
-    # functions
-    elif callable(x):
-        return prefect.tasks.core.function.FunctionTask(fn=x)
-
     # constants
     else:
         return prefect.tasks.core.constants.Constant(value=x)

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -92,7 +92,16 @@ class TestTaskDecorator:
 class TestAsTask:
     @pytest.mark.parametrize(
         "obj",
-        [1, (3, 4), ["a", "b"], "string", dict(x=42), type(None), lambda *args: None],
+        [
+            1,
+            (3, 4),
+            ["a", "b"],
+            "string",
+            dict(x=42),
+            type(None),
+            lambda *args: None,
+            {None: 88},
+        ],
     )
     def test_as_task_with_basic_python_objs(self, obj):
         @tasks.task

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -106,7 +106,7 @@ class TestAsTask:
     def test_as_task_with_basic_python_objs(self, obj):
         @tasks.task
         def return_val(x):
-            "Necessary because constant tasks are tracked inside the flow"
+            "Necessary because constant tasks aren't tracked inside the flow"
             return x
 
         with Flow("test") as f:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
This PR fixes our `as_task` utility for auto-converting python objects to Prefect Tasks, specifically for callables and dictionaries.  Closes #894 

## Why is this PR important?
`as_task` is used internally to track _all_ task dependencies, including constants.  This utility was implicitly assuming that dictionaries were only keyed by strings and also would attempt to convert _all_ callables into `FunctionTask`s.  This isn't actually possible because python builtins cannot be inspected via `inspect.getfullargspec` and consequently users were seeing errors when passing these types of objects around in their Flow.