### PR TITLE
Add LocalEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Flow now has optional `storage` keyword - [#936](https://github.com/PrefectHQ/prefect/pull/936)
 - Flow `environment` argument now defaults to a `CloudEnvironment` - [#936](https://github.com/PrefectHQ/prefect/pull/936)
 - `Queued` states accept `start_time` arguments - [#955](https://github.com/PrefectHQ/prefect/pull/955)
-- Add new `Memory`storage for local testing - [#956](https://github.com/PrefectHQ/prefect/pull/956)
+- Add new `Memory` storage for local testing - [#956](https://github.com/PrefectHQ/prefect/pull/956)
+- Add new `LocalEnvironment` execution environment for local testing - [#957](https://github.com/PrefectHQ/prefect/pull/957)
 
 ### Task Library
 

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -131,6 +131,11 @@ title = "Storage"
 module = "prefect.environments.storage"
 classes = ["Storage", "Docker", "Memory"]
 
+[pages.environments.execution]
+title = "Execution Environments"
+module = "prefect.environments.execution"
+classes = ["LocalEnvironment"]
+
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"
 module = "prefect.tasks.control_flow"

--- a/src/prefect/environments/__init__.py
+++ b/src/prefect/environments/__init__.py
@@ -1,2 +1,2 @@
-from prefect.environments.execution import Environment
+from prefect.environments.execution import Environment, LocalEnvironment
 from prefect.environments.execution.cloud import CloudEnvironment

--- a/src/prefect/environments/execution/__init__.py
+++ b/src/prefect/environments/execution/__init__.py
@@ -1,1 +1,2 @@
 from prefect.environments.execution.base import Environment
+from prefect.environments.execution.local import LocalEnvironment

--- a/src/prefect/environments/execution/local.py
+++ b/src/prefect/environments/execution/local.py
@@ -1,0 +1,35 @@
+import os
+
+import prefect
+from prefect.environments.execution.base import Environment
+from prefect.environments.storage import Storage
+
+
+class LocalEnvironment(Environment):
+    """
+    A LocalEnvironment class for executing a flow contained in Storage in the local process.
+    Execution will first attempt to call `get_runner` on the storage object, and if that fails it will
+    fall back to `get_env_runner`.  If `get_env_runner` is used, the environment variables from this
+    process will be passed.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def execute(self, storage: "Storage", flow_location: str) -> None:
+        """
+        Executes the flow for this environment from the storage parameter,
+        by calling `get_runner` on the storage; if that fails, `get_env_runner` will
+        be used with the OS environment variables inherited from this process.
+
+        Args:
+            - storage (Storage): the Storage object that contains the flow
+            - flow_location (str): the location of the Flow to execute
+        """
+        try:
+            runner = storage.get_runner(flow_location)
+            runner.run()
+        except NotImplementedError:
+            runner = storage.get_env_runner(flow_location)
+            current_env = os.environ.copy()
+            runner(env=current_env)

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -1,11 +1,16 @@
 import prefect
-from prefect.environments import CloudEnvironment, Environment
+from prefect.environments import CloudEnvironment, Environment, LocalEnvironment
 from prefect.utilities.serialization import ObjectSchema, OneOfSchema
 
 
 class BaseEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = Environment
+
+
+class LocalEnvironmentSchema(ObjectSchema):
+    class Meta:
+        object_class = LocalEnvironment
 
 
 class CloudEnvironmentSchema(ObjectSchema):
@@ -22,4 +27,5 @@ class EnvironmentSchema(OneOfSchema):
     type_schemas = {
         "CloudEnvironment": CloudEnvironmentSchema,
         "Environment": BaseEnvironmentSchema,
+        "LocalEnvironment": LocalEnvironmentSchema,
     }

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -1,0 +1,62 @@
+import pytest
+
+import prefect
+from prefect.environments.execution import LocalEnvironment
+from prefect.environments.storage import Docker, Memory
+
+
+def test_create_environment():
+    environment = LocalEnvironment()
+    assert environment
+
+
+def test_setup_environment_passes():
+    environment = LocalEnvironment()
+    environment.setup(storage=Docker())
+    assert environment
+
+
+def test_serialize_environment():
+    environment = LocalEnvironment()
+    env = environment.serialize()
+    assert env["type"] == "LocalEnvironment"
+
+
+def test_environment_execute():
+    global_dict = {}
+
+    @prefect.task
+    def add_to_dict():
+        global_dict["run"] = True
+
+    environment = LocalEnvironment()
+    storage = Memory()
+    flow = prefect.Flow("test", tasks=[add_to_dict])
+    flow_loc = storage.add_flow(flow)
+
+    environment.execute(storage, flow_loc)
+    assert global_dict.get("run") is True
+
+
+def test_environment_execute_with_env_runner():
+    class TestStorage(Memory):
+        def get_runner(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def get_env_runner(self, flow_loc):
+            runner = super().get_runner(flow_loc)
+            return lambda env: runner.run()
+
+    global_dict = {}
+
+    @prefect.task
+    def add_to_dict():
+        global_dict["run"] = True
+
+    environment = LocalEnvironment()
+    storage = TestStorage()
+    flow = prefect.Flow("test", tasks=[add_to_dict])
+    flow_loc = storage.add_flow(flow)
+
+    environment.execute(storage, flow_loc)
+    assert global_dict.get("run") is True


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a simple implementation of a `LocalEnvironment` execution environment for running flows in storage via their runners.  This environment is currently intended only for local testing, but I could see it being useful in real scenarios as well.

I'd like to use this PR to discuss a few things:
- whether `get_runner` / `get_env_runner` should hook into `flow.run`, `FlowRunner(flow=flow).run()`, or whether they should both allow for an environment to toggle between the two
- whether `get_env_runner` should return something with a proper `run` _method_ vs. it's current return value (a callable)

## Why is this PR important?
Hopefully this PR clarifies the Storage / Environment interface for everyone and shows how easy / flexible it can be!