### PR TITLE
Add auto generated property to task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Refactor caching to allow for caching across multiple runs - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
 - Allow for custom secret names in Result Handlers - [#1098](https://github.com/PrefectHQ/prefect/issues/1098)
 - Have `execute cloud-flow` CLI immediately set the flow run state to `Failed` if environment fails - [#1122](https://github.com/PrefectHQ/prefect/pull/1122)
+- Add `auto_generated` property to Tasks for convenient filtering - [#1135](https://github.com/PrefectHQ/prefect/pull/1135)
 
 ### Task Library
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -223,6 +223,15 @@ class Task(metaclass=SignatureValidator):
             self.state_handlers.append(
                 callback_factory(on_failure, check=lambda s: s.is_failed())
             )
+        self.auto_generated = False
+
+    @property
+    def auto_generated(self) -> bool:
+        return self._auto_generated
+
+    @auto_generated.setter
+    def auto_generated(self, val: bool) -> None:
+        self._auto_generated = val
 
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -225,14 +225,6 @@ class Task(metaclass=SignatureValidator):
             )
         self.auto_generated = False
 
-    @property
-    def auto_generated(self) -> bool:
-        return self._auto_generated
-
-    @auto_generated.setter
-    def auto_generated(self, val: bool) -> None:
-        self._auto_generated = val
-
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)
 

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -63,10 +63,12 @@ class TaskMethodsMixin:
         cache.
         """
         slug = data.get("slug")
+        auto_generated = data.pop("auto_generated", False)
 
         # if the slug is not in the task cache, create a task object and add it
         if slug not in self.context.setdefault("task_cache", {}):  # type: ignore
             task = super().create_object(data)  # type: ignore
+            task.auto_generated = auto_generated  # type: ignore
             self.context["task_cache"][slug] = task  # type: ignore
 
         # return the task object from the cache
@@ -119,6 +121,7 @@ class TaskSchema(TaskMethodsMixin, ObjectSchema):
         reject_invalid=False,
         allow_none=True,
     )
+    auto_generated = fields.Boolean(allow_none=True)
 
 
 class ParameterSchema(TaskMethodsMixin, ObjectSchema):

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -59,21 +59,26 @@ def as_task(x: Any) -> "prefect.Task":
 
     # collections
     elif isinstance(x, list):
-        return prefect.tasks.core.collections.List().bind(*x)
+        return_task = prefect.tasks.core.collections.List().bind(*x)
     elif isinstance(x, tuple):
-        return prefect.tasks.core.collections.Tuple().bind(*x)
+        return_task = prefect.tasks.core.collections.Tuple().bind(*x)
     elif isinstance(x, set):
-        return prefect.tasks.core.collections.Set().bind(*x)
+        return_task = prefect.tasks.core.collections.Set().bind(*x)
     elif isinstance(x, dict):
         keys, values = [], []
         for k, v in x.items():
             keys.append(k)
             values.append(v)
-        return prefect.tasks.core.collections.Dict().bind(keys=keys, values=values)
+        return_task = prefect.tasks.core.collections.Dict().bind(
+            keys=keys, values=values
+        )
 
     # constants
     else:
-        return prefect.tasks.core.constants.Constant(value=x)
+        return_task = prefect.tasks.core.constants.Constant(value=x)
+
+    return_task.auto_generated = True
+    return return_task
 
 
 def pause_task(message: str = None) -> None:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -136,6 +136,18 @@ class TestCreateFlow:
         f2 = Flow(name="test")
         assert isinstance(f2.environment, prefect.environments.CloudEnvironment)
 
+    def test_create_flow_auto_generates_tasks(self):
+        with Flow("auto") as f:
+            res = AddTask()(x=1, y=2)
+
+        assert res.auto_generated is False
+        assert all(
+            [
+                t.auto_generated is True
+                for t in f.get_tasks(task_type=prefect.tasks.core.constants.Constant)
+            ]
+        )
+
 
 def test_add_task_to_flow():
     f = Flow(name="test")

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -26,6 +26,9 @@ class TestCreateTask:
         """Tasks can be created with no arguments"""
         assert Task()
 
+    def test_create_task_is_not_auto_generated(self):
+        assert Task().auto_generated is False
+
     def test_create_task_with_name(self):
         t1 = Task()
         assert t1.name == "Task"

--- a/tests/serialization/test_tasks.py
+++ b/tests/serialization/test_tasks.py
@@ -16,6 +16,7 @@ def test_serialize_empty_dict():
 def test_deserialize_empty_dict():
     t = TaskSchema().load({})
     assert isinstance(t, Task)
+    assert t.auto_generated is False
 
 
 def test_serialize_task():
@@ -46,6 +47,14 @@ def test_deserialize_task():
         "cache_for",
     ]:
         assert getattr(task, key) == getattr(deserialized, key)
+    assert task.auto_generated is False
+
+
+def test_deserialize_auto_generated_task():
+    task = Task(name="hi")
+    task.auto_generated = True
+    deserialized = TaskSchema().load(TaskSchema().dump(task))
+    assert task.auto_generated is True
 
 
 def test_deserialize_task_subclass_is_task_but_not_task_subclass():

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -114,10 +114,16 @@ class TestAsTask:
             val = return_val(t)
 
         assert isinstance(t, Task)
+        assert t.auto_generated is True
         res = FlowRunner(f).run(return_tasks=[val])
 
         assert res.is_successful()
         assert res.result[val].result == obj
+
+    def test_as_task_doesnt_label_tasks_as_auto_generated(self):
+        t = Task()
+        assert t.auto_generated is False
+        assert tasks.as_task(t).auto_generated is False
 
 
 def test_tag_contextmanager_works_with_task_decorator():
@@ -192,6 +198,7 @@ class TestUnmappedContainer:
         t1 = Task()
         unmapped_t1 = tasks.unmapped(t1)
         assert tasks.as_task(t1) is t1
+        assert tasks.as_task(t1).auto_generated is False
 
 
 class TestPauseTask:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a new `auto_generated` property to all Tasks which is set only when using the `as_task` utility method. This property allows for convenient filtering of tasks when making graphql queries, in the UI, etc. etc.

## Why is this PR important?
Useful for filtering out "noise".