### PR TITLE
Rename `scheduled_start_time` -> `flow_run_scheduled_start_time` for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Breaking Changes
 
 - Rename `CloudEnvironment` to `DaskKubernetesEnvironment` - [#1250](https://github.com/PrefectHQ/prefect/issues/1250)
+- Renamed a context variable from `scheduled_start_time` to `flow_run_scheduled_start_time` for clarity - [#1403](https://github.com/PrefectHQ/prefect/pull/1403)
 
 ### Contributors
 

--- a/examples/airflow_tutorial_dag.py
+++ b/examples/airflow_tutorial_dag.py
@@ -21,7 +21,7 @@ t2 = ShellTask(name="sleep", command="sleep 5", max_retries=3, retry_delay=retry
 
 @task(max_retries=1, retry_delay=retry_delay)
 def add_7():
-    date = prefect.context.get("scheduled_start_time", datetime.utcnow())
+    date = prefect.context.get("flow_run_scheduled_start_time", datetime.utcnow())
     return date + timedelta(days=7)
 
 
@@ -29,8 +29,8 @@ def add_7():
 ## any passed kwargs to the task
 command = """
     {% for i in range(5) %}
-        echo "{{ scheduled_start_time }}"
-        echo "{{ scheduled_start_time_7 }}"
+        echo "{{ flow_run_scheduled_start_time }}"
+        echo "{{ flow_run_scheduled_start_time_7 }}"
         echo "{{ my_param }}"
     {% endfor %}
 """
@@ -47,7 +47,7 @@ with Flow("tutorial") as flow:
     my_param = Parameter("my_param")
     t2(upstream_tasks=[t1])
     t3 = templated_command(
-        scheduled_start_time_7=add_7, my_param=my_param, upstream_tasks=[t1]
+        flow_run_scheduled_start_time_7=add_7, my_param=my_param, upstream_tasks=[t1]
     )
 
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -41,6 +41,8 @@ TaskRunInfoResult = NamedTuple(
 FlowRunInfoResult = NamedTuple(
     "FlowRunInfoResult",
     [
+        ("id", str),
+        ("flow_id", str),
         ("parameters", Dict[str, Any]),
         ("context", Dict[str, Any]),
         ("version", int),
@@ -471,6 +473,8 @@ class Client:
         query = {
             "query": {
                 with_args("flow_run_by_pk", {"id": flow_run_id}): {
+                    "id": True,
+                    "flow_id": True,
                     "parameters": True,
                     "context": True,
                     "version": True,

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -155,8 +155,10 @@ class CloudFlowRunner(FlowRunner):
         updated_context = context or {}
         updated_context.update(flow_run_info.context or {})
         updated_context.update(
+            flow_id=flow_run_info.id,
+            flow_run_id=flow_run_info.id,
             flow_run_version=flow_run_info.version,
-            scheduled_start_time=flow_run_info.scheduled_start_time,
+            flow_run_scheduled_start_time=flow_run_info.scheduled_start_time,
         )
 
         tasks = {t.slug: t for t in self.flow.tasks}
@@ -165,9 +167,9 @@ class CloudFlowRunner(FlowRunner):
             task = tasks[task_run.task_slug]
             task_states.setdefault(task, task_run.state)
             task_contexts.setdefault(task, {}).update(
+                task_id=task_run.task_id,
                 task_run_id=task_run.id,
                 task_run_version=task_run.version,
-                task_id=task_run.task_id,
             )
 
         # if state is set, keep it; otherwise load from Cloud

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -155,7 +155,7 @@ class FlowRunner(Runner):
                 context_params[param] = value
 
         context.update(flow_name=self.flow.name)
-        context.setdefault("scheduled_start_time", pendulum.now("utc"))
+        context.setdefault("flow_run_scheduled_start_time", pendulum.now("utc"))
 
         # add various formatted dates to context
         now = pendulum.now("utc")

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -19,7 +19,6 @@ Prefect provides various key / value pairs in context that are always available 
 
 | Variable | Description |
 | :--- | --- |
-| `scheduled_start_time` | an actual datetime object representing the scheduled start time for the Flow run; falls back to `now` for unscheduled runs |
 | `date` | an actual datetime object representing the current time |
 | `today` | the current date formatted as `YYYY-MM-DD`|
 | `today_nodash` | the current date formatted as `YYYYMMDD`|
@@ -35,6 +34,18 @@ Prefect provides various key / value pairs in context that are always available 
 | `task_full_name` | the name of the current task, including map index |
 | `task_tags` | the tags on the current task |
 | `task_run_count` | the run count of the task run - typically only interesting for retrying tasks |
+| `flow_run_scheduled_start_time` | a datetime object representing the scheduled start time for the Flow run; falls back to `now` for unscheduled runs |
+
+In addition, Prefect Cloud supplies some additional context variables:
+
+| Variable | Description |
+| :--- | --- |
+| `flow_id` | the id of the current flow |
+| `flow_run_id` | the id of the current flow run |
+| `flow_run_version` | the state version of the current flow run |
+| `task_id` | the id of the current task |
+| `task_run_id` | the id of the current task run |
+| `task_run_version` | the state version of the current task run |
 
 Users can also provide values to context at runtime.
 """

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -386,44 +386,47 @@ def test_client_deploy_with_flow_that_cant_be_deserialized(monkeypatch):
 
 
 def test_get_flow_run_info(monkeypatch):
-    response = """
-{
-    "flow_run_by_pk": {
-        "version": 0,
-        "parameters": {},
-        "context": null,
-        "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
-        "serialized_state": {
-            "type": "Pending",
-            "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-            "message": null,
-            "__version__": "0.3.3+309.gf1db024",
-            "cached_inputs": null
-        },
-        "task_runs":[
-            {
-                "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                "task": {
+    response = {
+        "flow_run_by_pk": {
+            "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "flow_id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "version": 0,
+            "parameters": {},
+            "context": None,
+            "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
+            "serialized_state": {
+                "type": "Pending",
+                "_result": {
+                    "type": "SafeResult",
+                    "value": "42",
+                    "result_handler": {"type": "JSONResultHandler"},
+                },
+                "message": None,
+                "__version__": "0.3.3+309.gf1db024",
+                "cached_inputs": None,
+            },
+            "task_runs": [
+                {
                     "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                    "slug": "da344768-5f5d-4eaf-9bca-83815617f713"
+                    "task": {
+                        "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+                        "slug": "da344768-5f5d-4eaf-9bca-83815617f713",
                     },
-                "version": 0,
-                "serialized_state": {
-                    "type": "Pending",
-                    "result": null,
-                    "message": null,
-                    "__version__": "0.3.3+309.gf1db024",
-                    "cached_inputs": null
+                    "version": 0,
+                    "serialized_state": {
+                        "type": "Pending",
+                        "result": None,
+                        "message": None,
+                        "__version__": "0.3.3+309.gf1db024",
+                        "cached_inputs": None,
+                    },
                 }
-            }
-        ]
+            ],
+        }
     }
-}
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -446,44 +449,47 @@ def test_get_flow_run_info(monkeypatch):
 
 
 def test_get_flow_run_info_with_nontrivial_payloads(monkeypatch):
-    response = """
-{
-    "flow_run_by_pk": {
-        "version": 0,
-        "parameters": {"x": {"deep": {"nested": 5}}},
-        "context": {"my_val": "test"},
-        "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
-        "serialized_state": {
-            "type": "Pending",
-            "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-            "message": null,
-            "__version__": "0.3.3+309.gf1db024",
-            "cached_inputs": null
-        },
-        "task_runs":[
-            {
-                "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                "task": {
+    response = {
+        "flow_run_by_pk": {
+            "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "flow_id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "version": 0,
+            "parameters": {"x": {"deep": {"nested": 5}}},
+            "context": {"my_val": "test"},
+            "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
+            "serialized_state": {
+                "type": "Pending",
+                "_result": {
+                    "type": "SafeResult",
+                    "value": "42",
+                    "result_handler": {"type": "JSONResultHandler"},
+                },
+                "message": None,
+                "__version__": "0.3.3+309.gf1db024",
+                "cached_inputs": None,
+            },
+            "task_runs": [
+                {
                     "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                    "slug": "da344768-5f5d-4eaf-9bca-83815617f713"
+                    "task": {
+                        "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+                        "slug": "da344768-5f5d-4eaf-9bca-83815617f713",
                     },
-                "version": 0,
-                "serialized_state": {
-                    "type": "Pending",
-                    "result": null,
-                    "message": null,
-                    "__version__": "0.3.3+309.gf1db024",
-                    "cached_inputs": null
+                    "version": 0,
+                    "serialized_state": {
+                        "type": "Pending",
+                        "result": None,
+                        "message": None,
+                        "__version__": "0.3.3+309.gf1db024",
+                        "cached_inputs": None,
+                    },
                 }
-            }
-        ]
+            ],
+        }
     }
-}
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -510,15 +516,9 @@ def test_get_flow_run_info_with_nontrivial_payloads(monkeypatch):
 
 
 def test_get_flow_run_info_raises_informative_error(monkeypatch):
-    response = """
-    {
-        "flow_run_by_pk": null
-    }
-    """
+    response = {"flow_run_by_pk": None}
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -565,30 +565,29 @@ def test_set_flow_run_state_with_error(monkeypatch):
 
 
 def test_get_task_run_info(monkeypatch):
-    response = """
-    {
+    response = {
         "getOrCreateTaskRun": {
             "task_run": {
                 "id": "772bd9ee-40d7-479c-9839-4ab3a793cabd",
                 "version": 0,
                 "serialized_state": {
                     "type": "Pending",
-                    "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-                    "message": null,
+                    "_result": {
+                        "type": "SafeResult",
+                        "value": "42",
+                        "result_handler": {"type": "JSONResultHandler"},
+                    },
+                    "message": None,
                     "__version__": "0.3.3+310.gd19b9b7.dirty",
-                    "cached_inputs": null
+                    "cached_inputs": None,
                 },
-                "task": {
-                    "slug": "slug"
-                }
+                "task": {"slug": "slug"},
             }
         }
     }
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -270,7 +270,7 @@ def test_flow_runner_loads_context_from_cloud(monkeypatch):
     assert res.context["a"] == 1
 
 
-def test_flow_runner_puts_scheduled_start_time_in_context(monkeypatch):
+def test_flow_runner_puts_flow_run_scheduled_start_time_in_context(monkeypatch):
     flow = prefect.Flow(name="test")
     date = pendulum.parse("19860920")
     get_flow_run_info = MagicMock(
@@ -287,9 +287,12 @@ def test_flow_runner_puts_scheduled_start_time_in_context(monkeypatch):
         state=None, task_states={}, context={}, task_contexts={}, parameters={}
     )
 
-    assert "scheduled_start_time" in res.context
-    assert isinstance(res.context["scheduled_start_time"], datetime.datetime)
-    assert res.context["scheduled_start_time"].strftime("%Y-%m-%d") == "1986-09-20"
+    assert "flow_run_scheduled_start_time" in res.context
+    assert isinstance(res.context["flow_run_scheduled_start_time"], datetime.datetime)
+    assert (
+        res.context["flow_run_scheduled_start_time"].strftime("%Y-%m-%d")
+        == "1986-09-20"
+    )
 
 
 def test_flow_runner_prioritizes_user_context_over_default_context(monkeypatch):

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 class FlowRun:
+    flow_id = str(uuid.uuid4())
     def __init__(self, id, state=None, version=None):
         self.id = id
         self.state = state or Pending()
@@ -50,7 +51,7 @@ class TaskRun:
 
 @prefect.task
 def whats_the_time():
-    return prefect.context.get("scheduled_start_time")
+    return prefect.context.get("flow_run_scheduled_start_time")
 
 
 @prefect.task
@@ -104,6 +105,8 @@ class MockedCloudClient(MagicMock):
         task_runs = [t for t in self.task_runs.values() if t.flow_run_id == flow_run_id]
 
         return FlowRunInfoResult(
+            id=flow_run.id,
+            flow_id=flow_run.flow_id,
             parameters={},
             context=None,
             version=flow_run.version,
@@ -211,7 +214,7 @@ def test_simple_two_task_flow(monkeypatch, executor):
 
 
 @pytest.mark.parametrize("executor", ["local", "sync"], indirect=True)
-def test_scheduled_start_time_is_in_context(monkeypatch, executor):
+def test_flow_run_scheduled_start_time_is_in_context(monkeypatch, executor):
     flow_run_id = str(uuid.uuid4())
     task_run_id_1 = str(uuid.uuid4())
 

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 class FlowRun:
     flow_id = str(uuid.uuid4())
+
     def __init__(self, id, state=None, version=None):
         self.id = id
         self.state = state or Pending()

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1366,31 +1366,31 @@ class TestContext:
         assert flow_state.is_successful()
         assert flow_state.result[runner.flow.tasks.pop()].result == 42
 
-    def test_flow_runner_provides_scheduled_start_time(self):
+    def test_flow_runner_provides_flow_run_scheduled_start_time(self):
         @prefect.task
-        def return_scheduled_start_time():
-            return prefect.context.get("scheduled_start_time")
+        def return_flow_run_scheduled_start_time():
+            return prefect.context.get("flow_run_scheduled_start_time")
 
-        f = Flow(name="test", tasks=[return_scheduled_start_time])
+        f = Flow(name="test", tasks=[return_flow_run_scheduled_start_time])
         res = f.run()
 
         assert res.is_successful()
-        assert res.result[return_scheduled_start_time].is_successful()
+        assert res.result[return_flow_run_scheduled_start_time].is_successful()
         assert isinstance(
-            res.result[return_scheduled_start_time].result, datetime.datetime
+            res.result[return_flow_run_scheduled_start_time].result, datetime.datetime
         )
 
-    def test_flow_runner_doesnt_override_scheduled_start_time(self):
+    def test_flow_runner_doesnt_override_flow_run_scheduled_start_time(self):
         @prefect.task
-        def return_scheduled_start_time():
-            return prefect.context.get("scheduled_start_time")
+        def return_flow_run_scheduled_start_time():
+            return prefect.context.get("flow_run_scheduled_start_time")
 
-        f = Flow(name="test", tasks=[return_scheduled_start_time])
-        res = f.run(context=dict(scheduled_start_time=42))
+        f = Flow(name="test", tasks=[return_flow_run_scheduled_start_time])
+        res = f.run(context=dict(flow_run_scheduled_start_time=42))
 
         assert res.is_successful()
-        assert res.result[return_scheduled_start_time].is_successful()
-        assert res.result[return_scheduled_start_time].result == 42
+        assert res.result[return_flow_run_scheduled_start_time].is_successful()
+        assert res.result[return_flow_run_scheduled_start_time].result == 42
 
     @pytest.mark.parametrize(
         "date", ["today_nodash", "tomorrow_nodash", "yesterday_nodash"]


### PR DESCRIPTION
To clarify that this context variable refers to the flow run start time, not the task run start time, I've tweaked its name to be more explicit. I've also added a table of what additional information is available in context when running in Cloud.
