### PR TITLE
Suppress print to stdout from subprocess.call in test collection

### DIFF
--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -35,7 +35,10 @@ def test_shell_raises_if_no_command_provided():
             out = f.run()
 
 
-@pytest.mark.skipif(subprocess.call(["which", "zsh"]), reason="zsh not installed.")
+@pytest.mark.skipif(
+    subprocess.call(["which", "zsh"], stdout=open(os.devnull, "w")),
+    reason="zsh not installed.",
+)
 def test_shell_runs_other_shells():
     with Flow(name="test") as f:
         task = ShellTask(shell="zsh")(command="echo -n $ZSH_NAME")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x ] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
As described in issue #1411, the test tests/tasks/test_shell.py::test_shell_runs_other_shells makes a subprocess call, which can cause printing to stdout. This is an hidden effect of the test collection, and e.g. causes the built-in test discovery of the VS Code [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) to fail. This PR suppresses the printing by directing it to /dev/null instead of stdout. 


## Why is this PR important?
It removes hidden effects of the test collection and allows developers using VS Code to run the tests with the built-in tools. 