### PR TITLE
Don't redundantly set flow run state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
 
       - run:
           name: Install Airflow
-          command: source activate airflow && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install apache-airflow && source deactivate
+          command: source activate airflow && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install apache-airflow flask==1.0.4 && source deactivate
 
       - run:
           name: Install prefect

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -492,6 +492,7 @@ class FlowRunner(Runner):
         # check that the flow is finished
         if not all(s.is_finished() for s in terminal_states):
             self.logger.info("Flow run RUNNING: terminal tasks are incomplete.")
+            state.result = return_states
 
         # check if any key task failed
         elif any(s.is_failed() for s in key_states):

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -462,6 +462,7 @@ class FlowRunner(Runner):
         return_states = {t: final_states[t] for t in return_tasks}
 
         state = self.determine_final_state(
+            state=state,
             key_states=key_states,
             return_states=return_states,
             terminal_states=terminal_states,
@@ -471,6 +472,7 @@ class FlowRunner(Runner):
 
     def determine_final_state(
         self,
+        state: State,
         key_states: Set[State],
         return_states: Dict[Task, State],
         terminal_states: Set[State],
@@ -479,6 +481,7 @@ class FlowRunner(Runner):
         Implements the logic for determining the final state of the flow run.
 
         Args:
+            - state (State): the current state of the Flow
             - key_states (Set[State]): the states which will determine the success / failure of the flow run
             - return_states (Dict[Task, State]): states to return as results
             - terminal_states (Set[State]): the states of the terminal tasks for this flow
@@ -486,12 +489,9 @@ class FlowRunner(Runner):
         Returns:
             - State: the final state of the flow run
         """
-        state = State()  # mypy initialization
-
         # check that the flow is finished
         if not all(s.is_finished() for s in terminal_states):
             self.logger.info("Flow run RUNNING: terminal tasks are incomplete.")
-            state = Running(message="Flow run in progress.", result=return_states)
 
         # check if any key task failed
         elif any(s.is_failed() for s in key_states):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -713,6 +713,9 @@ class TaskRunner(Runner):
             run_fn, initial_states, range(len(map_upstream_states)), map_upstream_states
         )
 
+        self.logger.debug(
+            "{} mapped tasks submitted for execution.".format(len(map_states))
+        )
         new_state = Mapped(
             message="Mapped tasks submitted for execution.", map_states=map_states
         )

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -506,6 +506,22 @@ class TestRunFlowStep:
         assert new_state.is_failed()
         assert new_state.message == "Very specific error message"
 
+    def test_determine_final_state_preserves_running_states_when_tasks_still_running(
+        self
+    ):
+        task = Task()
+        flow = Flow(name="test", tasks=[task])
+        old_state = Running()
+        new_state = FlowRunner(flow=flow).get_flow_run_state(
+            state=old_state,
+            task_states={task: Retrying(start_time=pendulum.now("utc").add(days=1))},
+            task_contexts={},
+            return_tasks=set(),
+            task_runner_state_handlers=[],
+            executor=LocalExecutor(),
+        )
+        assert new_state is old_state
+
 
 class TestInputCaching:
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR implements a minor optimization that prevents  a flow run `Running` state from being redundantly set twice.  In cloud, setting this state would increment all flow state versions and led to some annoying delays.