### PR TITLE
Flow save / load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Add a `save`/`load` interface to Flows - [#1685](https://github.com/PrefectHQ/prefect/pull/1685)
 
 ### Task Library
 

--- a/docs/cloud/deployment.md
+++ b/docs/cloud/deployment.md
@@ -24,6 +24,10 @@ Whenever you call `flow.deploy` or build a [Docker storage object](../api/unrele
 [cloudpickle](https://github.com/cloudpipe/cloudpickle) is an excellent alternative to the standard libary's Pickle protocol for converting Python objects to a serialized byte representation.  Note that cloudpickle typically stores _imported objects_ as importable references.  So, for example, if you used a function `foo` that you imported as `from my_file import foo`, cloudpickle (and consequently Prefect) will assume this same import can take place inside the Docker container.  For this reason, it is considered best practice in Prefect to ensure all utility scripts and custom Python code be accessible on your Docker image's system `PATH`.
 :::
 
+::: tip Flows have a save / load interface
+Oftentimes users want to separate their flow's build logic from its deploy logic.  Because of the nature of `cloudpickle` and relative imports, instead of importing your Flow object from another file it is recommended that you save your Flow to disk using `flow.save`, and then load it using `Flow.load` prior to deployment.
+:::
+
 ### How are Prefect Flows run inside Docker containers?
 
 Whenever a Prefect Cloud flow run is created and submitted for execution, Prefect performs the following actions inside your Flow's Docker image:

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1,3 +1,4 @@
+import cloudpickle
 import collections
 import copy
 import functools
@@ -1179,6 +1180,28 @@ class Flow:
         return serialized
 
     # Deployment ------------------------------------------------------------------
+
+    @classmethod
+    def load(cls, fpath: str) -> "Flow":
+        """
+        Reads a Flow from a file that was created with `flow.save()`.
+
+        Args:
+            - fpath (str): the filepath where your Flow will be loaded from
+        """
+        with open(fpath, "rb") as f:
+            return cloudpickle.load(f)
+
+    def save(self, fpath: str) -> None:
+        """
+        Saves the Flow to a file by serializing it with cloudpickle.  This method is
+        recommended if you wish to separate out the building of your Flow from its deployment.
+
+        Args:
+            - fpath (str): the filepath where your Flow will be saved
+        """
+        with open(fpath, "wb") as f:
+            cloudpickle.dump(self, f)
 
     def deploy(
         self,

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2340,3 +2340,18 @@ def test_starting_at_arbitrary_loop_index():
     assert flow_state.is_successful()
     assert flow_state.result[inter].result == 10
     assert flow_state.result[final].result == 100
+
+
+class TestSaveLoad:
+    def test_save_saves_and_load_loads(self):
+        f = Flow("test")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "save"), "wb") as tmp:
+                assert f.save(tmp.name) is None
+
+            new_obj = Flow.load(tmp.name)
+
+        assert isinstance(new_obj, Flow)
+        assert new_obj.tasks == set()
+        assert new_obj.name == "test"

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2344,7 +2344,7 @@ def test_starting_at_arbitrary_loop_index():
 
 class TestSaveLoad:
     def test_save_saves_and_load_loads(self):
-        f = Flow("test")
+        f = Flow("test", tasks=[Task(name="foo")])
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "save"), "wb") as tmp:
@@ -2353,5 +2353,6 @@ class TestSaveLoad:
             new_obj = Flow.load(tmp.name)
 
         assert isinstance(new_obj, Flow)
-        assert new_obj.tasks == set()
+        assert len(new_obj.tasks) == 1
+        assert list(new_obj.tasks)[0].name == "foo"
         assert new_obj.name == "test"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a `save` / `load` interface to Flows for a smoother deployment experience.


## Why is this PR important?
Some users were annoyed with `cloudpickle`'s behavior if you create a Flow in a file called "my_flow.py" and then imported that flow inside "my_deploy.py" like `from my_flow import flow`, deploy health checks would fail.  This is because `cloudpickle` sees your flow's logic as living inside a module called "my_flow".  

Using the new `save / load` interface allows users to save their flow at build time, so that cloudpickle correctly manages the imports.

