### PR TITLE
Add fix for calling serialize twice

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1131,7 +1131,7 @@ class Flow:
         if build:
             if not self.storage:
                 raise ValueError("This flow has no storage to build")
-            if self not in self.storage:
+            if self.name not in self.storage:
                 self.storage.add_flow(self)
             storage = self.storage.build()  # type: Optional[Storage]
         else:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1401,6 +1401,14 @@ class TestSerialize:
         s_build = f.serialize(build=True)
         assert f.name in f.storage
 
+    def test_serialize_can_be_called_twice(self):
+        f = Flow(name="test", storage=prefect.environments.storage.Memory())
+        s_no_build = f.serialize()
+        assert f.name not in f.storage
+
+        f.serialize(build=True)
+        f.serialize(build=True)
+
     def test_serialize_fails_with_no_storage(self):
         f = Flow(name="test")
         with pytest.raises(ValueError):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Does the correct containment check when calling `flow.serialize` with `build=True`


## Why is this PR important?
For re-deploying flows in the same live session.