### PR TITLE
Don't submit constant tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Replace `DotDict` with `box.Box` - [#1518](https://github.com/PrefectHQ/prefect/pull/1518)
 - Store `cached_inputs` on Failed states and call their result handlers if they were provided - [#1557](https://github.com/PrefectHQ/prefect/pull/1557)
 - `raise_on_exception` no longer raises for Prefect Signals, as these are typically intentional / for control flow - [#1562](https://github.com/PrefectHQ/prefect/pull/1562)
+- Always consider `Constant` tasks successful and unpack them immediately instead of submitting them for execution - [#1527](https://github.com/PrefectHQ/prefect/issues/1527)
 
 ### Task Library
 

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -395,6 +395,10 @@ class FlowRunner(Runner):
             for task in self.flow.sorted_tasks():
 
                 task_state = task_states.get(task)
+                if task_state is None and isinstance(
+                    task, prefect.tasks.core.constants.Constant
+                ):
+                    task_states[task] = task_state = Success(result=task.value)
 
                 # if the state is finished, don't run the task, just use the provided state
                 if (

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -333,15 +333,13 @@ def test_client_is_always_called_even_during_failures(client):
     ]
     assert [type(s).__name__ for s in flow_states] == ["Running", "Failed"]
 
-    assert (
-        client.set_task_run_state.call_count == 6
-    )  # (Pending -> Running -> Finished) * 3
+    assert client.set_task_run_state.call_count == 2  # (Pending -> Running -> Finished)
 
     task_states = [
         call[1]["state"] for call in client.set_task_run_state.call_args_list
     ]
-    assert len([s for s in task_states if s.is_running()]) == 3
-    assert len([s for s in task_states if s.is_successful()]) == 2
+    assert len([s for s in task_states if s.is_running()]) == 1
+    assert len([s for s in task_states if s.is_successful()]) == 0
     assert len([s for s in task_states if s.is_failed()]) == 1
 
 

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1538,3 +1538,57 @@ def test_task_runners_submitted_to_remote_machines_respect_original_config(monke
         "prefect.CustomFlowRunner",
         "prefect.Task: log_stuff",
     }
+
+
+def test_constant_tasks_arent_submitted(caplog):
+    calls = []
+
+    class TrackSubmissions(LocalExecutor):
+        def submit(self, *args, **kwargs):
+            calls.append(kwargs)
+            return super().submit(*args, **kwargs)
+
+    @prefect.task
+    def add(x):
+        return x + 1
+
+    with Flow("constants") as flow:
+        output = add(5)
+
+    runner = FlowRunner(flow=flow)
+    flow_state = runner.run(return_tasks=[output], executor=TrackSubmissions())
+    assert flow_state.is_successful()
+    assert flow_state.result[output].result == 6
+
+    ## only add was submitted
+    assert len(calls) == 1
+
+    ## to be safe, ensure '5' isn't in the logs
+    assert len([log.message for log in caplog.records if "5" in log.message]) == 0
+
+
+def test_constant_tasks_arent_submitted_when_mapped(caplog):
+    calls = []
+
+    class TrackSubmissions(LocalExecutor):
+        def submit(self, *args, **kwargs):
+            calls.append(kwargs)
+            return super().submit(*args, **kwargs)
+
+    @prefect.task
+    def add(x):
+        return x + 1
+
+    with Flow("constants") as flow:
+        output = add.map([99] * 10)
+
+    runner = FlowRunner(flow=flow)
+    flow_state = runner.run(return_tasks=[output], executor=TrackSubmissions())
+    assert flow_state.is_successful()
+    assert flow_state.result[output].result == [100] * 10
+
+    ## only add and the List task were submitted
+    assert len(calls) == 2
+
+    ## to be safe, ensure '5' isn't in the logs
+    assert len([log.message for log in caplog.records if "99" in log.message]) == 0

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -134,8 +134,14 @@ def test_merge_with_upstream_skip_arg_raises_error():
 
 def test_merge_diamond_flow_with_results():
     condition = Condition()
-    true_branch = Constant(1)
-    false_branch = Constant(0)
+
+    @task
+    def true_branch():
+        return 1
+
+    @task
+    def false_branch():
+        return 0
 
     with Flow(name="test") as flow:
         ifelse(condition, true_branch, false_branch)
@@ -156,8 +162,14 @@ def test_merge_diamond_flow_with_results():
 
 def test_merge_can_distinguish_between_a_none_result_and_an_unrun_task():
     condition = Condition()
-    true_branch = Constant(None)
-    false_branch = Constant(0)
+
+    @task
+    def true_branch():
+        return None
+
+    @task
+    def false_branch():
+        return 0
 
     with Flow(name="test") as flow:
         ifelse(condition, true_branch, false_branch)
@@ -169,11 +181,16 @@ def test_merge_can_distinguish_between_a_none_result_and_an_unrun_task():
 
 
 def test_merge_with_list():
+    @task
+    def false_branch():
+        return 0
+
+    @task
+    def true_branch():
+        return [1, 2]
+
     with Flow(name="test") as flow:
         condition = Condition()
-        true_branch = prefect.utilities.tasks.as_task([Constant(1), Constant(2)])
-        false_branch = Constant(0)
-
         ifelse(condition, true_branch, false_branch)
         merge_task = merge(true_branch, false_branch)
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR greedily wraps Constant tasks in `Success` states to prevent their submission for "execution", thereby greatly reducing noise in logs and also time spent "running" the constants.


## Why is this PR important?
Closes #1527; working on this also exposed a large number of edge cases for Prefect Cloud that I will be investigating ASAP

**cc:** @bnaul 