### PR TITLE
Respect order of inputs in merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix executor initialization missing `self` in `KubernetesJobEnvironment` - [#1713](https://github.com/PrefectHQ/prefect/pull/1713)
 - Fix `identifier_label` not being generated on each run for Kubernetes based environments - [#1718](https://github.com/PrefectHQ/prefect/pull/1718)
 - Fix issue where users could not override their user config path when deploying Docker to Cloud - [#1719](https://github.com/PrefectHQ/prefect/pull/1719)
+- Respect order of inputs in merge - [#1736](https://github.com/~/1736)
 
 ### Deprecations
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -16,7 +16,7 @@ class Merge(Task):
 
     def run(self, **task_results: Any) -> Any:
         return next(
-            (v for v in task_results.values() if not isinstance(v, NoResultType)), None
+            (v for k, v in sorted(task_results.items()) if not isinstance(v, NoResultType)), None
         )
 
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -16,7 +16,12 @@ class Merge(Task):
 
     def run(self, **task_results: Any) -> Any:
         return next(
-            (v for k, v in sorted(task_results.items()) if not isinstance(v, NoResultType)), None
+            (
+                v
+                for k, v in sorted(task_results.items())
+                if not isinstance(v, NoResultType)
+            ),
+            None,
         )
 
 

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -224,9 +224,9 @@ def test_merge_with_list():
 
 def test_merge_order():
     with Flow(name="test") as flow:
-        x = 'x'
-        y = 'y'
-        merge_task = merge('x', 'y')
+        x = "x"
+        y = "y"
+        merge_task = merge("x", "y")
 
     state = flow.run()
     assert state.result[merge_task].result == "x"

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -222,6 +222,16 @@ def test_merge_with_list():
         assert state.result[merge_task].result == [1, 2]
 
 
+def test_merge_order():
+    with Flow(name="test") as flow:
+        x = 'x'
+        y = 'y'
+        merge_task = merge('x', 'y')
+
+    state = flow.run()
+    assert state.result[merge_task].result == "x"
+
+
 class TestFilterTask:
     def test_empty_initialization(self):
         task = FilterTask()

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -223,10 +223,16 @@ def test_merge_with_list():
 
 
 def test_merge_order():
+    @task
+    def x():
+        return "x"
+
+    @task
+    def y():
+        return "y"
+
     with Flow(name="test") as flow:
-        x = "x"
-        y = "y"
-        merge_task = merge("x", "y")
+        merge_task = merge(x(), y())
 
     state = flow.run()
     assert state.result[merge_task].result == "x"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Currently `merge(a, b)` randomly returns either `a` or `b` if both tasks have results. However, the docs say:

> The merge will return the first real result it encounters, or None.

which to me implies that the result in that case should be `a`. The randomness comes from the fact that task results come from edges, which are stored as a set, which have non-deterministic ordering.


## Why is this PR important?
@cicdw mentioned this is maybe not the original intended use of `merge`, but to me it feels valid and the docs definitely suggest that this should work. Also less randomness in results when re-running some flows seems desirable.
