### PR TITLE
Flow Name fix for Docker Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix Docker storage not pulling correct flow path - [#968](https://github.com/PrefectHQ/prefect/pull/968)
 - Set Docker storage to pull master git branch until next version is released - [#968](https://github.com/PrefectHQ/prefect/pull/968)
+- Fix Docker storage for handling flow names with spaces and weird characters - [#969](https://github.com/PrefectHQ/prefect/pull/969)
 
 ### Breaking Changes
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,4 +8,3 @@ pytest-cov>=2.6.0, < 3.0
 pytest-env >=0.6.2, < 0.7.0
 pytest-xdist >=1.23.2, < 2.0
 Pygments == 2.2.0
-python-slugify >= 1.2.6, < 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ mypy_extensions >= 0.4.0, < 0.5
 pendulum >= 2.0.4, < 3.0
 python-dateutil >2.7.3, < 3.0
 pyyaml >= 3.13, < 4.3
+python-slugify >= 1.2.6, < 2.0
 pytz >= 2018.7
 requests >= 2.20, < 3.0
 toml >= 0.9.4, < 1.0

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -290,11 +290,12 @@ class Docker(Storage):
             # Write all flows to file and load into the image
             copy_flows = ""
             for flow_name, flow_location in self.flows.items():
-                flow_path = os.path.join(directory, "{}.flow".format(flow_name))
+                clean_name = slugify(flow_name)
+                flow_path = os.path.join(directory, "{}.flow".format(clean_name))
                 with open(flow_path, "wb") as f:
                     cloudpickle.dump(self._flows[flow_name], f)
                 copy_flows += "COPY {source} {dest}\n".format(
-                    source="{}.flow".format(flow_name), dest=flow_location
+                    source="{}.flow".format(clean_name), dest=flow_location
                 )
 
             # Write a healthcheck script into the image

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import textwrap
 import uuid
+from slugify import slugify
 from typing import Any, Callable, Dict, Iterable, List
 
 import docker
@@ -125,7 +126,7 @@ class Docker(Storage):
                     flow.name
                 )
             )
-        flow_path = "/root/.prefect/{}.prefect".format(flow.name.replace(" ", ""))
+        flow_path = "/root/.prefect/{}.prefect".format(slugify(flow.name))
         self.flows[flow.name] = flow_path
         self._flows[flow.name] = flow  # needed prior to build
         return flow_path

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -185,6 +185,27 @@ def test_create_dockerfile_from_base_image():
         assert "FROM python:3.6" in output
 
 
+def test_create_dockerfile_with_weird_flow_name():
+    with tempfile.TemporaryDirectory() as tempdir_outside:
+
+        with open(os.path.join(tempdir_outside, "test"), "w+") as t:
+            t.write("asdf")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+
+            storage = Docker(registry_url="test1", base_image="test3")
+            f = Flow("WHAT IS THIS !!! ~~~~")
+            storage.add_flow(f)
+            storage.create_dockerfile_object(directory=tempdir)
+
+            with open(os.path.join(tempdir, "Dockerfile"), "r") as dockerfile:
+                output = dockerfile.read()
+
+            assert (
+                "COPY what-is-this.flow /root/.prefect/what-is-this.prefect" in output
+            )
+
+
 def test_create_dockerfile_from_everything():
 
     with tempfile.TemporaryDirectory() as tempdir_outside:

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -278,3 +278,13 @@ def test_add_similar_flows_fails():
     storage.add_flow(flow)
     with pytest.raises(ValueError):
         storage.add_flow(flow)
+
+
+def test_add_flow_with_weird_name_is_cleaned():
+    storage = Docker()
+    flow = prefect.Flow("WELL what do you know?!~? looks like a test!!!!")
+    loc = storage.add_flow(flow)
+    assert "?" not in loc
+    assert "!" not in loc
+    assert " " not in loc
+    assert "~" not in loc


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Fixes docker storage to use slugified Flow names to prevent weird file copying behavior in the docker image. Closes #969 


## Why is this PR important?
Because people like @jlowin like to put emojis in flow names for some reason.  Btw this _does_ work with emojis, but I was too afraid to put an emoji in our codebase........