### PR TITLE
Add start time to queued states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - `DaskExecutor(local_processes=True)` supports timeouts - [#886](https://github.com/PrefectHQ/prefect/issues/886)
 - Calling `Secret.get()` from within a Flow context raises an informative error - [#927](https://github.com/PrefectHQ/prefect/issues/927)
 - Add new keywords to `Task.set_upstream` and `Task.set_downstream` for handling keyed and mapped dependencies - [#823](https://github.com/PrefectHQ/prefect/issues/823)
+- Add start times to queued states - [#937](https://github.com/PrefectHQ/prefect/pull/937)
 
 ### Task Library
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -343,6 +343,7 @@ class Queued(_MetaState):
         super().__init__(message=message, result=result, state=state)
         self.start_time = pendulum.now("utc")
 
+
 class Resume(Scheduled):
     """
     Resume state indicating the object can resume execution (presumably from a `Paused` state).

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -337,6 +337,11 @@ class Queued(_MetaState):
 
     """
 
+    def __init__(
+        self, message: str = None, result: Any = NoResult, state: State = None
+    ):
+        super().__init__(message=message, result=result, state=state)
+        self.start_time = pendulum.now("utc")
 
 class Resume(Scheduled):
     """

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -69,7 +69,7 @@ class QueuedSchema(MetaStateSchema):
         object_class = state.Queued
 
     @post_load
-    def create_object(self, data: dict) -> state.State:    
+    def create_object(self, data: dict) -> state.State:
         start_time = data.pop("start_time", None)
         base_obj = super().create_object(data)
         base_obj.start_time = start_time

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -68,7 +68,12 @@ class QueuedSchema(MetaStateSchema):
     class Meta:
         object_class = state.Queued
 
-    start_time = fields.DateTime(allow_none=True)
+    @post_load
+    def create_object(self, data: dict) -> state.State:    
+        start_time = data.pop("start_time", None)
+        base_obj = super().create_object(data)
+        base_obj.start_time = start_time
+        return base_obj
 
 
 class ScheduledSchema(PendingSchema):

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -67,7 +67,7 @@ class SubmittedSchema(MetaStateSchema):
 class QueuedSchema(MetaStateSchema):
     class Meta:
         object_class = state.Queued
-        
+
     start_time = fields.DateTime(allow_none=True)
 
 

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -67,6 +67,8 @@ class SubmittedSchema(MetaStateSchema):
 class QueuedSchema(MetaStateSchema):
     class Meta:
         object_class = state.Queued
+        
+    start_time = fields.DateTime(allow_none=True)
 
 
 class ScheduledSchema(PendingSchema):

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -68,6 +68,8 @@ class QueuedSchema(MetaStateSchema):
     class Meta:
         object_class = state.Queued
 
+    start_time = fields.DateTime(allow_none=True)
+
     @post_load
     def create_object(self, data: dict) -> state.State:
         start_time = data.pop("start_time", None)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -107,6 +107,10 @@ def test_scheduled_states_have_default_times():
     assert now - Scheduled().start_time < datetime.timedelta(seconds=0.1)
     assert now - Retrying().start_time < datetime.timedelta(seconds=0.1)
 
+def test_queued_states_have_default_times():
+    now = pendulum.now("utc")
+    assert now - Queued().start_time < datetime.timedelta(seconds=0.1)
+
 
 @pytest.mark.parametrize("cls", all_states)
 def test_only_scheduled_states_have_start_times(cls):

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -107,6 +107,7 @@ def test_scheduled_states_have_default_times():
     assert now - Scheduled().start_time < datetime.timedelta(seconds=0.1)
     assert now - Retrying().start_time < datetime.timedelta(seconds=0.1)
 
+
 def test_queued_states_have_default_times():
     now = pendulum.now("utc")
     assert now - Queued().start_time < datetime.timedelta(seconds=0.1)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -121,8 +121,9 @@ def test_only_scheduled_states_have_start_times(cls):
     """
     state = cls()
     if hasattr(state, "start_time"):
-        assert isinstance(state, Scheduled)
-        assert state.is_scheduled()
+        assert isinstance(state, Scheduled) or isinstance(state, Queued)
+        if isinstance(state, Scheduled):
+            assert state.is_scheduled()
     else:
         assert not isinstance(state, Scheduled)
         assert not state.is_scheduled()

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -108,7 +108,7 @@ def test_scheduled_states_have_default_times():
     assert now - Retrying().start_time < datetime.timedelta(seconds=0.1)
 
 
-def test_queued_states_have_default_times():
+def test_queued_states_have_start_times():
     now = pendulum.now("utc")
     assert now - Queued().start_time < datetime.timedelta(seconds=0.1)
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR adds start times to queued states.

## Why is this PR important?

This could be useful for using queued states.
