### PR TITLE
slack_notifier pulls from secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Breaking Changes
 
 - The CLI command `prefect execute-flow` and `prefect execute-cloud-flow` no longer exist - [#1059](https://github.com/PrefectHQ/prefect/pull/1059)
+- The `slack_notifier` state handler now uses a `webhook_secret` kwarg to pull the URL from a Secret - [#1075](https://github.com/PrefectHQ/prefect/issues/1075)
 
 ### Contributors
 

--- a/src/prefect/utilities/notifications.py
+++ b/src/prefect/utilities/notifications.py
@@ -227,7 +227,7 @@ def slack_notifier(
     new_state: "prefect.engine.state.State",
     ignore_states: list = None,
     only_states: list = None,
-    webhook_url: str = None,
+    webhook_secret: str = None,
 ) -> "prefect.engine.state.State":
     """
     Slack state change handler; requires having the Prefect slack app installed.
@@ -243,8 +243,8 @@ def slack_notifier(
             e.g., `[Running, Scheduled]`. If `new_state` is an instance of one of the passed states, no notification will occur.
         - only_states ([State], optional): similar to `ignore_states`, but
             instead _only_ notifies you if the Task / Flow is in a state from the provided list of `State` classes
-        - webhook_url (str, optional): the Prefect slack app webhook URL; if not
-            provided, will attempt to use your `"SLACK_WEBHOOK_URL"` Prefect Secret
+        - webhook_secret (str, optional): the name of the Prefect Secret which stores your slack webhook URL;
+            defaults to `"SLACK_WEBHOOK_URL"`
 
     Returns:
         - State: the `new_state` object which was provided
@@ -263,7 +263,7 @@ def slack_notifier(
         ```
     """
     webhook_url = cast(
-        str, webhook_url or prefect.client.Secret("SLACK_WEBHOOK_URL").get()
+        str, prefect.client.Secret(webhook_secret or "SLACK_WEBHOOK_URL").get()
     )
     ignore_states = ignore_states or []
     only_states = only_states or []


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR changes the `slack_notifier` kwarg `webhook_url` to `webhook_secret`.  Now you must specify a secret name instead of the URL directly.  This:
- ensures consistency with other slack tasks
- encourages best practices with sensitive information


## Why is this PR important?
Closes #1075 