### PR TITLE
Change serialized flow loading to use cloudpickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix Docker storage not pulling correct flow path - [#968](https://github.com/PrefectHQ/prefect/pull/968)
 - Set Docker storage to pull master git branch until next version is released - [#968](https://github.com/PrefectHQ/prefect/pull/968)
+- Fix `run_flow` loading to decode properly by use cloudpickle - [#978](https://github.com/PrefectHQ/prefect/pull/978)
 
 ### Breaking Changes
 

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -5,6 +5,7 @@ import uuid
 from os import path
 from typing import Any, List
 
+import cloudpickle
 import docker
 import yaml
 
@@ -94,14 +95,13 @@ class CloudEnvironment(Environment):
             cluster.adapt(minimum=1, maximum=1)
 
             # Load serialized flow from file and run it with a DaskExecutor
-            schema = prefect.serialization.flow.FlowSchema()
             with open(
                 prefect.context.get(
                     "flow_file_path", "/root/.prefect/flow_env.prefect"
                 ),
                 "r",
             ) as f:
-                flow = schema.load(json.load(f))
+                flow = cloudpickle.load(f)
 
                 executor = DaskExecutor(address=cluster.scheduler_address)
                 FlowRunner(flow=flow).run(executor=executor)

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -99,7 +99,7 @@ class CloudEnvironment(Environment):
                 prefect.context.get(
                     "flow_file_path", "/root/.prefect/flow_env.prefect"
                 ),
-                "r",
+                "rb",
             ) as f:
                 flow = cloudpickle.load(f)
 

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -4,6 +4,7 @@ import tempfile
 from os import path
 from unittest.mock import MagicMock
 
+import cloudpickle
 import pytest
 import yaml
 
@@ -99,8 +100,8 @@ def test_run_flow(monkeypatch):
         with open(os.path.join(directory, "flow_env.prefect"), "w+") as env:
             flow = prefect.Flow("test")
             flow_path = os.path.join(directory, "flow_env.prefect")
-            with open(flow_path, "w") as f:
-                json.dump(flow.serialize(), f)
+            with open(flow_path, "wb") as f:
+                cloudpickle.dump(flow, f)
 
         with set_temporary_config({"cloud.auth_token": "test"}):
             with prefect.context(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Changes the flow loading in the `run_flow` of the CloudEnvironment to use `cloudpickle.load`

Closes #977 

## Why is this PR important?
We need to be able to load the file in a way which matches how it is dumped https://github.com/PrefectHQ/prefect/blob/master/src/prefect/environments/storage/docker.py#L294

