### PR TITLE
Add friendly success message when creating a project in Cloud

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -391,6 +391,11 @@ class Client:
             project_mutation, variables=dict(input=dict(name=project_name))
         )  # type: Any
 
+        print(
+            'Project "{}" created with ID: {}'.format(
+                project_name, res.data.createProject.id
+            )
+        )
         return res.data.createProject.id
 
     def create_flow_run(


### PR DESCRIPTION
Simple change to add a friendly success message to `client.create_project()`, based on observing Cloud onboarding.