### PR TITLE
Introducing: Union schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Features
 
-- None
+- Add new `UnionSchedule` for combining multiple schedules, allowing for complex schedule specifications - [#428](https://github.com/PrefectHQ/prefect/issues/428)
 
 ### Enhancements
 

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -34,6 +34,7 @@ classes = [
             "Schedule",
             "IntervalSchedule",
             "CronSchedule",
+            "UnionSchedule",
         ]
 
 [pages.core.edge]

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -254,14 +254,23 @@ class UnionSchedule(Schedule):
 
         from prefect.schedules import CronSchedule, IntervalSchedule, UnionSchedule
 
-        cron = CronSchedule("30 6 * * 1-5", start_date=pendulum.parse("2019-03-14", tz="US/Pacific"))
+        cron = CronSchedule("0 * * * *", start_date=pendulum.now("US/Eastern"))
         cron.next(2)
+        # [DateTime(2019, 5, 15, 19, 0, 0, tzinfo=Timezone('US/Eastern')),
+        # DateTime(2019, 5, 15, 20, 0, 0, tzinfo=Timezone('US/Eastern'))]
 
-        interval = IntervalSchedule(start_date=pendulum.parse("2019-03-14", tz="US/Eastern"), interval=timedelta(minutes=30, hours=1))
+        first_cron = cron.next(1)[0]
+        interval = IntervalSchedule(start_date=first_cron.in_timezone("US/Pacific"), interval=timedelta(minutes=30))
         interval.next(2)
+        # [DateTime(2019, 5, 15, 16, 0, 0, tzinfo=Timezone('US/Pacific')),
+        # DateTime(2019, 5, 15, 16, 30, 0, tzinfo=Timezone('US/Pacific'))]
 
         union = UnionSchedule([cron, interval])
         union.next(4)
+        # [DateTime(2019, 5, 15, 19, 0, 0, tzinfo=Timezone('US/Eastern')),
+        # DateTime(2019, 5, 15, 16, 30, 0, tzinfo=Timezone('US/Pacific')),
+        # DateTime(2019, 5, 15, 20, 0, 0, tzinfo=Timezone('US/Eastern')),
+        # DateTime(2019, 5, 15, 17, 30, 0, tzinfo=Timezone('US/Pacific'))]
         ```
 
     """

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -233,3 +233,65 @@ class OneTimeSchedule(IntervalSchedule):
         super().__init__(
             start_date=start_date, interval=timedelta(days=1), end_date=start_date
         )
+
+
+class UnionSchedule(Schedule):
+    """
+    A schedule formed by adding `timedelta` increments to a start_date.
+
+    IntervalSchedules only support intervals of one minute or greater.
+
+    NOTE: If the `IntervalSchedule` start time is provided with a DST-observing timezone,
+    then the schedule will adjust itself appropriately. Intervals greater than 24
+    hours will follow DST conventions, while intervals of less than 24 hours will
+    follow UTC intervals. For example, an hourly schedule will fire every UTC hour,
+    even across DST boundaries. When clocks are set back, this will result in two
+    runs that *appear* to both be scheduled for 1am local time, even though they are
+    an hour apart in UTC time. For longer intervals, like a daily schedule, the
+    interval schedule will adjust for DST boundaries so that the clock-hour remains
+    constant. This means that a daily schedule that always fires at 9am will observe
+    DST and continue to fire at 9am in the local time zone.
+
+    Note that this behavior is different from the `CronSchedule`.
+
+    Args:
+        - start_date (datetime): first date of schedule
+        - interval (timedelta): interval on which this schedule occurs
+        - end_date (datetime, optional): an optional end date for the schedule
+
+    Raises:
+        - TypeError: if start_date is not a datetime
+        - ValueError: if provided interval is less than one minute
+    """
+
+    def __init__(self, *schedules: Schedule):
+        self.schedules = schedules
+        start_date = min(
+            [s.start_date for s in schedules if s.start_date is not None], default=None
+        )
+        end_date = max(
+            [s.end_date for s in schedules if s.end_date is not None], default=None
+        )
+        super().__init__(start_date=start_date, end_date=end_date)
+
+    def next(self, n: int, after: datetime = None) -> List[datetime]:
+        """
+        Retrieve next scheduled dates.
+
+        Args:
+            - n (int): the number of future scheduled dates to return
+            - after (datetime, optional): the first result will be after this date
+
+        Returns:
+            - list: list of next scheduled dates
+        """
+        if after is None:
+            after = pendulum.now("utc")
+
+        assert isinstance(after, datetime)  # mypy assertion
+        assert isinstance(self.start_date, pendulum.DateTime)  # mypy assertion
+
+        after = pendulum.instance(after)
+        dates = []  # type: List[pendulum.DateTime]
+
+        return dates

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -293,8 +293,10 @@ class UnionSchedule(Schedule):
 
         after = pendulum.instance(after)
         dates = []  # type: List[pendulum.DateTime]
+        default = pendulum.instance(datetime.max)
         candidates = {
-            idx: s.next(1, after=after) for idx, s in enumerate(self.schedules)
+            idx: next(iter(s.next(1, after=after)), default)
+            for idx, s in enumerate(self.schedules)
         }
 
         while len(dates) < n:
@@ -302,7 +304,7 @@ class UnionSchedule(Schedule):
 
             ## get next date for all dates whose current values agree with the current minimum
             updates = {
-                i: self.schedules[i].next(1, after=dates[-1])
+                i: next(iter(self.schedules[i].next(1, after=dates[-1])), default)
                 for i, val in candidates.items()
                 if val == dates[-1]
             }

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -264,7 +264,8 @@ class UnionSchedule(Schedule):
         - ValueError: if provided interval is less than one minute
     """
 
-    def __init__(self, *schedules: Schedule):
+    def __init__(self, schedules: List[Schedule] = None):
+        schedules = schedules or []
         self.schedules = schedules
         start_date = min(
             [s.start_date for s in schedules if s.start_date is not None], default=None

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -241,10 +241,29 @@ class UnionSchedule(Schedule):
 
     Both `start_date` and `end_date` are inferred as the min / max (resp.) of
     all provided schedules.  Note that the schedules are not required to all
-    be from the same timezone.
+    be from the same timezone.  If multiple schedules have overlapping dates,
+    only a single run will be created for that date.
 
     Args:
         - schedules (List[Schedule]): a list of schedules to combine
+
+    Example:
+        ```python
+        import pendulum
+        from datetime import timedelta
+
+        from prefect.schedules import CronSchedule, IntervalSchedule, UnionSchedule
+
+        cron = CronSchedule("30 6 * * 1-5", start_date=pendulum.parse("2019-03-14", tz="US/Pacific"))
+        cron.next(2)
+
+        interval = IntervalSchedule(start_date=pendulum.parse("2019-03-14", tz="US/Eastern"), interval=timedelta(minutes=30, hours=1))
+        interval.next(2)
+
+        union = UnionSchedule([cron, interval])
+        union.next(4)
+        ```
+
     """
 
     def __init__(self, schedules: List[Schedule] = None):

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -237,40 +237,23 @@ class OneTimeSchedule(IntervalSchedule):
 
 class UnionSchedule(Schedule):
     """
-    A schedule formed by adding `timedelta` increments to a start_date.
+    A schedule formed by combining multiple other schedules.
 
-    IntervalSchedules only support intervals of one minute or greater.
-
-    NOTE: If the `IntervalSchedule` start time is provided with a DST-observing timezone,
-    then the schedule will adjust itself appropriately. Intervals greater than 24
-    hours will follow DST conventions, while intervals of less than 24 hours will
-    follow UTC intervals. For example, an hourly schedule will fire every UTC hour,
-    even across DST boundaries. When clocks are set back, this will result in two
-    runs that *appear* to both be scheduled for 1am local time, even though they are
-    an hour apart in UTC time. For longer intervals, like a daily schedule, the
-    interval schedule will adjust for DST boundaries so that the clock-hour remains
-    constant. This means that a daily schedule that always fires at 9am will observe
-    DST and continue to fire at 9am in the local time zone.
-
-    Note that this behavior is different from the `CronSchedule`.
+    Both `start_date` and `end_date` are inferred as the min / max (resp.) of
+    all provided schedules.  Note that the schedules are not required to all
+    be from the same timezone.
 
     Args:
-        - start_date (datetime): first date of schedule
-        - interval (timedelta): interval on which this schedule occurs
-        - end_date (datetime, optional): an optional end date for the schedule
-
-    Raises:
-        - TypeError: if start_date is not a datetime
-        - ValueError: if provided interval is less than one minute
+        - schedules (List[Schedule]): a list of schedules to combine
     """
 
     def __init__(self, schedules: List[Schedule] = None):
         schedules = schedules or []
         self.schedules = schedules
-        start_date = min(
+        start_date = min(  # type: ignore
             [s.start_date for s in schedules if s.start_date is not None], default=None
         )
-        end_date = max(
+        end_date = max(  # type: ignore
             [s.end_date for s in schedules if s.end_date is not None], default=None
         )
         super().__init__(start_date=start_date, end_date=end_date)

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -293,5 +293,19 @@ class UnionSchedule(Schedule):
 
         after = pendulum.instance(after)
         dates = []  # type: List[pendulum.DateTime]
+        candidates = {
+            idx: s.next(1, after=after) for idx, s in enumerate(self.schedules)
+        }
+
+        while len(dates) < n:
+            dates.append(min(candidates.values()))
+
+            ## get next date for all dates whose current values agree with the current minimum
+            updates = {
+                i: self.schedules[i].next(1, after=dates[-1])
+                for i, val in candidates.items()
+                if val == dates[-1]
+            }
+            candidates.update(updates)
 
         return dates

--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -241,8 +241,8 @@ class UnionSchedule(Schedule):
 
     Both `start_date` and `end_date` are inferred as the min / max (resp.) of
     all provided schedules.  Note that the schedules are not required to all
-    be from the same timezone.  If multiple schedules have overlapping dates,
-    only a single run will be created for that date.
+    be from the same timezone.  Only unique dates will be used if multiple
+    overlapping schedules are provided.
 
     Args:
         - schedules (List[Schedule]): a list of schedules to combine

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 import marshmallow
-from marshmallow import fields
+from marshmallow import fields, post_load
 
 import prefect
 from prefect.utilities.serialization import (
@@ -40,6 +40,21 @@ class OneTimeScheduleSchema(ObjectSchema):
     start_date = DateTimeTZ(required=True)
 
 
+class UnionScheduleSchema(ObjectSchema):
+    class Meta:
+        object_class = prefect.schedules.UnionSchedule
+
+    start_date = DateTimeTZ(required=True)
+    end_date = DateTimeTZ(allow_none=True)
+    schedules = fields.Nested("ScheduleSchema", many=True)
+
+    @post_load
+    def create_object(self, data: dict) -> prefect.schedules.UnionSchedule:
+        schedules = data.pop("schedules", [])
+        base_obj = super().create_object({"schedules": schedules})
+        return base_obj
+
+
 class ScheduleSchema(OneOfSchema):
     """
     Field that chooses between several nested schemas
@@ -50,4 +65,5 @@ class ScheduleSchema(OneOfSchema):
         "IntervalSchedule": IntervalScheduleSchema,
         "CronSchedule": CronScheduleSchema,
         "OneTimeSchedule": OneTimeScheduleSchema,
+        "UnionSchedule": UnionScheduleSchema,
     }

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -143,3 +143,22 @@ def test_deserialize_schedule_with_overridden_interval():
     with pytest.raises(ValueError) as exc:
         schema.load(serialized)
     assert "Interval can not be less than one minute." in str(exc.value)
+
+
+def test_serialize_union_schedule(cron_schedule, interval_schedule):
+    schedule = schedules.UnionSchedule([cron_schedule, interval_schedule])
+    schema = schemas.UnionScheduleSchema()
+    serialized = schema.dump(schedule)
+    assert serialized["schedules"] == [
+        cron_schedule.serialize(),
+        interval_schedule.serialize(),
+    ]
+
+
+def test_roundtrip_serialization_of_union_schedule(cron_schedule, interval_schedule):
+    schedule = schedules.UnionSchedule([cron_schedule, interval_schedule])
+    schema = schemas.UnionScheduleSchema()
+    new = schema.load(schema.dump(schedule))
+    assert isinstance(new, schedules.UnionSchedule)
+    assert len(new.schedules) == 2
+    assert [type(s) for s in new.schedules] == [type(s) for s in schedule.schedules]

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -556,7 +556,7 @@ class TestUnionSchedule:
         assert s.end_date is None
 
     def test_initialization_with_schedules(self, list_of_schedules):
-        s = schedules.UnionSchedule(*list_of_schedules)
+        s = schedules.UnionSchedule(list_of_schedules)
         assert s.start_date == pendulum.datetime(2000, 1, 1)
         assert s.end_date == pendulum.datetime(2017, 1, 1)
 
@@ -565,7 +565,7 @@ class TestUnionSchedule:
         now = pendulum.now("UTC")
         s = schedules.IntervalSchedule(start_date, timedelta(days=1))
         t = schedules.OneTimeSchedule(start_date=now.add(hours=1))
-        main = schedules.UnionSchedule(s, t)
+        main = schedules.UnionSchedule([s, t])
         assert main.next(2) == [now.add(hours=1), s.next(1)[0]]
 
     def test_next_n_with_no_next(self):
@@ -573,14 +573,14 @@ class TestUnionSchedule:
         now = pendulum.now("UTC")
         s = schedules.IntervalSchedule(start_date, timedelta(days=1))
         t = schedules.OneTimeSchedule(start_date=now.add(hours=-1))
-        main = schedules.UnionSchedule(s, t)
+        main = schedules.UnionSchedule([s, t])
         assert main.next(2) == s.next(2)
 
     def test_next_n_with_repeated_schedule_values(self):
         start_date = pendulum.datetime(2018, 1, 1)
         now = pendulum.now("UTC")
         s = schedules.IntervalSchedule(start_date, timedelta(days=1))
-        main = schedules.UnionSchedule(s, s, s, s)
+        main = schedules.UnionSchedule([s, s, s, s])
         assert main.next(3) == s.next(3)
 
     def test_next_n_with_different_timezones(self):
@@ -590,6 +590,6 @@ class TestUnionSchedule:
         west = schedules.CronSchedule(
             "30 6 * * 1-5", start_date=pendulum.parse("2019-03-14", tz="US/Pacific")
         )
-        main = schedules.UnionSchedule(east, west)
+        main = schedules.UnionSchedule([east, west])
         expected = [east.next(1)[0], west.next(1)[0], east.next(2)[1], west.next(2)[1]]
         assert main.next(4) == expected

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -527,3 +527,35 @@ class TestSerialization:
             "interval": 3600000000,
             "__version__": __version__,
         }
+
+
+class TestUnionSchedule:
+    @pytest.fixture
+    def list_of_schedules(self):
+        sd = pendulum.datetime(2000, 1, 1)
+        ed = pendulum.datetime(2010, 1, 1)
+
+        list_sched = []
+        list_sched.append(
+            schedules.IntervalSchedule(
+                interval=timedelta(hours=1), start_date=sd, end_date=ed
+            )
+        )
+
+        sd = pendulum.datetime(2004, 1, 1)
+        ed = pendulum.datetime(2017, 1, 1)
+        list_sched.append(
+            schedules.CronSchedule("0 0 * * *", start_date=sd, end_date=ed)
+        )
+        list_sched.append(schedules.CronSchedule("0 9 * * 1-5"))
+        return list_sched
+
+    def test_initialization(self):
+        s = schedules.UnionSchedule()
+        assert s.start_date is None
+        assert s.end_date is None
+
+    def test_initialization_with_schedules(self, list_of_schedules):
+        s = schedules.UnionSchedule(*list_of_schedules)
+        assert s.start_date == pendulum.datetime(2000, 1, 1)
+        assert s.end_date == pendulum.datetime(2017, 1, 1)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -559,3 +559,37 @@ class TestUnionSchedule:
         s = schedules.UnionSchedule(*list_of_schedules)
         assert s.start_date == pendulum.datetime(2000, 1, 1)
         assert s.end_date == pendulum.datetime(2017, 1, 1)
+
+    def test_next_n(self):
+        start_date = pendulum.datetime(2018, 1, 1)
+        now = pendulum.now("UTC")
+        s = schedules.IntervalSchedule(start_date, timedelta(days=1))
+        t = schedules.OneTimeSchedule(start_date=now.add(hours=1))
+        main = schedules.UnionSchedule(s, t)
+        assert main.next(2) == [now.add(hours=1), s.next(1)[0]]
+
+    def test_next_n_with_no_next(self):
+        start_date = pendulum.datetime(2018, 1, 1)
+        now = pendulum.now("UTC")
+        s = schedules.IntervalSchedule(start_date, timedelta(days=1))
+        t = schedules.OneTimeSchedule(start_date=now.add(hours=-1))
+        main = schedules.UnionSchedule(s, t)
+        assert main.next(2) == s.next(2)
+
+    def test_next_n_with_repeated_schedule_values(self):
+        start_date = pendulum.datetime(2018, 1, 1)
+        now = pendulum.now("UTC")
+        s = schedules.IntervalSchedule(start_date, timedelta(days=1))
+        main = schedules.UnionSchedule(s, s, s, s)
+        assert main.next(3) == s.next(3)
+
+    def test_next_n_with_different_timezones(self):
+        east = schedules.CronSchedule(
+            "0 9 * * 1-5", start_date=pendulum.parse("2019-03-14", tz="US/Eastern")
+        )
+        west = schedules.CronSchedule(
+            "30 6 * * 1-5", start_date=pendulum.parse("2019-03-14", tz="US/Pacific")
+        )
+        main = schedules.UnionSchedule(east, west)
+        expected = [east.next(1)[0], west.next(1)[0], east.next(2)[1], west.next(2)[1]]
+        assert main.next(4) == expected


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a new schedule type: the `UnionSchedule`. This schedule is formed by simply combining an arbitrary number of other schedules in one, in the "natural" way.


## Why is this PR important?
This PR allows for complex schedule specification that wasn't possible before; for example: a single flow which runs at _both_ market open _and_ market close each day.

I propose that this PR closes #428 

