### PR TITLE
Place Task logger in context earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Allow for Agents to correctly run in environments with differently calibrated clocks - [#1402](https://github.com/PrefectHQ/prefect/issues/1402)
+- Ensure Task logger is available in context throughout every pipeline step of the run - [#1509](https://github.com/PrefectHQ/prefect/issues/1509)
 
 ### Task Library
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -172,6 +172,7 @@ class TaskRunner(Runner):
             task_slug=self.task.slug,
         )
         context.setdefault("checkpointing", config.flows.checkpointing)
+        context.update(logger=self.task.logger)
 
         return TaskRunnerInitializeResult(state=state, context=context)
 
@@ -857,10 +858,9 @@ class TaskRunner(Runner):
                 timeout_handler or prefect.utilities.executors.timeout_handler
             )
             raw_inputs = {k: r.value for k, r in inputs.items()}
-            with prefect.context(logger=self.task.logger):
-                result = timeout_handler(
-                    self.task.run, timeout=self.task.timeout, **raw_inputs
-                )
+            result = timeout_handler(
+                self.task.run, timeout=self.task.timeout, **raw_inputs
+            )
 
         # inform user of timeout
         except TimeoutError as exc:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -941,6 +941,35 @@ class TestCheckTaskCached:
         assert new is state
         assert new.result == 2
 
+    def test_all_of_run_context_is_available_to_custom_cache_validators(self):
+        ctxt = dict()
+
+        def custom_validator(state, inputs, parameters):
+            ctxt.update(prefect.context.to_dict())
+            return False
+
+        # have to have a state worth checking to trigger the validator
+        with prefect.context(caches={"Task": [State()]}):
+            task = Task(
+                cache_for=timedelta(seconds=10), cache_validator=custom_validator
+            )
+            state = TaskRunner(task).run()
+
+        expected_subset = dict(
+            map_index=None,
+            task_full_name="Task",
+            task_run_count=1,
+            task_name="Task",
+            task_tags=set(),
+            task_slug=task.slug,
+            checkpointing=False,
+        )
+        for key, val in expected_subset.items():
+            assert ctxt[key] == val
+
+        assert "config" in ctxt
+        assert ctxt["logger"] is task.logger
+
 
 class TestSetTaskRunning:
     @pytest.mark.parametrize("state", [Pending()])


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds the Task logger in context within `initialize_run` instead of only during `get_task_run_state`.  This ensures that the Task logger is available during every single pipeline step, including during cache validation.


## Why is this PR important?
See #1509 for an excellent description of why having a properly populated context object is important.

Closes #1509 