### PR TITLE
Init validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Warn users if their Docker storage base image uses a different python version than their local machine - [#999](https://github.com/PrefectHQ/prefect/issues/999)
 - Add flow run id to k8s labels on Cloud Environment jobs / pods for easier filtering in deployment - [#1016](https://github.com/PrefectHQ/prefect/pull/1016)
 - Allow for `SlackTask` to pull the Slack webhook URL from a custom named Secret - [#1023](https://github.com/PrefectHQ/prefect/pull/1023)
+- Add signature validator for `__init__` methods of custom `Task` implementations - [#1024](https://github.com/PrefectHQ/prefect/pull/1024)
 
 ### Task Library
 

--- a/src/prefect/tasks/core/constants.py
+++ b/src/prefect/tasks/core/constants.py
@@ -12,17 +12,17 @@ import prefect
 
 class Constant(prefect.Task):
     """
-    The Constant class represents a single value in the flow graph.
+    The Constant class represents a single value in the flow graph. If a `name`
+    isn't provided, defaults to "Constant[(type(value))]".
 
     Args:
         - value (Any): a constant value
-        - name (str): a name for the constant; defaults to "Constant[(type(value))]"
-            if not provided
         - **kwargs (Any): kwargs to pass to the Task constructor
     """
 
-    def __init__(self, value: Any, name: str = None, **kwargs: Any):
+    def __init__(self, value: Any, **kwargs: Any):
         self.value = value
+        name = kwargs.pop("name", None)
 
         # set the name from the value
         if name is None:

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -18,7 +18,6 @@ class FunctionTask(prefect.Task):
 
     Args:
         - fn (callable): the function to be the task's `run` method
-        - name (str, optional): the name of this task
         - **kwargs: keyword arguments which will be passed to the Task
             constructor
 
@@ -35,11 +34,12 @@ class FunctionTask(prefect.Task):
     ```
     """
 
-    def __init__(self, fn: Callable, name: str = None, **kwargs: Any):
+    def __init__(self, fn: Callable, **kwargs: Any):
         if not callable(fn):
             raise TypeError("fn must be callable.")
 
         # set the name from the fn
+        name = kwargs.pop("name", None)
         if name is None:
             name = getattr(fn, "__name__", type(self).__name__)
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -92,6 +92,19 @@ class TestCreateTask:
         with pytest.raises(TypeError):
             Task(state_handlers=lambda *a: 1)
 
+    def test_class_creation_rejects_reserved_init_kwargs(self):
+        with pytest.raises(ValueError):
+
+            class BadTask(Task):
+                def __init__(self, name):
+                    pass
+
+        with pytest.raises(ValueError):
+
+            class BadTask(Task):
+                def __init__(self, checkpoint):
+                    pass
+
     def test_class_instantiation_rejects_varargs(self):
         with pytest.raises(ValueError):
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a new signature validator for the `__init__` method of custom `Task` subclasses.


## Why is this PR important?
As we saw in #1020 there are many situations in which the `Task` initialization kwargs might be reused by subclasses.  This can cause ambiguity + actual runtime errors, and relies on careful reviews to identify.  With the signature validator, a clear error message is raised at `Task` creation time to prevent the situation from occurring.


