### PR TITLE
Decrease dask worker timeout to 60s in CloudEnvironment

### DIFF
--- a/src/prefect/environments/execution/cloud/worker_pod.yaml
+++ b/src/prefect/environments/execution/cloud/worker_pod.yaml
@@ -7,7 +7,7 @@ spec:
   containers:
   - image: gcr.io/prefect-dev/prefect
     imagePullPolicy: IfNotPresent
-    args: [dask-worker, --no-bokeh, --death-timeout, '600']
+    args: [dask-worker, --no-bokeh, --death-timeout, '60']
     name: dask-worker
     env:
       - name: PREFECT__CLOUD__GRAPHQL


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Decreases the dask worker timeout to 60s (down from 600s)


## Why is this PR important?
If workers lose connection to the scheduler they don't need to sit around for 10 minutes and should just be killed quickly

