### PR TITLE
Replace explicit asserts with pytest functions

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -125,9 +125,8 @@ def test_client_posts_raises_with_no_token(monkeypatch):
         {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": None}
     ):
         client = Client()
-    with pytest.raises(AuthorizationError) as exc:
+    with pytest.raises(AuthorizationError, match="Client.login"):
         result = client.post("/foo/bar")
-    assert "Client.login" in str(exc.value)
 
 
 def test_headers_are_passed_to_get(monkeypatch):
@@ -231,9 +230,8 @@ def test_graphql_errors_get_raised(monkeypatch):
         {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
     ):
         client = Client()
-    with pytest.raises(ClientError) as exc:
-        res = client.graphql("query: {}")
-    assert "GraphQL issue!" in str(exc.value)
+    with pytest.raises(ClientError, match="GraphQL issue!"):
+        client.graphql("query: {}")
 
 
 @pytest.mark.parametrize("compressed", [True, False])
@@ -503,9 +501,8 @@ def test_get_flow_run_info_raises_informative_error(monkeypatch):
         {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
     ):
         client = Client()
-    with pytest.raises(ClientError) as exc:
-        result = client.get_flow_run_info(flow_run_id="74-salt")
-    assert "not found" in str(exc.value)
+    with pytest.raises(ClientError, match="not found"):
+        client.get_flow_run_info(flow_run_id="74-salt")
 
 
 def test_set_flow_run_state(monkeypatch):
@@ -537,9 +534,8 @@ def test_set_flow_run_state_with_error(monkeypatch):
         {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
     ):
         client = Client()
-    with pytest.raises(ClientError) as exc:
+    with pytest.raises(ClientError, match="something went wrong"):
         client.set_flow_run_state(flow_run_id="74-salt", version=0, state=Pending())
-    assert "something went wrong" in str(exc.value)
 
 
 def test_get_task_run_info(monkeypatch):
@@ -600,12 +596,10 @@ def test_get_task_run_info_with_error(monkeypatch):
     ):
         client = Client()
 
-    with pytest.raises(ClientError) as exc:
+    with pytest.raises(ClientError, match="something went wrong"):
         client.get_task_run_info(
             flow_run_id="74-salt", task_id="72-salt", map_index=None
         )
-
-    assert "something went wrong" in str(exc.value)
 
 
 def test_set_task_run_state(monkeypatch):
@@ -639,8 +633,8 @@ def test_set_task_run_state_serializes(monkeypatch):
         client = Client()
 
     res = SafeResult(lambda: None, result_handler=None)
-    with pytest.raises(marshmallow.exceptions.ValidationError) as exc:
-        result = client.set_task_run_state(
+    with pytest.raises(marshmallow.exceptions.ValidationError):
+        client.set_task_run_state(
             task_run_id="76-salt", version=0, state=Pending(result=res)
         )
 
@@ -660,9 +654,8 @@ def test_set_task_run_state_with_error(monkeypatch):
     ):
         client = Client()
 
-    with pytest.raises(ClientError) as exc:
+    with pytest.raises(ClientError, match="something went wrong"):
         client.set_task_run_state(task_run_id="76-salt", version=0, state=Pending())
-    assert "something went wrong" in str(exc.value)
 
 
 def test_write_log_successfully(monkeypatch):
@@ -695,6 +688,5 @@ def test_write_log_with_error(monkeypatch):
     ):
         client = Client()
 
-    with pytest.raises(ClientError) as exc:
+    with pytest.raises(ClientError, match="something went wrong"):
         client.write_run_log(flow_run_id="1")
-    assert "something went wrong" in str(exc.value)

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -21,9 +21,8 @@ def test_create_secret():
 def test_secret_raises_if_doesnt_exist():
     secret = Secret(name="test")
     with set_temporary_config({"cloud.use_local_secrets": True}):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="not found"):
             secret.get()
-    assert "not found" in str(exc.value)
 
 
 def test_secret_value_pulled_from_context():
@@ -41,9 +40,8 @@ def test_secret_value_depends_on_use_local_secrets():
         {"cloud.use_local_secrets": False, "cloud.auth_token": None}
     ):
         with prefect.context(secrets=dict(test=42)):
-            with pytest.raises(AuthorizationError) as exc:
+            with pytest.raises(AuthorizationError, match="Client.login"):
                 secret.get()
-    assert "Client.login" in str(exc.value)
 
 
 def test_secrets_use_client(monkeypatch):
@@ -74,7 +72,7 @@ def test_secrets_raise_if_in_flow_context():
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(test=42)):
             with prefect.Flow("test"):
-                with pytest.raises(ValueError) as exc:
+                with pytest.raises(ValueError):
                     secret.get()
 
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -393,7 +393,7 @@ def test_add_edge_raise_error_for_duplicate_key_if_validate():
     a = AddTask()
 
     f.add_edge(upstream_task=t, downstream_task=a, key="x")
-    with pytest.raises(ValueError, match='already been assigned'):
+    with pytest.raises(ValueError, match="already been assigned"):
         f.add_edge(upstream_task=t, downstream_task=a, key="x", validate=True)
 
 
@@ -899,7 +899,7 @@ def test_validate_missing_edge_downstream_tasks():
     t2 = Task()
     f.add_edge(t1, t2)
     f.tasks.remove(t2)
-    with pytest.raises(ValueError,match="edges refer to tasks"):
+    with pytest.raises(ValueError, match="edges refer to tasks"):
         f.validate()
 
 
@@ -909,7 +909,7 @@ def test_validate_missing_edge_upstream_tasks():
     t2 = Task()
     f.add_edge(t1, t2)
     f.tasks.remove(t1)
-    with pytest.raises(ValueError,match="edges refer to tasks"):
+    with pytest.raises(ValueError, match="edges refer to tasks"):
         f.validate()
 
 
@@ -966,9 +966,8 @@ class TestFlowVisualize:
 
         with monkeypatch.context() as m:
             m.setattr(sys, "path", "")
-            with pytest.raises(ImportError,match="pip install prefect\[viz\]"):
+            with pytest.raises(ImportError, match="pip install prefect\[viz\]"):
                 f.visualize()
-
 
     def test_viz_returns_graph_object_if_in_ipython(self):
         import graphviz
@@ -1410,7 +1409,7 @@ class TestSerialize:
         # default settings should allow this even though it's illegal
         f.add_edge(t2, t1)
 
-        with pytest.raises(ValueError, match='Cycle found'):
+        with pytest.raises(ValueError, match="Cycle found"):
             f.serialize()
 
     def test_default_environment_is_cloud_environment(self):
@@ -1477,7 +1476,7 @@ class TestFlowRunMethod:
         t = StatefulTask()
         schedule = MockSchedule()
         f = Flow(name="test", tasks=[t], schedule=schedule)
-        with pytest.raises(SyntaxError, match='Cease'):
+        with pytest.raises(SyntaxError, match="Cease"):
             f.run()
         assert t.call_count == 2
 
@@ -1597,7 +1596,7 @@ class TestFlowRunMethod:
         )
         schedule = MockSchedule()
         f = Flow(name="test", tasks=[t], schedule=schedule)
-        with pytest.raises(SyntaxError, match='Cease'):
+        with pytest.raises(SyntaxError, match="Cease"):
             f.run()
         assert t.call_count == 2
         assert len(state_history) == 5  # Running, Failed, Retrying, Running, Success
@@ -2033,8 +2032,9 @@ def test_flow_run_raises_if_no_more_scheduled_runs():
         ]
     )
     f = Flow(name="test", schedule=schedule)
-    with pytest.raises(ValueError, match='no more scheduled runs'):
+    with pytest.raises(ValueError, match="no more scheduled runs"):
         f.run()
+
 
 def test_flow_run_respects_state_kwarg():
     f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -383,10 +383,8 @@ def test_add_edge_raise_error_for_downstream_parameter():
     t = Task()
     p = Parameter("p")
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="can not have upstream dependencies"):
         f.add_edge(upstream_task=t, downstream_task=p)
-
-    assert "can not have upstream dependencies" in str(exc.value)
 
 
 def test_add_edge_raise_error_for_duplicate_key_if_validate():
@@ -395,10 +393,8 @@ def test_add_edge_raise_error_for_duplicate_key_if_validate():
     a = AddTask()
 
     f.add_edge(upstream_task=t, downstream_task=a, key="x")
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='already been assigned'):
         f.add_edge(upstream_task=t, downstream_task=a, key="x", validate=True)
-
-    assert "already been assigned" in str(exc.value)
 
 
 def test_add_edge_returns_edge():
@@ -597,9 +593,8 @@ def test_set_reference_tasks():
 
 def test_set_reference_tasks_at_init_with_empty_flow_raises_error():
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="must be part of the flow"):
         Flow(name="test", reference_tasks=[Task()])
-    assert "must be part of the flow" in str(exc.value)
 
 
 def test_set_reference_tasks_at_init():
@@ -739,21 +734,17 @@ def test_upstream_and_downstream_error_msgs_when_task_is_not_in_flow():
     f = Flow(name="test")
     t = Task()
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="was not found in Flow"):
         f.edges_to(t)
-        assert "was not found in Flow" in e
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="was not found in Flow"):
         f.edges_from(t)
-        assert "was not found in Flow" in e
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="was not found in Flow"):
         f.upstream_tasks(t)
-        assert "was not found in Flow" in e
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="was not found in Flow"):
         f.downstream_tasks(t)
-        assert "was not found in Flow" in e
 
 
 def test_sorted_tasks():
@@ -832,9 +823,8 @@ def test_sorted_tasks_with_invalid_start_task():
     t3 = Task("3")
     f.add_edge(t1, t2)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="not found in Flow"):
         f.sorted_tasks(root_tasks=[t3])
-    assert "not found in Flow" in str(exc.value)
 
 
 def test_flow_raises_for_irrelevant_user_provided_parameters():
@@ -899,9 +889,8 @@ def test_validate_cycles():
     t2 = Task()
     f.add_edge(t1, t2)
     f.add_edge(t2, t1)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="Cycle found"):
         f.validate()
-    assert "cycle found" in str(exc.value).lower()
 
 
 def test_validate_missing_edge_downstream_tasks():
@@ -910,9 +899,8 @@ def test_validate_missing_edge_downstream_tasks():
     t2 = Task()
     f.add_edge(t1, t2)
     f.tasks.remove(t2)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError,match="edges refer to tasks"):
         f.validate()
-    assert "edges refer to tasks" in str(exc.value).lower()
 
 
 def test_validate_missing_edge_upstream_tasks():
@@ -921,9 +909,8 @@ def test_validate_missing_edge_upstream_tasks():
     t2 = Task()
     f.add_edge(t1, t2)
     f.tasks.remove(t1)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError,match="edges refer to tasks"):
         f.validate()
-    assert "edges refer to tasks" in str(exc.value).lower()
 
 
 def test_validate_missing_reference_tasks():
@@ -934,9 +921,8 @@ def test_validate_missing_reference_tasks():
     f.add_task(t2)
     f.set_reference_tasks([t1])
     f.tasks.remove(t1)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="reference tasks are not contained"):
         f.validate()
-    assert "reference tasks are not contained" in str(exc.value).lower()
 
 
 def test_validate_edges_kwarg():
@@ -980,10 +966,9 @@ class TestFlowVisualize:
 
         with monkeypatch.context() as m:
             m.setattr(sys, "path", "")
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError,match="pip install prefect\[viz\]"):
                 f.visualize()
 
-        assert "pip install prefect[viz]" in repr(exc.value)
 
     def test_viz_returns_graph_object_if_in_ipython(self):
         import graphviz
@@ -1425,9 +1410,8 @@ class TestSerialize:
         # default settings should allow this even though it's illegal
         f.add_edge(t2, t1)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Cycle found'):
             f.serialize()
-        assert "cycle found" in str(exc.value).lower()
 
     def test_default_environment_is_cloud_environment(self):
         f = Flow(name="test")
@@ -1493,9 +1477,8 @@ class TestFlowRunMethod:
         t = StatefulTask()
         schedule = MockSchedule()
         f = Flow(name="test", tasks=[t], schedule=schedule)
-        with pytest.raises(SyntaxError) as exc:
+        with pytest.raises(SyntaxError, match='Cease'):
             f.run()
-        assert "Cease" in str(exc.value)
         assert t.call_count == 2
 
     def test_flow_dot_run_doesnt_run_on_schedule(self):
@@ -1614,9 +1597,8 @@ class TestFlowRunMethod:
         )
         schedule = MockSchedule()
         f = Flow(name="test", tasks=[t], schedule=schedule)
-        with pytest.raises(SyntaxError) as exc:
+        with pytest.raises(SyntaxError, match='Cease'):
             f.run()
-        assert "Cease" in str(exc.value)
         assert t.call_count == 2
         assert len(state_history) == 5  # Running, Failed, Retrying, Running, Success
 
@@ -2038,9 +2020,8 @@ def test_bad_flow_runner_code_still_returns_state_obj():
 
 def test_flow_run_raises_informative_error_for_certain_kwargs():
     f = Flow(name="test")
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="`return_tasks` keyword cannot be provided"):
         f.run(return_tasks=f.tasks)
-    assert "`return_tasks` keyword cannot be provided" in str(exc.value)
 
 
 def test_flow_run_raises_if_no_more_scheduled_runs():
@@ -2052,10 +2033,8 @@ def test_flow_run_raises_if_no_more_scheduled_runs():
         ]
     )
     f = Flow(name="test", schedule=schedule)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='no more scheduled runs'):
         f.run()
-    assert "no more scheduled runs" in str(exc.value)
-
 
 def test_flow_run_respects_state_kwarg():
     f = Flow(name="test")

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -516,7 +516,7 @@ class TestTaskArgs:
     def test_task_args_raises_for_non_attrs(self):
         t = Task()
         with Flow(name="test") as f:
-            with pytest.raises(AttributeError, match='foo'):
+            with pytest.raises(AttributeError, match="foo"):
                 res = t(task_args={"foo": "bar"})
 
     @pytest.mark.parametrize(

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -413,9 +413,8 @@ class TestDependencies:
         f = Flow(name="test")
         t1 = Task()
         t2 = Task()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="No Flow was passed"):
             t1.set_downstream(t2)
-        assert "No Flow was passed" in str(exc.value)
 
     @pytest.mark.parametrize(
         "props", [{"mapped": True}, {"key": "x"}, {"key": "x", "mapped": True}]
@@ -445,9 +444,8 @@ class TestDependencies:
         f = Flow(name="test")
         t1 = Task()
         t2 = Task()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="No Flow was passed"):
             t2.set_upstream(t1)
-        assert "No Flow was passed" in str(exc.value)
 
     @pytest.mark.parametrize(
         "props", [{"mapped": True}, {"key": "x"}, {"key": "x", "mapped": True}]
@@ -518,10 +516,8 @@ class TestTaskArgs:
     def test_task_args_raises_for_non_attrs(self):
         t = Task()
         with Flow(name="test") as f:
-            with pytest.raises(AttributeError) as exc:
+            with pytest.raises(AttributeError, match='foo'):
                 res = t(task_args={"foo": "bar"})
-
-        assert "foo" in str(exc.value)
 
     @pytest.mark.parametrize(
         "attr,val",

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -167,17 +167,14 @@ def test_executor_has_compatible_timeout_handler(executor):
     slow_fn = lambda: time.sleep(3)
     with executor.start():
         with pytest.raises(TimeoutError):
-            res = executor.wait(
-                executor.submit(executor.timeout_handler, slow_fn, timeout=1)
-            )
+            executor.wait(executor.submit(executor.timeout_handler, slow_fn, timeout=1))
 
 
 def test_dask_processes_executor_handles_timeouts(mproc):
     slow_fn = lambda: time.sleep(2)
     with mproc.start():
-        with pytest.raises(TimeoutError) as exc:
-            res = mproc.wait(mproc.submit(mproc.timeout_handler, slow_fn, timeout=1))
-    assert "Execution timed out" in str(exc.value)
+        with pytest.raises(TimeoutError, match="Execution timed out"):
+            mproc.wait(mproc.submit(mproc.timeout_handler, slow_fn, timeout=1))
 
 
 class TestDaskExecutor:

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -86,28 +86,22 @@ def test_result_handlers_must_implement_read_and_write_to_work():
     class MyHandler(ResultHandler):
         pass
 
-    with pytest.raises(TypeError) as exc:
-        m = MyHandler()
-
-    assert "abstract methods read, write" in str(exc.value)
+    with pytest.raises(TypeError, match="abstract methods read, write"):
+        MyHandler()
 
     class WriteHandler(ResultHandler):
         def write(self, val):
             pass
 
-    with pytest.raises(TypeError) as exc:
-        m = WriteHandler()
-
-    assert "abstract methods read" in str(exc.value)
+    with pytest.raises(TypeError, match="abstract methods read"):
+        WriteHandler()
 
     class ReadHandler(ResultHandler):
         def read(self, val):
             pass
 
-    with pytest.raises(TypeError) as exc:
-        m = ReadHandler()
-
-    assert "abstract methods write" in str(exc.value)
+    with pytest.raises(TypeError, match="abstract methods write"):
+        ReadHandler()
 
 
 @pytest.mark.xfail(raises=ImportError, reason="google extras not installed.")

--- a/tests/engine/test_result.py
+++ b/tests/engine/test_result.py
@@ -17,9 +17,8 @@ class TestInitialization:
             n()
 
     def test_result_requires_value(self):
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(TypeError, match="value"):
             r = Result()
-        assert "value" in str(exc.value)
 
     def test_result_inits_with_value(self):
         r = Result(3)
@@ -40,17 +39,14 @@ class TestInitialization:
         assert r.result_handler == handler
 
     def test_safe_result_requires_both_init_args(self):
-        with pytest.raises(TypeError) as exc:
-            res = SafeResult()
-        assert "2 required positional arguments" in str(exc.value)
+        with pytest.raises(TypeError, match="2 required positional arguments"):
+            SafeResult()
 
-        with pytest.raises(TypeError) as exc:
-            res = SafeResult(value="3")
-        assert "1 required positional argument" in str(exc.value)
+        with pytest.raises(TypeError, match="1 required positional argument"):
+            SafeResult(value="3")
 
-        with pytest.raises(TypeError) as exc:
-            res = SafeResult(result_handler=JSONResultHandler())
-        assert "1 required positional argument" in str(exc.value)
+        with pytest.raises(TypeError, match="1 required positional argument"):
+            SafeResult(result_handler=JSONResultHandler())
 
     def test_safe_result_inits_with_both_args(self):
         res = SafeResult(value="3", result_handler=JSONResultHandler())

--- a/tests/environments/storage/test_bytes_storage.py
+++ b/tests/environments/storage/test_bytes_storage.py
@@ -28,9 +28,8 @@ def test_add_flow_raises_if_name_conflict():
     f = Flow("test")
     res = storage.add_flow(f)
     g = Flow("test")
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='name "test"'):
         storage.add_flow(g)
-    assert 'name "test"' in str(exc.value)
 
 
 def test_get_env_runner_raises():

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -340,9 +340,8 @@ def test_pull_image_raises_if_error_encountered(monkeypatch):
     ]
     monkeypatch.setattr("docker.APIClient", MagicMock(return_value=client))
 
-    with pytest.raises(InterruptedError) as exc:
+    with pytest.raises(InterruptedError, match="you know nothing jon snow"):
         storage.pull_image()
-    assert "you know nothing jon snow" in str(exc.value)
 
 
 def test_push_image(capsys, monkeypatch):
@@ -370,9 +369,8 @@ def test_push_image_raises_if_error_encountered(monkeypatch):
     ]
     monkeypatch.setattr("docker.APIClient", MagicMock(return_value=client))
 
-    with pytest.raises(InterruptedError) as exc:
+    with pytest.raises(InterruptedError, match="you know nothing jon snow"):
         storage.push_image(image_name="test", image_tag="test")
-    assert "you know nothing jon snow" in str(exc.value)
 
 
 def test_parse_output():

--- a/tests/environments/storage/test_local_storage.py
+++ b/tests/environments/storage/test_local_storage.py
@@ -45,9 +45,8 @@ def test_add_flow_raises_if_name_conflict():
         f = Flow("test")
         res = storage.add_flow(f)
         g = Flow("test")
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='name "test"'):
             storage.add_flow(g)
-        assert 'name "test"' in str(exc.value)
 
 
 def test_get_env_runner_raises():

--- a/tests/environments/storage/test_memory_storage.py
+++ b/tests/environments/storage/test_memory_storage.py
@@ -27,9 +27,8 @@ def test_add_flow_raises_if_name_conflict():
     f = Flow("test")
     res = storage.add_flow(f)
     g = Flow("test")
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='name "test"'):
         storage.add_flow(g)
-    assert 'name "test"' in str(exc.value)
 
 
 def test_get_env_runner_raises():

--- a/tests/flows/test_parameter.py
+++ b/tests/flows/test_parameter.py
@@ -66,17 +66,15 @@ def test_call_accepts_flow():
 
 
 def test_call_must_have_a_flow_out_of_context():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="infer an active Flow"):
         Parameter("x")()
-    assert "infer an active Flow" in str(exc.value)
 
 
 @pytest.mark.parametrize("attr", ["mapped", "task_args", "upstream_tasks"])
 def test_call_does_not_accept_most_args(attr):
     x = Parameter("x")
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
         x(**{attr: None})
-    assert "unexpected keyword argument" in str(exc.value)
 
 
 def test_copy_with_new_name():
@@ -89,6 +87,5 @@ def test_copy_with_new_name():
 
 def test_copy_requires_name():
     x = Parameter("x")
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="required positional argument"):
         x.copy()
-    assert "required positional argument" in str(exc.value)

--- a/tests/serialization/test_edges.py
+++ b/tests/serialization/test_edges.py
@@ -13,9 +13,8 @@ def test_serialize_empty_dict():
 
 
 def test_deserialize_empty_dict_fails():
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="required positional arguments"):
         EdgeSchema().load({})
-    assert "required positional arguments" in str(exc.value).lower()
 
 
 def test_deserialize_empty_dict_without_create_object():

--- a/tests/serialization/test_result.py
+++ b/tests/serialization/test_result.py
@@ -72,7 +72,7 @@ def test_safe_result_disallows_none_result_handler_at_deserialization_time():
     schema = SafeResultSchema()
     r = SafeResult(value=None, result_handler=None)
     serialized = schema.dump(r)
-    with pytest.raises(marshmallow.exceptions.ValidationError) as exc:
+    with pytest.raises(marshmallow.exceptions.ValidationError):
         schema.load(serialized)
 
 

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -19,9 +19,8 @@ class TestS3Download:
 
     def test_raises_if_bucket_not_eventually_provided(self):
         task = S3Download()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="bucket"):
             task.run(key="")
-        assert "bucket" in str(exc.value)
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
         task = S3Download(bucket="bob")
@@ -51,9 +50,8 @@ class TestS3Upload:
 
     def test_raises_if_bucket_not_eventually_provided(self):
         task = S3Upload()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="bucket"):
             task.run(data="")
-        assert "bucket" in str(exc.value)
 
     def test_generated_key_is_str(self, monkeypatch):
         task = S3Upload(bucket="test")

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -31,9 +31,8 @@ class TestOpenGithubIssueInitialization:
 
     def test_repo_is_required_eventually(self):
         task = OpenGitHubIssue()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="repo"):
             task.run()
-        assert "repo" in str(exc.value)
 
 
 class TestCredentialsandProjects:

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -32,9 +32,8 @@ class TestCreateGitHubPRInitialization:
 
     def test_repo_is_required_eventually(self):
         task = CreateGitHubPR()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="repo"):
             task.run()
-        assert "repo" in str(exc.value)
 
 
 class TestCredentialsandProjects:

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -27,9 +27,8 @@ class TestGetRepoInfoInitialization:
 
     def test_repo_is_required_eventually(self):
         task = GetRepoInfo()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="repo"):
             task.run()
-        assert "repo" in str(exc.value)
 
 
 class TestCreateBranchInitialization:
@@ -53,15 +52,13 @@ class TestCreateBranchInitialization:
 
     def test_repo_is_required_eventually(self):
         task = CreateBranch(branch_name="bob")
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="repo"):
             task.run()
-        assert "repo" in str(exc.value)
 
     def test_branch_name_is_required_eventually(self):
         task = CreateBranch(repo="org/bob")
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="branch name"):
             task.run()
-        assert "branch name" in str(exc.value)
 
 
 class TestCredentials:
@@ -85,11 +82,10 @@ class TestCredentials:
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-                with pytest.raises(ValueError) as exc:
+                with pytest.raises(ValueError, match="not found"):
                     task.run(repo="org/repo", branch_name="new")
 
         assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
-        assert "not found" in str(exc.value)
 
     def test_creds_secret_can_be_overwritten_repo_info(self, monkeypatch):
         task = GetRepoInfo(token_secret="MY_SECRET")

--- a/tests/tasks/google/test_bigquery.py
+++ b/tests/tasks/google/test_bigquery.py
@@ -51,9 +51,8 @@ class TestBigQueryInitialization:
 
     def test_query_is_required_eventually(self):
         task = BigQueryTask()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="query"):
             task.run()
-        assert "query" in str(exc.value)
 
     @pytest.mark.parametrize("attr", ["dataset_dest", "table_dest"])
     def test_dataset_dest_and_table_dest_are_required_together_eventually(self, attr):
@@ -254,13 +253,11 @@ class TestDryRuns:
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                with pytest.raises(ValueError) as exc:
+                with pytest.raises(
+                    ValueError,
+                    match="Query will process 21836427 bytes which is above the set maximum of 1200 for this task",
+                ):
                     task.run(query="SELECT *")
-
-        assert (
-            "Query will process 21836427 bytes which is above the set maximum of 1200 for this task"
-            in str(exc.value)
-        )
 
 
 class TestCreateBigQueryTableInitialization:

--- a/tests/tasks/google/test_gcs_upload_download.py
+++ b/tests/tasks/google/test_gcs_upload_download.py
@@ -31,10 +31,8 @@ class TestInitialization:
         assert task.tags == {"bob"}
 
     def test_default_bucket_name_is_required(self, klass):
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(TypeError, match="bucket"):
             task = klass()
-
-        assert "bucket" in str(exc.value)
 
     @pytest.mark.parametrize(
         "attr", ["blob", "encryption_key_secret", "credentials_secret", "project"]
@@ -154,10 +152,8 @@ class TestBuckets:
 
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                with pytest.raises(NotFound) as exc:
+                with pytest.raises(NotFound, match="no bucket"):
                     task.run(**{run_arg: "empty"})
-
-        assert "no bucket" in str(exc.value)
 
     def test_bucket_doesnt_exist_can_be_created_on_upload(self, monkeypatch):
         task = GCSUpload(bucket="test", create_bucket=True)

--- a/tests/tasks/postgres/test_postgres.py
+++ b/tests/tasks/postgres/test_postgres.py
@@ -35,4 +35,3 @@ class TestPostgresFetch:
             match="The 'fetch' parameter must be one of the following - \('one', 'many', 'all'\)",
         ):
             task.run(query="SELECT * FROM some_table", fetch="not a valid parameter")
-

--- a/tests/tasks/postgres/test_postgres.py
+++ b/tests/tasks/postgres/test_postgres.py
@@ -14,9 +14,8 @@ class TestPostgresExecute:
         task = PostgresExecute(
             db_name="test", user="test", password="test", host="test"
         )
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A query string must be provided"):
             task.run()
-        assert "A query string must be provided" == str(exc.value)
 
 
 class TestPostgresFetch:
@@ -26,15 +25,14 @@ class TestPostgresFetch:
 
     def test_query_string_must_be_provided(self):
         task = PostgresFetch(db_name="test", user="test", password="test", host="test")
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A query string must be provided"):
             task.run()
-        assert "A query string must be provided" == str(exc.value)
 
     def test_bad_fetch_param_raises(self):
         task = PostgresFetch(db_name="test", user="test", password="test", host="test")
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="The 'fetch' parameter must be one of the following - \('one', 'many', 'all'\)",
+        ):
             task.run(query="SELECT * FROM some_table", fetch="not a valid parameter")
-        assert (
-            "The 'fetch' parameter must be one of the following - ('one', 'many', 'all')"
-            == str(exc.value)
-        )
+

--- a/tests/tasks/redis/test_redis_tasks.py
+++ b/tests/tasks/redis/test_redis_tasks.py
@@ -16,17 +16,20 @@ class TestRedisSet:
         task = RedisSet()
 
         ## raises if neither provided
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="redis_key and redis_val must be provided"
+        ):
             task.run()
-        assert "redis_key and redis_val must be provided" == str(exc.value)
 
         ## raises if only one arg is missing
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="redis_key and redis_val must be provided"
+        ):
             task.run(redis_key="foo")
-        assert "redis_key and redis_val must be provided" == str(exc.value)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="redis_key and redis_val must be provided"
+        ):
             task.run(redis_val="bar")
-        assert "redis_key and redis_val must be provided" == str(exc.value)
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
         task = RedisSet()
@@ -55,9 +58,8 @@ class TestRedisGet:
 
     def test_raises_key_val_not_provided(self):
         task = RedisGet()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="redis_key must be provided"):
             task.run()
-        assert "redis_key must be provided" == str(exc.value)
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
         task = RedisGet()
@@ -86,9 +88,8 @@ class TestRedisExecute:
 
     def test_raises_if_command_not_provided(self):
         task = RedisExecute()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A redis command must be specified"):
             task.run()
-        assert "A redis command must be specified" == str(exc.value)
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
         task = RedisExecute()

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -18,11 +18,10 @@ class TestSpacyNLP:
         assert task.text == "This is some text"
 
     def test_bad_model_raises_error(self):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="not_a_spacy_model"):
             task = SpacyNLP(
                 text="This is some text", spacy_model_name="not_a_spacy_model"
             )
-        assert "not_a_spacy_model" in str(exc.value)
 
     def test_text_passed_to_run(self):
         nlp = MagicMock()
@@ -45,10 +44,8 @@ class TestSpacyTagger:
 
     def test_nlp_model_provided(self):
         task = SpacyTagger()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A spaCy pipeline must be provided"):
             task.run()
-
-        assert "A spaCy pipeline must be provided" == str(exc.value)
 
 
 class TestSpacyParser:
@@ -65,10 +62,8 @@ class TestSpacyParser:
 
     def test_nlp_model_provided(self):
         task = SpacyParser()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A spaCy pipeline must be provided"):
             task.run()
-
-        assert "A spaCy pipeline must be provided" == str(exc.value)
 
 
 class TestSpacyNER:
@@ -85,10 +80,8 @@ class TestSpacyNER:
 
     def test_nlp_model_provided(self):
         task = SpacyNER()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A spaCy pipeline must be provided"):
             task.run()
-
-        assert "A spaCy pipeline must be provided" == str(exc.value)
 
 
 class TestSpacyComponent:
@@ -105,7 +98,6 @@ class TestSpacyComponent:
 
     def test_nlp_model_provided(self):
         task = SpacyComponent()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="A spaCy pipeline must be provided"):
             task.run()
 
-        assert "A spaCy pipeline must be provided" == str(exc.value)

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -100,4 +100,3 @@ class TestSpacyComponent:
         task = SpacyComponent()
         with pytest.raises(ValueError, match="A spaCy pipeline must be provided"):
             task.run()
-

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -131,9 +131,8 @@ def test_list_of_tasks():
 
 
 def test_merge_with_upstream_skip_arg_raises_error():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="skip_on_upstream_skip=False") :
         prefect.tasks.control_flow.conditional.Merge(skip_on_upstream_skip=True)
-    assert "skip_on_upstream_skip=False" in str(exc.value)
 
 
 def test_merge_diamond_flow_with_results():

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -131,7 +131,7 @@ def test_list_of_tasks():
 
 
 def test_merge_with_upstream_skip_arg_raises_error():
-    with pytest.raises(ValueError, match="skip_on_upstream_skip=False") :
+    with pytest.raises(ValueError, match="skip_on_upstream_skip=False"):
         prefect.tasks.control_flow.conditional.Merge(skip_on_upstream_skip=True)
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -147,9 +147,8 @@ def test_repr(config):
 
 
 def test_getattr_missing(config):
-    with pytest.raises(AttributeError) as exc:
+    with pytest.raises(AttributeError, match="Config has no key 'hello'"):
         config.hello
-    assert "Config has no key 'hello'" in str(exc.value)
 
 
 def test_debug(config):

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -187,10 +187,8 @@ def test_some_failed_with_no_args(states):
 
 def test_some_failed_error_msg():
     trigger = triggers.some_failed(at_least=23)
-    with pytest.raises(signals.TRIGGERFAIL) as exc:
+    with pytest.raises(signals.TRIGGERFAIL, match="some_failed"):
         trigger(generate_states(success=1))
-
-    assert "some_failed" in str(exc.value)
 
 
 def test_some_failed_with_one_arg():
@@ -257,10 +255,8 @@ def test_some_successful_with_no_args(states):
 
 def test_some_successful_error_msg():
     trigger = triggers.some_successful(at_least=23)
-    with pytest.raises(signals.TRIGGERFAIL) as exc:
+    with pytest.raises(signals.TRIGGERFAIL, match='some_successful') :
         trigger(generate_states(success=1))
-
-    assert "some_successful" in str(exc.value)
 
 
 def test_some_successful_with_one_arg():

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -255,7 +255,7 @@ def test_some_successful_with_no_args(states):
 
 def test_some_successful_error_msg():
     trigger = triggers.some_successful(at_least=23)
-    with pytest.raises(signals.TRIGGERFAIL, match='some_successful') :
+    with pytest.raises(signals.TRIGGERFAIL, match="some_successful"):
         trigger(generate_states(success=1))
 
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -58,9 +58,8 @@ def test_timeout_handler_reraises():
     def do_something():
         raise ValueError("test")
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="test"):
         timeout_handler(do_something, timeout=1)
-        assert "test" in exc
 
 
 def test_timeout_handler_allows_function_to_spawn_new_process():

--- a/tests/utilities/test_notifications.py
+++ b/tests/utilities/test_notifications.py
@@ -167,10 +167,8 @@ def test_slack_notifier_pulls_url_from_secret(monkeypatch):
     monkeypatch.setattr("prefect.utilities.notifications.requests.post", post)
     state = Failed(message="1", result=0)
     with set_temporary_config({"cloud.use_local_secrets": True}):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="SLACK_WEBHOOK_URL"):
             slack_notifier(Task(), "", state)
-
-        assert "SLACK_WEBHOOK_URL" in str(exc.value)
 
         with prefect.context(secrets=dict(SLACK_WEBHOOK_URL="https://foo/bar")):
             slack_notifier(Task(), "", state)

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -32,9 +32,8 @@ class TestTaskDecorator:
         def fn(x):
             return x
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="Could not infer an active Flow context"):
             fn(1)
-        assert "Could not infer an active Flow context" in str(exc.value)
 
     def test_task_decorator_with_no_args_must_be_called_inside_flow_context(self):
         @tasks.task
@@ -321,7 +320,5 @@ class TestDefaultFromAttrs:
                 return x
 
         t = Forgot()
-        with pytest.raises(AttributeError) as exc:
+        with pytest.raises(AttributeError, match="no attribute 'x'"):
             t.run()
-
-        assert "no attribute 'x'" in str(exc.value)


### PR DESCRIPTION
This PR updates unit tests to replace this pattern:

```python
with pytest.raises(ValueError) as exc:
    do_something()
    assert "an error" in str(exc.value)
```

with:

```python
with pytest.raises(ValueError, match="an error"):
    do_something()
```