### PR TITLE
Random Docker nits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Add `prefect_version` kwarg to `Docker` storage for controlling the version of prefect installed into your containers - [#1010](https://github.com/PrefectHQ/prefect/pull/1010)
+- Warn users if their Docker storage base image uses a different python version than their local machine - [#999](https://github.com/PrefectHQ/prefect/issues/999)
 
 ### Task Library
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG GIT_POINTER=master
 ARG PYTHON_VERSION=3.6
 
 FROM python:${PYTHON_VERSION}
 LABEL maintainer="help@prefect.io"
+ARG GIT_POINTER=master
 
-RUN pip install git+https://github.com/PrefectHQ/prefect.git@master#egg=prefect[kubernetes]
+RUN pip install git+https://github.com/PrefectHQ/prefect.git@${GIT_POINTER}#egg=prefect[kubernetes]
 RUN mkdir /root/.prefect/

--- a/docs/guide/development/release-checklist.md
+++ b/docs/guide/development/release-checklist.md
@@ -7,6 +7,7 @@ There are a few steps we need to take when cutting a new Prefect release; this d
 - [ ] [Draft a new release in GitHub](https://github.com/PrefectHQ/prefect/releases) - typically we try to name them and include the changelog in the notes
 - [ ] Pull the new `git tag` locally, [rebuild the distribution archives](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives) and use `twine upload dist/*` to upload to PyPI
 - [ ] Pushing to PyPI should trigger a PR to the [`prefect-feedstock` conda-forge repo](https://github.com/conda-forge/prefect-feedstock) (although it could take hours); upon approval and merge, this will land the new release in `conda-forge` as well.  Alternatively, you can open a PR yourself to get the ball rolling
+- [ ] Push a new tagged docker image to [DockerHub](https://hub.docker.com/r/prefecthq/prefect) using our repo `Dockerfile`
 - [ ] Lastly, [archive the new tagged release API documentation](documentation.html#archiving-api-docs)
 
 That's it!

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1133,6 +1133,11 @@ class Flow:
                 raise ValueError("This flow has no storage to build")
             if self.name not in self.storage:
                 self.storage.add_flow(self)
+            else:
+                warnings.warn(
+                    "This flow is already contained in storage; if you changed your Flow since"
+                    " the last build, you might experience unexpected issues."
+                )
             storage = self.storage.build()  # type: Optional[Storage]
         else:
             storage = self.storage

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1135,8 +1135,8 @@ class Flow:
                 self.storage.add_flow(self)
             else:
                 warnings.warn(
-                    "This flow is already contained in storage; if you changed your Flow since"
-                    " the last build, you might experience unexpected issues."
+                    "A flow with the same name is already contained in storage; if you changed your Flow since"
+                    " the last build, you might experience unexpected issues and should re-create your storage object."
                 )
             storage = self.storage.build()  # type: Optional[Storage]
         else:

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import textwrap
 import uuid
@@ -53,7 +54,11 @@ class Docker(Storage):
         prefect_version: str = None,
     ) -> None:
         self.registry_url = registry_url
-        self.base_image = base_image
+
+        if base_image is None:
+            python_version =
+            self.base_image = "python:3.6"
+
         self.image_name = image_name
         self.image_tag = image_tag
         self.python_dependencies = python_dependencies or []
@@ -169,9 +174,6 @@ class Docker(Storage):
                 where the flow is stored. Image name and tag are generated during the
                 build process.
         """
-        if not self.base_image:
-            self.base_image = "python:3.6"
-
         image_name, image_tag = self.build_image(push=push)
         self.image_name = image_name
         self.image_tag = image_tag

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -313,15 +313,23 @@ class Docker(Storage):
                 """\
             print('Beginning health check...')
             import cloudpickle
+            import sys
+            import warnings
 
             for flow_file in [{flow_file_paths}]:
                 with open(flow_file, 'rb') as f:
                     flow = cloudpickle.load(f)
+
+            if sys.version_info.minor < {python_version}[1] or sys.version_info.minor > {python_version}[1]:
+                msg = "Your Docker container is using python version {{sys_ver}}, but your Flow was serialized using {{user_ver}}; this could lead to unexpected errors in deployment.".format(sys_ver=(sys.version_info.major, sys.version_info.minor), user_ver={python_version})
+                warnings.warn(msg)
+
             print('Healthcheck: OK')
             """.format(
                     flow_file_paths=", ".join(
                         ["'{}'".format(k) for k in self.flows.values()]
-                    )
+                    ),
+                    python_version=(sys.version_info.major, sys.version_info.minor),
                 )
             )
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -56,8 +56,12 @@ class Docker(Storage):
         self.registry_url = registry_url
 
         if base_image is None:
-            python_version =
-            self.base_image = "python:3.6"
+            python_version = "{}.{}".format(
+                sys.version_info.major, sys.version_info.minor
+            )
+            self.base_image = "python:{}".format(python_version)
+        else:
+            self.base_image = base_image
 
         self.image_name = image_name
         self.image_tag = image_tag

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1407,7 +1407,11 @@ class TestSerialize:
         assert f.name not in f.storage
 
         f.serialize(build=True)
-        f.serialize(build=True)
+        with pytest.warns(UserWarning) as warning:
+            f.serialize(build=True)
+
+        w = warning.pop()
+        assert "flow is already contained in storage" in str(w.message)
 
     def test_serialize_fails_with_no_storage(self):
         f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1411,7 +1411,7 @@ class TestSerialize:
             f.serialize(build=True)
 
         w = warning.pop()
-        assert "flow is already contained in storage" in str(w.message)
+        assert "already contained in storage" in str(w.message)
 
     def test_serialize_fails_with_no_storage(self):
         f = Flow(name="test")

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 from unittest.mock import MagicMock
 
@@ -35,7 +36,7 @@ def test_empty_docker_storage():
     storage = Docker()
 
     assert not storage.registry_url
-    assert not storage.base_image
+    assert storage.base_image.startswith("python:")
     assert not storage.image_name
     assert not storage.image_tag
     assert not storage.python_dependencies
@@ -45,7 +46,15 @@ def test_empty_docker_storage():
     assert storage.base_url == "unix://var/run/docker.sock"
 
 
-def test_empty_docker_storage():
+@pytest.mark.parametrize("version_info", [(3, 5), (3, 6), (3, 7)])
+def test_docker_init_responds_to_python_version(monkeypatch, version_info):
+    version_mock = MagicMock(major=version_info[0], minor=version_info[1])
+    monkeypatch.setattr(sys, "version_info", version_mock)
+    storage = Docker()
+    assert storage.base_image == "python:{}.{}".format(*version_info)
+
+
+def test_initialized_docker_storage():
     storage = Docker(
         registry_url="test1",
         base_image="test3",


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- adds a warning for building a flow's storage twice
- updates the `Dockerfile` to properly accept `GIT_POINTER` build arg (note: build args are reset after `FROM`)
- updates the release checklist to remind us to push a new tag to docker hub 

## Why is this PR important?
Improves UX for deploying flows; we were bit earlier by a flow which changed but wasn't added back to its storage because the storage class thought the flow was already present.  I am open to more aggressively removing the flow from storage and re-adding it back if anyone wants to push for that.

Also adds a warning if their are python version mismatches in `Docker` storage, closes #999 