### PR TITLE
Remove imagePullSecrets on k8s agent install if not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix map error by removing `imagePullSecrets` from Kubernetes Agent install if not provided - [#1524](https://github.com/PrefectHQ/prefect/pull/1524)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -124,6 +124,7 @@ class KubernetesAgent(Agent):
         token: str = None,
         api: str = None,
         namespace: str = None,
+        image_pull_secrets: str = None,
         resource_manager_enabled: bool = False,
     ) -> str:
 
@@ -143,6 +144,7 @@ class KubernetesAgent(Agent):
         agent_env[1]["value"] = api
         agent_env[2]["value"] = namespace
 
+        # Populate resource manager if requested
         if resource_manager_enabled:
             resource_manager_env = deployment["spec"]["template"]["spec"]["containers"][
                 1
@@ -153,6 +155,14 @@ class KubernetesAgent(Agent):
             resource_manager_env[3]["value"] = namespace
         else:
             del deployment["spec"]["template"]["spec"]["containers"][1]
+
+        # Populate image pull secrets if provided
+        if image_pull_secrets:
+            agent_env = deployment["spec"]["template"]["spec"]["imagePullSecrets"][0][
+                "name"
+            ] = image_pull_secrets
+        else:
+            del deployment["spec"]["template"]["spec"]["imagePullSecrets"]
 
         return yaml.safe_dump(deployment)
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -93,24 +93,32 @@ def start(name, token, no_pull, base_url):
     hidden=True,
 )
 @click.option(
+    "--image-pull-secrets",
+    "-i",
+    required=False,
+    help="Name of image pull secrets to use for workloads.",
+    hidden=True,
+)
+@click.option(
     "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
 )
-def install(name, token, api, namespace, resource_manager):
+def install(name, token, api, namespace, image_pull_secrets, resource_manager):
     """
     Install an agent. Outputs configuration text which can be used to install on various
     platforms.
 
     \b
     Arguments:
-        name                TEXT    The name of an agent to start (e.g. `kubernetes`)
-                                    Defaults to `kubernetes`
+        name                        TEXT    The name of an agent to start (e.g. `kubernetes`)
+                                            Defaults to `kubernetes`
 
     \b
     Options:
-        --token, -t         TEXT    A Prefect Cloud API token
-        --api, -a           TEXT    A Prefect Cloud API URL
-        --namespace, -n     TEXT    Agent namespace to launch workloads
-        --resource-manager          Enable resource manager on install
+        --token, -t                 TEXT    A Prefect Cloud API token
+        --api, -a                   TEXT    A Prefect Cloud API URL
+        --namespace, -n             TEXT    Agent namespace to launch workloads
+        --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
+        --resource-manager                  Enable resource manager on install
     """
 
     supported_agents = {"kubernetes": "prefect.agent.kubernetes.KubernetesAgent"}
@@ -125,6 +133,7 @@ def install(name, token, api, namespace, resource_manager):
         token=token,
         api=api,
         namespace=namespace,
+        image_pull_secrets=image_pull_secrets,
         resource_manager_enabled=resource_manager,
     )
     click.echo(deployment)

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -218,6 +218,44 @@ def test_k8s_agent_generate_deployment_yaml_no_resource_manager(
     assert len(deployment["spec"]["template"]["spec"]["containers"]) == 1
 
 
+def test_k8s_agent_generate_deployment_yaml_no_image_pull_secrets(
+    monkeypatch, runner_token
+):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    agent = KubernetesAgent()
+    deployment = agent.generate_deployment_yaml(
+        token="test_token", api="test_api", namespace="test_namespace"
+    )
+
+    deployment = yaml.safe_load(deployment)
+
+    assert not deployment["spec"]["template"]["spec"].get("imagePullSecrets")
+
+
+def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
+    monkeypatch, runner_token
+):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    agent = KubernetesAgent()
+    deployment = agent.generate_deployment_yaml(
+        token="test_token",
+        api="test_api",
+        namespace="test_namespace",
+        image_pull_secrets="secrets",
+    )
+
+    deployment = yaml.safe_load(deployment)
+
+    assert (
+        deployment["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+        == "secrets"
+    )
+
+
 def test_k8s_agent_heartbeat_creates_file(monkeypatch, runner_token):
     k8s_config = MagicMock()
     monkeypatch.setattr("kubernetes.config", k8s_config)

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -231,7 +231,7 @@ def test_k8s_agent_generate_deployment_yaml_no_image_pull_secrets(
 
     deployment = yaml.safe_load(deployment)
 
-    assert not deployment["spec"]["template"]["spec"].get("imagePullSecrets")
+    assert deployment["spec"]["template"]["spec"].get("imagePullSecrets") is None
 
 
 def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -104,6 +104,8 @@ def test_agent_install_passes_args():
             "--namespace",
             "TEST_NAMESPACE",
             "--resource-manager",
+            "--image-pull-secrets",
+            "secret-test",
         ],
     )
     assert result.exit_code == 0
@@ -111,6 +113,7 @@ def test_agent_install_passes_args():
     assert "TEST_API" in result.output
     assert "TEST_NAMESPACE" in result.output
     assert "resource-manager" in result.output
+    assert "secret-test" in result.output
 
 
 def test_agent_install_no_resource_manager():
@@ -125,6 +128,8 @@ def test_agent_install_no_resource_manager():
             "TEST_API",
             "--namespace",
             "TEST_NAMESPACE",
+            "--image-pull-secrets",
+            "secret-test",
         ],
     )
     assert result.exit_code == 0
@@ -132,3 +137,4 @@ def test_agent_install_no_resource_manager():
     assert "TEST_API" in result.output
     assert "TEST_NAMESPACE" in result.output
     assert not "resource-manager" in result.output
+    assert "secret-test" in result.output


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1468 by removing the `imagePullSecrets` block if not provided


## Why is this PR important?
Possible kubectl issues with the YAML can be avoided that were sometimes caused when the imagePullSecrets were blank

