### PR TITLE
Add flow run id to pod labels and handle client errors in resource manager

### DIFF
--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -77,6 +77,9 @@ class KubernetesAgent(Agent):
         job["metadata"]["labels"]["flow_run_id"] = flow_run.id  # type: ignore
         job["metadata"]["labels"]["flow_id"] = flow_run.flow.id  # type: ignore
         job["spec"]["template"]["metadata"]["labels"]["app"] = job_name
+        job["spec"]["template"]["metadata"]["labels"][
+            "flow_run_id"
+        ] = flow_run.id  # type: ignore
         job["spec"]["template"]["metadata"]["labels"]["identifier"] = identifier
 
         # Use flow storage image for job

--- a/src/prefect/agent/kubernetes/resource_manager.py
+++ b/src/prefect/agent/kubernetes/resource_manager.py
@@ -3,6 +3,7 @@ import os
 import time
 
 import pendulum
+from requests.exceptions import HTTPError
 
 from prefect import Client
 from prefect import config as prefect_config
@@ -263,15 +264,18 @@ class ResourceManager:
             "Reporting failed pod {} in namespace {}".format(name, self.namespace)
         )
 
-        self.client.write_run_log(
-            flow_run_id=pod.metadata.labels.get("flow_run_id"),
-            task_run_id="",
-            timestamp=pendulum.now(),
-            name="resource-manager",
-            message=logs,
-            level="ERROR",
-            info={},
-        )
+        try:
+            self.client.write_run_log(
+                flow_run_id=pod.metadata.labels.get("flow_run_id"),
+                task_run_id="",
+                timestamp=pendulum.now(),
+                name="resource-manager",
+                message=logs,
+                level="ERROR",
+                info={},
+            )
+        except HTTPError as exc:
+            self.logger.error(exc)
 
     def report_unknown_pod(self, pod: "kubernetes.client.V1Pod") -> None:
         """
@@ -282,17 +286,20 @@ class ResourceManager:
             "Reporting unknown pod {} in namespace {}".format(name, self.namespace)
         )
 
-        self.client.write_run_log(
-            flow_run_id=pod.metadata.labels.get("flow_run_id"),
-            task_run_id="",
-            timestamp=pendulum.now(),
-            name="resource-manager",
-            message="Flow run pod {} entered an unknown state in namespace {}".format(
-                name, self.namespace
-            ),
-            level="ERROR",
-            info={},
-        )
+        try:
+            self.client.write_run_log(
+                flow_run_id=pod.metadata.labels.get("flow_run_id"),
+                task_run_id="",
+                timestamp=pendulum.now(),
+                name="resource-manager",
+                message="Flow run pod {} entered an unknown state in namespace {}".format(
+                    name, self.namespace
+                ),
+                level="ERROR",
+                info={},
+            )
+        except HTTPError as exc:
+            self.logger.error(exc)
 
     def report_pod_image_pull_error(self, pod: "kubernetes.client.V1Pod") -> None:
         """
@@ -308,17 +315,20 @@ class ResourceManager:
                     )
                 )
 
-                self.client.write_run_log(
-                    flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                    task_run_id="",
-                    timestamp=pendulum.now(),
-                    name="resource-manager",
-                    message="Flow run image pull error for pod {} in namespace {}".format(
-                        pod.metadata.name, self.namespace
-                    ),
-                    level="ERROR",
-                    info={},
-                )
+                try:
+                    self.client.write_run_log(
+                        flow_run_id=pod.metadata.labels.get("flow_run_id"),
+                        task_run_id="",
+                        timestamp=pendulum.now(),
+                        name="resource-manager",
+                        message="Flow run image pull error for pod {} in namespace {}".format(
+                            pod.metadata.name, self.namespace
+                        ),
+                        level="ERROR",
+                        info={},
+                    )
+                except HTTPError as exc:
+                    self.logger.error(exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
The flow run id needed to be a label on the pods created by a job in order to be used by error reporting of the resource manager. Also added `HTTPError` handling to the resource manager because the entire process shouldn't halt if there is an error reporting conflict.


## Why is this PR important?
@TylerWanner 

