### PR TITLE
Attempt to parse cloud secrets as JSON first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix defaults for unspecified ARNs in the Fargate Agent - [#1634](https://github.com/PrefectHQ/prefect/pull/1634)
 - Fix ShellTask return value on empty stdout - [#1632](https://github.com/PrefectHQ/prefect/pull/1632)
+- Fix issue with some Cloud Secrets not being converted from strings - [#1655](https://github.com/PrefectHQ/prefect/pull/1655)
 
 ### Deprecations
 

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -116,4 +116,8 @@ class Secret:
             # the result object is a Box, so we recursively restore builtin
             # dict/list classes
             result_dict = result.to_dict()
-            return result_dict["data"]["secretValue"]
+            value = result_dict["data"]["secretValue"]
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return value

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -52,7 +52,7 @@ def test_secret_value_depends_on_use_local_secrets(monkeypatch):
 
 
 def test_secrets_use_client(monkeypatch):
-    response = {"data": {"secretValue": "1234"}}
+    response = {"data": {"secretValue": '"1234"'}}
     post = MagicMock(return_value=MagicMock(json=MagicMock(return_value=response)))
     session = MagicMock()
     session.return_value.post = post
@@ -82,6 +82,21 @@ def test_cloud_secrets_remain_plain_dictionaries(monkeypatch):
     assert isinstance(val2, list) and not isinstance(val2, box.BoxList)
     val3 = val["b"][2]
     assert isinstance(val3, dict) and not isinstance(val3, box.Box)
+
+
+def test_cloud_secrets_auto_load_json_strings(monkeypatch):
+    response = {"data": {"secretValue": '{"x": 42}'}}
+    post = MagicMock(return_value=MagicMock(json=MagicMock(return_value=response)))
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+    with set_temporary_config(
+        {"cloud.auth_token": "secret_token", "cloud.use_local_secrets": False}
+    ):
+        my_secret = Secret(name="the-key")
+        val = my_secret.get()
+
+    assert isinstance(val, dict)
 
 
 def test_local_secrets_auto_load_json_strings():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes an issue we've seen where secrets set from e.g., the UI are sometimes preserved as strings when they should be interpreted as JSON documents.


## Why is this PR important?
Makes the full life cycle of secrets more polished.

