### PR TITLE
Typo fix in docs (right-hand side of assignment should be a tuple)

### DIFF
--- a/docs/guide/tutorials/local-debugging.md
+++ b/docs/guide/tutorials/local-debugging.md
@@ -203,7 +203,7 @@ Using our silly flow from above, let's define a new task and swap it out using t
 def fixed():
     tup = ('a', ('b',))
     try:
-        tup[1] += ('c')
+        tup[1] += ('c',)
     except TypeError:
         assert len(tup[1]) == 1
 


### PR DESCRIPTION
Tiny typo fix which was missed in #1160.