### PR TITLE
Change kubernetes requirements order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
         "google-cloud-bigquery >= 1.6.0, < 2.0",
         "google-cloud-storage >= 1.13, < 2.0",
     ],
-    "kubernetes": ["dask-kubernetes == 0.7.0", "kubernetes >= 8.0.1, < 9.0"],
+    "kubernetes": ["kubernetes >= 8.0.1, < 9.0", "dask-kubernetes == 0.7.0"],
     "rss": ["feedparser >= 5.0.1, < 6.0"],
     "templates": ["jinja2 >= 2.0, < 3.0"],
     "viz": ["graphviz >= 0.8.3"],


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
dask-kubernetes has the requirements set to `kubernetes>=4` however version `9.0.0` introduced some breaking changes https://github.com/dask/dask-kubernetes/issues/118 therefore we should install kubernetes before dask-kubernetes


## Why is this PR important?
To avoid running into deployment issues such as:
```
TypeError: delete_namespaced_pod() takes 3 positional arguments but 4 were given
    at _cleanup_pods (/usr/local/lib/python3.6/site-packages/dask_kubernetes/core.py:510)
    at __call__ (/usr/local/lib/python3.6/weakref.py:548)
    at _exitfunc (/usr/local/lib/python3.6/weakref.py:624)
```

