### PR TITLE
Add Codecov integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,11 @@ jobs:
 
       - run:
           name: Run tests w/ airflow
-          command: pytest --airflow
+          command: pytest --airflow --cov=prefect .
+
+      - run:
+          name: Upload Coverage
+          command: bash <(curl -s https://codecov.io/bash) -cF python
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,16 @@ jobs:
 
       - run:
           name: Install testing packages
-          command: pip install black pytest==3.10.1 pytest-env
+          command: pip install black pytest==3.10.1 pytest-cov pytest-env
 
       - run:
           name: Run tests
-          command: pytest -k "not examples"
+          command: pytest -k "not examples" --cov=prefect .
 
+      - run:
+          name: Upload Coverage
+          command: bash <(curl -s https://codecov.io/bash) -cF python
+          #
   # ----------------------------------
   # Run unit tests in Python 3.5-3.7
   # ----------------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,11 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest
+          command: pytest --cov=prefect .
+
+      - run:
+          name: Upload Coverage
+          command: bash <(curl -s https://codecov.io/bash) -cF python
 
   test-3.6:
     docker:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
     <img src="https://circleci.com/gh/PrefectHQ/prefect/tree/master.svg?style=shield&circle-token=28689a55edc3c373486aaa5f11a1af3e5fc53344">
 </a>
 
+<a href="https://codecov.io/gh/PrefectHQ/prefect">
+  <img src="https://codecov.io/gh/PrefectHQ/prefect/branch/master/graph/badge.svg" />
+</a>
+
 <a href=https://github.com/ambv/black style="margin-left: 10px">
     <img src="https://img.shields.io/badge/code%20style-black-000000.svg">
 </a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,9 @@ comment:
   require_base: no        # [yes :: must have a base report to post]
   require_head: yes       # [yes :: must have a head report to post]
   branches: null          # branch names that can post comment
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -256,43 +256,6 @@ def format_subheader(obj, level=1, in_table=False):
     return call_sig
 
 
-def generate_coverage():
-    """
-    Generates a coverage report in a subprocess; if one already exists,
-    will _not_ recreate for the sake of efficiency
-    """
-
-    # write file for VuePress
-    with open("api/unreleased/coverage.md", "w+") as f:
-        f.write(
-            textwrap.dedent(
-                """
-            ---
-            title: Test Coverage
-            ---
-
-            # Unit test coverage report
-
-            To view the test coverage report, <a href="/prefect-coverage/">click here</a>.
-            """
-            ).lstrip()
-        )
-
-    # abort if coverage report already exists
-    if os.path.exists(".vuepress/public/prefect-coverage"):
-        return
-
-    try:
-        tests = subprocess.check_output(
-            "cd .. && coverage run `which pytest` && coverage html --directory=docs/.vuepress/public/prefect-coverage/",
-            shell=True,
-        )
-        if "failed" in tests.decode():
-            warnings.warn("Some tests failed.")
-    except subprocess.CalledProcessError as exc:
-        warnings.warn(f"Coverage report was not generated: {exc.output}")
-
-
 def get_class_methods(obj):
     members = inspect.getmembers(
         obj, predicate=lambda x: inspect.isroutine(x) and obj.__name__ in x.__qualname__
@@ -359,7 +322,22 @@ if __name__ == "__main__":
 
     shutil.rmtree("api/unreleased", ignore_errors=True)
     os.makedirs("api/unreleased", exist_ok=True)
-    generate_coverage()
+
+    ## write link to hosted coverage reports
+    with open("api/unreleased/coverage.md", "w+") as f:
+        f.write(
+            textwrap.dedent(
+                """
+            ---
+            title: Test Coverage
+            ---
+
+            # Unit test coverage report
+
+            To view test coverage reports, <a href="https://codecov.io/gh/PrefectHQ/prefect">click here</a>.
+            """
+            ).lstrip()
+        )
 
     ## UPDATE README
     with open("api/unreleased/README.md", "w+") as f:


### PR DESCRIPTION
This PR closes #902 via [codecov](https://codecov.io/gh) integration.

Notes:
- our hosted coverage reports can be found here: https://codecov.io/gh/PrefectHQ/prefect (see the "commits" section to see the reports by commits from this PR)
- this will allow us to display a badge of our awesome test coverage: [![codecov](https://codecov.io/gh/PrefectHQ/prefect/branch/master/graph/badge.svg)](https://codecov.io/gh/PrefectHQ/prefect) (unknown right now because we haven't uploaded reports from master yet)
- we can optionally turn off the codecov bot if we don't like it's comments
- we can use codecov to actually enforce coverage thresholds on PRs (see https://docs.codecov.io/docs/commit-status) (I didn't implement this yet because I want some feedback)