### PR TITLE
Move k8s agent deployment imagePullSecrets level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix incorrect import in `DaskKubernetesEnvironment` job template - [#1458](https://github.com/PrefectHQ/prefect/pull/1458)
 - Raise error on Agents started without an appropriate API token - [#1459](https://github.com/PrefectHQ/prefect/pull/1459)
 - Fix bug when calling `as_nested_dict` on `DotDicts` with an `items` key - [#1462](https://github.com/PrefectHQ/prefect/pull/1462)
+- Fix `--resource-manager` flag on agent install invalidating `imagePullSecrets` - [#1469](https://github.com/PrefectHQ/prefect/pull/1469)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: prefect-agent
     spec:
+      imagePullSecrets:
+        - name: ""
       containers:
         - name: agent
           image: prefecthq/prefect:latest
@@ -51,5 +53,3 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "100m"
-      imagePullSecrets:
-      - name: ""


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1468 


## Why is this PR important?
`prefect agent install` w/ `--resource-manager` caused the imagePullSecrets to invalidate on an empty secret name. Moving it to the top of the spec appears to fix the issue:

```
➜ prefect agent install --resource-manager | kubectl apply --namespace=default -f -
deployment.apps/prefect-agent created
```

