### PR TITLE
Defer loading optional dependencies, including Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Implement backoff retry settings on Client calls - [#1187](https://github.com/PrefectHQ/prefect/pull/1187)
 - Explicitly set Dask keys for a better Dask visualization experience - [#1218](https://github.com/PrefectHQ/prefect/issues/1218)
 - Implement a local cache which persists for the duration of a Python session - [#1221](https://github.com/PrefectHQ/prefect/issues/1221)
+- Adds `lazy_import` to support deferred imports of optional dependency - [#1233](https://github.com/PrefectHQ/prefect/pull/1233)
 
 ### Task Library
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 black
+docker >=3.4.1, <5.0
 graphviz >= 0.8.3
 jinja2 >= 2.0, < 3.0
 mypy >= 0.600, < 0.800

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 black
-docker >=3.4.1, <5.0
 graphviz >= 0.8.3
 jinja2 >= 2.0, < 3.0
 mypy >= 0.600, < 0.800

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -69,12 +69,32 @@ def load_outline(
                 classes=[],
                 functions=[],
             )
+
             module = importlib.import_module(data["module"])
             page["top-level-doc"] = module
+
             for fun in data.get("functions", []):
-                page["functions"].append(getattr(module, fun))
+                # see if the function is in a nested module
+                if "." in fun:
+                    fun_module, fun = fun.rsplit(".", 1)
+                    fun_module = importlib.import_module(
+                        ".".join([data["module"], fun_module])
+                    )
+                else:
+                    fun_module = module
+                page["functions"].append(getattr(fun_module, fun))
+
             for clss in data.get("classes", []):
-                page["classes"].append(getattr(module, clss))
+                # see if the class is in a nested module
+                if "." in clss:
+                    clss_module, clss = clss.rsplit(".", 1)
+                    clss_module = importlib.import_module(
+                        ".".join([data["module"], clss_module])
+                    )
+                else:
+                    clss_module = module
+                page["classes"].append(getattr(clss_module, clss))
+
             OUTLINE.append(page)
         else:
             OUTLINE.extend(load_outline(data, prefix=fname))

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -344,6 +344,11 @@ module = "prefect.utilities.graphql"
 classes = ["GraphQLResult", "EnumValue"]
 functions = ["parse_graphql", "parse_graphql_arguments", "with_args", "compress", "decompress"]
 
+[pages.utilities.imports]
+title = "Imports"
+module = "prefect.utilities.imports"
+functions = ["lazy_import"]
+
 [pages.utilities.logging]
 title = "Logging"
 module = "prefect.utilities.logging"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -122,7 +122,12 @@ classes = ["Result", "SafeResult", "NoResultType"]
 [pages.engine.result_handlers]
 title = "Result Handlers"
 module = "prefect.engine.result_handlers"
-classes = ["JSONResultHandler", "GCSResultHandler", "LocalResultHandler", "S3ResultHandler"]
+classes = [
+    "LocalResultHandler",
+    "JSONResultHandler",
+    "gcs_result_handler.GCSResultHandler",
+    "s3_result_handler.S3ResultHandler"
+    ]
 
 [pages.engine.cloud]
 title = "Cloud"
@@ -132,12 +137,18 @@ classes = ["CloudFlowRunner", "CloudTaskRunner"]
 [pages.environments.storage]
 title = "Storage"
 module = "prefect.environments.storage"
-classes = ["Storage", "Docker", "LocalStorage", "Memory", "Bytes"]
+classes = [
+    "Storage",
+    "LocalStorage",
+    "Memory",
+    "Bytes",
+    "docker.Docker"
+    ]
 
 [pages.environments.execution]
-title = "Execution Environments"
-module = "prefect.environments"
-classes = ["LocalEnvironment", "RemoteEnvironment"]
+title = "Execution"
+module = "prefect.environments.execution"
+classes = ["LocalEnvironment", "remote.RemoteEnvironment"]
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ cloudpickle >=0.6.0, <1.3
 croniter >= 0.3, < 0.4
 dask >=0.18, <2.0.1
 distributed >= 1.26.1, < 2.0
-docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 4.0.0
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
 mypy_extensions >= 0.4.0, < 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cloudpickle >=0.6.0, <1.3
 croniter >= 0.3, < 0.4
 dask >=0.18, <2.0.1
 distributed >= 1.26.1, < 2.0
+docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 4.0.0
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
 mypy_extensions >= 0.4.0, < 0.5

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras = {
     "airtable": ["airtable-python-wrapper >= 0.11, < 0.12"],
     "aws": ["boto3 >= 1.9, < 2.0"],
     "dev": dev_requires,
+    "docker": ["docker >=3.4.1, <5.0"],
     "dropbox": ["dropbox ~= 9.0"],
     "google": [
         "google-cloud-bigquery >= 1.6.0, < 2.0",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ extras = {
     "airtable": ["airtable-python-wrapper >= 0.11, < 0.12"],
     "aws": ["boto3 >= 1.9, < 2.0"],
     "dev": dev_requires,
-    "docker": ["docker >=3.4.1, <5.0"],
     "dropbox": ["dropbox ~= 9.0"],
     "google": [
         "google-cloud-bigquery >= 1.6.0, < 2.0",

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -32,11 +32,10 @@ from prefect.core.edge import Edge
 from prefect.core.task import Parameter, Task
 from prefect.engine.result import NoResult
 from prefect.engine.result_handlers import ResultHandler
-from prefect.environments import CloudEnvironment, Environment
+from prefect.environments import Environment
 from prefect.environments.storage import Storage
 from prefect.utilities import logging
 from prefect.utilities.notifications import callback_factory
-from prefect.utilities.serialization import to_qualified_name
 from prefect.utilities.tasks import as_task, unmapped
 
 ParameterDetails = TypedDict("ParameterDetails", {"default": Any, "required": bool})
@@ -156,7 +155,7 @@ class Flow:
 
         self.name = name
         self.schedule = schedule
-        self.environment = environment or prefect.environments.CloudEnvironment()
+        self.environment = environment
         self.storage = storage
         self.result_handler = (
             result_handler or prefect.engine.get_default_result_handler_class()()

--- a/src/prefect/engine/__init__.py
+++ b/src/prefect/engine/__init__.py
@@ -7,7 +7,6 @@ import prefect.engine.result
 import prefect.engine.result_handlers
 from prefect.engine.flow_runner import FlowRunner
 from prefect.engine.task_runner import TaskRunner
-import prefect.engine.cloud
 
 
 def get_default_executor_class() -> type:

--- a/src/prefect/engine/result_handlers/__init__.py
+++ b/src/prefect/engine/result_handlers/__init__.py
@@ -6,13 +6,3 @@ The only requirement for a Result handler implementation is that the `write` met
 from prefect.engine.result_handlers.result_handler import ResultHandler
 from prefect.engine.result_handlers.json_result_handler import JSONResultHandler
 from prefect.engine.result_handlers.local_result_handler import LocalResultHandler
-
-try:
-    from prefect.engine.result_handlers.gcs_result_handler import GCSResultHandler
-except ImportError:
-    pass
-
-try:
-    from prefect.engine.result_handlers.s3_result_handler import S3ResultHandler
-except ImportError:
-    pass

--- a/src/prefect/environments/__init__.py
+++ b/src/prefect/environments/__init__.py
@@ -1,3 +1,2 @@
 from prefect.environments.execution import Environment, LocalEnvironment
-from prefect.environments.execution.cloud import CloudEnvironment
 from prefect.environments.execution.remote import RemoteEnvironment

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -8,7 +8,7 @@ from slugify import slugify
 from typing import Any, List
 
 import cloudpickle
-import docker
+
 import yaml
 
 import prefect

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -14,7 +14,7 @@ import yaml
 import prefect
 from prefect.client import Secret
 from prefect.environments.execution import Environment
-from prefect.environments.storage import Docker
+from prefect.environments.storage.docker import Docker
 from prefect.utilities import logging
 
 

--- a/src/prefect/environments/storage/__init__.py
+++ b/src/prefect/environments/storage/__init__.py
@@ -11,7 +11,11 @@ The Prefect Storage interface encapsulates logic for storing, serializing and ev
 """
 
 from prefect.environments.storage.base import Storage
-from prefect.environments.storage.docker import Docker
 from prefect.environments.storage.bytes import Bytes
 from prefect.environments.storage.local import LocalStorage
 from prefect.environments.storage.memory import Memory
+
+# lazy imports
+from prefect.utilities.imports import lazy_import
+
+docker = lazy_import("prefect.environments.storage.docker", globals(), "docker")

--- a/src/prefect/environments/storage/__init__.py
+++ b/src/prefect/environments/storage/__init__.py
@@ -14,8 +14,4 @@ from prefect.environments.storage.base import Storage
 from prefect.environments.storage.bytes import Bytes
 from prefect.environments.storage.local import LocalStorage
 from prefect.environments.storage.memory import Memory
-
-# lazy imports
-from prefect.utilities.imports import lazy_import
-
-docker = lazy_import("prefect.environments.storage.docker", globals(), "docker")
+from prefect.environments.storage.docker import Docker

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -11,11 +11,13 @@ import uuid
 from slugify import slugify
 from typing import Any, Callable, Dict, Iterable, List
 
-import docker
-
 import prefect
 from prefect.environments.storage import Storage
 from prefect.utilities.exceptions import SerializationError
+from prefect.utilities.imports import lazy_import
+
+# lazy import docker
+docker = lazy_import("docker", globals())
 
 
 class Docker(Storage):

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -1,12 +1,12 @@
 from marshmallow import fields
 
-from prefect.environments import (
-    CloudEnvironment,
-    Environment,
-    LocalEnvironment,
-    RemoteEnvironment,
-)
+from prefect.environments import Environment, LocalEnvironment, RemoteEnvironment
+from prefect.utilities.imports import lazy_import
 from prefect.utilities.serialization import ObjectSchema, OneOfSchema
+
+lazy_cloud = lazy_import(
+    "prefect.environments.execution.cloud", globals(), "lazy_cloud"
+)
 
 
 class BaseEnvironmentSchema(ObjectSchema):
@@ -21,7 +21,7 @@ class LocalEnvironmentSchema(ObjectSchema):
 
 class CloudEnvironmentSchema(ObjectSchema):
     class Meta:
-        object_class = CloudEnvironment
+        object_class = lambda: lazy_cloud.CloudEnvironment
 
     docker_secret = fields.String(allow_none=True)
     private_registry = fields.Boolean(allow_none=False)

--- a/src/prefect/serialization/result_handlers.py
+++ b/src/prefect/serialization/result_handlers.py
@@ -4,17 +4,31 @@ from typing import Any, Dict, Optional
 from marshmallow import ValidationError, fields, post_load
 
 from prefect.engine.result_handlers import (
-    GCSResultHandler,
     JSONResultHandler,
     LocalResultHandler,
     ResultHandler,
-    S3ResultHandler,
 )
+
+
 from prefect.utilities.serialization import (
     JSONCompatible,
     ObjectSchema,
     OneOfSchema,
     to_qualified_name,
+)
+
+
+from prefect.utilities.imports import lazy_import
+
+lazy_gcs_result_handler = lazy_import(
+    "prefect.engine.result_handlers.gcs_result_handler",
+    globals(),
+    "lazy_gcs_result_handler",
+)
+lazy_s3_result_handler = lazy_import(
+    "prefect.engine.result_handlers.s3_result_handler",
+    globals(),
+    "lazy_s3_result_handler",
 )
 
 
@@ -40,7 +54,7 @@ class CustomResultHandlerSchema(ObjectSchema):
 
 class GCSResultHandlerSchema(BaseResultHandlerSchema):
     class Meta:
-        object_class = GCSResultHandler
+        object_class = lambda: lazy_gcs_result_handler.GCSResultHandler
 
     bucket = fields.String(allow_none=False)
     credentials_secret = fields.String(allow_none=True)
@@ -60,7 +74,7 @@ class LocalResultHandlerSchema(BaseResultHandlerSchema):
 
 class S3ResultHandlerSchema(BaseResultHandlerSchema):
     class Meta:
-        object_class = S3ResultHandler
+        object_class = lambda: lazy_s3_result_handler.S3ResultHandler
 
     bucket = fields.String(allow_none=False)
     aws_credentials_secret = fields.String(allow_none=True)

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -3,19 +3,12 @@ from marshmallow import fields, post_load
 from typing import Any
 
 import prefect
-from prefect.environments.storage import Bytes, Memory, LocalStorage, Storage
-
-from prefect.utilities.imports import lazy_import
+from prefect.environments.storage import Bytes, Memory, LocalStorage, Storage, Docker
 
 from prefect.utilities.serialization import (
     ObjectSchema,
     OneOfSchema,
     Bytes as BytesField,
-)
-
-
-lazy_docker = lazy_import(
-    "prefect.environments.storage.docker", globals(), "lazy_docker"
 )
 
 
@@ -55,7 +48,7 @@ class LocalSchema(ObjectSchema):
 
 class DockerSchema(ObjectSchema):
     class Meta:
-        object_class = lambda: lazy_docker.Docker
+        object_class = Docker
 
     registry_url = fields.String(allow_none=True)
     image_name = fields.String(allow_none=True)

--- a/src/prefect/tasks/__init__.py
+++ b/src/prefect/tasks/__init__.py
@@ -5,7 +5,11 @@ from prefect.core.task import Task
 import prefect.tasks.core
 import prefect.tasks.control_flow
 import prefect.tasks.database
-import prefect.tasks.docker
 import prefect.tasks.github
 import prefect.tasks.notifications
 import prefect.tasks.shell
+
+from prefect.utilities.imports import lazy_import
+
+# lazy imports due to optional dependencies
+docker = lazy_import("prefect.tasks.docker", globals(), import_as="docker")

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -1,10 +1,12 @@
 from typing import Any, Union
-
-import docker
-
 from prefect import Task
 from prefect.engine.signals import FAIL
 from prefect.utilities.tasks import defaults_from_attrs
+
+from prefect.utilities.imports import lazy_import
+
+# lazy import docker
+docker = lazy_import("docker", globals())
 
 
 class CreateContainer(Task):

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -1,9 +1,12 @@
 from typing import Any
 
-import docker
-
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
+
+from prefect.utilities.imports import lazy_import
+
+# lazy import docker
+docker = lazy_import("docker", globals())
 
 
 class ListImages(Task):

--- a/src/prefect/utilities/imports.py
+++ b/src/prefect/utilities/imports.py
@@ -1,0 +1,109 @@
+"""
+Utilities for working with imports. This is especially important for a framework like Prefect,
+which will need to have first-class support for a wide variety of other libraries. We want
+to make sure we have good ways of working with optional / lazy dependencies so that users
+aren't burdened with unecessary cruft.
+"""
+
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import types
+import logging
+from typing import Any, List
+
+
+class LazyLoader(types.ModuleType):
+    """
+    Lazily import a module, mainly to avoid pulling in large dependencies. `contrib`,
+    and `ffmpeg` are examples of modules that are large and not always needed, and this
+    allows them to only be loaded when they are used.
+
+    This code was taken from
+    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/lazy_loader.py
+    on July 13, 2019.
+    """
+
+    # The lint error here is incorrect.
+    def __init__(
+        self,
+        local_name: str,
+        parent_module_globals: dict,
+        name: str,
+        warning: str = None,
+    ):  # pylint: disable=super-on-old-class
+        self._local_name = local_name
+        self._parent_module_globals = parent_module_globals
+        self._warning = warning
+
+        super(LazyLoader, self).__init__(name)
+
+    def _load(self) -> types.ModuleType:
+        """Load the module and insert it into the parent's globals."""
+        # Import the target module and insert it into the parent's namespace
+        module = importlib.import_module(self.__name__)
+        self._parent_module_globals[self._local_name] = module
+
+        # Emit a warning if one was specified
+        if self._warning:
+            logging.warning(self._warning)
+            # Make sure to only warn once.
+            self._warning = None
+
+        # Update this object's dict so that if someone keeps a reference to the
+        #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups
+        #   that fail).
+        self.__dict__.update(module.__dict__)
+
+        return module
+
+    def __getattr__(self, item: str) -> Any:
+        module = self._load()
+        return getattr(module, item)
+
+    def __dir__(self) -> List[str]:
+        module = self._load()
+        return dir(module)
+
+
+def lazy_import(
+    import_module: str, parent_module_globals: dict, import_as: str = None
+) -> LazyLoader:
+    """
+    Get a reference to a lazily-loaded module.
+
+    Args:
+        - import_module (str): the module to import
+        - import_as (str, optional): the name to import it as; defaults to `import_module`
+        - parent_module_globals (dict): a globals dictionary that the imported module
+            should be added to. This should be the result of calling `globals()` from the
+            same module calling this function.
+
+    Returns:
+        - LazyLoader: a module that will lazily resolve to the requested import
+
+    Example:
+
+    ```
+    # equivalent to `import numpy`
+    numpy = lazy_import('numpy', globals())
+
+    # equivalent to `import numpy as np`
+    np = lazy_import('numpy', globals(), import_as='np', )
+
+    # lazy import of nested modules
+    lazy_docker = lazy_import('prefect.environments.execution.docker', globals(), 'lazy_docker')
+    ```
+    """
+
+    if import_as is None:
+        import_as = import_module
+
+    return LazyLoader(
+        local_name=import_as,
+        parent_module_globals=parent_module_globals,
+        name=import_module,
+    )

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -134,12 +134,17 @@ class TestCreateFlow:
         assert isinstance(f2.storage, prefect.environments.storage.Memory)
 
     def test_create_flow_with_environment(self):
-        f2 = Flow(name="test", environment=prefect.environments.CloudEnvironment())
-        assert isinstance(f2.environment, prefect.environments.CloudEnvironment)
+        f2 = Flow(
+            name="test",
+            environment=prefect.environments.execution.cloud.CloudEnvironment(),
+        )
+        assert isinstance(
+            f2.environment, prefect.environments.execution.cloud.CloudEnvironment
+        )
 
-    def test_create_flow_has_default_environment(self):
+    def test_create_flow_has_no_default_environment(self):
         f2 = Flow(name="test")
-        assert isinstance(f2.environment, prefect.environments.CloudEnvironment)
+        assert f2.environment is None
 
     def test_create_flow_auto_generates_tasks(self):
         with Flow("auto") as f:
@@ -1427,10 +1432,6 @@ class TestSerialize:
         with pytest.raises(ValueError) as exc:
             f.serialize()
         assert "cycle found" in str(exc.value).lower()
-
-    def test_default_environment_is_cloud_environment(self):
-        f = Flow(name="test")
-        assert isinstance(f.environment, prefect.environments.CloudEnvironment)
 
     def test_serialize_includes_storage(self):
         f = Flow(name="test", storage=prefect.environments.storage.Memory())

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -10,12 +10,13 @@ import pytest
 import prefect
 from prefect.client import Client
 from prefect.engine.result_handlers import (
-    GCSResultHandler,
     JSONResultHandler,
     LocalResultHandler,
     ResultHandler,
-    S3ResultHandler,
 )
+from prefect.engine.result_handlers.gcs_result_handler import GCSResultHandler
+from prefect.engine.result_handlers.s3_result_handler import S3ResultHandler
+
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/environments/execution/test_base_environment.py
+++ b/tests/environments/execution/test_base_environment.py
@@ -1,7 +1,7 @@
 import pytest
 
 from prefect.environments import Environment
-from prefect.environments.storage import Docker
+from prefect.environments.storage.docker import Docker
 
 
 def test_create_environment():

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -9,8 +9,9 @@ import pytest
 import yaml
 
 import prefect
-from prefect.environments import CloudEnvironment
-from prefect.environments.storage import Memory, Docker
+from prefect.environments.execution.cloud import CloudEnvironment
+from prefect.environments.storage import Memory
+from prefect.environments.storage.docker import Docker
 from prefect.utilities.configuration import set_temporary_config
 
 
@@ -47,7 +48,8 @@ def test_setup_doesnt_pass_if_private_registry(monkeypatch):
 
     create_secret = MagicMock()
     monkeypatch.setattr(
-        "prefect.environments.CloudEnvironment._create_namespaced_secret", create_secret
+        "prefect.environments.execution.cloud.CloudEnvironment._create_namespaced_secret",
+        create_secret,
     )
     with set_temporary_config({"cloud.auth_token": "test"}):
         environment.setup(storage=Docker())
@@ -71,7 +73,8 @@ def test_create_secret_isnt_called_if_exists(monkeypatch):
 
     create_secret = MagicMock()
     monkeypatch.setattr(
-        "prefect.environments.CloudEnvironment._create_namespaced_secret", create_secret
+        "prefect.environments.execution.cloud.CloudEnvironment._create_namespaced_secret",
+        create_secret,
     )
     with set_temporary_config({"cloud.auth_token": "test"}):
         with prefect.context(namespace="foo"):
@@ -98,7 +101,8 @@ def test_execute(monkeypatch):
 
     create_flow_run = MagicMock()
     monkeypatch.setattr(
-        "prefect.environments.CloudEnvironment.create_flow_run_job", create_flow_run
+        "prefect.environments.execution.cloud.CloudEnvironment.create_flow_run_job",
+        create_flow_run,
     )
 
     environment.execute(storage=storage, flow_location="")

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -10,8 +10,7 @@ import yaml
 
 import prefect
 from prefect.environments.execution.cloud import CloudEnvironment
-from prefect.environments.storage import Memory
-from prefect.environments.storage.docker import Docker
+from prefect.environments.storage import Memory, Docker
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -2,7 +2,8 @@ import pytest
 
 import prefect
 from prefect.environments.execution import LocalEnvironment
-from prefect.environments.storage import Docker, Memory
+from prefect.environments.storage import Memory
+from prefect.environments.storage.docker import Docker
 
 
 def test_create_environment():

--- a/tests/environments/execution/test_remote_environment.py
+++ b/tests/environments/execution/test_remote_environment.py
@@ -5,8 +5,9 @@ import cloudpickle
 import pytest
 
 import prefect
-from prefect.environments import RemoteEnvironment
-from prefect.environments.storage import Memory, Docker
+from prefect.environments.execution.remote import RemoteEnvironment
+from prefect.environments.storage import Memory
+from prefect.environments.storage.docker import Docker
 
 
 def test_create_remote_environment():

--- a/tests/environments/execution/test_remote_environment.py
+++ b/tests/environments/execution/test_remote_environment.py
@@ -6,8 +6,7 @@ import pytest
 
 import prefect
 from prefect.environments.execution.remote import RemoteEnvironment
-from prefect.environments.storage import Memory
-from prefect.environments.storage.docker import Docker
+from prefect.environments.storage import Memory, Docker
 
 
 def test_create_remote_environment():

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -7,7 +7,7 @@ import pytest
 
 import prefect
 from prefect import Flow
-from prefect.environments.storage import Docker
+from prefect.environments.storage.docker import Docker
 from prefect.utilities.exceptions import SerializationError
 
 
@@ -102,7 +102,9 @@ def test_build_base_image(monkeypatch):
     storage = Docker(registry_url="reg", base_image="test")
 
     build_image = MagicMock(return_value=("1", "2"))
-    monkeypatch.setattr("prefect.environments.storage.Docker.build_image", build_image)
+    monkeypatch.setattr(
+        "prefect.environments.storage.docker.Docker.build_image", build_image
+    )
 
     output = storage.build()
     assert output.registry_url == storage.registry_url
@@ -114,7 +116,9 @@ def test_build_no_default(monkeypatch):
     storage = Docker(registry_url="reg")
 
     build_image = MagicMock(return_value=("1", "2"))
-    monkeypatch.setattr("prefect.environments.storage.Docker.build_image", build_image)
+    monkeypatch.setattr(
+        "prefect.environments.storage.docker.Docker.build_image", build_image
+    )
 
     output = storage.build()
     assert output.registry_url == storage.registry_url
@@ -149,7 +153,9 @@ def test_build_image_passes(monkeypatch):
     storage = Docker(registry_url="reg", base_image="python:3.6")
 
     pull_image = MagicMock()
-    monkeypatch.setattr("prefect.environments.storage.Docker.pull_image", pull_image)
+    monkeypatch.setattr(
+        "prefect.environments.storage.docker.Docker.pull_image", pull_image
+    )
 
     build = MagicMock()
     monkeypatch.setattr("docker.APIClient.build", build)
@@ -169,10 +175,14 @@ def test_build_image_passes_and_pushes(monkeypatch):
     storage = Docker(registry_url="reg", base_image="python:3.6")
 
     pull_image = MagicMock()
-    monkeypatch.setattr("prefect.environments.storage.Docker.pull_image", pull_image)
+    monkeypatch.setattr(
+        "prefect.environments.storage.docker.Docker.pull_image", pull_image
+    )
 
     push_image = MagicMock()
-    monkeypatch.setattr("prefect.environments.storage.Docker.push_image", push_image)
+    monkeypatch.setattr(
+        "prefect.environments.storage.docker.Docker.push_image", push_image
+    )
 
     build = MagicMock()
     monkeypatch.setattr("docker.APIClient.build", build)

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -1,5 +1,6 @@
 import prefect
 from prefect import environments
+import prefect.environments.execution.cloud
 from prefect.serialization.environment import (
     BaseEnvironmentSchema,
     CloudEnvironmentSchema,
@@ -16,7 +17,7 @@ def test_serialize_base_environment():
 
 
 def test_serialize_cloud_environment():
-    env = environments.CloudEnvironment()
+    env = environments.execution.cloud.CloudEnvironment()
 
     schema = CloudEnvironmentSchema()
     serialized = schema.dump(env)
@@ -30,7 +31,9 @@ def test_serialize_cloud_environment():
 
 
 def test_serialize_cloud_environment_with_private_registry():
-    env = environments.CloudEnvironment(private_registry=True, docker_secret="FOO")
+    env = environments.execution.cloud.CloudEnvironment(
+        private_registry=True, docker_secret="FOO"
+    )
 
     schema = CloudEnvironmentSchema()
     serialized = schema.dump(env)

--- a/tests/serialization/test_flows.py
+++ b/tests/serialization/test_flows.py
@@ -124,13 +124,14 @@ def test_reference_tasks():
 
 
 def test_serialize_container_environment():
-    storage = prefect.environments.storage.Docker(
+
+    storage = prefect.environments.storage.docker.Docker(
         base_image="a", python_dependencies=["b", "c"], registry_url="f"
     )
     deserialized = FlowSchema().load(
         FlowSchema().dump(Flow(name="test", storage=storage))
     )
-    assert isinstance(deserialized.storage, prefect.environments.storage.Docker)
+    assert isinstance(deserialized.storage, prefect.environments.storage.docker.Docker)
     assert deserialized.storage.registry_url == storage.registry_url
 
 

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -5,12 +5,12 @@ import pytest
 import prefect
 from prefect.client import Client
 from prefect.engine.result_handlers import (
-    GCSResultHandler,
     JSONResultHandler,
     LocalResultHandler,
     ResultHandler,
-    S3ResultHandler,
 )
+from prefect.engine.result_handlers.gcs_result_handler import GCSResultHandler
+from prefect.engine.result_handlers.s3_result_handler import S3ResultHandler
 from prefect.serialization.result_handlers import (
     ResultHandlerSchema,
     CustomResultHandlerSchema,

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -10,6 +10,7 @@ from prefect.serialization.storage import (
     MemorySchema,
     BytesSchema,
 )
+from prefect.environments.storage.docker import Docker
 
 
 @pytest.mark.parametrize("cls", storage.Storage.__subclasses__())
@@ -20,7 +21,7 @@ def test_serialization_on_all_subclasses(cls):
 
 
 def test_docker_empty_serialize():
-    docker = storage.Docker()
+    docker = Docker()
     serialized = DockerSchema().dump(docker)
 
     assert serialized
@@ -49,7 +50,7 @@ def test_memory_roundtrip():
 
 
 def test_docker_full_serialize():
-    docker = storage.Docker(
+    docker = Docker(
         registry_url="url", image_name="name", image_tag="tag", prefect_version="0.5.2"
     )
     serialized = DockerSchema().dump(docker)
@@ -64,7 +65,7 @@ def test_docker_full_serialize():
 
 
 def test_docker_serialize_with_flows():
-    docker = storage.Docker(registry_url="url", image_name="name", image_tag="tag")
+    docker = Docker(registry_url="url", image_name="name", image_tag="tag")
     f = prefect.Flow("test")
     docker.add_flow(f)
     serialized = DockerSchema().dump(docker)

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import docker
 import pytest
 
 from prefect.engine.signals import FAIL
@@ -54,7 +55,7 @@ class TestCreateContainerTask:
         task = CreateContainer(image_name="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -63,7 +64,7 @@ class TestCreateContainerTask:
         task = CreateContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image_name="test")
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -72,7 +73,7 @@ class TestCreateContainerTask:
         task = CreateContainer(image_name="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image_name="test")
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -103,7 +104,7 @@ class TestGetContainerLogsTask:
         task = GetContainerLogs(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -112,7 +113,7 @@ class TestGetContainerLogsTask:
         task = GetContainerLogs()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -121,7 +122,7 @@ class TestGetContainerLogsTask:
         task = GetContainerLogs(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -142,7 +143,7 @@ class TestListContainersTask:
         task = ListContainers(all_containers=True)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.containers.call_args[1]["all"]
@@ -151,7 +152,7 @@ class TestListContainersTask:
         task = ListContainers()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(all_containers=True)
         assert api.return_value.containers.call_args[1]["all"]
@@ -160,7 +161,7 @@ class TestListContainersTask:
         task = ListContainers(all_containers=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(all_containers=True)
         assert api.return_value.containers.call_args[1]["all"]
@@ -191,7 +192,7 @@ class TestStartContainerTask:
         task = StartContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -200,7 +201,7 @@ class TestStartContainerTask:
         task = StartContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -209,7 +210,7 @@ class TestStartContainerTask:
         task = StartContainer(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -240,7 +241,7 @@ class TestStopContainerTask:
         task = StopContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -249,7 +250,7 @@ class TestStopContainerTask:
         task = StopContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -258,7 +259,7 @@ class TestStopContainerTask:
         task = StopContainer(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -293,7 +294,7 @@ class TestWaitOnContainerTask:
         task = WaitOnContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {}
 
         task.run()
@@ -303,7 +304,7 @@ class TestWaitOnContainerTask:
         task = WaitOnContainer(container_id="init")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {}
 
         task.run(container_id="test")
@@ -313,7 +314,7 @@ class TestWaitOnContainerTask:
         task = WaitOnContainer(container_id="noise")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"StatusCode": 1}
 
         with pytest.raises(FAIL):
@@ -323,7 +324,7 @@ class TestWaitOnContainerTask:
         task = WaitOnContainer(container_id="noise")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"Error": "oops!"}
 
         with pytest.raises(FAIL):
@@ -333,7 +334,7 @@ class TestWaitOnContainerTask:
         task = WaitOnContainer(container_id="noise", raise_on_exit_code=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"StatusCode": 1, "Error": "oops!"}
 
         task.run()

--- a/tests/utilities/test_imports.py
+++ b/tests/utilities/test_imports.py
@@ -26,5 +26,6 @@ def test_lazy_import_with_bad_module():
     module = lazy_import("abcdefghijklmnop", globals())
 
     # error is not raised until we try to access module
-    with pytest.raises(ModuleNotFoundError):
+    # use ImportError instead of ModuleNotFoundError for python 3.5 compat
+    with pytest.raises(ImportError):
         dir(module)

--- a/tests/utilities/test_imports.py
+++ b/tests/utilities/test_imports.py
@@ -1,0 +1,30 @@
+import pytest
+import pendulum as real_pendulum
+import requests as real_requests
+from prefect.utilities.imports import lazy_import
+
+
+def test_lazy_import():
+    pendulum = lazy_import("pendulum", globals())
+    assert pendulum is not real_pendulum
+    assert pendulum.datetime is real_pendulum.datetime
+
+
+def test_lazy_import_alias():
+    lazy_pendulum = lazy_import("pendulum", globals(), "lazy_pendulum")
+    assert lazy_pendulum is not real_pendulum
+    assert lazy_pendulum.datetime is real_pendulum.datetime
+
+
+def test_lazy_import_submodule():
+    lazy_requests = lazy_import("requests.utils", globals(), "lazy_requests")
+    assert lazy_requests is not real_requests.utils
+    assert lazy_requests.codecs is real_requests.utils.codecs
+
+
+def test_lazy_import_with_bad_module():
+    module = lazy_import("abcdefghijklmnop", globals())
+
+    # error is not raised until we try to access module
+    with pytest.raises(ModuleNotFoundError):
+        dir(module)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Prefect optimistically loads almost its entire deploy machinery on startup, which adds latency but also creates heavy dependencies. As new `Environments` and `Storage` are added, this is only going to get worse. As an example, the docker module (which takes ~ 1 second to import) is required to import Prefect, even if users don't use docker!

This PR has a few changes:
- defers imports of non-critical environments (like `CloudEnvironment`) and storage (like `Docker`), rather than loading them in the respective `__init__.py`
- adds a `lazy_import()` helper function for including lazily-imported modules. This means users can access `prefect.environments.storage.docker.Docker` even though `prefect.environments.storage.docker` is NOT being loaded on startup anymore. The code for this function is taken from TensorFlow, which uses it to handle `contrib`.
- Removes the default `CloudEnvironment` from flows

Note: I tried to make Docker completely optional, but it's so important to the deploy machinery that it's way more effort than it's worth. Instead, I just made it a lazy import.

## Why is this PR important?

Closes #1219 
