### PR TITLE
Fix collections automatical apply using the imperative API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Contributors
 
 - [Kwangyoun Jung](https://github.com/initialkommit)
+- [Anes Benmerzoug](https://github.com/AnesBenmerzoug)
 
 ## 0.5.4 <Badge text="beta" type="success"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with `flow.update` not preserving mapped edges - [#1164](https://github.com/PrefectHQ/prefect/issues/1164)
 - Fix issue with Parameters and Context not being raw dictionaries - [#1186](https://github.com/PrefectHQ/prefect/issues/1186)
 - Fix issue with asynchronous, long-running mapped retries in Prefect Cloud - [#1208](https://github.com/PrefectHQ/prefect/pull/1208) 
+- Fix issue with automatically applied collections to task call arguments when using the imperative API - [#1211](https://github.com/PrefectHQ/prefect/issues/1211)
 
 ### Breaking Changes
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -272,7 +272,7 @@ class Flow:
         if old not in self.tasks:
             raise ValueError("Task {t} was not found in Flow {f}".format(t=old, f=self))
 
-        new = as_task(new)
+        new = as_task(new, flow=self)
 
         # update tasks
         self.tasks.remove(old)

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -777,7 +777,7 @@ class Flow:
             - None
         """
 
-        task = as_task(task)
+        task = as_task(task, flow=self)
         assert isinstance(task, Task)  # mypy assert
 
         # add the main task (in case it was called with no arguments)
@@ -786,7 +786,7 @@ class Flow:
         # add upstream tasks
         for t in upstream_tasks or []:
             is_mapped = mapped & (not isinstance(t, unmapped))
-            t = as_task(t)
+            t = as_task(t, flow=self)
             assert isinstance(t, Task)  # mypy assert
             self.add_edge(
                 upstream_task=t,
@@ -797,14 +797,14 @@ class Flow:
 
         # add downstream tasks
         for t in downstream_tasks or []:
-            t = as_task(t)
+            t = as_task(t, flow=self)
             assert isinstance(t, Task)  # mypy assert
             self.add_edge(upstream_task=task, downstream_task=t, validate=validate)
 
         # add data edges to upstream tasks
         for key, t in (keyword_tasks or {}).items():
             is_mapped = mapped & (not isinstance(t, unmapped))
-            t = as_task(t)
+            t = as_task(t, flow=self)
             assert isinstance(t, Task)  # mypy assert
             self.add_edge(
                 upstream_task=t,

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -10,6 +10,8 @@ import prefect
 __all__ = ["tags", "as_task", "pause_task", "task", "unmapped", "defaults_from_attrs"]
 
 if TYPE_CHECKING:
+    import prefect.tasks.core.constants
+    import prefect.tasks.core.collections
     import prefect.tasks.core.function
     from prefect.core.flow import Flow  # pylint: disable=W0611
 

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -1,7 +1,7 @@
 import inspect
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Optional, Iterator
 
 from toolz import curry
 
@@ -11,6 +11,7 @@ __all__ = ["tags", "as_task", "pause_task", "task", "unmapped", "defaults_from_a
 
 if TYPE_CHECKING:
     import prefect.tasks.core.function
+    from prefect.core.flow import Flow  # pylint: disable=W0611
 
 
 @contextmanager
@@ -41,12 +42,13 @@ def tags(*tags: str) -> Iterator[None]:
         yield
 
 
-def as_task(x: Any) -> "prefect.Task":
+def as_task(x: Any, flow: Optional["Flow"] = None) -> "prefect.Task":
     """
     Wraps a function, collection, or constant with the appropriate Task type.
 
     Args:
         - x (object): any Python object to convert to a prefect Task
+        - flow (Flow, optional): Flow to which the prefect Task will be bound
 
     Returns:
         - a prefect Task representing the passed object
@@ -59,18 +61,18 @@ def as_task(x: Any) -> "prefect.Task":
 
     # collections
     elif isinstance(x, list):
-        return_task = prefect.tasks.core.collections.List().bind(*x)
+        return_task = prefect.tasks.core.collections.List().bind(*x, flow=flow)
     elif isinstance(x, tuple):
-        return_task = prefect.tasks.core.collections.Tuple().bind(*x)
+        return_task = prefect.tasks.core.collections.Tuple().bind(*x, flow=flow)
     elif isinstance(x, set):
-        return_task = prefect.tasks.core.collections.Set().bind(*x)
+        return_task = prefect.tasks.core.collections.Set().bind(*x, flow=flow)
     elif isinstance(x, dict):
         keys, values = [], []
         for k, v in x.items():
             keys.append(k)
             values.append(v)
         return_task = prefect.tasks.core.collections.Dict().bind(
-            keys=keys, values=values
+            keys=keys, values=values, flow=flow
         )
 
     # constants

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1334,6 +1334,18 @@ class TestReplace:
         assert state.is_successful()
         assert state.result[res].result == 61
 
+    def test_replace_converts_new_collections_to_tasks(self):
+        add = AddTask()
+        with Flow(name="test") as f:
+            x, y = Parameter("x"), Parameter("y")
+            res = add(x, y)
+        f.replace(x, [55, 56])
+        f.replace(y, [1, 2])
+        assert len(f.tasks) == 7
+        state = f.run()
+        assert state.is_successful()
+        assert state.result[res].result == [55, 56, 1, 2]
+
 
 class TestGetTasks:
     def test_get_tasks_defaults_to_return_everything(self):

--- a/tests/tasks/test_core.py
+++ b/tests/tasks/test_core.py
@@ -131,6 +131,19 @@ class TestCollections:
         assert sum(isinstance(t, collections.List) for t in f.tasks) == 1
         assert state.result[identity].result == [1, 2]
 
+    def test_list_automatically_applied_to_callargs_imperative(self):
+        x = Parameter("x")
+        y = Parameter("y")
+        identity = IdentityTask()
+        f = Flow(name="test")
+        f.add_task(identity)
+        identity.bind(x=[x, y], flow=f)
+        state = f.run(parameters=dict(x=1, y=2))
+
+        assert len(f.tasks) == 4
+        assert sum(isinstance(t, collections.List) for t in f.tasks) == 1
+        assert state.result[identity].result == [1, 2]
+
     def test_tuple_automatically_applied_to_callargs(self):
         x = Parameter("x")
         y = Parameter("y")
@@ -143,12 +156,38 @@ class TestCollections:
         assert sum(isinstance(t, collections.Tuple) for t in f.tasks) == 1
         assert state.result[identity].result == (1, 2)
 
+    def test_tuple_automatically_applied_to_callargs_imperative(self):
+        x = Parameter("x")
+        y = Parameter("y")
+        identity = IdentityTask()
+        f = Flow(name="test")
+        f.add_task(identity)
+        identity.bind(x=(x, y), flow=f)
+        state = f.run(parameters=dict(x=1, y=2))
+
+        assert len(f.tasks) == 4
+        assert sum(isinstance(t, collections.Tuple) for t in f.tasks) == 1
+        assert state.result[identity].result == (1, 2)
+
     def test_set_automatically_applied_to_callargs(self):
         x = Parameter("x")
         y = Parameter("y")
         identity = IdentityTask()
         with Flow(name="test") as f:
             identity.bind(x=set([x, y]))
+        state = f.run(parameters=dict(x=1, y=2))
+
+        assert len(f.tasks) == 4
+        assert sum(isinstance(t, collections.Set) for t in f.tasks) == 1
+        assert state.result[identity].result == set([1, 2])
+
+    def test_set_automatically_applied_to_callargs_imperative(self):
+        x = Parameter("x")
+        y = Parameter("y")
+        identity = IdentityTask()
+        f = Flow(name="test")
+        f.add_task(identity)
+        identity.bind(x=set([x, y]), flow=f)
         state = f.run(parameters=dict(x=1, y=2))
 
         assert len(f.tasks) == 4
@@ -169,12 +208,39 @@ class TestCollections:
         assert sum(isinstance(t, collections.Dict) for t in f.tasks) == 1
         assert state.result[identity].result == dict(a=1, b=2)
 
+    def test_dict_automatically_applied_to_callargs_imperative(self):
+        x = Parameter("x")
+        y = Parameter("y")
+        identity = IdentityTask()
+        f = Flow(name="test")
+        f.add_task(identity)
+        identity.bind(x=dict(a=x, b=y), flow=f)
+        state = f.run(parameters=dict(x=1, y=2))
+
+        assert (
+            len(f.tasks) == 8
+        )  # 2 params, identity, Dict, 2 Lists for Dict, "a" and "b"
+        assert sum(isinstance(t, collections.Dict) for t in f.tasks) == 1
+        assert state.result[identity].result == dict(a=1, b=2)
+
     def test_nested_collection_automatically_applied_to_callargs(self):
         x = Parameter("x")
         y = Parameter("y")
         identity = IdentityTask()
         with Flow(name="test") as f:
             identity.bind(x=dict(a=[x, dict(y=y)], b=(y, set([x]))))
+        state = f.run(parameters=dict(x=1, y=2))
+
+        assert len(f.tasks) == 15
+        assert state.result[identity].result == dict(a=[1, dict(y=2)], b=(2, set([1])))
+
+    def test_nested_collection_automatically_applied_to_callargs_imperative(self):
+        x = Parameter("x")
+        y = Parameter("y")
+        identity = IdentityTask()
+        f = Flow(name="test")
+        f.add_task(identity)
+        identity.bind(x=dict(a=[x, dict(y=y)], b=(y, set([x]))), flow=f)
         state = f.run(parameters=dict(x=1, y=2))
 
         assert len(f.tasks) == 15


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR fixes an issue that arises when using the imperative API and binding a task with call arguments of type: dict, list, set, or a nested combination of the 3

## Why is this PR important?

Closes [#1211](https://github.com/PrefectHQ/prefect/issues/1211)
