### PR TITLE
Default fargate ARNs to empty string and relax logger warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix defaults for unspecified ARNs in the Fargate Agent - [#1634](https://github.com/PrefectHQ/prefect/pull/1634)
 
 ### Deprecations
 

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -86,14 +86,12 @@ class FargateAgent(Agent):
         region_name = region_name or os.getenv("REGION_NAME")
 
         # Agent task config
-        self.task_role_arn = task_role_arn or os.getenv("TASK_ROLE_ARN")
+        self.task_role_arn = task_role_arn or os.getenv("TASK_ROLE_ARN", "")
         self.logger.debug("Task role arn {}".format(self.task_role_arn))
 
-        self.execution_role_arn = execution_role_arn or os.getenv("EXECUTION_ROLE_ARN")
-        if not self.execution_role_arn:
-            self.logger.warning(
-                "Fargate requires task definition to have execution role ARN to support ECR images"
-            )
+        self.execution_role_arn = execution_role_arn or os.getenv(
+            "EXECUTION_ROLE_ARN", ""
+        )
         self.logger.debug("Execution role arn {}".format(self.execution_role_arn))
 
         self.cluster = cluster or os.getenv("CLUSTER", "default")

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -32,8 +32,8 @@ def test_ecs_agent_config_options_default(monkeypatch, runner_token):
     assert not agent.subnets
     assert not agent.security_groups
     assert not agent.repository_credentials
-    assert not agent.task_role_arn
-    assert not agent.execution_role_arn
+    assert agent.task_role_arn == ""
+    assert agent.execution_role_arn == ""
     assert agent.assign_public_ip == "ENABLED"
     assert agent.task_cpu == "256"
     assert agent.task_memory == "512"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updates the fargate agent to handle non-specified ARNs and relaxes the logger warning if not specified
Closes #1625 
Closes #1624 

## Why is this PR important?
UX

