### PR TITLE
Add default 30s timeout to client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Adds an "Ask for help" button with a link to the prefect.io support page - [#1637](https://github.com/PrefectHQ/prefect/pull/1637)
 - Reduces the size of the `prefecthq/prefect` Docker image by ~400MB, which is now the base Docker image used in Flows - [#1648](https://github.com/PrefectHQ/prefect/pull/1648)
 - Add a new healthcheck for environment dependencies - [#1653](https://github.com/PrefectHQ/prefect/pull/1653)
+- Add default 30 second timeout to Client requests - [#1672](https://github.com/PrefectHQ/prefect/pull/1672)
 
 ### Task Library
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -275,11 +275,11 @@ class Client:
         )
         session.mount("https://", HTTPAdapter(max_retries=retries))
         if method == "GET":
-            response = session.get(url, headers=headers, params=params)
+            response = session.get(url, headers=headers, params=params, timeout=30)
         elif method == "POST":
-            response = session.post(url, headers=headers, json=params)
+            response = session.post(url, headers=headers, json=params, timeout=30)
         elif method == "DELETE":
-            response = session.delete(url, headers=headers)
+            response = session.delete(url, headers=headers, timeout=30)
         else:
             raise ValueError("Invalid method: {}".format(method))
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updates the Client requests to have a default timeout of 30 seconds


## Why is this PR important?
Without providing a timeout it has the potential to hang indefinitely 

