### PR TITLE
Fix missed rename of `CloudEnvironment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix incorrect import in `DaskKubernetesEnvironment` job template - [#1458](https://github.com/PrefectHQ/prefect/pull/1458)
 
 ### Deprecations
 

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -15,7 +15,7 @@ spec:
           image: gcr.io/prefect-dev/prefect
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
-          args: ['python -c "from prefect.environments import CloudEnvironment; CloudEnvironment().run_flow()"']
+          args: ['python -c "from prefect.environments import DaskKubernetesEnvironment; DaskKubernetesEnvironment().run_flow()"']
           env:
             - name: PREFECT__CLOUD__GRAPHQL
               value: $PREFECT__CLOUD__GRAPHQL


### PR DESCRIPTION
```
(model) ➜  model git:(chicago) ✗ kl -f prefect-dask-job-1e0579da-5fde-4c6a-adfe-ce618147bcff-c2qgb
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'CloudEnvironment' from 'prefect.environments' (/usr/local/lib/python3.7/site-packages/prefect/environments/__init__.py)
```