### PR TITLE
Add test to ensure flows can be deserialized prior to depoy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Improve logging functionality to include tracebacks - [#1374](https://github.com/PrefectHQ/prefect/issues/1374)
 - Improve CLI user experience while working with Cloud - [#1384](https://github.com/PrefectHQ/prefect/pull/1384/)
 - Users can now create projects from the CLI - [#1388](https://github.com/PrefectHQ/prefect/pull/1388)
+- Add a health check to confirm that serialized flows are valid prior to Cloud deploy - [#1397](https://github.com/PrefectHQ/prefect/pull/1397)
 
 ### Task Library
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -348,6 +348,17 @@ class Client:
             )
 
         serialized_flow = flow.serialize(build=build)  # type: Any
+
+        # verify that the serialized flow can be deserialized
+        try:
+            prefect.serialization.flow.FlowSchema().load(serialized_flow)
+        except Exception as exc:
+            raise ValueError(
+                "Flow could not be deserialized successfully. Error was: {}".format(
+                    repr(exc)
+                )
+            )
+
         if compressed:
             serialized_flow = compress(serialized_flow)
         res = self.graphql(

--- a/src/prefect/environments/storage/_healthcheck.py
+++ b/src/prefect/environments/storage/_healthcheck.py
@@ -26,7 +26,7 @@ def system_check(python_version: str):
         print("System Version check: OK")
 
 
-def serialization_check(flow_file_paths: str):
+def cloudpickle_deserialization_check(flow_file_paths: str):
     flow_file_paths = ast.literal_eval(
         flow_file_paths
     )  # convert string to list of strings
@@ -36,7 +36,7 @@ def serialization_check(flow_file_paths: str):
         with open(flow_file, "rb") as f:
             flows.append(cloudpickle.load(f))
 
-    print("Serialization check: OK")
+    print("Cloudpickle serialization check: OK")
     return flows
 
 
@@ -97,6 +97,6 @@ if __name__ == "__main__":
 
     print("Beginning health checks...")
     system_check(python_version)
-    flows = serialization_check(flow_file_path)
+    flows = cloudpickle_serialization_check(flow_file_path)
     result_handler_check(flows)
     print("All health checks passed.")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -359,6 +359,33 @@ def test_client_deploy_with_bad_proj_name(monkeypatch):
     assert "client.create_project" in str(exc.value)
 
 
+def test_client_deploy_with_flow_that_cant_be_deserialized(monkeypatch):
+    response = {"data": {"project": [{"id": "proj-id"}]}}
+    post = MagicMock(return_value=MagicMock(json=MagicMock(return_value=response)))
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+
+    task = prefect.Task()
+    # we add a max_retries value to the task without a corresponding retry_delay; this will fail at deserialization
+    task.max_retries = 3
+    flow = prefect.Flow(name="test", tasks=[task])
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "(Flow could not be deserialized).*"
+            "(`retry_delay` must be provided if max_retries > 0)"
+        ),
+    ) as exc:
+        client.deploy(flow, project_name="my-default-project", build=False)
+
+
+
 def test_get_flow_run_info(monkeypatch):
     response = """
 {

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -385,7 +385,6 @@ def test_client_deploy_with_flow_that_cant_be_deserialized(monkeypatch):
         client.deploy(flow, project_name="my-default-project", build=False)
 
 
-
 def test_get_flow_run_info(monkeypatch):
     response = """
 {

--- a/tests/environments/storage/test_docker_healthcheck.py
+++ b/tests/environments/storage/test_docker_healthcheck.py
@@ -10,20 +10,24 @@ from prefect.environments.storage import _healthcheck as healthchecks
 
 
 class TestSerialization:
-    def test_serialization_check_raises_on_bad_imports(self):
+    def test_cloudpickle_deserialization_check_raises_on_bad_imports(self):
         bad_bytes = b"\x80\x04\x95\x18\x00\x00\x00\x00\x00\x00\x00\x8c\x0bfoo_machine\x94\x8c\x04func\x94\x93\x94."
         with tempfile.NamedTemporaryFile() as f:
             f.write(bad_bytes)
             f.seek(0)
             with pytest.raises(ImportError, match="foo_machine"):
-                objs = healthchecks.serialization_check("['{}']".format(f.name))
+                objs = healthchecks.cloudpickle_deserialization_check(
+                    "['{}']".format(f.name)
+                )
 
-    def test_serialization_check_passes_and_returns_objs(self):
+    def test_cloudpickle_deserialization_check_passes_and_returns_objs(self):
         good_bytes = cloudpickle.dumps(Flow("empty"))
         with tempfile.NamedTemporaryFile() as f:
             f.write(good_bytes)
             f.seek(0)
-            objs = healthchecks.serialization_check("['{}']".format(f.name))
+            objs = healthchecks.cloudpickle_deserialization_check(
+                "['{}']".format(f.name)
+            )
 
         assert len(objs) == 1
 
@@ -32,7 +36,7 @@ class TestSerialization:
         assert flow.name == "empty"
         assert flow.tasks == set()
 
-    def test_serialization_check_passes_and_returns_multiple_objs(self):
+    def test_cloudpickle_deserialization_check_passes_and_returns_multiple_objs(self):
         flow_one = cloudpickle.dumps(Flow("one"))
         flow_two = cloudpickle.dumps(Flow("two"))
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -45,7 +49,7 @@ class TestSerialization:
                 f.write(flow_two)
 
             paths = "['{0}', '{1}']".format(file_one, file_two)
-            objs = healthchecks.serialization_check(paths)
+            objs = healthchecks.cloudpickle_deserialization_check(paths)
 
         assert len(objs) == 2
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
A user had a situation in which he modified attributes of a task in a way that Core would have prevented if the same arguments were provided at task initialization. Specifically: setting a `max_retries` value without a corresponding `retry_delay`. The user then deployed the flow to Cloud. All healthchecks passed, including serialization. However, Cloud (correctly, in this case) rejected the flow as invalid. 

The issue is that the serialization healthcheck is a *cloudpickle* serialization check, not a JSON serialization check. In this case, the Flow was indeed a valid Python object -- there was nothing Pythonically "wrong" with assigning max_retries a value (though it would have caused an issue at runtime!). Cloudpickle serialization doesn't call `__init__()`, so it didn't apply the validation logic. JSON deserialization DOES call __init__(), so it validates that arguments (like `max_retries` and `retry_delay`) are appropriately set. 

In order to avoid this poor user experience, this PR adds a check to make sure that the serialized flow can also be immediately deserialized.


## Why is this PR important?
User experience, finding out right away if a flow's serialized form is invalid!

