### PR TITLE
Add validation for configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Refactor caching to allow for caching across multiple runs - [#1082](https://github.com/PrefectHQ/prefect/issues/1082)
 - Allow for custom secret names in Result Handlers - [#1098](https://github.com/PrefectHQ/prefect/issues/1098)
 - Have `execute cloud-flow` CLI immediately set the flow run state to `Failed` if environment fails - [#1122](https://github.com/PrefectHQ/prefect/pull/1122)
+- Validate configuration objects on initial load - [#1136](https://github.com/PrefectHQ/prefect/pull/1136)
 
 ### Task Library
 

--- a/docs/guide/core_concepts/configuration.md
+++ b/docs/guide/core_concepts/configuration.md
@@ -10,6 +10,10 @@ Any Prefect configuration key can be set by environment variable. In order to do
 
 For example, if you set `PREFECT__TASKS__DEFAULTS__MAX_RETRIES=4`, then `prefect.config.tasks.defaults.max_retries == 4`.
 
+::: tip Config keys are lowercase
+Environment variables are always interpreted as lowercase configuration keys.
+:::
+
 ### Automatic type casting
 
 Prefect will do its best to detect the type of your environment variable and cast it appropriately.
@@ -50,6 +54,8 @@ path = "$DIR/file.txt"
 
 In this case, loading `prefect.config.path == "/foo/file.txt"`
 
+Environment variables are always interpreted as lowercase values.
+
 #### Configuration interpolation
 
 If a string value refers to any other configuration key, enclosed in "\${" and "}", then the value of that key will be interpolated at runtime. This process is iterated a few times to resolve multiple references.
@@ -75,14 +81,20 @@ user = "${environments.${environment}}"
 
 [environments]
 
-    [environments.DEV]
+    [environments.dev]
         user = "test"
 
-    [environments.PROD]
+    [environments.prod]
         user = "admin"
 ```
 
 ```python
-assert prefect.config.environment == "PROD"
+assert prefect.config.environment == "prod"
 assert prefect.config.user == "admin"
 ```
+
+#### Validation
+
+Configs are recursively validated when first loaded. `ValueErrors` are raised for invalid config definitions. The checks include:
+    - invalid keys: because `Config` objects have dictionary-like methods, it can create problems if any of their keys shadow one of their methods. For example, `"keys"` is an invalid key because `Config.keys()` is an important method.
+    - uppercase keys: all config keys should be lowercase, because only lowercase keys can be set by environment variables.

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -1,3 +1,4 @@
+import inspect
 import datetime
 import logging
 import os
@@ -245,9 +246,36 @@ def process_task_defaults(config: Config) -> Config:
 
 def validate_config(config: Config) -> None:
     """
-    Placeholder for future config validation. For example, invalid values could raise an error.
+    Validates that the configuration file is valid.
+        - keys are lowercase
+        - keys do not shadow Config methods
+
+    Note that this is performed when the config is first loaded, but not after.
     """
-    pass
+
+    def check_lowercase_keys(config: Config) -> None:
+        """
+        Recursively check that keys are lowercase
+        """
+        for k, v in config.items():
+            if k != k.lower():
+                raise ValueError('Config keys must be lowercase: "{}"'.format(k))
+            if isinstance(v, Config):
+                check_lowercase_keys(v)
+
+    def check_valid_keys(config: Config) -> None:
+        """
+        Recursively check that keys do not shadow methods of the Config object
+        """
+        invalid_keys = dir(Config)
+        for k, v in config.items():
+            if k in invalid_keys:
+                raise ValueError('Invalid config key: "{}"'.format(k))
+            if isinstance(v, Config):
+                check_valid_keys(v)
+
+    check_lowercase_keys(config)
+    check_valid_keys(config)
 
 
 # Load configuration ----------------------------------------------------------
@@ -258,7 +286,7 @@ def load_toml(path: str) -> dict:
     Loads a config dictionary from TOML
     """
     return {
-        key.lower(): value
+        key: value
         for key, value in toml.load(cast(str, interpolate_env_vars(path))).items()
     }
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -401,4 +401,3 @@ class TestConfigValidation:
 
             with pytest.raises(ValueError):
                 configuration.load_configuration(test_config.name)
-


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- Adds two validation steps for configuration files:
1. makes sure config keys don't shadow methods of the `Config` object, which causes nasty errors if you try to interact with the object (for example, a config key called "keys" would shadow the `Config.keys()` method).
2. makes sure config keys are lowercase, because keys set by environment variables are always interpreted as lowercase, so upper case key's can't be set by env var.


## Why is this PR important?


