### PR TITLE
Serialize secret name

### DIFF
--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -44,7 +44,10 @@ class CloudEnvironment(Environment):
     ) -> None:
         self.identifier_label = str(uuid.uuid4())
         self.private_registry = private_registry
-        self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
+        if self.private_registry:
+            self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
+        else:
+            self.docker_secret = None
         self.logger = logging.get_logger("CloudEnvironment")
 
     def setup(self, storage: "Docker") -> None:  # type: ignore

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -47,7 +47,7 @@ class CloudEnvironment(Environment):
         if self.private_registry:
             self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
         else:
-            self.docker_secret = None
+            self.docker_secret = None  # type: ignore
         self.logger = logging.get_logger("CloudEnvironment")
 
     def setup(self, storage: "Docker") -> None:  # type: ignore

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -19,6 +19,7 @@ class CloudEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = CloudEnvironment
 
+    docker_secret = fields.String(allow_none=True)
     private_registry = fields.Boolean(allow_none=False)
 
 

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -17,6 +17,8 @@ from prefect.utilities.configuration import set_temporary_config
 def test_create_cloud_environment():
     environment = CloudEnvironment()
     assert environment
+    assert environment.private_registry is False
+    assert environment.docker_secret is None
 
 
 def test_create_cloud_environment_identifier_label():
@@ -32,6 +34,7 @@ def test_setup_cloud_environment_passes():
 
 def test_setup_doesnt_pass_if_private_registry(monkeypatch):
     environment = CloudEnvironment(private_registry=True)
+    assert environment.docker_secret == "DOCKER_REGISTRY_CREDENTIALS"
 
     config = MagicMock()
     monkeypatch.setattr("kubernetes.config", config)

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -20,16 +20,23 @@ def test_serialize_cloud_environment():
     serialized = CloudEnvironmentSchema().dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
+    assert "docker_secret" not in serialized
+
+    new = schema.load(serialized)
+    assert new.private_registry is False
+    assert new.docker_secret is None
 
 
 def test_serialize_cloud_environment_with_private_registry():
-    env = environments.CloudEnvironment(private_registry=True)
+    env = environments.CloudEnvironment(private_registry=True, docker_secret="FOO")
 
     schema = CloudEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
     assert serialized["private_registry"] is True
+    assert serialized["docker_secret"] == "FOO"
 
     new = schema.load(serialized)
     assert new.private_registry is True
+    assert new.docker_secret == "FOO"

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -17,7 +17,8 @@ def test_serialize_base_environment():
 def test_serialize_cloud_environment():
     env = environments.CloudEnvironment()
 
-    serialized = CloudEnvironmentSchema().dump(env)
+    schema = CloudEnvironmentSchema()
+    serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
     assert serialized["docker_secret"] is None

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -20,7 +20,7 @@ def test_serialize_cloud_environment():
     serialized = CloudEnvironmentSchema().dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert "docker_secret" not in serialized
+    assert serialized["docker_secret"] is None
 
     new = schema.load(serialized)
     assert new.private_registry is False


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that the `CloudEnvironment` docker secret attribute is serialized correctly.  Note that I've set it to `None` if not using a private registry, so that when displayed in the UI it isn't misleading.


## Why is this PR important?
For users which require multiple docker secrets for multiple private registries, being able to customize the name is important.  Prior to this PR, serialization was not preserving the custom secret name.