### PR TITLE
Agent Platform Error Logs for Flow Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Refactor `RemoteEnvironment` to utilize the `get_flow` storage interface - [#1476](https://github.com/PrefectHQ/prefect/issues/1476)
 - Ensure Task logger is available in context throughout every pipeline step of the run - [#1509](https://github.com/PrefectHQ/prefect/issues/1509)
 - Skip Docker registry pushing and pulling on empty `registry_url` attribute - [#1525](https://github.com/PrefectHQ/prefect/pull/1525)
+- Agents now log platform errors to flow runs which cannot deploy - [#1528](https://github.com/PrefectHQ/prefect/pull/1528)
 
 ### Task Library
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -150,6 +150,7 @@ class Agent:
                 )
         except Exception as exc:
             self.logger.error(exc)
+            self._log_flow_run_exceptions(flow_runs, exc)
 
         return bool(flow_runs)
 
@@ -274,6 +275,13 @@ class Agent:
                             state=state.StateSchema().load(task_run.serialized_state),
                         ),
                     )
+
+    def _log_flow_run_exceptions(self, flow_runs: list, exc: Exception) -> None:
+        """"""
+        for flow_run in flow_runs:
+            self.client.write_run_log(
+                flow_run_id=flow_run.id, name="agent", message=str(exc), level="ERROR"
+            )
 
     def deploy_flows(self, flow_runs: list) -> None:
         """

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -10,6 +10,7 @@ from prefect.serialization import state
 from prefect.engine.state import Submitted
 from prefect.utilities.exceptions import AuthorizationError
 from prefect.utilities.graphql import with_args
+from prefect.utilities.graphql import GraphQLResult
 
 
 ascii_name = r"""
@@ -150,7 +151,7 @@ class Agent:
                 )
         except Exception as exc:
             self.logger.error(exc)
-            self._log_flow_run_exceptions(flow_runs, exc)
+            self._log_flow_run_exceptions(flow_runs, exc)  # type: ignore
 
         return bool(flow_runs)
 
@@ -276,11 +277,23 @@ class Agent:
                         ),
                     )
 
-    def _log_flow_run_exceptions(self, flow_runs: list, exc: Exception) -> None:
-        """"""
+    def _log_flow_run_exceptions(
+        self, flow_runs: list, exc: Exception
+    ) -> None:
+        """
+        Log platform issues to Prefect Cloud, attached to each flow run which
+        could not start.
+
+        Args:
+            - flow_runs (list): A list of GraphQLResult flow run objects
+            - exc (Exception): A caught exception to log
+        """
         for flow_run in flow_runs:
             self.client.write_run_log(
-                flow_run_id=flow_run.id, name="agent", message=str(exc), level="ERROR"
+                flow_run_id=flow_run.id,  # type: ignore
+                name="agent",
+                message=str(exc),
+                level="ERROR",
             )
 
     def deploy_flows(self, flow_runs: list) -> None:

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -277,9 +277,7 @@ class Agent:
                         ),
                     )
 
-    def _log_flow_run_exceptions(
-        self, flow_runs: list, exc: Exception
-    ) -> None:
+    def _log_flow_run_exceptions(self, flow_runs: list, exc: Exception) -> None:
         """
         Log platform issues to Prefect Cloud, attached to each flow run which
         could not start.

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -255,3 +255,51 @@ def test_agent_process_no_runs_found(monkeypatch, runner_token):
     # Assert it doesn't return everything but all functions are called properly
     agent = Agent()
     assert not agent.agent_process("id")
+
+
+def test_agent_logs_flow_run_exceptions(monkeypatch, runner_token):
+    gql_return = MagicMock(
+        return_value=MagicMock(data=MagicMock(writeRunLog=MagicMock(success=True)))
+    )
+    client = MagicMock()
+    client.return_value.write_run_log = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", MagicMock(return_value=client))
+
+    agent = Agent()
+    agent._log_flow_run_exceptions(
+        flow_runs=[
+            GraphQLResult(
+                {
+                    "id": "id",
+                    "serialized_state": Scheduled().serialize(),
+                    "version": 1,
+                    "task_runs": [
+                        GraphQLResult(
+                            {
+                                "id": "id",
+                                "version": 1,
+                                "serialized_state": Scheduled().serialize(),
+                            }
+                        )
+                    ],
+                }
+            )
+        ],
+        exc=ValueError("Error Here"),
+    )
+
+    assert client.write_run_log.called
+    client.write_run_log.assert_called_with(
+        flow_run_id="id", level="ERROR", message="Error Here", name="agent"
+    )
+
+
+def test_agent_process_raises_exception_and_logs(monkeypatch, runner_token):
+    client = MagicMock()
+    client.return_value.graphql.side_effect = ValueError("Error")
+    monkeypatch.setattr("prefect.agent.agent.Client", client)
+
+    agent = Agent()
+    with pytest.raises(Exception):
+        agent.agent_process("id")
+        assert client.write_run_log.called


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1500 
Logs possible platform errors that may arise when deploying a flow run

e.g. using the Fargate agent with the name of a cluster that does not exist at time of deploy:

![image](https://user-images.githubusercontent.com/40716964/65153710-383ab880-d9f8-11e9-9658-cfa8f154fd7f.png)


## Why is this PR important?
Makes some logs easier to see without having to go to the agent itself

