### PR TITLE
create default config with `prefect make user config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- `prefect make-user-config` now creates default user config from src/prefect/config.toml
 
 ### Task Library
 

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -35,7 +35,7 @@ def make_user_config():
             "# This is a user configuration file.\n"
             "# Settings placed here will overwrite Prefect's defaults.\n"
         )
-        config_loc = os.path.join(__file__, '../config.toml')
+        config_loc = os.path.join(__file__, "../config.toml")
         with open(config_loc) as defaults_file:
             for line in defaults_file:
                 user_config.write()

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -33,8 +33,12 @@ def make_user_config():
     with open(user_config_path, "w") as user_config:
         user_config.write(
             "# This is a user configuration file.\n"
-            "# Settings placed here will overwrite Prefect's defaults."
+            "# Settings placed here will overwrite Prefect's defaults.\n"
         )
+        config_loc = os.path.join(__file__, '../config.toml')
+        with open(config_loc) as defaults_file:
+            for line in defaults_file:
+                user_config.write()
 
     click.secho("Config created at {}".format(user_config_path), fg="green")
 


### PR DESCRIPTION
closes #904 
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
`prefect make-user-config` generate the default file instead of just comments



## Why is this PR important?
Provides the user their full workbench of settings to manipulate