### PR TITLE
Two tweaks - remove recursion and update GraphQLResult repr

### DIFF
--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -258,7 +258,7 @@ class CloudTaskRunner(TaskRunner):
             context=context,
             executor=executor,
         )
-        if (end_state.is_retrying() or end_state.is_queued()) and (
+        while (end_state.is_retrying() or end_state.is_queued()) and (
             end_state.start_time <= pendulum.now("utc").add(minutes=1)  # type: ignore
         ):
             assert isinstance(end_state, (Retrying, Queued))
@@ -275,11 +275,10 @@ class CloudTaskRunner(TaskRunner):
             )
             context.update(task_run_version=task_run_info.version)  # type: ignore
 
-            return self.run(
+            end_state = super().run(
                 state=end_state,
                 upstream_states=upstream_states,
                 context=context,
                 executor=executor,
             )
-        else:
-            return end_state
+        return end_state

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -20,7 +20,11 @@ def lowercase_first_letter(s: str) -> str:
 
 
 class GraphQLResult(Box):
-    pass
+    def __repr__(self) -> str:
+        try:
+            return json.dumps(self, indent=4)
+        except TypeError:
+            return repr(self.to_dict())
 
 
 class EnumValue:

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 import pytest
 from box import Box
 
+from prefect.engine.state import Pending
 from prefect.utilities.graphql import (
     EnumValue,
     GQLObject,
@@ -425,3 +426,16 @@ def test_decompress():
 )
 def test_compression_back_translation(obj):
     assert decompress(compress(obj)) == obj
+
+
+def test_graphql_result_has_nice_repr():
+    expected = """{\n    "flow_run": {\n        "flow": [\n            {\n                "id": 1\n            },\n            {\n                "version": 2\n            }\n        ]\n    }\n}"""
+    gql = {"flow_run": {"flow": [{"id": 1}, {"version": 2}]}}
+    res = GraphQLResult(gql)
+    assert repr(res) == expected
+
+
+def test_graphql_repr_falls_back_to_dict_repr():
+    gql = {"flow_run": Pending("test")}
+    res = GraphQLResult(gql)
+    assert repr(res) == """{'flow_run': <Pending: "test">}"""


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR replaces the `CloudTaskRunner`'s recursive run calls with a while loop, so that tasks can remain queued / retrying for extended periods of time without running into recursion errors.  Also reintroduces the old `GraphQLResult` reprs because I personally really enjoyed those and used them often.


## Why is this PR important?
Closes #1575 

