### PR TITLE
Uninstall pytest-cov prior to installing from git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           # temporary patch until https://github.com/pytest-dev/pytest-cov/pull/262 is released
           name: Install latest pytest-cov
-          command: pip install git+https://github.com/pytest-dev/pytest-cov.git@master
+          command: pip uninstall pytest-cov -y && pip install git+https://github.com/pytest-dev/pytest-cov.git@master
 
       - run:
           name: Run tests


### PR DESCRIPTION
It's still happening: https://circleci.com/gh/PrefectHQ/prefect/18779

It looks like bleeding edge `pytest-cov` wasn't actually installed since the version was the same as the released version.