### PR TITLE
removing cli command `prefect make user config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ Released January 31, 2019
 - Serialization of States will _ignore_ any result data that hasn't been processed - [#581](https://github.com/PrefectHQ/prefect/pull/581)
 - Removes `VersionedSchema` in favor of implicit versioning: serializers will ignore unknown fields and the `create_object` method is responsible for recreating missing ones - [#583](https://github.com/PrefectHQ/prefect/pull/583)
 - Convert and rename `CachedState` to a successful state named `Cached`, and also remove the superfluous `cached_result` attribute - [#586](https://github.com/PrefectHQ/prefect/issues/586)
+- Removes `prefect make user config` from cli commands [904](https://github.com/PrefectHQ/prefect/issues/904)
 
 ## 0.4.0 <Badge text="beta" type="success"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Breaking Changes
 
-- None
+- Removes `prefect make user config` from cli commands - [#904](https://github.com/PrefectHQ/prefect/issues/904)
 
 ### Contributors
 
@@ -212,7 +212,6 @@ Released January 31, 2019
 - Serialization of States will _ignore_ any result data that hasn't been processed - [#581](https://github.com/PrefectHQ/prefect/pull/581)
 - Removes `VersionedSchema` in favor of implicit versioning: serializers will ignore unknown fields and the `create_object` method is responsible for recreating missing ones - [#583](https://github.com/PrefectHQ/prefect/pull/583)
 - Convert and rename `CachedState` to a successful state named `Cached`, and also remove the superfluous `cached_result` attribute - [#586](https://github.com/PrefectHQ/prefect/issues/586)
-- Removes `prefect make user config` from cli commands [904](https://github.com/PrefectHQ/prefect/issues/904)
 
 ## 0.4.0 <Badge text="beta" type="success"/>
 

--- a/docs/guide/core_concepts/configuration.md
+++ b/docs/guide/core_concepts/configuration.md
@@ -26,9 +26,6 @@ In addition to environment variables, users can provide a custom configuration f
 
 Prefect will look for the user configuration at a location specified by `prefect.config.user_config_path`. By default, this is `$HOME/.prefect/config.toml`.
 
-You can automatically generate a user configuration file at the default location by running `prefect make-user-config` from the CLI.
-
-
 ::: tip Changing the user config location
 Since you shouldn't change the default settings directly, if you want to change the configuration location, set an environment variable `PREFECT__USER_CONFIG_PATH` appropriately.
 :::

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -19,27 +19,6 @@ def cli():
 
 
 @cli.command()
-def make_user_config():
-    """
-    Generates a user configuration file
-    """
-    user_config_path = prefect.config.get("user_config_path")
-    if not user_config_path:
-        raise ValueError("No user config path set!")
-    elif os.path.isfile(user_config_path):
-        raise ValueError("A file already exists at {}".format(user_config_path))
-
-    os.makedirs(os.path.dirname(user_config_path), exist_ok=True)
-    with open(user_config_path, "w") as user_config:
-        user_config.write(
-            "# This is a user configuration file.\n"
-            "# Settings placed here will overwrite Prefect's defaults."
-        )
-
-    click.secho("Config created at {}".format(user_config_path), fg="green")
-
-
-@cli.command()
 @click.argument("environment_file", type=click.Path(exists=True))
 @click.option("--runner_kwargs", default={})
 def run(environment_file, runner_kwargs):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,17 +14,6 @@ def test_cli_is_installed():
     assert b"The Prefect CLI" in output
 
 
-def test_make_user_config():
-    with tempfile.TemporaryDirectory() as td:
-        path = os.path.join(td, "test-config.toml")
-        with prefect.utilities.configuration.set_temporary_config(
-            {"user_config_path": path}
-        ):
-            CliRunner().invoke(prefect.cli.make_user_config)
-        with open(path, "r") as f:
-            assert f.read().startswith("# This is a user configuration file")
-
-
 def error_flow():
     @prefect.task
     def zero_error():


### PR DESCRIPTION
closes #904 
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
Removes the cli command (and its tests) `prefect make user config` and updates docs and changelog accordingly


## Why is this PR important?
per discussion in #904, this feature was more trouble than it was worth.  Users should just create their own user configuration manually, and we don't need a utility for touching a functionally empty file.