### PR TITLE
On empty registry_url skip Docker Storage push and Local Agent pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Allow for Agents to correctly run in environments with differently calibrated clocks - [#1402](https://github.com/PrefectHQ/prefect/issues/1402)
 - Refactor `RemoteEnvironment` to utilize the `get_flow` storage interface - [#1476](https://github.com/PrefectHQ/prefect/issues/1476)
 - Ensure Task logger is available in context throughout every pipeline step of the run - [#1509](https://github.com/PrefectHQ/prefect/issues/1509)
+- Skip Docker registry pushing and pulling on empty `registry_url` attribute - [#1525](https://github.com/PrefectHQ/prefect/pull/1525)
 
 ### Task Library
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -64,7 +64,7 @@ class LocalAgent(Agent):
 
             env_vars = self.populate_env_vars(flow_run=flow_run)
 
-            if not self.no_pull:
+            if not self.no_pull and storage.registry_url:
                 self.logger.debug("Pulling image {}...".format(storage.name))
                 try:
                     self.docker_client.pull(storage.name)

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import uuid
 from typing import Any, Callable, Dict, Iterable, List
+import warnings
 
 import cloudpickle
 import docker
@@ -254,9 +255,11 @@ class Docker(Storage):
             if self.registry_url:
                 full_name = str(PurePosixPath(self.registry_url, self.image_name))
             elif push is True:
-                raise ValueError(
-                    "This Docker storage object has no `registry_url`, and cannot be pushed."
+                warnings.warn(
+                    "This Docker storage object has no `registry_url`, and will not be pushed.",
+                    UserWarning,
                 )
+                full_name = self.image_name
             else:
                 full_name = self.image_name
 
@@ -275,7 +278,7 @@ class Docker(Storage):
                 )
 
             # Push the image if requested
-            if push:
+            if push and self.registry_url:
                 self.push_image(full_name, self.image_tag)
 
                 # Remove the image locally after being pushed

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -182,11 +182,11 @@ class Docker(Storage):
         """
         Full name of the Docker image.
         """
-        if None in [self.registry_url, self.image_name, self.image_tag]:
+        if None in [self.image_name, self.image_tag]:
             raise ValueError("Docker storage is missing required fields")
 
         return "{}:{}".format(
-            PurePosixPath(self.registry_url, self.image_name),  # type: ignore
+            PurePosixPath(self.registry_url or "", self.image_name),  # type: ignore
             self.image_tag,  # type: ignore
         )
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -210,3 +210,35 @@ def test_local_agent_deploy_flows_no_pull(monkeypatch, runner_token):
     assert not api.pull.called
     assert api.create_container.called
     assert api.start.called
+
+
+def test_local_agent_deploy_flows_no_registry_does_not_pull(monkeypatch, runner_token):
+
+    api = MagicMock()
+    api.ping.return_value = True
+    api.create_container.return_value = {"Id": "container_id"}
+    monkeypatch.setattr(
+        "prefect.agent.local.agent.docker.APIClient", MagicMock(return_value=api)
+    )
+
+    agent = LocalAgent()
+    agent.deploy_flows(
+        flow_runs=[
+            GraphQLResult(
+                {
+                    "flow": GraphQLResult(
+                        {
+                            "storage": Docker(
+                                registry_url="", image_name="name", image_tag="tag"
+                            ).serialize()
+                        }
+                    ),
+                    "id": "id",
+                }
+            )
+        ]
+    )
+
+    assert not api.pull.called
+    assert api.create_container.called
+    assert api.start.called

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -447,6 +447,16 @@ def test_docker_storage_name():
     assert storage.name == "test1/test2:test3"
 
 
+def test_docker_storage_name_registry_url_none():
+    storage = Docker(base_image="python:3.6")
+    with pytest.raises(ValueError):
+        storage.name
+
+    storage.image_name = "test2"
+    storage.image_tag = "test3"
+    assert storage.name == "test2:test3"
+
+
 def test_docker_storage_get_flow_method():
     storage = Docker(base_image="python:3.6")
     with tempfile.TemporaryDirectory() as directory:

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -275,14 +275,18 @@ def test_build_image_passes_and_pushes(monkeypatch):
     assert "reg" in remove.call_args[1]["image"]
 
 
-def test_build_image_fails_no_registry(monkeypatch):
+@pytest.mark.filterwarnings("error")
+def test_build_image_passes_but_raises_warning(monkeypatch):
     storage = Docker(base_image="python:3.6", image_name="test", image_tag="latest")
 
     client = MagicMock()
-    monkeypatch.setattr("docker.APIClient", client)
+    client.images.return_value = ["name"]
+    monkeypatch.setattr("docker.APIClient", MagicMock(return_value=client))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(UserWarning):
         image_name, image_tag = storage._build_image()
+        assert image_name == "test"
+        assert image_tag == "latest"
 
 
 def test_create_dockerfile_from_base_image():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1498 by skipping the push step of a Docker build if no registry URL is set. Also skip pull step of Local Agent if flow's storage has no registry URL set.


## Why is this PR important?
We can now avoid the push/pull workarounds by simply providing `registry_url=""` to `flow.deploy()` (or `Docker()`)

