### PR TITLE
Ensure the flow.run() scheduled_start_time updates with each loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Users can now create projects from the CLI - [#1388](https://github.com/PrefectHQ/prefect/pull/1388)
 - Add a health check to confirm that serialized flows are valid prior to Cloud deploy - [#1397](https://github.com/PrefectHQ/prefect/pull/1397)
 - Add `task_slug`, `flow_id`, and `flow_run_id` to context - [#1405](https://github.com/PrefectHQ/prefect/pull/1405)
-- Support persistent `scheduled_start_time` for scheduled flow runs when run locally with `flow.run()` - [#1418](https://github.com/PrefectHQ/prefect/pull/1418)
+- Support persistent `scheduled_start_time` for scheduled flow runs when run locally with `flow.run()` - [#1418](https://github.com/PrefectHQ/prefect/pull/1418), [#1429](https://github.com/PrefectHQ/prefect/pull/1429)
 - Add `task_args` to `Task.map` - [#1390](https://github.com/PrefectHQ/prefect/issues/1390)
 - Add auth flows for `USER`-scoped Cloud API tokens - [#1423](https://github.com/PrefectHQ/prefect/pull/1423)
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1003,7 +1003,7 @@ class Flow:
             run_on_schedule = cast(bool, prefect.config.flows.run_on_schedule)
         if run_on_schedule is False:
             runner = runner_cls(flow=self)
-            state = runner.run(parameters=parameters, **kwargs)
+            state = runner.run(parameters=parameters, return_tasks=self.tasks, **kwargs)
         else:
             state = self._run_on_schedule(
                 parameters=parameters, runner_cls=runner_cls, **kwargs

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -843,10 +843,12 @@ class Flow:
         flow_run_context = kwargs.pop(
             "context", {}
         ).copy()  # copy to avoid modification
-        flow_run_context.setdefault("scheduled_start_time", next_run_time)
 
         ## run this flow indefinitely, so long as its schedule has future dates
         while True:
+
+            flow_run_context.update(scheduled_start_time=next_run_time)
+
             if flow_state.is_scheduled():
                 next_run_time = flow_state.start_time
                 now = pendulum.now("utc")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2060,6 +2060,25 @@ class TestFlowRunMethod:
         state = f.run()
         assert state.result[report_start_time].result is start_time
 
+    def test_flow_dot_run_updates_the_scheduled_start_time_of_each_scheduled_run(self):
+
+        start_times = [pendulum.now().add(seconds=i * 0.1) for i in range(1, 4)]
+        REPORTED_START_TIMES = []
+
+        @task
+        def record_start_time():
+            REPORTED_START_TIMES.append(prefect.context.scheduled_start_time)
+
+        f = Flow(
+            name="test",
+            tasks=[record_start_time],
+            schedule=prefect.schedules.Schedule(
+                clocks=[prefect.schedules.clocks.DatesClock(dates=start_times)]
+            ),
+        )
+        f.run()
+        assert REPORTED_START_TIMES == start_times
+
 
 class TestFlowDeploy:
     @pytest.mark.parametrize(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1514,6 +1514,18 @@ class TestFlowRunMethod:
         state = f.run(run_on_schedule=False)
         assert t.call_count == 1
 
+    def test_flow_dot_run_returns_tasks_when_running_off_schedule(self):
+        @prefect.task
+        def test_task():
+            return 2
+
+        f = Flow(name="test", tasks=[test_task])
+        res = f.run(run_on_schedule=False)
+
+        assert res.is_successful()
+        assert res.result[test_task].is_successful()
+        assert res.result[test_task].result == 2
+
     def test_flow_dot_run_responds_to_config(self):
         class MockSchedule(prefect.schedules.Schedule):
             call_count = 0

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1380,17 +1380,32 @@ class TestContext:
             res.result[return_scheduled_start_time].result, datetime.datetime
         )
 
-    def test_flow_runner_doesnt_override_scheduled_start_time(self):
+    def test_flow_runner_does_override_scheduled_start_time_when_running_off_schedule(
+        self
+    ):
         @prefect.task
         def return_scheduled_start_time():
             return prefect.context.get("scheduled_start_time")
 
         f = Flow(name="test", tasks=[return_scheduled_start_time])
-        res = f.run(context=dict(scheduled_start_time=42))
+        res = f.run(context=dict(scheduled_start_time=42), run_on_schedule=False)
 
         assert res.is_successful()
         assert res.result[return_scheduled_start_time].is_successful()
         assert res.result[return_scheduled_start_time].result == 42
+
+    def test_flow_runner_doesnt_override_scheduled_start_time_when_running_on_schedule(
+        self
+    ):
+        @prefect.task
+        def return_scheduled_start_time():
+            return prefect.context.get("scheduled_start_time")
+
+        f = Flow(name="test", tasks=[return_scheduled_start_time])
+        res = f.run(context=dict(scheduled_start_time=42), run_on_schedule=True)
+
+        assert res.is_successful()
+        assert res.result[return_scheduled_start_time].result != 42
 
     @pytest.mark.parametrize(
         "date", ["today_nodash", "tomorrow_nodash", "yesterday_nodash"]


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
#1418 updated `flow.run()` to populate scheduled start time, but had a bug in that it didn't update across scheduled runs, as identified in #1428. This fixes that bug by moving the update line into the loop.

Closes #1428.