### PR TITLE
Task run logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix map error by removing `imagePullSecrets` from Kubernetes Agent install if not provided - [#1524](https://github.com/PrefectHQ/prefect/pull/1524)
+- Fix issue with two INFO logs not being associated with the Task Run in Cloud - [#1526](https://github.com/PrefectHQ/prefect/pull/1526)
 
 ### Deprecations
 

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -461,24 +461,9 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
     class CustomFlowRunner(CloudFlowRunner):
         def run_task(self, *args, **kwargs):
             with prefect.utilities.configuration.set_temporary_config(
-                {
-                    "logging.log_to_cloud": False,
-                    "special_key": 99,
-                    "cloud.auth_token": "",
-                }
+                {"logging.log_to_cloud": False, "cloud.auth_token": ""}
             ):
                 return super().run_task(*args, **kwargs)
-
-    calls = []
-
-    class Client(MagicMock):
-        def write_run_log(self, *args, **kwargs):
-            calls.append(kwargs)
-
-    monkeypatch.setattr("prefect.client.Client", Client)
-    monkeypatch.setattr("prefect.engine.cloud.task_runner.Client", Client)
-    monkeypatch.setattr("prefect.engine.cloud.flow_runner.Client", Client)
-    prefect.utilities.logging.prefect_logger.handlers[-1].client = Client()
 
     @prefect.task
     def log_stuff():
@@ -489,6 +474,22 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
             prefect.context.config.cloud.auth_token,
         )
 
+    calls = []
+
+    class Client(MagicMock):
+        def write_run_log(self, *args, **kwargs):
+            calls.append(kwargs)
+
+        def get_flow_run_info(self, *args, **kwargs):
+            return MagicMock(
+                task_runs=[MagicMock(task_slug=log_stuff.slug, id="TESTME")]
+            )
+
+    monkeypatch.setattr("prefect.client.Client", Client)
+    monkeypatch.setattr("prefect.engine.cloud.task_runner.Client", Client)
+    monkeypatch.setattr("prefect.engine.cloud.flow_runner.Client", Client)
+    prefect.utilities.logging.prefect_logger.handlers[-1].client = Client()
+
     with prefect.utilities.configuration.set_temporary_config(
         {
             "logging.log_to_cloud": True,
@@ -498,7 +499,9 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
     ):
         # captures config at init
         runner = CustomFlowRunner(flow=prefect.Flow("test", tasks=[log_stuff]))
-        flow_state = runner.run(return_tasks=[log_stuff])
+        flow_state = runner.run(
+            return_tasks=[log_stuff], task_contexts={log_stuff: dict(special_key=99)}
+        )
 
     assert flow_state.is_successful()
     assert flow_state.result[log_stuff].result == (42, "original")
@@ -510,3 +513,6 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
         "prefect.CustomFlowRunner",
         "prefect.Task: log_stuff",
     }
+
+    task_run_ids = [c["task_run_id"] for c in calls if c["task_run_id"]]
+    assert task_run_ids == ["TESTME"] * 3

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1494,11 +1494,7 @@ def test_task_runners_submitted_to_remote_machines_respect_original_config(monke
     class CustomFlowRunner(FlowRunner):
         def run_task(self, *args, **kwargs):
             with prefect.utilities.configuration.set_temporary_config(
-                {
-                    "logging.log_to_cloud": False,
-                    "special_key": 99,
-                    "cloud.auth_token": "",
-                }
+                {"logging.log_to_cloud": False, "cloud.auth_token": ""}
             ):
                 return super().run_task(*args, **kwargs)
 
@@ -1528,7 +1524,9 @@ def test_task_runners_submitted_to_remote_machines_respect_original_config(monke
     ):
         # captures config at init
         runner = CustomFlowRunner(flow=Flow("test", tasks=[log_stuff]))
-        flow_state = runner.run(return_tasks=[log_stuff])
+        flow_state = runner.run(
+            return_tasks=[log_stuff], task_contexts={log_stuff: dict(special_key=99)}
+        )
 
     assert flow_state.is_successful()
     assert flow_state.result[log_stuff].result == (42, "original")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that the beginning / end logs of a task run are correctly associated with their task run IDs in Cloud.

## Why is this PR important?
It is annoying to visit an individual Task Run page and not see logs; the logs _were_ present on the Flow Run page, just not the individual pages.