### PR TITLE
Local agent windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add OS platform check to Local Agent - [#1441](https://github.com/PrefectHQ/prefect/pull/1441)
+- Add OS platform check to Local Agent for running on Windows machines - [#1441](https://github.com/PrefectHQ/prefect/pull/1441)
 - Add `--base-url` argument for Docker daemons to `agent start` CLI command - [#1441](https://github.com/PrefectHQ/prefect/pull/1441)
 
 ### Task Library

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -65,6 +65,7 @@ class LocalAgent(Agent):
             env_vars = self.populate_env_vars(flow_run=flow_run)
 
             if not self.no_pull:
+                self.logger.debug("Pulling image {}...".format(storage.name))
                 try:
                     self.docker_client.pull(storage.name)
                 except docker.errors.APIError:

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, Iterable, List
 
 import cloudpickle
 import docker
+from pathlib import PurePosixPath
 from slugify import slugify
 
 import prefect
@@ -165,7 +166,7 @@ class Docker(Storage):
             raise ValueError("Docker storage is missing required fields")
 
         return "{}:{}".format(
-            os.path.join(self.registry_url, self.image_name),  # type: ignore
+            PurePosixPath(self.registry_url, self.image_name),  # type: ignore
             self.image_tag,  # type: ignore
         )
 
@@ -232,7 +233,7 @@ class Docker(Storage):
 
             # Verify that a registry url has been provided for images that should be pushed
             if self.registry_url:
-                full_name = os.path.join(self.registry_url, self.image_name)
+                full_name = str(PurePosixPath(self.registry_url, self.image_name))
             elif push is True:
                 raise ValueError(
                     "This environment has no `registry_url`, and cannot be pushed."


### PR DESCRIPTION
Updates paths related to Docker registries to _always_ be POSIX regardless of OS; with these minimal changes I was able to successfully run a Local Agent on a Windows 10 machine