### PR TITLE
Secrets now raise when not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Breaking Changes
 
 - Changed the signature of `configuration.load_configuration()` - [#1037](https://github.com/PrefectHQ/prefect/pull/1037)
+- Local Secrets now raise `ValueError`s when not found in context - [#1047](https://github.com/PrefectHQ/prefect/pull/1047)
 
 ### Contributors
 

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -52,7 +52,7 @@ class Secret:
             try:
                 value = secrets[self.name]
             except KeyError:
-                raise ValueError("Secret {} was not found.".format(self.name))
+                raise ValueError("Secret {} was not found.".format(self.name)) from None
             try:
                 return json.loads(value)
             except (json.JSONDecodeError, TypeError):

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -35,11 +35,12 @@ class Secret:
         JSON documents to avoid ambiguous behavior.
 
         Returns:
-            - Any: the value of the secret; if not found, returns `None`
+            - Any: the value of the secret; if not found, raises an error
 
         Raises:
-            - ValueError: if `.get()` is called within a Flow building context
-            - ValueError: if `use_local_secrets=False` and the Client fails to retrieve your secret
+            - ValueError: if `.get()` is called within a Flow building context, or if `use_local_secrets=True`
+                and your Secret doesn't exist
+            - ClientError: if `use_local_secrets=False` and the Client fails to retrieve your secret
         """
         if isinstance(prefect.context.get("flow"), prefect.core.flow.Flow):
             raise ValueError(
@@ -48,7 +49,10 @@ class Secret:
 
         if prefect.config.cloud.use_local_secrets is True:
             secrets = prefect.context.get("secrets", {})
-            value = secrets.get(self.name)
+            try:
+                value = secrets[self.name]
+            except KeyError:
+                raise ValueError("Secret {} was not found.".format(self.name))
             try:
                 return json.loads(value)
             except (json.JSONDecodeError, TypeError):

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -18,10 +18,12 @@ def test_create_secret():
     assert secret
 
 
-def test_secret_get_none():
+def test_secret_raises_if_doesnt_exist():
     secret = Secret(name="test")
     with set_temporary_config({"cloud.use_local_secrets": True}):
-        assert secret.get() is None
+        with pytest.raises(ValueError) as exc:
+            secret.get()
+    assert "not found" in str(exc.value)
 
 
 def test_secret_value_pulled_from_context():
@@ -29,7 +31,8 @@ def test_secret_value_pulled_from_context():
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(test=42)):
             assert secret.get() == 42
-        assert secret.get() is None
+        with pytest.raises(ValueError):
+            secret.get()
 
 
 def test_secret_value_depends_on_use_local_secrets():

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -41,7 +41,7 @@ def test_secret_value_depends_on_use_local_secrets():
         with prefect.context(secrets=dict(test=42)):
             with pytest.raises(AuthorizationError) as exc:
                 secret.get()
-            assert "Client.login" in str(exc.value)
+    assert "Client.login" in str(exc.value)
 
 
 def test_secrets_use_client(monkeypatch):
@@ -61,7 +61,8 @@ def test_local_secrets_auto_load_json_strings():
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(test='{"x": 42}')):
             assert secret.get() == {"x": 42}
-        assert secret.get() is None
+        with pytest.raises(ValueError):
+            secret.get()
 
 
 def test_secrets_raise_if_in_flow_context():

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -157,7 +157,7 @@ class TestGCSResultHandler:
         assert blob.upload_from_string.called
         assert isinstance(blob.upload_from_string.call_args[0][0], str)
 
-    def test_gcs_handler_is_pickleable(self, monkeypatch):
+    def test_gcs_handler_is_pickleable(self, google_client, monkeypatch):
         class gcs_bucket:
             def __init__(self, *args, **kwargs):
                 pass
@@ -165,18 +165,9 @@ class TestGCSResultHandler:
             def __getstate__(self):
                 raise ValueError("I cannot be pickled.")
 
-        client = MagicMock(bucket=gcs_bucket)
-        storage = MagicMock(Client=MagicMock(return_value=client))
-        with patch.dict(
-            "sys.modules",
-            {
-                "google.cloud": MagicMock(storage=storage),
-                "google.oauth2.service_account": MagicMock(),
-            },
-        ):
-            handler = GCSResultHandler("foo")
-            res = cloudpickle.loads(cloudpickle.dumps(handler))
-            assert isinstance(res, GCSResultHandler)
+        handler = GCSResultHandler("foo")
+        res = cloudpickle.loads(cloudpickle.dumps(handler))
+        assert isinstance(res, GCSResultHandler)
 
 
 @pytest.mark.xfail(raises=ImportError)

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -174,7 +174,8 @@ class TestGCSResultHandler:
             "sys.modules",
             {"google.cloud": MagicMock(), "google.oauth2.service_account": MagicMock()},
         ):
-            yield
+            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS="")):
+                yield
 
     def test_serialize(self, google_client):
         handler = GCSResultHandler(bucket="my-bucket")

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -127,7 +127,7 @@ def test_base_name_is_filtered_for(monkeypatch):
     monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
 
     with set_temporary_config({"cloud.use_local_secrets": True}):
-        with prefect.context(secrets=dict(MY_SECRET={"key": 42})):
+        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
             task.run(repo="org/repo")
 
     assert req.post.call_args[1]["json"] == {

--- a/tests/tasks/google/test_bigquery.py
+++ b/tests/tasks/google/test_bigquery.py
@@ -303,7 +303,11 @@ class TestCreateBigQueryTableInitialization:
         )
         task = CreateBigQueryTable()
         with pytest.raises(prefect.engine.signals.SUCCESS) as exc:
-            task.run()
+            with set_temporary_config({"cloud.use_local_secrets": True}):
+                with prefect.context(
+                    secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={"key": 42})
+                ):
+                    task.run()
 
         assert "already exists" in str(exc.value)
 

--- a/tests/tasks/kubernetes/test_deployment.py
+++ b/tests/tasks/kubernetes/test_deployment.py
@@ -14,6 +14,13 @@ from prefect.tasks.kubernetes import (
 from prefect.utilities.configuration import set_temporary_config
 
 
+@pytest.fixture(autouse=True)
+def kube_secret():
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+            yield
+
+
 class TestCreateNamespacedDeploymentTask:
     def test_empty_initialization(self):
         task = CreateNamespacedDeployment()
@@ -49,14 +56,14 @@ class TestCreateNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = CreateNamespacedDeployment(body={"test": "a"})
@@ -106,7 +113,9 @@ class TestCreateNamespacedDeploymentTask:
             MagicMock(ExtensionsV1beta1Api=MagicMock(return_value=extensionsapi)),
         )
 
-        task.run(body={"test": "a"})
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+                task.run(body={"test": "a"})
         assert extensionsapi.create_namespaced_deployment.call_args[1]["body"] == {
             "test": "a"
         }
@@ -193,14 +202,14 @@ class TestDeleteNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = DeleteNamespacedDeployment(
@@ -275,14 +284,14 @@ class TestListNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ListNamespacedDeployment(kube_kwargs={"test": "a"})
@@ -374,14 +383,14 @@ class TestPatchNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = PatchNamespacedDeployment(body={"test": "a"}, deployment_name="test")
@@ -521,14 +530,14 @@ class TestReadNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ReadNamespacedDeployment(
@@ -626,14 +635,14 @@ class TestReplaceNamespacedDeploymentTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.deployment.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.deployment.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = ReplaceNamespacedDeployment(body={"test": "a"}, deployment_name="test")

--- a/tests/tasks/kubernetes/test_job.py
+++ b/tests/tasks/kubernetes/test_job.py
@@ -14,6 +14,13 @@ from prefect.tasks.kubernetes import (
 from prefect.utilities.configuration import set_temporary_config
 
 
+@pytest.fixture(autouse=True)
+def kube_secret():
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+            yield
+
+
 class TestCreateNamespacedJobTask:
     def test_empty_initialization(self):
         task = CreateNamespacedJob()
@@ -49,14 +56,14 @@ class TestCreateNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = CreateNamespacedJob(body={"test": "a"})
@@ -189,14 +196,14 @@ class TestDeleteNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = DeleteNamespacedJob(job_name="test", kube_kwargs={"test": "a"})
@@ -267,14 +274,14 @@ class TestListNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ListNamespacedJob(kube_kwargs={"test": "a"})
@@ -366,14 +373,14 @@ class TestPatchNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = PatchNamespacedJob(body={"test": "a"}, job_name="test")
@@ -509,14 +516,14 @@ class TestReadNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ReadNamespacedJob(job_name="test", kube_kwargs={"test": "a"})
@@ -608,14 +615,14 @@ class TestReplaceNamespacedJobTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.job.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.job.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = ReplaceNamespacedJob(body={"test": "a"}, job_name="test")

--- a/tests/tasks/kubernetes/test_pod.py
+++ b/tests/tasks/kubernetes/test_pod.py
@@ -14,6 +14,13 @@ from prefect.tasks.kubernetes import (
 from prefect.utilities.configuration import set_temporary_config
 
 
+@pytest.fixture(autouse=True)
+def kube_secret():
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+            yield
+
+
 class TestCreateNamespacedPodTask:
     def test_empty_initialization(self):
         task = CreateNamespacedPod()
@@ -49,14 +56,14 @@ class TestCreateNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = CreateNamespacedPod(body={"test": "a"})
@@ -189,14 +196,14 @@ class TestDeleteNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = DeleteNamespacedPod(pod_name="test", kube_kwargs={"test": "a"})
@@ -267,14 +274,14 @@ class TestListNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ListNamespacedPod(kube_kwargs={"test": "a"})
@@ -366,14 +373,14 @@ class TestPatchNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = PatchNamespacedPod(body={"test": "a"}, pod_name="test")
@@ -509,14 +516,14 @@ class TestReadNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ReadNamespacedPod(pod_name="test", kube_kwargs={"test": "a"})
@@ -608,14 +615,14 @@ class TestReplaceNamespacedPodTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.pod.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.pod.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = ReplaceNamespacedPod(body={"test": "a"}, pod_name="test")

--- a/tests/tasks/kubernetes/test_service.py
+++ b/tests/tasks/kubernetes/test_service.py
@@ -14,6 +14,13 @@ from prefect.tasks.kubernetes import (
 from prefect.utilities.configuration import set_temporary_config
 
 
+@pytest.fixture(autouse=True)
+def kube_secret():
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+            yield
+
+
 class TestCreateNamespacedServiceTask:
     def test_empty_initialization(self):
         task = CreateNamespacedService()
@@ -49,14 +56,14 @@ class TestCreateNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = CreateNamespacedService(body={"test": "a"})
@@ -189,14 +196,14 @@ class TestDeleteNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = DeleteNamespacedService(service_name="test", kube_kwargs={"test": "a"})
@@ -267,14 +274,14 @@ class TestListNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ListNamespacedService(kube_kwargs={"test": "a"})
@@ -366,14 +373,14 @@ class TestPatchNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = PatchNamespacedService(body={"test": "a"}, service_name="test")
@@ -509,14 +516,14 @@ class TestReadNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_kube_kwargs_value_is_replaced(self, monkeypatch):
         task = ReadNamespacedService(service_name="test", kube_kwargs={"test": "a"})
@@ -608,14 +615,14 @@ class TestReplaceNamespacedServiceTask:
         client = MagicMock()
         monkeypatch.setattr("prefect.tasks.kubernetes.service.client", client)
 
+        api_key = {}
         conf_call = MagicMock()
+        conf_call.return_value.api_key = api_key
         monkeypatch.setattr(
             "prefect.tasks.kubernetes.service.client.Configuration", conf_call
         )
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
-                task.run()
-        assert conf_call.called
+        task.run()
+        assert api_key == {"authorization": "test_key"}
 
     def test_body_value_is_replaced(self, monkeypatch):
         task = ReplaceNamespacedService(body={"test": "a"}, service_name="test")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR changes the behavior of secrets (notable _local_ secrets) to raise errors when they aren't found.


## Why is this PR important?
Raising an error does a few things:
- disambiguates between a `None` that is explicitly set as a secret value vs. a not-found secret
- provides an earlier, more explicit error when something involving secrets goes wrong (e.g., instead of AWS telling you your password is incorrect, Prefect tells you your AWS secret wasn't found)
- Closes #1043 
- makes the behavior of local vs deployed Flows consistent