### PR TITLE
Introducing: Task Tag throttling (in Prefect Cloud)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Features
 
 - Added `KubernetesJobEnvironment` - [#1548](https://github.com/PrefectHQ/prefect/pull/1548)
+- Add ability to enforce Task concurrency limits by tag in Prefect Cloud - [#1570](https://github.com/PrefectHQ/prefect/pull/1570)
 
 ### Enhancements
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -929,9 +929,8 @@ class Client:
         )  # type: Any
         state_payload = result.data.setTaskRunStates.states[0]
         if state_payload.status == "QUEUED":
-            # note that we don't populate the 'state' attribute of the Queued MetaState yet;
-            # this is because the actual state we want to start from is the _previous_ state
-            # of this task, which is more readily available by the caller of this method
+            # If appropriate, the state attribute of the Queued state can be
+            # set by the caller of this method
             return prefect.engine.state.Queued(
                 message=state_payload.get("message"),
                 start_time=pendulum.now("UTC").add(

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -929,9 +929,11 @@ class Client:
         )  # type: Any
         state_payload = result.data.setTaskRunStates.states[0]
         if state_payload.status == "QUEUED":
+            # note that we don't populate the 'state' attribute of the Queued MetaState yet;
+            # this is because the actual state we want to start from is the _previous_ state
+            # of this task, which is more readily available by the caller of this method
             return prefect.engine.state.Queued(
                 message=state_payload.get("message"),
-                state=state,
                 start_time=pendulum.now("UTC").add(
                     seconds=prefect.context.config.cloud.queue_interval
                 ),

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -775,15 +775,19 @@ class Client:
         mutation = {
             "mutation($state: JSON!)": {
                 with_args(
-                    "setFlowRunState",
+                    "setFlowRunStates",
                     {
                         "input": {
-                            "flowRunId": flow_run_id,
-                            "version": version,
-                            "state": EnumValue("$state"),
+                            "states": [
+                                {
+                                    "flowRunId": flow_run_id,
+                                    "version": version,
+                                    "state": EnumValue("$state"),
+                                }
+                            ]
                         }
                     },
-                ): {"id"}
+                ): {"states": {"id"}}
             }
         }
 
@@ -899,15 +903,19 @@ class Client:
         mutation = {
             "mutation($state: JSON!)": {
                 with_args(
-                    "setTaskRunState",
+                    "setTaskRunStates",
                     {
                         "input": {
-                            "taskRunId": task_run_id,
-                            "version": version,
-                            "state": EnumValue("$state"),
+                            "states": [
+                                {
+                                    "taskRunId": task_run_id,
+                                    "version": version,
+                                    "state": EnumValue("$state"),
+                                }
+                            ]
                         }
                     },
-                ): {"id"}
+                ): {"states": {"id"}}
             }
         }
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -964,7 +964,7 @@ class Client:
         if not result.data.setSecret.success:
             raise ValueError("Setting secret failed.")
 
-    def get_task_tag_limit(self, tag: str) -> int:
+    def get_task_tag_limit(self, tag: str) -> Optional[int]:
         """
         Retrieve the current task tag concurrency limit for a given tag.
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -930,7 +930,7 @@ class Client:
         state_payload = result.data.setTaskRunStates.states[0]
         if state_payload.status == "QUEUED":
             return prefect.engine.state.Queued(
-                message=state_payload.message,
+                message=state_payload.get("message"),
                 state=state,
                 start_time=pendulum.now("UTC").add(
                     seconds=prefect.context.config.cloud.queue_interval

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -11,6 +11,7 @@ api = "https://api.prefect.io"
 graphql = "${cloud.api}/graphql/alpha"
 use_local_secrets = true
 heartbeat_interval = 30.0
+queue_interval = 30.0
 
     [cloud.agent]
     # Agents require different API tokens

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -248,7 +248,7 @@ class CloudTaskRunner(TaskRunner):
             context=context,
             executor=executor,
         )
-        if end_state.is_retrying() and (
+        if (end_state.is_retrying() or end_state.is_queued()) and (
             end_state.start_time <= pendulum.now("utc").add(minutes=1)  # type: ignore
         ):
             assert isinstance(end_state, Retrying)

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -275,12 +275,6 @@ class CloudTaskRunner(TaskRunner):
             )
             context.update(task_run_version=task_run_info.version)  # type: ignore
 
-            start_state = (
-                end_state
-                if not end_state.is_queued()
-                else end_state.state  # type: ignore
-            )  # type: ignore
-
             return self.run(
                 state=end_state,
                 upstream_states=upstream_states,

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -88,12 +88,14 @@ class CloudTaskRunner(TaskRunner):
 
         try:
             cloud_state = prepare_state_for_cloud(new_state)
-            self.client.set_task_run_state(
+            state = self.client.set_task_run_state(
                 task_run_id=task_run_id,
                 version=version,
                 state=cloud_state,
                 cache_for=self.task.cache_for,
             )
+            if state.is_queued():
+                raise ENDRUN(state=state)
         except Exception as exc:
             self.logger.exception(
                 "Failed to set task state with error: {}".format(repr(exc))

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -97,6 +97,16 @@ class State:
 
         return isinstance(self, Pending)
 
+    def is_queued(self) -> bool:
+        """
+        Checks if the state is currently in a queued state
+
+        Returns:
+            - bool: `True` if the state is queued, `False` otherwise
+        """
+
+        return isinstance(self, Queued)
+
     def is_retrying(self) -> bool:
         """
         Checks if the state is currently in a retrying state

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -436,7 +436,7 @@ def test_set_task_run_state_responds_to_status(patch_post):
     result = client.set_task_run_state(task_run_id="76-salt", version=0, state=state)
 
     assert result.is_queued()
-    assert result.state is state
+    assert result.state is None  # caller should set this
 
 
 def test_set_task_run_state_responds_to_config_when_queued(patch_post):
@@ -461,7 +461,7 @@ def test_set_task_run_state_responds_to_config_when_queued(patch_post):
         )
 
     assert result.is_queued()
-    assert result.state is state
+    assert result.state is None  # caller should set this
     assert result.message == "hol up"
     assert result.start_time >= pendulum.now("UTC").add(seconds=749)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -424,6 +424,48 @@ def test_set_task_run_state(patch_post):
     assert result is state
 
 
+def test_set_task_run_state_responds_to_status(patch_post):
+    response = {"data": {"setTaskRunStates": {"states": [{"status": "QUEUED"}]}}}
+    post = patch_post(response)
+    state = Pending()
+
+    with set_temporary_config(
+        {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+    result = client.set_task_run_state(task_run_id="76-salt", version=0, state=state)
+
+    assert result.is_queued()
+    assert result.state is state
+
+
+def test_set_task_run_state_responds_to_config_when_queued(patch_post):
+    response = {
+        "data": {
+            "setTaskRunStates": {"states": [{"status": "QUEUED", "message": "hol up"}]}
+        }
+    }
+    post = patch_post(response)
+    state = Pending()
+
+    with set_temporary_config(
+        {
+            "cloud.graphql": "http://my-cloud.foo",
+            "cloud.auth_token": "secret_token",
+            "cloud.queue_interval": 750,
+        }
+    ):
+        client = Client()
+        result = client.set_task_run_state(
+            task_run_id="76-salt", version=0, state=state
+        )
+
+    assert result.is_queued()
+    assert result.state is state
+    assert result.message == "hol up"
+    assert result.start_time >= pendulum.now("UTC").add(seconds=749)
+
+
 def test_set_task_run_state_serializes(patch_post):
     response = {"data": {"setTaskRunStates": {"states": [{"status": "SUCCESS"}]}}}
     post = patch_post(response)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -411,22 +411,21 @@ def test_get_task_run_info_with_error(patch_post):
 
 
 def test_set_task_run_state(patch_post):
-    response = {"data": {"setTaskRunState": None}}
+    response = {"data": {"setTaskRunStates": {"states": [{"status": "SUCCESS"}]}}}
     post = patch_post(response)
+    state = Pending()
 
     with set_temporary_config(
         {"cloud.graphql": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
     ):
         client = Client()
-    result = client.set_task_run_state(
-        task_run_id="76-salt", version=0, state=Pending()
-    )
+    result = client.set_task_run_state(task_run_id="76-salt", version=0, state=state)
 
-    assert result is None
+    assert result is state
 
 
 def test_set_task_run_state_serializes(patch_post):
-    response = {"data": {"setTaskRunState": None}}
+    response = {"data": {"setTaskRunStates": {"states": [{"status": "SUCCESS"}]}}}
     post = patch_post(response)
 
     with set_temporary_config(
@@ -443,7 +442,7 @@ def test_set_task_run_state_serializes(patch_post):
 
 def test_set_task_run_state_with_error(patch_post):
     response = {
-        "data": {"setTaskRunState": None},
+        "data": {"setTaskRunStates": None},
         "errors": [{"message": "something went wrong"}],
     }
     post = patch_post(response)

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -47,7 +47,9 @@ def client(monkeypatch):
         get_flow_run_info=MagicMock(return_value=MagicMock(state=None, parameters={})),
         set_flow_run_state=MagicMock(),
         get_task_run_info=MagicMock(return_value=MagicMock(state=None)),
-        set_task_run_state=MagicMock(),
+        set_task_run_state=MagicMock(
+            side_effect=lambda task_run_id, version, state, cache_for: state
+        ),
         get_latest_task_run_states=MagicMock(
             side_effect=lambda flow_run_id, states, result_handler: states
         ),
@@ -481,6 +483,9 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
     class Client(MagicMock):
         def write_run_log(self, *args, **kwargs):
             calls.append(kwargs)
+
+        def set_task_run_state(self, *args, **kwargs):
+            return kwargs.get("state")
 
         def get_flow_run_info(self, *args, **kwargs):
             return MagicMock(

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -180,6 +180,7 @@ class MockedCloudClient(MagicMock):
             tr.version += 1
         else:
             raise ValueError("Invalid task run update")
+        return state
 
 
 @pytest.mark.parametrize("executor", ["local", "sync"], indirect=True)

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -119,10 +119,13 @@ def test_task_runner_places_task_tags_in_state_context_and_serializes_them(monke
     call_vars = [
         json.loads(call[1]["json"]["variables"]) for call in session.post.call_args_list
     ]
-    assert call_vars[0]["state"]["type"] == "Running"
-    assert set(call_vars[0]["state"]["context"]["tags"]) == set(["1", "2", "tag"])
-    assert call_vars[-1]["state"]["type"] == "Success"
-    assert set(call_vars[-1]["state"]["context"]["tags"]) == set(["1", "2", "tag"])
+
+    # do some mainpulation to get the state payloads
+    inputs = [c["input"]["states"][0] for c in call_vars if c is not None]
+    assert inputs[0]["state"]["type"] == "Running"
+    assert set(inputs[0]["state"]["context"]["tags"]) == set(["1", "2", "tag"])
+    assert inputs[-1]["state"]["type"] == "Success"
+    assert set(inputs[-1]["state"]["context"]["tags"]) == set(["1", "2", "tag"])
 
 
 def test_task_runner_calls_get_task_run_info_if_map_index_is_not_none(client):

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -393,7 +393,7 @@ class TestStateHierarchy:
         dict(state=Mapped(), assert_true={"is_finished", "is_mapped", "is_successful"}),
         dict(state=Paused(), assert_true={"is_pending", "is_scheduled"}),
         dict(state=Pending(), assert_true={"is_pending"}),
-        dict(state=Queued(), assert_true={"is_meta_state"}),
+        dict(state=Queued(), assert_true={"is_meta_state", "is_queued"}),
         dict(state=Resume(), assert_true={"is_pending", "is_scheduled"}),
         dict(
             state=Retrying(), assert_true={"is_pending", "is_scheduled", "is_retrying"}


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR:
- adds two new methods to the Prefect Python Client for getting / setting task tag concurrency limits
- introduces logic for in-process retries of Queued states, which arise out of concurrency limits being hit in Prefect Cloud
- introduces a new config var for specifying how long Queued states should wait before retrying their run
- adds some new tests


## Why is this PR important?
Task Throttling / Concurrency Limiting is a very popular request, and will now be a first-class feature in Prefect Cloud.  Note to any Cloud users watching: this will not be made widely available until the next Cloud release.