### PR TITLE
Call sys.exit when cloud environment finishes running flow

### DIFF
--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import sys
 import time
 import uuid
 from os import path
@@ -213,6 +214,7 @@ class CloudEnvironment(Environment):
                     executor = DaskExecutor(address=cluster.scheduler_address)
                     runner_cls = get_default_flow_runner_class()
                     runner_cls(flow=flow).run(executor=executor)
+                    sys.exit(0)  # attempt to force resource cleanup
         except Exception as exc:
             self.logger.error("Unexpected error raised during flow run: {}".format(exc))
             raise exc

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -145,6 +145,9 @@ def test_run_flow(monkeypatch):
         "prefect.engine.get_default_flow_runner_class",
         MagicMock(return_value=flow_runner),
     )
+    monkeypatch.setattr(
+        "prefect.environments.execution.cloud.environment.sys.exit", MagicMock()
+    )
 
     kube_cluster = MagicMock()
     monkeypatch.setattr("dask_kubernetes.KubeCluster", kube_cluster)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR explicitly calls `sys.exit` when the `CloudEnvironment` is done running its flow.  


## Why is this PR important?
We occasionally see kubernetes jobs in which the Flow is visibly complete (based on its state, logs, etc.) but the Dask Cluster remains alive in k8s.  It appears to happen more frequently for Python 3.7 jobs, and _appears_ to be caused by a hanging Python process that is stuck in some sort of garbage collection phase.  Explicitly calling `sys.exit` will hopefully trigger the appropriate resource cleanup and end these jobs so that the resource manager doesn't have to worry about cleaning them up.