### PR TITLE
Add the ability to delete task tag limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,12 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Agents can accept an optional `name` for logging and debugging - [#1612](https://github.com/PrefectHQ/prefect/pull/1612)
 - Added AWS configuration options for Fargate Agent (task_role_arn, execution_role_arn) - [#1614](https://github.com/PrefectHQ/prefect/pull/1614)
 - Change EmailTask to accept SMTP server settings as well as an email_from kwarg - [#1619](https://github.com/PrefectHQ/prefect/pull/1619)
+- Add the ability to delete task tag limits using the client - [#1622](https://github.com/PrefectHQ/prefect/pull/1622)
 
 ### Task Library
 
 - Add `return_all` kwarg to `ShellTask` for optionally returning all lines of stdout - [#1598](https://github.com/PrefectHQ/prefect/pull/1598)
-- Add `CosmosDBCreateItem`, `CosmosDBReadItems`, `CosmosDBQueryItems` and  for interacting with data stored on Azure Cosmos DB - [#1617](https://github.com/PrefectHQ/prefect/pull/1617)
+- Add `CosmosDBCreateItem`, `CosmosDBReadItems`, `CosmosDBQueryItems` and for interacting with data stored on Azure Cosmos DB - [#1617](https://github.com/PrefectHQ/prefect/pull/1617)
 
 ### Fixes
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1022,7 +1022,7 @@ class Client:
         Deletes a given task tag concurrency limit; requires tenant admin permissions.
 
         Args:
-            - limit (str): the ID of the tag to delete
+            - limit_id (str): the ID of the tag to delete
 
         Raises:
             - ClientError: if the GraphQL mutation is bad for any reason

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1017,6 +1017,30 @@ class Client:
         if not result.data.updateTaskTagLimit.id:
             raise ValueError("Updating the task tag concurrency limit failed.")
 
+    def delete_task_tag_limit(self, limit_id: str) -> None:
+        """
+        Deletes a given task tag concurrency limit; requires tenant admin permissions.
+
+        Args:
+            - limit (str): the ID of the tag to delete
+
+        Raises:
+            - ClientError: if the GraphQL mutation is bad for any reason
+            - ValueError: if the tag deletion was unsuccessful, or if a bad tag ID was provided
+        """
+        mutation = {
+            "mutation($input: deleteTaskTagLimitInput!)": {
+                "deleteTaskTagLimit(input: $input)": {"success"}
+            }
+        }
+
+        result = self.graphql(
+            mutation, variables=dict(input=dict(limitId=limit_id))
+        )  # type: Any
+
+        if not result.data.deleteTaskTagLimit.success:
+            raise ValueError("Deleting the task tag concurrency limit failed.")
+
     def write_run_log(
         self,
         flow_run_id: str,


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR adds the `delete_task_tag_limit` method to the client. 

## Why is this PR important?

As it stands, we have methods to get and update task tag limits via the client, but not to delete them. It's a bit add to make users use GraphQL for this one case in particular, so adding the method to the client streamlines UX. 
