### PR TITLE
ResultHandler fixes and upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Refactor mapped caching to be independent of order - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
 - Refactor caching to allow for caching across multiple runs - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
+- Allow for custom secret names in Result Handlers - [#1098](https://github.com/PrefectHQ/prefect/issues/1098)
 
 ### Task Library
 
@@ -20,6 +21,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with mapped caching in Prefect Cloud - [#1096](https://github.com/PrefectHQ/prefect/pull/1096)
+- Fix issue with Result Handlers deserializing incorrectly in Cloud - [#1112](https://github.com/PrefectHQ/prefect/issues/1112)
 
 ### Breaking Changes
 

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -52,7 +52,9 @@ class Secret:
             try:
                 value = secrets[self.name]
             except KeyError:
-                raise ValueError("Secret {} was not found.".format(self.name)) from None
+                raise ValueError(
+                    "Local Secret {} was not found.".format(self.name)
+                ) from None
             try:
                 return json.loads(value)
             except (json.JSONDecodeError, TypeError):

--- a/src/prefect/engine/result_handlers/gcs_result_handler.py
+++ b/src/prefect/engine/result_handlers/gcs_result_handler.py
@@ -33,7 +33,6 @@ class GCSResultHandler(ResultHandler):
     ) -> None:
         self.bucket = bucket
         self.credentials_secret = credentials_secret
-        self.initialize_client()
         super().__init__()
 
     def initialize_client(self) -> None:

--- a/src/prefect/engine/result_handlers/gcs_result_handler.py
+++ b/src/prefect/engine/result_handlers/gcs_result_handler.py
@@ -26,9 +26,13 @@ class GCSResultHandler(ResultHandler):
     must be made available.
     """
 
-    def __init__(self, bucket: str = None, credentials_secret: str = None) -> None:
+    def __init__(
+        self,
+        bucket: str = None,
+        credentials_secret: str = "GOOGLE_APPLICATION_CREDENTIALS",
+    ) -> None:
         self.bucket = bucket
-        self.credentials_secret = credentials_secret or "GOOGLE_APPLICATION_CREDENTIALS"
+        self.credentials_secret = credentials_secret
         self.initialize_client()
         super().__init__()
 

--- a/src/prefect/engine/result_handlers/gcs_result_handler.py
+++ b/src/prefect/engine/result_handlers/gcs_result_handler.py
@@ -18,13 +18,17 @@ class GCSResultHandler(ResultHandler):
 
     Args:
         - bucket (str): the name of the bucket to write to / read from
+        - credentials_secret (str, optional): the name of the Prefect Secret
+            which stores a JSON representation of your Google Cloud credentials.
+            Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
 
     Note that for this result handler to work properly, your Google Application Credentials
     must be made available.
     """
 
-    def __init__(self, bucket: str = None) -> None:
+    def __init__(self, bucket: str = None, credentials_secret: str = None) -> None:
         self.bucket = bucket
+        self.credentials_secret = credentials_secret or "GOOGLE_APPLICATION_CREDENTIALS"
         self.initialize_client()
         super().__init__()
 
@@ -35,7 +39,7 @@ class GCSResultHandler(ResultHandler):
         from google.oauth2.service_account import Credentials
         from google.cloud import storage
 
-        creds = Secret("GOOGLE_APPLICATION_CREDENTIALS").get()
+        creds = Secret(self.credentials_secret).get()
         credentials = Credentials.from_service_account_info(creds)
         project = credentials.project_id
         client = storage.Client(project=project, credentials=credentials)

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -33,7 +33,6 @@ class S3ResultHandler(ResultHandler):
     ) -> None:
         self.bucket = bucket
         self.aws_credentials_secret = aws_credentials_secret
-        self.initialize_client()
         super().__init__()
 
     def initialize_client(self) -> None:

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -20,13 +20,19 @@ class S3ResultHandler(ResultHandler):
 
     Args:
         - bucket (str): the name of the bucket to write to / read from
+        - aws_credentials_secret (str, optional): the name of the Prefect Secret
+            which stores your AWS credentials; this Secret must be a JSON string
+            with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY`
 
     Note that for this result handler to work properly, your AWS Credentials must
     be made available in the `"AWS_CREDENTIALS"` Prefect Secret.
     """
 
-    def __init__(self, bucket: str = None) -> None:
+    def __init__(
+        self, bucket: str = None, aws_credentials_secret: str = "AWS_CREDENTIALS"
+    ) -> None:
         self.bucket = bucket
+        self.aws_credentials_secret = aws_credentials_secret
         self.initialize_client()
         super().__init__()
 
@@ -36,7 +42,7 @@ class S3ResultHandler(ResultHandler):
         """
         import boto3
 
-        aws_credentials = Secret("AWS_CREDENTIALS").get()
+        aws_credentials = Secret(self.aws_credentials_secret).get()
         if isinstance(aws_credentials, str):
             aws_credentials = json.loads(aws_credentials)
 

--- a/src/prefect/serialization/result_handlers.py
+++ b/src/prefect/serialization/result_handlers.py
@@ -51,6 +51,7 @@ class GCSResultHandlerSchema(BaseResultHandlerSchema):
         object_class = GCSResultHandler
 
     bucket = fields.String(allow_none=False)
+    credentials_secret = fields.String(allow_none=True)
 
 
 class JSONResultHandlerSchema(BaseResultHandlerSchema):
@@ -70,6 +71,7 @@ class S3ResultHandlerSchema(BaseResultHandlerSchema):
         object_class = S3ResultHandler
 
     bucket = fields.String(allow_none=False)
+    aws_credentials_secret = fields.String(allow_none=True)
 
 
 class ResultHandlerSchema(OneOfSchema):

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -212,6 +212,19 @@ class TestS3ResultHandler:
             "aws_secret_access_key": 42,
         }
 
+    def test_s3_client_init_uses_custom_secrets(self, s3_client):
+        with prefect.context(
+            secrets=dict(MY_FOO=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=999))
+        ):
+            with set_temporary_config({"cloud.use_local_secrets": True}):
+                handler = S3ResultHandler(bucket="bob", aws_credentials_secret="MY_FOO")
+
+        assert handler.bucket == "bob"
+        assert s3_client.call_args[1] == {
+            "aws_access_key_id": 1,
+            "aws_secret_access_key": 999,
+        }
+
     def test_s3_writes_to_blob_prefixed_by_date_suffixed_by_prefect(self, s3_client):
         with prefect.context(
             secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR allows for pulling credentials from custom-named Prefect Secrets in both the `GCSResultHandler` and `S3ResultHandler`.  In addition, it ensures that clients are not created during initialization / deserialization.


## Why is this PR important?
Improper deserialization was throwing errors on some Flows in Cloud. Having customizable secret names is important when multiple users want to access different resources within a tenant.

Closes #1098 
Closes #1112 