### PR TITLE
Fix GraphQL doc typo

### DIFF
--- a/docs/cloud/concepts/graphql.md
+++ b/docs/cloud/concepts/graphql.md
@@ -32,7 +32,7 @@ most recently:
 query {
   task_run(
     where: { state: { _eq: "Failed" } }
-    order_by: { timestamp: desc }
+    order_by: { state_timestamp: desc }
     limit: 5
   ) {
     name


### PR DESCRIPTION
Example doesn't run, this appears to fix it.

As a side note: for someone pretty unfamiliar with GraphQL (<--), even with these docs it's pretty intimidating to try to figure out what kinds of things could be done through the API :)