### PR TITLE
Enhancement Fargate Agent - temporary credentials 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Raise more informative error when calling `flow.visualize()` if Graphviz executable not installed - [#1602](https://github.com/PrefectHQ/prefect/pull/1602)
 - Allow authentication to Azure Blob Storage with SAS token - [#1600](https://github.com/PrefectHQ/prefect/pull/1600)
+- Changes to Fargate agent to support temporary credentials and IAM role based credentials within AWS compute such as a container or ec2 instance. [#1603](https://github.com/PrefectHQ/prefect/pull/1603)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Raise more informative error when calling `flow.visualize()` if Graphviz executable not installed - [#1602](https://github.com/PrefectHQ/prefect/pull/1602)
 - Allow authentication to Azure Blob Storage with SAS token - [#1600](https://github.com/PrefectHQ/prefect/pull/1600)
-- Changes to Fargate agent to support temporary credentials and IAM role based credentials within AWS compute such as a container or ec2 instance. [#1603](https://github.com/PrefectHQ/prefect/pull/1603)
+- Changes to Fargate agent to support temporary credentials and IAM role based credentials within AWS compute such as a container or ec2 instance. [#1607](https://github.com/PrefectHQ/prefect/pull/1607)
 
 ### Task Library
 

--- a/docs/cloud/agent/fargate.md
+++ b/docs/cloud/agent/fargate.md
@@ -4,7 +4,7 @@ The Fargate Agent is an agent designed to deploy flows as Tasks using AWS Fargat
 
 ### Requirements
 
-Running the Fargate Agent requires that you provide an `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `REGION_NAME` and `CLUSTER`. The first three values are required to initialize the [boto3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#client) while the `CLUSTER` tells the agent where to run Fargate Tasks.
+Running the Fargate Agent requires that you provide a `REGION_NAME` and `CLUSTER`. Optionally, you may provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` (specific to temporary credentials). If these three items are not explicitly defined, boto3 will default to environment variables or your credentials file. Having the `REGION_NAME` defined along with the appropriate credentials stored per aws expectations are required to initialize the [boto3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#client) while the `CLUSTER` tells the agent where to run Fargate Tasks. For more information on properly setting your credentials, check out the boto3 documentation [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).
 
 ### Usage
 
@@ -44,6 +44,7 @@ Through the Prefect CLI:
 ```
 $ export AWS_ACCESS_KEY_ID=MY_ACCESS
 $ export AWS_SECRET_ACCESS_KEY=MY_SECRET
+$ export AWS_SESSION_TOKEN=MY_SESSION
 $ export REGION_NAME=MY_REGION
 $ export CLUSTER=MY_CLUSTER
 $ prefect agent start fargate
@@ -57,6 +58,7 @@ from prefect.agent.fargate import FargateAgent
 agent = FargateAgent(
         aws_access_key_id="MY_ACCESS",
         aws_secret_access_key="MY_SECRET",
+        aws_session_token="MY_SESSION",
         region_name="MY_REGION",
         cluser="MY_CLUSTER"
         )
@@ -83,7 +85,7 @@ When the flow run is found and the Task is run the logs of the agent should refl
 2019-09-01 19:01:09,158 - agent - INFO - Submitted 1 flow run(s) for execution.
 ```
 
-The Fargate Task run should be created and it will start in a `PENDING` state. Once the resources are provisioned it rill enter a `RUNNING` state and on completion it will finish as `COMPLETED`.
+The Fargate Task run should be created and it will start in a `PENDING` state. Once the resources are provisioned it will enter a `RUNNING` state and on completion it will finish as `COMPLETED`.
 
 :::warning Resources
 The current default resource usage of a prefect-task has a limit for CPU of `256` and a limit for memory of `512`. Make sure you are aware of the resource usage of your Tasks. You may adjust the CPU and memory for the Tasks on the agent through `task_cpu` and `task_memory` or through the environment variables `TASK_CPU` and `TASK_MEMORY`
@@ -95,6 +97,7 @@ The Fargate Agent allows for a set of AWS configuration options to be set or pro
 
 - aws_access_key_id (str, optional): AWS access key id for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_ACCESS_KEY_ID`.
 - aws_secret_access_key (str, optional): AWS secret access key for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_SECRET_ACCESS_KEY`.
+- aws_session_token (str, optional): AWS session key for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_SESSION_TOKEN`.
 - region_name (str, optional): AWS region name for connecting the boto3 client. Defaults to the value set in the environment variable `REGION_NAME`.
 - cluster (str, optional): The Fargate cluster to deploy tasks. Defaults to the value set in the environment variable `CLUSTER`.
 - subnets (list, optional): A list of AWS VPC subnets to use for the tasks that are deployed on Fargate. Defaults to the subnets found which have `MapPublicIpOnLaunch` disabled.

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -20,6 +20,9 @@ class FargateAgent(Agent):
         - aws_secret_access_key (str, optional): AWS secret access key for connecting
             the boto3 client. Defaults to the value set in the environment variable
             `AWS_SECRET_ACCESS_KEY`.
+        - aws_session_token (str, optional): AWS session key for connecting the boto3
+            client. Defaults to the value set in the environment variable
+            `AWS_SESSION_TOKEN`.
         - region_name (str, optional): AWS region name for connecting the boto3 client.
             Defaults to the value set in the environment variable `REGION_NAME`.
         - cluster (str, optional): The Fargate cluster to deploy tasks. Defaults to the

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -47,6 +47,7 @@ class FargateAgent(Agent):
         self,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
+        aws_session_token: str = None,
         region_name: str = None,
         cluster: str = None,
         subnets: list = None,
@@ -64,6 +65,9 @@ class FargateAgent(Agent):
         aws_access_key_id = aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID")
         aws_secret_access_key = aws_secret_access_key or os.getenv(
             "AWS_SECRET_ACCESS_KEY"
+        )
+        aws_session_token = aws_session_token or os.getenv(
+            "AWS_SESSION_TOKEN"
         )
         region_name = region_name or os.getenv("REGION_NAME")
 
@@ -100,6 +104,7 @@ class FargateAgent(Agent):
             "ecs",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             region_name=region_name,
         )
 
@@ -110,6 +115,7 @@ class FargateAgent(Agent):
                 "ec2",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
                 region_name=region_name,
             )
             for subnet in ec2.describe_subnets()["Subnets"]:

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -66,9 +66,7 @@ class FargateAgent(Agent):
         aws_secret_access_key = aws_secret_access_key or os.getenv(
             "AWS_SECRET_ACCESS_KEY"
         )
-        aws_session_token = aws_session_token or os.getenv(
-            "AWS_SESSION_TOKEN"
-        )
+        aws_session_token = aws_session_token or os.getenv("AWS_SESSION_TOKEN")
         region_name = region_name or os.getenv("REGION_NAME")
 
         # Agent task config

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -44,6 +44,7 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
     agent = FargateAgent(
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="token",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],
@@ -66,6 +67,7 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
         "ecs",
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="token",
         region_name="region",
     )
 
@@ -76,6 +78,7 @@ def test_ecs_agent_config_env_vars(monkeypatch, runner_token):
 
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "token")
     monkeypatch.setenv("REGION_NAME", "region")
     monkeypatch.setenv("CLUSTER", "cluster")
     monkeypatch.setenv("REPOSITORY_CREDENTIALS", "repo")
@@ -95,6 +98,7 @@ def test_ecs_agent_config_env_vars(monkeypatch, runner_token):
         "ecs",
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="token",
         region_name="region",
     )
 
@@ -156,6 +160,7 @@ def test_deploy_flows_all_args(monkeypatch, runner_token):
     agent = FargateAgent(
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="token",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],
@@ -291,6 +296,7 @@ def test_deploy_flows_register_task_definition_all_args(monkeypatch, runner_toke
     agent = FargateAgent(
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="token",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds in functionality to support temporary credentials and IAM role based credentials to the Fargate agent by introducing the aws_session_token per documentation found here: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html

## Why is this PR important?
This is important because using the existing state of the agent does not allow you to use temporary credentials. Also, it should never be required to supply access keys when using a library inside of AWS compute. 

