### PR TITLE
Add webhook_secret to SlackTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add `prefect_version` kwarg to `Docker` storage for controlling the version of prefect installed into your containers - [#1010](https://github.com/PrefectHQ/prefect/pull/1010)
 - Warn users if their Docker storage base image uses a different python version than their local machine - [#999](https://github.com/PrefectHQ/prefect/issues/999)
 - Add flow run id to k8s labels on Cloud Environment jobs / pods for easier filtering in deployment - [#1016](https://github.com/PrefectHQ/prefect/pull/1016)
+- Allow for `SlackTask` to pull the Slack webhook URL from a custom named Secret - [#1023](https://github.com/PrefectHQ/prefect/pull/1023)
 
 ### Task Library
 

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -19,9 +19,14 @@ class SlackTask(Task):
         - **kwargs (Any, optional): additional keyword arguments to pass to the base Task initialization
     """
 
-    def __init__(self, message: str = None, webhook_secret: str = None, **kwargs: Any):
+    def __init__(
+        self,
+        message: str = None,
+        webhook_secret: str = "SLACK_WEBHOOK_URL",
+        **kwargs: Any
+    ):
         self.message = message
-        self.webhook_secret = webhook_secret or "SLACK_WEBHOOK_URL"
+        self.webhook_secret = webhook_secret
         super().__init__(**kwargs)
 
     @defaults_from_attrs("message")

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -9,16 +9,19 @@ from prefect.utilities.tasks import defaults_from_attrs
 class SlackTask(Task):
     """
     Task for sending a message via Slack.  For this task to function properly,
-    you must have the `"SLACK_WEBHOOK_URL"` Prefect Secret.  For installing the Prefect App,
+    you must have a Prefect Secret set which stores your Slack webhook URL.  For installing the Prefect App,
     please see these [installation instructions](https://docs.prefect.io/guide/tutorials/slack-notifications.html#installation-instructions).
 
     Args:
         - message (str, optional): the message to send; can also be provided at runtime
+        - webhook_secret (str, optional): the name of the Prefect Secret which stores your slack webhook URL;
+            defaults to `"SLACK_WEBHOOK_URL"`
         - **kwargs (Any, optional): additional keyword arguments to pass to the base Task initialization
     """
 
-    def __init__(self, message: str = None, **kwargs: Any):
+    def __init__(self, message: str = None, webhook_secret: str = None, **kwargs: Any):
         self.message = message
+        self.webhook_secret = webhook_secret or "SLACK_WEBHOOK_URL"
         super().__init__(**kwargs)
 
     @defaults_from_attrs("message")
@@ -34,6 +37,6 @@ class SlackTask(Task):
             - None
         """
 
-        webhook_url = cast(str, Secret("SLACK_WEBHOOK_URL").get())
+        webhook_url = cast(str, Secret(self.webhook_secret).get())
         r = requests.post(webhook_url, json={"text": message})
         r.raise_for_status()

--- a/tests/tasks/notifications/test_slack_task.py
+++ b/tests/tasks/notifications/test_slack_task.py
@@ -27,3 +27,13 @@ class TestInitialization:
                 res = t.run(message="o hai mark")
         assert req.post.call_args[0] == ("http://foo/bar",)
         assert req.post.call_args[1]["json"]["text"] == "o hai mark"
+
+    def test_custom_webhook_url_pulled_from_secrets(self, monkeypatch):
+        req = MagicMock()
+        monkeypatch.setattr("prefect.tasks.notifications.slack_task.requests", req)
+        t = SlackTask(webhook_secret="MY_URL")
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with context({"secrets": dict(MY_URL="http://foo/bar")}):
+                res = t.run(message="o hai mark")
+        assert req.post.call_args[0] == ("http://foo/bar",)
+        assert req.post.call_args[1]["json"]["text"] == "o hai mark"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a new kwarg to `SlackTask` for customizing the name of the Prefect Secret which stores the webhook URL.

## Why is this PR important?
Turns out this is a very very popular task, and when multiple people in the same tenant want to redirect their messages to custom locations, this is necessary!  **cc:** @nanseay 

