### PR TITLE
Allow users to provide a Dockerfile instead of a base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Local Docker agent proactively fails flow runs if image cannot be pulled - [#1395](https://github.com/PrefectHQ/prefect/issues/1395)
 - Add graceful keyboard interrupt shutdown for all agents - [#1731](https://github.com/PrefectHQ/prefect/pull/1731)
 - `agent start` CLI command now allows for Agent kwargs - [#1737](https://github.com/PrefectHQ/prefect/pull/1737)
+- Add users to specify a custom Dockerfile for Docker storage - [#1738](https://github.com/PrefectHQ/prefect/pull/1738)
 
 ### Task Library
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -38,6 +38,7 @@ class Docker(Storage):
         - registry_url (str, optional): URL of a registry to push the image to; image will not be pushed if not provided
         - base_image (str, optional): the base image for this environment (e.g. `python:3.6`), defaults to the `prefecthq/prefect` image
             matching your python version and prefect core library version used at runtime.
+        - dockerfile (str, optional): a path to a Dockerfile to use in building this storage
         - python_dependencies (List[str], optional): list of pip installable dependencies for the image
         - image_name (str, optional): name of the image to use when building, populated with a UUID after build
         - image_tag (str, optional): tag of the image to use when building, populated with a UUID after build
@@ -48,6 +49,10 @@ class Docker(Storage):
             you want installed into the container; defaults to the version you are currently using or `"master"` if your version is ahead of
             the latest tag
         - local_image(bool, optional): an optional flag whether or not to use a local docker image, if True then a pull will not be attempted
+
+    Raises:
+        - ValueError: if both `base_image` and `dockerfile` are provided
+
     """
 
     def __init__(
@@ -113,7 +118,7 @@ class Docker(Storage):
                 "Only one of `base_image` and `dockerfile` can be provided."
             )
         else:
-            self.base_image = base_image
+            self.base_image = base_image  # type: ignore
 
         self.dockerfile = dockerfile
         # we should always try to install prefect, unless it is already installed. We can't determine this until
@@ -428,7 +433,6 @@ class Docker(Storage):
                 """.format(
                     base_commands=base_commands,
                     extra_commands=extra_commands,
-                    base_image=self.base_image,
                     pip_installs=pip_installs,
                     copy_flows=copy_flows,
                     copy_files=copy_files,


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR exposes a new `dockerfile` keyword argument for users to provide a custom dockerfile for flow docker storage. 


## Why is this PR important?
Allows for better more efficient control of Docker images for flows instead of having to first build a base image.