### PR TITLE
Ensure results can be passed to Prefect Signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with mapped caching in Prefect Cloud - [#1096](https://github.com/PrefectHQ/prefect/pull/1096)
 - Fix issue with Result Handlers deserializing incorrectly in Cloud - [#1112](https://github.com/PrefectHQ/prefect/issues/1112)
 - Fix issue caused by breaking change in `marshmallow==3.0.0rc7` - [#1151](https://github.com/PrefectHQ/prefect/pull/1151)
+- Fix issue with passing results to Prefect signals - [#1163](https://github.com/PrefectHQ/prefect/issues/1163)
 
 ### Breaking Changes
 

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -23,8 +23,9 @@ class PrefectStateSignal(PrefectError):
 
     def __init__(self, message: str = None, *args, **kwargs):  # type: ignore
         super().__init__(message)  # type: ignore
+        kwargs.setdefault("result", self)
         self.state = self._state_cls(  # type: ignore
-            result=self, message=message, *args, **kwargs
+            message=message, *args, **kwargs
         )
 
 

--- a/tests/engine/test_signals.py
+++ b/tests/engine/test_signals.py
@@ -38,6 +38,14 @@ def test_signals_create_states():
     assert exc.value.state.message == "message"
 
 
+def test_signals_create_states_with_results():
+    with pytest.raises(Exception) as exc:
+        raise PrefectStateSignal("message", result=5)
+    assert isinstance(exc.value.state, State)
+    assert exc.value.state.result == 5
+    assert exc.value.state.message == "message"
+
+
 def test_signals_dont_pass_invalid_arguments_to_states():
     with pytest.raises(TypeError):
         raise SUCCESS(bad_result=100)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Ensures that the `result` kwarg can be passed to the underlying state associated with a Prefect signal. 


## Why is this PR important?
Closes #1163 