### PR TITLE
Streamline Cloud login with API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Explicitly set Dask keys for a better Dask visualization experience - [#1218](https://github.com/PrefectHQ/prefect/issues/1218)
 - Implement a local cache which persists for the duration of a Python session - [#1221](https://github.com/PrefectHQ/prefect/issues/1221)
 - Implement in-process retries for Cloud Tasks which request retry in less than one minute - [#1228](https://github.com/PrefectHQ/prefect/pull/1228)
+- Support `Client.login()` with API tokens - [#1240](https://github.com/PrefectHQ/prefect/pull/1240)
 
 ### Task Library
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -82,7 +82,7 @@ class Client:
         self.token = token
 
     @property
-    def local_token_path(self):
+    def local_token_path(self) -> str:
         """
         Returns the local token path corresponding to the provided graphql_server
         """

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -64,18 +64,7 @@ class Client:
             to; if not provided, will be pulled from `cloud.graphql` config var
     """
 
-    def _initialize_logger(self) -> None:
-        # The Client requires its own logging setup because the RemoteLogger actually
-        # uses a Client to ship its logs; we currently don't send Client logs to Cloud.
-        self.logger = logging.getLogger("Client")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(prefect.config.logging.format)
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
-        self.logger.setLevel(prefect.config.logging.level)
-
     def __init__(self, graphql_server: str = None):
-        self._initialize_logger()
 
         if not graphql_server:
             graphql_server = prefect.config.cloud.get("graphql")
@@ -83,17 +72,23 @@ class Client:
 
         token = prefect.config.cloud.get("auth_token", None)
 
+        self.token_is_local = False
         if token is None:
-            token_path = os.path.expanduser("~/.prefect/.credentials/auth_token")
-            if os.path.exists(token_path):
-                with open(token_path, "r") as f:
+            if os.path.exists(self.local_token_path):
+                with open(self.local_token_path, "r") as f:
                     token = f.read() or None
-            if token is not None:
-                # this is a rare event and we don't expect it to happen
-                # leaving this log in case it ever happens we'll know
-                self.logger.debug("Client token set from file {}".format(token_path))
+                    self.token_is_local = True
 
         self.token = token
+
+    @property
+    def local_token_path(self):
+        """
+        Returns the local token path corresponding to the provided graphql_server
+        """
+        return os.path.expanduser(
+            "~/.prefect/tokens/{}".format(self.graphql_server.replace("/", "_"))
+        )
 
     # -------------------------------------------------------------------------
     # Utilities
@@ -202,114 +197,66 @@ class Client:
         assert isinstance(server, str)  # mypy assert
 
         if self.token is None:
-            raise AuthorizationError("Call Client.login() to set the client token.")
+            raise AuthorizationError("No token found; call Client.login() to set one.")
 
         url = os.path.join(server, path.lstrip("/")).rstrip("/")
 
         params = params or {}
 
-        # write this as a function to allow reuse in next try/except block
-        def request_fn() -> "requests.models.Response":
-            headers = {"Authorization": "Bearer {}".format(self.token)}
-            session = requests.Session()
-            retries = Retry(
-                total=6,
-                backoff_factor=1,
-                status_forcelist=[500, 502, 503, 504],
-                method_whitelist=["DELETE", "GET", "POST"],
-            )
-            session.mount("https://", HTTPAdapter(max_retries=retries))
-            if method == "GET":
-                response = session.get(url, headers=headers, params=params)
-            elif method == "POST":
-                response = session.post(url, headers=headers, json=params)
-            elif method == "DELETE":
-                response = session.delete(url, headers=headers)
-            else:
-                raise ValueError("Invalid method: {}".format(method))
+        headers = {"Authorization": "Bearer {}".format(self.token)}
+        session = requests.Session()
+        retries = Retry(
+            total=6,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            method_whitelist=["DELETE", "GET", "POST"],
+        )
+        session.mount("https://", HTTPAdapter(max_retries=retries))
+        if method == "GET":
+            response = session.get(url, headers=headers, params=params)
+        elif method == "POST":
+            response = session.post(url, headers=headers, json=params)
+        elif method == "DELETE":
+            response = session.delete(url, headers=headers)
+        else:
+            raise ValueError("Invalid method: {}".format(method))
 
-            # Check if request returned a successful status
-            response.raise_for_status()
+        # Check if request returned a successful status
+        response.raise_for_status()
 
-            return response
-
-        # If a 401 status code is returned, refresh the login token
-        try:
-            return request_fn()
-        except requests.HTTPError as err:
-            if err.response.status_code == 401:
-                self.refresh_token()
-                return request_fn()
-            raise
+        return response
 
     # -------------------------------------------------------------------------
     # Auth
     # -------------------------------------------------------------------------
 
-    def login(
-        self,
-        email: str,
-        password: str,
-        account_slug: str = None,
-        account_id: str = None,
-    ) -> None:
+    def login(self, api_token: str) -> None:
         """
-        Login to the server in order to gain access
+        Logs in to Prefect Cloud with an API token. The token is written to local storage
+        so it persists across Prefect sessions.
 
         Args:
-            - email (str): User's email on the platform
-            - password (str): User's password on the platform
-            - account_slug (str, optional): Slug that is unique to the user
-            - account_id (str, optional): Specific Account ID for this user to use
+            - api_token (str): a Prefect Cloud API token
 
         Raises:
             - AuthorizationError if unable to login to the server (request does not return `200`)
         """
-
-        # lazy import for performance
-        import requests
-
-        # TODO: This needs to call the main graphql server and be adjusted for auth0
-        url = os.path.join(self.graphql_server, "login_email")  # type: ignore
-        response = requests.post(
-            url,
-            auth=(email, password),
-            json=dict(account_id=account_id, account_slug=account_slug),
-        )
-
-        # Load the current auth token if able to login
-        if not response.ok:
-            raise AuthorizationError("Could not log in.")
-        self.token = response.json().get("token")
-        if self.token:
-            creds_path = os.path.expanduser("~/.prefect/.credentials")
-            if not os.path.exists(creds_path):
-                os.makedirs(creds_path)
-            with open(os.path.join(creds_path, "auth_token"), "w+") as f:
-                f.write(self.token)
+        if not os.path.exists(self.local_token_path):
+            os.makedirs(self.local_token_path)
+        with open(self.local_token_path, "w+") as f:
+            f.write(api_token)
+        self.token = api_token
+        self.token_is_local = True
 
     def logout(self) -> None:
         """
-        Logs out by clearing all tokens, including deleting `~/.prefect/credentials/auth_token`
+        Deletes the token from this client, and removes it from local storage.
         """
-        token_path = os.path.expanduser("~/.prefect/.credentials/auth_token")
-        if os.path.exists(token_path):
-            os.remove(token_path)
-        del self.token
-
-    def refresh_token(self) -> None:
-        """
-        Refresh the auth token for this user on the server. It is only valid for fifteen minutes.
-        """
-        # lazy import for performance
-        import requests
-
-        # TODO: This needs to call the main graphql server
-        url = os.path.join(self.graphql_server, "refresh_token")  # type: ignore
-        response = requests.post(
-            url, headers={"Authorization": "Bearer {}".format(self.token)}
-        )
-        self.token = response.json().get("token")
+        self.token = None
+        if self.token_is_local:
+            if os.path.exists(self.local_token_path):
+                os.remove(self.local_token_path)
+            self.token_is_local = False
 
     def deploy(
         self,

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -86,9 +86,8 @@ class Client:
         """
         Returns the local token path corresponding to the provided graphql_server
         """
-        return os.path.expanduser(
-            "~/.prefect/tokens/{}".format(self.graphql_server.replace("/", "_"))
-        )
+        graphql_server = (self.graphql_server or "").replace("/", "_")
+        return os.path.expanduser("~/.prefect/tokens/{}".format(graphql_server))
 
     # -------------------------------------------------------------------------
     # Utilities

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -240,8 +240,8 @@ class Client:
         Raises:
             - AuthorizationError if unable to login to the server (request does not return `200`)
         """
-        if not os.path.exists(self.local_token_path):
-            os.makedirs(self.local_token_path)
+        if not os.path.exists(os.path.dirname(self.local_token_path)):
+            os.makedirs(os.path.dirname(self.local_token_path))
         with open(self.local_token_path, "w+") as f:
             f.write(api_token)
         self.token = api_token

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,8 +1,7 @@
-import base64
+import tempfile
 import datetime
 import json
 import os
-import uuid
 from unittest.mock import MagicMock, mock_open
 
 import marshmallow
@@ -13,22 +12,7 @@ import requests
 import prefect
 from prefect.client.client import Client, FlowRunInfoResult, TaskRunInfoResult
 from prefect.engine.result import NoResult, Result, SafeResult
-from prefect.engine.state import (
-    Cached,
-    Failed,
-    Finished,
-    Mapped,
-    Paused,
-    Pending,
-    Retrying,
-    Running,
-    Scheduled,
-    Skipped,
-    State,
-    Success,
-    TimedOut,
-    TriggerFailed,
-)
+from prefect.engine.state import Pending
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.exceptions import AuthorizationError, ClientError
 from prefect.utilities.graphql import GraphQLResult, decompress
@@ -56,93 +40,64 @@ def test_client_initializes_and_prioritizes_kwargs():
     assert client.token == "token"
 
 
+def test_client_token_path_depends_on_graphql_server():
+    assert Client(graphql_server="a").local_token_path == os.path.expanduser(
+        "~/.prefect/tokens/a"
+    )
+
+    assert Client(graphql_server="b").local_token_path == os.path.expanduser(
+        "~/.prefect/tokens/b"
+    )
+
+
 def test_client_token_initializes_from_file(monkeypatch):
-    monkeypatch.setattr("os.path.exists", MagicMock(return_value=True))
-    monkeypatch.setattr("builtins.open", mock_open(read_data="TOKEN"))
-    with set_temporary_config({"cloud.auth_token": None}):
+
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b"TOKEN")
+        f.seek(0)
+        monkeypatch.setattr("prefect.client.Client.local_token_path", f.name)
+
         client = Client()
     assert client.token == "TOKEN"
 
 
 def test_client_token_priotizes_config_over_file(monkeypatch):
-    monkeypatch.setattr("os.path.exists", MagicMock(return_value=True))
-    monkeypatch.setattr("builtins.open", mock_open(read_data="file-token"))
-    with set_temporary_config({"cloud.auth_token": "config-token"}):
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b"TOKEN")
+        f.seek(0)
+        monkeypatch.setattr("prefect.client.Client.local_token_path", f.name)
+
+        with set_temporary_config({"cloud.auth_token": "CONFIG-TOKEN"}):
+            client = Client()
+    assert client.token == "CONFIG-TOKEN"
+
+
+def test_login_writes_token(monkeypatch):
+    with tempfile.NamedTemporaryFile() as f:
+        monkeypatch.setattr("prefect.client.Client.local_token_path", f.name)
+
         client = Client()
-    assert client.token == "config-token"
+
+        client.login(api_token="a")
+        assert f.read() == b"a"
+
+        f.seek(0)
+
+        client.login(api_token="b")
+        assert f.read() == b"b"
 
 
-def test_client_doesnt_write_to_file_if_token_provided_from_config(monkeypatch):
-    monkeypatch.setattr("os.path.exists", MagicMock(return_value=True))
-    mock_file = mock_open()
-    monkeypatch.setattr("builtins.open", mock_file)
-    with set_temporary_config(
-        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "token"}
-    ):
+def test_logout_removes_token(monkeypatch):
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        monkeypatch.setattr("prefect.client.Client.local_token_path", f.name)
+
         client = Client()
-    assert not mock_file.called
 
+        client.login(api_token="a")
+        assert f.read() == b"a"
 
-@pytest.mark.parametrize("cloud", [True, False])
-def test_client_doesnt_login_if_no_tokens_available(monkeypatch, cloud):
-    post = MagicMock(
-        return_value=MagicMock(
-            ok=True, json=MagicMock(return_value=dict(token="secrettoken"))
-        )
-    )
-    mock_file = mock_open()
-    monkeypatch.setattr("builtins.open", mock_file)
-    session = MagicMock()
-    session.return_value.post = post
-    monkeypatch.setattr("requests.Session", session)
-
-    config = {
-        "cloud.graphql": "http://my-cloud.foo",
-        "cloud.auth_token": None,
-        "cloud.email": "test@example.com",
-        "cloud.password": "1234",
-    }
-
-    if cloud:
-        config.update(
-            {
-                "engine.flow_runner.default_class": "prefect.engine.cloud.CloudFlowRunner",
-                "engine.task_runner.default_class": "prefect.engine.cloud.CloudTaskRunner",
-            }
-        )
-    with set_temporary_config(config):
-        client = Client()
-    assert not post.called
-    assert client.token is None
-
-
-def test_client_logs_out_and_deletes_auth_token(monkeypatch):
-    post = MagicMock(
-        return_value=MagicMock(
-            ok=True, json=MagicMock(return_value=dict(token="secrettoken"))
-        )
-    )
-    monkeypatch.setattr("requests.post", post)
-    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
-        client = Client()
-    client.login("test@example.com", "1234")
-    token_path = os.path.expanduser("~/.prefect/.credentials/auth_token")
-    assert os.path.exists(token_path)
-    with open(token_path, "r") as f:
-        assert f.read() == "secrettoken"
     client.logout()
-    assert not os.path.exists(token_path)
-
-
-def test_client_raises_if_login_fails(monkeypatch):
-    post = MagicMock(return_value=MagicMock(ok=False))
-    monkeypatch.setattr("requests.post", post)
-    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
-        client = Client()
-    with pytest.raises(AuthorizationError):
-        client.login("test@example.com", "1234")
-    assert post.called
-    assert post.call_args[0][0] == "http://my-cloud.foo/login_email"
+    assert not os.path.exists(f.name)
 
 
 def test_client_posts_raises_with_no_token(monkeypatch):
@@ -176,31 +131,6 @@ def test_client_posts_to_graphql_server(monkeypatch):
     assert post.call_args[0][0] == "http://my-cloud.foo/foo/bar"
 
 
-def test_client_posts_retries_if_token_needs_refreshing(monkeypatch):
-    error = requests.HTTPError()
-    error.response = MagicMock(status_code=401)  # unauthorized
-    post = MagicMock(
-        return_value=MagicMock(
-            raise_for_status=MagicMock(side_effect=error),
-            json=MagicMock(return_value=dict(token="new-token")),
-        )
-    )
-    session = MagicMock()
-    session.return_value.post = post
-    monkeypatch.setattr("requests.Session", session)
-    monkeypatch.setattr("requests.post", post)
-    with set_temporary_config(
-        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
-    ):
-        client = Client()
-    with pytest.raises(requests.HTTPError) as exc:
-        result = client.post("/foo/bar")
-    assert exc.value is error
-    assert post.call_count == 3  # first call -> refresh token -> last call
-    assert post.call_args[0][0] == "http://my-cloud.foo/foo/bar"
-    assert client.token == "new-token"
-
-
 def test_client_posts_graphql_to_graphql_server(monkeypatch):
     post = MagicMock(
         return_value=MagicMock(
@@ -218,31 +148,6 @@ def test_client_posts_graphql_to_graphql_server(monkeypatch):
     assert result.data == {"success": True}
     assert post.called
     assert post.call_args[0][0] == "http://my-cloud.foo"
-
-
-def test_client_graphql_retries_if_token_needs_refreshing(monkeypatch):
-    error = requests.HTTPError()
-    error.response = MagicMock(status_code=401)  # unauthorized
-    post = MagicMock(
-        return_value=MagicMock(
-            raise_for_status=MagicMock(side_effect=error),
-            json=MagicMock(return_value=dict(token="new-token")),
-        )
-    )
-    session = MagicMock()
-    session.return_value.post = post
-    monkeypatch.setattr("requests.post", post)
-    monkeypatch.setattr("requests.Session", session)
-    with set_temporary_config(
-        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
-    ):
-        client = Client()
-    with pytest.raises(requests.HTTPError) as exc:
-        result = client.graphql("{}")
-    assert exc.value is error
-    assert post.call_count == 3  # first call -> refresh token -> last call
-    assert post.call_args[0][0] == "http://my-cloud.foo"
-    assert client.token == "new-token"
 
 
 ## test actual mutation and query handling

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -87,6 +87,21 @@ def test_login_writes_token(monkeypatch):
         assert f.read() == b"b"
 
 
+def test_login_creates_directories(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+
+        f_path = os.path.join(tmp, "a", "b", "c")
+
+        monkeypatch.setattr("prefect.client.Client.local_token_path", f_path)
+
+        client = Client()
+
+        client.login(api_token="a")
+
+        with open(f_path) as f:
+            assert f.read() == "a"
+
+
 def test_logout_removes_token(monkeypatch):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         monkeypatch.setattr("prefect.client.Client.local_token_path", f.name)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR streamlines the process of logging in to Cloud and storing API tokens. Previously, `Client.login()` was a deprecated call that used old email/password auth. Now, `Client.login()` accepts an API token as its sole argument, and writes it to a known location. If the token is found in that location, it will be used automatically. 

This PR also removes token refresh behavior, as API tokens don't need refreshing.
