### PR TITLE
Default prefect version in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add `prefect_version` kwarg to `Docker` storage for controlling the version of prefect installed into your containers - [#1010](https://github.com/PrefectHQ/prefect/pull/1010)
+- Add `prefect_version` kwarg to `Docker` storage for controlling the version of prefect installed into your containers - [#1010](https://github.com/PrefectHQ/prefect/pull/1010), [#533](https://github.com/PrefectHQ/prefect/issues/533)
 - Warn users if their Docker storage base image uses a different python version than their local machine - [#999](https://github.com/PrefectHQ/prefect/issues/999)
 - Add flow run id to k8s labels on Cloud Environment jobs / pods for easier filtering in deployment - [#1016](https://github.com/PrefectHQ/prefect/pull/1016)
 - Allow for `SlackTask` to pull the Slack webhook URL from a custom named Secret - [#1023](https://github.com/PrefectHQ/prefect/pull/1023)

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -38,7 +38,8 @@ class Docker(Storage):
         - files (dict, optional): a dictionary of files to copy into the image when building
         - base_url: (str, optional): a URL of a Docker daemon to use when for Docker related functionality
         - prefect_version (str, optional): an optional branch, tag, or commit specifying the version of prefect
-            you want installed into the container; defaults to `"0.5.3"`
+            you want installed into the container; defaults to the version you are currently using or `"master"` if your version is ahead of
+            the latest tag
     """
 
     def __init__(
@@ -71,7 +72,12 @@ class Docker(Storage):
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
         self.base_url = base_url
-        self.prefect_version = prefect_version or "0.5.3"
+
+        version = prefect.__version__.split("+")
+        if prefect_version is None:
+            self.prefect_version = "master" if len(version) > 1 else version[0]
+        else:
+            self.prefect_version = prefect_version
 
         not_absolute = [
             file_path for file_path in self.files if not os.path.isabs(file_path)

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -77,7 +77,7 @@ def test_initialized_docker_storage():
         image_tag="test5",
         env_vars={"test": "1"},
         base_url="test_url",
-        prefect_version="master",
+        prefect_version="my-branch",
     )
 
     assert storage.registry_url == "test1"
@@ -87,7 +87,7 @@ def test_initialized_docker_storage():
     assert storage.python_dependencies == ["test"]
     assert storage.env_vars == {"test": "1"}
     assert storage.base_url == "test_url"
-    assert storage.prefect_version == "master"
+    assert storage.prefect_version == "my-branch"
 
 
 def test_files_not_absolute_path():

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -42,7 +42,7 @@ def test_empty_docker_storage():
     assert not storage.python_dependencies
     assert not storage.env_vars
     assert not storage.files
-    assert storage.prefect_version == "0.5.3"
+    assert storage.prefect_version
     assert storage.base_url == "unix://var/run/docker.sock"
 
 
@@ -52,6 +52,20 @@ def test_docker_init_responds_to_python_version(monkeypatch, version_info):
     monkeypatch.setattr(sys, "version_info", version_mock)
     storage = Docker()
     assert storage.base_image == "python:{}.{}".format(*version_info)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        ("0.5.3", "0.5.3"),
+        ("0.5.3+114.g35bc7ba4", "master"),
+        ("0.5.2+999.gr34343.dirty", "master"),
+    ],
+)
+def test_docker_init_responds_to_prefect_version(monkeypatch, version):
+    monkeypatch.setattr(prefect, "__version__", version[0])
+    storage = Docker()
+    assert storage.prefect_version == version[1]
 
 
 def test_initialized_docker_storage():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR attempts to add a smart default for the Docker storage `prefect_version` based on the user's local version.


## Why is this PR important?
Closes #533 

