### PR TITLE
Pin prefecthq/prefect image version on agent deployment yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with certain Pause / Resume / Retry pipelines retrying indefinitely - [#1177](https://github.com/PrefectHQ/prefect/issues/1177)
+- Kubernetes Agent deployment YAML generation defaults to local Prefect version - [#1573](https://github.com/PrefectHQ/prefect/pull/1573)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -166,7 +166,8 @@ class KubernetesAgent(Agent):
         api = api or "https://api.prefect.io"
         namespace = namespace or "default"
 
-        version = prefect.__version__.split("+")[0]
+        version = prefect.__version__.split("+")
+        image_version = "latest" if len(version) > 1 else version[0]
 
         with open(
             path.join(path.dirname(__file__), "deployment.yaml"), "r"
@@ -182,7 +183,7 @@ class KubernetesAgent(Agent):
         # Use local prefect version for image
         deployment["spec"]["template"]["spec"]["containers"][0][
             "image"
-        ] = "prefecthq/prefect:{}".format(version)
+        ] = "prefecthq/prefect:{}".format(image_version)
 
         # Populate resource manager if requested
         if resource_manager_enabled:
@@ -197,7 +198,7 @@ class KubernetesAgent(Agent):
             # Use local prefect version for image
             deployment["spec"]["template"]["spec"]["containers"][1][
                 "image"
-            ] = "prefecthq/prefect:{}".format(version)
+            ] = "prefecthq/prefect:{}".format(image_version)
         else:
             del deployment["spec"]["template"]["spec"]["containers"][1]
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -117,7 +117,7 @@ def start(name, token, verbose, no_pull, base_url):
 def install(name, token, api, namespace, image_pull_secrets, resource_manager):
     """
     Install an agent. Outputs configuration text which can be used to install on various
-    platforms.
+    platforms. The Prefect image version will default to your local prefect.__version__
 
     \b
     Arguments:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -117,7 +117,7 @@ def start(name, token, verbose, no_pull, base_url):
 def install(name, token, api, namespace, image_pull_secrets, resource_manager):
     """
     Install an agent. Outputs configuration text which can be used to install on various
-    platforms. The Prefect image version will default to your local prefect.__version__
+    platforms. The Prefect image version will default to your local `prefect.__version__`
 
     \b
     Arguments:

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -197,7 +197,19 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, runner_token):
     assert resource_manager_env[3]["value"] == "test_namespace"
 
 
-def test_k8s_agent_generate_deployment_yaml_local_version(monkeypatch, runner_token):
+@pytest.mark.parametrize(
+    "version",
+    [
+        ("0.6.3", "0.6.3"),
+        ("0.5.3+114.g35bc7ba4", "latest"),
+        ("0.5.2+999.gr34343.dirty", "latest"),
+    ],
+)
+def test_k8s_agent_generate_deployment_yaml_local_version(
+    monkeypatch, runner_token, version
+):
+    monkeypatch.setattr(prefect, "__version__", version[0])
+
     k8s_config = MagicMock()
     monkeypatch.setattr("kubernetes.config", k8s_config)
 
@@ -214,12 +226,8 @@ def test_k8s_agent_generate_deployment_yaml_local_version(monkeypatch, runner_to
     agent_yaml = deployment["spec"]["template"]["spec"]["containers"][0]
     resource_manager_yaml = deployment["spec"]["template"]["spec"]["containers"][1]
 
-    assert agent_yaml["image"] == "prefecthq/prefect:{}".format(
-        prefect.__version__.split("+")[0]
-    )
-    assert resource_manager_yaml["image"] == "prefecthq/prefect:{}".format(
-        prefect.__version__.split("+")[0]
-    )
+    assert agent_yaml["image"] == "prefecthq/prefect:{}".format(version[1])
+    assert resource_manager_yaml["image"] == "prefecthq/prefect:{}".format(version[1])
 
 
 def test_k8s_agent_generate_deployment_yaml_no_resource_manager(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Default's the generated agent k8s YAML to use a prefect docker image pinned to your local version


## Why is this PR important?
Consistency and to prevent redeploy issues on k8s if there is a new latest image built off of master

