### PR TITLE
Remove idna as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cryptography >= 2.2.2, < 3.0
 dask >=0.18,<1.2.3
 distributed >= 1.26.1, < 2.0
 docker >=3.4.1,<5.0
-idna < 2.8, >= 2.5
 marshmallow == 3.0.0b19
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
 mypy >= 0.600, < 0.800


### PR DESCRIPTION
Part of the whole requirements cleanup; we don't explicitly depend on this package, and it's presence in our requirements is an artifact of an old `requests` issue.