### PR TITLE
Add Algolia search to our docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 
       - run:
           name: Install mypy
-          command: pip install mypy mypy_extensions
+          command: pip install "mypy<0.730" mypy_extensions
 
       - run:
           name: Run mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 black
 graphviz >= 0.8, < 0.14
 jinja2 >= 2.0, < 3.0
-mypy >= 0.600, < 0.800
+mypy >= 0.600, < 0.730
 pytest >= 5.0, < 6.0
 pytest-cov >= 2.6, < 3.0
 pytest-env >= 0.6.0, < 0.7.0

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,6 +42,10 @@ module.exports = {
     ["vuepress-plugin-code-copy", true]
   ],
   themeConfig: {
+    algolia: {
+      apiKey: '553c75634e1d4f09c84f7a513f9cc4f9',
+      indexName: 'prefect'
+    },
     repo: "PrefectHQ/prefect",
     docsDir: "docs",
     editLinks: true,


### PR DESCRIPTION
This PR introduces Algolia search to our Documentation.  This superpowers our search bar!  This will allow me to also introduce "stop_urls" to prevent indexing of archived API documentation (I have to make a PR against another repo where our configuration lives to do this).

Will eventually address https://github.com/PrefectHQ/prefect/issues/1119 by removing archived docs from our search index