### PR TITLE
Ensure validation isn't performed unless specified in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with timeouts behaving incorrectly with unpickleable objects - [#886](https://github.com/PrefectHQ/prefect/issues/886)
+- Fix issue with Flow validation being performed even when eager validation was turned off - [#919](https://github.com/PrefectHQ/prefect/issues/919)
 
 ### Breaking Changes
 
-- Removes `prefect make user config` from cli commands - [#904](https://github.com/PrefectHQ/prefect/issues/904)
+- Remove `prefect make user config` from cli commands - [#904](https://github.com/PrefectHQ/prefect/issues/904)
 
 ### Contributors
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -796,7 +796,7 @@ class Flow:
                 _not_ be mapped over.
             - validate (bool, optional): Whether or not to check the validity of
                 the flow (e.g., presence of cycles).  Defaults to the value of `eager_edge_validation`
-                in your prefect configuration file.
+                in your Prefect configuration file.
 
         Returns:
             - None

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -479,7 +479,9 @@ class Task(metaclass=SignatureValidator):
             to the task under the specified keyword arguments.
             - mapped (bool, optional): Whether the results of these tasks should be mapped over
                 with the specified keyword arguments
-            - validate (bool, optional): Whether or not to check the validity of the flow
+            - validate (bool, optional): Whether or not to check the validity of the flow. If not
+                provided, defaults to the value of `eager_edge_validation` in your Prefect
+                configuration file.
 
         Returns:
             - None

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -465,7 +465,7 @@ class Task(metaclass=SignatureValidator):
         downstream_tasks: Iterable[object] = None,
         keyword_tasks: Dict[str, object] = None,
         mapped: bool = False,
-        validate: bool = True,
+        validate: bool = None,
     ) -> None:
         """
         Set dependencies for a flow either specified or in the current context using this task


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- Changes the validation argument of `Task.set_dependencies()` from a default of `True` to `None`, which will in turn pick up the value from `prefect.config` (unless provided explicitly)



## Why is this PR important?
- Closes #919, which was seeing runaway flow build times when dealing with many auto-generated `Constant` tasks, because each task was invoking flow validation due to the default parameter.

Thanks @Joselinejamy for identifying the issue!