### PR TITLE
Remove user_config_path from config to avoid circular loads

### DIFF
--- a/docs/guide/core_concepts/configuration.md
+++ b/docs/guide/core_concepts/configuration.md
@@ -22,13 +22,10 @@ Prefect will do its best to detect the type of your environment variable and cas
 
 ## User configuration
 
-In addition to environment variables, users can provide a custom configuration file. Any values in the custom configuration will be loaded *on top* of the default values, meaning the user configuration only needs to contain values you want to change.
+In addition to environment variables, users can provide a custom configuration file. Any values in the custom configuration will be loaded *on top* of the default values, but prior to interpolation, meaning the user configuration only needs to contain values you want to change.
 
-Prefect will look for the user configuration at a location specified by `prefect.config.user_config_path`. By default, this is `$HOME/.prefect/config.toml`.
+By default, Prefect will look for a user configuration file at `$HOME/.prefect/config.toml`, but you can change that location by setting the environment variable `PREFECT__USER_CONFIG_PATH` appropriately. Please note the double-underscore (`__`) in the variable name; this ensures that it will be available at runtime as `prefect.config.user_config_path`.
 
-::: tip Changing the user config location
-Since you shouldn't change the default settings directly, if you want to change the configuration location, set an environment variable `PREFECT__USER_CONFIG_PATH` appropriately.
-:::
 
 ### Configuration precedence
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -1,6 +1,3 @@
-# the location of the user's config file
-user_config_path = "$HOME/.prefect/config.toml"
-
 # debug mode
 debug = false
 

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -9,6 +9,7 @@ import toml
 from prefect.utilities import collections
 
 DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "config.toml")
+USER_CONFIG = os.getenv("PREFECT__USER_CONFIG_PATH", "~/.prefect/config.toml")
 ENV_VAR_PREFIX = "PREFECT"
 INTERPOLATION_REGEX = re.compile(r"\${(.[^${}]*)}")
 
@@ -358,8 +359,7 @@ def load_configuration(
 
     Args:
         - path (str): the path to the TOML configuration file
-        - user_config_path (str): an optional path to a user config file. If not provided,
-            the main config will be checked for a `user_config_path` key. If a user config
+        - user_config_path (str): an optional path to a user config file. If a user config
             is provided, it will be used to update the main config prior to interpolation
         - env_var_prefix (str): any env vars matching this prefix will be used to create
             configuration values
@@ -372,9 +372,6 @@ def load_configuration(
     default_config = load_toml(path)
 
     # load user config
-    if not user_config_path:
-        user_config_path = default_config.get("user_config_path", None)
-
     if user_config_path and os.path.isfile(str(interpolate_env_vars(user_config_path))):
         user_config = load_toml(user_config_path)
         # merge user config into default config
@@ -389,4 +386,6 @@ def load_configuration(
     return config
 
 
-config = load_configuration(path=DEFAULT_CONFIG, env_var_prefix=ENV_VAR_PREFIX)
+config = load_configuration(
+    path=DEFAULT_CONFIG, user_config_path=USER_CONFIG, env_var_prefix=ENV_VAR_PREFIX
+)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -269,7 +269,7 @@ class TestUserConfig:
             )
             user_config.seek(0)
             config = configuration.load_configuration(
-                test_config_file_path, user_config.name
+                path=test_config_file_path, user_config_path=user_config.name
             )
 
             # check that user values are loaded


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- This PR removes a configuration key from the default config called `user_config_path`. This change has little impact because in practice, that value needed to be set via environment variable anyway (since setting it in a user config was useless unless the user config path was already set!). However, the redundant check for that value was creating issues with unit tests, since we set `PREFECT__USER_CONFIG_PATH=""` and the logic I implemented in #1037 loaded the config key if the env var was "None-ish". 

- tldr; no behavior changes but avoids a circular load that was caused by loading the config and checking a key that had to be set by env var anyway.


## Why is this PR important?
Fixes a bug where unit tests loaded user configs instead of respecting that user config path was set to ""


