### PR TITLE
Fargate Agent configuration options enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Additional debug logs to `Docker Container` and `Docker Image` tasks - [#920](https://github.com/PrefectHQ/prefect/issues/920)
 - Changes to Fargate agent to support temporary credentials and IAM role based credentials within AWS compute such as a container or ec2 instance. [#1607](https://github.com/PrefectHQ/prefect/pull/1607)
 - Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
+- Added AWS configuration options for Fargate Agent (task_role_arn, execution_role_arn) - [#1614](https://github.com/PrefectHQ/prefect/pull/1614)
 
 ### Task Library
 

--- a/docs/cloud/agent/fargate.md
+++ b/docs/cloud/agent/fargate.md
@@ -60,7 +60,7 @@ agent = FargateAgent(
         aws_secret_access_key="MY_SECRET",
         aws_session_token="MY_SESSION",
         region_name="MY_REGION",
-        cluser="MY_CLUSTER"
+        cluster="MY_CLUSTER"
         )
 
 agent.start()
@@ -98,10 +98,12 @@ The Fargate Agent allows for a set of AWS configuration options to be set or pro
 - aws_access_key_id (str, optional): AWS access key id for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_ACCESS_KEY_ID`.
 - aws_secret_access_key (str, optional): AWS secret access key for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_SECRET_ACCESS_KEY`.
 - aws_session_token (str, optional): AWS session key for connecting the boto3 client. Defaults to the value set in the environment variable `AWS_SESSION_TOKEN`.
+- task_role_arn (str, optional): AWS Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that grants containers in the task permission to call AWS APIs on your behalf. Defaults to the value set in the environment variable `TASK_ROLE_ARN`.
+- execution_role_arn (str, optional): AWS Amazon Resource Name (ARN) of the task execution role that containers in this task can assume. Defaults to the value set in the environment variable `EXECUTION_ROLE_ARN`.
 - region_name (str, optional): AWS region name for connecting the boto3 client. Defaults to the value set in the environment variable `REGION_NAME`.
 - cluster (str, optional): The Fargate cluster to deploy tasks. Defaults to the value set in the environment variable `CLUSTER`.
-- subnets (list, optional): A list of AWS VPC subnets to use for the tasks that are deployed on Fargate. Defaults to the subnets found which have `MapPublicIpOnLaunch` disabled.
-- security_groups (list, optional): A list of security groups to associate with the deployed tasks. Defaults to the default security group of the VPC.
+- subnets (list, optional): A list of AWS VPC subnets to use for the tasks that are deployed on Fargate. Defaults to the value set in the environment variable `SUBNETS`.
+- security_groups (list, optional): A list of security groups to associate with the deployed tasks. Defaults to the value set in the environment variable `SECURITY_GROUPS`.
 - repository_credentials (str, optional): An Amazon Resource Name (ARN) of the secret containing the private repository credentials. Defaults to the value set in the environment variable `REPOSITORY_CREDENTIALS`.
 - assign_public_ip (str, optional): Whether the task's elastic network interface receives a public IP address. Defaults to the value set in the environment variable `ASSIGN_PUBLIC_IP` or `ENABLED` otherwise.
 - task_cpu (str, optional): The number of cpu units reserved for the container. Defaults to the value set in the environment variable `TASK_CPU` or `256` otherwise.

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -14,7 +14,6 @@ class FargateAgent(Agent):
     Fargate Agent can be found at https://docs.prefect.io/cloud/agent/fargate.html
 
     Args:
-
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
             `AWS_ACCESS_KEY_ID`.
@@ -28,7 +27,7 @@ class FargateAgent(Agent):
             Identity and Access Management (IAM) role that grants containers in the
             task permission to call AWS APIs on your behalf. Defaults to the value set
              in the environment variable `TASK_ROLE_ARN`.
-        - execution_role_arn (str, required): AWS Amazon Resource Name (ARN) of the
+        - execution_role_arn (str, optional): AWS Amazon Resource Name (ARN) of the
             task execution role that containers in this task can assume. Defaults to
              the value set in the environment variable `EXECUTION_ROLE_ARN`.
         - region_name (str, optional): AWS region name for connecting the boto3 client.

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -127,7 +127,7 @@ class FargateAgent(Agent):
         )
 
         # Look for default subnets with `MapPublicIpOnLaunch` disabled
-        if not subnets:
+        if not self.subnets:
             self.logger.debug("No subnets provided, finding defaults")
             ec2 = boto3_client(
                 "ec2",

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -89,10 +89,9 @@ class FargateAgent(Agent):
 
         self.execution_role_arn = execution_role_arn or os.getenv("EXECUTION_ROLE_ARN")
         if not self.execution_role_arn:
-            self.logger.exception(
+            self.logger.warning(
                 "Fargate requires task definition to have execution role ARN to support ECR images"
             )
-            raise Exception("Fargate task execution role required")
         self.logger.debug("Execution role arn {}".format(self.execution_role_arn))
 
         self.cluster = cluster or os.getenv("CLUSTER", "default")
@@ -101,7 +100,7 @@ class FargateAgent(Agent):
         if subnets:
             self.subnets = subnets
         elif os.getenv("SUBNETS"):
-            self.subnets = os.getenv("SUBNETS").split(",")
+            self.subnets = str(os.getenv("SUBNETS")).split(",")
         else:
             self.subnets = []
         self.logger.debug("Subnets {}".format(self.subnets))
@@ -109,7 +108,7 @@ class FargateAgent(Agent):
         if security_groups:
             self.security_groups = security_groups
         elif os.getenv("SECURITY_GROUPS"):
-            self.security_groups = os.getenv("SECURITY_GROUPS").split(",")
+            self.security_groups = str(os.getenv("SECURITY_GROUPS")).split(",")
         else:
             self.security_groups = []
         self.logger.debug("Security groups {}".format(self.security_groups))

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -15,33 +15,24 @@ from botocore.exceptions import ClientError
 def test_ecs_agent_init(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)
-    monkeypatch.setenv("EXECUTION_ROLE_ARN", "execution_role_arn")
 
     agent = FargateAgent()
     assert agent
     assert agent.boto3_client
 
 
-def test_ecs_agent_init_execution_role_arn_not_set(monkeypatch, runner_token):
-    with pytest.raises(Exception):
-        boto3_client = MagicMock()
-        monkeypatch.setattr("boto3.client", boto3_client)
-
-        agent = FargateAgent()
-
-
 def test_ecs_agent_config_options_default(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     assert agent
     assert agent.cluster == "default"
     assert not agent.subnets
     assert not agent.security_groups
     assert not agent.repository_credentials
     assert not agent.task_role_arn
-    assert agent.execution_role_arn == "ecsTaskExecutionRole"
+    assert not agent.execution_role_arn
     assert agent.assign_public_ip == "ENABLED"
     assert agent.task_cpu == "256"
     assert agent.task_memory == "512"
@@ -132,7 +123,7 @@ def test_default_subnets(monkeypatch, runner_token):
     }
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     assert agent.subnets == ["id"]
 
 
@@ -144,7 +135,7 @@ def test_deploy_flows(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -242,7 +233,7 @@ def test_deploy_flows_no_security_group(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -278,7 +269,7 @@ def test_deploy_flows_register_task_definition(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -397,7 +388,7 @@ def test_deploy_flows_register_task_definition_no_repo_credentials(
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
+    agent = FargateAgent()
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -15,22 +15,33 @@ from botocore.exceptions import ClientError
 def test_ecs_agent_init(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)
+    monkeypatch.setenv("EXECUTION_ROLE_ARN", "execution_role_arn")
 
     agent = FargateAgent()
     assert agent
     assert agent.boto3_client
 
 
+def test_ecs_agent_init_execution_role_arn_not_set(monkeypatch, runner_token):
+    with pytest.raises(Exception):
+        boto3_client = MagicMock()
+        monkeypatch.setattr("boto3.client", boto3_client)
+
+        agent = FargateAgent()
+
+
 def test_ecs_agent_config_options_default(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     assert agent
     assert agent.cluster == "default"
     assert not agent.subnets
     assert not agent.security_groups
     assert not agent.repository_credentials
+    assert not agent.task_role_arn
+    assert agent.execution_role_arn == "ecsTaskExecutionRole"
     assert agent.assign_public_ip == "ENABLED"
     assert agent.task_cpu == "256"
     assert agent.task_memory == "512"
@@ -45,6 +56,8 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="token",
+        task_role_arn="task_role_arn",
+        execution_role_arn="execution_role_arn",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],
@@ -55,6 +68,8 @@ def test_ecs_agent_config_options_init(monkeypatch, runner_token):
         task_memory="2",
     )
     assert agent
+    assert agent.task_role_arn == "task_role_arn"
+    assert agent.execution_role_arn == "execution_role_arn"
     assert agent.cluster == "cluster"
     assert agent.subnets == ["subnet"]
     assert agent.security_groups == ["security_group"]
@@ -79,6 +94,8 @@ def test_ecs_agent_config_env_vars(monkeypatch, runner_token):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "token")
+    monkeypatch.setenv("TASK_ROLE_ARN", "task_role_arn")
+    monkeypatch.setenv("EXECUTION_ROLE_ARN", "execution_role_arn")
     monkeypatch.setenv("REGION_NAME", "region")
     monkeypatch.setenv("CLUSTER", "cluster")
     monkeypatch.setenv("REPOSITORY_CREDENTIALS", "repo")
@@ -88,6 +105,8 @@ def test_ecs_agent_config_env_vars(monkeypatch, runner_token):
 
     agent = FargateAgent(subnets=["subnet"])
     assert agent
+    assert agent.execution_role_arn == "execution_role_arn"
+    assert agent.task_role_arn == "task_role_arn"
     assert agent.cluster == "cluster"
     assert agent.repository_credentials == "repo"
     assert agent.assign_public_ip == "DISABLED"
@@ -113,7 +132,7 @@ def test_default_subnets(monkeypatch, runner_token):
     }
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     assert agent.subnets == ["id"]
 
 
@@ -125,7 +144,7 @@ def test_deploy_flows(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -161,6 +180,8 @@ def test_deploy_flows_all_args(monkeypatch, runner_token):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="token",
+        task_role_arn="task_role_arn",
+        execution_role_arn="execution_role_arn",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],
@@ -221,7 +242,7 @@ def test_deploy_flows_no_security_group(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -257,7 +278,7 @@ def test_deploy_flows_register_task_definition(monkeypatch, runner_token):
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(
@@ -297,6 +318,8 @@ def test_deploy_flows_register_task_definition_all_args(monkeypatch, runner_toke
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="token",
+        task_role_arn="task_role_arn",
+        execution_role_arn="execution_role_arn",
         region_name="region",
         cluster="cluster",
         subnets=["subnet"],
@@ -374,7 +397,7 @@ def test_deploy_flows_register_task_definition_no_repo_credentials(
 
     monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
 
-    agent = FargateAgent()
+    agent = FargateAgent(execution_role_arn="ecsTaskExecutionRole")
     agent.deploy_flows(
         flow_runs=[
             GraphQLResult(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x ] adds new tests (if appropriate)
- [x ] updates `CHANGELOG.md` (if appropriate)
- [x ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR makes a few changes to the Fargate Agent. The first change is that it allows subnets and security groups to be set based on environment variables. The second change is that it adds two AWS configuration options to the Fargate Agent: `task_role_arn` and `execution_role_arn`.


## Why is this PR important?
This PR is important because Fargate requires the task definition to have execution role ARN to support ECR images. These configurations are necessary for the IAM role of the agent to be properly set.
