### PR TITLE
Attempt at CircleCI fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,9 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest -k "not examples" --cov=prefect .
+          command: pytest -k "not examples" --cov=prefect . || false
+          # we had issues with this job not registering an exit code and timing out, even
+          # when tests ran successfully.  Adding a bash "or" appears to make the issue go away...
 
       - run:
           name: Upload Coverage


### PR DESCRIPTION
Per the conversation here: https://discuss.circleci.com/t/jobs-complete-but-the-circleci-status-times-out/29966/2

This PR introduces a weird (but easily maintainable) hack which _appears_ to force CircleCI to register an exit code for our tests.

Tentatively addresses #964