### PR TITLE
Fix map retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with Docker storage not respecting user-provided image names - [#1335](https://github.com/PrefectHQ/prefect/pull/1335)
 - Fix issue with local retries in Cloud not always running in-process - [#1348](https://github.com/PrefectHQ/prefect/pull/1348)
+- Fix issue with reduced mapped tasks not respecting retries - [#1436](https://github.com/PrefectHQ/prefect/issues/1436)
 
 ### Deprecations
 

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -597,6 +597,72 @@ def test_reduce_task_honors_trigger_across_all_mapped_states(executor):
 @pytest.mark.parametrize(
     "executor", ["local", "sync", "mproc", "mthread"], indirect=True
 )
+def test_reduce_task_properly_applies_trigger_across_all_mapped_states(executor):
+    """
+    The `take_sum` task reduces over the `div` task, which is going to return one Success
+    and one Failure. The `take_sum` should fail its trigger check.
+    """
+
+    @prefect.task
+    def ll():
+        return [0, 1]
+
+    @prefect.task(max_retries=5, retry_delay=datetime.timedelta(hours=1))
+    def div(x):
+        return 1 / x
+
+    @prefect.task
+    def take_sum(x):
+        return sum(x)
+
+    with Flow(name="test") as f:
+        d = div.map(ll)
+        t = div.map(d)
+        s = take_sum(d)
+
+    state = FlowRunner(flow=f).run(executor=executor, return_tasks=[s, t])
+    assert state.is_running()
+    assert state.result[s].is_pending()
+    assert state.result[t].is_mapped()
+    assert state.result[t].map_states[0].is_pending()
+    assert all(s.is_successful() for s in state.result[t].map_states[1:])
+
+
+@pytest.mark.parametrize(
+    "executor", ["local", "sync", "mproc", "mthread"], indirect=True
+)
+def test_reduce_task_properly_applies_trigger_across_all_mapped_states_for_deep_pipelines(
+    executor
+):
+    """
+    The `take_sum` task reduces over the `div` task, which is going to return one Success
+    and one Failure. The `take_sum` should fail its trigger check.
+    """
+
+    @prefect.task
+    def ll():
+        return [0, 1]
+
+    @prefect.task(max_retries=5, retry_delay=datetime.timedelta(hours=1))
+    def div(x):
+        return 1 / x
+
+    @prefect.task
+    def take_sum(x):
+        return sum(x)
+
+    with Flow(name="test") as f:
+        d = div.map(ll)
+        s = take_sum(d)
+
+    state = FlowRunner(flow=f).run(executor=executor, return_tasks=[s])
+    assert state.is_running()
+    assert state.result[s].is_pending()
+
+
+@pytest.mark.parametrize(
+    "executor", ["local", "sync", "mproc", "mthread"], indirect=True
+)
 def test_task_map_downstreams_handle_single_failures(executor):
     @prefect.task
     def ll():

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -600,7 +600,7 @@ def test_reduce_task_honors_trigger_across_all_mapped_states(executor):
 def test_reduce_task_properly_applies_trigger_across_all_mapped_states(executor):
     """
     The `take_sum` task reduces over the `div` task, which is going to return one Success
-    and one Failure. The `take_sum` should fail its trigger check.
+    and one Retrying. The `take_sum` should fail its upstream finished check.
     """
 
     @prefect.task
@@ -634,11 +634,6 @@ def test_reduce_task_properly_applies_trigger_across_all_mapped_states(executor)
 def test_reduce_task_properly_applies_trigger_across_all_mapped_states_for_deep_pipelines(
     executor
 ):
-    """
-    The `take_sum` task reduces over the `div` task, which is going to return one Success
-    and one Failure. The `take_sum` should fail its trigger check.
-    """
-
     @prefect.task
     def ll():
         return [0, 1]

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -461,6 +461,26 @@ class TestCheckUpstreamFinished:
                 state=state, upstream_states={1: Success(), 2: Running()}
             )
 
+    def test_raises_if_mapped_upstream_retrying(self):
+        state = Pending()
+        task = Task()
+        with pytest.raises(ENDRUN) as exc:
+            edge = Edge(1, 2, mapped=False)
+            new_state = TaskRunner(task).check_upstream_finished(
+                state=state,
+                upstream_states={edge: Mapped(map_states=[Retrying(), Success()])},
+            )
+
+    def test_doesnt_raise_if_mapped_upstream_complete(self):
+        state = Pending()
+        task = Task()
+        edge = Edge(1, 2, mapped=False)
+        new_state = TaskRunner(task).check_upstream_finished(
+            state=state,
+            upstream_states={edge: Mapped(map_states=[Failed(), Success()])},
+        )
+        assert new_state is state
+
 
 class TestCheckUpstreamSkipped:
     def test_empty(self):


### PR DESCRIPTION
Closes #1436 

It appears we were not unpacking upstream mapped states when checking if a task was ready to proceed.  This PR fixes that and adds multiple tests.