### PR TITLE
Add two new keywords to task.set_upstream and task.set_downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - `DaskExecutor(local_processes=True)` supports timeouts - [#886](https://github.com/PrefectHQ/prefect/issues/886)
+- Add new keywords to `Task.set_upstream` and `Task.set_downstream` for handling keyed and mapped dependencies - [#823](https://github.com/PrefectHQ/prefect/issues/823)
 
 ### Task Library
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -472,9 +472,8 @@ class Flow:
         Args:
             - upstream_task (Task): The task that the edge should start from
             - downstream_task (Task): The task that the edge should end with
-            - key (str, optional): The key to be set for the new edge; this is
-                the argument name the result of the upstream task will be bound to in the
-                `run()` method of the downstream task
+            - key (str, optional): The key to be set for the new edge; the result of the upstream task
+            will be passed to the downstream task's `run()` method under this keyword argument
             - mapped (bool, optional): Whether this edge represents a call to `Task.map()`; defaults to `False`
             - validate (bool, optional): Whether or not to check the validity of
                 the flow (e.g., presence of cycles and illegal keys). Defaults to the value

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -530,14 +530,13 @@ class Task(metaclass=SignatureValidator):
             self.set_dependencies(flow=flow, upstream_tasks=[task], mapped=mapped)
 
     def set_downstream(
-        self, task: object, flow: "Flow" = None, key: str = None, mapped: bool = False
+        self, task: "Task", flow: "Flow" = None, key: str = None, mapped: bool = False
     ) -> None:
         """
         Sets the provided task as a downstream dependency of this task.
 
         Args:
-            - task (object): A task or object that will be converted to a task that will be set
-                as a downstream dependency of this task.
+            - task (object): A task that will be set as a downstream dependency of this task.
             - flow (Flow, optional): The flow to set dependencies on, defaults to the current
                 flow in context if no flow is specified
             - key (str, optional): The key to be set for the new edge; this is

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -476,7 +476,7 @@ class Task(metaclass=SignatureValidator):
             - upstream_tasks ([object], optional): A list of upstream tasks for this task
             - downstream_tasks ([object], optional): A list of downtream tasks for this task
             - keyword_tasks ({str, object}}, optional): The results of these tasks will be provided
-            to the task under the specified keyword arguments.
+            to this task under the specified keyword arguments.
             - mapped (bool, optional): Whether the results of the _upstream_ tasks should be mapped over
                 with the specified keyword arguments
             - validate (bool, optional): Whether or not to check the validity of the flow. If not
@@ -515,9 +515,8 @@ class Task(metaclass=SignatureValidator):
                 as a upstream dependency of this task.
             - flow (Flow, optional): The flow to set dependencies on, defaults to the current
                 flow in context if no flow is specified
-            - key (str, optional): The key to be set for the new edge; this is
-                the argument name the result of the upstream task will be bound to in the
-                `run()` method of the downstream task
+            - key (str, optional): The key to be set for the new edge; the result of the upstream task
+                will be passed to this task's `run()` method under this keyword argument.
             - mapped (bool, optional): Whether this dependency is mapped; defaults to `False`
 
         Raises:
@@ -536,12 +535,11 @@ class Task(metaclass=SignatureValidator):
         Sets the provided task as a downstream dependency of this task.
 
         Args:
-            - task (object): A task that will be set as a downstream dependency of this task.
+            - task (Task): A task that will be set as a downstream dependency of this task.
             - flow (Flow, optional): The flow to set dependencies on, defaults to the current
                 flow in context if no flow is specified
-            - key (str, optional): The key to be set for the new edge; this is
-                the argument name the result of the upstream task will be bound to in the
-                `run()` method of the downstream task
+            - key (str, optional): The key to be set for the new edge; the result of this task
+                will be passed to the downstream task's `run()` method under this keyword argument.
             - mapped (bool, optional): Whether this dependency is mapped; defaults to `False`
 
         Raises:
@@ -549,7 +547,9 @@ class Task(metaclass=SignatureValidator):
         """
         if key is not None:
             keyword_tasks = {key: self}
-            task.set_dependencies(flow=flow, keyword_tasks=keyword_tasks, mapped=mapped)
+            task.set_dependencies(  # type: ignore
+                flow=flow, keyword_tasks=keyword_tasks, mapped=mapped
+            )  # type: ignore
         else:
             task.set_dependencies(flow=flow, upstream_tasks=[self], mapped=mapped)
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -410,6 +410,16 @@ class TestDependencies:
             t1.set_downstream(t2)
         assert "No Flow was passed" in str(exc.value)
 
+    @pytest.mark.parametrize(
+        "props", [{"mapped": True}, {"key": "x"}, {"key": "x", "mapped": True}]
+    )
+    def test_set_downstream_with_properties(self, props):
+        with Flow(name="test") as f:
+            t1 = Task()
+            t2 = Task()
+            t1.set_downstream(t2, **props)
+            assert Edge(t1, t2, **props) in f.edges
+
     def test_set_upstream(self):
         f = Flow(name="test")
         t1 = Task()
@@ -431,6 +441,16 @@ class TestDependencies:
         with pytest.raises(ValueError) as exc:
             t2.set_upstream(t1)
         assert "No Flow was passed" in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "props", [{"mapped": True}, {"key": "x"}, {"key": "x", "mapped": True}]
+    )
+    def test_set_upstream_with_properties(self, props):
+        with Flow(name="test") as f:
+            t1 = Task()
+            t2 = Task()
+            t2.set_upstream(t1, **props)
+            assert Edge(t1, t2, **props) in f.edges
 
 
 class TestSerialization:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds `key` and `mapped` keywords to both `Task.set_upstream` and `Task.set_downstream` for representing more interesting Task dependencies.

## Why is this PR important?
Ensures the imperative API has the same functionality / exposed features as the functional API.  Closes #823 

