### PR TITLE
Fix bug caused by mis-scoped import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Task Library
 
-- Add task for creating new branches in a GitHub repository - [#1011](https://github.com/PrefectHQ/prefect/pull/1011) 
+- Add task for creating new branches in a GitHub repository - [#1011](https://github.com/PrefectHQ/prefect/pull/1011)
 - Add tasks to create, delete, invoke, and list AWS Lambda functions [#1009](https://github.com/PrefectHQ/prefect/issues/1009)
 
 ### Fixes
 
 - Ensure that state change handlers are called even when unexpected initialization errors occur - [#1015](https://github.com/PrefectHQ/prefect/pull/1015)
+- Fix an issue where a mypy assert relied on an unavailable import - [#1034](https://github.com/PrefectHQ/prefect/pull/1034)
 
 ### Breaking Changes
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -29,12 +29,13 @@ class RemoteHandler(logging.StreamHandler):
 
     def emit(self, record) -> None:  # type: ignore
         try:
+            from prefect.client import Client
+
             if self.errored_out is True:
                 return
             if self.client is None:
-                from prefect.client import Client
-
                 self.client = Client()  # type: ignore
+
             assert isinstance(self.client, Client)  # mypy assert
             r = self.client.post(path="", server=self.logger_server, **record.__dict__)
         except:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
A mypy assert checked that a `client` attribute was a `Client` object, but unfortunately the `Client` class was imported in a scope that wasn't always available to the mypy assert.

The `Client` import needs to be deferred due to circular imports.


## Why is this PR important?


