### PR TITLE
Add Optional "Name" to Agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Additional debug logs to `Docker Container` and `Docker Image` tasks - [#920](https://github.com/PrefectHQ/prefect/issues/920)
 - Changes to Fargate agent to support temporary credentials and IAM role based credentials within AWS compute such as a container or ec2 instance. [#1607](https://github.com/PrefectHQ/prefect/pull/1607)
 - Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
+- Agents can accept an optional `name` for logging and debugging - [#1612](https://github.com/PrefectHQ/prefect/pull/1612)
 
 ### Task Library
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from typing import Union
 
@@ -38,11 +37,11 @@ class Agent:
 
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `AGENT_NAME`. Defaults to "agent"
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
     """
 
     def __init__(self, name: str = None) -> None:
-        self.name = name or os.getenv("AGENT_NAME", "agent")
+        self.name = name or config.cloud.agent.get("name", "agent")
 
         token = config.cloud.agent.get("auth_token")
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from typing import Union
 
@@ -34,16 +35,21 @@ class Agent:
 
     In order for this to operate `PREFECT__CLOUD__AGENT__AUTH_TOKEN` must be set as an
     environment variable or in your user configuration file.
+
+    Args:
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `AGENT_NAME`. Defaults to "agent"
     """
 
-    def __init__(self) -> None:
+    def __init__(self, name: str = None) -> None:
+        self.name = name or os.getenv("AGENT_NAME", "agent")
 
         token = config.cloud.agent.get("auth_token")
 
         self.client = Client(api_token=token)
         self._verify_token(token)
 
-        logger = logging.getLogger("agent")
+        logger = logging.getLogger(self.name)
         logger.setLevel(config.cloud.agent.get("level"))
         ch = logging.StreamHandler()
         formatter = logging.Formatter(

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -15,7 +15,7 @@ class FargateAgent(Agent):
 
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `AGENT_NAME`. Defaults to "agent"
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
             `AWS_ACCESS_KEY_ID`.

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -14,6 +14,8 @@ class FargateAgent(Agent):
     Fargate Agent can be found at https://docs.prefect.io/cloud/agent/fargate.html
 
     Args:
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `AGENT_NAME`. Defaults to "agent"
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
             `AWS_ACCESS_KEY_ID`.
@@ -48,6 +50,7 @@ class FargateAgent(Agent):
 
     def __init__(
         self,
+        name: str = None,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: str = None,
@@ -60,7 +63,7 @@ class FargateAgent(Agent):
         task_cpu: str = None,
         task_memory: str = None,
     ) -> None:
-        super().__init__()
+        super().__init__(name=name)
 
         from boto3 import client as boto3_client
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -34,10 +34,14 @@ class KubernetesAgent(Agent):
     run on a k8s cluster or on a local machine where the kube_config is pointing at the
     desired cluster. Information on using the Kubernetes Agent can be found at
     https://docs.prefect.io/cloud/agent/kubernetes.html
+
+    Args:
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `AGENT_NAME`. Defaults to "agent"
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, name: str = None) -> None:
+        super().__init__(name=name)
 
         from kubernetes import client, config
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -37,7 +37,7 @@ class KubernetesAgent(Agent):
 
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `AGENT_NAME`. Defaults to "agent"
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
     """
 
     def __init__(self, name: str = None) -> None:

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -15,6 +15,8 @@ class LocalAgent(Agent):
     Local Agent can be found at https://docs.prefect.io/cloud/agent/local.html
 
     Args:
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `AGENT_NAME`. Defaults to "agent"
         - base_url (str, optional): URL for a Docker daemon server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as
             `tcp://0.0.0.0:2375` can be provided
@@ -22,8 +24,10 @@ class LocalAgent(Agent):
             Defaults to `False` if not provided here or in context.
     """
 
-    def __init__(self, base_url: str = None, no_pull: bool = None) -> None:
-        super().__init__()
+    def __init__(
+        self, name: str = None, base_url: str = None, no_pull: bool = None
+    ) -> None:
+        super().__init__(name=name)
 
         if platform == "win32":
             default_url = "npipe:////./pipe/docker_engine"

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -16,7 +16,7 @@ class LocalAgent(Agent):
 
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `AGENT_NAME`. Defaults to "agent"
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
         - base_url (str, optional): URL for a Docker daemon server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as
             `tcp://0.0.0.0:2375` can be provided

--- a/src/prefect/agent/nomad/agent.py
+++ b/src/prefect/agent/nomad/agent.py
@@ -19,7 +19,7 @@ class NomadAgent(Agent):
 
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `AGENT_NAME`. Defaults to "agent"
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
     """
 
     def __init__(self, name: str = None) -> None:

--- a/src/prefect/agent/nomad/agent.py
+++ b/src/prefect/agent/nomad/agent.py
@@ -16,10 +16,14 @@ class NomadAgent(Agent):
     """
     Agent which deploys flow runs as Nomad jobs to a Nomad cluster based on the
     `NOMAD_HOST` environment variable.
+
+    Args:
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `AGENT_NAME`. Defaults to "agent"
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, name: str = None) -> None:
+        super().__init__(name=name)
 
     def deploy_flows(self, flow_runs: list) -> None:
         """

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -43,27 +43,31 @@ def agent():
 
 
 @agent.command(hidden=True)
-@click.argument("name", default="local")
+@click.argument("agent-option", default="local")
 @click.option(
     "--token", "-t", required=False, help="A Prefect Cloud API token.", hidden=True
 )
 @click.option(
     "--verbose", "-v", is_flag=True, help="Enable verbose agent logs.", hidden=True
 )
+@click.option(
+    "--name", "-n", required=False, help="A name to use for the agent", hidden=True
+)
 @click.option("--no-pull", is_flag=True, help="Pull images flag.", hidden=True)
 @click.option("--base-url", "-b", help="Docker daemon base URL.", hidden=True)
-def start(name, token, verbose, no_pull, base_url):
+def start(agent_option, token, verbose, name, no_pull, base_url):
     """
     Start an agent.
 
     \b
     Arguments:
-        name            TEXT    The name of an agent to start (e.g. `local`, `kubernetes`, `fargate`, `nomad`)
+        agent-option    TEXT    The name of an agent to start (e.g. `local`, `kubernetes`, `fargate`, `nomad`)
                                 Defaults to `local`
 
     \b
     Options:
         --token, -t     TEXT    A Prefect Cloud API token with RUNNER scope
+        --name, -n      TEXT    A name to use for the agent
         --verbose, -v           Enable verbose agent DEBUG logs
                                 Defaults to INFO level logging
 
@@ -79,14 +83,14 @@ def start(name, token, verbose, no_pull, base_url):
             "cloud.agent.level": "INFO" if not verbose else "DEBUG",
         }
     ):
-        retrieved_agent = _agents.get(name, None)
+        retrieved_agent = _agents.get(agent_option, None)
 
         if not retrieved_agent:
-            click.secho("{} is not a valid agent".format(name), fg="red")
+            click.secho("{} is not a valid agent".format(agent_option), fg="red")
             return
 
         with context(no_pull=no_pull, base_url=base_url):
-            from_qualified_name(retrieved_agent)().start()
+            from_qualified_name(retrieved_agent)(name=name).start()
 
 
 @agent.command(hidden=True)

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -51,7 +51,12 @@ def agent():
     "--verbose", "-v", is_flag=True, help="Enable verbose agent logs.", hidden=True
 )
 @click.option(
-    "--name", "-n", required=False, help="A name to use for the agent", hidden=True
+    "--name",
+    "-n",
+    required=False,
+    help="A name to use for the agent",
+    hidden=True,
+    default=None,
 )
 @click.option("--no-pull", is_flag=True, help="Pull images flag.", hidden=True)
 @click.option("--base-url", "-b", help="Docker daemon base URL.", hidden=True)

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -17,6 +17,7 @@ queue_interval = 30.0
     # Agents require different API tokens
     auth_token = ""
     level = "INFO"
+    name = "agent"
 
         [cloud.agent.resource_manager]
         # Separate loop interval for resource managers

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -18,7 +18,27 @@ def test_agent_config_options(runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
         agent = Agent()
         assert agent.client.get_auth_token() == "TEST_TOKEN"
+        assert agent.name == "agent"
         assert agent.logger
+        assert agent.logger.name == "agent"
+
+
+def test_agent_name_set_options(runner_token, monkeypatch):
+    # Default
+    agent = Agent()
+    assert agent.name == "agent"
+    assert agent.logger.name == "agent"
+
+    # Init arg
+    agent = Agent(name="test1")
+    assert agent.name == "test1"
+    assert agent.logger.name == "test1"
+
+    # Environment var
+    monkeypatch.setenv("AGENT_NAME", "test2")
+    agent = Agent()
+    assert agent.name == "test2"
+    assert agent.logger.name == "test2"
 
 
 def test_agent_log_level(runner_token):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -34,11 +34,11 @@ def test_agent_name_set_options(runner_token, monkeypatch):
     assert agent.name == "test1"
     assert agent.logger.name == "test1"
 
-    # Environment var
-    monkeypatch.setenv("AGENT_NAME", "test2")
-    agent = Agent()
-    assert agent.name == "test2"
-    assert agent.logger.name == "test2"
+    # Config
+    with set_temporary_config({"cloud.agent.name": "test2"}):
+        agent = Agent()
+        assert agent.name == "test2"
+        assert agent.logger.name == "test2"
 
 
 def test_agent_log_level(runner_token):

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -27,6 +27,7 @@ def test_ecs_agent_config_options_default(monkeypatch, runner_token):
 
     agent = FargateAgent()
     assert agent
+    assert agent.name == "agent"
     assert agent.cluster == "default"
     assert not agent.subnets
     assert not agent.security_groups
@@ -42,6 +43,7 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
     monkeypatch.setattr("boto3.client", boto3_client)
 
     agent = FargateAgent(
+        name="test",
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="token",
@@ -55,6 +57,7 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
         task_memory="2",
     )
     assert agent
+    assert agent.name == "test"
     assert agent.cluster == "cluster"
     assert agent.subnets == ["subnet"]
     assert agent.security_groups == ["security_group"]

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -22,6 +22,7 @@ def test_k8s_agent_init(monkeypatch, runner_token):
 
     agent = KubernetesAgent()
     assert agent
+    assert agent.name == "agent"
     assert agent.batch_client
 
 
@@ -30,8 +31,9 @@ def test_k8s_agent_config_options(monkeypatch, runner_token):
     monkeypatch.setattr("kubernetes.config", k8s_config)
 
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
-        agent = KubernetesAgent()
+        agent = KubernetesAgent(name="test")
         assert agent
+        assert agent.name == "test"
         assert agent.client.get_auth_token() == "TEST_TOKEN"
         assert agent.logger
         assert agent.batch_client

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -15,6 +15,7 @@ def test_local_agent_init(monkeypatch, runner_token):
 
     agent = LocalAgent()
     assert agent
+    assert agent.name == "agent"
 
 
 def test_local_agent_config_options(monkeypatch, runner_token):
@@ -23,7 +24,8 @@ def test_local_agent_config_options(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.local.agent.platform", "osx")
 
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
-        agent = LocalAgent()
+        agent = LocalAgent(name="test")
+        assert agent.name == "test"
         assert agent.client.get_auth_token() == "TEST_TOKEN"
         assert agent.logger
         assert not agent.no_pull

--- a/tests/agent/test_nomad_agent.py
+++ b/tests/agent/test_nomad_agent.py
@@ -11,12 +11,14 @@ from prefect.utilities.graphql import GraphQLResult
 def test_nomad_agent_init(runner_token):
     agent = NomadAgent()
     assert agent
+    assert agent.name == "agent"
 
 
 def test_nomad_agent_config_options(runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
-        agent = NomadAgent()
+        agent = NomadAgent(name="test")
         assert agent
+        assert agent.name == "test"
         assert agent.client.get_auth_token() == "TEST_TOKEN"
         assert agent.logger
 

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -55,6 +55,18 @@ def test_agent_start_verbose(monkeypatch, runner_token):
     assert result.exit_code == 0
 
 
+def test_agent_start_name(monkeypatch, runner_token):
+    start = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)
+
+    docker_client = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.docker.APIClient", docker_client)
+
+    runner = CliRunner()
+    result = runner.invoke(agent, ["start", "--name", "test_agent"])
+    assert result.exit_code == 0
+
+
 def test_agent_start_local_context_vars(monkeypatch, runner_token):
     start = MagicMock()
     monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1611 
Adds a `name` init arg to agents that can also be set through the `AGENT_NAME` environment variable


## Why is this PR important?
Being able to name agents is a great tiny feature to have for division of work and clarity.

