### PR TITLE
Add new CLI auth flow w/ tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Support persistent `scheduled_start_time` for scheduled flow runs when run locally with `flow.run()` - [#1418](https://github.com/PrefectHQ/prefect/pull/1418)
 - Add `task_args` to `Task.map` - [#1390](https://github.com/PrefectHQ/prefect/issues/1390)
 - Add auth flows for `USER`-scoped Cloud API tokens - [#1423](https://github.com/PrefectHQ/prefect/pull/1423)
+- Add CLI commands for working with Prefect Cloud auth - [#1431](https://github.com/PrefectHQ/prefect/pull/1431)
 
 ### Task Library
 

--- a/docs/cloud/cloud_concepts/cli.md
+++ b/docs/cloud/cloud_concepts/cli.md
@@ -373,6 +373,60 @@ $ prefect auth login --token BAD_TOKEN
 Error attempting to use Prefect API token BAD_TOKEN
 ```
 
+#### auth logout
+
+Running `prefect auth logout` will log you out of your active tenant if one if currently logged in to.
+```
+$ prefect auth logout
+Are you sure you want to log out of Prefect Cloud? (y/N) Y
+Logged out from tenant PREVIOUS_ACTIVE_TENANT_ID
+```
+
+If there is no current active tenant then you should see:
+```
+$ prefect auth logout
+Are you sure you want to log out of Prefect Cloud? (y/N) Y
+No tenant currently active
+```
+
+#### auth list-tenants
+
+Running `prefect auth list-tenants` will output all of the tenants that you have access to use.
+```
+$ prefect auth list-tenants
+NAME                        SLUG                        ID
+Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d
+test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1  *
+```
+
+#### auth switch-tenants
+
+Running `prefect auth switch-tenants --id TENANT_ID --slug TENANT_SLUG` will switch your active tenants. Either the tenant ID or the tenant slug need to be provided.
+```
+$ prefect auth switch-tenants --slug test-person
+Tenant switched
+```
+
+If you are unable to switch tenants for various reasons (bad id, bad slug, not providing either) then you should see:
+```
+$ prefect auth switch-tenants --slug test-person
+Unable to switch tenant
+```
+
+#### auth create-token
+
+Running `prefect auth create-token --name MY_TOKEN --role RUNNER` will generate a Prefect Cloud API token and output it to stdout. For more information on API tokens visit go [here](./api.html).
+```
+$ prefect auth create-token -n MyToken -r RUNNER
+...token output...
+```
+
+If you are unable to create an API token then you should see:
+```
+$ prefect auth create-token -n MyToken -r RUNNER
+Issue creating API token
+```
+
 ## Miscellaneous Commands
 
 `prefect version` outputs the current version of Prefect you are using:

--- a/docs/cloud/cloud_concepts/cli.md
+++ b/docs/cloud/cloud_concepts/cli.md
@@ -401,7 +401,7 @@ test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-
 
 #### auth switch-tenants
 
-Running `prefect auth switch-tenants --id TENANT_ID --slug TENANT_SLUG` will switch your active tenants. Either the tenant ID or the tenant slug need to be provided.
+Running `prefect auth switch-tenants --id TENANT_ID --slug TENANT_SLUG` will switch your active tenants. Either the tenant ID or the tenant slug needs to be provided.
 ```
 $ prefect auth switch-tenants --slug test-person
 Tenant switched

--- a/docs/cloud/cloud_concepts/cli.md
+++ b/docs/cloud/cloud_concepts/cli.md
@@ -375,7 +375,7 @@ Error attempting to use Prefect API token BAD_TOKEN
 
 #### auth logout
 
-Running `prefect auth logout` will log you out of your active tenant if one if currently logged in to.
+Running `prefect auth logout` will log you out of your active tenant (if you are logged in)
 ```
 $ prefect auth logout
 Are you sure you want to log out of Prefect Cloud? (y/N) Y

--- a/docs/cloud/cloud_concepts/cli.md
+++ b/docs/cloud/cloud_concepts/cli.md
@@ -359,6 +359,10 @@ TIMESTAMP                         LEVEL    MESSAGE
 
 `auth` is a group of commands that handle authentication related configuration with Prefect Cloud.
 
+::: warning Config
+Having an API token set as a config value prior to using auth CLI commands, either in your config.toml or as an environment variable, will cause all auth commands to abort on use.
+:::
+
 #### auth login
 
 Running `prefect auth login` requires that a Prefect Cloud API token be provided and when executed the API token is used to login to Prefect Cloud.
@@ -425,6 +429,35 @@ If you are unable to create an API token then you should see:
 ```
 $ prefect auth create-token -n MyToken -r RUNNER
 Issue creating API token
+```
+
+#### auth revoke-token
+
+Running `prefect auth revoke-token --id TOKEN_ID` will revoke API tokens in Prefect Cloud.
+```
+$ prefect auth revoke-token --id TOKEN_ID
+Token successfully revoked
+```
+
+If the token is not found then you should see:
+```
+$ prefect auth revoke-token --id TOKEN_ID
+Unable to revoke token with ID TOKEN_ID
+```
+
+#### auth list-tokens
+
+Running `prefect auth list-tokens` will list your available API tokens in Prefect Cloud. Note: only the name and ID of the token will be shown, not the actual token.
+```
+$ prefect auth list-tokens
+NAME        ID
+My_Token    87gh22f4-333c-47fc-ae8f-0b61ghu811c3
+```
+
+If you are unable to list API tokens then you should see:
+```
+$ prefect auth list-tokens
+Unable to list API tokens
 ```
 
 ## Miscellaneous Commands

--- a/docs/cloud/cloud_concepts/cli.md
+++ b/docs/cloud/cloud_concepts/cli.md
@@ -415,7 +415,7 @@ Unable to switch tenant
 
 #### auth create-token
 
-Running `prefect auth create-token --name MY_TOKEN --role RUNNER` will generate a Prefect Cloud API token and output it to stdout. For more information on API tokens visit go [here](./api.html).
+Running `prefect auth create-token --name MY_TOKEN --role RUNNER` will generate a Prefect Cloud API token and output it to stdout. For more information on API tokens go [here](./api.html).
 ```
 $ prefect auth create-token -n MyToken -r RUNNER
 ...token output...

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -1,4 +1,5 @@
 import click
+from tabulate import tabulate
 
 from prefect import Client, config
 from prefect.utilities.exceptions import AuthorizationError, ClientError
@@ -15,11 +16,34 @@ def auth():
 
     \b
     Arguments:
-        login       Login to Prefect Cloud
+        login           Log in to Prefect Cloud
+        logout          Log out of Prefect Cloud
+        list-tenants    List your available tenants
+        switch-tenants  Switch to a different tenant
+        create-token    Create an API token
 
     \b
     Examples:
         $ prefect auth login --token MY_TOKEN
+        Log in successful
+
+    \b
+        $ prefect auth logout
+        Logged out from tenant TENANT_ID
+
+    \b
+        $ prefect auth list-tenants
+        NAME                        SLUG                        ID
+        Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d
+        test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1  *
+
+    \b
+        $ prefect auth switch-tenants --slug test-person
+        Tenant switched
+
+    \b
+        $ prefect auth create-token -n MyToken -r RUNNER
+        ...token output...
     """
     pass
 
@@ -30,7 +54,7 @@ def auth():
 )
 def login(token):
     """
-    Login to Prefect Cloud with an api token to use for Cloud communication.
+    Log in to Prefect Cloud with an api token to use for Cloud communication.
 
     \b
     Options:
@@ -61,4 +85,113 @@ def login(token):
     # save token
     client.save_api_token()
 
-    click.secho("Login successful", fg="green")
+    click.secho("Log in successful", fg="green")
+
+
+@auth.command(hidden=True)
+def logout():
+    """
+    Log out of Prefect Cloud
+    """
+    click.confirm(
+        "Are you sure you want to log out of Prefect Cloud?", default=False, abort=True
+    )
+
+    client = Client()
+    tenant_id = client._active_tenant_id
+
+    if not tenant_id:
+        click.secho("No tenant currently active", fg="red")
+        return
+
+    client.logout_from_tenant()
+
+    click.secho("Logged out from tenant {}".format(tenant_id), fg="green")
+
+
+@auth.command(hidden=True)
+def list_tenants():
+    """
+    List available tenants
+    """
+
+    client = Client()
+
+    tenants = client.get_available_tenants()
+    active_tenant_id = client._active_tenant_id
+
+    output = []
+    for item in tenants:
+        active = None
+        if item.id == active_tenant_id:
+            active = "*"
+        output.append([item.name, item.slug, item.id, active])
+
+    click.echo(
+        tabulate(
+            output,
+            headers=["NAME", "SLUG", "ID", ""],
+            tablefmt="plain",
+            numalign="left",
+            stralign="left",
+        )
+    )
+
+
+@auth.command(hidden=True)
+@click.option(
+    "--id", "-i", required=False, help="A Prefect Cloud tenant id.", hidden=True
+)
+@click.option(
+    "--slug", "-s", required=False, help="A Prefect Cloud tenant slug.", hidden=True
+)
+def switch_tenants(id, slug):
+    """
+    Switch active tenant
+
+    \b
+    Options:
+        --id, -i    TEXT    A Prefect Cloud tenant id
+        --slug, -s  TEXT    A Prefect Cloud tenant slug
+    """
+
+    client = Client()
+
+    login_success = client.login_to_tenant(tenant_slug=slug, tenant_id=id)
+    if not login_success:
+        click.secho("Unable to switch tenant", fg="red")
+        return
+
+    click.secho("Tenant switched", fg="green")
+
+
+@auth.command(hidden=True)
+@click.option("--name", "-n", required=True, help="A token name.", hidden=True)
+@click.option("--role", "-r", required=True, help="A token role.", hidden=True)
+def create_token(name, role):
+    """
+    Create a Prefect Cloud API token.
+
+    For more info on API tokens visit https://docs.prefect.io/cloud/cloud_concepts/api.html
+
+    \b
+    Options:
+        --name, -n      TEXT    A name to give the generated token
+        --role, -r      TEXT    A role for the token
+    """
+    client = Client()
+
+    output = client.graphql(
+        query={
+            "mutation($input: createAPITokenInput!)": {
+                "createAPIToken(input: $input)": {"token"}
+            }
+        },
+        variables=dict(input=dict(name=name, role=role)),
+    )
+
+    if not output.get("data", None):
+        click.secho("Issue creating API token", fg="red")
+        return
+
+    click.echo(output.data.createAPIToken.token)

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -253,7 +253,7 @@ def revoke_token(id):
 
     \b
     Options:
-        --id, -i    TEXT    An id of a token to revoke
+        --id, -i    TEXT    The id of a token to revoke
     """
     check_override_auth_token()
 
@@ -269,7 +269,7 @@ def revoke_token(id):
     )
 
     if not output.get("data", None) or not output.data.deleteAPIToken.success:
-        click.secho("Unable to revoke token with id {}".format(id), fg="red")
+        click.secho("Unable to revoke token with ID {}".format(id), fg="red")
         return
 
     click.secho("Token successfully revoked", fg="green")

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -28,13 +28,10 @@ def test_auth_help():
 def test_auth_login(patch_post):
     patch_post(dict(data=dict(tenant="id")))
 
-    with set_temporary_config(
-        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
-    ):
+    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
         runner = CliRunner()
         result = runner.invoke(auth, ["login", "--token", "test"])
         assert result.exit_code == 0
-        assert "Login successful" in result.output
 
 
 def test_auth_login_client_error(patch_post):
@@ -58,7 +55,6 @@ def test_auth_login_confirm(patch_post):
         runner = CliRunner()
         result = runner.invoke(auth, ["login", "--token", "test"], input="Y")
         assert result.exit_code == 0
-        assert "Login successful" in result.output
 
 
 def test_auth_login_not_confirm(patch_post):
@@ -70,3 +66,116 @@ def test_auth_login_not_confirm(patch_post):
         runner = CliRunner()
         result = runner.invoke(auth, ["login", "--token", "test"], input="N")
         assert result.exit_code == 1
+
+
+def test_auth_logout_after_login(patch_post):
+    patch_post(dict(data=dict(tenant="id")))
+
+    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
+        runner = CliRunner()
+
+        result = runner.invoke(auth, ["login", "--token", "test"])
+        assert result.exit_code == 0
+
+        c = prefect.Client()
+        assert c._api_token == "test"
+
+        result = runner.invoke(auth, ["logout"], input="Y")
+        assert result.exit_code == 0
+
+        c = prefect.Client()
+        assert not c._active_tenant_id
+
+
+def test_auth_logout_not_confirm(patch_post):
+    patch_post(dict(data=dict(tenant="id")))
+
+    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
+        runner = CliRunner()
+        result = runner.invoke(auth, ["logout"], input="N")
+        assert result.exit_code == 1
+
+
+def test_auth_logout_no_active_tenant(patch_post):
+    patch_post(dict(data=dict(tenant="id")))
+
+    with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
+        runner = CliRunner()
+        result = runner.invoke(auth, ["logout"], input="Y")
+        assert result.exit_code == 0
+        assert "No tenant currently active" in result.output
+
+
+def test_list_tenants(patch_post):
+    patch_post(
+        dict(
+            data=dict(
+                tenant=[{"id": "id", "slug": "slug", "name": "name"}],
+                switchTenant={
+                    "accessToken": "accessToken",
+                    "expiresIn": "expiresIn",
+                    "refreshToken": "refreshToken",
+                },
+            )
+        )
+    )
+
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        runner = CliRunner()
+        result = runner.invoke(auth, ["list-tenants"])
+        assert result.exit_code == 0
+        assert "id" in result.output
+        assert "slug" in result.output
+        assert "name" in result.output
+
+
+def test_switch_tenants(monkeypatch):
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        monkeypatch.setattr("prefect.cli.auth.Client", MagicMock())
+
+        runner = CliRunner()
+        result = runner.invoke(auth, ["switch-tenants", "--slug", "slug"])
+        assert result.exit_code == 0
+        assert "Tenant switched" in result.output
+
+
+def test_switch_tenants(monkeypatch):
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = MagicMock()
+        client.return_value.login_to_tenant = MagicMock(return_value=False)
+        monkeypatch.setattr("prefect.cli.auth.Client", client)
+
+        runner = CliRunner()
+        result = runner.invoke(auth, ["switch-tenants", "--slug", "slug"])
+        assert result.exit_code == 0
+        assert "Unable to switch tenant" in result.output
+
+
+def test_create_token(patch_post):
+    patch_post(dict(data=dict(createAPIToken={"token": "token"})))
+
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        runner = CliRunner()
+        result = runner.invoke(auth, ["create-token", "-n", "name", "-r", "role"])
+        assert result.exit_code == 0
+        assert "token" in result.output
+
+
+def test_create_token_fails(patch_post):
+    patch_post(dict())
+
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        runner = CliRunner()
+        result = runner.invoke(auth, ["create-token", "-n", "name", "-r", "role"])
+        assert result.exit_code == 0
+        assert "Issue creating API token" in result.output

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -200,7 +200,7 @@ def test_revoke_token_fails(patch_post):
         runner = CliRunner()
         result = runner.invoke(auth, ["revoke-token", "--id", "id"])
         assert result.exit_code == 0
-        assert "Unable to revoke token with id id" in result.output
+        assert "Unable to revoke token with ID id" in result.output
 
 
 def test_check_override_function():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1417 
Adds new CLI commands for working with Prefect Cloud auth
Related to changes in #1423

e.g.
```
        $ prefect auth login --token MY_TOKEN
        Log in successful

        $ prefect auth list-tenants
        NAME                        SLUG                        ID
        Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d
        test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1 

        $ prefect auth switch-tenants --slug test-person
        Tenant switched

        $ prefect auth list-tenants
        NAME                        SLUG                        ID
        Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d    *
        test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1 

        $ prefect auth logout
        Logged out from tenant 

        $ prefect auth list-tenants
        NAME                        SLUG                        ID
        Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d
        test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1 

```

Depends on #1426 

## Why is this PR important?
Makes auth really easy to work with in the CLI

