### PR TITLE
Add ValueError Handling in `execute cloud-flow`

### DIFF
--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -51,8 +51,11 @@ def cloud_flow():
 
     result = Client().graphql(query)
 
-    flow_data = result.data.flow_run[0].flow
+    flow_run = result.data.flow_run
+    if not flow_run:
+        raise ValueError("Flow run {} not found".format(flow_run_id))
 
+    flow_data = flow_run.flow
     storage_schema = prefect.serialization.storage.StorageSchema()
     storage = storage_schema.load(flow_data.storage)
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Raises a ValueError if the flow run id provided in context to `prefect execute cloud-flow` does not exist.


## Why is this PR important?
Error handling in the CLI makes a more pleasant experience

