### PR TITLE
Remove unused xxhash dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ tabulate >= 0.8.0, <0.9.0
 toml >= 0.9.4, < 1.0
 typing >= 3.6.4, < 4.0
 typing_extensions >= 3.6.4, < 4.0
-xxhash >= 1.2.0, < 2.0

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 import pendulum
-import xxhash
 from mypy_extensions import TypedDict
 
 import prefect


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Removes the xxhash dependency.


## Why is this PR important?
Unused dependencies should go bye bye

