### PR TITLE
Paused states subclass Scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Introduce configurable default for storage class on Flows - [#1044](https://github.com/PrefectHQ/prefect/issues/1044)
 - Allow for min and max workers to be specified in `DaskKubernetesEnvironment` - [#1338](https://github.com/PrefectHQ/prefect/pulls/1338)
 - Use task and flow names for corresponding logger names for better organization - [#1355](https://github.com/PrefectHQ/prefect/pull/1355)
+- `Paused` states subclass `Scheduled` and can have predefined expirations - [#1375](https://github.com/PrefectHQ/prefect/pull/1375)
 
 ### Task Library
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -291,6 +291,8 @@ class Paused(Scheduled):
         - message (str or Exception, optional): Defaults to `None`. A message about the
             state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
         - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - start_time (datetime): time at which the task is scheduled to resume; defaults
+            to 10 years from now if not provided.
         - cached_inputs (dict): Defaults to `None`. A dictionary of input
             keys to fully hydrated `Result`s.  Used / set if the Task requires Retries.
     """

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -252,21 +252,6 @@ class Pending(State):
         self.cached_inputs = cached_inputs
 
 
-class Paused(Pending):
-    """
-    Paused state for tasks that require manual execution.
-
-    Args:
-        - message (str or Exception, optional): Defaults to `None`. A message about the
-            state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
-        - result (Any, optional): Defaults to `None`. A data payload for the state.
-        - cached_inputs (dict): Defaults to `None`. A dictionary of input
-            keys to fully hydrated `Result`s.  Used / set if the Task requires Retries.
-    """
-
-    color = "#cfd8dc"
-
-
 class Scheduled(Pending):
     """
     Pending state indicating the object has been scheduled to run.
@@ -295,6 +280,39 @@ class Scheduled(Pending):
     ):
         super().__init__(message=message, result=result, cached_inputs=cached_inputs)
         self.start_time = pendulum.instance(start_time or pendulum.now("utc"))
+
+
+class Paused(Scheduled):
+    """
+    Paused state for tasks. This allows manual intervention or pausing for a set amount of
+    time.
+
+    Args:
+        - message (str or Exception, optional): Defaults to `None`. A message about the
+            state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
+        - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - cached_inputs (dict): Defaults to `None`. A dictionary of input
+            keys to fully hydrated `Result`s.  Used / set if the Task requires Retries.
+    """
+
+    color = "#cfd8dc"
+
+    def __init__(
+        self,
+        message: str = None,
+        result: Any = NoResult,
+        start_time: datetime.datetime = None,
+        cached_inputs: Dict[str, Result] = None,
+    ):
+        if start_time is None:
+            start_time = pendulum.now().add(years=10)
+
+        super().__init__(
+            message=message,
+            result=result,
+            start_time=start_time,
+            cached_inputs=cached_inputs,
+        )
 
 
 class _MetaState(State):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -467,8 +467,6 @@ class TaskRunner(Runner):
         """
         Checks to make sure the task is ready to run (Pending or Mapped).
 
-        If the state is Paused, an ENDRUN is raised.
-
         Args:
             - state (State): the current state of this task
 
@@ -479,17 +477,8 @@ class TaskRunner(Runner):
             - ENDRUN: if the task is not ready to run
         """
 
-        # the task is paused
-        if isinstance(state, Paused):
-            self.logger.debug(
-                "Task '{name}': task is paused; ending run.".format(
-                    name=prefect.context.get("task_full_name", self.task.name)
-                )
-            )
-            raise ENDRUN(state)
-
         # the task is ready
-        elif state.is_pending():
+        if state.is_pending():
             return state
 
         # the task is mapped, in which case we still proceed so that the children tasks

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -182,7 +182,7 @@ class SkippedSchema(SuccessSchema):
         exclude_fields = ["cached"]
 
 
-class PausedSchema(PendingSchema):
+class PausedSchema(ScheduledSchema):
     class Meta:
         object_class = state.Paused
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -334,7 +334,7 @@ class TestStateHierarchy:
         dict(state=Finished(), assert_true={"is_finished"}),
         dict(state=Looped(), assert_true={"is_finished", "is_looped"}),
         dict(state=Mapped(), assert_true={"is_finished", "is_mapped", "is_successful"}),
-        dict(state=Paused(), assert_true={"is_pending"}),
+        dict(state=Paused(), assert_true={"is_pending", "is_scheduled"}),
         dict(state=Pending(), assert_true={"is_pending"}),
         dict(state=Queued(), assert_true={"is_meta_state"}),
         dict(state=Resume(), assert_true={"is_pending", "is_scheduled"}),

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1274,7 +1274,7 @@ class TestCheckScheduledStep:
             Retrying(start_time=pendulum.now("utc").add(minutes=10)),
             Paused(),
             Paused(start_time=None),
-            Paused(start_time=pendulum.now('utc').add(minutes=10))
+            Paused(start_time=pendulum.now("utc").add(minutes=10)),
         ],
     )
     def test_scheduled_states_with_future_start_time(self, state):

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -681,14 +681,15 @@ class TestCheckTaskTrigger:
 
 
 class TestCheckTaskReady:
-    @pytest.mark.parametrize("state", [Cached(), Pending(), Mapped()])
+    @pytest.mark.parametrize(
+        "state", [Cached(), Pending(), Mapped(), Paused(), Scheduled()]
+    )
     def test_ready_states(self, state):
         new_state = TaskRunner(task=Task()).check_task_is_ready(state=state)
         assert new_state is state
 
     @pytest.mark.parametrize(
-        "state",
-        [Running(), Finished(), TriggerFailed(), Skipped(), Success(), Paused()],
+        "state", [Running(), Finished(), TriggerFailed(), Skipped(), Success()]
     )
     def test_not_ready_doesnt_run(self, state):
 
@@ -1269,8 +1270,11 @@ class TestCheckScheduledStep:
     @pytest.mark.parametrize(
         "state",
         [
-            Scheduled(start_time=pendulum.now("utc") + timedelta(minutes=10)),
-            Retrying(start_time=pendulum.now("utc") + timedelta(minutes=10)),
+            Scheduled(start_time=pendulum.now("utc").add(minutes=10)),
+            Retrying(start_time=pendulum.now("utc").add(minutes=10)),
+            Paused(),
+            Paused(start_time=None),
+            Paused(start_time=pendulum.now('utc').add(minutes=10))
         ],
     )
     def test_scheduled_states_with_future_start_time(self, state):


### PR DESCRIPTION
Paused states can have fixed expirations

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1342 and allows pauses to have pre-defined expirations.



