### PR TITLE
Update state docs

### DIFF
--- a/docs/guide/core_concepts/states.md
+++ b/docs/guide/core_concepts/states.md
@@ -49,7 +49,13 @@ To be clear: the default trigger will not run tasks that follow failed tasks, so
 
 ## State types
 
-There are three main states: `Pending`, `Running`, and `Finished`. Flows and tasks typically progress through these three states. At each stage of the execution pipeline, the current state determines what actions are taken. For example, if you attempt to run a task in a `Success` state (a type of `Finished`) it will simply exit the pipeline without changing. If you attempt to run a task in a `Retrying` state (a type of `Pending`), it will proceed as long as the state's scheduled retry time has already passed.
+There are three main types of states: `Pending`, `Running`, and `Finished`. Flows and tasks typically progress through them in that order, possibly more than once. Each state type has many children. For example, `Scheduled` and `Retrying` are both `Pending` states; `Success` and `Failed` are both `Finished` states.
+
+At each stage of the execution pipeline, the current state determines what actions are taken. For example, if you attempt to run a task in a `Success` state it will simply exit the pipeline, because `Finished` states are never re-run. If you attempt to run a task in a `Retrying` state, it will proceed only as long as the state's scheduled retry time has already passed. In this way, states carry all of the critical information the Prefect engine uses to make decisions about workflow logic.
+
+::: tip Meta-states
+There's actually a fourth kind of state, called a `MetaState`, but it doesn't affect the execution pipeline. Instead, meta-states are used by Prefect to enhance existing states with additional information. For example, two meta-states are `Submitted` and `Queued`. These are used to "wrap" other states in a way that makes the original state recoverable. For example, a `Scheduled` state might be put into a `Submitted` state to indicate that it's been submitted for execution, but the original `Scheduled` state is needed by the engine to perform runtime logic. By wrapping the `Scheduled` state with the `Submitted` meta-state, rather than replacing it, the engine is able to recover the original information it needs.
+:::
 
 ## State handlers & callbacks
 


### PR DESCRIPTION
From An Hoang in Slack:


> Just a little comment on the documentation. As an ESL person, when reading https://docs.prefect.io/guide/core_concepts/states.html#state-types section I got confused a bit between state and state types. I'd propose changing it to:
"There are three main state types: Pending, Running, and Finished. Flows and tasks typically progress through these three states types. At each stage of the execution pipeline, the current state type determines what actions are taken.
Sorry if this seems like nitpicking! I don't mean to :slightly_smiling_face:

The suggested corrections are valuable, and this PR goes one step further in trying to clarify state types!