### PR TITLE
Long-running Mapped Retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with passing results to Prefect signals - [#1163](https://github.com/PrefectHQ/prefect/issues/1163)
 - Fix issue with `flow.update` not preserving mapped edges - [#1164](https://github.com/PrefectHQ/prefect/issues/1164)
 - Fix issue with Parameters and Context not being raw dictionaries - [#1186](https://github.com/PrefectHQ/prefect/issues/1186)
+- Fix issue with asynchronous, long-running mapped retries in Prefect Cloud - [#1208](https://github.com/PrefectHQ/prefect/pull/1208) 
 
 ### Breaking Changes
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -600,7 +600,6 @@ class TaskRunner(Runner):
                 return Pending("Cache was invalid; ready to run.")
         return state
 
-    @call_state_handlers
     def run_mapped_task(
         self,
         state: State,
@@ -701,14 +700,23 @@ class TaskRunner(Runner):
             initial_states = []
         initial_states.extend([None] * (len(map_upstream_states) - len(initial_states)))
 
+        current_state = Mapped(  # type: ignore
+            message="Preparing to submit {} mapped tasks.".format(len(initial_states)),
+            map_states=initial_states,
+        )
+        state = self.handle_state_change(old_state=state, new_state=current_state)
+        if state is not current_state:
+            return state
+
         # map over the initial states, a counter representing the map_index, and also the mapped upstream states
         map_states = executor.map(
             run_fn, initial_states, range(len(map_upstream_states)), map_upstream_states
         )
 
-        return Mapped(
+        new_state = Mapped(
             message="Mapped tasks submitted for execution.", map_states=map_states
         )
+        return self.handle_state_change(old_state=state, new_state=new_state)
 
     @call_state_handlers
     def wait_for_mapped_task(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1926,7 +1926,7 @@ class TestFlowRunMethod:
         assert flow_state.is_successful()
         assert all([s.is_successful() for s in flow_state.result[res].map_states])
         assert res.call_count == 4
-        assert len(state_history) == 11
+        assert len(state_history) == 13
 
     def test_flow_run_accepts_state_kwarg(self):
         f = Flow(name="test")

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1355,7 +1355,7 @@ class TestRunMappedStep:
     @pytest.mark.parametrize("state", [Pending(), Mapped(), Scheduled()])
     def test_run_mapped_returns_mapped(self, state):
         state = TaskRunner(task=Task()).run_mapped_task(
-            state=Pending(),
+            state=state,
             upstream_states={},
             context={},
             executor=prefect.engine.executors.LocalExecutor(),

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1289,10 +1289,10 @@ class TestTaskRunnerStateHandlers:
         state = runner.run(
             upstream_states={Edge(Task(), Task(), mapped=True): Success(result=[1])}
         )
-        # the parent task changed state one time: Pending -> Mapped
+        # the parent task changed state two times: Pending -> Mapped -> Mapped
         # the child task changed state one time: Pending -> Running -> Success
         assert isinstance(state, Mapped)
-        assert task_runner_handler.call_count == 3
+        assert task_runner_handler.call_count == 4
 
     def test_multiple_task_runner_handlers_are_called(self):
         task_runner_handler = MagicMock(side_effect=lambda t, o, n: n)
@@ -1367,7 +1367,7 @@ class TestRunMappedStep:
         def tt(foo):
             pass
 
-        with prefect.context(cloud=True):
+        with prefect.context(cloud=True, caches={}):
             state = TaskRunner(task=tt).run_mapped_task(
                 state=Pending(),
                 upstream_states={
@@ -1474,10 +1474,10 @@ def test_mapped_tasks_parents_and_children_respond_to_individual_triggers():
     state = runner.run(
         upstream_states={Edge(Task(), Task(), mapped=True): Success(result=[1])}
     )
-    # the parent task changed state one time: Pending -> Mapped
+    # the parent task changed state two times: Pending -> Mapped -> Mapped
     # the child task changed state one time: Pending -> TriggerFailed
     assert isinstance(state, Mapped)
-    assert task_runner_handler.call_count == 2
+    assert task_runner_handler.call_count == 3
     assert isinstance(state.map_states[0], TriggerFailed)
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes an issue that we recently observed in Prefect Cloud - if a Task is mapping over a large number of slow-running children, and one of those child tasks goes into immediate Retry, the asynchronously retrying Flow Run does not have access to the `Mapped` state and thus cannot regenerate its children appropriately. 


## Why is this PR important?
For large scale mapped Flows, retries need to work properly!