### PR TITLE
Context cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Refactor mapped caching to be independent of order - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Refactor mapped caching to be independent of order - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
+- Refactor caching to allow for caching across multiple runs - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
 
 ### Task Library
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -836,6 +836,7 @@ class Flow:
             flow_state.result = {}
         task_states = kwargs.pop("task_states", {})
         flow_state.result.update(task_states)
+        prefect.context.map_caches = {}
 
         ## run this flow indefinitely, so long as its schedule has future dates
         while True:
@@ -892,16 +893,11 @@ class Flow:
                         sub_state.is_cached() for sub_state in s.map_states
                     ):
                         cached_sub_states = [
-                            sub_state if sub_state.is_cached() else None
+                            sub_state
                             for sub_state in s.map_states
+                            if sub_state.is_cached()
                         ]
-                        cached_tasks.update(
-                            {
-                                t: prefect.engine.state.Mapped(
-                                    map_states=cached_sub_states
-                                )
-                            }
-                        )
+                        prefect.context.map_caches.update({t.name: cached_sub_states})
                 if self.schedule is not None:
                     next_run_time = self.schedule.next(1)[0]
                 else:

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -151,9 +151,7 @@ class CloudTaskRunner(TaskRunner):
         return super().initialize_run(state=state, context=context)
 
     @call_state_handlers
-    def check_task_is_cached(
-        self, state: State, inputs: Dict[str, Result], map_index: int = None
-    ) -> State:
+    def check_task_is_cached(self, state: State, inputs: Dict[str, Result]) -> State:
         """
         Checks if task is cached in the DB and whether any of the caches are still valid.
 
@@ -161,7 +159,6 @@ class CloudTaskRunner(TaskRunner):
             - state (State): the current state of this task
             - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
                 to the task's `run()` arguments.
-            - map_index (int, optional): if mapped, the map index for this task
 
         Returns:
             - State: the state of the task after running the check

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -151,7 +151,9 @@ class CloudTaskRunner(TaskRunner):
         return super().initialize_run(state=state, context=context)
 
     @call_state_handlers
-    def check_task_is_cached(self, state: State, inputs: Dict[str, Result]) -> State:
+    def check_task_is_cached(
+        self, state: State, inputs: Dict[str, Result], map_index: int = None
+    ) -> State:
         """
         Checks if task is cached in the DB and whether any of the caches are still valid.
 
@@ -159,6 +161,7 @@ class CloudTaskRunner(TaskRunner):
             - state (State): the current state of this task
             - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
                 to the task's `run()` arguments.
+            - map_index (int, optional): if mapped, the map index for this task
 
         Returns:
             - State: the state of the task after running the check

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -245,9 +245,7 @@ class TaskRunner(Runner):
                 )
 
                 # check to see if the task has a cached result
-                state = self.check_task_is_cached(
-                    state, inputs=task_inputs, map_index=map_index
-                )
+                state = self.check_task_is_cached(state, inputs=task_inputs)
 
                 # check if the task's trigger passes
                 # triggers can raise Pauses, which require task_inputs to be available for caching
@@ -560,9 +558,7 @@ class TaskRunner(Runner):
         return task_inputs
 
     @call_state_handlers
-    def check_task_is_cached(
-        self, state: State, inputs: Dict[str, Result], map_index: int = None
-    ) -> State:
+    def check_task_is_cached(self, state: State, inputs: Dict[str, Result]) -> State:
         """
         Checks if task is cached and whether the cache is still valid.
 
@@ -570,7 +566,6 @@ class TaskRunner(Runner):
             - state (State): the current state of this task
             - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
                 to the task's `run()` arguments.
-            - map_index (int, optional): if mapped, the map index for this task
 
         Returns:
             - State: the state of the task after running the check

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -578,8 +578,8 @@ class TaskRunner(Runner):
         Raises:
             - ENDRUN: if the task is not ready to run
         """
-        if self.task.cache_for and map_index is not None:
-            candidate_states = prefect.context.map_caches.get(self.task.name, [])
+        if self.task.cache_for is not None:
+            candidate_states = prefect.context.caches.get(self.task.name, [])
             sanitized_inputs = {key: res.value for key, res in inputs.items()}
             for candidate in candidate_states:
                 if self.task.cache_validator(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1651,6 +1651,116 @@ class TestFlowRunMethod:
 
         assert storage == dict(y=[[1, 1, 1], [1, 1, 1], [3, 3, 3]])
 
+    def test_flow_dot_run_handles_cached_states_across_runs(self):
+        class MockSchedule(prefect.schedules.Schedule):
+            call_count = 0
+
+            def next(self, n):
+                if self.call_count < 3:
+                    self.call_count += 1
+                    return [pendulum.now("utc")]
+                else:
+                    return []
+
+        class StatefulTask(Task):
+            def __init__(self, maxit=False, **kwargs):
+                self.maxit = maxit
+                super().__init__(**kwargs)
+
+            call_count = 0
+
+            def run(self):
+                # returns 1 on the first run, 2 on the second run, and 1 on the third
+                self.call_count += 1
+                return self.call_count if self.call_count < 3 else 1
+
+        @task(cache_for=datetime.timedelta(minutes=10), cache_validator=all_inputs)
+        def return_x(x):
+            return round(random.random(), 4)
+
+        storage = {"output": []}
+
+        @task(trigger=prefect.triggers.always_run)
+        def store_output(y):
+            storage["output"].append(y)
+
+        t = StatefulTask()
+        schedule = MockSchedule()
+        with Flow(name="test", schedule=schedule) as f:
+            res = store_output(return_x(x=t))
+
+        f.run()
+
+        first_run = storage["output"][0]
+        second_run = storage["output"][1]
+        third_run = storage["output"][2]
+
+        ## first run: nothing interesting
+        assert first_run > 0
+
+        ## second run: all tasks succeed, no cache used
+        assert first_run != second_run
+
+        ## third run: all tasks succeed, caching from previous runs used
+        assert third_run == first_run
+
+    def test_flow_dot_run_handles_mapped_cached_states_across_runs(self):
+        class MockSchedule(prefect.schedules.Schedule):
+            call_count = 0
+
+            def next(self, n):
+                if self.call_count < 3:
+                    self.call_count += 1
+                    return [pendulum.now("utc")]
+                else:
+                    return []
+
+        class StatefulTask(Task):
+            def __init__(self, maxit=False, **kwargs):
+                self.maxit = maxit
+                super().__init__(**kwargs)
+
+            call_count = 0
+            return_vals = {1: [1], 2: [2, 2], 3: [1, 2, 3]}
+
+            def run(self):
+                # returns [1] on the first run, [2, 2] on the second run, and [1, 2, 3] on the third
+                self.call_count += 1
+                return self.return_vals[self.call_count]
+
+        @task(cache_for=datetime.timedelta(minutes=10), cache_validator=all_inputs)
+        def return_x(x):
+            return round(random.random(), 4)
+
+        storage = {"output": []}
+
+        @task(trigger=prefect.triggers.always_run)
+        def store_output(y):
+            storage["output"].append(y)
+
+        t = StatefulTask()
+        schedule = MockSchedule()
+        with Flow(name="test", schedule=schedule) as f:
+            res = store_output(return_x.map(x=t))
+
+        f.run()
+
+        first_run = storage["output"][0]
+        second_run = storage["output"][1]
+        third_run = storage["output"][2]
+
+        ## first run: nothing interesting
+        assert first_run[0] > 0
+
+        ## second run: all tasks succeed, no cache used
+        assert first_run[0] not in second_run
+
+        ## third run: all tasks succeed, caching from previous runs used
+        assert third_run[0] == first_run[0]
+        assert third_run[1] == second_run[0]
+        assert third_run[2] not in first_run
+        assert third_run[2] not in second_run
+
     def test_flow_dot_run_handles_mapped_cached_states_with_differing_lengths(self):
         class MockSchedule(prefect.schedules.Schedule):
             call_count = 0


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR refactors mapped caching in the open source engine to look in `prefect.context` for candidate cached states.


## Why is this PR important?
This implementation closes #1082 and allows for mapped caches to exist independent of ordering; additionally, it allows for a cached mapped task to return results of differing lengths across runs, all while using a shared cache.

I'm satisfied with this implementation, but there are a few things I'd like to add / get some feedback on:
- [x] a test for a cached mapped task which returns results of differing lengths across runs and properly uses its cache
- [x] whether storing the mapped caches by task name is appropriate; I personally always use different names for my tasks, but I don't have insight into how universal that is.  Either way, once decided I'd like to add a test for this as well