### PR TITLE
Checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Features
 
-- None
+- Introduce new `flows.checkpointing` configuration setting for checkpointing Tasks in local execution - [#1283](https://github.com/PrefectHQ/prefect/pull/1283)
 
 ### Enhancements
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -30,7 +30,8 @@ eager_edge_validation = false
 # If true, `flow.run` will run on schedule by default.
 # If false, only a single execution will occur (no retries, etc.)
 run_on_schedule = true
-
+# If true, tasks which set `checkpoint=True` will have their result handlers called
+checkpointing = false
 
 [tasks]
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -149,7 +149,7 @@ class CloudTaskRunner(TaskRunner):
 
         # we assign this so it can be shared with heartbeat thread
         self.task_run_id = context.get("task_run_id")  # type: ignore
-        context.update(cloud=True)
+        context.update(checkpointing=True)
 
         return super().initialize_run(state=state, context=context)
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -150,6 +150,7 @@ class TaskRunner(Runner):
         context.update(
             task_run_count=run_count, task_name=self.task.name, task_tags=self.task.tags
         )
+        context.setdefault("checkpointing", config.flows.checkpointing)
 
         return TaskRunnerInitializeResult(state=state, context=context)
 
@@ -838,10 +839,10 @@ class TaskRunner(Runner):
         result = Result(value=result, result_handler=self.result_handler)
         state = Success(result=result, message="Task run succeeded.")
 
-        ## only checkpoint tasks if running in cloud
+        ## only checkpoint tasks if checkpointing is turned on
         if (
             state.is_successful()
-            and prefect.context.get("cloud") is True
+            and prefect.context.get("checkpointing") is True
             and self.task.checkpoint is True
         ):
             state._result.store_safe_value()

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -74,7 +74,7 @@ def client(monkeypatch):
 def test_task_runner_puts_cloud_in_context(client):
     @prefect.task
     def whats_in_ctx():
-        return prefect.context.get("cloud")
+        return prefect.context.get("checkpointing")
 
     res = CloudTaskRunner(task=whats_in_ctx).run()
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a new config setting `flows.checkpointing` for turning on task checkpoints in local (non-cloud) execution.  The setting defaults to `False`, but when `True` Task result handlers will be called to "checkpoint" their results.

## Why is this PR important?
This PR has a few key advantages:
- allows for selective persistence of data
- allows users to more easily / naturally test their result handlers before deploying to Cloud

This will also make #892 easier to write