### PR TITLE
Introducing: Appveyor jobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      ARCH: "64"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+- "%PYTHON%/Scripts/pip.exe install pytest"
+- "%PYTHON%/Scripts/pip.exe install ."
+
+test_script:
+- "%PYTHON%/Scripts/pytest . --skip-formatting"


### PR DESCRIPTION
Adds an Appveyor job to our PRs.  This will test our most basic Windows functionality on Python 3.6.

Of course, we can always add to this by:
- including formatting tests
- installing _all_ extras to ensure Windows compatibility with the extended Task Library
- test against more Python versions

but this will get us started and in a good place to confidently ensure Windows compatibility. Closes #1576 