### PR TITLE
Add identifier_label property to relevant environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix `identifier_label` not being generated on each run for Kubernetes based environments - [#1718](https://github.com/PrefectHQ/prefect/pull/1718)
 
 ### Deprecations
 

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -99,6 +99,16 @@ class DaskKubernetesEnvironment(Environment):
             self._identifier_label = str(uuid.uuid4())
         return self._identifier_label
 
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        # Ensure _identifier_label is not persisted
+        if "_identifier_label" in state:
+            del state["_identifier_label"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
     def setup(self, storage: "Docker") -> None:  # type: ignore
         if self.private_registry:
             from kubernetes import client, config

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -74,7 +74,6 @@ class DaskKubernetesEnvironment(Environment):
     ) -> None:
         self.min_workers = min_workers
         self.max_workers = max_workers
-        self.identifier_label = str(uuid.uuid4())
         self.private_registry = private_registry
         if self.private_registry:
             self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
@@ -91,6 +90,12 @@ class DaskKubernetesEnvironment(Environment):
     @property
     def dependencies(self) -> list:
         return ["kubernetes"]
+
+    @property
+    def identifier_label(self) -> str:
+        if not hasattr(self, "_identifier_label"):
+            self._identifier_label = str(uuid.uuid4())
+        return self._identifier_label
 
     def setup(self, storage: "Docker") -> None:  # type: ignore
         if self.private_registry:

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -93,7 +93,7 @@ class DaskKubernetesEnvironment(Environment):
 
     @property
     def identifier_label(self) -> str:
-        if not hasattr(self, "_identifier_label"):
+        if not hasattr(self, "_identifier_label") or not self._identifier_label:
             self._identifier_label = str(uuid.uuid4())
         return self._identifier_label
 

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -85,6 +85,8 @@ class DaskKubernetesEnvironment(Environment):
         # Load specs from file if path given, store on object
         self._scheduler_spec, self._worker_spec = self._load_specs_from_file()
 
+        self._identifier_label = ""
+
         super().__init__(labels=labels, on_start=on_start, on_exit=on_exit)
 
     @property

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -56,6 +56,8 @@ class KubernetesJobEnvironment(Environment):
         # Load specs from file if path given, store on object
         self._job_spec = self._load_spec_from_file()
 
+        self._identifier_label = ""
+
         super().__init__(labels=labels, on_start=on_start, on_exit=on_exit)
 
     @property

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -51,7 +51,6 @@ class KubernetesJobEnvironment(Environment):
         on_start: Callable = None,
         on_exit: Callable = None,
     ) -> None:
-        self.identifier_label = str(uuid.uuid4())
         self.job_spec_file = os.path.abspath(job_spec_file) if job_spec_file else None
 
         # Load specs from file if path given, store on object
@@ -62,6 +61,12 @@ class KubernetesJobEnvironment(Environment):
     @property
     def dependencies(self) -> list:
         return ["kubernetes"]
+
+    @property
+    def identifier_label(self) -> str:
+        if not hasattr(self, "_identifier_label"):
+            self._identifier_label = str(uuid.uuid4())
+        return self._identifier_label
 
     def execute(  # type: ignore
         self, storage: "Docker", flow_location: str, **kwargs: Any

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -70,6 +70,16 @@ class KubernetesJobEnvironment(Environment):
             self._identifier_label = str(uuid.uuid4())
         return self._identifier_label
 
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        # Ensure _identifier_label is not persisted
+        if "_identifier_label" in state:
+            del state["_identifier_label"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
     def execute(  # type: ignore
         self, storage: "Docker", flow_location: str, **kwargs: Any
     ) -> None:

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -64,7 +64,7 @@ class KubernetesJobEnvironment(Environment):
 
     @property
     def identifier_label(self) -> str:
-        if not hasattr(self, "_identifier_label"):
+        if not hasattr(self, "_identifier_label") or not self._identifier_label:
             self._identifier_label = str(uuid.uuid4())
         return self._identifier_label
 

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -425,3 +425,9 @@ def test_roundtrip_cloudpickle():
         assert isinstance(new, DaskKubernetesEnvironment)
         assert new._scheduler_spec == "scheduler"
         assert new._worker_spec == "worker"
+
+        # Identifer labels do not persist
+        assert environment.identifier_label
+        assert new.identifier_label
+
+        assert environment.identifier_label != new.identifier_label

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -50,6 +50,12 @@ def test_create_dask_environment_identifier_label():
     assert environment.identifier_label
 
 
+def test_create_dask_environment_identifier_label_none():
+    environment = DaskKubernetesEnvironment()
+    environment._identifier_label = None
+    assert environment.identifier_label
+
+
 def test_setup_dask_environment_passes():
     environment = DaskKubernetesEnvironment()
     environment.setup(storage=Docker())

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -423,3 +423,9 @@ def test_roundtrip_cloudpickle():
         new = cloudpickle.loads(cloudpickle.dumps(environment))
         assert isinstance(new, KubernetesJobEnvironment)
         assert new._job_spec == "job"
+
+        # Identifer labels do not persist
+        assert environment.identifier_label
+        assert new.identifier_label
+
+        assert environment.identifier_label != new.identifier_label

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -80,6 +80,19 @@ def test_create_k8s_job_environment_identifier_label():
         assert environment.identifier_label
 
 
+def test_create_k8s_job_environment_identifier_label_none():
+    with tempfile.TemporaryDirectory() as directory:
+
+        with open(os.path.join(directory, "job.yaml"), "w+") as file:
+            file.write("job")
+
+        environment = KubernetesJobEnvironment(
+            job_spec_file=os.path.join(directory, "job.yaml")
+        )
+        environment._identifier_label = None
+        assert environment.identifier_label
+
+
 def test_setup_k8s_job_environment_passes():
     with tempfile.TemporaryDirectory() as directory:
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds an `identifier_label` property to the Dask Kubernetes Environment and Kubernetes Job Environment.


## Why is this PR important?
The `identifier_label` was not being recreated on each run due to the way environments are stored on the Flow now

