### PR TITLE
Rename EmailTask to GmailTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Breaking Changes
 
 - Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
+- Changed `prefect.tasks.notifications.email_task.EmailTask` to `prefect.tasks.notifications.gmail_task.GmailTask`
 
 ### Contributors
 
-- None
+- [Sherman K](https://github.com/shrmnk)
 
 ## 0.6.6 <Badge text="beta" type="success"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Breaking Changes
 
 - Local Secrets set through environment variable now retain their casing - [#1601](https://github.com/PrefectHQ/prefect/issues/1601)
-- Changed `prefect.tasks.notifications.email_task.EmailTask` to `prefect.tasks.notifications.gmail_task.GmailTask`
+- Changed `prefect.tasks.notifications.email_task.EmailTask` to `prefect.tasks.notifications.gmail_task.GmailTask` - [#1616](https://github.com/PrefectHQ/prefect/pull/1616)
 
 ### Contributors
 

--- a/docs/core/task_library/notifications.md
+++ b/docs/core/task_library/notifications.md
@@ -1,7 +1,7 @@
 # Notifications
 
-## EmailTask <Badge text="task"/>
+## GmailTask <Badge text="task"/>
 
 Task for sending email from an authenticated Gmail address.  For this task to function properly, you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect Secrets set.  It is recommended you use a [Google App Password](https://support.google.com/accounts/answer/185833) for this purpose.
 
-[API Reference](/api/unreleased/tasks/notifications.html#prefect-tasks-notifications-email-task-emailtask)
+[API Reference](/api/unreleased/tasks/notifications.html#prefect-tasks-notifications-gmail-task-gmailtask)

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -284,7 +284,7 @@ classes = [
 [pages.tasks.notifications]
 title = "Notification Tasks"
 module = "prefect.tasks.notifications"
-classes = ["EmailTask", "SlackTask"]
+classes = ["GmailTask", "SlackTask"]
 
 [pages.tasks.postgres]
 title = "Postgres Tasks"

--- a/src/prefect/tasks/notifications/__init__.py
+++ b/src/prefect/tasks/notifications/__init__.py
@@ -3,5 +3,5 @@ Collection of tasks for sending notifications.
 
 Useful for situations in which state handlers are inappropriate.
 """
-from prefect.tasks.notifications.email_task import EmailTask
+from prefect.tasks.notifications.gmail_task import GmailTask
 from prefect.tasks.notifications.slack_task import SlackTask

--- a/src/prefect/tasks/notifications/gmail_task.py
+++ b/src/prefect/tasks/notifications/gmail_task.py
@@ -9,7 +9,7 @@ from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
 
 
-class EmailTask(Task):
+class GmailTask(Task):
     """
     Task for sending email from an authenticated Gmail address.  For this task to function properly,
     you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect Secrets set.  It is recommended

--- a/tests/tasks/notifications/test_gmail_task.py
+++ b/tests/tasks/notifications/test_gmail_task.py
@@ -3,25 +3,25 @@ from unittest.mock import MagicMock
 import pytest
 
 from prefect import context
-from prefect.tasks.notifications import EmailTask
+from prefect.tasks.notifications import GmailTask
 from prefect.utilities.configuration import set_temporary_config
 
 
 class TestInitialization:
     def test_inits_with_no_args(self):
-        t = EmailTask()
+        t = GmailTask()
         assert t
 
     def test_kwargs_get_passed_to_task_init(self):
-        t = EmailTask(name="bob", checkpoint=True, tags=["foo"])
+        t = GmailTask(name="bob", checkpoint=True, tags=["foo"])
         assert t.name == "bob"
         assert t.checkpoint is True
         assert t.tags == {"foo"}
 
     def test_username_password_pulled_from_secrets(self, monkeypatch):
         smtp = MagicMock()
-        monkeypatch.setattr("prefect.tasks.notifications.email_task.smtplib", smtp)
-        t = EmailTask(msg="")
+        monkeypatch.setattr("prefect.tasks.notifications.gmail_task.smtplib", smtp)
+        t = GmailTask(msg="")
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with context({"secrets": dict(EMAIL_USERNAME="foo", EMAIL_PASSWORD="bar")}):
                 res = t.run()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Changed `prefect.tasks.notifications.email_task.EmailTask` to `prefect.tasks.notifications.gmail_task.GmailTask`

## Why is this PR important?

The Email Task that is provided is locked to the gmail SMTP server with no parameter to change it. Thus, its name "Email Task" is misleading. This PR renames that task to Gmail Task instead.

A separate PR will come later with a more generic EmailTask providing SMTP server as a parameter.

