### PR TITLE
Fix issue with user config path being overwritten in docker storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue where users could not override their user config path when deploying Docker to Cloud - [#1719](https://github.com/PrefectHQ/prefect/pull/1719)
 
 ### Deprecations
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -76,7 +76,9 @@ class Docker(Storage):
         self.python_dependencies.append("wheel")
 
         self.env_vars = env_vars or {}
-        self.env_vars["PREFECT__USER_CONFIG_PATH"] = "/root/.prefect/config.toml"
+        self.env_vars.setdefault(
+            "PREFECT__USER_CONFIG_PATH", "/root/.prefect/config.toml"
+        )
 
         self.files = files or {}
         self.flows = dict()  # type: Dict[str, str]

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -111,6 +111,14 @@ def test_initialized_docker_storage():
     assert storage.local_image
 
 
+def test_docker_storage_allows_for_user_provided_config_locations():
+    storage = Docker(env_vars={"PREFECT__USER_CONFIG_PATH": "1"},)
+
+    assert storage.env_vars == {
+        "PREFECT__USER_CONFIG_PATH": "1",
+    }
+
+
 def test_files_not_absolute_path():
     with pytest.raises(ValueError):
         storage = Docker(files={"test": "test"})


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.
