### PR TITLE
Raise informative error whenever context is pickled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
+- Raise an informative error when context objects are pickled - [#1710](https://github.com/PrefectHQ/prefect/issues/1710)
+
+### Task Library
+
+- None
+
+### Fixes
+
+- None
+
+### Deprecations
+
+- None
+
+### Breaking Changes
+
+- None
+
+### Contributors
+
+- None
+
+## 0.7.1 <Badge text="beta" type="success"/>
+
+Released on Nov 5, 2019
+
+### Features
+
+- None
+
+### Enhancements
+
 - Add a `save`/`load` interface to Flows - [#1685](https://github.com/PrefectHQ/prefect/pull/1685), [#1695](https://github.com/PrefectHQ/prefect/pull/1695)
 - Add option to specify `aws_session_token` for the `FargateTaskEnvironment` - [#1688](https://github.com/PrefectHQ/prefect/pull/1688)
 - Add `EnvVarSecrets` for loading sensitive information from environment variables - [#1683](https://github.com/PrefectHQ/prefect/pull/1683)

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -80,6 +80,21 @@ class Context(DotDict, threading.local):
             self.update(config.context)
         self["config"] = merge_dicts(config, self.get("config", {}))  # order matters
 
+    def __getstate__(self):
+        """
+        Because we dynamically update context during runs, we don't ever want to pickle
+        or "freeze" the contents of context.  Consequently it should always be accessed
+        as an attribute of the prefect module.
+        """
+        raise TypeError(
+            "\n".join(
+                [
+                    "Pickling context objects is explicitly not supported.",
+                    "You should always access context as an attribute of the `prefect` module, as in `prefect.context`",
+                ]
+            )
+        )
+
     def __repr__(self) -> str:
         return "<Context>"
 

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -80,7 +80,7 @@ class Context(DotDict, threading.local):
             self.update(config.context)
         self["config"] = merge_dicts(config, self.get("config", {}))  # order matters
 
-    def __getstate__(self):
+    def __getstate__(self) -> None:
         """
         Because we dynamically update context during runs, we don't ever want to pickle
         or "freeze" the contents of context.  Consequently it should always be accessed

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,4 @@
+import cloudpickle
 import queue
 import threading
 import time
@@ -181,3 +182,10 @@ def test_contexts_are_thread_safe():
         results.add(result_queue.get(block=False))
 
     assert results == set(range(len(threads)))
+
+
+def test_context_raises_informative_error_if_pickled():
+    c = Context()
+
+    with pytest.raises(TypeError, match="prefect.context"):
+        cloudpickle.dumps(c)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR raises an informative error whenever `context` is pickled.  Closes #1710 

## Why is this PR important?
Users are tempted to use context like:
```python
from prefect import context

@task
def my_fn():
    logger = context['logger']
```
and submit such tasks to dask.  This is problematic, because if we freeze context (which is what this import pattern effectively does), we lose all the dynamic information that is placed into context by the various runners.  

Consequently, users should _always_ access context as an attribute of the top-level module so that dynamically added keys will be available.

This PR raises an informative error for how to access context in the event that it is pickled.