### PR TITLE
Add support for directly-passing secrets to task library tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Task Library
 
 - Add new Secret Tasks for a pluggable and reusable Secrets API - [#1346](https://github.com/PrefectHQ/prefect/issues/1346), [#1587](https://github.com/PrefectHQ/prefect/issues/1587)
+- Add support for directly passing credentials to task library tasks, instead of passing secret names - [#1667](https://github.com/PrefectHQ/prefect/pull/1673)
 
 ### Fixes
 
@@ -31,12 +32,13 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Deprecations
 
-- None
+- Tasks that accepted the name of a secret (often `credentials_secret`) will raise a deprecation warning - [#1667](https://github.com/PrefectHQ/prefect/pull/1673)
 
 ### Breaking Changes
 
 - Fargate Agent now takes in all boto3 camel case arguments instead of specific snake case options - [#1649](https://github.com/PrefectHQ/prefect/pull/1649)
 - `kubernetes` is no longer installed by default in deployed flow images - [#1653](https://github.com/PrefectHQ/prefect/pull/1653)
+- Tasks that accepted the name of a secret (often `credentials_secret`) no longer have a default value for that argument, as it has been deprecated - [#1667](https://github.com/PrefectHQ/prefect/pull/1673)
 
 ### Contributors
 

--- a/docs/core/task_library/google.md
+++ b/docs/core/task_library/google.md
@@ -6,9 +6,6 @@ title: GCP
 
 Tasks that interface with various components of Google Cloud Platform.
 
-Tasks in this collection require a Prefect Secret called `"GOOGLE_APPLICATION_CREDENTIALS"` that contains
-valid Google Credentials in a JSON document.
-
 ## Google Cloud Storage
 
 ### GCSDownload <Badge text="task"/>

--- a/src/prefect/tasks/airtable/__init__.py
+++ b/src/prefect/tasks/airtable/__init__.py
@@ -1,7 +1,5 @@
 """
 A collection of tasks for interacting with Airtable.
-
-The default Airtable credential secret name is `"AIRTABLE_API_KEY"`
 """
 try:
     from prefect.tasks.airtable.airtable import WriteAirtableRow

--- a/src/prefect/tasks/dropbox/__init__.py
+++ b/src/prefect/tasks/dropbox/__init__.py
@@ -1,8 +1,5 @@
 """
 Tasks that interface with Dropbox.
-
-Tasks in this collection require a Prefect Secret called `"DROPBOX_ACCESS_TOKEN"` that contains
-a valid Dropbox access token.
 """
 try:
     from prefect.tasks.dropbox.dropbox import DropboxDownload

--- a/src/prefect/tasks/dropbox/dropbox.py
+++ b/src/prefect/tasks/dropbox/dropbox.py
@@ -1,3 +1,5 @@
+import warnings
+
 import dropbox
 
 from prefect.client import Secret
@@ -12,25 +14,31 @@ class DropboxDownload(Task):
 
     Args:
         - path (str, optional): the path to the file to download. May be provided at runtime.
-        - access_token_secret (str, optional): the name of the Prefect Secret containing a
-            Dropbox access token; defaults to `"DROPBOX_ACCESS_TOKEN"`
+        - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing a
+            Dropbox access token
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
     def __init__(self, path: str = None, access_token_secret: str = None, **kwargs):
         self.path = path
-        self.access_token_secret = access_token_secret or "DROPBOX_ACCESS_TOKEN"
+        self.access_token_secret = access_token_secret
         super().__init__(**kwargs)
 
     @defaults_from_attrs("path", "access_token_secret")
-    def run(self, path: str = None, access_token_secret: str = None) -> bytes:
+    def run(
+        self,
+        path: str = None,
+        access_token: str = None,
+        access_token_secret: str = None,
+    ) -> bytes:
         """
         Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
 
         Args:
             - path (str, optional): the path to the file to download
-            - access_token_secret (str, optional): the name of the Prefect Secret containing a
-                Dropbox access token; defaults to `"DROPBOX_ACCESS_TOKEN"`
+            - access_token (str): a Dropbox access token, provided with a Prefect secret.
+            - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing a
+                Dropbox access token
 
         Raises:
             - ValueError: if the `path` is `None`
@@ -42,7 +50,13 @@ class DropboxDownload(Task):
         if path is None:
             raise ValueError("No path provided.")
 
-        access_token = Secret(access_token_secret).get()
+        if access_token_secret is not None:
+            warnings.warn(
+                "The `access_token_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the credentials value at runtime instead.",
+                UserWarning,
+            )
+            access_token = Secret(access_token_secret).get()
         dbx = dropbox.Dropbox(access_token)
         response = dbx.files_download(path)[1]
         return response.content

--- a/src/prefect/tasks/github/__init__.py
+++ b/src/prefect/tasks/github/__init__.py
@@ -1,8 +1,5 @@
 """
 A collection of tasks for interacting with GitHub.
-
-Note that the tasks in this collection require a Prefect Secret called `"GITHUB_ACCESS_TOKEN"`
-containing a valid GitHub Access Token.
 """
 
 from .issues import OpenGitHubIssue

--- a/src/prefect/tasks/google/__init__.py
+++ b/src/prefect/tasks/google/__init__.py
@@ -1,9 +1,6 @@
 """
 Tasks that interface with various components of Google Cloud Platform.
 
-Tasks in this collection require a Prefect Secret called `"GOOGLE_APPLICATION_CREDENTIALS"` that contains
-valid Google Credentials in a JSON document.
-
 Note that these tasks allow for a wide range of custom usage patterns, such as:
 
 - Initialize a task with all settings for one time use

--- a/src/prefect/tasks/google/storage.py
+++ b/src/prefect/tasks/google/storage.py
@@ -57,10 +57,9 @@ class GCSBaseTask(Task):
             creds = Secret(credentials_secret).get()
             credentials = Credentials.from_service_account_info(creds)
             project = project or credentials.project_id
-        else:
-            project = project or credentials.get("project")
 
         if credentials is not None:
+            project = project or credentials.get("project")
             client = storage.Client(project=project, credentials=credentials)
         else:
             client = storage.Client(project=project)

--- a/src/prefect/tasks/google/storage.py
+++ b/src/prefect/tasks/google/storage.py
@@ -1,4 +1,5 @@
 import uuid
+import warnings
 
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
@@ -13,7 +14,7 @@ from prefect.utilities.tasks import defaults_from_attrs
 class GCSBaseTask(Task):
     def __init__(
         self,
-        bucket: str,
+        bucket: str = None,
         blob: str = None,
         project: str = None,
         credentials_secret: str = None,
@@ -25,19 +26,44 @@ class GCSBaseTask(Task):
         self.blob = blob
         self.project = project
         self.create_bucket = create_bucket
-        if credentials_secret is None:
-            self.credentials_secret = "GOOGLE_APPLICATION_CREDENTIALS"
-        else:
-            self.credentials_secret = credentials_secret
+        if credentials_secret is not None:
+            warnings.warn(
+                "The `credentials_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the credentials value at runtime instead.",
+                UserWarning,
+            )
+        self.credentials_secret = credentials_secret
+        if encryption_key_secret is not None:
+            warnings.warn(
+                "The `encryption_key_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the key value at runtime instead.",
+                UserWarning,
+            )
         self.encryption_key_secret = encryption_key_secret
         super().__init__(**kwargs)
 
-    def _load_client(self, project: str, credentials_secret: str):
-        "Creates and returns a GCS Client instance"
-        creds = Secret(credentials_secret).get()
-        credentials = Credentials.from_service_account_info(creds)
-        project = project or credentials.project_id
-        client = storage.Client(project=project, credentials=credentials)
+    def _get_client(
+        self, project: str, credentials: dict, credentials_secret: str = None
+    ):
+        """
+        Creates and returns a GCS Client instance
+        """
+        if credentials_secret is not None:
+            warnings.warn(
+                "The `credentials_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the credentials value at runtime instead.",
+                UserWarning,
+            )
+            creds = Secret(credentials_secret).get()
+            credentials = Credentials.from_service_account_info(creds)
+            project = project or credentials.project_id
+        else:
+            project = project or credentials.get("project")
+
+        if credentials is not None:
+            client = storage.Client(project=project, credentials=credentials)
+        else:
+            client = storage.Client(project=project)
         return client
 
     def _retrieve_bucket(self, client, bucket: str, create_bucket: bool):
@@ -52,16 +78,25 @@ class GCSBaseTask(Task):
                 raise exc
         return bucket
 
-    def _get_blob(self, bucket: str, blob: str, encryption_key_secret: str):
+    def _get_blob(
+        self,
+        bucket: str,
+        blob: str,
+        encryption_key: str = None,
+        encryption_key_secret: str = None,
+    ):
         "Retrieves blob based on user settings."
         if blob is None:
             blob = "prefect-" + context.get("task_run_id", "no-id-" + str(uuid.uuid4()))
 
         ## pull encryption_key if requested
         if encryption_key_secret is not None:
+            warnings.warn(
+                "The `encryption_key_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the credentials value at runtime instead.",
+                UserWarning,
+            )
             encryption_key = Secret(encryption_key_secret).get()
-        else:
-            encryption_key = None
 
         return bucket.blob(blob, encryption_key=encryption_key)
 
@@ -75,10 +110,9 @@ class GCSDownload(GCSBaseTask):
         - blob (str, optional): default blob name to download.
         - project (str, optional): default Google Cloud project to work within.
             If not provided, will be inferred from your Google Cloud credentials
-        - credentials_secret (str, optional): the name of the Prefect Secret
+        - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             which stores a JSON representation of your Google Cloud credentials.
-            Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
-        - encryption_key_secret (str, optional): the name of the Prefect Secret
+        - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             storing an optional `encryption_key` to be used when downloading the Blob
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
 
@@ -113,6 +147,8 @@ class GCSDownload(GCSBaseTask):
         bucket: str = None,
         blob: str = None,
         project: str = None,
+        credentials: dict = None,
+        encryption_key: str = None,
         credentials_secret: str = None,
         encryption_key_secret: str = None,
     ) -> str:
@@ -128,10 +164,12 @@ class GCSDownload(GCSBaseTask):
             - blob (str, optional): blob name to download from
             - project (str, optional): Google Cloud project to work within.
                 If not provided here or at initialization, will be inferred from your Google Cloud credentials
-            - credentials_secret (str, optional): the name of the Prefect Secret
+            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
+                You should provide these at runtime with an upstream Secret task.
+            - encryption_key (str, optional): an encryption key
+            - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
                 that stores a JSON represenation of your Google Cloud credentials
-                `GOOGLE_APPLICATION_CREDENTIALS` will be used.
-            - encryption_key_secret (str, optional): the name of the Prefect Secret
+            - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
                 storing an optional `encryption_key` to be used when uploading the Blob
 
         Returns:
@@ -144,7 +182,9 @@ class GCSDownload(GCSBaseTask):
 
         """
         ## create client
-        client = self._load_client(project, credentials_secret)
+        client = self._get_client(
+            project, credentials=credentials, credentials_secret=credentials_secret
+        )
 
         ## retrieve bucket
         bucket = self._retrieve_bucket(
@@ -152,7 +192,12 @@ class GCSDownload(GCSBaseTask):
         )
 
         ## identify blob name
-        gcs_blob = self._get_blob(bucket, blob, encryption_key_secret)
+        gcs_blob = self._get_blob(
+            bucket,
+            blob,
+            encryption_key=encryption_key,
+            encryption_key_secret=encryption_key_secret,
+        )
         data = gcs_blob.download_as_string()
         return data
 
@@ -168,12 +213,11 @@ class GCSUpload(GCSBaseTask):
             beginning with `prefect-` and containing the Task Run ID will be used
         - project (str, optional): default Google Cloud project to work within.
             If not provided, will be inferred from your Google Cloud credentials
-        - credentials_secret (str, optional): the name of the Prefect Secret
+        - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             which stores a JSON represenation of your Google Cloud credentials.
-            Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
         - create_bucket (bool, optional): boolean specifying whether to create the bucket if it does not exist,
             otherwise an Exception is raised. Defaults to `False`.
-        - encryption_key_secret (str, optional): the name of the Prefect Secret
+        - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             storing an optional `encryption_key` to be used when uploading the Blob
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
 
@@ -217,6 +261,8 @@ class GCSUpload(GCSBaseTask):
         bucket: str = None,
         blob: str = None,
         project: str = None,
+        credentials: dict = None,
+        encryption_key: str = None,
         credentials_secret: str = None,
         create_bucket: bool = False,
         encryption_key_secret: str = None,
@@ -235,12 +281,14 @@ class GCSUpload(GCSBaseTask):
                 a string beginning with `prefect-` and containing the Task Run ID will be used
             - project (str, optional): Google Cloud project to work within. Can be inferred
                 from credentials if not provided.
-            - credentials_secret (str, optional): the name of the Prefect Secret
-                which stores a JSON represenation of your Google Cloud credentials.
-                Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
+            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
+                You should provide these at runtime with an upstream Secret task.
+            - encryption_key (str, optional): an encryption key
+            - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
+                that stores a JSON represenation of your Google Cloud credentials
             - create_bucket (bool, optional): boolean specifying whether to create the bucket
                 if it does not exist, otherwise an Exception is raised. Defaults to `False`.
-            - encryption_key_secret (str, optional): the name of the Prefect Secret
+            - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
                 storing an optional `encryption_key` to be used when uploading the Blob.
 
         Raises:
@@ -250,7 +298,9 @@ class GCSUpload(GCSBaseTask):
             - str: the blob name that now stores the provided data
         """
         ## create client
-        client = self._load_client(project, credentials_secret)
+        client = self._get_client(
+            project, credentials=credentials, credentials_secret=credentials_secret
+        )
 
         ## retrieve bucket
         bucket = self._retrieve_bucket(
@@ -258,12 +308,17 @@ class GCSUpload(GCSBaseTask):
         )
 
         ## identify blob name
-        gcs_blob = self._get_blob(bucket, blob, encryption_key_secret)
+        gcs_blob = self._get_blob(
+            bucket,
+            blob,
+            encryption_key=encryption_key,
+            encryption_key_secret=encryption_key_secret,
+        )
         gcs_blob.upload_from_string(data)
         return gcs_blob.name
 
 
-class GCSCopy(Task):
+class GCSCopy(GCSBaseTask):
     """
     Task template for copying data from one Google Cloud Storage bucket to another, without
     downloading it locally.
@@ -278,9 +333,8 @@ class GCSCopy(Task):
         - dest_blob (str, optional): default destination blob name.
         - project (str, optional): default Google Cloud project to work within.
             If not provided, will be inferred from your Google Cloud credentials
-        - credentials_secret (str, optional): the name of the Prefect Secret
+        - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             which stores a JSON representation of your Google Cloud credentials.
-            Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
 
@@ -303,13 +357,10 @@ class GCSCopy(Task):
         self.source_blob = source_blob
         self.dest_bucket = dest_bucket
         self.dest_blob = dest_blob
-        self.project = project
-        if credentials_secret is None:
-            self.credentials_secret = "GOOGLE_APPLICATION_CREDENTIALS"
-        else:
-            self.credentials_secret = credentials_secret
 
-        super().__init__(**kwargs)
+        super().__init__(
+            project=project, credentials_secret=credentials_secret, **kwargs
+        )
 
     @defaults_from_attrs(
         "source_bucket",
@@ -326,6 +377,7 @@ class GCSCopy(Task):
         dest_bucket: str = None,
         dest_blob: str = None,
         project: str = None,
+        credentials: dict = None,
         credentials_secret: str = None,
     ) -> str:
         """
@@ -342,9 +394,10 @@ class GCSCopy(Task):
             - dest_blob (str, optional): default destination blob name.
             - project (str, optional): default Google Cloud project to work within.
                 If not provided, will be inferred from your Google Cloud credentials
-            - credentials_secret (str, optional): the name of the Prefect Secret
-                which stores a JSON representation of your Google Cloud credentials.
-                Defaults to `GOOGLE_APPLICATION_CREDENTIALS`.
+            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
+                You should provide these at runtime with an upstream Secret task.
+            - credentials_secret (str, optional, DEPRECATED): the name of the Prefect Secret
+                that stores a JSON represenation of your Google Cloud credentials
 
         Returns:
             - str: the name of the destination blob
@@ -360,10 +413,11 @@ class GCSCopy(Task):
             raise ValueError("Source and destination are identical.")
 
         ## create client
-        creds = Secret(credentials_secret).get()
-        credentials = Credentials.from_service_account_info(creds)
-        project = project or credentials.project_id
-        client = storage.Client(project=project, credentials=credentials)
+        client = self._get_client(
+            project=project,
+            credentials=credentials,
+            credentials_secret=credentials_secret,
+        )
 
         # get source bucket and blob
         source_bucket_obj = client.get_bucket(source_bucket)

--- a/src/prefect/tasks/twitter/__init__.py
+++ b/src/prefect/tasks/twitter/__init__.py
@@ -1,7 +1,5 @@
 """
 Tasks for interacting with Twitter.
-
-The default Twitter credential secret name is `"TWITTER_API_CREDENTIALS"`, and should be a JSON document with four keys: `"api_key"`, `"api_secret"`, `"access_token"`, and `"access_token_secret"`
 """
 try:
     from prefect.tasks.twitter.twitter import LoadTweetReplies

--- a/src/prefect/tasks/twitter/twitter.py
+++ b/src/prefect/tasks/twitter/twitter.py
@@ -1,12 +1,11 @@
 from typing import Any
+import warnings
 
 import tweepy
 
 from prefect.client import Secret
 from prefect.core import Task
 from prefect.utilities.tasks import defaults_from_attrs
-
-DEFAULT_CREDENTIALS_SECRET = "TWITTER_API_CREDENTIALS"
 
 
 class LoadTweetReplies(Task):
@@ -34,7 +33,7 @@ class LoadTweetReplies(Task):
         self,
         user: str = None,
         tweet_id: str = None,
-        credentials_secret: str = DEFAULT_CREDENTIALS_SECRET,
+        credentials_secret: str = None,
         **kwargs: Any
     ):
         self.user = user
@@ -44,18 +43,31 @@ class LoadTweetReplies(Task):
 
     @defaults_from_attrs("user", "tweet_id", "credentials_secret")
     def run(
-        self, user: str = None, tweet_id: str = None, credentials_secret: str = None
+        self,
+        user: str = None,
+        tweet_id: str = None,
+        credentials: dict = None,
+        credentials_secret: str = None,
     ) -> list:
         """
         Args:
             - user (str): a Twitter user
             - tweet_id (str): a tweet ID; replies to this tweet will be retrieved
-            - credentials_secret (str): the name of a secret that contains Twitter API credentials.
+            - credentials(dict): a JSON document with four keys:
+                "api_key", "api_secret", "access_token", and "access_token_secret".
+            - credentials_secret (str, DEPRECATED): the name of a secret that contains Twitter API credentials.
                 The secret must be formatted as a JSON document with four keys:
                 "api_key", "api_secret", "access_token", and "access_token_secret"
         """
         # auth
-        credentials = Secret(credentials_secret).get()
+        if credentials_secret is not None:
+            warnings.warn(
+                "The `credentials_secret` argument is deprecated. Use a `Secret` task "
+                "to pass the credentials value at runtime instead.",
+                UserWarning,
+            )
+            credentials = Secret(credentials_secret).get()
+
         auth = tweepy.OAuthHandler(credentials["api_key"], credentials["api_secret"])
         auth.set_access_token(
             credentials["access_token"], credentials["access_token_secret"]

--- a/src/prefect/tasks/twitter/twitter.py
+++ b/src/prefect/tasks/twitter/twitter.py
@@ -68,6 +68,9 @@ class LoadTweetReplies(Task):
             )
             credentials = Secret(credentials_secret).get()
 
+        if credentials is None:
+            raise ValueError("Credentials dictionary wasn't provided.")
+
         auth = tweepy.OAuthHandler(credentials["api_key"], credentials["api_secret"])
         auth.set_access_token(
             credentials["access_token"], credentials["access_token_secret"]

--- a/tests/tasks/airtable/test_airtable.py
+++ b/tests/tasks/airtable/test_airtable.py
@@ -23,14 +23,14 @@ class TestWriteAirtableRow:
         task = WriteAirtableRow(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"
 
+    # DEPRECATED FEATURE
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = WriteAirtableRow()
+        task = WriteAirtableRow(credentials_secret="AIRTABLE_API_KEY")
 
         airtable = MagicMock()
         monkeypatch.setattr("prefect.tasks.airtable.airtable.airtable", airtable)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(AIRTABLE_API_KEY="key")):
-                task.run({}, base_key="a", table_name="b")
+        with prefect.context(secrets=dict(AIRTABLE_API_KEY="key")):
+            task.run({}, base_key="a", table_name="b")
 
         assert airtable.Airtable.call_args[0] == ("a", "b", "key")

--- a/tests/tasks/airtable/test_airtable.py
+++ b/tests/tasks/airtable/test_airtable.py
@@ -12,14 +12,13 @@ class TestWriteAirtableRow:
         task = WriteAirtableRow()
         assert task.base_key is None
         assert task.table_name is None
-        assert task.credentials_secret == "AIRTABLE_API_KEY"
 
     def test_initialize_kwargs_are_processed(self):
         task = WriteAirtableRow(checkpoint=True, name="test")
         assert task.name == "test"
         assert task.checkpoint is True
 
-    @pytest.mark.parametrize("attr", ["base_key", "table_name", "credentials_secret"])
+    @pytest.mark.parametrize("attr", ["base_key", "table_name"])
     def test_initializes_attr_from_kwargs(self, attr):
         task = WriteAirtableRow(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"

--- a/tests/tasks/dropbox/test_dropbox.py
+++ b/tests/tasks/dropbox/test_dropbox.py
@@ -26,29 +26,27 @@ class TestInitialization:
 
 class TestCredentials:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = DropboxDownload(path="test")
+        task = DropboxDownload(path="test", access_token_secret="DROPBOX_ACCESS_TOKEN")
 
         dbx = MagicMock()
         monkeypatch.setattr("prefect.tasks.dropbox.dropbox.dropbox.Dropbox", dbx)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(DROPBOX_ACCESS_TOKEN="HI")):
-                task.run()
+        with prefect.context(secrets=dict(DROPBOX_ACCESS_TOKEN="HI")):
+            task.run()
 
         assert dbx.call_args[0][0] == "HI"
 
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = DropboxDownload(path="test")
+        task = DropboxDownload(path="test", access_token_secret="DROPBOX_ACCESS_TOKEN")
 
         dbx = MagicMock()
         monkeypatch.setattr("prefect.tasks.dropbox.dropbox.dropbox.Dropbox", dbx)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(DROPBOX_ACCESS_TOKEN="HI", TEST_SECRET="BYE")
-            ):
-                task.run()
-                task.run(access_token_secret="TEST_SECRET")
+        with prefect.context(
+            secrets=dict(DROPBOX_ACCESS_TOKEN="HI", TEST_SECRET="BYE")
+        ):
+            task.run()
+            task.run(access_token_secret="TEST_SECRET")
 
         first_call, second_call = dbx.call_args_list
         assert first_call[0][0] == "HI"

--- a/tests/tasks/dropbox/test_dropbox.py
+++ b/tests/tasks/dropbox/test_dropbox.py
@@ -11,7 +11,6 @@ class TestInitialization:
     def test_initializes_with_defaults(self):
         task = DropboxDownload()
         assert task.path == None
-        assert task.access_token_secret == "DROPBOX_ACCESS_TOKEN"
 
     def test_additional_kwargs_passed_upstream(self):
         task = DropboxDownload(path="", name="test-task", checkpoint=True, tags=["bob"])
@@ -19,7 +18,7 @@ class TestInitialization:
         assert task.checkpoint is True
         assert task.tags == {"bob"}
 
-    @pytest.mark.parametrize("attr", ["path", "access_token_secret"])
+    @pytest.mark.parametrize("attr", ["path"])
     def test_download_initializes_attr_from_kwargs(self, attr):
         task = DropboxDownload(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -34,25 +34,12 @@ class TestOpenGithubIssueInitialization:
 
 class TestCredentialsandProjects:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = OpenGitHubIssue()
+        task = OpenGitHubIssue(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
         monkeypatch.setattr("prefect.tasks.github.issues.requests", req)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-                task.run(repo="org/repo")
-
-        assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
-
-    def test_creds_secret_can_be_overwritten(self, monkeypatch):
-        task = OpenGitHubIssue(token_secret="MY_SECRET")
-
-        req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.issues.requests", req)
-
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(MY_SECRET={"key": 42})):
-                task.run(repo="org/repo")
+        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
+            task.run(repo="org/repo")
 
         assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -14,7 +14,6 @@ class TestOpenGithubIssueInitialization:
         assert task.title is None
         assert task.body is None
         assert task.labels == []
-        assert task.token_secret == "GITHUB_ACCESS_TOKEN"
 
     def test_additional_kwargs_passed_upstream(self):
         task = OpenGitHubIssue(name="test-task", checkpoint=True, tags=["bob"])
@@ -22,9 +21,7 @@ class TestOpenGithubIssueInitialization:
         assert task.checkpoint is True
         assert task.tags == {"bob"}
 
-    @pytest.mark.parametrize(
-        "attr", ["repo", "body", "title", "labels", "token_secret"]
-    )
+    @pytest.mark.parametrize("attr", ["repo", "body", "title", "labels"])
     def test_initializes_attr_from_kwargs(self, attr):
         task = OpenGitHubIssue(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -15,7 +15,6 @@ class TestCreateGitHubPRInitialization:
         assert task.title is None
         assert task.head is None
         assert task.base is None
-        assert task.token_secret == "GITHUB_ACCESS_TOKEN"
 
     def test_additional_kwargs_passed_upstream(self):
         task = CreateGitHubPR(name="test-task", checkpoint=True, tags=["bob"])
@@ -23,9 +22,7 @@ class TestCreateGitHubPRInitialization:
         assert task.checkpoint is True
         assert task.tags == {"bob"}
 
-    @pytest.mark.parametrize(
-        "attr", ["repo", "body", "title", "head", "base", "token_secret"]
-    )
+    @pytest.mark.parametrize("attr", ["repo", "body", "title", "head", "base"])
     def test_initializes_attr_from_kwargs(self, attr):
         task = CreateGitHubPR(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -35,25 +35,12 @@ class TestCreateGitHubPRInitialization:
 
 class TestCredentialsandProjects:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = CreateGitHubPR()
+        task = CreateGitHubPR(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
         monkeypatch.setattr("prefect.tasks.github.prs.requests", req)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-                task.run(repo="org/repo")
-
-        assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
-
-    def test_creds_secret_can_be_overwritten(self, monkeypatch):
-        task = CreateGitHubPR(token_secret="MY_SECRET")
-
-        req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.prs.requests", req)
-
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(MY_SECRET={"key": 42})):
-                task.run(repo="org/repo")
+        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
+            task.run(repo="org/repo")
 
         assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -59,54 +59,28 @@ class TestCreateBranchInitialization:
             task.run()
 
 
-class TestCredentials:
+# deprecated
+class TestCredentialsSecret:
     def test_creds_are_pulled_from_secret_at_runtime_repo_info(self, monkeypatch):
-        task = GetRepoInfo()
+        task = GetRepoInfo(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
         monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-                task.run(repo="org/repo")
+        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
+            task.run(repo="org/repo")
 
         assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
 
     def test_creds_are_pulled_from_secret_at_runtime_create_branch(self, monkeypatch):
-        task = CreateBranch()
+        task = CreateBranch(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
         monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-                with pytest.raises(ValueError, match="not found"):
-                    task.run(repo="org/repo", branch_name="new")
-
-        assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
-
-    def test_creds_secret_can_be_overwritten_repo_info(self, monkeypatch):
-        task = GetRepoInfo(token_secret="MY_SECRET")
-
-        req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
-
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(MY_SECRET={"key": 42})):
-                task.run(repo="org/repo")
-
-        assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
-
-    def test_creds_secret_can_be_overwritten_create_branch(self, monkeypatch):
-        task = CreateBranch(token_secret="MY_SECRET")
-
-        req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
-
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(MY_SECRET={"key": 42})):
-                with pytest.raises(ValueError):
-                    task.run(repo="org/repo", branch_name="new")
+        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
+            with pytest.raises(ValueError, match="not found"):
+                task.run(repo="org/repo", branch_name="new")
 
         assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
 

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -12,7 +12,6 @@ class TestGetRepoInfoInitialization:
         task = GetRepoInfo()
         assert task.repo is None
         assert task.info_keys == []
-        assert task.token_secret == "GITHUB_ACCESS_TOKEN"
 
     def test_additional_kwargs_passed_upstream(self):
         task = GetRepoInfo(name="test-task", checkpoint=True, tags=["bob"])
@@ -20,7 +19,7 @@ class TestGetRepoInfoInitialization:
         assert task.checkpoint is True
         assert task.tags == {"bob"}
 
-    @pytest.mark.parametrize("attr", ["repo", "info_keys", "token_secret"])
+    @pytest.mark.parametrize("attr", ["repo", "info_keys",])
     def test_initializes_attr_from_kwargs(self, attr):
         task = GetRepoInfo(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"
@@ -37,7 +36,6 @@ class TestCreateBranchInitialization:
         assert task.repo is None
         assert task.base == "master"
         assert task.branch_name is None
-        assert task.token_secret == "GITHUB_ACCESS_TOKEN"
 
     def test_additional_kwargs_passed_upstream(self):
         task = CreateBranch(name="test-task", checkpoint=True, tags=["bob"])
@@ -45,7 +43,7 @@ class TestCreateBranchInitialization:
         assert task.checkpoint is True
         assert task.tags == {"bob"}
 
-    @pytest.mark.parametrize("attr", ["repo", "base", "branch_name", "token_secret"])
+    @pytest.mark.parametrize("attr", ["repo", "base", "branch_name",])
     def test_initializes_attr_from_kwargs(self, attr):
         task = CreateBranch(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"
@@ -122,9 +120,7 @@ def test_base_name_is_filtered_for(monkeypatch):
     )
     monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
 
-    with set_temporary_config({"cloud.use_local_secrets": True}):
-        with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
-            task.run(repo="org/repo")
+    task.run(repo="org/repo", token={"key": 42})
 
     assert req.post.call_args[1]["json"] == {
         "ref": "refs/heads/NEWBRANCH",

--- a/tests/tasks/google/test_bigquery.py
+++ b/tests/tasks/google/test_bigquery.py
@@ -21,7 +21,7 @@ class TestBigQueryInitialization:
         assert task.project is None
         assert task.location == "US"
         assert task.dry_run_max_bytes is None
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert task.credentials_secret is None
         assert task.dataset_dest is None
         assert task.table_dest is None
         assert task.job_config == dict()
@@ -69,7 +69,7 @@ class TestBigQueryStreamingInsertInitialization:
         task = BigQueryStreamingInsert()
         assert task.project is None
         assert task.location == "US"
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert task.credentials_secret is None
         assert task.dataset_id is None
         assert task.table is None
 
@@ -100,7 +100,7 @@ class TestBigQueryLoadGoogleCloudStorageInitialization:
         task = BigQueryLoadGoogleCloudStorage()
         assert task.project is None
         assert task.location == "US"
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert task.credentials_secret is None
         assert task.dataset_id is None
         assert task.table is None
         assert task.uri is None
@@ -131,7 +131,7 @@ class TestBigQueryLoadGoogleCloudStorageInitialization:
 
 class TestBigQueryCredentialsandProjects:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = BigQueryTask()
+        task = BigQueryTask(credentials_secret="GOOGLE_APPLICATION_CREDENTIALS")
 
         creds_loader = MagicMock()
         monkeypatch.setattr("prefect.tasks.google.bigquery.Credentials", creds_loader)
@@ -168,8 +168,10 @@ class TestBigQueryCredentialsandProjects:
     def test_project_is_pulled_from_creds_and_can_be_overriden_at_anytime(
         self, monkeypatch
     ):
-        task = BigQueryTask()
-        task_proj = BigQueryTask(project="test-init")
+        task = BigQueryTask(credentials_secret="GOOGLE_APPLICATION_CREDENTIALS")
+        task_proj = BigQueryTask(
+            project="test-init", credentials_secret="GOOGLE_APPLICATION_CREDENTIALS"
+        )
 
         client = MagicMock()
         service_account_info = MagicMock(return_value=MagicMock(project_id="default"))
@@ -194,7 +196,11 @@ class TestBigQueryCredentialsandProjects:
 
 class TestBigQueryStreamingInsertCredentialsandProjects:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = BigQueryStreamingInsert(dataset_id="id", table="table")
+        task = BigQueryStreamingInsert(
+            dataset_id="id",
+            table="table",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
+        )
 
         creds_loader = MagicMock()
         monkeypatch.setattr("prefect.tasks.google.bigquery.Credentials", creds_loader)
@@ -231,9 +237,16 @@ class TestBigQueryStreamingInsertCredentialsandProjects:
     def test_project_is_pulled_from_creds_and_can_be_overriden_at_anytime(
         self, monkeypatch
     ):
-        task = BigQueryStreamingInsert(dataset_id="id", table="table")
+        task = BigQueryStreamingInsert(
+            dataset_id="id",
+            table="table",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
+        )
         task_proj = BigQueryStreamingInsert(
-            dataset_id="id", table="table", project="test-init"
+            dataset_id="id",
+            table="table",
+            project="test-init",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
         )
 
         client = MagicMock()
@@ -299,7 +312,7 @@ class TestCreateBigQueryTableInitialization:
     def test_initializes_with_nothing_and_sets_defaults(self):
         task = CreateBigQueryTable()
         assert task.project is None
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert task.credentials_secret is None
         assert task.dataset is None
         assert task.table is None
         assert task.schema is None
@@ -344,7 +357,7 @@ class TestCreateBigQueryTableInitialization:
         assert "already exists" in str(exc.value)
 
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = CreateBigQueryTable()
+        task = CreateBigQueryTable(credentials_secret="GOOGLE_APPLICATION_CREDENTIALS")
 
         creds_loader = MagicMock()
         monkeypatch.setattr("prefect.tasks.google.bigquery.Credentials", creds_loader)

--- a/tests/tasks/google/test_gcs_copy.py
+++ b/tests/tasks/google/test_gcs_copy.py
@@ -15,7 +15,6 @@ class TestInitialization:
         assert task.source_blob is None
         assert task.dest_bucket is None
         assert task.dest_blob is None
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
         assert task.project is None
 
     def test_additional_kwargs_passed_upstream(self):
@@ -64,10 +63,15 @@ class TestRuntimeValidation:
             )
 
 
-class TestCredentialsandProjects:
+# deprecated tests of `credentials_secret`
+class TestCredentialsandProjects_DEPRECATED:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
         task = GCSCopy(
-            source_bucket="s", source_blob="s", dest_bucket="d", dest_blob="d"
+            source_bucket="s",
+            source_blob="s",
+            dest_bucket="d",
+            dest_blob="d",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
         )
 
         creds_loader = MagicMock()
@@ -106,7 +110,11 @@ class TestCredentialsandProjects:
         self, monkeypatch
     ):
         task = GCSCopy(
-            source_bucket="s", source_blob="s", dest_bucket="d", dest_blob="d"
+            source_bucket="s",
+            source_blob="s",
+            dest_bucket="d",
+            dest_blob="d",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
         )
         task_proj = GCSCopy(
             source_bucket="s",
@@ -114,6 +122,7 @@ class TestCredentialsandProjects:
             dest_bucket="d",
             dest_blob="d",
             project="test-init",
+            credentials_secret="GOOGLE_APPLICATION_CREDENTIALS",
         )
 
         client = MagicMock()

--- a/tests/tasks/google/test_gcs_copy.py
+++ b/tests/tasks/google/test_gcs_copy.py
@@ -78,33 +78,10 @@ class TestCredentialsandProjects_DEPRECATED:
         monkeypatch.setattr("prefect.tasks.google.storage.Credentials", creds_loader)
         monkeypatch.setattr("prefect.tasks.google.storage.storage.Client", MagicMock())
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS=42)):
-                task.run()
+        with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS=42)):
+            task.run()
 
         assert creds_loader.from_service_account_info.call_args[0][0] == 42
-
-    def test_creds_secret_name_can_be_overwritten_at_anytime(self, monkeypatch):
-        task = GCSCopy(
-            source_bucket="s",
-            source_blob="s",
-            dest_bucket="d",
-            dest_blob="d",
-            credentials_secret="TEST",
-        )
-
-        creds_loader = MagicMock()
-        monkeypatch.setattr("prefect.tasks.google.storage.Credentials", creds_loader)
-        monkeypatch.setattr("prefect.tasks.google.storage.storage.Client", MagicMock())
-
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(TEST='"42"', RUN={})):
-                task.run()
-                task.run(**{"credentials_secret": "RUN"})
-
-        first_call, second_call = creds_loader.from_service_account_info.call_args_list
-        assert first_call[0][0] == "42"
-        assert second_call[0][0] == {}
 
     def test_project_is_pulled_from_creds_and_can_be_overriden_at_anytime(
         self, monkeypatch
@@ -133,11 +110,10 @@ class TestCredentialsandProjects_DEPRECATED:
         )
         monkeypatch.setattr("prefect.tasks.google.storage.storage.Client", client)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                task.run()
-                task_proj.run()
-                task_proj.run(**{"project": "run-time"})
+        with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
+            task.run()
+            task_proj.run()
+            task_proj.run(**{"project": "run-time"})
 
         x, y, z = client.call_args_list
 

--- a/tests/tasks/google/test_gcs_upload_download.py
+++ b/tests/tasks/google/test_gcs_upload_download.py
@@ -20,7 +20,6 @@ class TestInitialization:
         assert task.bucket == ""
         assert task.blob is None
         assert task.encryption_key_secret is None
-        assert task.credentials_secret == "GOOGLE_APPLICATION_CREDENTIALS"
         assert task.project is None
         assert task.create_bucket is False
 
@@ -34,23 +33,14 @@ class TestInitialization:
         with pytest.raises(TypeError, match="bucket"):
             task = klass()
 
-    @pytest.mark.parametrize(
-        "attr", ["blob", "encryption_key_secret", "credentials_secret", "project"]
-    )
+    @pytest.mark.parametrize("attr", ["blob", "project"])
     def test_download_initializes_attr_from_kwargs(self, attr):
         task = GCSDownload(bucket="bucket", **{attr: "my-value"})
         assert task.bucket == "bucket"
         assert getattr(task, attr) == "my-value"
 
     @pytest.mark.parametrize(
-        "attr",
-        [
-            "blob",
-            "encryption_key_secret",
-            "credentials_secret",
-            "project",
-            "create_bucket",
-        ],
+        "attr", ["blob", "project", "create_bucket",],
     )
     def test_upload_initializes_attr_from_kwargs(self, attr):
         task = GCSUpload(bucket="bucket", **{attr: "my-value"})
@@ -58,9 +48,10 @@ class TestInitialization:
         assert getattr(task, attr) == "my-value"
 
 
-class TestCredentialsandProjects:
+# Deprecated tests
+class TestCredentialsandProjects_DEPRECATED:
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch, klass):
-        task = klass(bucket="test")
+        task = klass(bucket="test", credentials_secret="GOOGLE_APPLICATION_CREDENTIALS")
         run_arg = "data" if isinstance(task, GCSUpload) else "blob"
 
         creds_loader = MagicMock()
@@ -93,7 +84,7 @@ class TestCredentialsandProjects:
     def test_project_is_pulled_from_creds_and_can_be_overriden_at_anytime(
         self, monkeypatch, klass
     ):
-        task = klass(bucket="test")
+        task = klass(bucket="test", credentials_secret="GOOGLE_APPLICATION_CREDENTIALS")
         task_proj = klass(bucket="test", project="test-init")
         run_arg = "data" if isinstance(task, GCSUpload) else "blob"
 
@@ -130,10 +121,8 @@ class TestBuckets:
             MagicMock(return_value=client),
         )
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                task.run(**{run_arg: "empty"})
-                task.run(**{run_arg: "empty", "bucket": "run"})
+        task.run(**{run_arg: "empty"}, credentials={})
+        task.run(**{run_arg: "empty", "bucket": "run"}, credentials={})
 
         first, second = client.get_bucket.call_args_list
         assert first[0][0] == "test"
@@ -150,10 +139,8 @@ class TestBuckets:
             MagicMock(return_value=client),
         )
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                with pytest.raises(NotFound, match="no bucket"):
-                    task.run(**{run_arg: "empty"})
+        with pytest.raises(NotFound, match="no bucket"):
+            task.run(**{run_arg: "empty"}, credentials={})
 
     def test_bucket_doesnt_exist_can_be_created_on_upload(self, monkeypatch):
         task = GCSUpload(bucket="test", create_bucket=True)
@@ -165,10 +152,8 @@ class TestBuckets:
             MagicMock(return_value=client),
         )
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(secrets=dict(GOOGLE_APPLICATION_CREDENTIALS={})):
-                task.run(data="empty")
-                task.run(data="empty", bucket="run")
+        task.run(data="empty", credentials={})
+        task.run(data="empty", bucket="run", credentials={})
 
         assert client.create_bucket.called
         assert client.create_bucket.call_args_list[0][0][0] == "test"
@@ -212,12 +197,8 @@ class TestBlob:
             MagicMock(return_value=client),
         )
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(encrypt="42", GOOGLE_APPLICATION_CREDENTIALS={})
-            ):
-                task.run(data="empty")
-                task.run(data="empty", blob="run-time")
+        task.run(data="empty", credentials={})
+        task.run(data="empty", blob="run-time", credentials={})
 
         first, second = blob.call_args_list
         assert first[0] == ("blobber",)
@@ -234,10 +215,6 @@ class TestBlob:
             MagicMock(return_value=client),
         )
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(encrypt="42", GOOGLE_APPLICATION_CREDENTIALS={})
-            ):
-                task.run(blob="run-time")
+        task.run(blob="run-time", credentials={})
 
         assert blob.call_args[0] == ("run-time",)

--- a/tests/tasks/twitter/test_twitter.py
+++ b/tests/tasks/twitter/test_twitter.py
@@ -24,22 +24,21 @@ class TestLoadTweetReplies:
         assert getattr(task, attr) == "my-value"
 
     def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
-        task = LoadTweetReplies()
+        task = LoadTweetReplies(credentials_secret="TWITTER_API_CREDENTIALS")
 
         tweepy = MagicMock()
         monkeypatch.setattr("prefect.tasks.twitter.twitter.tweepy", tweepy)
 
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    TWITTER_API_CREDENTIALS={
-                        "api_key": "a",
-                        "api_secret": "b",
-                        "access_token": "c",
-                        "access_token_secret": "d",
-                    }
-                )
-            ):
-                task.run(user="")
+        with prefect.context(
+            secrets=dict(
+                TWITTER_API_CREDENTIALS={
+                    "api_key": "a",
+                    "api_secret": "b",
+                    "access_token": "c",
+                    "access_token_secret": "d",
+                }
+            )
+        ):
+            task.run(user="")
 
         assert tweepy.OAuthHandler.call_args[0] == ("a", "b")

--- a/tests/tasks/twitter/test_twitter.py
+++ b/tests/tasks/twitter/test_twitter.py
@@ -12,14 +12,13 @@ class TestLoadTweetReplies:
         task = LoadTweetReplies()
         assert task.user is None
         assert task.tweet_id is None
-        assert task.credentials_secret == "TWITTER_API_CREDENTIALS"
 
     def test_initialize_kwargs_are_processed(self):
         task = LoadTweetReplies(checkpoint=True, name="test")
         assert task.name == "test"
         assert task.checkpoint is True
 
-    @pytest.mark.parametrize("attr", ["user", "tweet_id", "credentials_secret"])
+    @pytest.mark.parametrize("attr", ["user", "tweet_id"])
     def test_initializes_attr_from_kwargs(self, attr):
         task = LoadTweetReplies(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"


### PR DESCRIPTION
Closes #1669 by adding support for passing values directly to various task library tasks.

This PR attempts to maintain all prior behavior, just raising a `warning` if the secret name is passed instead of a value.

In addition, it's a little noisy because it coincides with the release of a new version of `black`