### PR TITLE
Loosen the dask-kubernetes pin to accomodate newest distributed versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
         "google-cloud-bigquery >= 1.6.0, < 2.0",
         "google-cloud-storage >= 1.13, < 2.0",
     ],
-    "kubernetes": ["kubernetes >= 9.0.0a1, < 10.0", "dask-kubernetes == 0.8.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1, < 10.0", "dask-kubernetes >= 0.8.0"],
     "rss": ["feedparser >= 5.0.1, < 6.0"],
     "postgres": ["psycopg2-binary >= 2.8.2"],
     "redis": ["redis >= 3.2.1"],


### PR DESCRIPTION
`dask-kubernetes==0.8.0` is not compatible with newer versions of `distributed` -- @joshmeek I'll look to your guidance as to whether this requires any changes to the `CloudEnvironment` (which we should rename to `DaskKubernetesEnvironment` or something)