### PR TITLE
Remove default version for Python in Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix Fargate Agent access defaults and environment variable support - [#1687](https://github.com/PrefectHQ/prefect/pull/1687)
+- Removed default python version for docker builds - [#1705](https://github.com/PrefectHQ/prefect/pull/1705)
 
 ### Deprecations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=${PYTHON_VERSION:-3.6}
+ARG PYTHON_VERSION=${PYTHON_VERSION}
 FROM python:${PYTHON_VERSION}-slim
 
 RUN apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Removes the default python version from the dockerfile. This should always be explicitly provided by CircleCI (or the user for manual builds)

## Why is this PR important?
This ensures the proper images are built and tagged, preventing unexpected image contents.

