### PR TITLE
Add more variables to context

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -41,6 +41,8 @@ TaskRunInfoResult = NamedTuple(
 FlowRunInfoResult = NamedTuple(
     "FlowRunInfoResult",
     [
+        ("id", str),
+        ("flow_id", str),
         ("parameters", Dict[str, Any]),
         ("context", Dict[str, Any]),
         ("version", int),
@@ -471,6 +473,8 @@ class Client:
         query = {
             "query": {
                 with_args("flow_run_by_pk", {"id": flow_run_id}): {
+                    "id": True,
+                    "flow_id": True,
                     "parameters": True,
                     "context": True,
                     "version": True,

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -155,6 +155,8 @@ class CloudFlowRunner(FlowRunner):
         updated_context = context or {}
         updated_context.update(flow_run_info.context or {})
         updated_context.update(
+            flow_id=flow_run_info.id,
+            flow_run_id=flow_run_info.id,
             flow_run_version=flow_run_info.version,
             scheduled_start_time=flow_run_info.scheduled_start_time,
         )
@@ -165,9 +167,9 @@ class CloudFlowRunner(FlowRunner):
             task = tasks[task_run.task_slug]
             task_states.setdefault(task, task_run.state)
             task_contexts.setdefault(task, {}).update(
+                task_id=task_run.task_id,
                 task_run_id=task_run.id,
                 task_run_version=task_run.version,
-                task_id=task_run.task_id,
             )
 
         # if state is set, keep it; otherwise load from Cloud

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -154,7 +154,7 @@ class FlowRunner(Runner):
             for param, value in parameters.items():
                 context_params[param] = value
 
-        context.update(flow_name=self.flow.name)
+        context.update(flow=self.flow, flow_name=self.flow.name)
         context.setdefault("scheduled_start_time", pendulum.now("utc"))
 
         # add various formatted dates to context

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -166,7 +166,11 @@ class TaskRunner(Runner):
                 context.update(loop_context)
 
         context.update(
-            task_run_count=run_count, task_name=self.task.name, task_tags=self.task.tags
+            task=self.task,
+            task_run_count=run_count,
+            task_name=self.task.name,
+            task_tags=self.task.tags,
+            task_slug=self.task.slug,
         )
         context.setdefault("checkpointing", config.flows.checkpointing)
 

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -19,7 +19,6 @@ Prefect provides various key / value pairs in context that are always available 
 
 | Variable | Description |
 | :--- | --- |
-| `scheduled_start_time` | an actual datetime object representing the scheduled start time for the Flow run; falls back to `now` for unscheduled runs |
 | `date` | an actual datetime object representing the current time |
 | `today` | the current date formatted as `YYYY-MM-DD`|
 | `today_nodash` | the current date formatted as `YYYYMMDD`|
@@ -28,13 +27,28 @@ Prefect provides various key / value pairs in context that are always available 
 | `tomorrow` | tomorrow's date formatted as `YYYY-MM-DD`|
 | `tomorrow_nodash` | tomorrow's date formatted as `YYYYMMDD`|
 | `logger` | the logger for the current task |
+| `flow` | the current flow object |
 | `flow_name` | the name of the current flow |
+| `scheduled_start_time` | a datetime object representing the scheduled start time for the flow run; falls back to `now` for unscheduled runs |
 | `parameters` | a dictionary of parameter values for the current flow run |
 | `map_index` | the map index of the current task (if mapped, otherwise `None`) |
+| `task` | the current task object |
 | `task_name` | the name of the current task |
 | `task_full_name` | the name of the current task, including map index |
+| `task_slug` | the slug of the current task
 | `task_tags` | the tags on the current task |
 | `task_run_count` | the run count of the task run - typically only interesting for retrying tasks |
+
+In addition, Prefect Cloud supplies some additional context variables:
+
+| Variable | Description |
+| :--- | --- |
+| `flow_id` | the id of the current flow |
+| `flow_run_id` | the id of the current flow run |
+| `flow_run_version` | the state version of the current flow run |
+| `task_id` | the id of the current task |
+| `task_run_id` | the id of the current task run |
+| `task_run_version` | the state version of the current task run |
 
 Users can also provide values to context at runtime.
 """

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -386,44 +386,47 @@ def test_client_deploy_with_flow_that_cant_be_deserialized(monkeypatch):
 
 
 def test_get_flow_run_info(monkeypatch):
-    response = """
-{
-    "flow_run_by_pk": {
-        "version": 0,
-        "parameters": {},
-        "context": null,
-        "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
-        "serialized_state": {
-            "type": "Pending",
-            "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-            "message": null,
-            "__version__": "0.3.3+309.gf1db024",
-            "cached_inputs": null
-        },
-        "task_runs":[
-            {
-                "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                "task": {
+    response = {
+        "flow_run_by_pk": {
+            "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "flow_id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "version": 0,
+            "parameters": {},
+            "context": None,
+            "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
+            "serialized_state": {
+                "type": "Pending",
+                "_result": {
+                    "type": "SafeResult",
+                    "value": "42",
+                    "result_handler": {"type": "JSONResultHandler"},
+                },
+                "message": None,
+                "__version__": "0.3.3+309.gf1db024",
+                "cached_inputs": None,
+            },
+            "task_runs": [
+                {
                     "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                    "slug": "da344768-5f5d-4eaf-9bca-83815617f713"
+                    "task": {
+                        "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+                        "slug": "da344768-5f5d-4eaf-9bca-83815617f713",
                     },
-                "version": 0,
-                "serialized_state": {
-                    "type": "Pending",
-                    "result": null,
-                    "message": null,
-                    "__version__": "0.3.3+309.gf1db024",
-                    "cached_inputs": null
+                    "version": 0,
+                    "serialized_state": {
+                        "type": "Pending",
+                        "result": None,
+                        "message": None,
+                        "__version__": "0.3.3+309.gf1db024",
+                        "cached_inputs": None,
+                    },
                 }
-            }
-        ]
+            ],
+        }
     }
-}
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -446,44 +449,47 @@ def test_get_flow_run_info(monkeypatch):
 
 
 def test_get_flow_run_info_with_nontrivial_payloads(monkeypatch):
-    response = """
-{
-    "flow_run_by_pk": {
-        "version": 0,
-        "parameters": {"x": {"deep": {"nested": 5}}},
-        "context": {"my_val": "test"},
-        "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
-        "serialized_state": {
-            "type": "Pending",
-            "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-            "message": null,
-            "__version__": "0.3.3+309.gf1db024",
-            "cached_inputs": null
-        },
-        "task_runs":[
-            {
-                "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                "task": {
+    response = {
+        "flow_run_by_pk": {
+            "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "flow_id": "da344768-5f5d-4eaf-9bca-83815617f713",
+            "version": 0,
+            "parameters": {"x": {"deep": {"nested": 5}}},
+            "context": {"my_val": "test"},
+            "scheduled_start_time": "2019-01-25T19:15:58.632412+00:00",
+            "serialized_state": {
+                "type": "Pending",
+                "_result": {
+                    "type": "SafeResult",
+                    "value": "42",
+                    "result_handler": {"type": "JSONResultHandler"},
+                },
+                "message": None,
+                "__version__": "0.3.3+309.gf1db024",
+                "cached_inputs": None,
+            },
+            "task_runs": [
+                {
                     "id": "da344768-5f5d-4eaf-9bca-83815617f713",
-                    "slug": "da344768-5f5d-4eaf-9bca-83815617f713"
+                    "task": {
+                        "id": "da344768-5f5d-4eaf-9bca-83815617f713",
+                        "slug": "da344768-5f5d-4eaf-9bca-83815617f713",
                     },
-                "version": 0,
-                "serialized_state": {
-                    "type": "Pending",
-                    "result": null,
-                    "message": null,
-                    "__version__": "0.3.3+309.gf1db024",
-                    "cached_inputs": null
+                    "version": 0,
+                    "serialized_state": {
+                        "type": "Pending",
+                        "result": None,
+                        "message": None,
+                        "__version__": "0.3.3+309.gf1db024",
+                        "cached_inputs": None,
+                    },
                 }
-            }
-        ]
+            ],
+        }
     }
-}
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -510,15 +516,9 @@ def test_get_flow_run_info_with_nontrivial_payloads(monkeypatch):
 
 
 def test_get_flow_run_info_raises_informative_error(monkeypatch):
-    response = """
-    {
-        "flow_run_by_pk": null
-    }
-    """
+    response = {"flow_run_by_pk": None}
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post
@@ -565,30 +565,29 @@ def test_set_flow_run_state_with_error(monkeypatch):
 
 
 def test_get_task_run_info(monkeypatch):
-    response = """
-    {
+    response = {
         "getOrCreateTaskRun": {
             "task_run": {
                 "id": "772bd9ee-40d7-479c-9839-4ab3a793cabd",
                 "version": 0,
                 "serialized_state": {
                     "type": "Pending",
-                    "_result": {"type": "SafeResult", "value": "42", "result_handler": {"type": "JSONResultHandler"}},
-                    "message": null,
+                    "_result": {
+                        "type": "SafeResult",
+                        "value": "42",
+                        "result_handler": {"type": "JSONResultHandler"},
+                    },
+                    "message": None,
                     "__version__": "0.3.3+310.gd19b9b7.dirty",
-                    "cached_inputs": null
+                    "cached_inputs": None,
                 },
-                "task": {
-                    "slug": "slug"
-                }
+                "task": {"slug": "slug"},
             }
         }
     }
-    """
+
     post = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value=dict(data=json.loads(response)))
-        )
+        return_value=MagicMock(json=MagicMock(return_value=dict(data=response)))
     )
     session = MagicMock()
     session.return_value.post = post

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -29,6 +29,8 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 class FlowRun:
+    flow_id = str(uuid.uuid4())
+
     def __init__(self, id, state=None, version=None):
         self.id = id
         self.state = state or Pending()
@@ -104,6 +106,8 @@ class MockedCloudClient(MagicMock):
         task_runs = [t for t in self.task_runs.values() if t.flow_run_id == flow_run_id]
 
         return FlowRunInfoResult(
+            id=flow_run.id,
+            flow_id=flow_run.flow_id,
             parameters={},
             context=None,
             version=flow_run.version,

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1437,6 +1437,20 @@ class TestContext:
         output = res.result[return_ctx_key].result
         assert isinstance(output, datetime.datetime)
 
+    def test_context_includes_flow_object(self):
+
+        f = Flow(name="test")
+
+        @prefect.task
+        def check_ctx():
+            # assert isinstance(prefect.context.get("flow"), Flow)
+            assert prefect.context["flow"] is f
+
+        f.add_task(check_ctx)
+        res = f.run()
+
+        assert res.is_successful()
+
     def test_user_provided_context_is_prioritized(self):
         @prefect.task
         def return_ctx_key():

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -384,6 +384,21 @@ class TestInitializeRun:
                 result = TaskRunner(Task()).initialize_run(state=None, context=ctx)
             assert result.context.checkpointing == "FOO"
 
+    def test_task_runner_puts_task_slug_in_context(self):
+        with prefect.context() as ctx:
+            assert "task_slug" not in ctx
+            result = TaskRunner(Task(slug="test-slug")).initialize_run(
+                state=None, context=ctx
+            )
+            assert result.context.task_slug == "test-slug"
+
+    def test_task_runner_puts_task_in_context(self):
+        with prefect.context() as ctx:
+            assert "task" not in ctx
+            t = Task()
+            result = TaskRunner(t).initialize_run(state=None, context=ctx)
+            assert result.context.task is t
+
     def test_task_runner_puts_tags_in_context(self):
         with prefect.context() as ctx:
             assert "task_tags" not in ctx


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR pulls the non-breaking changes out of #1403:
- Adds `task_slug`, `task`, and `flow` to context
- Adds `flow_id` and `flow_run_id` to context when running in Cloud
- Updates context documentation


## Why is this PR important?


