### PR TITLE
Remove sentence saying CloudResultHandler is default

### DIFF
--- a/docs/guide/core_concepts/results.md
+++ b/docs/guide/core_concepts/results.md
@@ -55,7 +55,7 @@ When running on Prefect Cloud, the output of a Result Handler's `write` method i
 ### How to specify a `ResultHandler`
 
 There is a hierarchy to determining what `ResultHandler` to use for a given piece of data:
-1. First, users can set a global default in their Prefect user config; if you never mention or think about Result Handlers again, this is the handler that will always be used.  As of this writing, the default handler that ships with a standard install of Prefect is the `CloudResultHandler` that writes data to a Prefect-managed Google Cloud Storage bucket.
+1. First, users can set a global default in their Prefect user config; if you never mention or think about Result Handlers again, this is the handler that will always be used.
 1. Next, you can specify a Flow-level result handler at Flow-initialization using the `result_handler` keyword argument.  Once again, if you never specify another result handler, this is the one that will be used for all your tasks in this particular Flow.
 1. Lastly, you can set a Task-level result handler.  This is achieved using the `result_handler` keyword argument at Task initialization (or in the `@task` decorator).  If you provide a result handler here, it will _always_ be used if the _output_ of this Task needs to be cached for any reason whatsoever.
 


### PR DESCRIPTION
It looks like CloudResultHandler was removed as the default in the 0.6.0 release. (See https://github.com/PrefectHQ/prefect/releases/tag/0.6.0 and https://github.com/PrefectHQ/prefect/pull/1198) Yet, the current documentation still refers to it as the default result handler.

As a healthcare company dealing with HIPAA/PHI data, it was scary to read this sentence (that I'm proposing to remove) in the docs: "As of this writing, the default handler that ships with a standard install of Prefect is the CloudResultHandler that writes data to a Prefect-managed Google Cloud Storage bucket." It caused me to worry that in testing Prefect Core locally we might have unwittingly shipped PHI data to a Google Cloud Storage bucket managed by Prefect.

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Documentation only


## Why is this PR important?
The current wording could cause people testing Prefect Core to worry that their data has been shipped to a Prefect-controlled Google Cloud Storage bucket.

