### PR TITLE
Ensure context config can still be interpreted in a case-sensitive way

### DIFF
--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -260,7 +260,7 @@ def validate_config(config: Config) -> None:
         for k, v in config.items():
             if k != k.lower():
                 raise ValueError('Config keys must be lowercase: "{}"'.format(k))
-            if isinstance(v, Config):
+            if isinstance(v, Config) and k != "context":
                 check_lowercase_keys(v)
 
     def check_valid_keys(config: Config) -> None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -401,3 +401,36 @@ class TestConfigValidation:
 
             with pytest.raises(ValueError):
                 configuration.load_configuration(test_config.name)
+
+    def test_non_lowercase_keys_are_ok_in_context(self):
+
+        with tempfile.NamedTemporaryFile() as test_config:
+            test_config.write(
+                b"""
+                [context]
+                KeY = 1
+                """
+            )
+            test_config.seek(0)
+
+            config = configuration.load_configuration(test_config.name)
+
+        assert "KeY" in config.context
+        assert config.context.KeY == 1
+
+    def test_non_lowercase_keys_are_ok_in_context_subsections(self):
+
+        with tempfile.NamedTemporaryFile() as test_config:
+            test_config.write(
+                b"""
+                [context.secrets]
+                API_CREDS = 4
+                """
+            )
+            test_config.seek(0)
+
+            config = configuration.load_configuration(test_config.name)
+
+        assert "secrets" in config.context
+        assert "API_CREDS" in config.context.secrets
+        assert config.context.secrets["API_CREDS"] == 4


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
#1136 accidentally removed the ability to use local secrets, which are typically stored as all uppercase var names.  In fact, it removed the ability to set case sensitive keys in context, which is important.  This PR ensures that context is treated specially and not case-handled in any particular way.