### PR TITLE
add python version constraint to prevent installing typing on 3.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pyyaml >= 3.13, < 4.3
 pytz >= 2018.7
 requests >= 2.20, < 3.0
 toml >= 0.9.4, < 1.0
-typing >= 3.6.4, < 4.0
+typing >= 3.6.4, < 4.0; python_version < "3.5"
 typing_extensions >= 3.6.4, < 4.0
 xxhash >= 1.2.0, < 2.0


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Adds a `python_version` constraint to `requirements.txt` to prevent installing the `typing` backport to Python 3.5 and later.


## Why is this PR important?
If the `typing` backport package is installed unnecessarily on more recent versions of Python it can break other libraries (such as `black`):
```
Traceback (most recent call last):
  File "<string>", line 56, in <module>
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/black.py", line 19, in <module>
    from typing import (
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/typing.py", line 1356, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/typing.py", line 1004, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```
Adding the constraint in `requirements.txt` allows the package to be ignored on more modern versions of Python.