### PR TITLE
Bump dask-kubernetes version to 0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
         "google-cloud-bigquery >= 1.6.0, < 2.0",
         "google-cloud-storage >= 1.13, < 2.0",
     ],
-    "kubernetes": ["kubernetes >= 9.0.0a1, < 10.0", "dask-kubernetes == 0.7.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1, < 10.0", "dask-kubernetes == 0.8.0"],
     "rss": ["feedparser >= 5.0.1, < 6.0"],
     "postgres": ["psycopg2-binary >= 2.8.2"],
     "redis": ["redis >= 3.2.1"],


### PR DESCRIPTION
In order to support Kubernetes 9.0.0 API changes we need dask-kubernetes to be on 0.8.0