### PR TITLE
Persist task_run_count using state context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with certain Pause / Resume / Retry pipelines retrying indefinitely - [#1177](https://github.com/PrefectHQ/prefect/issues/1177)
 
 ### Deprecations
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -280,6 +280,9 @@ class Scheduled(Pending):
     ):
         super().__init__(message=message, result=result, cached_inputs=cached_inputs)
         self.start_time = pendulum.instance(start_time or pendulum.now("utc"))
+        run_count = prefect.context.get("task_run_count")
+        if run_count is not None:
+            self.context.update(task_run_count=run_count)
 
 
 class Paused(Scheduled):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -144,7 +144,7 @@ class TaskRunner(Runner):
         if isinstance(state, Retrying):
             run_count = state.run_count + 1
         else:
-            run_count = 1
+            run_count = state.context.get("task_run_count", 1)
 
         if isinstance(state, Resume):
             context.update(resume=True)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -17,11 +17,13 @@ from prefect.core.flow import Flow
 from prefect.core.task import Parameter, Task
 from prefect.engine.cache_validators import all_inputs, partial_inputs_only
 from prefect.engine.result_handlers import LocalResultHandler, ResultHandler
-from prefect.engine.signals import PrefectError, LOOP
+from prefect.engine.signals import PrefectError, FAIL, LOOP
 from prefect.engine.state import (
     Failed,
     Finished,
     Mapped,
+    Paused,
+    Resume,
     Pending,
     Skipped,
     State,
@@ -2204,6 +2206,31 @@ def test_looping_works_in_a_flow():
     assert flow_state.is_successful()
     assert flow_state.result[inter].result == 200
     assert flow_state.result[final].result == 200 ** 2
+
+
+def test_pause_resume_works_with_retries():
+    runs = []
+
+    def state_handler(obj, old, new):
+        if isinstance(new, Paused):
+            return Resume()
+        elif old.is_running():
+            raise FAIL("cant pass go")
+
+    @task(
+        max_retries=2,
+        retry_delay=datetime.timedelta(seconds=0),
+        state_handlers=[state_handler],
+        trigger=prefect.triggers.manual_only,
+    )
+    def fail():
+        runs.append(1)
+
+    f = Flow("huh", tasks=[fail])
+    flow_state = f.run()
+
+    assert flow_state.is_failed()
+    assert len(runs) == 3
 
 
 def test_looping_with_retries_works_in_a_flow():

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -152,6 +152,22 @@ def test_serialize_state_with_context():
     assert deserialized.context == dict(tags=["foo", "bar"])
 
 
+def test_serialize_scheduled_state_with_context():
+    with prefect.context(task_run_count=42):
+        s = state.Scheduled(message="hi")
+
+    serialized = StateSchema().dump(s)
+    assert isinstance(serialized, dict)
+    assert serialized["type"] == "Scheduled"
+    assert serialized["message"] == "hi"
+    assert serialized["__version__"] == prefect.__version__
+    assert serialized["context"] == dict(task_run_count=42)
+
+    deserialized = StateSchema().load(serialized)
+    assert deserialized.is_scheduled()
+    assert deserialized.context == dict(task_run_count=42)
+
+
 def test_serialize_state_with_context_allows_for_diverse_values():
     s = state.Running(message="hi")
     s.context = dict(tags=["foo", "bar"], info=dict(x=42), baz="99")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR persists `task_run_count` within the newly introduced `state.context` attribute for communicating the current run count across multiple state transitions (e.g., Retrying -> Paused -> Resume -> Running -> Failed -> Retrying -> etc.).   Note that this PR only attaches this data to `Scheduled` states, as attaching it to other states causes the run count to effectively "freeze" across runs.


## Why is this PR important?
Closes #1177 

