### PR TITLE
Always attempt to install prefect in base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add an informative version header to all Cloud client requests - [#1690](https://github.com/PrefectHQ/prefect/pull/1690)
 - Auto-label Flow environments when using Local storage - [#1696](https://github.com/PrefectHQ/prefect/pull/1696)
 - Batch upload logs to Cloud in a background thread for improved performance - [#1691](https://github.com/PrefectHQ/prefect/pull/1691)
-- Attempt to install prefect in any docker image (if it is not already installed) - [#1704](https://github.com/PrefectHQ/prefect/pull/1704)
 - Include agent labels within each flow's configuration environment - [#1671](https://github.com/PrefectHQ/prefect/issues/1671)
 
 ### Task Library
@@ -26,6 +25,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix Fargate Agent access defaults and environment variable support - [#1687](https://github.com/PrefectHQ/prefect/pull/1687)
+- Attempt to install prefect in any docker image (if it is not already installed) - [#1704](https://github.com/PrefectHQ/prefect/pull/1704)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add an informative version header to all Cloud client requests - [#1690](https://github.com/PrefectHQ/prefect/pull/1690)
 - Auto-label Flow environments when using Local storage - [#1696](https://github.com/PrefectHQ/prefect/pull/1696)
 - Batch upload logs to Cloud in a background thread for improved performance - [#1691](https://github.com/PrefectHQ/prefect/pull/1691)
+- Attempt to install prefect in any docker image (if it is not already installed) - [#1704](https://github.com/PrefectHQ/prefect/pull/1704)
 
 ### Task Library
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -102,16 +102,19 @@ class Docker(Storage):
             else:
                 # create an image from python:*-slim directly
                 self.base_image = "python:{}-slim".format(python_version)
-                self.extra_commands.extend(
-                    [
-                        "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*",
-                        "pip install git+https://github.com/PrefectHQ/prefect.git@{}#egg=prefect[kubernetes]".format(
-                            self.prefect_version
-                        ),
-                    ]
+                self.extra_commands.append(
+                    "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*",
                 )
         else:
             self.base_image = base_image
+
+        # we should always try to install prefect, unless it is already installed. We can't determine this until
+        # image build time.
+        self.extra_commands.append(
+            "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@{}#egg=prefect[kubernetes]".format(
+                self.prefect_version
+            ),
+        )
 
         not_absolute = [
             file_path for file_path in self.files if not os.path.isabs(file_path)

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -316,7 +316,7 @@ def test_create_dockerfile_from_base_image():
             "master",
             (
                 "FROM python:3.6-slim",
-                "pip install git+https://github.com/PrefectHQ/prefect.git@master",
+                "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@master",
             ),
         ),
         (
@@ -324,7 +324,7 @@ def test_create_dockerfile_from_base_image():
             (
                 "FROM python:3.6-slim",
                 "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*",
-                "pip install git+https://github.com/PrefectHQ/prefect.git@424be6b5ed8d3be85064de4b95b5c3d7cb665510#egg=prefect[kubernetes]",
+                "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@424be6b5ed8d3be85064de4b95b5c3d7cb665510#egg=prefect[kubernetes]",
             ),
         ),
     ],


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] modifies/adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Currently no prefect installation is attempted if you are providing your own image. This change attempts to install prefect if it is not already installed, regardless of the base image. This closes #1698 .

## Why is this PR important?
This makes deploying a flow easier --provide an image with what you need to run whats contained within a task, prefect will bring what it needs to run.

