### PR TITLE
Add informative error logs if heartbeat thread fails or dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Raise an informative error when context objects are pickled - [#1710](https://github.com/PrefectHQ/prefect/issues/1710)
+- Add informative logs in the event that a heartbeat thread dies - [#1721](https://github.com/PrefectHQ/prefect/pull/1721)
 
 ### Task Library
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -52,29 +52,6 @@ def test_heartbeat_logs_if_first_call_fails(caplog):
     assert "zombie" in log.message
 
 
-def test_heartbeat_logs_if_first_call_fails(caplog):
-    class A:
-        def __init__(self):
-            self.logger = prefect.utilities.logging.get_logger("A")
-
-        def _heartbeat(self):
-            raise SyntaxError("oops")
-
-        @run_with_heartbeat
-        def run(self):
-            pass
-
-    a = A()
-    a.run()
-
-    assert caplog.records
-
-    log = caplog.records[0]
-    assert log.name == "prefect.A"
-    assert "Heartbeat" in log.message
-    assert "zombie" in log.message
-
-
 def test_heartbeat_logs_if_thread_dies(caplog):
     class A:
         def __init__(self):

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock
 import pytest
 
 import prefect
-from prefect.utilities.executors import Heartbeat, timeout_handler
+from prefect.utilities.configuration import set_temporary_config
+from prefect.utilities.executors import Heartbeat, timeout_handler, run_with_heartbeat
 
 
 def test_heartbeat_calls_function_on_interval():
@@ -26,6 +27,79 @@ def test_heartbeat_calls_function_on_interval():
     timer.cancel()
     timer.join()
     assert a.called == 2
+
+
+def test_heartbeat_logs_if_first_call_fails(caplog):
+    class A:
+        def __init__(self):
+            self.logger = prefect.utilities.logging.get_logger("A")
+
+        def _heartbeat(self):
+            raise SyntaxError("oops")
+
+        @run_with_heartbeat
+        def run(self):
+            pass
+
+    a = A()
+    a.run()
+
+    assert caplog.records
+
+    log = caplog.records[0]
+    assert log.name == "prefect.A"
+    assert "Heartbeat" in log.message
+    assert "zombie" in log.message
+
+
+def test_heartbeat_logs_if_first_call_fails(caplog):
+    class A:
+        def __init__(self):
+            self.logger = prefect.utilities.logging.get_logger("A")
+
+        def _heartbeat(self):
+            raise SyntaxError("oops")
+
+        @run_with_heartbeat
+        def run(self):
+            pass
+
+    a = A()
+    a.run()
+
+    assert caplog.records
+
+    log = caplog.records[0]
+    assert log.name == "prefect.A"
+    assert "Heartbeat" in log.message
+    assert "zombie" in log.message
+
+
+def test_heartbeat_logs_if_thread_dies(caplog):
+    class A:
+        def __init__(self):
+            self.calls = 0
+            self.logger = prefect.utilities.logging.get_logger("A")
+
+        def _heartbeat(self):
+            if self.calls == 1:
+                raise SyntaxError("oops")
+
+        @run_with_heartbeat
+        def run(self):
+            self.calls = 1
+            time.sleep(1)
+
+    a = A()
+    with set_temporary_config({"cloud.heartbeat_interval": 0.25}):
+        a.run()
+
+    assert caplog.records
+
+    log = caplog.records[0]
+    assert log.name == "prefect.A"
+    assert "Heartbeat thread died" in log.message
+    assert "zombie" in log.message
 
 
 def test_timeout_handler_times_out():

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -47,7 +47,7 @@ def test_remote_handler_captures_errors_and_logs_them(caplog):
             child_logger = logger.getChild("sub-test")
             child_logger.critical("this should raise an error in the handler")
 
-            time.sleep(1)  # wait for batch upload to occur
+            time.sleep(1.25)  # wait for batch upload to occur
             critical_logs = [r for r in caplog.records if r.levelname == "CRITICAL"]
             assert len(critical_logs) == 2
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces two new `ERROR` logs for heartbeats in the event that a failure or thread death occurs.

## Why is this PR important?
There are situations involving dask worker clients that appear to cause either a GIL deadlock or thread death, resulting in Zombied task / flow runs.  While we haven't isolated the root cause yet, the absence / presence of these logs would help in debugging this and any future heartbeat related issues.

