### PR TITLE
Attempt to git pull tags in netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 [build]
   base    = ""
   publish = "docs/.vuepress/dist"
-  command = 'export GIT_SHA=$COMMIT_REF && pip install -e ".[dev]" && yarn docs:build'
+  command = 'export GIT_SHA=$COMMIT_REF && git pull && pip install -e ".[dev]" && yarn docs:build'
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Currently our docs are built on netlify and appear to have stale tags, so the "autogenerated by" message appears old (even though it isn't).  Testing a `git pull` to pull tags down prior to generating docs