### PR TITLE
Add `aws_session_token` kwarg to FargateTaskEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Add a `save`/`load` interface to Flows - [#1685](https://github.com/PrefectHQ/prefect/pull/1685)
+- Add option to specify `aws_session_token` for the `FargateTaskEnvironment` - [#1688](https://github.com/PrefectHQ/prefect/pull/1688)
 
 ### Task Library
 

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -51,12 +51,15 @@ class FargateTaskEnvironment(Environment):
     Args:
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
-            `AWS_ACCESS_KEY_ID`.
+            `AWS_ACCESS_KEY_ID` or `None`
         - aws_secret_access_key (str, optional): AWS secret access key for connecting
             the boto3 client. Defaults to the value set in the environment variable
-            `AWS_SECRET_ACCESS_KEY`.
+            `AWS_SECRET_ACCESS_KEY` or `None`
+        - aws_session_token (str, optional): AWS session key for connecting the boto3
+            client. Defaults to the value set in the environment variable
+            `AWS_SESSION_TOKEN` or `None`
         - region_name (str, optional): AWS region name for connecting the boto3 client.
-            Defaults to the value set in the environment variable `REGION_NAME`.
+            Defaults to the value set in the environment variable `REGION_NAME` or `None`
         - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
             Agents when polling for work
         - on_start (Callable, optional): a function callback which will be called before the flow begins to run
@@ -69,6 +72,7 @@ class FargateTaskEnvironment(Environment):
         self,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
+        aws_session_token: str = None,
         region_name: str = None,
         labels: List[str] = None,
         on_start: Callable = None,
@@ -80,6 +84,7 @@ class FargateTaskEnvironment(Environment):
         self.aws_secret_access_key = aws_secret_access_key or os.getenv(
             "AWS_SECRET_ACCESS_KEY"
         )
+        self.aws_session_token = aws_session_token or os.getenv("AWS_SESSION_TOKEN")
         self.region_name = region_name or os.getenv("REGION_NAME")
 
         # Parse accepted kwargs for definition and run
@@ -162,6 +167,7 @@ class FargateTaskEnvironment(Environment):
             "ecs",
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
             region_name=self.region_name,
         )
 
@@ -244,6 +250,7 @@ class FargateTaskEnvironment(Environment):
             "ecs",
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
             region_name=self.region_name,
         )
 

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -48,18 +48,21 @@ def test_create_fargate_task_environment_aws_creds_provided():
         labels=["foo"],
         aws_access_key_id="id",
         aws_secret_access_key="secret",
+        aws_session_token="session",
         region_name="region",
     )
     assert environment
     assert environment.labels == set(["foo"])
     assert environment.aws_access_key_id == "id"
     assert environment.aws_secret_access_key == "secret"
+    assert environment.aws_session_token == "session"
     assert environment.region_name == "region"
 
 
 def test_create_fargate_task_environment_aws_creds_environment(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session")
     monkeypatch.setenv("REGION_NAME", "region")
 
     environment = FargateTaskEnvironment(labels=["foo"])
@@ -67,6 +70,7 @@ def test_create_fargate_task_environment_aws_creds_environment(monkeypatch):
     assert environment.labels == set(["foo"])
     assert environment.aws_access_key_id == "id"
     assert environment.aws_secret_access_key == "secret"
+    assert environment.aws_session_token == "session"
     assert environment.region_name == "region"
 
 
@@ -380,6 +384,7 @@ def test_entire_environment_process_together(monkeypatch):
 
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session")
     monkeypatch.setenv("REGION_NAME", "region")
 
     with prefect.context({"flow_run_id": "id"}):
@@ -404,6 +409,7 @@ def test_entire_environment_process_together(monkeypatch):
         assert environment
         assert environment.aws_access_key_id == "id"
         assert environment.aws_secret_access_key == "secret"
+        assert environment.aws_session_token == "session"
         assert environment.region_name == "region"
 
         environment.setup(storage=storage)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds the option to specify an `aws_session_token` for the FargateTaskEnvironment


## Why is this PR important?
This is useful when in an IAM / ARN setup

