### PR TITLE
Map Caching in Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with mapped caching in Prefect Cloud - [#1096](https://github.com/PrefectHQ/prefect/pull/1096)
 
 ### Breaking Changes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 
 
 [tool:pytest]
+addopts = -rfEsx
 norecursedirs = *.egg-info .git .mypy_cache node_modules .pytest_cache .vscode
 env =
     SKIP_DOCKER_ENVIRONMENT_TESTS = True

--- a/src/prefect/engine/cache_validators.py
+++ b/src/prefect/engine/cache_validators.py
@@ -88,9 +88,7 @@ def all_inputs(
     """
     if duration_only(state, inputs, parameters) is False:
         return False
-    elif {key: res.value for key, res in state.cached_inputs.items()} == {
-        key: res.value for key, res in inputs.items()
-    }:
+    elif {key: res.value for key, res in (state.cached_inputs or {}).items()} == inputs:
         return True
     else:
         return False
@@ -265,7 +263,9 @@ def partial_inputs_only(validate_on: Iterable[str] = None,) -> Callable:
                 True
             )  # if you dont want to validate on anything, then the cache is valid
         else:
-            cached = state.cached_inputs or {}
+            cached = {
+                key: res.value for key, res in (state.cached_inputs or {}).items()
+            }
             partial_provided = {
                 key: value for key, value in inputs.items() if key in validate_on
             }

--- a/src/prefect/engine/cache_validators.py
+++ b/src/prefect/engine/cache_validators.py
@@ -88,7 +88,9 @@ def all_inputs(
     """
     if duration_only(state, inputs, parameters) is False:
         return False
-    elif state.cached_inputs == inputs:
+    elif {key: res.value for key, res in state.cached_inputs.items()} == {
+        key: res.value for key, res in inputs.items()
+    }:
         return True
     else:
         return False

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -189,8 +189,10 @@ class CloudTaskRunner(TaskRunner):
 
             for candidate_state in cached_states:
                 assert isinstance(candidate_state, Cached)  # mypy assert
-                candidate_state.cached_inputs = {key: res.to_result() for key, res in candidate_state.cached_inputs.items()}
-                from IPython import embed; embed()
+                candidate_state.cached_inputs = {
+                    key: res.to_result()
+                    for key, res in candidate_state.cached_inputs.items()
+                }
                 if self.task.cache_validator(
                     candidate_state, inputs, prefect.context.get("parameters")
                 ):

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -189,6 +189,8 @@ class CloudTaskRunner(TaskRunner):
 
             for candidate_state in cached_states:
                 assert isinstance(candidate_state, Cached)  # mypy assert
+                candidate_state.cached_inputs = {key: res.to_result() for key, res in candidate_state.cached_inputs.items()}
+                from IPython import embed; embed()
                 if self.task.cache_validator(
                     candidate_state, inputs, prefect.context.get("parameters")
                 ):

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -189,12 +189,13 @@ class CloudTaskRunner(TaskRunner):
 
             for candidate_state in cached_states:
                 assert isinstance(candidate_state, Cached)  # mypy assert
-                candidate_state.cached_inputs = {
+                candidate_state.cached_inputs = {  # type: ignore
                     key: res.to_result()
-                    for key, res in candidate_state.cached_inputs.items()
+                    for key, res in (candidate_state.cached_inputs or {}).items()
                 }
+                sanitized_inputs = {key: res.value for key, res in inputs.items()}
                 if self.task.cache_validator(
-                    candidate_state, inputs, prefect.context.get("parameters")
+                    candidate_state, sanitized_inputs, prefect.context.get("parameters")
                 ):
                     candidate_state._result = candidate_state._result.to_result()
                     return candidate_state

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -575,8 +575,9 @@ class TaskRunner(Runner):
         """
         if state.is_cached():
             assert isinstance(state, Cached)  # mypy assert
+            sanitized_inputs = {key: res.value for key, res in inputs.items()}
             if self.task.cache_validator(
-                state, inputs, prefect.context.get("parameters")
+                state, sanitized_inputs, prefect.context.get("parameters")
             ):
                 state._result = state._result.to_result()
                 return state

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -655,9 +655,11 @@ class TaskRunner(Runner):
                         # Therefore, we only try to get a result if EITHER this task's
                         # state is not already mapped OR the upstream result is not None.
                         if not state.is_mapped() or upstream_state.result != NoResult:
-                            states[edge].result = upstream_state.result[  # type: ignore
-                                i
-                            ]
+                            upstream_result = Result(
+                                upstream_state.result[i],
+                                result_handler=upstream_state._result.result_handler,  # type: ignore
+                            )
+                            states[edge].result = upstream_result
                         elif state.is_mapped():
                             if i >= len(state.map_states):  # type: ignore
                                 raise IndexError()

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1566,7 +1566,7 @@ class TestFlowRunMethod:
                     self.call_count += 1
                     return [pendulum.now("utc")]
                 else:
-                    raise SyntaxError("Cease scheduling!")
+                    return []
 
         class StatefulTask(Task):
             def __init__(self, maxit=False, **kwargs):
@@ -1600,8 +1600,7 @@ class TestFlowRunMethod:
         with Flow(name="test", schedule=schedule) as f:
             res = store_y(return_x(x=t1, y=t2))
 
-        with pytest.raises(SyntaxError) as exc:
-            f.run()
+        f.run()
 
         assert storage == dict(y=[1, 1, 3])
 

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -185,7 +185,9 @@ def test_task_runner_validates_cached_states_if_task_has_caching(client):
 
 def test_task_runner_validates_cached_state_inputs_if_task_has_caching(client):
     @prefect.task(
-        cache_for=datetime.timedelta(minutes=1), cache_validator=all_inputs, result_handler=JSONResultHandler()
+        cache_for=datetime.timedelta(minutes=1),
+        cache_validator=all_inputs,
+        result_handler=JSONResultHandler(),
     )
     def cached_task(x):
         return 42
@@ -198,7 +200,9 @@ def test_task_runner_validates_cached_state_inputs_if_task_has_caching(client):
     )
     client.get_latest_cached_states = MagicMock(return_value=[state])
 
-    res = CloudTaskRunner(task=cached_task).check_task_is_cached(Pending(), inputs={"x": Result(2, result_handler=JSONResultHandler())})
+    res = CloudTaskRunner(task=cached_task).check_task_is_cached(
+        Pending(), inputs={"x": Result(2, result_handler=LocalResultHandler())}
+    )
     assert client.get_latest_cached_states.called
     assert res.is_successful()
     assert res.is_cached()

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -192,13 +192,18 @@ def test_task_runner_validates_cached_state_inputs_if_task_has_caching(client):
     def cached_task(x):
         return 42
 
+    dull_state = Cached(
+        cached_result_expiration=datetime.datetime.utcnow()
+        + datetime.timedelta(minutes=2),
+        result=Result(-1, JSONResultHandler()),
+    )
     state = Cached(
         cached_result_expiration=datetime.datetime.utcnow()
         + datetime.timedelta(minutes=2),
         result=Result(99, JSONResultHandler()),
         cached_inputs={"x": SafeResult("2", result_handler=JSONResultHandler())},
     )
-    client.get_latest_cached_states = MagicMock(return_value=[state])
+    client.get_latest_cached_states = MagicMock(return_value=[dull_state, state])
 
     res = CloudTaskRunner(task=cached_task).check_task_is_cached(
         Pending(), inputs={"x": Result(2, result_handler=LocalResultHandler())}

--- a/tests/engine/test_cache_validators.py
+++ b/tests/engine/test_cache_validators.py
@@ -11,6 +11,7 @@ from prefect.engine.cache_validators import (
     partial_inputs_only,
     partial_parameters_only,
 )
+from prefect.engine.result import Result
 from prefect.engine.state import Cached
 
 all_validators = [all_inputs, all_parameters, never_use, duration_only]
@@ -45,15 +46,15 @@ class TestDurationOnly:
 
 class TestAllInputs:
     def test_inputs_invalidate(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert all_inputs(state, dict(x=1, s="strs"), None) is False
 
     def test_inputs_validate(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert all_inputs(state, dict(x=1, s="str"), None) is True
 
     def test_additional_inputs_invalidate(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert all_inputs(state, dict(x=1, s="str", noise="e"), None) is False
 
 
@@ -73,18 +74,18 @@ class TestAllParameters:
 
 class TestPartialInputsOnly:
     def test_inputs_validate_with_defaults(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert partial_inputs_only(None)(state, dict(x=1, s="str"), None) is True
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert partial_inputs_only(None)(state, dict(x=1, s="strs"), None) is True
 
     def test_validate_on_kwarg(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert (
             partial_inputs_only(validate_on=["x", "s"])(state, dict(x=1, s="str"), None)
             is True
         )
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         assert (
             partial_inputs_only(validate_on=["x", "s"])(
                 state, dict(x=1, s="strs"), None
@@ -103,11 +104,11 @@ class TestPartialInputsOnly:
     def test_handles_none(self):
         state = Cached(cached_parameters=dict(x=5))
         assert partial_inputs_only(validate_on=["x"])(state, dict(x=5), None) is False
-        state = Cached(cached_inputs=dict(x=5))
+        state = Cached(cached_inputs=dict(x=Result(5)))
         assert partial_inputs_only(validate_on=["x"])(state, None, None) is False
 
     def test_curried(self):
-        state = Cached(cached_inputs=dict(x=1, s="str"))
+        state = Cached(cached_inputs=dict(x=Result(1), s=Result("str")))
         validator = partial_inputs_only(validate_on=["x"])
         assert validator(state, dict(x=1), None) is True
         assert validator(state, dict(x=2, s="str"), None) is False
@@ -145,7 +146,7 @@ class TestPartialParametersOnly:
         )
 
     def test_handles_none(self):
-        state = Cached(cached_inputs=dict(x=5))
+        state = Cached(cached_inputs=dict(x=Result(5)))
         assert (
             partial_parameters_only(validate_on=["x"])(state, None, dict(x=5)) is False
         )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
OK this is a doozy; caching with mapped tasks was not working in cloud because cache validators were comparing _safe results_ from the database with _raw inputs_ from the process; this has been updated to now convert safe results to real results prior to comparisons and then only compare _values_ of the results (so that the conclusion is independent of result handler)

Additionally, mapping was _not_ preserving the fully-hydrated "Result" object from upstream; instead, it was stripping out result handler info.  This has been fixed.