### PR TITLE
Add quotes into visualize ImportError error msg

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1043,7 +1043,7 @@ class Flow:
         except ImportError:
             msg = (
                 "This feature requires graphviz.\n"
-                "Try re-installing prefect with `pip install prefect[viz]`"
+                "Try re-installing prefect with `pip install 'prefect[viz]'`"
             )
             raise ImportError(msg)
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -967,7 +967,7 @@ class TestFlowVisualize:
 
         with monkeypatch.context() as m:
             m.setattr(sys, "path", "")
-            with pytest.raises(ImportError, match="pip install prefect\[viz\]"):
+            with pytest.raises(ImportError, match="pip install 'prefect\[viz\]'"):
                 f.visualize()
 
     def test_viz_returns_graph_object_if_in_ipython(self):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR adds quotes to `pip install 'prefect[viz]'` command in error msg in `visualize()` method.

## Why is this PR important?

Because most of developers wants to copy/paste command from error message and command without quotes will failed.

```
$ pip install prefect[viz]
zsh: no matches found: prefect[viz]
```
