### PR TITLE
Finally fix union timezone test

### DIFF
--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -592,13 +592,16 @@ class TestUnionSchedule:
         )
         main = schedules.UnionSchedule([east, west])
 
+        ## have to do some additional work so this test passes
+        ## regardless of what time it is
+        now = pendulum.now("US/Pacific")
+        after = east.next(1, after=now)[0] + pendulum.duration(minutes=-1)
+
         expected = [
-            east.next(1)[0],
-            west.next(1)[0],
-            east.next(2)[1],
-            west.next(2)[1],
-            east.next(3)[2],
+            east.next(1, after=after)[0],
+            west.next(1, after=after)[0],
+            east.next(2, after=after)[1],
+            west.next(2, after=after)[1],
         ]
 
-        # there is an edge case if this test runs between 9-9:30AM EST
-        assert main.next(4) in [expected[:4], expected[1:]]
+        assert main.next(4, after=after) == expected


### PR DESCRIPTION
Fixes the occasionally failing union-next-n-different-timezone test by ensuring `east.next(1)` is always the next scheduled time.