### PR TITLE
Fix issue with merge task and comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with running local Flow without a schedule containing cached tasks - [#1599](https://github.com/PrefectHQ/prefect/pull/1599)
 - Remove blank string for `task_run_id` in k8s resource manager - [#1604](https://github.com/PrefectHQ/prefect/pull/1604)
+- Fix issue with merge task not working for pandas dataframes and numpy arrays - [#1609](https://github.com/PrefectHQ/prefect/pull/1609)
 
 ### Deprecations
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import prefect
 from prefect import Task
 from prefect.engine import signals
-from prefect.engine.result import NoResult
+from prefect.engine.result import NoResultType
 
 __all__ = ["switch", "ifelse"]
 
@@ -15,7 +15,9 @@ class Merge(Task):
         super().__init__(**kwargs)
 
     def run(self, **task_results: Any) -> Any:
-        return next((v for v in task_results.values() if v != NoResult), None)
+        return next(
+            (v for v in task_results.values() if not isinstance(v, NoResultType)), None
+        )
 
 
 class CompareValue(Task):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR updates the `merge` task to do an `isinstance` check instead of a direct comparison; this allows for the merge task to work with objects that don't have a robust `__bool__` method such as pandas dataframes and numpy arrays.


## Why is this PR important?
We should strive to be agnostic to what types of objects tasks return

