### PR TITLE
FIX: Mapped skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix an issue where a mypy assert relied on an unavailable import - [#1034](https://github.com/PrefectHQ/prefect/pull/1034)
 - Fix an issue where user configurations were loaded after config interpolation had already taken place - [#1037](https://github.com/PrefectHQ/prefect/pull/1037)
 - Fix an issue with saving a flow visualization to a file from a notebook - [#1056](https://github.com/PrefectHQ/prefect/pull/1056)
+- Fix an issue in which mapped tasks incorrectly tried to run when their upstream was skipped - [#1068](https://github.com/PrefectHQ/prefect/issues/1068)
 
 ### Breaking Changes
 

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -451,6 +451,26 @@ class TestCheckUpstreamSkipped:
         )
         assert new_state is state
 
+    def test_raises_if_single_mapped_upstream_skipped(self):
+        state = Pending()
+        task = Task()
+        with pytest.raises(ENDRUN) as exc:
+            edge = Edge(1, 2, mapped=False)
+            new_state = TaskRunner(task).check_upstream_skipped(
+                state=state,
+                upstream_states={edge: Mapped(map_states=[Skipped(), Success()])},
+            )
+
+    def test_doesnt_raise_if_single_mapped_upstream_skipped_and_edge_is_mapped(self):
+        state = Pending()
+        task = Task()
+        edge = Edge(1, 2, mapped=True)
+        new_state = TaskRunner(task).check_upstream_skipped(
+            state=state,
+            upstream_states={edge: Mapped(map_states=[Skipped(), Success()])},
+        )
+        assert new_state is state
+
 
 class TestCheckTaskTrigger:
     def test_all_successful_pass(self):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that if a mapped task follows a task which is skipped, the mapped task skips itself and doesn't error out.  Previously, the upstream skipped state was indexed into (because the `check_upstream_skipped` pipeline step was run _after_ the `run_mapped_task` step).  I had to:

- Change the order of these pipeline steps so that upstream skips were handled better
- update the logic of `check_upstream_skipped` so that in the case of `c.map(b.map(a))`, where maybe _one_ mapped child of `b` skips, all of `c` does _not_ skip as well (only the individual child of `c` with an upstream skip should skip...)


## Why is this PR important?
Bug fix - closes #1068 

