### PR TITLE
Distributed logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with logs not always arriving in long-standing Dask clusters - [#1244](https://github.com/PrefectHQ/prefect/pull/1244)
 
 ### Breaking Changes
 

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -88,6 +88,7 @@ class FlowRunner(Runner):
         task_runner_cls: type = None,
         state_handlers: Iterable[Callable] = None,
     ):
+        self.context = prefect.context.to_dict()
         self.flow = flow
         if task_runner_cls is None:
             task_runner_cls = prefect.engine.get_default_task_runner_class()

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -599,12 +599,13 @@ class TaskRunner(Runner):
                     candidate._result = candidate._result.to_result()
                     return candidate
 
-        self.logger.warning(
-            "Task '{name}': can't use cache because it "
-            "is now invalid".format(
-                name=prefect.context.get("task_full_name", self.task.name)
+        if self.task.cache_for is not None:
+            self.logger.warning(
+                "Task '{name}': can't use cache because it "
+                "is now invalid".format(
+                    name=prefect.context.get("task_full_name", self.task.name)
+                )
             )
-        )
         return state or Pending("Cache was invalid; ready to run.")
 
     def run_mapped_task(
@@ -692,13 +693,14 @@ class TaskRunner(Runner):
         ) -> State:
             map_context = context.copy()
             map_context.update(map_index=map_index)
-            return self.run(
-                upstream_states=upstream_states,
-                # if we set the state here, then it will not be processed by `initialize_run()`
-                state=state,
-                context=map_context,
-                executor=executor,
-            )
+            with prefect.context(self.context):
+                return self.run(
+                    upstream_states=upstream_states,
+                    # if we set the state here, then it will not be processed by `initialize_run()`
+                    state=state,
+                    context=map_context,
+                    executor=executor,
+                )
 
         # generate initial states, if available
         if isinstance(state, Mapped):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -82,6 +82,7 @@ class TaskRunner(Runner):
         state_handlers: Iterable[Callable] = None,
         result_handler: "ResultHandler" = None,
     ):
+        self.context = prefect.context.to_dict()
         self.task = task
         self.result_handler = (
             task.result_handler

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -22,7 +22,7 @@ class CloudHandler(logging.StreamHandler):
     def __init__(self) -> None:
         super().__init__()
         self.client = None
-        self.logger = logger = logging.getLogger("CloudHandler")
+        self.logger = logging.getLogger("CloudHandler")
         handler = logging.StreamHandler()
         formatter = logging.Formatter(config.logging.format)
         formatter.converter = time.gmtime  # type: ignore

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -22,14 +22,18 @@ class CloudHandler(logging.StreamHandler):
     def __init__(self) -> None:
         super().__init__()
         self.client = None
-        self.errored_out = False
+        self.logger = logger = logging.getLogger("CloudHandler")
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(config.logging.format)
+        formatter.converter = time.gmtime  # type: ignore
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
+        self.logger.setLevel(config.logging.level)
 
     def emit(self, record) -> None:  # type: ignore
         try:
             from prefect.client import Client
 
-            if self.errored_out is True:
-                return
             if self.client is None:
                 self.client = Client()  # type: ignore
 
@@ -52,8 +56,8 @@ class CloudHandler(logging.StreamHandler):
                 level=level,
                 info=record_dict,
             )
-        except:
-            self.errored_out = True
+        except Exception as exc:
+            self.logger.critical("Failed to write log with error: {}".format(str(exc)))
 
 
 def configure_logging(testing: bool = False) -> logging.Logger:

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -384,6 +384,20 @@ def test_flow_runner_makes_copy_of_task_results_dict():
     assert task_states == {t1: Pending()}
 
 
+class TestContext:
+    def test_flow_runner_inits_with_current_context(self):
+        runner = FlowRunner(Flow(name="test"))
+        assert isinstance(runner.context, dict)
+        assert "chris" not in runner.context
+
+        with prefect.context(chris="foo"):
+            runner2 = TaskRunner(Task())
+            assert "chris" in runner2.context
+
+        assert "chris" not in prefect.context
+        assert runner2.context["chris"] == "foo"
+
+
 class TestCheckFlowPendingOrRunning:
     @pytest.mark.parametrize("state", [Pending(), Running(), Retrying(), Scheduled()])
     def test_pending_or_running_are_ok(self, state):

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1332,7 +1332,7 @@ class TestContext:
         assert "chris" not in runner.context
 
         with prefect.context(chris="foo"):
-            runner2 = TaskRunner(Task())
+            runner2 = prefect.engine.task_runner.TaskRunner(Task())
             assert "chris" in runner2.context
 
         assert "chris" not in prefect.context

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -330,6 +330,20 @@ def test_runner_checks_cached_inputs_correctly():
     assert post.result == 99
 
 
+class TestContext:
+    def test_task_runner_inits_with_current_context(self):
+        runner = TaskRunner(Task())
+        assert isinstance(runner.context, dict)
+        assert "chris" not in runner.context
+
+        with prefect.context(chris="foo"):
+            runner2 = TaskRunner(Task())
+            assert "chris" in runner2.context
+
+        assert "chris" not in prefect.context
+        assert runner2.context["chris"] == "foo"
+
+
 class TestInitializeRun:
     @pytest.mark.parametrize(
         "state", [Success(), Failed(), Pending(), Scheduled(), Skipped(), Cached()]

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -35,7 +35,7 @@ def test_remote_handler_is_configured_for_cloud():
         logger.handlers = []
 
 
-def test_remote_handler_captures_errors_then_passes():
+def test_remote_handler_captures_errors_and_logs_them(caplog):
     try:
         with utilities.configuration.set_temporary_config(
             {"logging.log_to_cloud": True}
@@ -44,7 +44,16 @@ def test_remote_handler_captures_errors_then_passes():
             assert hasattr(logger.handlers[-1], "client")
             child_logger = logger.getChild("sub-test")
             child_logger.critical("this should raise an error in the handler")
-            assert logger.handlers[-1].errored_out == True
+
+            critical_logs = [r for r in caplog.records if r.levelname == "CRITICAL"]
+            assert len(critical_logs) == 2
+
+            assert (
+                "Failed to write log with error"
+                in [
+                    log.message for log in critical_logs if log.name == "CloudHandler"
+                ].pop()
+            )
     finally:
         # reset root_logger
         logger = utilities.logging.configure_logging(testing=True)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes some issues we were seeing with logging in long-standing Dask clusters (namely, some logs didn't arrive).  In particular, this PR introduces the following behavior: whatever `prefect.context` is at _initialization_ time for the runners is guaranteed to be present during a run.  This ensures, in particular, that `flow_run_id` is always available for the logger.