### PR TITLE
Allow saving graph from notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Ensure that state change handlers are called even when unexpected initialization errors occur - [#1015](https://github.com/PrefectHQ/prefect/pull/1015)
 - Fix an issue where a mypy assert relied on an unavailable import - [#1034](https://github.com/PrefectHQ/prefect/pull/1034)
 - Fix an issue where user configurations were loaded after config interpolation had already taken place - [#1037](https://github.com/PrefectHQ/prefect/pull/1037)
+- Fix an issue with saving a flow visualization to a file from a notebook - [#1056](https://github.com/PrefectHQ/prefect/pull/1056)
 
 ### Breaking Changes
 
@@ -40,6 +41,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - [Zach Angell](https://github.com/zangell44)
 - [Nanda H Krishna](https://nandahkrishna.me)
+- [Brett Naul](https://github.com/bnaul)
 
 ## 0.5.3 <Badge text="beta" type="success"/>
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1090,23 +1090,20 @@ class Flow:
                     style=style,
                 )
 
-        try:
-            from IPython import get_ipython
-
-            if get_ipython().config.get("IPKernelApp") is not None:
-                return graph
-        except Exception:
-            pass
-
         if filename:
             graph.render(filename, view=False)
         else:
-            with tempfile.NamedTemporaryFile(delete=False) as tmp:
-                tmp.close()
-                try:
-                    graph.render(tmp.name, view=True)
-                finally:
-                    os.unlink(tmp.name)
+            try:
+                from IPython import get_ipython
+
+                assert get_ipython().config.get("IPKernelApp") is not None
+            except Exception:
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    tmp.close()
+                    try:
+                        graph.render(tmp.name, view=True)
+                    finally:
+                        os.unlink(tmp.name)
 
         return graph
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Changes the order of the `visualize()` flow so that saving to a file is possible within a notebook.

## Why is this PR important?

IMO it's counterintuitive that `visualize(filename='blah')` does not save a file if running in a notebook. The current behavior does not match the docstring but I believe the updated behavior does, so I left the docstring as-is.