### PR TITLE
Actuall call environment.setup in the execute-cloud-flow CLI

### DIFF
--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -62,4 +62,5 @@ def execute_cloud_flow():
     environment_schema = prefect.serialization.environment.EnvironmentSchema()
     environment = environment_schema.load(flow_data.environment)
 
+    environment.setup(storage=storage)
     environment.execute(storage=storage, flow_location=storage.flows[flow_data.name])

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -31,17 +31,17 @@ class CloudEnvironment(Environment):
     set with a UUID so resources can be cleaned up independently of other deployments.
 
     Args:
-        - private (bool, optional): a boolean specifying whether your Flow's Docker container will be in a private
+        - private_registry (bool, optional): a boolean specifying whether your Flow's Docker container will be in a private
             Docker registry; if so, requires a `DOCKER_REGISTRY_CREDENTIALS` Prefect Secret to be set.
             Defaults to `False`.
     """
 
-    def __init__(self, private: bool = False) -> None:
+    def __init__(self, private_registry: bool = False) -> None:
         self.identifier_label = str(uuid.uuid4())
-        self.private = private
+        self.private_registry = private_registry
 
     def setup(self, storage: "Docker") -> None:  # type: ignore
-        if self.private:
+        if self.private_registry:
             from kubernetes import client, config
 
             # Verify environment is running in cluster
@@ -207,7 +207,7 @@ class CloudEnvironment(Environment):
 
         # set environment variables
         env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
-        if self.private:
+        if self.private_registry:
             pod_spec = yaml_obj["spec"]["template"]["spec"]
             pod_spec["imagePullSecrets"] = []
             pod_spec["imagePullSecrets"].append({"name": namespace + "-docker"})
@@ -251,7 +251,7 @@ class CloudEnvironment(Environment):
         env[3]["value"] = prefect.config.cloud.auth_token
         env[4]["value"] = prefect.context.get("flow_run_id", "")
 
-        if self.private:
+        if self.private_registry:
             namespace = prefect.context.get("namespace", "")
             pod_spec = yaml_obj["spec"]
             pod_spec["imagePullSecrets"] = []

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -50,11 +50,14 @@ class CloudEnvironment(Environment):
             except config.config_exception.ConfigException:
                 raise EnvironmentError("Environment not currently inside a cluster")
 
-            v1_client = client.CoreV1Api()
+            v1 = client.CoreV1Api()
             namespace = prefect.context.get("namespace", "")
-            secrets = v1_client.list_namespaced_secret(namespace=namespace, watch=False)
+            secret_name = namespace + "-docker"
+            secrets = v1.list_namespaced_secret(namespace=namespace, watch=False)
             if not [
-                secret for secret in secrets.items if secret.type == "docker-registry"
+                secret
+                for secret in secrets.items
+                if secret.metadata.name == secret_name
             ]:
                 self._create_namespaced_secret()
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -195,8 +195,8 @@ class Docker(Storage):
         Returns:
             - tuple: generated UUID strings `image_name`, `image_tag`
         """
-        image_name = str(uuid.uuid4())
-        image_tag = str(uuid.uuid4())
+        image_name = self.image_name or str(uuid.uuid4())
+        image_tag = self.image_tag or str(uuid.uuid4())
 
         # Make temporary directory to hold serialized flow, healthcheck script, and dockerfile
         with tempfile.TemporaryDirectory() as tempdir:

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -19,7 +19,7 @@ class CloudEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = CloudEnvironment
 
-    private = fields.Boolean(allow_none=False)
+    private_registry = fields.Boolean(allow_none=False)
 
 
 class EnvironmentSchema(OneOfSchema):

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -30,8 +30,8 @@ def test_setup_cloud_environment_passes():
     assert environment
 
 
-def test_setup_doesnt_pass_if_private(monkeypatch):
-    environment = CloudEnvironment(private=True)
+def test_setup_doesnt_pass_if_private_registry(monkeypatch):
+    environment = CloudEnvironment(private_registry=True)
 
     config = MagicMock()
     monkeypatch.setattr("kubernetes.config", config)
@@ -53,7 +53,7 @@ def test_setup_doesnt_pass_if_private(monkeypatch):
 
 
 def test_create_secret_isnt_called_if_exists(monkeypatch):
-    environment = CloudEnvironment(private=True)
+    environment = CloudEnvironment(private_registry=True)
 
     config = MagicMock()
     monkeypatch.setattr("kubernetes.config", config)
@@ -247,8 +247,8 @@ def test_populate_worker_pod_yaml():
     assert yaml_obj["spec"]["containers"][0]["image"] == "my_image"
 
 
-def test_populate_worker_pod_yaml_with_private():
-    environment = CloudEnvironment(private=True)
+def test_populate_worker_pod_yaml_with_private_registry():
+    environment = CloudEnvironment(private_registry=True)
 
     file_path = os.path.dirname(
         prefect.environments.execution.cloud.environment.__file__

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -30,6 +30,53 @@ def test_setup_cloud_environment_passes():
     assert environment
 
 
+def test_setup_doesnt_pass_if_private(monkeypatch):
+    environment = CloudEnvironment(private=True)
+
+    config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", config)
+
+    v1 = MagicMock()
+    v1.list_namespaced_secret.return_value = MagicMock(items=[])
+    monkeypatch.setattr(
+        "kubernetes.client", MagicMock(CoreV1Api=MagicMock(return_value=v1))
+    )
+
+    create_secret = MagicMock()
+    monkeypatch.setattr(
+        "prefect.environments.CloudEnvironment._create_namespaced_secret", create_secret
+    )
+    with set_temporary_config({"cloud.auth_token": "test"}):
+        environment.setup(storage=Docker())
+
+    assert create_secret.called
+
+
+def test_create_secret_isnt_called_if_exists(monkeypatch):
+    environment = CloudEnvironment(private=True)
+
+    config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", config)
+
+    secret = MagicMock()
+    secret.metadata.name = "foo-docker"
+    v1 = MagicMock()
+    v1.list_namespaced_secret.return_value = MagicMock(items=[secret])
+    monkeypatch.setattr(
+        "kubernetes.client", MagicMock(CoreV1Api=MagicMock(return_value=v1))
+    )
+
+    create_secret = MagicMock()
+    monkeypatch.setattr(
+        "prefect.environments.CloudEnvironment._create_namespaced_secret", create_secret
+    )
+    with set_temporary_config({"cloud.auth_token": "test"}):
+        with prefect.context(namespace="foo"):
+            environment.setup(storage=Docker())
+
+    assert not create_secret.called
+
+
 def test_execute_improper_storage():
     environment = CloudEnvironment()
     with pytest.raises(TypeError):
@@ -198,3 +245,29 @@ def test_populate_worker_pod_yaml():
     assert env[4]["value"] == "id_test"
 
     assert yaml_obj["spec"]["containers"][0]["image"] == "my_image"
+
+
+def test_populate_worker_pod_yaml_with_private():
+    environment = CloudEnvironment(private=True)
+
+    file_path = os.path.dirname(
+        prefect.environments.execution.cloud.environment.__file__
+    )
+
+    with open(path.join(file_path, "worker_pod.yaml")) as pod_file:
+        pod = yaml.safe_load(pod_file)
+
+    with set_temporary_config(
+        {
+            "cloud.graphql": "gql_test",
+            "cloud.log": "log_test",
+            "cloud.result_handler": "rh_test",
+            "cloud.auth_token": "auth_test",
+        }
+    ):
+        with prefect.context(
+            flow_run_id="id_test", image="my_image", namespace="foo-man"
+        ):
+            yaml_obj = environment._populate_worker_pod_yaml(yaml_obj=pod)
+
+    yaml_obj["spec"]["imagePullSecrets"][0] == dict(name="foo-man-docker")

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -22,14 +22,14 @@ def test_serialize_cloud_environment():
     assert serialized["__version__"] == prefect.__version__
 
 
-def test_serialize_cloud_environment_with_private():
-    env = environments.CloudEnvironment(private=True)
+def test_serialize_cloud_environment_with_private_registry():
+    env = environments.CloudEnvironment(private_registry=True)
 
     schema = CloudEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert serialized["private"] is True
+    assert serialized["private_registry"] is True
 
     new = schema.load(serialized)
-    assert new.private is True
+    assert new.private_registry is True


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Actually calls environment.setup inside the execute-cloud-flow CLI; this wasn't a bug per se, because previously the CloudEnvironment didn't have a non-trivial `setup` method, but now it does!


## Why is this PR important?
The final piece of the puzzle for fully automated private docker registry support.

