### PR TITLE
Agent log fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix defaults for unspecified ARNs in the Fargate Agent - [#1634](https://github.com/PrefectHQ/prefect/pull/1634)
 - Fix ShellTask return value on empty stdout - [#1632](https://github.com/PrefectHQ/prefect/pull/1632)
 - Fix issue with some Cloud Secrets not being converted from strings - [#1655](https://github.com/PrefectHQ/prefect/pull/1655)
+- Fix issue with Agent logging config setting not working - [#1657](https://github.com/PrefectHQ/prefect/pull/1657)
 
 ### Deprecations
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -91,12 +91,11 @@ def start(agent_option, token, name, verbose, label, no_pull, base_url):
         --no-pull               Pull images for a LocalAgent
                                 Defaults to pulling if not provided
     """
-    with set_temporary_config(
-        {
-            "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
-            "cloud.agent.level": "INFO" if not verbose else "DEBUG",
-        }
-    ):
+    tmp_config = {"cloud.agent.auth_token": token or config.cloud.agent.auth_token}
+    if verbose:
+        tmp_config["cloud.agent.level"] = "DEBUG"
+
+    with set_temporary_config(tmp_config):
         retrieved_agent = _agents.get(agent_option, None)
 
         if not retrieved_agent:

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -48,6 +48,14 @@ def test_agent_log_level(runner_token):
         assert agent.logger.level == 20
 
 
+def test_agent_log_level_responds_to_config(runner_token):
+    with set_temporary_config(
+        {"cloud.agent.auth_token": "TEST_TOKEN", "cloud.agent.level": "DEBUG"}
+    ):
+        agent = Agent()
+        assert agent.logger.level == 10
+
+
 def test_agent_labels(runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
         agent = Agent(labels=["test", "2"])


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Ensures that agent configuration settings are respected regardless of whether `--verbose` was passed or not


## Why is this PR important?
Env vars can be easier than CLI flags

