### PR TITLE
Fix typo in help text of get tasks CLI command

### DIFF
--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -299,7 +299,7 @@ def tasks(name, flow_name, flow_version, project, limit):
     Options:
         --name, -n          TEXT    A task name to query
         --flow-name, -fn    TEXT    A flow name to query
-        --flow-version, -fx INTEGER A flow version to query
+        --flow-version, -fv INTEGER A flow version to query
         --project, -p       TEXT    The name of a project to query
         --limit, -l         INTEGER A limit amount of tasks to query, defaults to 10
     """


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Minor typo fix in `get tasks` CLI command


## Why is this PR important?
Clarity of help texts

