### PR TITLE
Disable work stealing in Dask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Have `execute cloud-flow` CLI immediately set the flow run state to `Failed` if environment fails - [#1122](https://github.com/PrefectHQ/prefect/pull/1122)
 - Validate configuration objects on initial load - [#1136](https://github.com/PrefectHQ/prefect/pull/1136)
 - Add `auto_generated` property to Tasks for convenient filtering - [#1135](https://github.com/PrefectHQ/prefect/pull/1135)
+- Disable dask work-stealing in kubernetes via scheduler config - [#1166](https://github.com/PrefectHQ/prefect/pull/1166)
 
 ### Task Library
 

--- a/src/prefect/environments/execution/cloud/job.yaml
+++ b/src/prefect/environments/execution/cloud/job.yaml
@@ -47,6 +47,8 @@ spec:
               value: "DEBUG"
             - name: PREFECT__DEBUG
               value: "true"
+            - name: DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING
+              value: "false"
             - name: DASK_DISTRIBUTED__SCHEDULER__BLOCKED_HANDLERS
               value: "['feed', 'run_function']"
           resources:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Disable dask [work stealing](http://distributed.dask.org/en/latest/work-stealing.html) via env var config.

## Why is this PR important?
We saw a few situations in which a task future was resolved twice; because of our version lock system the task didn't actually _execute_ twice, but it did add some noise to the logs that we'd like to prevent.