### PR TITLE
Fix minor bug involving locally cached tasks and no schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with running local Flow without a schedule containing cached tasks - [#1599](https://github.com/PrefectHQ/prefect/pull/1599)
 
 ### Deprecations
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -836,9 +836,6 @@ class Flow:
         task_states = kwargs.pop("task_states", {})
         flow_state.result.update(task_states)
 
-        # set global caches that persist across runs
-        prefect.context.setdefault("caches", {})
-
         # set context for this flow run
         flow_run_context = kwargs.pop(
             "context", {}
@@ -998,6 +995,9 @@ class Flow:
                     fmt_params
                 )
             )
+
+        # set global caches that persist across runs
+        prefect.context.setdefault("caches", {})
 
         if run_on_schedule is None:
             run_on_schedule = cast(bool, prefect.config.flows.run_on_schedule)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1712,6 +1712,21 @@ class TestFlowRunMethod:
 
         assert storage == dict(y=[1, 1, 3])
 
+    def test_flow_dot_run_without_schedule_can_run_cached_tasks(self):
+        # simulate fresh environment
+        if "caches" in prefect.context:
+            del prefect.context["caches"]
+
+        @task(cache_for=datetime.timedelta(minutes=1))
+        def noop():
+            pass
+
+        f = Flow("test-caches", tasks=[noop])
+        flow_state = f.run(run_on_schedule=False)
+
+        assert flow_state.is_successful()
+        assert flow_state.result[noop].result is None
+
     def test_flow_dot_run_handles_mapped_cached_states(self):
         class MockSchedule(prefect.schedules.Schedule):
             call_count = 0


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Flows which:
- run with `run_on_schedule=False`
- have a cached task
would error out with:
```
AttributeError: 'Context' object has no attribute 'caches'
```
because of the place that we set this key.  This PR moves that key-setting to a more universal location and adds a test.


## Why is this PR important?
For local development and testing!