### PR TITLE
Remove coverage from 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,6 @@ jobs:
           name: Run tests
           command: pytest .
 
-      - run:
-          name: Upload Coverage
-          command: bash <(curl -s https://codecov.io/bash) -cF python
-
   test-airflow:
     docker:
       - image: continuumio/miniconda3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,13 +121,8 @@ jobs:
           command: pip install ".[all_extras]"
 
       - run:
-          # temporary patch until https://github.com/pytest-dev/pytest-cov/pull/262 is released
-          name: Install latest pytest-cov
-          command: pip uninstall pytest-cov -y && pip install git+https://github.com/pytest-dev/pytest-cov.git@master
-
-      - run:
           name: Run tests
-          command: pytest --cov=prefect .
+          command: pytest .
 
       - run:
           name: Upload Coverage


### PR DESCRIPTION
Yet another attempt at closing #964 -- just don't track coverage in the 3.7 job.  We currently don't have any code paths that are unique to 3.7 so this shouldn't actually affect our coverage reports.

I have 0 proof that this is the cause of the issue, only a suspicion. 