### PR TITLE
TASK LOOPING (in both Core and Cloud)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Features
 
 - Added Local, Kubernetes, and Nomad agents - [#1341](https://github.com/PrefectHQ/prefect/pull/1341)
+- Add the ability for Tasks to sequentially loop - [#1356](https://github.com/PrefectHQ/prefect/pull/1356)
 
 ### Enhancements
 

--- a/docs/guide/PINs/PIN-11-Task-Loops.md
+++ b/docs/guide/PINs/PIN-11-Task-Loops.md
@@ -5,7 +5,7 @@ Author: Jeremiah Lowin
 
 # Status
 
-Proposed
+Accepted
 
 # Context
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -95,7 +95,7 @@ class CloudTaskRunner(TaskRunner):
                 cache_for=self.task.cache_for,
             )
         except Exception as exc:
-            self.logger.debug(
+            self.logger.error(
                 "Failed to set task state with error: {}".format(repr(exc))
             )
             raise ENDRUN(state=ClientFailed(state=new_state))

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -70,6 +70,12 @@ class LOOP(PrefectStateSignal):
 
     _state_cls = state.Looped
 
+    def __init__(self, message: str = None, *args, **kwargs):  # type: ignore
+        kwargs.setdefault(
+            "result", repr(self)
+        )  # looped results are always result handled
+        super().__init__(message, *args, **kwargs)  # type: ignore
+
 
 class TRIGGERFAIL(FAIL):
     """

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -56,6 +56,21 @@ class FAIL(PrefectStateSignal):
     _state_cls = state.Failed
 
 
+class LOOP(PrefectStateSignal):
+    """
+    Indicates that a task should loop.
+
+    Args:
+        - message (Any, optional): Defaults to `None`. A message about the signal.
+        - *args (Any, optional): additional arguments to pass to this Signal's
+            associated state constructor
+        - **kwargs (Any, optional): additional keyword arguments to pass to this Signal's
+            associated state constructor
+    """
+
+    _state_cls = state.Looped
+
+
 class TRIGGERFAIL(FAIL):
     """
     Indicates that a task trigger failed.

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -125,6 +125,15 @@ class State:
         """
         return isinstance(self, Finished)
 
+    def is_looped(self) -> bool:
+        """
+        Checks if the state is currently in a looped state
+
+        Returns:
+            - bool: `True` if the state is looped, `False` otherwise
+        """
+        return isinstance(self, Looped)
+
     def is_scheduled(self) -> bool:
         """
         Checks if the state is currently in a scheduled state, which includes retrying.

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -485,21 +485,21 @@ class Looped(Finished):
         - message (str or Exception, optional): Defaults to `None`. A message about the
             state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
         - result (Any, optional): Defaults to `None`. A data payload for the state.
-        - loop_index (int): The iteration number of the looping task.
-            Defaults to the value stored in context under "task_loop_index" or 1,
+        - loop_count (int): The iteration number of the looping task.
+            Defaults to the value stored in context under "task_loop_count" or 1,
             if that value isn't found.
     """
 
     color = "#003ccb"
 
     def __init__(
-        self, message: str = None, result: Any = NoResult, loop_index: int = None
+        self, message: str = None, result: Any = NoResult, loop_count: int = None
     ):
         super().__init__(result=result, message=message)
-        if loop_index is None:
-            loop_index = prefect.context.get("task_loop_index", 1)
-        assert loop_index is not None  # mypy assert
-        self.loop_index = loop_index  # type: int
+        if loop_count is None:
+            loop_count = prefect.context.get("task_loop_count", 1)
+        assert loop_count is not None  # mypy assert
+        self.loop_count = loop_count  # type: int
 
 
 class Success(Finished):

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -467,6 +467,32 @@ class Finished(State):
     color = "#003ccb"
 
 
+class Looped(Finished):
+    """
+    Finished state indicating one successful run of a looped task - if a Task is in this state, it will
+    run the next iteration of the loop immediately after.
+
+    Args:
+        - message (str or Exception, optional): Defaults to `None`. A message about the
+            state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
+        - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - loop_index (int): The iteration number of the looping task.
+            Defaults to the value stored in context under "task_loop_index" or 1,
+            if that value isn't found.
+    """
+
+    color = "#003ccb"
+
+    def __init__(
+        self, message: str = None, result: Any = NoResult, loop_index: int = None
+    ):
+        super().__init__(result=result, message=message)
+        if loop_index is None:
+            loop_index = prefect.context.get("task_loop_index", 1)
+        assert loop_index is not None  # mypy assert
+        self.loop_index = loop_index  # type: int
+
+
 class Success(Finished):
     """
     Finished state indicating success.

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -868,11 +868,12 @@ class TaskRunner(Runner):
 
         except signals.LOOP as exc:
             new_state = exc.state
+            assert isinstance(new_state, Looped)
             new_state.result = Result(
                 value=new_state.result, result_handler=self.result_handler
             )
             new_state.message = exc.state.message or "Task is looping ({})".format(
-                exc.state.loop_count
+                new_state.loop_count
             )
             return new_state
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -149,9 +149,9 @@ class TaskRunner(Runner):
             context.update(resume=True)
 
         if isinstance(state, Pending):
-            if "_loop_index" in (state.cached_inputs or {}):
+            if "_loop_count" in (state.cached_inputs or {}):
                 loop_context = {
-                    "loop_index": state.cached_inputs.pop("_loop_index")
+                    "loop_count": state.cached_inputs.pop("_loop_count")
                     .to_result()
                     .value,
                     "loop_result": state.cached_inputs.pop("_loop_result")
@@ -311,7 +311,7 @@ class TaskRunner(Runner):
             if prefect.context.get("raise_on_exception"):
                 raise exc
 
-        if prefect.context.get("task_loop_index") is None:
+        if prefect.context.get("task_loop_count") is None:
             # to prevent excessive repetition of this log
             # since looping relies on recursively calling self.run
             # TODO: figure out a way to only log this one single time instead of twice
@@ -956,7 +956,7 @@ class TaskRunner(Runner):
         executor: "prefect.engine.executors.Executor" = None,
     ) -> State:
         """
-        Checks to see if the task is in a `Looped` state and if so, rerun the pipeline with an incremeneted `loop_index`.
+        Checks to see if the task is in a `Looped` state and if so, rerun the pipeline with an incremeneted `loop_count`.
 
         Args:
             - state (State, optional): initial `State` to begin task run from;
@@ -974,11 +974,11 @@ class TaskRunner(Runner):
             - `State` object representing the final post-run state of the Task
         """
         if state.is_looped():
-            msg = "Looping task (on loop index {})".format(state.loop_index)
+            msg = "Looping task (on loop index {})".format(state.loop_count)
             context.update(
                 {
                     "task_loop_result": state.result,
-                    "task_loop_index": state.loop_index + 1,
+                    "task_loop_count": state.loop_count + 1,
                 }
             )
             new_state = Pending(message=msg)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -216,9 +216,12 @@ class TaskRunner(Runner):
         mapped = any([e.mapped for e in upstream_states]) and map_index is None
         task_inputs = {}  # type: Dict[str, Any]
 
-        self.logger.info(
-            "Task '{name}': Starting task run...".format(name=context["task_full_name"])
-        )
+        if context.get("task_loop_count") is None:
+            self.logger.info(
+                "Task '{name}': Starting task run...".format(
+                    name=context["task_full_name"]
+                )
+            )
 
         try:
             # initialize the run

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1000,6 +1000,8 @@ class TaskRunner(Runner):
                     "task_loop_count": state.loop_count + 1,
                 }
             )
+            if "task_run_version" in prefect.context:
+                context.update(task_run_version=prefect.context["task_run_version"])
             new_state = Pending(message=msg)
             return self.run(
                 new_state,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -871,6 +871,9 @@ class TaskRunner(Runner):
             new_state.result = Result(
                 value=new_state.result, result_handler=self.result_handler
             )
+            new_state.message = exc.state.message or "Task is looping ({})".format(
+                exc.state.loop_count
+            )
             return new_state
 
         result = Result(value=result, result_handler=self.result_handler)
@@ -1000,8 +1003,7 @@ class TaskRunner(Runner):
                     "task_loop_count": state.loop_count + 1,
                 }
             )
-            if "task_run_version" in prefect.context:
-                context.update(task_run_version=prefect.context["task_run_version"])
+            context.update(task_run_version=prefect.context.get("task_run_version"))
             new_state = Pending(message=msg)
             return self.run(
                 new_state,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -311,11 +311,15 @@ class TaskRunner(Runner):
             if prefect.context.get("raise_on_exception"):
                 raise exc
 
-        self.logger.info(
-            "Task '{name}': finished task run for task with final state: '{state}'".format(
-                name=context["task_full_name"], state=type(state).__name__
+        if prefect.context.get("task_loop_index") is None:
+            # to prevent excessive repetition of this log
+            # since looping relies on recursively calling self.run
+            # TODO: figure out a way to only log this one single time instead of twice
+            self.logger.info(
+                "Task '{name}': finished task run for task with final state: '{state}'".format(
+                    name=context["task_full_name"], state=type(state).__name__
+                )
             )
-        )
 
         return state
 

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -109,6 +109,8 @@ class LoopedSchema(BaseStateSchema):
     class Meta:
         object_class = state.Looped
 
+    loop_count = fields.Int(allow_none=False)
+
 
 class SuccessSchema(FinishedSchema):
     class Meta:

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -105,6 +105,11 @@ class FinishedSchema(BaseStateSchema):
         object_class = state.Finished
 
 
+class LoopedSchema(BaseStateSchema):
+    class Meta:
+        object_class = state.Looped
+
+
 class SuccessSchema(FinishedSchema):
     class Meta:
         object_class = state.Success
@@ -192,6 +197,7 @@ class StateSchema(OneOfSchema):
         "ClientFailed": ClientFailedSchema,
         "Failed": FailedSchema,
         "Finished": FinishedSchema,
+        "Looped": LoopedSchema,
         "Mapped": MappedSchema,
         "Paused": PausedSchema,
         "Pending": PendingSchema,

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -16,7 +16,7 @@ from prefect.core.flow import Flow
 from prefect.core.task import Parameter, Task
 from prefect.engine.cache_validators import all_inputs, partial_inputs_only
 from prefect.engine.result_handlers import LocalResultHandler, ResultHandler
-from prefect.engine.signals import PrefectError
+from prefect.engine.signals import PrefectError, LOOP
 from prefect.engine.state import (
     Failed,
     Finished,
@@ -2094,3 +2094,75 @@ def test_flow_run_handles_error_states_when_initial_state_is_provided():
         res = AddTask()("5", 5)
     state = f.run(state=Pending())
     assert state.is_failed()
+
+
+def test_looping_works_in_a_flow():
+    @task
+    def looper(x):
+        if prefect.context.get("task_loop_count", 1) < 20:
+            raise LOOP(result=prefect.context.get("task_loop_result", 0) + x)
+        return prefect.context.get("task_loop_result") + x
+
+    @task
+    def downstream(l):
+        return l ** 2
+
+    with Flow(name="looping") as f:
+        inter = looper(10)
+        final = downstream(inter)
+
+    flow_state = f.run()
+
+    assert flow_state.is_successful()
+    assert flow_state.result[inter].result == 200
+    assert flow_state.result[final].result == 200 ** 2
+
+
+def test_looping_with_retries_works_in_a_flow():
+    @task(max_retries=1, retry_delay=datetime.timedelta(seconds=0))
+    def looper(x):
+        if (
+            prefect.context.get("task_loop_count") == 2
+            and prefect.context.get("task_run_count", 1) == 1
+        ):
+            raise ValueError("err")
+
+        if prefect.context.get("task_loop_count", 1) < 20:
+            raise LOOP(result=prefect.context.get("task_loop_result", 0) + x)
+        return prefect.context.get("task_loop_result") + x
+
+    @task
+    def downstream(l):
+        return l ** 2
+
+    with Flow(name="looping") as f:
+        inter = looper(10)
+        final = downstream(inter)
+
+    flow_state = f.run()
+
+    assert flow_state.is_successful()
+    assert flow_state.result[inter].result == 200
+    assert flow_state.result[final].result == 200 ** 2
+
+
+def test_starting_at_arbitrary_loop_index():
+    @task
+    def looper(x):
+        if prefect.context.get("task_loop_count", 1) < 20:
+            raise LOOP(result=prefect.context.get("task_loop_result", 0) + x)
+        return prefect.context.get("task_loop_result", 0) + x
+
+    @task
+    def downstream(l):
+        return l ** 2
+
+    with Flow(name="looping") as f:
+        inter = looper(10)
+        final = downstream(inter)
+
+    flow_state = f.run(context={"task_loop_count": 20})
+
+    assert flow_state.is_successful()
+    assert flow_state.result[inter].result == 10
+    assert flow_state.result[final].result == 100

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -402,7 +402,7 @@ def test_state_handler_failures_are_handled_appropriately(client):
     assert isinstance(states[1].result, SyntaxError)
 
 
-def test_starting_at_arbitrary_loop_index_from_cloud_context(monkeypatch):
+def test_starting_at_arbitrary_loop_index_from_cloud_context(client):
     @prefect.task
     def looper(x):
         if prefect.context.get("task_loop_count", 1) < 20:
@@ -417,16 +417,10 @@ def test_starting_at_arbitrary_loop_index_from_cloud_context(monkeypatch):
         inter = looper(10)
         final = downstream(inter)
 
-    get_flow_run_info = MagicMock(
+    client.get_flow_run_info = MagicMock(
         return_value=MagicMock(context={"task_loop_count": 20})
     )
-    set_flow_run_state = MagicMock()
-    client = MagicMock(
-        get_flow_run_info=get_flow_run_info, set_flow_run_state=set_flow_run_state
-    )
-    monkeypatch.setattr(
-        "prefect.engine.cloud.flow_runner.Client", MagicMock(return_value=client)
-    )
+    client.set_flow_run_state = MagicMock()
 
     flow_state = CloudFlowRunner(flow=f).run(return_tasks=[inter, final])
 

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -400,3 +400,36 @@ def test_state_handler_failures_are_handled_appropriately(client):
     assert states[0].is_running()
     assert states[1].is_failed()
     assert isinstance(states[1].result, SyntaxError)
+
+
+def test_starting_at_arbitrary_loop_index_from_cloud_context(monkeypatch):
+    @prefect.task
+    def looper(x):
+        if prefect.context.get("task_loop_count", 1) < 20:
+            raise LOOP(result=prefect.context.get("task_loop_result", 0) + x)
+        return prefect.context.get("task_loop_result", 0) + x
+
+    @prefect.task
+    def downstream(l):
+        return l ** 2
+
+    with prefect.Flow(name="looping") as f:
+        inter = looper(10)
+        final = downstream(inter)
+
+    get_flow_run_info = MagicMock(
+        return_value=MagicMock(context={"task_loop_count": 20})
+    )
+    set_flow_run_state = MagicMock()
+    client = MagicMock(
+        get_flow_run_info=get_flow_run_info, set_flow_run_state=set_flow_run_state
+    )
+    monkeypatch.setattr(
+        "prefect.engine.cloud.flow_runner.Client", MagicMock(return_value=client)
+    )
+
+    flow_state = CloudFlowRunner(flow=f).run(return_tasks=[inter, final])
+
+    assert flow_state.is_successful()
+    assert flow_state.result[inter].result == 10
+    assert flow_state.result[final].result == 100

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -663,3 +663,97 @@ def test_task_runner_handles_looping(client):
     )  # Pending -> Running -> Looped (1) -> Running -> Looped (2) -> Running -> Success
     versions = [call[1]["version"] for call in client.set_task_run_state.call_args_list]
     assert versions == [1, 2, 3, 4, 5, 6]
+
+
+def test_task_runner_handles_looping_with_no_result(client):
+    @prefect.task
+    def looper():
+        if prefect.context.get("task_loop_count", 1) < 3:
+            raise LOOP()
+        return 42
+
+    res = CloudTaskRunner(task=looper).run(
+        context={"task_run_version": 1},
+        state=None,
+        upstream_states={},
+        executor=prefect.engine.executors.LocalExecutor(),
+    )
+
+    ## assertions
+    assert res.is_successful()
+    assert client.get_task_run_info.call_count == 0
+    assert (
+        client.set_task_run_state.call_count == 6
+    )  # Pending -> Running -> Looped (1) -> Running -> Looped (2) -> Running -> Success
+    versions = [call[1]["version"] for call in client.set_task_run_state.call_args_list]
+    assert versions == [1, 2, 3, 4, 5, 6]
+
+
+def test_task_runner_handles_looping_with_retries_with_no_result(client):
+    # note that looping _requires_ a result handler in Cloud
+    @prefect.task(
+        max_retries=1,
+        retry_delay=datetime.timedelta(seconds=0),
+        result_handler=JSONResultHandler(),
+    )
+    def looper():
+        if (
+            prefect.context.get("task_loop_count") == 2
+            and prefect.context.get("task_run_count", 1) == 1
+        ):
+            raise ValueError("Stop")
+        if prefect.context.get("task_loop_count", 1) < 3:
+            raise LOOP()
+        return 42
+
+    client.get_task_run_info.side_effect = [MagicMock(version=i) for i in range(6, 9)]
+    res = CloudTaskRunner(task=looper).run(
+        context={"task_run_version": 1},
+        state=None,
+        upstream_states={},
+        executor=prefect.engine.executors.LocalExecutor(),
+    )
+
+    ## assertions
+    assert res.is_successful()
+    assert client.get_task_run_info.call_count == 1  # called once for retry
+    assert (
+        client.set_task_run_state.call_count == 9
+    )  # Pending -> Running -> Looped (1) -> Running -> Failed -> Retrying -> Running -> Looped(2) -> Running -> Success
+    versions = [call[1]["version"] for call in client.set_task_run_state.call_args_list]
+    assert versions == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_task_runner_handles_looping_with_retries(client):
+    # note that looping _requires_ a result handler in Cloud
+    @prefect.task(
+        max_retries=1,
+        retry_delay=datetime.timedelta(seconds=0),
+        result_handler=JSONResultHandler(),
+    )
+    def looper():
+        if (
+            prefect.context.get("task_loop_count") == 2
+            and prefect.context.get("task_run_count", 1) == 1
+        ):
+            raise ValueError("Stop")
+        if prefect.context.get("task_loop_count", 1) < 3:
+            raise LOOP(result=prefect.context.get("task_loop_result", 0) + 10)
+        return prefect.context.get("task_loop_result")
+
+    client.get_task_run_info.side_effect = [MagicMock(version=i) for i in range(6, 9)]
+    res = CloudTaskRunner(task=looper).run(
+        context={"task_run_version": 1},
+        state=None,
+        upstream_states={},
+        executor=prefect.engine.executors.LocalExecutor(),
+    )
+
+    ## assertions
+    assert res.is_successful()
+    assert client.get_task_run_info.call_count == 1  # called once for retry
+    assert (
+        client.set_task_run_state.call_count == 9
+    )  # Pending -> Running -> Looped (1) -> Running -> Failed -> Retrying -> Running -> Looped(2) -> Running -> Success
+    versions = [call[1]["version"] for call in client.set_task_run_state.call_args_list]
+    assert versions == [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -690,7 +690,7 @@ def test_task_runner_handles_looping_with_no_result(client):
 
 
 def test_task_runner_handles_looping_with_retries_with_no_result(client):
-    # note that looping _requires_ a result handler in Cloud
+    # note that looping with retries _requires_ a result handler in Cloud
     @prefect.task(
         max_retries=1,
         retry_delay=datetime.timedelta(seconds=0),

--- a/tests/engine/test_signals.py
+++ b/tests/engine/test_signals.py
@@ -6,6 +6,7 @@ import pytest
 import prefect
 from prefect.engine.signals import (
     FAIL,
+    LOOP,
     PAUSE,
     RETRY,
     SKIP,
@@ -15,6 +16,7 @@ from prefect.engine.signals import (
 )
 from prefect.engine.state import (
     Failed,
+    Looped,
     Paused,
     Retrying,
     Skipped,
@@ -82,6 +84,7 @@ def test_retry_signals_prefer_supplied_run_count_to_context():
     "signal,state",
     [
         (FAIL, Failed),
+        (LOOP, Looped),
         (TRIGGERFAIL, TriggerFailed),
         (SUCCESS, Success),
         (PAUSE, Paused),

--- a/tests/engine/test_signals.py
+++ b/tests/engine/test_signals.py
@@ -84,7 +84,6 @@ def test_retry_signals_prefer_supplied_run_count_to_context():
     "signal,state",
     [
         (FAIL, Failed),
-        (LOOP, Looped),
         (TRIGGERFAIL, TriggerFailed),
         (SUCCESS, Success),
         (PAUSE, Paused),
@@ -99,6 +98,15 @@ def test_signals_creates_correct_states(signal, state):
     assert type(exc.value.state) is state
     assert exc.value.state.result is exc.value
     assert exc.value.state.message == state.__name__
+
+
+def test_signals_creates_correct_states_for_looped():
+    with pytest.raises(Exception) as exc:
+        raise LOOP("signal")
+    assert isinstance(exc.value, LOOP)
+    assert type(exc.value.state) is Looped
+    assert exc.value.state.result == repr(exc.value)
+    assert exc.value.state.message == "signal"
 
 
 def test_retry_signals_carry_default_retry_time_on_state():

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -332,7 +332,7 @@ class TestStateHierarchy:
         dict(state=ClientFailed(), assert_true={"is_meta_state"}),
         dict(state=Failed(), assert_true={"is_finished", "is_failed"}),
         dict(state=Finished(), assert_true={"is_finished"}),
-        dict(state=Looped(), assert_true={"is_finished"}),
+        dict(state=Looped(), assert_true={"is_finished", "is_looped"}),
         dict(state=Mapped(), assert_true={"is_finished", "is_mapped", "is_successful"}),
         dict(state=Paused(), assert_true={"is_pending"}),
         dict(state=Pending(), assert_true={"is_pending"}),

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -138,20 +138,20 @@ def test_only_scheduled_and_queued_states_have_start_times(cls):
         assert not state.is_scheduled()
 
 
-def test_retry_stores_loop_index():
-    state = Looped(loop_index=2)
-    assert state.loop_index == 2
+def test_retry_stores_loop_count():
+    state = Looped(loop_count=2)
+    assert state.loop_count == 2
 
 
-def test_looped_stores_default_loop_index():
+def test_looped_stores_default_loop_count():
     state = Looped()
-    assert state.loop_index == 1
+    assert state.loop_count == 1
 
 
-def test_looped_stores_default_loop_index_in_context():
-    with prefect.context(task_loop_index=5):
+def test_looped_stores_default_loop_count_in_context():
+    with prefect.context(task_loop_count=5):
         state = Looped()
-    assert state.loop_index == 5
+    assert state.loop_count == 5
 
 
 def test_retry_stores_run_count():

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -962,6 +962,19 @@ class TestRunTaskStep:
         )
         assert new_state.is_failed()
 
+    def test_raise_loop_signal(self):
+        @prefect.task
+        def fn():
+            raise signals.LOOP(result=1)
+
+        state = Running()
+        new_state = TaskRunner(task=fn).get_task_run_state(
+            state=state, inputs={}, timeout_handler=None
+        )
+        assert new_state.is_looped()
+        assert new_state.result == 1
+        assert new_state.loop_index == 1
+
     def test_raise_skip_signal(self):
         @prefect.task
         def fn():

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -986,7 +986,7 @@ class TestRunTaskStep:
             state=state, inputs={}, timeout_handler=None
         )
         assert new_state.is_looped()
-        assert isinstance(new_state.result, signals.LOOP)
+        assert "LOOP" in new_state.result
         assert new_state.loop_count == 1
         assert new_state.message == "My message"
 

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -46,6 +46,7 @@ def complex_states():
         cached_result_expiration=naive_dt,
     )
     test_states = [
+        state.Looped(loop_count=45),
         state.Pending(cached_inputs=complex_result),
         state.Paused(cached_inputs=complex_result),
         state.Retrying(start_time=utc_dt, run_count=3),


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces "Task Looping" (first described in [PIN 11](https://docs.prefect.io/guide/PINs/PIN-11-Task-Loops.html)).  The implementation here will actually work in Cloud almost immediately (once the Cloud serializers are updated).

In order to make Looping work off-the-shelf, this PR:
- introduces a new `Looped` state which carries the `loop_count`
- introduces a new `LOOP` signal for triggering a loop
- places the appropriate data in context (loop count + loop result)
- re-uses our `cached_inputs` mechanism for conveying relevant data to retries
- allows for loops to begin at arbitrary points by setting the appropriate `task_loop_count` in context

## Why is this PR important?
This PR furthers the ability for Flows to dynamically spawn tasks.  _Mapping is to for loops as Looping is to while loops_.

This of course will need extensive documentation to fully expose.