### PR TITLE
Local retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Implement backoff retry settings on Client calls - [#1187](https://github.com/PrefectHQ/prefect/pull/1187)
 - Explicitly set Dask keys for a better Dask visualization experience - [#1218](https://github.com/PrefectHQ/prefect/issues/1218)
 - Implement a local cache which persists for the duration of a Python session - [#1221](https://github.com/PrefectHQ/prefect/issues/1221)
+- Implement in-process retries for Cloud Tasks which request retry in less than one minute - [#1228](https://github.com/PrefectHQ/prefect/pull/1228)
 
 ### Task Library
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -12,7 +12,7 @@ heartbeat_interval = 30.0
 
 [logging]
 # The logging level: NOTSET, DEBUG, INFO, WARNING, ERROR, or CRITICAL
-level = "INFO"
+level = "DEBUG"
 
 # The log format
 format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -12,7 +12,7 @@ heartbeat_interval = 30.0
 
 [logging]
 # The logging level: NOTSET, DEBUG, INFO, WARNING, ERROR, or CRITICAL
-level = "DEBUG"
+level = "INFO"
 
 # The log format
 format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -12,7 +12,7 @@ from prefect.engine.cloud.utilities import prepare_state_for_cloud
 from prefect.engine.result import NoResult, Result
 from prefect.engine.result_handlers import ResultHandler
 from prefect.engine.runner import ENDRUN, call_state_handlers
-from prefect.engine.state import Cached, ClientFailed, Failed, Mapped, State
+from prefect.engine.state import Cached, ClientFailed, Failed, Mapped, Retrying, State
 from prefect.engine.task_runner import TaskRunner, TaskRunnerInitializeResult
 from prefect.utilities.graphql import with_args
 
@@ -245,8 +245,9 @@ class CloudTaskRunner(TaskRunner):
             executor=executor,
         )
         if end_state.is_retrying() and (
-            end_state.start_time <= pendulum.now("utc").add(minutes=1)
+            end_state.start_time <= pendulum.now("utc").add(minutes=1)  # type: ignore
         ):
+            assert isinstance(end_state, Retrying)
             naptime = max(
                 (end_state.start_time - pendulum.now("utc")).total_seconds(), 0
             )

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -359,7 +359,7 @@ def test_heartbeat_traps_errors_caused_by_client(monkeypatch):
 
 
 def test_task_failure_caches_inputs_automatically(client):
-    @prefect.task(max_retries=2, retry_delay=timedelta(seconds=10))
+    @prefect.task(max_retries=2, retry_delay=timedelta(seconds=100))
     def is_p_three(p):
         if p == 3:
             raise ValueError("No thank you.")

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -10,7 +10,7 @@ import prefect
 from prefect.client.client import Client, FlowRunInfoResult, TaskRunInfoResult
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
 from prefect.engine.executors import LocalExecutor
-from prefect.engine.result_handlers import ResultHandler
+from prefect.engine.result_handlers import ResultHandler, JSONResultHandler
 from prefect.engine.state import (
     Failed,
     Finished,
@@ -76,6 +76,7 @@ def cloud_settings():
             "cloud.auth_token": "token",
             "engine.flow_runner.default_class": "prefect.engine.cloud.CloudFlowRunner",
             "engine.task_runner.default_class": "prefect.engine.cloud.CloudTaskRunner",
+            "logging.level": "DEBUG",
         }
     ):
         yield
@@ -365,7 +366,7 @@ def test_simple_three_task_flow_with_first_task_retrying(monkeypatch, executor):
     because they won't pass their upstream checks
     """
 
-    @prefect.task(max_retries=1, retry_delay=datetime.timedelta(minutes=1))
+    @prefect.task(max_retries=1, retry_delay=datetime.timedelta(minutes=2))
     def error():
         1 / 0
 
@@ -547,7 +548,7 @@ def test_deep_map_with_a_failure(monkeypatch, executor):
     assert t3_0.state.is_failed()
 
 
-@pytest.mark.xfail(reason="Sometimes fails due to some shared-state error")
+# @pytest.mark.xfail(reason="Sometimes fails due to some shared-state error")
 def test_deep_map_with_a_retry(monkeypatch):
     """
     Creates a situation in which a deeply-mapped Flow encounters a one-time error in one
@@ -561,13 +562,13 @@ def test_deep_map_with_a_retry(monkeypatch):
     task_run_id_2 = str(uuid.uuid4())
     task_run_id_3 = str(uuid.uuid4())
 
-    with prefect.Flow(name="test") as flow:
+    with prefect.Flow(name="test", result_handler=JSONResultHandler()) as flow:
         t1 = plus_one.map([-1, 0, 1])
         t2 = invert_fail_once.map(t1)
         t3 = plus_one.map(t2)
 
     t2.max_retries = 1
-    t2.retry_delay = datetime.timedelta(seconds=0)
+    t2.retry_delay = datetime.timedelta(seconds=100)
 
     monkeypatch.setattr("requests.Session", MagicMock())
     monkeypatch.setattr("requests.post", MagicMock())
@@ -617,7 +618,14 @@ def test_deep_map_with_a_retry(monkeypatch):
     )
     assert t3_0.state.is_pending()
 
-    # RUN A SECOND TIME
+    # RUN A SECOND TIME with an artificially updated start time
+    failed_id = [
+        t_id
+        for t_id, tr in client.task_runs.items()
+        if tr.task_slug == t2.slug and tr.map_index == 0
+    ].pop()
+    client.task_runs[failed_id].state.start_time = pendulum.now("UTC")
+
     with prefect.context(flow_run_id=flow_run_id):
         CloudFlowRunner(flow=flow).run(executor=LocalExecutor())
 

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 import uuid
 from collections import Counter, namedtuple
 from unittest.mock import MagicMock

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -548,7 +548,10 @@ def test_deep_map_with_a_failure(monkeypatch, executor):
     assert t3_0.state.is_failed()
 
 
-# @pytest.mark.xfail(reason="Sometimes fails due to some shared-state error")
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="Mysteriously fails in different ways on Python 3.5. TODO: Investigate.",
+)
 def test_deep_map_with_a_retry(monkeypatch):
     """
     Creates a situation in which a deeply-mapped Flow encounters a one-time error in one


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR implements "local retries" in the Cloud Task Runner.  Essentially, we found that tasks which request fast retries tend to eat up infrastructure in a way that just felt unnecessary.  This PR will retry tasks whose retry start time is <= 1 minute away by sleeping in the local process.  This prevents additional infrastructure spin ups.