### PR TITLE
Raise on exception no longer raises for prefect signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Allow the `Client` to more gracefully handle failed login attempts on initialization - [#1535](https://github.com/PrefectHQ/prefect/pull/1535)
 - Replace `DotDict` with `box.Box` - [#1518](https://github.com/PrefectHQ/prefect/pull/1518)
 - Store `cached_inputs` on Failed states and call their result handlers if they were provided - [#1557](https://github.com/PrefectHQ/prefect/pull/1557)
+- `raise_on_exception` no longer raises for Prefect Signals, as these are typically intentional / for control flow - [#1562](https://github.com/PrefectHQ/prefect/pull/1562)
 
 ### Task Library
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -309,10 +309,6 @@ class TaskRunner(Runner):
             if exc.state.is_pending() or exc.state.is_failed():
                 exc.state.cached_inputs = task_inputs or {}  # type: ignore
             state = exc.state
-            if not isinstance(exc, ENDRUN) and prefect.context.get(
-                "raise_on_exception"
-            ):
-                raise exc
 
         except Exception as exc:
             msg = "Task '{name}': unexpected error while running task: {exc}".format(

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -260,10 +260,11 @@ def test_task_runner_raise_on_exception_when_task_errors():
             TaskRunner(ErrorTask()).run()
 
 
-def test_task_runner_raise_on_exception_when_task_signals():
+def test_task_runner_does_not_raise_when_task_signals():
     with raise_on_exception():
-        with pytest.raises(prefect.engine.signals.FAIL):
-            TaskRunner(RaiseFailTask()).run()
+        state = TaskRunner(RaiseFailTask()).run()
+
+    assert state.is_failed()
 
 
 def test_task_runner_does_not_raise_on_exception_when_endrun_raised_by_mapping():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
The `raise_on_exception` no longer re-raises Prefect Signals during execution.


## Why is this PR important?
This PR helps target the re-raises to "unexpected" errors, for a better debugging experience when using things like `switch` control flow tasks.