### PR TITLE
Raise ValueError if Secret.get is called from within flow context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - `DaskExecutor(local_processes=True)` supports timeouts - [#886](https://github.com/PrefectHQ/prefect/issues/886)
+- Calling `Secret.get()` from within a Flow context raises an informative error - [#927](https://github.com/PrefectHQ/prefect/issues/927)
 
 ### Task Library
 

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -43,7 +43,7 @@ class Secret:
         """
         if isinstance(prefect.context.get("flow"), prefect.core.flow.Flow):
             raise ValueError(
-                "Secrets should only be retrieved from within a Flow run, not while building a Flow."
+                "Secrets should only be retrieved during a Flow run, not while building a Flow."
             )
 
         if prefect.config.cloud.use_local_secrets is True:

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -38,8 +38,14 @@ class Secret:
             - Any: the value of the secret; if not found, returns `None`
 
         Raises:
+            - ValueError: if `.get()` is called within a Flow building context
             - ValueError: if `use_local_secrets=False` and the Client fails to retrieve your secret
         """
+        if isinstance(prefect.context.get("flow"), prefect.core.flow.Flow):
+            raise ValueError(
+                "Secrets should only be retrieved from within a Flow run, not while building a Flow."
+            )
+
         if prefect.config.cloud.use_local_secrets is True:
             secrets = prefect.context.get("secrets", {})
             value = secrets.get(self.name)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR raises an informative error if `Secret.get` is called from with a Flow building context. @dylanbhughes could you let me know what you think of this error message?
```python
ValueError: Secrets should only be retrieved during a Flow run, not while building a Flow.
```


## Why is this PR important?
Closes #927 and improves user experience by helping users employ best practices.