### PR TITLE
Fix documentation mistake

### DIFF
--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -363,4 +363,5 @@ functions = ["to_qualified_name", "from_qualified_name"]
 [pages.utilities.tasks]
 title = "Task Utilities"
 module = "prefect.utilities.tasks"
-functions = ["tags", "as_task", "pause_task", "task", "unmapped", "defaults_from_attrs"]
+classes = ["unmapped"]
+functions = ["tags", "as_task", "pause_task", "task", "defaults_from_attrs"]


### PR DESCRIPTION
Fixes an issue wherein `unmapped` was listed as a function when in fact it is a class.  This messes up the auto-generated docs as can be seen here: 

<img width="943" alt="Screen Shot 2019-07-13 at 3 03 26 PM" src="https://user-images.githubusercontent.com/13255838/61176977-670f5b00-a57f-11e9-85d9-7ea729d9ab06.png">
