### PR TITLE
Update dask config to False

### DIFF
--- a/src/prefect/environments/execution/cloud/job.yaml
+++ b/src/prefect/environments/execution/cloud/job.yaml
@@ -48,7 +48,7 @@ spec:
             - name: PREFECT__DEBUG
               value: "true"
             - name: DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING
-              value: "false"
+              value: "False"
             - name: DASK_DISTRIBUTED__SCHEDULER__BLOCKED_HANDLERS
               value: "['feed', 'run_function']"
           resources:


### PR DESCRIPTION
I pattern matched with our other boolean configs, but Prefect's type casting is more generous than Dask's, so this setting needs to be properly cased.