### PR TITLE
Bound urllib3 below due to an issue in older versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tabulate >= 0.8.0, <1.0
 toml >= 0.9.4, <1.0
 typing >= 3.6.1, <4.0
 typing_extensions >= 3.6.2, <4.0
+urllib3 >= 1.24.3


### PR DESCRIPTION
It seems that some python packages install older versions of `urllib3` that are incompatible with our Python client.  This PR bounds `urllib3` from below in our `requirements.txt` so that users don't have to go on a bug hunt!