### PR TITLE
Allow mixed-case keys in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Allow passing of custom headers in `Client` calls - [#1255](https://github.com/PrefectHQ/prefect/pull/1255)
 - Autogenerate informative names and tags for Docker images built for Flow storage - [#1237](https://github.com/PrefectHQ/prefect/issues/1237)
+- Allow mixed-case configuration keys (environment variables are interpolated as lowercase) - [#1288](https://github.com/PrefectHQ/prefect/issues/1288)
 
 ### Task Library
 

--- a/docs/guide/core_concepts/configuration.md
+++ b/docs/guide/core_concepts/configuration.md
@@ -6,11 +6,11 @@ The configuration file is parsed when Prefect is first imported and is available
 
 ## Environment variables
 
-Any Prefect configuration key can be set by environment variable. In order to do so, prefix the variable with `PREFECT__` and use two underscores (`__`) to separate each part of the key.
+Any lowercase Prefect configuration key can be set by environment variable. In order to do so, prefix the variable with `PREFECT__` and use two underscores (`__`) to separate each part of the key.
 
 For example, if you set `PREFECT__TASKS__DEFAULTS__MAX_RETRIES=4`, then `prefect.config.tasks.defaults.max_retries == 4`.
 
-::: tip Config keys are lowercase
+::: tip Interpolated keys are lowercase
 Environment variables are always interpreted as lowercase configuration keys.
 :::
 
@@ -54,7 +54,7 @@ path = "$DIR/file.txt"
 
 In this case, loading `prefect.config.path == "/foo/file.txt"`
 
-Environment variables are always interpreted as lowercase values.
+Environment variables are always interpreted as lowercase keys.
 
 #### Configuration interpolation
 
@@ -97,4 +97,3 @@ assert prefect.config.user == "admin"
 
 Configs are recursively validated when first loaded. `ValueErrors` are raised for invalid config definitions. The checks include:
     - invalid keys: because `Config` objects have dictionary-like methods, it can create problems if any of their keys shadow one of their methods. For example, `"keys"` is an invalid key because `Config.keys()` is an important method.
-    - uppercase keys: all config keys should be lowercase, because only lowercase keys can be set by environment variables.

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -247,21 +247,10 @@ def process_task_defaults(config: Config) -> Config:
 def validate_config(config: Config) -> None:
     """
     Validates that the configuration file is valid.
-        - keys are lowercase
         - keys do not shadow Config methods
 
     Note that this is performed when the config is first loaded, but not after.
     """
-
-    def check_lowercase_keys(config: Config) -> None:
-        """
-        Recursively check that keys are lowercase
-        """
-        for k, v in config.items():
-            if k != k.lower():
-                raise ValueError('Config keys must be lowercase: "{}"'.format(k))
-            if isinstance(v, Config) and k != "context":
-                check_lowercase_keys(v)
 
     def check_valid_keys(config: Config) -> None:
         """
@@ -274,7 +263,6 @@ def validate_config(config: Config) -> None:
             if isinstance(v, Config):
                 check_valid_keys(v)
 
-    check_lowercase_keys(config)
     check_valid_keys(config)
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Previously, configuration keys were required to be lower-case. This was intended to prevent issues where case-insensitive environment variables were improperly interpolated. However it was overly-restrictive (see #1288). Now Prefect will allow mixed-case configs, and documents that environment variables can only be applied to lower-case keys.

Closes #1288 	


