### PR TITLE
Special case secrets in environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Raise more informative error when calling `flow.visualize()` if Graphviz executable not installed - [#1602](https://github.com/PrefectHQ/prefect/pull/1602)
 - Allow authentication to Azure Blob Storage with SAS token - [#1600](https://github.com/PrefectHQ/prefect/pull/1600)
+- Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
 
 ### Task Library
 
@@ -28,7 +29,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Breaking Changes
 
-- None
+- Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
 
 ### Contributors
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 build: false
+skip_branch_with_pr: true
 
 environment:
   matrix:

--- a/docs/core/concepts/configuration.md
+++ b/docs/core/concepts/configuration.md
@@ -11,7 +11,12 @@ Any lowercase Prefect configuration key can be set by environment variable. In o
 For example, if you set `PREFECT__TASKS__DEFAULTS__MAX_RETRIES=4`, then `prefect.config.tasks.defaults.max_retries == 4`.
 
 ::: tip Interpolated keys are lowercase
-Environment variables are always interpreted as lowercase configuration keys.
+Environment variables are always interpreted as lowercase configuration keys, _except_ whenever they are specifying local secrets.  For example,
+```
+export PREFECT__LOGGING__LEVEL="INFO"
+export PREFECT__CONTEXT__SECRETS__my_KEY="val"
+```
+will result in two configuration settings: one for `config.logging.level` and one for `config.context.secrets.my_KEY` (note that the casing on the latter is preserved).
 :::
 
 ### Automatic type casting

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -31,6 +31,12 @@ prefect.context.setdefault("secrets", {}) # to make sure context has a secrets a
 prefect.context.secrets["MY_KEY"] = "MY_VALUE"
 ```
 
+or specify the secret via environment variable:
+
+```bash
+export PREFECT__CONTEXT__SECRETS__MY_KEY="MY_VALUE"
+```
+
 ::: tip
 When settings secrets via `.toml` config files, you can use the [TOML Keys](https://github.com/toml-lang/toml#keys) docs for data structure specifications. Running `prefect` commands with invalid `.toml` config files will lead to tracebacks that contain references to: `..../toml/decoder.py`.
 :::

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -222,9 +222,17 @@ def interpolate_config(config: dict, env_var_prefix: str = None) -> Config:
                 value = cast(str, env_var_value.encode().decode("unicode_escape"))
 
                 # place the env var in the flat config as a compound key
-                config_option = collections.CompoundKey(
-                    env_var_option.lower().split("__")
-                )
+                if env_var_option.upper().startswith("CONTEXT"):
+                    formatted_option = env_var_option.split("__")
+                    formatted_option[:-1] = [
+                        val.lower() for val in formatted_option[:-1]
+                    ]
+                    config_option = collections.CompoundKey(formatted_option)
+                else:
+                    config_option = collections.CompoundKey(
+                        env_var_option.lower().split("__")
+                    )
+
                 flat_config[config_option] = string_to_type(
                     cast(str, interpolate_env_vars(value))
                 )

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -222,7 +222,7 @@ def interpolate_config(config: dict, env_var_prefix: str = None) -> Config:
                 value = cast(str, env_var_value.encode().decode("unicode_escape"))
 
                 # place the env var in the flat config as a compound key
-                if env_var_option.upper().startswith("CONTEXT"):
+                if env_var_option.upper().startswith("CONTEXT__SECRETS"):
                     formatted_option = env_var_option.split("__")
                     formatted_option[:-1] = [
                         val.lower() for val in formatted_option[:-1]

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -36,6 +36,12 @@ def test_secret_value_pulled_from_context():
 
 
 def test_secret_value_depends_on_use_local_secrets(monkeypatch):
+    response = {"errors": "Malformed Authorization header"}
+    post = MagicMock(return_value=MagicMock(json=MagicMock(return_value=response)))
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+
     secret = Secret(name="test")
     with set_temporary_config(
         {"cloud.use_local_secrets": False, "cloud.auth_token": None}

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -368,10 +368,11 @@ class TestConfigValidation:
         assert config.SeCtIoN.KeY == 1
         assert config.section.key == 2
 
-    def test_env_vars_for_context_are_not_lower_cased(self, monkeypatch):
+    def test_env_vars_for_secrets_alone_are_not_lower_cased(self, monkeypatch):
 
         monkeypatch.setenv("PREFECT_TEST__CONTEXT__SECRETS__mY_spECIal_kEY", "42")
         monkeypatch.setenv("PREFECT_TEST__CONTEXT__strange_VAlUE", "false")
+        monkeypatch.setenv("PREFECT_TEST__CONTEXT__FLOW_RUN_ID", "12345")
 
         with tempfile.TemporaryDirectory() as test_config_dir:
             test_config_loc = os.path.join(test_config_dir, "test_config.toml")
@@ -394,4 +395,5 @@ class TestConfigValidation:
         assert config.context.secrets.mY_spECIal_kEY == 42
         assert config.context.secrets.KeY == 1
         assert config.context.spECIAL_TOP_key == "foo"
-        assert config.context.strange_VAlUE is False
+        assert config.context.flow_run_id == 12345
+        assert config.context.strange_value is False

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 import uuid
 
@@ -368,6 +369,10 @@ class TestConfigValidation:
         assert config.SeCtIoN.KeY == 1
         assert config.section.key == 2
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows converts env vars to uppercase automatically.",
+    )
     def test_env_vars_for_secrets_alone_are_not_lower_cased(self, monkeypatch):
 
         monkeypatch.setenv("PREFECT_TEST__CONTEXT__SECRETS__mY_spECIal_kEY", "42")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that secrets set through environment variable retain their casing when placed in Context.


## Why is this PR important?
Closes #1601 - using ephemeral environment variables for setting local secrets provides slightly better security than hardcoding them into config, and also feels more natural.  Previously, secret names would also get lower-cased, preventing many system secrets from being set this way (e.g., `SLACK_WEBHOOK_URL`, etc.)

