### PR TITLE
Local storage labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add option to specify `aws_session_token` for the `FargateTaskEnvironment` - [#1688](https://github.com/PrefectHQ/prefect/pull/1688)
 - Add `EnvVarSecrets` for loading sensitive information from environment variables - [#1683](https://github.com/PrefectHQ/prefect/pull/1683)
 - Add an informative version header to all Cloud client requests - [#1690](https://github.com/PrefectHQ/prefect/pull/1690)
+- Auto-label Flow environments when using Local storage - [#1696](https://github.com/PrefectHQ/prefect/pull/1696)
 
 ### Task Library
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1250,6 +1250,7 @@ class Flow:
             self.storage = get_default_storage_class()(**kwargs)
 
         if isinstance(self.storage, prefect.environments.storage.Local):
+            self.environment.labels.add("local")
             self.environment.labels.add(slugify(self.name))
 
         client = prefect.Client()

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1249,6 +1249,9 @@ class Flow:
         if self.storage is None:
             self.storage = get_default_storage_class()(**kwargs)
 
+        if isinstance(self.storage, prefect.environments.storage.Local):
+            self.environment.labels.add(slugify(self.name))
+
         client = prefect.Client()
         deployed_flow = client.deploy(
             flow=self,

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -15,6 +15,10 @@ class Local(Storage):
     """
     Local storage class.  This class represents the Storage
     interface for Flows stored as bytes in the local filesystem.
+    Note that if you deploy a Flow to Prefect Cloud using this storage,
+    your flow's environment will automatically be labeled with two labels:
+    "local" and your flow's name.  This ensures that only agents who are
+    known to be running on the same filesystem can run your flow.
 
     Args:
         - directory (str, optional): the directory the flows will be stored in;

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2179,6 +2179,29 @@ class TestFlowDeploy:
 
         assert isinstance(f.storage, prefect.environments.storage.Local)
         assert "test-me-i-should-get-labeled" in f.environment.labels
+        assert "local" in f.environment.labels
+
+    def test_flow_deploy_doesnt_overwrite_labels_if_local_storage_is_used(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("prefect.Client", MagicMock())
+        f = Flow(
+            name="test",
+            environment=prefect.environments.RemoteEnvironment(labels=["foo"]),
+        )
+
+        assert f.storage is None
+        with set_temporary_config(
+            {
+                "flows.defaults.storage.default_class": "prefect.environments.storage.Local"
+            }
+        ):
+            f.deploy("My-project")
+
+        assert isinstance(f.storage, prefect.environments.storage.Local)
+        assert "test" in f.environment.labels
+        assert "foo" in f.environment.labels
+        assert "local" in f.environment.labels
 
 
 def test_bad_flow_runner_code_still_returns_state_obj():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2161,6 +2161,24 @@ class TestFlowDeploy:
         assert f.storage.registry_url == "FOO"
         assert f.storage.image_name == "BAR"
         assert f.storage.image_tag == "BIG"
+        assert f.environment.labels == set()
+
+    def test_flow_deploy_auto_labels_environment_if_local_storage_used(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("prefect.Client", MagicMock())
+        f = Flow(name="Test me!! I should get labeled")
+
+        assert f.storage is None
+        with set_temporary_config(
+            {
+                "flows.defaults.storage.default_class": "prefect.environments.storage.Local"
+            }
+        ):
+            f.deploy("My-project")
+
+        assert isinstance(f.storage, prefect.environments.storage.Local)
+        assert "test-me-i-should-get-labeled" in f.environment.labels
 
 
 def test_bad_flow_runner_code_still_returns_state_obj():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR auto-labels flow environments with a slugified flow name whenever `Local` storage is used.


## Why is this PR important?
Using local storage greatly restricts what types of agents can run the work - this PR pre-emptively helps with that.