### PR TITLE
Welcome back old friend

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,11 @@ ignore_errors = True
 disallow_untyped_defs = False
 check_untyped_defs = True
 
+[coverage:paths]
+source=
+    src/prefect
+    */site-packages/prefect
+
 [coverage:run]
 omit=
     # special files
@@ -46,8 +51,7 @@ omit=
     **__init__.py
     *_version.py
     *_siginfo.py
-source = src/prefect
-parallel = False
+parallel = True
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
Updates `setup.cfg` to identify `src/prefect` with `site-packages/prefect` so that the path names that are uploaded to codecov are correct.  I still don't know what changed to trigger this behavior, but here we are.

Closes #1132 