### PR TITLE
Add CLI command for executing a cloud flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add new `Bytes` and `Memory` storage classes for local testing - [#956](https://github.com/PrefectHQ/prefect/pull/956), [#961](https://github.com/PrefectHQ/prefect/pull/961)
 - Add new `LocalEnvironment` execution environment for local testing - [#957](https://github.com/PrefectHQ/prefect/pull/957)
 - Add new `Aborted` state for Flow runs which are cancelled by users - [#959](https://github.com/PrefectHQ/prefect/issues/959)
+- Added an `execute-cloud-flow` CLI command for working with cloud deployed flows - [#971](https://github.com/PrefectHQ/prefect/pull/971)
 
 ### Task Library
 

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -62,7 +62,4 @@ def execute_cloud_flow():
     environment_schema = prefect.serialization.environment.EnvironmentSchema()
     environment = environment_schema.load(flow_data.environment)
 
-    flow_file_path = "/root/.prefect/{}.prefect".format(flow_data.name)
-
-    environment.setup(storage)
-    environment.execute(storage, flow_file_path)
+    environment.execute(storage=storage, flow_file_path=storage.flows[flow_data.name])

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -7,7 +7,10 @@ import logging
 import os
 import requests
 import sys
+
 import prefect
+from prefect.client import Client
+from prefect.utilities.graphql import with_args
 
 
 @click.group()
@@ -31,3 +34,35 @@ def execute_flow(storage_metadata, environment_metadata):
 
     environment.setup(storage)
     environment.execute(storage)
+
+
+@cli.command()
+def execute_cloud_flow():
+    flow_run_id = prefect.context.get("flow_run_id")
+    if not flow_run_id:
+        click.echo("Not currently executing a flow within a cloud context.")
+        return
+
+    query = {
+        "query": {
+            with_args("flow_run", {"where": {"id": {"_eq": flow_run_id}}}): {
+                "flow": {"name": True, "storage": True, "environment": True}
+            }
+        }
+    }
+
+    result = Client().graphql(query)
+
+    flow_data = result.data.flow_run[0].flow
+
+    storage_schema = prefect.serialization.storage.StorageSchema()
+    storage = storage_schema.load(flow_data.storage)
+
+    environment_schema = prefect.serialization.environment.EnvironmentSchema()
+    environment = environment_schema.load(flow_data.environment)
+
+    flow_file_path = "/root/.prefect/{}.prefect".format(flow_data.name)
+
+    environment.setup(storage)
+    environment.execute(storage, flow_file_path)
+

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -65,4 +65,3 @@ def execute_cloud_flow():
 
     environment.setup(storage)
     environment.execute(storage, flow_file_path)
-

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -62,4 +62,4 @@ def execute_cloud_flow():
     environment_schema = prefect.serialization.environment.EnvironmentSchema()
     environment = environment_schema.load(flow_data.environment)
 
-    environment.execute(storage=storage, flow_file_path=storage.flows[flow_data.name])
+    environment.execute(storage=storage, flow_location=storage.flows[flow_data.name])

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -34,7 +34,7 @@ def execute_flow(storage_metadata, environment_metadata, flow_location):
     environment = environment_schema.load(json.loads(environment_metadata))
 
     environment.setup(storage)
-    environment.execute(storage)
+    environment.execute(storage, flow_location)
 
 
 @cli.command()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds an `execute-cloud-flow` CLI command


## Why is this PR important?
It didn't make sense to pump the storage and environment through the pipeline of execution and instead this allows us to run a small query to retrieve it at the time of execution

