### PR TITLE
Handle initialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Ensure that state change handlers are called even when unexpected initialization errors occur - [#1015](https://github.com/PrefectHQ/prefect/pull/1015)
 
 ### Breaking Changes
 

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -260,10 +260,11 @@ class FlowRunner(Runner):
             )
             if prefect.context.get("raise_on_exception"):
                 raise exc
-            return Failed(
+            new_state = Failed(
                 message="Unexpected error while running flow: {}".format(repr(exc)),
                 result=exc,
             )
+            state = self.handle_state_change(state or Pending(), new_state)
 
         return state
 

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -921,6 +921,20 @@ class TestFlowStateHandlers:
         # the flow changed state twice: Pending -> Running -> Success
         assert handler_results["Flow"] == 2
 
+    def test_flow_handlers_are_called_even_when_initialize_run_fails(self):
+        class BadRunner(FlowRunner):
+            def initialize_run(self, *args, **kwargs):
+                raise SyntaxError("bad")
+
+        def handler(runner, old, new):
+            handler_results["Flow"] += 1
+            return new
+
+        flow = Flow(name="test", state_handlers=[handler])
+        BadRunner(flow=flow).run()
+        # the flow changed state twice: Pending -> Failed
+        assert handler_results["Flow"] == 1
+
     def test_flow_handlers_can_return_none(self):
         flow_handler = MagicMock(side_effect=lambda t, o, n: None)
         flow = Flow(name="test", state_handlers=[flow_handler])


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR explicitly calls state handlers in the event that an unexpected error occurs.


## Why is this PR important?
Rarely, there can be errors in `initialize_run` when a Flow was deployed incorrectly.  Previously, the run would end but the state wouldn't formally update in the system to `Failed`.  This ensures that the state change handlers are called in this scenario, and allows for a much smoother debugging experience.