### PR TITLE
Call join on heartbeat timer to ensure thread is cleaned

### DIFF
--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -50,6 +50,7 @@ def run_with_heartbeat(
             return runner_method(self, *args, **kwargs)
         finally:
             timer.cancel()
+            timer.join()
 
     return inner
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -23,6 +23,7 @@ def test_heartbeat_calls_function_on_interval():
     timer.start()
     time.sleep(0.2)
     timer.cancel()
+    timer.join()
     assert a.called == 2
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
For best practices, also calls `.join()` on the heartbeat timer thread after cancel.  It turns out that `.cancel()` doesn't guarantee that the thread itself is killed, but rather that the function the Timer is calling will not be called.  

## Why is this PR important?
I have a suspicion that this is at the heart of the various hanging processes we've seen in different situations (possibly even the hanging CircleCI jobs...).  I can't prove it, but we'll find out!

