### PR TITLE
Pre-release housekeeping: sort all imports

### DIFF
--- a/examples/feature_engineering.py
+++ b/examples/feature_engineering.py
@@ -17,10 +17,10 @@ from typing import Any, Dict, List
 from urllib.request import urlretrieve
 
 import numpy as np
-
 import pandas as pd
-from prefect import Flow, Parameter, Task, task, unmapped
 from sklearn.decomposition import PCA
+
+from prefect import Flow, Parameter, Task, task, unmapped
 
 
 # tasks to fetch and prepare data

--- a/examples/functional_docker.py
+++ b/examples/functional_docker.py
@@ -7,12 +7,11 @@ to running this Flow.
 from prefect import Flow
 from prefect.tasks.docker import (
     CreateContainer,
-    StartContainer,
     GetContainerLogs,
+    StartContainer,
     WaitOnContainer,
 )
 from prefect.triggers import always_run
-
 
 ## initialize tasks
 container = CreateContainer(

--- a/examples/imperative_docker.py
+++ b/examples/imperative_docker.py
@@ -7,12 +7,11 @@ to running this Flow.
 from prefect import Flow
 from prefect.tasks.docker import (
     CreateContainer,
-    StartContainer,
     GetContainerLogs,
+    StartContainer,
     WaitOnContainer,
 )
 from prefect.triggers import always_run
-
 
 container = CreateContainer(
     image_name="prefecthq/prefect",

--- a/examples/spacy_nlp.py
+++ b/examples/spacy_nlp.py
@@ -2,17 +2,16 @@
 This example walks through the basics of using Prefect tasks to run spaCy pipelines and interact with components.
 """
 
-from prefect import Flow
-from prefect.tasks.spacy.spacy_tasks import (
-    SpacyNLP,
-    SpacyTagger,
-    SpacyParser,
-    SpacyNER,
-    SpacyComponent,
-)
-
 import spacy
 
+from prefect import Flow
+from prefect.tasks.spacy.spacy_tasks import (
+    SpacyComponent,
+    SpacyNER,
+    SpacyNLP,
+    SpacyParser,
+    SpacyTagger,
+)
 
 # load a spacy language model
 nlp = spacy.load("en_core_web_sm")

--- a/examples/task_library/google/storage.py
+++ b/examples/task_library/google/storage.py
@@ -5,8 +5,9 @@ Each task is instantiated as a template in order to demonstrate how arguments ca
 passed either at initialization or when building the flow.
 """
 import json
+
 from prefect import Flow
-from prefect.tasks.google.storage import GCSDownload, GCSUpload, GCSCopy
+from prefect.tasks.google.storage import GCSCopy, GCSDownload, GCSUpload
 
 BUCKET = "gcs-bucket"
 BLOB = "path/to/blob"

--- a/src/prefect/cli/describe.py
+++ b/src/prefect/cli/describe.py
@@ -3,7 +3,7 @@ import pendulum
 from tabulate import tabulate
 
 from prefect.client import Client
-from prefect.utilities.graphql import with_args, EnumValue
+from prefect.utilities.graphql import EnumValue, with_args
 
 
 @click.group(hidden=True)

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -4,7 +4,7 @@ from tabulate import tabulate
 
 from prefect import config
 from prefect.client import Client
-from prefect.utilities.graphql import with_args, EnumValue
+from prefect.utilities.graphql import EnumValue, with_args
 
 
 @click.group(hidden=True)

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -3,7 +3,7 @@ import time
 import click
 
 from prefect.client import Client
-from prefect.utilities.graphql import with_args, EnumValue
+from prefect.utilities.graphql import EnumValue, with_args
 
 
 @click.group(hidden=True)

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -3,12 +3,11 @@ import datetime
 import json
 import logging
 import os
-
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 
 import pendulum
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 import prefect
 from prefect.utilities.exceptions import AuthorizationError, ClientError
@@ -16,9 +15,9 @@ from prefect.utilities.graphql import (
     EnumValue,
     GraphQLResult,
     as_nested_dict,
+    compress,
     parse_graphql,
     with_args,
-    compress,
 )
 
 if TYPE_CHECKING:

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -1,5 +1,5 @@
-import inspect
 import datetime
+import inspect
 import logging
 import os
 import re

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -1,9 +1,10 @@
 import copy
 import datetime
-import pendulum
 import time
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+import pendulum
 
 import prefect
 from prefect.client import Client

--- a/src/prefect/engine/runner.py
+++ b/src/prefect/engine/runner.py
@@ -7,7 +7,6 @@ from prefect.engine import signals
 from prefect.engine.state import Failed, Pending, State
 from prefect.utilities import logging
 
-
 # for backwards compatibility
 ENDRUN = signals.ENDRUN
 

--- a/src/prefect/environments/execution/cloud/environment.py
+++ b/src/prefect/environments/execution/cloud/environment.py
@@ -4,12 +4,12 @@ import sys
 import time
 import uuid
 from os import path
-from slugify import slugify
 from typing import Any, List
 
 import cloudpickle
 import docker
 import yaml
+from slugify import slugify
 
 import prefect
 from prefect.client import Secret

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import prefect
 

--- a/src/prefect/environments/storage/bytes.py
+++ b/src/prefect/environments/storage/bytes.py
@@ -1,5 +1,6 @@
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
+
 import cloudpickle
-from typing import Any, Dict, Iterable, List, TYPE_CHECKING, Union
 
 import prefect
 from prefect.environments.storage import Storage

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -1,4 +1,3 @@
-import cloudpickle
 import filecmp
 import json
 import logging
@@ -8,10 +7,11 @@ import sys
 import tempfile
 import textwrap
 import uuid
-from slugify import slugify
 from typing import Any, Callable, Dict, Iterable, List
 
+import cloudpickle
 import docker
+from slugify import slugify
 
 import prefect
 from prefect.environments.storage import Storage

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -1,7 +1,8 @@
-import cloudpickle
 import os
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
+
+import cloudpickle
 from slugify import slugify
-from typing import Any, Dict, Iterable, List, TYPE_CHECKING, Union
 
 import prefect
 from prefect.environments.storage import Storage

--- a/src/prefect/environments/storage/memory.py
+++ b/src/prefect/environments/storage/memory.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
 
 import prefect
 from prefect.environments.storage import Storage

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -1,14 +1,12 @@
-import marshmallow
-from marshmallow import fields, post_load
 from typing import Any
 
+import marshmallow
+from marshmallow import fields, post_load
+
 import prefect
-from prefect.environments.storage import Bytes, Memory, Docker, LocalStorage, Storage
-from prefect.utilities.serialization import (
-    ObjectSchema,
-    OneOfSchema,
-    Bytes as BytesField,
-)
+from prefect.environments.storage import Bytes, Docker, LocalStorage, Memory, Storage
+from prefect.utilities.serialization import Bytes as BytesField
+from prefect.utilities.serialization import ObjectSchema, OneOfSchema
 
 
 class BaseStorageSchema(ObjectSchema):

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -9,9 +9,9 @@ import prefect
 from prefect.utilities.serialization import (
     UUID,
     FunctionReference,
-    StatefulFunctionReference,
     JSONCompatible,
     ObjectSchema,
+    StatefulFunctionReference,
     from_qualified_name,
     to_qualified_name,
 )

--- a/src/prefect/tasks/aws/lambda_function.py
+++ b/src/prefect/tasks/aws/lambda_function.py
@@ -1,5 +1,5 @@
-from base64 import b64encode
 import json
+from base64 import b64encode
 
 import boto3
 

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -1,5 +1,6 @@
-import requests
 from typing import Any, cast
+
+import requests
 
 from prefect import Task
 from prefect.client import Secret

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -1,7 +1,7 @@
+import psycopg2 as pg
+
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
-
-import psycopg2 as pg
 
 
 class PostgresExecute(Task):

--- a/src/prefect/tasks/redis/redis_tasks.py
+++ b/src/prefect/tasks/redis/redis_tasks.py
@@ -1,8 +1,8 @@
+import redis
+
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
-
-import redis
 
 
 class RedisSet(Task):

--- a/src/prefect/tasks/spacy/spacy_tasks.py
+++ b/src/prefect/tasks/spacy/spacy_tasks.py
@@ -1,7 +1,7 @@
+import spacy
+
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
-
-import spacy
 
 
 class SpacyNLP(Task):

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -1,6 +1,6 @@
 import base64
-import json
 import gzip
+import json
 import re
 import textwrap
 import uuid

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -1,7 +1,7 @@
 import inspect
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional
 
 from toolz import curry
 

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -2,9 +2,9 @@ import tempfile
 from unittest.mock import MagicMock
 
 import click
-from click.testing import CliRunner
 import requests
 import toml
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.auth import auth

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -2,9 +2,9 @@ import sys
 from unittest.mock import MagicMock
 
 import click
-from click.testing import CliRunner
 import pytest
 import requests
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.describe import describe

--- a/tests/cli/test_execute.py
+++ b/tests/cli/test_execute.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock, PropertyMock
 
 import click
-from click.testing import CliRunner
 import requests
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.execute import execute

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -2,9 +2,9 @@ import sys
 from unittest.mock import MagicMock
 
 import click
-from click.testing import CliRunner
 import pytest
 import requests
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.get import get

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -2,7 +2,7 @@ import click
 from click.testing import CliRunner
 
 import prefect
-from prefect.cli import cli, version, config
+from prefect.cli import cli, config, version
 
 
 def test_init():

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -2,9 +2,9 @@ import sys
 from unittest.mock import MagicMock
 
 import click
-from click.testing import CliRunner
 import pytest
 import requests
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.run import run

--- a/tests/cli/test_summarize.py
+++ b/tests/cli/test_summarize.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock
 
 import click
-from click.testing import CliRunner
 import requests
+from click.testing import CliRunner
 
 import prefect
 from prefect.cli.summarize import summarize

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -11,7 +11,7 @@ import prefect
 from prefect.client.client import Client, FlowRunInfoResult, TaskRunInfoResult
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
 from prefect.engine.executors import LocalExecutor
-from prefect.engine.result_handlers import ResultHandler, JSONResultHandler
+from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
 from prefect.engine.state import (
     Failed,
     Finished,

--- a/tests/environments/execution/test_cloud_environment.py
+++ b/tests/environments/execution/test_cloud_environment.py
@@ -10,7 +10,7 @@ import yaml
 
 import prefect
 from prefect.environments import CloudEnvironment
-from prefect.environments.storage import Memory, Docker
+from prefect.environments.storage import Docker, Memory
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/environments/execution/test_remote_environment.py
+++ b/tests/environments/execution/test_remote_environment.py
@@ -6,7 +6,7 @@ import pytest
 
 import prefect
 from prefect.environments import RemoteEnvironment
-from prefect.environments.storage import Memory, Docker
+from prefect.environments.storage import Docker, Memory
 
 
 def test_create_remote_environment():

--- a/tests/environments/storage/test_local_storage.py
+++ b/tests/environments/storage/test_local_storage.py
@@ -1,7 +1,8 @@
-import cloudpickle
 import os
-import pytest
 import tempfile
+
+import cloudpickle
+import pytest
 
 import prefect
 from prefect import Flow

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -12,8 +12,8 @@ from prefect.engine.result_handlers import (
     S3ResultHandler,
 )
 from prefect.serialization.result_handlers import (
-    ResultHandlerSchema,
     CustomResultHandlerSchema,
+    ResultHandlerSchema,
 )
 from prefect.utilities.configuration import set_temporary_config
 

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -1,14 +1,15 @@
-import pytest
 import tempfile
+
+import pytest
 
 import prefect
 from prefect.environments import storage
 from prefect.serialization.storage import (
     BaseStorageSchema,
+    BytesSchema,
     DockerSchema,
     LocalSchema,
     MemorySchema,
-    BytesSchema,
 )
 
 

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import prefect
-from prefect.tasks.github import GetRepoInfo, CreateBranch
+from prefect.tasks.github import CreateBranch, GetRepoInfo
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/tasks/redis/test_redis_tasks.py
+++ b/tests/tasks/redis/test_redis_tasks.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock
 
-import prefect
-from prefect.tasks.redis import RedisSet, RedisGet, RedisExecute
-from prefect.utilities.configuration import set_temporary_config
-
 import pytest
+
+import prefect
+from prefect.tasks.redis import RedisExecute, RedisGet, RedisSet
+from prefect.utilities.configuration import set_temporary_config
 
 
 class TestRedisSet:

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -1,16 +1,15 @@
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+import spacy
 
 from prefect.tasks.spacy.spacy_tasks import (
-    SpacyNLP,
-    SpacyTagger,
-    SpacyParser,
-    SpacyNER,
     SpacyComponent,
+    SpacyNER,
+    SpacyNLP,
+    SpacyParser,
+    SpacyTagger,
 )
-
-import spacy
 
 
 class TestSpacyNLP:

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -10,11 +10,11 @@ from prefect.utilities.collections import DotDict
 from prefect.utilities.graphql import (
     EnumValue,
     GQLObject,
+    compress,
+    decompress,
     parse_graphql,
     parse_graphql_arguments,
     with_args,
-    compress,
-    decompress,
 )
 
 

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -14,11 +14,11 @@ from prefect.utilities.serialization import (
     Bytes,
     DateTimeTZ,
     FunctionReference,
-    StatefulFunctionReference,
     JSONCompatible,
     Nested,
     ObjectSchema,
     OneOfSchema,
+    StatefulFunctionReference,
 )
 
 json_test_values = [


### PR DESCRIPTION
This PR runs `isort -y && black .` on the codebase to tidy up imports. No other changes.