### PR TITLE
Switch sys.exit to os._exit in CloudEnvironment

### DIFF
--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -1,6 +1,6 @@
 import base64
 import json
-import sys
+import os
 import time
 import uuid
 from os import path
@@ -214,7 +214,7 @@ class CloudEnvironment(Environment):
                     executor = DaskExecutor(address=cluster.scheduler_address)
                     runner_cls = get_default_flow_runner_class()
                     runner_cls(flow=flow).run(executor=executor)
-                    sys.exit(0)  # attempt to force resource cleanup
+                    os._exit(0)  # attempt to force resource cleanup
         except Exception as exc:
             self.logger.error("Unexpected error raised during flow run: {}".format(exc))
             raise exc

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -146,7 +146,7 @@ def test_run_flow(monkeypatch):
         MagicMock(return_value=flow_runner),
     )
     monkeypatch.setattr(
-        "prefect.environments.execution.cloud.environment.sys.exit", MagicMock()
+        "prefect.environments.execution.cloud.environment.os._exit", MagicMock()
     )
 
     kube_cluster = MagicMock()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Changes cloud environment sys.exit to use os._exit


## Why is this PR important?
sys.exit was trapped inside of the try/except block

