### PR TITLE
Fix local retries in Cloud to always run in-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fixes issue with Docker storage not respecting user-provided image names - [#1335](https://github.com/PrefectHQ/prefect/pull/1335)
+- Fix issue with Docker storage not respecting user-provided image names - [#1335](https://github.com/PrefectHQ/prefect/pull/1335)
+- Fix issue with local retries in Cloud not always running in-process - [#1348](https://github.com/PrefectHQ/prefect/pull/1348)
 
 ### Deprecations
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR makes an additional call to `get_task_run_info` whenever tasks have to retry locally.  Previously, prefect context was reset to its original state, meaning the task run version that was present in context was stale on the next run, preventing the retry from actually occurring in process (instead it occurred in a new run).  Note that local retries _were_ properly working for mapped tasks because of the additional call to `get_task_run_info` that mapped tasks always perform prior to a run.


## Why is this PR important?
It is much more efficient to retry in the same process for short duration retries.