### PR TITLE
Default storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Introduce configurable default for storage class on Flows - [#1044](https://github.com/PrefectHQ/prefect/issues/1044)
 
 ### Task Library
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -33,6 +33,12 @@ run_on_schedule = true
 # If true, tasks which set `checkpoint=True` will have their result handlers called
 checkpointing = false
 
+    [flows.defaults]
+        [flows.defaults.storage]
+
+        # the default storage class, specified using a full path
+        default_class = "prefect.environments.storage.Docker"
+
 [tasks]
 
     [tasks.defaults]

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1166,7 +1166,11 @@ class Flow:
     # Deployment ------------------------------------------------------------------
 
     def deploy(
-        self, project_name: str, build: bool = True, set_schedule_active: bool = True, **kwargs: Any
+        self,
+        project_name: str,
+        build: bool = True,
+        set_schedule_active: bool = True,
+        **kwargs: Any
     ) -> str:
         """
         Deploy the flow to Prefect Cloud; if no storage is present on the Flow, the default value from your config
@@ -1185,8 +1189,8 @@ class Flow:
         Returns:
             - str: the ID of the flow that was deployed
         """
-        if flow.storage is None:
-            flow.storage = get_default_storage_class(**kwargs)
+        if self.storage is None:
+            self.storage = get_default_storage_class()(**kwargs)
 
         client = prefect.Client()
         deployed_flow = client.deploy(

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -33,7 +33,7 @@ from prefect.core.task import Parameter, Task
 from prefect.engine.result import NoResult
 from prefect.engine.result_handlers import ResultHandler
 from prefect.environments import RemoteEnvironment, Environment
-from prefect.environments.storage import Storage
+from prefect.environments.storage import get_default_storage_class, Storage
 from prefect.utilities import logging
 from prefect.utilities.notifications import callback_factory
 from prefect.utilities.serialization import to_qualified_name
@@ -1166,10 +1166,11 @@ class Flow:
     # Deployment ------------------------------------------------------------------
 
     def deploy(
-        self, project_name: str, build: bool = True, set_schedule_active: bool = True
+        self, project_name: str, build: bool = True, set_schedule_active: bool = True, **kwargs: Any
     ) -> str:
         """
-        Deploy the flow to Prefect Cloud
+        Deploy the flow to Prefect Cloud; if no storage is present on the Flow, the default value from your config
+        will be used and initialized with `**kwargs`.
 
         Args:
             - project_name (str): the project that should contain this flow.
@@ -1178,10 +1179,15 @@ class Flow:
             - set_schedule_active (bool, optional): if `False`, will set the
                 schedule to inactive in the database to prevent auto-scheduling runs (if the Flow has a schedule).
                 Defaults to `True`. This can be changed later.
+            - **kwargs (Any): if instantiating a Storage object from default settings, these keyword arguments
+                will be passed to the initialization method of the default Storage class
 
         Returns:
             - str: the ID of the flow that was deployed
         """
+        if flow.storage is None:
+            flow.storage = get_default_storage_class(**kwargs)
+
         client = prefect.Client()
         deployed_flow = client.deploy(
             flow=self,

--- a/src/prefect/environments/storage/__init__.py
+++ b/src/prefect/environments/storage/__init__.py
@@ -40,8 +40,8 @@ def get_default_storage_class() -> type:
         except ValueError:
             warn(
                 "Could not import {}; using "
-                "prefect.environments.storage.Storage instead.".format(config_value)
+                "prefect.environments.storage.Docker instead.".format(config_value)
             )
-            return Storage
+            return Docker
     else:
         return config_value

--- a/tests/environments/storage/test_defaults.py
+++ b/tests/environments/storage/test_defaults.py
@@ -1,5 +1,20 @@
 from prefect.environments import storage
+from prefect import utilities
 
 
 def test_default_storage():
     assert storage.get_default_storage_class() is storage.Docker
+
+
+def test_default_storage_responds_to_config():
+    with utilities.configuration.set_temporary_config(
+        {"flows.defaults.storage.default_class": "prefect.environments.storage.Memory"}
+    ):
+        assert storage.get_default_storage_class() is storage.Memory
+
+
+def test_default_storage_ignores_bad_config():
+    with utilities.configuration.set_temporary_config(
+        {"flows.defaults.storage.default_class": "FOOBAR"}
+    ):
+        assert storage.get_default_storage_class() is storage.Docker

--- a/tests/environments/storage/test_defaults.py
+++ b/tests/environments/storage/test_defaults.py
@@ -1,0 +1,5 @@
+from prefect.environments import storage
+
+
+def test_default_storage():
+    assert storage.get_default_storage_class() is storage.Docker


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Allows for a default storage class to be set in config, which will only be instantiated (with `**kwargs`) when `flow.deploy` is called.  Note that this _does_ introduce the possibility of some opaque error messages (e.g., deploying a Flow without knowing you need Docker and seeing something about a `registry_url` requirement). 

I still think this is a value add, but open to push back.

## Why is this PR important?
Allows for much faster deployment processes; for example, for lightweight flows the following is now valid:

```python
from prefect import Flow

Flow("lightweight").deploy("My Project", registry_url="prefecthq/example")
```




