### PR TITLE
Handle agent error logging for no flow runs found

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -151,7 +151,7 @@ class Agent:
                 )
         except Exception as exc:
             self.logger.error(exc)
-            self._log_flow_run_exceptions(flow_runs, exc)  # type: ignore
+            self._log_flow_run_exceptions(flow_runs or [], exc)  # type: ignore
 
         return bool(flow_runs)
 
@@ -286,14 +286,13 @@ class Agent:
             - flow_runs (list): A list of GraphQLResult flow run objects
             - exc (Exception): A caught exception to log
         """
-        if flow_runs:
-            for flow_run in flow_runs:
-                self.client.write_run_log(
-                    flow_run_id=flow_run.id,  # type: ignore
-                    name="agent",
-                    message=str(exc),
-                    level="ERROR",
-                )
+        for flow_run in flow_runs:
+            self.client.write_run_log(
+                flow_run_id=flow_run.id,  # type: ignore
+                name="agent",
+                message=str(exc),
+                level="ERROR",
+            )
 
     def deploy_flows(self, flow_runs: list) -> None:
         """

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -286,13 +286,14 @@ class Agent:
             - flow_runs (list): A list of GraphQLResult flow run objects
             - exc (Exception): A caught exception to log
         """
-        for flow_run in flow_runs:
-            self.client.write_run_log(
-                flow_run_id=flow_run.id,  # type: ignore
-                name="agent",
-                message=str(exc),
-                level="ERROR",
-            )
+        if flow_runs:
+            for flow_run in flow_runs:
+                self.client.write_run_log(
+                    flow_run_id=flow_run.id,  # type: ignore
+                    name="agent",
+                    message=str(exc),
+                    level="ERROR",
+                )
 
     def deploy_flows(self, flow_runs: list) -> None:
         """

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -294,6 +294,20 @@ def test_agent_logs_flow_run_exceptions(monkeypatch, runner_token):
     )
 
 
+def test_agent_logs_flow_run_exceptions_no_flow_runs(monkeypatch, runner_token):
+    gql_return = MagicMock(
+        return_value=MagicMock(data=MagicMock(writeRunLog=MagicMock(success=True)))
+    )
+    client = MagicMock()
+    client.return_value.write_run_log = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", MagicMock(return_value=client))
+
+    agent = Agent()
+    agent._log_flow_run_exceptions(flow_runs=[], exc=ValueError("Error Here"))
+
+    assert not client.write_run_log.called
+
+
 def test_agent_process_raises_exception_and_logs(monkeypatch, runner_token):
     client = MagicMock()
     client.return_value.graphql.side_effect = ValueError("Error")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Handles the situation where the error to be logged isn't dependent upon a flow run being deployed
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/prefect", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/prefect/cli/agent.py", line 81, in start
    from_qualified_name(retrieved_agent)().start()
  File "/usr/local/lib/python3.6/site-packages/prefect/agent/agent.py", line 94, in start
    runs = self.agent_process(tenant_id)
  File "/usr/local/lib/python3.6/site-packages/prefect/agent/agent.py", line 154, in agent_process
    self._log_flow_run_exceptions(flow_runs, exc)  # type: ignore
  File "/usr/local/lib/python3.6/site-packages/prefect/agent/agent.py", line 289, in _log_flow_run_exceptions
    for flow_run in flow_runs:
TypeError: 'NoneType' object is not iterable
```


## Why is this PR important?
Can't log to a flow run when there are no flow runs

