### PR TITLE
Failed state inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Allow the `Client` to more gracefully handle failed login attempts on initialization - [#1535](https://github.com/PrefectHQ/prefect/pull/1535)
 - Replace `DotDict` with `box.Box` - [#1518](https://github.com/PrefectHQ/prefect/pull/1518)
+- Store `cached_inputs` on Failed states and call their result handlers if they were provided - [#1557](https://github.com/PrefectHQ/prefect/pull/1557)
 
 ### Task Library
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ norecursedirs = *.egg-info .git .mypy_cache node_modules .pytest_cache .vscode
 env =
     SKIP_DOCKER_ENVIRONMENT_TESTS = True
     PREFECT__USER_CONFIG_PATH=""
+    PREFECT__LOGGING__LEVEL=DEBUG
 usedevelop = True
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ norecursedirs = *.egg-info .git .mypy_cache node_modules .pytest_cache .vscode
 env =
     SKIP_DOCKER_ENVIRONMENT_TESTS = True
     PREFECT__USER_CONFIG_PATH=""
-    PREFECT__LOGGING__LEVEL=DEBUG
 usedevelop = True
 
 [isort]

--- a/src/prefect/engine/cloud/utilities.py
+++ b/src/prefect/engine/cloud/utilities.py
@@ -16,9 +16,21 @@ def prepare_state_for_cloud(state: State) -> State:
         state._result.store_safe_value()
 
     if (
+        state.is_failed()
+        and state.cached_inputs is not None
+        and all(
+            r.result_handler is not None
+            for k, r in state.cached_inputs.items()  # type: ignore
+        )
+    ):  # type: ignore
+        for res in state.cached_inputs.values():  # type: ignore
+            res.store_safe_value()
+    elif (
         hasattr(state, "cached_inputs")
         and state.cached_inputs is not None  # type: ignore
+        and not state.is_failed()
     ):
         for res in state.cached_inputs.values():  # type: ignore
             res.store_safe_value()
+
     return state

--- a/src/prefect/engine/cloud/utilities.py
+++ b/src/prefect/engine/cloud/utilities.py
@@ -17,7 +17,7 @@ def prepare_state_for_cloud(state: State) -> State:
 
     if (
         state.is_failed()
-        and state.cached_inputs is not None
+        and state.cached_inputs is not None  # type: ignore
         and all(
             r.result_handler is not None
             for k, r in state.cached_inputs.items()  # type: ignore

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -636,6 +636,8 @@ class Aborted(Failed):
         - message (str or Exception, optional): Defaults to `None`. A message about the
             state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
         - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - cached_inputs (dict): Defaults to `None`. A dictionary of input
+            keys to fully hydrated `Result`s.  Used / set if the Task requires Retries.
     """
 
     color = "#c42800"
@@ -655,15 +657,6 @@ class TimedOut(Failed):
 
     color = "#ff4e33"
 
-    def __init__(
-        self,
-        message: str = None,
-        result: Any = NoResult,
-        cached_inputs: Dict[str, Result] = None,
-    ):
-        super().__init__(message=message, result=result)
-        self.cached_inputs = cached_inputs
-
 
 class TriggerFailed(Failed):
     """
@@ -673,6 +666,8 @@ class TriggerFailed(Failed):
         - message (str or Exception, optional): Defaults to `None`. A message about the
             state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
         - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - cached_inputs (dict): Defaults to `None`. A dictionary of input
+            keys to fully hydrated `Result`s.  Used / set if the Task requires Retries.
     """
 
     color = "#ff5131"

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -612,9 +612,20 @@ class Failed(Finished):
         - message (str or Exception, optional): Defaults to `None`. A message about the
             state, which could be an `Exception` (or [`Signal`](signals.html)) that caused it.
         - result (Any, optional): Defaults to `None`. A data payload for the state.
+        - cached_inputs (dict): Defaults to `None`. A dictionary of input
+            keys to fully hydrated `Result`s.  Used / set if the Task might require manual Retries.
     """
 
     color = "#eb0000"
+
+    def __init__(
+        self,
+        message: str = None,
+        result: Any = NoResult,
+        cached_inputs: Dict[str, Result] = None,
+    ):
+        super().__init__(message=message, result=result)
+        self.cached_inputs = cached_inputs
 
 
 class Aborted(Failed):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -306,7 +306,7 @@ class TaskRunner(Runner):
         # for pending signals, including retries and pauses we need to make sure the
         # task_inputs are set
         except (ENDRUN, signals.PrefectStateSignal) as exc:
-            if exc.state.is_pending():
+            if exc.state.is_pending() or exc.state.is_failed():
                 exc.state.cached_inputs = task_inputs or {}  # type: ignore
             state = exc.state
             if not isinstance(exc, ENDRUN) and prefect.context.get(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -900,7 +900,8 @@ class TaskRunner(Runner):
     @call_state_handlers
     def cache_result(self, state: State, inputs: Dict[str, Result]) -> State:
         """
-        Caches the result of a successful task, if appropriate.
+        Caches the result of a successful task, if appropriate. Alternatively,
+        if the task is failed, caches the inputs.
 
         Tasks are cached if:
             - task.cache_for is not None
@@ -916,6 +917,9 @@ class TaskRunner(Runner):
             - State: the state of the task after running the check
 
         """
+        if state.is_failed():
+            state.cached_inputs = inputs  # type: ignore
+
         if (
             state.is_successful()
             and not state.is_skipped()

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -597,7 +597,6 @@ class TaskRunner(Runner):
                     if task_inputs.get(k, NoResult) == NoResult
                 }
             )
-
         return task_inputs
 
     @call_state_handlers

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -151,6 +151,12 @@ class FailedSchema(FinishedSchema):
     class Meta:
         object_class = state.Failed
 
+    cached_inputs = fields.Dict(
+        key=fields.Str(),
+        values=Nested(StateResultSchema, value_selection_fn=get_safe),
+        allow_none=True,
+    )
+
 
 class AbortedSchema(FailedSchema):
     class Meta:

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -526,6 +526,32 @@ class TestStateResultHandling:
         assert states[2].cached_inputs == dict(x=result, y=result)
         assert states[2].result == 2
 
+    def test_task_runner_errors_if_no_result_provided_as_input(self, client):
+        @prefect.task
+        def add(x, y):
+            return x + y
+
+        base_state = prefect.serialization.state.StateSchema().load({"type": "Success"})
+        x_state, y_state = base_state, base_state
+
+        upstream_states = {
+            Edge(Task(), Task(), key="x"): x_state,
+            Edge(Task(), Task(), key="y"): y_state,
+        }
+
+        res = CloudTaskRunner(task=add).run(upstream_states=upstream_states)
+        assert res.is_failed()
+        assert "unsupported operand" in res.message
+
+        ## assertions
+        assert client.get_task_run_info.call_count == 0  # never called
+        assert client.set_task_run_state.call_count == 2  # Pending -> Running -> Failed
+
+        states = [call[1]["state"] for call in client.set_task_run_state.call_args_list]
+        assert states[0].is_running()  # this isn't ideal, it's a little confusing
+        assert states[1].is_failed()
+        assert "unsupported operand" in states[1].message
+
     def test_task_runner_sends_checkpointed_success_states_to_cloud(self, client):
         handler = JSONResultHandler()
 

--- a/tests/engine/cloud/test_utilities.py
+++ b/tests/engine/cloud/test_utilities.py
@@ -1,13 +1,66 @@
+import pytest
+
+import prefect
 from prefect.engine.cloud.utilities import prepare_state_for_cloud
 from prefect.engine.result import NoResult, Result, SafeResult
 from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
-from prefect.engine.state import Cached, Pending, Success
+from prefect.engine.state import Cached, Failed, Pending, Success, _MetaState
 
 
-def test_preparing_state_for_cloud_replaces_cached_inputs_with_safe():
+all_states = sorted(
+    set(
+        cls
+        for cls in prefect.engine.state.__dict__.values()
+        if isinstance(cls, type)
+        and issubclass(cls, prefect.engine.state.State)
+        and not cls is _MetaState
+    ),
+    key=lambda c: c.__name__,
+)
+
+cached_input_states = sorted(
+    set(cls for cls in all_states if hasattr(cls(), "cached_inputs")),
+    key=lambda c: c.__name__,
+)
+
+
+@pytest.mark.parametrize("cls", cached_input_states)
+def test_preparing_state_for_cloud_replaces_cached_inputs_with_safe(cls):
     xres = Result(3, result_handler=JSONResultHandler())
-    state = prepare_state_for_cloud(Pending(cached_inputs=dict(x=xres)))
-    assert state.is_pending()
+    state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
+    assert isinstance(state, cls)
+    assert state.result == NoResult
+    assert state.cached_inputs == dict(x=xres)
+
+
+@pytest.mark.parametrize(
+    "cls", [s for s in cached_input_states if not issubclass(s, Failed)]
+)
+def test_preparing_state_for_cloud_fails_if_cached_inputs_have_no_handler(cls):
+    xres = Result(3, result_handler=None)
+    with pytest.raises(AssertionError, match="no ResultHandler"):
+        state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
+
+
+@pytest.mark.parametrize(
+    "cls", [s for s in cached_input_states if issubclass(s, Failed)]
+)
+def test_preparing_state_for_cloud_passes_if_cached_inputs_dont_exist(cls):
+    state = prepare_state_for_cloud(cls())
+    assert isinstance(state, cls)
+    assert state.result == NoResult
+    assert state.cached_inputs is None
+
+
+@pytest.mark.parametrize(
+    "cls", [s for s in cached_input_states if issubclass(s, Failed)]
+)
+def test_preparing_state_for_cloud_passes_if_cached_inputs_have_no_handler_for_failed(
+    cls
+):
+    xres = Result(3, result_handler=None)
+    state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
+    assert isinstance(state, cls)
     assert state.result == NoResult
     assert state.cached_inputs == dict(x=xres)
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -226,13 +226,24 @@ def test_serialize_and_deserialize_on_safe_cached_state():
     assert new_state.cached_inputs == state.cached_inputs
 
 
-def test_serialization_of_cached_inputs():
+@pytest.mark.parametrize("cls", cached_input_states)
+def test_serialization_of_cached_inputs_with_safe_values(cls):
     safe5 = SafeResult(5, result_handler=JSONResultHandler())
-    state = Pending(cached_inputs=dict(hi=safe5, bye=safe5))
+    state = cls(cached_inputs=dict(hi=safe5, bye=safe5))
     serialized = state.serialize()
     new_state = State.deserialize(serialized)
-    assert isinstance(new_state, Pending)
+    assert isinstance(new_state, cls)
     assert new_state.cached_inputs == state.cached_inputs
+
+
+@pytest.mark.parametrize("cls", cached_input_states)
+def test_serialization_of_cached_inputs_with_unsafe_values(cls):
+    unsafe5 = Result(5, result_handler=JSONResultHandler())
+    state = cls(cached_inputs=dict(hi=unsafe5, bye=unsafe5))
+    serialized = state.serialize()
+    new_state = State.deserialize(serialized)
+    assert isinstance(new_state, cls)
+    assert new_state.cached_inputs == dict(hi=NoResult, bye=NoResult)
 
 
 def test_state_equality():

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1273,6 +1273,17 @@ class TestCacheResultStep:
         assert new_state._result.safe_value is NoResult
 
     @pytest.mark.parametrize(
+        "state", [cls() for cls in Failed.__subclasses__() + [Failed]]
+    )
+    def test_non_success_states(self, state):
+        new_state = TaskRunner(task=Task()).cache_result(
+            state=state, inputs={"x": Result(1)}
+        )
+        assert new_state is state
+        assert new_state._result.safe_value is NoResult
+        assert new_state.cached_inputs == {"x": Result(1)}
+
+    @pytest.mark.parametrize(
         "validator",
         [
             all_inputs,
@@ -1956,3 +1967,14 @@ class TestLooping:
         assert state.is_mapped()
         state.map_states[0].is_retrying()
         state.map_states[1].is_successful()
+
+
+def test_failure_caches_inputs():
+    @prefect.task
+    def fail(x):
+        raise ValueError()
+
+    upstream_states = {Edge(Task(), fail, key="x"): Success(result=Result(1))}
+    new_state = TaskRunner(task=fail).run(upstream_states=upstream_states)
+    assert new_state.is_failed()
+    assert new_state.cached_inputs == {"x": Result(1)}


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds `cached_inputs` to all `Failed` states.  When running in Cloud, Prefect will only call the input data's result handlers if _all_ are present, otherwise it will silently pass and not persist the upstream inputs.


## Why is this PR important?
This PR stores Failed state upstream inputs if possible, and passes if not.  This sets the stage for _manual_ retries in Prefect Cloud.  e.g., if my task failed very unexpectedly, I might want to rerun it manually.  Prior to this PR, if your task had upstream inputs that would _never_ work.  However, with this PR, as long as you set result handlers appropriately this situation will be possible with no additional configuration.  **cc:** @jlowin 

*NOTE:* In implementing this PR I realized that if a user in Cloud does in fact attempt to set a Task Run state that requires inputs, `NoResult` objects will be passed into all inputs.  This can lead to surprising error messages.  I attempted to raise an informative error in this situation, but it broke some of our control flow tasks so I decided to table it for now. 
