### PR TITLE
Add check to gracefully handle failed login attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Skip Docker registry pushing and pulling on empty `registry_url` attribute - [#1525](https://github.com/PrefectHQ/prefect/pull/1525)
 - Agents now log platform errors to flow runs which cannot deploy - [#1528](https://github.com/PrefectHQ/prefect/pull/1528)
 - Updating `ShellTask` to work more like Airflow Bash Operator for streaming logs and returning values - [#1451](https://github.com/PrefectHQ/prefect/pull/1451)
+- Allow the `Client` to more gracefully handle failed login attempts on initialization - [#1535](https://github.com/PrefectHQ/prefect/pull/1535)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Task Library
 
-- None
+- Add `BlobStorageDownload` and `BlobStorageUpload` for interacting with data stored on Azure Blob Storage - [#692](https://github.com/PrefectHQ/prefect/pull/1538)
 
 ### Fixes
 
@@ -30,7 +30,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- [Fredrik Sannholm](https://github.com/frsann)
 
 ## 0.6.5 <Badge text="beta" type="success"/>
 
@@ -51,7 +51,6 @@ Released September 20, 2019
 - Updating `ShellTask` to work more like Airflow Bash Operator for streaming logs and returning values - [#1451](https://github.com/PrefectHQ/prefect/pull/1451)
 - Agents now have a verbose/debug logging option for granular output - [#1532](https://github.com/PrefectHQ/prefect/pull/1532)
 - `DaskKubernetesEnvironment` now allows for custom scheduler and worker specs - [#1543](https://github.com/PrefectHQ/prefect/pull/1534), [#1537](https://github.com/PrefectHQ/prefect/pull/1537)
-- Add `BlobStorageDownload` and `BlobStorageUpload` for interacting with data stored on Azure Blob Storage - [#692](https://github.com/PrefectHQ/prefect/pull/1538)
 
 ### Task Library
 
@@ -73,7 +72,7 @@ Released September 20, 2019
 
 ### Contributors
 
-- None
+- [Braun Reyes](https://github.com/braunreyes)
 
 ## 0.6.4 <Badge text="beta" type="success"/>
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -215,10 +215,7 @@ class Client:
         )
 
         if raise_on_error and "errors" in result:
-            if (
-                result["errors"][0].get("extensions", {}).get("code")
-                == "UNAUTHENTICATED"
-            ):
+            if "UNAUTHENTICATED" in str(result["errors"]):
                 raise AuthorizationError(result["errors"])
             elif "Malformed Authorization header" in str(result["errors"]):
                 raise AuthorizationError(result["errors"])

--- a/src/prefect/utilities/exceptions.py
+++ b/src/prefect/utilities/exceptions.py
@@ -18,5 +18,5 @@ class ClientError(PrefectError):
     pass
 
 
-class AuthorizationError(PrefectError):
+class AuthorizationError(ClientError):
     pass


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
If users attempt to instantiate a Client with an invalid token and active tenant stored, the Client will (correctly) raise an error. However, because the error is raised during initialization it will not be possible to load the client object fully. This PR intercepts `AuthorizationErrors` when the Client is instantiated and clears the saved tenant id (but not the token, in case it is still valid). 

The use case:
- User logs in to a tenant with a token and saves those settings
- User is removed from the tenant, but the token remains valid
- User loads a new Client object; it should gracefully handle the invalid login attempt


## Why is this PR important?


