### PR TITLE
ClientFailed State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Downgrade default logging level to "INFO" from "DEBUG" - [#935](https://github.com/PrefectHQ/prefect/pull/935)
 - Add start times to queued states - [#937](https://github.com/PrefectHQ/prefect/pull/937)
 - Add `is_submitted` to states - [#944](https://github.com/PrefectHQ/prefect/pull/944)
+- Introduce new `ClientFailed` state - [#938](https://github.com/PrefectHQ/prefect/issues/938)
 
 ### Task Library
 
@@ -25,6 +26,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with timeouts behaving incorrectly with unpickleable objects - [#886](https://github.com/PrefectHQ/prefect/issues/886)
 - Fix issue with Flow validation being performed even when eager validation was turned off - [#919](https://github.com/PrefectHQ/prefect/issues/919)
+- Fix issue with downstream tasks with `all_failed` triggers running if an upstream Client call fails in Cloud - [#938](https://github.com/PrefectHQ/prefect/issues/938)
 
 ### Breaking Changes
 

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -88,6 +88,7 @@ classes = [
             "Retrying",
             "Submitted",
             "Queued",
+            "ClientFailed",
             "Running",
             "Finished",
             "Success",

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -10,7 +10,7 @@ from prefect.engine.cloud.utilities import prepare_state_for_cloud
 from prefect.engine.result import NoResult, Result
 from prefect.engine.result_handlers import ResultHandler
 from prefect.engine.runner import ENDRUN, call_state_handlers
-from prefect.engine.state import Cached, Failed, Mapped, State
+from prefect.engine.state import Cached, ClientFailed, Failed, Mapped, State
 from prefect.engine.task_runner import TaskRunner, TaskRunnerInitializeResult
 from prefect.utilities.graphql import with_args
 
@@ -95,7 +95,7 @@ class CloudTaskRunner(TaskRunner):
             self.logger.debug(
                 "Failed to set task state with error: {}".format(repr(exc))
             )
-            raise ENDRUN(state=new_state)
+            raise ENDRUN(state=ClientFailed(state=new_state))
 
         if version is not None:
             prefect.context.update(task_run_version=version + 1)  # type: ignore

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -310,6 +310,24 @@ class _MetaState(State):
         self.state = state
 
 
+class ClientFailed(_MetaState):
+    """
+    The `ClientFailed` state is used to indicate that the Prefect Client failed
+    to set a task run state, and thus this task run should exit, without triggering any
+    downstream task runs.
+
+    The `ClientFailed` state should be initialized with another state, which it wraps. The
+    wrapped state is the state which the client attempted to set in the database, but failed to
+    for some reason.
+
+    Args:
+        - message (string): a message for the state.
+        - result (Any, optional): Defaults to `None`.
+        - state (State): the `State` state that the task run ended in
+
+    """
+
+
 class Submitted(_MetaState):
     """
     The `Submitted` state is used to indicate that another state, usually a `Scheduled`

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -59,6 +59,11 @@ class MetaStateSchema(BaseStateSchema):
     state = fields.Nested("StateSchema", allow_none=True)
 
 
+class ClientFailedSchema(MetaStateSchema):
+    class Meta:
+        object_class = state.ClientFailed
+
+
 class SubmittedSchema(MetaStateSchema):
     class Meta:
         object_class = state.Submitted
@@ -185,6 +190,7 @@ class StateSchema(OneOfSchema):
     # map class name to schema
     type_schemas = {
         "Cached": CachedSchema,
+        "ClientFailed": ClientFailedSchema,
         "Failed": FailedSchema,
         "Finished": FinishedSchema,
         "Mapped": MappedSchema,

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -12,6 +12,7 @@ from prefect.engine.result import NoResult, Result, SafeResult
 from prefect.engine.result_handlers import JSONResultHandler, LocalResultHandler
 from prefect.engine.state import (
     Cached,
+    ClientFailed,
     Failed,
     Finished,
     Mapped,
@@ -367,6 +368,21 @@ class TestStateMethods:
         assert not state.is_failed()
         assert not state.is_mapped()
         assert not state.is_meta_state()
+        assert not state.is_submitted()
+
+    def test_state_type_methods_with_clientfailed_state(self):
+        state = ClientFailed()
+        assert not state.is_cached()
+        assert not state.is_retrying()
+        assert not state.is_pending()
+        assert not state.is_running()
+        assert not state.is_finished()
+        assert not state.is_skipped()
+        assert not state.is_scheduled()
+        assert not state.is_successful()
+        assert not state.is_failed()
+        assert not state.is_mapped()
+        assert state.is_meta_state()
         assert not state.is_submitted()
 
     def test_state_type_methods_with_submitted_state(self):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a new state (`ClientFailed`) for situations in which the Client fails to set a task run state.  This prevents downstream tasks with `all_failed` or `any_failed` triggers from accidentally running.


## Why is this PR important?
Closes #938 and fixes an edge case