### PR TITLE
Update marshmallow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ croniter >= 0.3.24, <1.0
 dask[bag] >=0.19.3, <3.0
 distributed >= 1.26.1, < 3.0
 docker >=3.4.1, <5.0
-marshmallow >= 3.0.0b19, < 3.1.0
+marshmallow >= 3.0.0b19, <= 3.2.1
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
 mypy_extensions >= 0.4.0, <1.0
 pendulum >= 2.0.4, < 3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,9 @@ ignore_errors = True
 [mypy-prefect.cli.*]
 ignore_errors = True
 
-[mypy-prefect.engine.cloud_handler] # going away soon anyway
+# marshmallow's typing sometimes fails mypy so
+# it's just not worth it
+[mypy-prefect.*.serialization.*]
 ignore_errors = True
 
 [mypy-prefect.tasks.*]


### PR DESCRIPTION
Supersedes #1543 and closes https://github.com/PrefectHQ/prefect/issues/1517

Ignores serialization files when type checking because marshmallow itself doesn't appear to pass `mypy` and it's just not worth trying to manage that.