### PR TITLE
Improvements to Flow save / load interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add a `save`/`load` interface to Flows - [#1685](https://github.com/PrefectHQ/prefect/pull/1685)
+- Add a `save`/`load` interface to Flows - [#1685](https://github.com/PrefectHQ/prefect/pull/1685), [#1695](https://github.com/PrefectHQ/prefect/pull/1695)
 - Add option to specify `aws_session_token` for the `FargateTaskEnvironment` - [#1688](https://github.com/PrefectHQ/prefect/pull/1688)
 - Add `EnvVarSecrets` for loading sensitive information from environment variables - [#1683](https://github.com/PrefectHQ/prefect/pull/1683)
 - Add an informative version header to all Cloud client requests - [#1690](https://github.com/PrefectHQ/prefect/pull/1690)

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -10,6 +10,8 @@ import time
 import uuid
 import warnings
 from collections import Counter
+from pathlib import Path
+from slugify import slugify
 from typing import (
     Any,
     Callable,
@@ -1192,14 +1194,21 @@ class Flow:
         with open(fpath, "rb") as f:
             return cloudpickle.load(f)
 
-    def save(self, fpath: str) -> None:
+    def save(self, fpath: str = None) -> None:
         """
         Saves the Flow to a file by serializing it with cloudpickle.  This method is
         recommended if you wish to separate out the building of your Flow from its deployment.
 
         Args:
-            - fpath (str): the filepath where your Flow will be saved
+            - fpath (str, optional): the filepath where your Flow will be saved; defaults to
+                `~/.prefect/flows/FLOW-NAME.prefect`
         """
+        if fpath is None:
+            path = "{home}/flows".format(home=prefect.context.config.home_dir)
+            fpath = Path(os.path.expanduser(path)) / "{}.prefect".format(
+                slugify(self.name)
+            )
+            fpath.parent.mkdir(exist_ok=True, parents=True)
         with open(fpath, "wb") as f:
             cloudpickle.dump(self, f)
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1195,7 +1195,7 @@ class Flow:
         if not os.path.isabs(fpath):
             path = "{home}/flows".format(home=prefect.context.config.home_dir)
             fpath = Path(os.path.expanduser(path)) / "{}.prefect".format(slugify(fpath))  # type: ignore
-        with open(fpath, "rb") as f:
+        with open(str(fpath), "rb") as f:
             return cloudpickle.load(f)
 
     def save(self, fpath: str = None) -> None:
@@ -1214,7 +1214,7 @@ class Flow:
             )
             assert fpath is not None  # mypy assert
             fpath.parent.mkdir(exist_ok=True, parents=True)
-        with open(fpath, "wb") as f:
+        with open(str(fpath), "wb") as f:
             cloudpickle.dump(self, f)
 
     def deploy(

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1189,8 +1189,12 @@ class Flow:
         Reads a Flow from a file that was created with `flow.save()`.
 
         Args:
-            - fpath (str): the filepath where your Flow will be loaded from
+            - fpath (str): either the absolute filepath where your Flow will be loaded from,
+                or the name of the Flow you wish to load
         """
+        if not os.path.isabs(fpath):
+            path = "{home}/flows".format(home=prefect.context.config.home_dir)
+            fpath = Path(os.path.expanduser(path)) / "{}.prefect".format(slugify(fpath))  # type: ignore
         with open(fpath, "rb") as f:
             return cloudpickle.load(f)
 
@@ -1205,9 +1209,10 @@ class Flow:
         """
         if fpath is None:
             path = "{home}/flows".format(home=prefect.context.config.home_dir)
-            fpath = Path(os.path.expanduser(path)) / "{}.prefect".format(
+            fpath = Path(os.path.expanduser(path)) / "{}.prefect".format(  # type: ignore
                 slugify(self.name)
             )
+            assert fpath is not None  # mypy assert
             fpath.parent.mkdir(exist_ok=True, parents=True)
         with open(fpath, "wb") as f:
             cloudpickle.dump(self, f)

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1198,7 +1198,7 @@ class Flow:
         with open(str(fpath), "rb") as f:
             return cloudpickle.load(f)
 
-    def save(self, fpath: str = None) -> None:
+    def save(self, fpath: str = None) -> str:
         """
         Saves the Flow to a file by serializing it with cloudpickle.  This method is
         recommended if you wish to separate out the building of your Flow from its deployment.
@@ -1206,6 +1206,9 @@ class Flow:
         Args:
             - fpath (str, optional): the filepath where your Flow will be saved; defaults to
                 `~/.prefect/flows/FLOW-NAME.prefect`
+
+        Returns:
+            - str: the full location the Flow was saved to
         """
         if fpath is None:
             path = "{home}/flows".format(home=prefect.context.config.home_dir)
@@ -1216,6 +1219,8 @@ class Flow:
             fpath.parent.mkdir(exist_ok=True, parents=True)
         with open(str(fpath), "wb") as f:
             cloudpickle.dump(self, f)
+
+        return str(fpath)
 
     def deploy(
         self,

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -36,7 +36,7 @@ class Docker(Storage):
 
     Args:
         - registry_url (str, optional): URL of a registry to push the image to; image will not be pushed if not provided
-        - base_image (str, optional): the base image for this environment (e.g. `python:3.6`), defaults to the `prefecthq/prefect` image 
+        - base_image (str, optional): the base image for this environment (e.g. `python:3.6`), defaults to the `prefecthq/prefect` image
             matching your python version and prefect core library version used at runtime.
         - python_dependencies (List[str], optional): list of pip installable dependencies for the image
         - image_name (str, optional): name of the image to use when building, populated with a UUID after build
@@ -179,7 +179,7 @@ class Docker(Storage):
                     flow.name
                 )
             )
-        flow_path = "/root/.prefect/{}.prefect".format(slugify(flow.name))
+        flow_path = "/root/.prefect/flows/{}.prefect".format(slugify(flow.name))
         self.flows[flow.name] = flow_path
         self._flows[flow.name] = flow  # needed prior to build
         return flow_path

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -48,9 +48,7 @@ class Local(Storage):
         if not flow_location in self.flows.values():
             raise ValueError("Flow is not contained in this Storage")
 
-        with open(flow_location, "rb") as f:
-            flow = cloudpickle.load(f)
-        return flow
+        return prefect.core.flow.Flow.load(flow_location)
 
     def add_flow(self, flow: "Flow") -> str:
         """
@@ -75,8 +73,7 @@ class Local(Storage):
         flow_location = os.path.join(
             self.directory, "{}.prefect".format(slugify(flow.name))
         )
-        with open(flow_location, "wb") as f:
-            cloudpickle.dump(flow, f)
+        flow_location = flow.save(flow_location)
         self.flows[flow.name] = flow_location
         return flow_location
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2344,7 +2344,8 @@ def test_starting_at_arbitrary_loop_index():
 
 class TestSaveLoad:
     def test_save_saves_and_load_loads(self):
-        f = Flow("test", tasks=[Task(name="foo")])
+        t = Task(name="foo")
+        f = Flow("test", tasks=[t])
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "save"), "wb") as tmp:
@@ -2355,10 +2356,12 @@ class TestSaveLoad:
         assert isinstance(new_obj, Flow)
         assert len(new_obj.tasks) == 1
         assert list(new_obj.tasks)[0].name == "foo"
+        assert list(new_obj.tasks)[0].slug == t.slug
         assert new_obj.name == "test"
 
     def test_save_saves_has_a_default(self):
-        f = Flow("test", tasks=[Task(name="foo")])
+        t = Task(name="foo")
+        f = Flow("test", tasks=[t])
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with set_temporary_config({"home_dir": tmpdir}):
@@ -2369,4 +2372,28 @@ class TestSaveLoad:
         assert isinstance(new_obj, Flow)
         assert len(new_obj.tasks) == 1
         assert list(new_obj.tasks)[0].name == "foo"
+        assert list(new_obj.tasks)[0].slug == t.slug
         assert new_obj.name == "test"
+
+    def test_load_accepts_name_and_sluggified_name(self):
+        t = Task(name="foo")
+        f = Flow("I aM a-test!", tasks=[t])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with set_temporary_config({"home_dir": tmpdir}):
+                assert f.save() is None
+
+                new_obj_from_name = Flow.load("I aM a-test!")
+                new_obj_from_slug = Flow.load("i-am-a-test")
+
+        assert isinstance(new_obj_from_name, Flow)
+        assert len(new_obj_from_name.tasks) == 1
+        assert list(new_obj_from_name.tasks)[0].name == "foo"
+        assert list(new_obj_from_name.tasks)[0].slug == t.slug
+        assert new_obj_from_name.name == "I aM a-test!"
+
+        assert isinstance(new_obj_from_slug, Flow)
+        assert len(new_obj_from_slug.tasks) == 1
+        assert list(new_obj_from_slug.tasks)[0].name == "foo"
+        assert list(new_obj_from_slug.tasks)[0].slug == t.slug
+        assert new_obj_from_slug.name == "I aM a-test!"

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -976,7 +976,7 @@ class TestFlowVisualize:
 
         with monkeypatch.context() as m:
             m.setattr(sys, "path", "")
-            with pytest.raises(ImportError, match="pip install 'prefect\[viz\]'"):
+            with pytest.raises(ImportError, match=r"pip install 'prefect\[viz\]'"):
                 f.visualize()
 
     def test_visualize_raises_informative_error_without_sys_graphviz(self, monkeypatch):
@@ -2349,7 +2349,7 @@ class TestSaveLoad:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "save"), "wb") as tmp:
-                assert f.save(tmp.name) is None
+                assert f.save(tmp.name) == tmp.name
 
             new_obj = Flow.load(tmp.name)
 
@@ -2365,7 +2365,7 @@ class TestSaveLoad:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with set_temporary_config({"home_dir": tmpdir}):
-                assert f.save() is None
+                f.save()
 
             new_obj = Flow.load(os.path.join(tmpdir, "flows", "test.prefect"))
 
@@ -2381,7 +2381,7 @@ class TestSaveLoad:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with set_temporary_config({"home_dir": tmpdir}):
-                assert f.save() is None
+                f.save()
 
                 new_obj_from_name = Flow.load("I aM a-test!")
                 new_obj_from_slug = Flow.load("i-am-a-test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2356,3 +2356,17 @@ class TestSaveLoad:
         assert len(new_obj.tasks) == 1
         assert list(new_obj.tasks)[0].name == "foo"
         assert new_obj.name == "test"
+
+    def test_save_saves_has_a_default(self):
+        f = Flow("test", tasks=[Task(name="foo")])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with set_temporary_config({"home_dir": tmpdir}):
+                assert f.save() is None
+
+            new_obj = Flow.load(os.path.join(tmpdir, "flows", "test.prefect"))
+
+        assert isinstance(new_obj, Flow)
+        assert len(new_obj.tasks) == 1
+        assert list(new_obj.tasks)[0].name == "foo"
+        assert new_obj.name == "test"

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -30,9 +30,9 @@ def test_add_flow_to_docker():
     storage = Docker()
     f = Flow("test")
     assert f not in storage
-    assert storage.add_flow(f) == "/root/.prefect/test.prefect"
+    assert storage.add_flow(f) == "/root/.prefect/flows/test.prefect"
     assert f.name in storage
-    assert storage.flows[f.name] == "/root/.prefect/test.prefect"
+    assert storage.flows[f.name] == "/root/.prefect/flows/test.prefect"
 
 
 @pytest.mark.parametrize(
@@ -361,7 +361,8 @@ def test_create_dockerfile_with_weird_flow_name():
                 output = dockerfile.read()
 
             assert (
-                "COPY what-is-this.flow /root/.prefect/what-is-this.prefect" in output
+                "COPY what-is-this.flow /root/.prefect/flows/what-is-this.prefect"
+                in output
             )
 
 
@@ -406,8 +407,8 @@ def test_create_dockerfile_from_everything():
             assert results.group("result") == "test=1"
 
             assert "COPY healthcheck.py /root/.prefect/healthcheck.py" in output
-            assert "COPY test.flow /root/.prefect/test.prefect" in output
-            assert "COPY other.flow /root/.prefect/other.prefect" in output
+            assert "COPY test.flow /root/.prefect/flows/test.prefect" in output
+            assert "COPY other.flow /root/.prefect/flows/other.prefect" in output
 
 
 def test_pull_image(capsys, monkeypatch):

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -76,7 +76,7 @@ def test_docker_serialize_with_flows():
     assert serialized["image_name"] == "name"
     assert serialized["image_tag"] == "tag"
     assert serialized["registry_url"] == "url"
-    assert serialized["flows"] == {"test": "/root/.prefect/test.prefect"}
+    assert serialized["flows"] == {"test": "/root/.prefect/flows/test.prefect"}
 
     deserialized = DockerSchema().load(serialized)
     assert f.name in deserialized


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR improves upon the save / load interface for flows by:
- introducing a sensible default save location which just happens to coincide with the save location inside Docker storage objects ;) 
- introducing a sensible inference pattern on load so that absolute paths, flow names, and slug-ified flow names are all acceptable inputs 
- uses the save / load interface inside Local storage