### PR TITLE
Add docker wait task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add task for creating new branches in a GitHub repository - [#1011](https://github.com/PrefectHQ/prefect/pull/1011)
 - Add tasks to create, delete, invoke, and list AWS Lambda functions [#1009](https://github.com/PrefectHQ/prefect/issues/1009)
 - Add tasks for integration with spaCy pipelines [#1018](https://github.com/PrefectHQ/prefect/issues/1018)
+- Add task for waiting on a Docker container to run and optionally raising for nonzero exit code - [#1061](https://github.com/PrefectHQ/prefect/pull/1061)
 
 ### Fixes
 

--- a/docs/guide/examples/imperative_docker.md
+++ b/docs/guide/examples/imperative_docker.md
@@ -1,8 +1,9 @@
-"""
+# Imperative API: Docker Pipeline 
+
 This Prefect Flow creates a Container based on the latest prefect image, and
 executes an empty Flow inside that container.
-"""
 
+```python
 from prefect import Flow
 from prefect.tasks.docker import (
     CreateContainer,
@@ -34,7 +35,9 @@ logs.set_upstream(status_code, flow=flow)
 
 ## run flow and print logs
 flow_state = flow.run()
+
 print("=" * 30)
 print("Container Logs")
 print("=" * 30)
 print(flow_state.result[logs].result)
+```

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -208,7 +208,8 @@ classes = [
         "GetContainerLogs",
         "ListContainers",
         "StartContainer",
-        "StopContainer"
+        "StopContainer",
+        "WaitOnContainer"
         ]
 
 [pages.tasks.google]

--- a/examples/imperative_docker.py
+++ b/examples/imperative_docker.py
@@ -1,0 +1,35 @@
+from prefect import Flow
+from prefect.tasks.docker import (
+    CreateContainer,
+    StartContainer,
+    GetContainerLogs,
+    WaitOnContainer,
+)
+from prefect.triggers import always_run
+
+
+container = CreateContainer(
+    image_name="prefecthq/prefect",
+    command='''python -c "from prefect import Flow; f = Flow('empty'); f.run()"''',
+)
+start = StartContainer()
+logs = GetContainerLogs(trigger=always_run)
+status_code = WaitOnContainer()
+
+
+flow = Flow("Run a Prefect Flow in Docker")
+
+## set individual task dependencies using imperative API
+start.set_upstream(container, flow=flow, key="container_id")
+logs.set_upstream(container, flow=flow, key="container_id")
+status_code.set_upstream(container, flow=flow, key="container_id")
+
+status_code.set_upstream(start, flow=flow)
+logs.set_upstream(status_code, flow=flow)
+
+## run flow and print logs
+flow_state = flow.run()
+print("=" * 30)
+print("Container Logs")
+print("=" * 30)
+print(flow_state.result[logs].result.decode())

--- a/examples/imperative_docker.py
+++ b/examples/imperative_docker.py
@@ -10,7 +10,7 @@ from prefect.triggers import always_run
 
 container = CreateContainer(
     image_name="prefecthq/prefect",
-    command='''python -c "from prefect import Flow; f = Flow('empty'); f.run()"''',
+    command='''python -c "from prefect import Flow; f = Flow("empty"); f.run()"''',
 )
 start = StartContainer()
 logs = GetContainerLogs(trigger=always_run)
@@ -32,4 +32,4 @@ flow_state = flow.run()
 print("=" * 30)
 print("Container Logs")
 print("=" * 30)
-print(flow_state.result[logs].result.decode())
+print(flow_state.result[logs].result)

--- a/src/prefect/tasks/docker/__init__.py
+++ b/src/prefect/tasks/docker/__init__.py
@@ -30,4 +30,5 @@ from prefect.tasks.docker.containers import (
     ListContainers,
     StartContainer,
     StopContainer,
+    WaitOnContainer,
 )

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -312,7 +312,7 @@ class WaitOnContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - raise_for_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
+        - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
             defaults to `True`
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task
             constructor
@@ -322,21 +322,21 @@ class WaitOnContainer(Task):
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        raise_for_exit_code: bool = True,
+        raise_on_exit_code: bool = True,
         **kwargs: Any
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
-        self.raise_for_exit_code = raise_for_exit_code
+        self.raise_on_exit_code = raise_on_exit_code
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url", "raise_for_exit_code")
+    @defaults_from_attrs("container_id", "docker_server_url", "raise_on_exit_code")
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        raise_for_exit_code: bool = True,
+        raise_on_exit_code: bool = True,
     ) -> None:
         """
         Task run method.
@@ -346,7 +346,7 @@ class WaitOnContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - raise_for_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
+            - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
                 defaults to `True`
 
         Returns:
@@ -354,7 +354,7 @@ class WaitOnContainer(Task):
 
         Raises:
             - ValueError: if `container_id` is `None`
-            - FAIL: if `raise_for_exit_code` is `True` and the container exits with a nonzero exit code
+            - FAIL: if `raise_on_exit_code` is `True` and the container exits with a nonzero exit code
         """
         if not container_id:
             raise ValueError("A container id must be provided.")
@@ -362,7 +362,7 @@ class WaitOnContainer(Task):
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
         result = client.wait(container=container_id)
-        if raise_for_exit_code and (
+        if raise_on_exit_code and (
             (result.get("Error") is not None) or result.get("StatusCode")
         ):
             raise FAIL(

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -342,7 +342,7 @@ class WaitOnContainer(Task):
         Task run method.
 
         Args:
-            - container_id (str, optional): The id of a container to start
+            - container_id (str, optional): The id of a container to wait on
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -149,7 +149,7 @@ class GetContainerLogs(Task):
 
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        return client.logs(container=container_id)
+        return client.logs(container=container_id).decode()
 
 
 class ListContainers(Task):
@@ -365,6 +365,8 @@ class WaitOnContainer(Task):
         if raise_on_exit_code and (
             (result.get("Error") is not None) or result.get("StatusCode")
         ):
+            logs = client.logs(container_id)
+            self.logger.error(logs.decode())
             raise FAIL(
                 "{id} failed with exit code {code}: {msg}".format(
                     id=container_id,

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -3,6 +3,7 @@ from typing import Any, Union
 import docker
 
 from prefect import Task
+from prefect.engine.signals import FAIL
 from prefect.utilities.tasks import defaults_from_attrs
 
 
@@ -299,3 +300,77 @@ class StopContainer(Task):
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
         client.stop(container=container_id)
+
+
+class WaitOnContainer(Task):
+    """
+    Task for waiting on an already started Docker container.
+    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+
+    Args:
+        - container_id (str, optional): The id of a container to start
+        - docker_server_url (str, optional): URL for the Docker server. Defaults to
+            `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
+            can be provided
+        - raise_for_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
+            defaults to `True`
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor
+    """
+
+    def __init__(
+        self,
+        container_id: str = None,
+        docker_server_url: str = "unix:///var/run/docker.sock",
+        raise_for_exit_code: bool = True,
+        **kwargs: Any
+    ):
+        self.container_id = container_id
+        self.docker_server_url = docker_server_url
+        self.raise_for_exit_code = raise_for_exit_code
+
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs("container_id", "docker_server_url", "raise_for_exit_code")
+    def run(
+        self,
+        container_id: str = None,
+        docker_server_url: str = "unix:///var/run/docker.sock",
+        raise_for_exit_code: bool = True,
+    ) -> None:
+        """
+        Task run method.
+
+        Args:
+            - container_id (str, optional): The id of a container to start
+            - docker_server_url (str, optional): URL for the Docker server. Defaults to
+                `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
+                can be provided
+            - raise_for_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
+                defaults to `True`
+
+        Returns:
+            - dict: a dictionary with `StatusCode` and `Error` keys
+
+        Raises:
+            - ValueError: if `container_id` is `None`
+            - FAIL: if `raise_for_exit_code` is `True` and the container exits with a nonzero exit code
+        """
+        if not container_id:
+            raise ValueError("A container id must be provided.")
+
+        client = docker.APIClient(base_url=docker_server_url, version="auto")
+
+        result = client.wait(container=container_id)
+        if raise_for_exit_code and (
+            (result.get("Error") is not None) or result.get("StatusCode")
+        ):
+            raise FAIL(
+                "{id} failed with exit code {code}: {msg}".format(
+                    id=container_id,
+                    code=result.get("StatusCode"),
+                    msg=result.get("Error"),
+                )
+            )
+
+        return result

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -365,8 +365,11 @@ class WaitOnContainer(Task):
         if raise_on_exit_code and (
             (result.get("Error") is not None) or result.get("StatusCode")
         ):
-            logs = client.logs(container_id)
-            self.logger.error(logs.decode())
+            try:
+                logs = client.logs(container_id)
+                self.logger.error(logs.decode())
+            except Exception as exc:
+                self.logger.error(exc)
             raise FAIL(
                 "{id} failed with exit code {code}: {msg}".format(
                     id=container_id,

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -297,7 +297,7 @@ class TestWaitOnContainerTask:
         api.return_value.wait.return_value = {}
 
         task.run()
-        assert api.return_value.stop.call_args[1]["container"] == "test"
+        assert api.return_value.wait.call_args[1]["container"] == "test"
 
     def test_container_id_run_value_is_used(self, monkeypatch):
         task = WaitOnContainer(container_id="init")
@@ -307,7 +307,7 @@ class TestWaitOnContainerTask:
         api.return_value.wait.return_value = {}
 
         task.run(container_id="test")
-        assert api.return_value.stop.call_args[1]["container"] == "test"
+        assert api.return_value.wait.call_args[1]["container"] == "test"
 
     def test_raises_for_nonzero_status(self, monkeypatch):
         task = WaitOnContainer(container_id="noise")

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -294,6 +294,7 @@ class TestWaitOnContainerTask:
 
         api = MagicMock()
         monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        api.return_value.wait.return_value = {}
 
         task.run()
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -303,6 +304,7 @@ class TestWaitOnContainerTask:
 
         api = MagicMock()
         monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        api.return_value.wait.return_value = {}
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -2,12 +2,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from prefect.engine.signals import FAIL
 from prefect.tasks.docker import (
     CreateContainer,
     GetContainerLogs,
     ListContainers,
     StartContainer,
     StopContainer,
+    WaitOnContainer,
 )
 
 
@@ -260,3 +262,76 @@ class TestStopContainerTask:
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"
+
+
+class TestWaitOnContainerTask:
+    def test_empty_initialization(self):
+        task = WaitOnContainer()
+        assert not task.container_id
+        assert task.docker_server_url == "unix:///var/run/docker.sock"
+        assert task.raise_on_exit_code is True
+
+    def test_filled_initialization(self):
+        task = WaitOnContainer(
+            container_id="test", docker_server_url="test", raise_on_exit_code=False
+        )
+        assert task.container_id == "test"
+        assert task.docker_server_url == "test"
+        assert task.raise_on_exit_code is False
+
+    def test_empty_container_id_raises_error(self):
+        task = WaitOnContainer()
+        with pytest.raises(ValueError):
+            task.run()
+
+    def test_invalid_container_id_raises_error(self):
+        task = WaitOnContainer()
+        with pytest.raises(ValueError):
+            task.run(container_id=None)
+
+    def test_container_id_init_value_is_used(self, monkeypatch):
+        task = WaitOnContainer(container_id="test")
+
+        api = MagicMock()
+        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+
+        task.run()
+        assert api.return_value.stop.call_args[1]["container"] == "test"
+
+    def test_container_id_run_value_is_used(self, monkeypatch):
+        task = WaitOnContainer(container_id="init")
+
+        api = MagicMock()
+        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+
+        task.run(container_id="test")
+        assert api.return_value.stop.call_args[1]["container"] == "test"
+
+    def test_raises_for_nonzero_status(self, monkeypatch):
+        task = WaitOnContainer(container_id="noise")
+
+        api = MagicMock()
+        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        api.return_value.wait.return_value = {"StatusCode": 1}
+
+        with pytest.raises(FAIL):
+            task.run()
+
+    def test_raises_for_error(self, monkeypatch):
+        task = WaitOnContainer(container_id="noise")
+
+        api = MagicMock()
+        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        api.return_value.wait.return_value = {"Error": "oops!"}
+
+        with pytest.raises(FAIL):
+            task.run()
+
+    def test_doesnt_raise_for_nonzero_status(self, monkeypatch):
+        task = WaitOnContainer(container_id="noise", raise_on_exit_code=False)
+
+        api = MagicMock()
+        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        api.return_value.wait.return_value = {"StatusCode": 1, "Error": "oops!"}
+
+        task.run()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a new task to the task library, `WaitOnContainer`, which waits for a Docker container to finish its run.  The task optionally raises a `FAIL` signal if the container exits with a non-zero status code.

Additionally, closes #760 with an imperative API example which sets up a full Docker pipeline.

## Why is this PR important?
If a Flow interacts with docker, there are many instances in which certain tasks should only start if a docker container exits.  This "final" Docker task allows for complete Docker pipelines written in Prefect.