### PR TITLE
Custom result handler upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with certain Pause / Resume / Retry pipelines retrying indefinitely - [#1177](https://github.com/PrefectHQ/prefect/issues/1177)
 - Kubernetes Agent deployment YAML generation defaults to local Prefect version - [#1573](https://github.com/PrefectHQ/prefect/pull/1573)
+- Fix issue with custom result handlers not working when called in `cached_inputs` - [#1585](https://github.com/PrefectHQ/prefect/pull/1585)
 
 ### Deprecations
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -206,14 +206,16 @@ class CloudTaskRunner(TaskRunner):
             for candidate_state in cached_states:
                 assert isinstance(candidate_state, Cached)  # mypy assert
                 candidate_state.cached_inputs = {
-                    key: res.to_result()  # type: ignore
+                    key: res.to_result(inputs[key].result_handler)  # type: ignore
                     for key, res in (candidate_state.cached_inputs or {}).items()
                 }
                 sanitized_inputs = {key: res.value for key, res in inputs.items()}
                 if self.task.cache_validator(
                     candidate_state, sanitized_inputs, prefect.context.get("parameters")
                 ):
-                    candidate_state._result = candidate_state._result.to_result()
+                    candidate_state._result = candidate_state._result.to_result(
+                        self.task.result_handler
+                    )
                     return candidate_state
 
                 self.logger.debug(

--- a/src/prefect/engine/result_handlers/result_handler.py
+++ b/src/prefect/engine/result_handlers/result_handler.py
@@ -5,7 +5,6 @@ Anytime a task needs its output or inputs stored, a result handler is used to de
 """
 import base64
 import tempfile
-from abc import ABCMeta, abstractmethod
 from typing import Any
 
 import cloudpickle
@@ -15,20 +14,18 @@ from prefect.client.client import Client
 from prefect.utilities import logging
 
 
-class ResultHandler(metaclass=ABCMeta):
+class ResultHandler:
     def __init__(self) -> None:
         self.logger = logging.get_logger(type(self).__name__)
 
     def __repr__(self) -> str:
         return "<ResultHandler: {}>".format(type(self).__name__)
 
-    @abstractmethod
-    def write(self, result: Any) -> str:
-        raise NotImplementedError()
+    def write(self, result: Any) -> Any:
+        return result
 
-    @abstractmethod
-    def read(self, loc: str) -> Any:
-        raise NotImplementedError()
+    def read(self, loc: str) -> str:
+        return loc
 
     def __eq__(self, other: object) -> bool:
         """

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -581,9 +581,12 @@ class TaskRunner(Runner):
         for edge, upstream_state in upstream_states.items():
             # construct task inputs
             if edge.key is not None:
+                handler = getattr(edge.upstream_task, "result_handler", None)
                 task_inputs[  # type: ignore
                     edge.key
-                ] = upstream_state._result.to_result()  # type: ignore
+                ] = upstream_state._result.to_result(  # type: ignore
+                    handler
+                )  # type: ignore
 
         if state.is_pending() and state.cached_inputs is not None:  # type: ignore
             task_inputs.update(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -623,7 +623,7 @@ class TaskRunner(Runner):
             if self.task.cache_validator(
                 state, sanitized_inputs, prefect.context.get("parameters")
             ):
-                state._result = state._result.to_result()
+                state._result = state._result.to_result(self.task.result_handler)
                 return state
             else:
                 state = Pending("Cache was invalid; ready to run.")
@@ -637,7 +637,9 @@ class TaskRunner(Runner):
                 if self.task.cache_validator(
                     candidate, sanitized_inputs, prefect.context.get("parameters")
                 ):
-                    candidate._result = candidate._result.to_result()
+                    candidate._result = candidate._result.to_result(
+                        self.task.result_handler
+                    )
                     return candidate
 
         if self.task.cache_for is not None:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -577,11 +577,14 @@ class TaskRunner(Runner):
 
         """
         task_inputs = {}  # type: Dict[str, Result]
+        handlers = {}  # type: Dict[str, ResultHandler]
 
         for edge, upstream_state in upstream_states.items():
             # construct task inputs
             if edge.key is not None:
-                handler = getattr(edge.upstream_task, "result_handler", None)
+                handlers[edge.key] = handler = getattr(
+                    edge.upstream_task, "result_handler", None
+                )
                 task_inputs[  # type: ignore
                     edge.key
                 ] = upstream_state._result.to_result(  # type: ignore
@@ -591,7 +594,7 @@ class TaskRunner(Runner):
         if state.is_pending() and state.cached_inputs is not None:  # type: ignore
             task_inputs.update(
                 {
-                    k: r.to_result()
+                    k: r.to_result(handlers.get(k))
                     for k, r in state.cached_inputs.items()  # type: ignore
                     if task_inputs.get(k, NoResult) == NoResult
                 }

--- a/src/prefect/serialization/result_handlers.py
+++ b/src/prefect/serialization/result_handlers.py
@@ -34,9 +34,9 @@ class CustomResultHandlerSchema(ObjectSchema):
     )
 
     @post_load
-    def create_object(self, data: dict, **kwargs: Any) -> None:
+    def create_object(self, data: dict, **kwargs: Any) -> ResultHandler:
         """Because we cannot deserialize a custom class, just return `None`"""
-        return None
+        return ResultHandler()
 
 
 class GCSResultHandlerSchema(BaseResultHandlerSchema):

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -83,26 +83,10 @@ class TestLocalHandler:
         assert isinstance(new, LocalResultHandler)
 
 
-def test_result_handlers_must_implement_read_and_write_to_work():
-    class MyHandler(ResultHandler):
-        pass
-
-    with pytest.raises(TypeError, match="abstract methods read, write"):
-        MyHandler()
-
-    class WriteHandler(ResultHandler):
-        def write(self, val):
-            pass
-
-    with pytest.raises(TypeError, match="abstract methods read"):
-        WriteHandler()
-
-    class ReadHandler(ResultHandler):
-        def read(self, val):
-            pass
-
-    with pytest.raises(TypeError, match="abstract methods write"):
-        ReadHandler()
+def test_result_handler_base_class_is_a_passthrough():
+    handler = ResultHandler()
+    assert handler.write("foo") == "foo"
+    assert handler.read(99) == 99
 
 
 @pytest.mark.xfail(raises=ImportError, reason="google extras not installed.")

--- a/tests/engine/test_result.py
+++ b/tests/engine/test_result.py
@@ -196,6 +196,28 @@ class TestToResult:
         assert res.safe_value is s
         assert res.result_handler is s.result_handler
 
+    def test_to_result_resets_with_provided_result_handler(self):
+        class WeirdHandler(ResultHandler):
+            def read(self, loc):
+                return 99
+
+        r = Result("4", result_handler=JSONResultHandler())
+        out = r.to_result(result_handler=WeirdHandler())
+        assert out is r
+        assert isinstance(out.result_handler, WeirdHandler)
+
+    def test_to_result_uses_provided_result_handler(self):
+        class WeirdHandler(ResultHandler):
+            def read(self, loc):
+                return 99
+
+        r = SafeResult("4", result_handler=JSONResultHandler())
+        out = r.to_result(result_handler=WeirdHandler())
+        assert isinstance(out, Result)
+        assert isinstance(out.result_handler, WeirdHandler)
+        assert out.value == 99
+        assert isinstance(out.safe_value.result_handler, WeirdHandler)
+
 
 @pytest.mark.parametrize(
     "obj",

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -918,6 +918,27 @@ class TestCheckTaskCached:
         assert new is state
         assert new.result == 2
 
+    def test_reads_result_using_handler_attribute_if_cached_valid(self):
+        class Handler(ResultHandler):
+            def read(self, val):
+                return 53
+
+        with pytest.warns(UserWarning):
+            task = Task(
+                cache_validator=cache_validators.duration_only, result_handler=Handler()
+            )
+        result = SafeResult("2", result_handler=JSONResultHandler())
+        state = Cached(
+            result=result,
+            cached_result_expiration=pendulum.now("utc") + timedelta(minutes=1),
+        )
+
+        new = TaskRunner(task).check_task_is_cached(
+            state=state, inputs={"a": Result(1)}
+        )
+        assert new is state
+        assert new.result == 53
+
     def test_reads_result_from_context_if_cached_valid(self):
         task = Task(
             cache_for=timedelta(minutes=1),
@@ -935,6 +956,29 @@ class TestCheckTaskCached:
             )
         assert new is state
         assert new.result == 2
+
+    def test_reads_result_from_context_if_cached_valid_using_task_handler(task):
+        class Handler(ResultHandler):
+            def read(self, val):
+                return 53
+
+        task = Task(
+            result_handler=Handler(),
+            cache_for=timedelta(minutes=1),
+            cache_validator=cache_validators.duration_only,
+        )
+        result = SafeResult("2", result_handler=JSONResultHandler())
+        state = Cached(
+            result=result,
+            cached_result_expiration=pendulum.now("utc") + timedelta(minutes=1),
+        )
+
+        with prefect.context(caches={"Task": [state]}):
+            new = TaskRunner(task).check_task_is_cached(
+                state=Pending(), inputs={"a": Result(1)}
+            )
+        assert new is state
+        assert new.result == 53
 
     def test_state_kwarg_is_prioritized_over_context_caches(self):
         task = Task(

--- a/tests/serialization/test_result.py
+++ b/tests/serialization/test_result.py
@@ -3,7 +3,7 @@ import pytest
 
 import prefect
 from prefect.engine.result import NoResult, NoResultType, Result, SafeResult
-from prefect.engine.result_handlers import JSONResultHandler
+from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
 from prefect.serialization.result import (
     NoResultSchema,
     SafeResultSchema,
@@ -48,7 +48,7 @@ def test_safe_result_with_custom_handler_deserializes():
     )
     assert isinstance(r, SafeResult)
     assert r.value == "3"
-    assert r.result_handler is None
+    assert isinstance(r.result_handler, ResultHandler)
 
 
 def test_roundtrip_for_results():

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -57,7 +57,8 @@ class TestCustomSchema:
 
         schema = CustomResultHandlerSchema()
         obj = schema.load(schema.dump(Dummy()))
-        assert obj is None
+        assert isinstance(obj, ResultHandler)
+        assert obj.read(42) == 42  # just the base class, not the Dummy class
 
     def test_custom_schema_roundtrip_on_stateful_class(self):
         class Stateful(ResultHandler):
@@ -72,7 +73,8 @@ class TestCustomSchema:
 
         schema = CustomResultHandlerSchema()
         obj = schema.load(schema.dump(Stateful(42)))
-        assert obj is None
+        assert isinstance(obj, ResultHandler)
+        assert obj.write("foo") == "foo"  # just the base class, not the Stateful class
 
     def test_result_handler_schema_defaults_to_custom(self):
         class Weird(ResultHandler):
@@ -91,7 +93,8 @@ class TestCustomSchema:
         assert serialized["__version__"] == prefect.__version__
 
         obj = schema.load(serialized)
-        assert obj is None
+        assert isinstance(obj, ResultHandler)
+        assert obj.write("foo") == "foo"  # just the base class, not the Weird class
 
     def test_cloud_can_deserialize_custom_handlers(self):
         schema = ResultHandlerSchema()
@@ -99,7 +102,7 @@ class TestCustomSchema:
             "type": "CustomResultHandler",
             "__version__": "0.6.3+120.g60ca943b",
         }
-        assert schema.load(serialized) is None
+        assert isinstance(schema.load(serialized), ResultHandler)
 
 
 class TestLocalResultHandler:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR seems small and weird, but it actually fixes a subtle issue: Cached / Retry / Failed states cache their inputs using the upstream task's result handler corresponding to each input.  The caching aspect worked just fine.  However, in future runs, if a Custom Result Handler (i.e., one which was user-written and not in the Prefect library) was used upstream, then whenever the state with `cached_inputs` was _deserialized_ from Cloud, the custom result handler was not present.  This PR always extracts the result handler from the upstream Task and uses it (if present) when hydrating cached inputs.  This required a few minor refactors of serializers and the result interface.


## Why is this PR important?
Ensures full support for custom written result handlers in Prefect Cloud.