### PR TITLE
Update Environment `run_flow` call to use Flow's original Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ## 0.7.2 <Badge text="beta" type="success"/>
 
-These changes are available in the [master branch](https://github.com/PrefectHQ/prefect).
+Released on Nov 15, 2019.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Features
 
+- None
+
+### Enhancements
+
+- None
+
+### Task Library
+
+- None
+
+### Fixes
+
+- Fix issue with Environments not calling `run_flow` on Environment stored on Flow object - [#1752](https://github.com/PrefectHQ/prefect/pull/1752)
+
+### Deprecations
+
+- None
+
+### Breaking Changes
+
+- None
+
+### Contributors
+
+- None
+
+## 0.7.2 <Badge text="beta" type="success"/>
+
+These changes are available in the [master branch](https://github.com/PrefectHQ/prefect).
+
+### Features
+
 - Allow users to provide a custom version group ID for controlling Cloud versioning - [#1665](https://github.com/PrefectHQ/prefect/issues/1665)
 - Stop autogenerating constant tasks - [#1730](https://github.com/PrefectHQ/prefect/pull/1730)
 

--- a/docs/cloud/execution/fargate_task_environment.md
+++ b/docs/cloud/execution/fargate_task_environment.md
@@ -95,7 +95,7 @@ The container dictionary above will be changed during setup:
 [
     "/bin/sh",
     "-c",
-    "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
+    "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
 ]
 ```
 

--- a/docs/cloud/execution/fargate_task_environment.md
+++ b/docs/cloud/execution/fargate_task_environment.md
@@ -95,7 +95,7 @@ The container dictionary above will be changed during setup:
 [
     "/bin/sh",
     "-c",
-    "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+    "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
 ]
 ```
 

--- a/docs/cloud/execution/fargate_task_environment.md
+++ b/docs/cloud/execution/fargate_task_environment.md
@@ -95,7 +95,7 @@ The container dictionary above will be changed during setup:
 [
     "/bin/sh",
     "-c",
-    "python -c 'from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()'",
+    "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
 ]
 ```
 

--- a/docs/cloud/execution/k8s_job_environment.md
+++ b/docs/cloud/execution/k8s_job_environment.md
@@ -57,7 +57,7 @@ In the above YAML block, `flow-container` will be changed during execution:
 - `command` and `args` will take the form of:
 
 ```bash
-/bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+/bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
 ```
 
 - `env` will have some extra variables automatically appended to it for Cloud-based Flow runs:

--- a/docs/cloud/execution/k8s_job_environment.md
+++ b/docs/cloud/execution/k8s_job_environment.md
@@ -57,7 +57,7 @@ In the above YAML block, `flow-container` will be changed during execution:
 - `command` and `args` will take the form of:
 
 ```bash
-/bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+/bin/sh -c "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
 ```
 
 - `env` will have some extra variables automatically appended to it for Cloud-based Flow runs:

--- a/docs/cloud/execution/k8s_job_environment.md
+++ b/docs/cloud/execution/k8s_job_environment.md
@@ -57,7 +57,7 @@ In the above YAML block, `flow-container` will be changed during execution:
 - `command` and `args` will take the form of:
 
 ```bash
-/bin/sh -c 'python -c "from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()"'
+/bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
 ```
 
 - `env` will have some extra variables automatically appended to it for Cloud-based Flow runs:

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -17,7 +17,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              'python -c "import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()"',
+              'python -c "import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()"',
             ]
           env:
             - name: PREFECT__CLOUD__GRAPHQL

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -17,7 +17,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              'python -c "import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()"',
+              'python -c "import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()"',
             ]
           env:
             - name: PREFECT__CLOUD__GRAPHQL

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -15,7 +15,10 @@ spec:
           image: prefecthq/prefect:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
-          args: ['python -c "from prefect.environments import DaskKubernetesEnvironment; DaskKubernetesEnvironment().run_flow()"']
+          args:
+            [
+              'python -c "import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()"',
+            ]
           env:
             - name: PREFECT__CLOUD__GRAPHQL
               value: PREFECT__CLOUD__GRAPHQL

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -229,7 +229,7 @@ class FargateTaskEnvironment(Environment):
             self.task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
                 "/bin/sh",
                 "-c",
-                "python -c 'from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
             ]
 
             boto3_c.register_task_definition(**self.task_definition_kwargs)

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -33,7 +33,7 @@ class FargateTaskEnvironment(Environment):
 
     Additionally, the following command will be applied to the first container:
 
-    `$ /bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
 
     All `kwargs` are accepted that one would normally pass to boto3 for `register_task_definition`
     and `run_task`. For information on the kwargs supported visit the following links:
@@ -229,7 +229,7 @@ class FargateTaskEnvironment(Environment):
             self.task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ]
 
             boto3_c.register_task_definition(**self.task_definition_kwargs)

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -33,7 +33,7 @@ class FargateTaskEnvironment(Environment):
 
     Additionally, the following command will be applied to the first container:
 
-    `$ /bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
 
     All `kwargs` are accepted that one would normally pass to boto3 for `register_task_definition`
     and `run_task`. For information on the kwargs supported visit the following links:
@@ -229,7 +229,7 @@ class FargateTaskEnvironment(Environment):
             self.task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ]
 
             boto3_c.register_task_definition(**self.task_definition_kwargs)

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -33,7 +33,7 @@ class FargateTaskEnvironment(Environment):
 
     Additionally, the following command will be applied to the first container:
 
-    `$ /bin/sh -c 'python -c "from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()"'`
+    `$ /bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"`
 
     All `kwargs` are accepted that one would normally pass to boto3 for `register_task_definition`
     and `run_task`. For information on the kwargs supported visit the following links:

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -264,7 +264,7 @@ class KubernetesJobEnvironment(Environment):
             yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
 
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "python -c 'from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         return yaml_obj

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -34,7 +34,7 @@ class KubernetesJobEnvironment(Environment):
     - `PREFECT__LOGGING__LOG_TO_CLOUD`
 
     Additionally, the following command will be applied to the first container:
-    `$ /bin/sh -c 'python -c "from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()"'`
+    `$ /bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"`
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -34,7 +34,7 @@ class KubernetesJobEnvironment(Environment):
     - `PREFECT__LOGGING__LOG_TO_CLOUD`
 
     Additionally, the following command will be applied to the first container:
-    `$ /bin/sh -c "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file
@@ -264,7 +264,7 @@ class KubernetesJobEnvironment(Environment):
             yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
 
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         return yaml_obj

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -34,7 +34,7 @@ class KubernetesJobEnvironment(Environment):
     - `PREFECT__LOGGING__LOG_TO_CLOUD`
 
     Additionally, the following command will be applied to the first container:
-    `$ /bin/sh -c "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"`
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file
@@ -264,7 +264,7 @@ class KubernetesJobEnvironment(Environment):
             yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
 
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         return yaml_obj

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -251,7 +251,7 @@ def test_setup_definition_register(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ],
             "environment": [
                 {
@@ -312,7 +312,7 @@ def test_setup_definition_register_no_defintions(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ],
         }
     ]
@@ -470,7 +470,7 @@ def test_entire_environment_process_together(monkeypatch):
                 "command": [
                     "/bin/sh",
                     "-c",
-                    "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+                    "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
                 ],
                 "environment": [
                     {

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -251,7 +251,7 @@ def test_setup_definition_register(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
             ],
             "environment": [
                 {
@@ -312,7 +312,7 @@ def test_setup_definition_register_no_defintions(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
             ],
         }
     ]
@@ -470,7 +470,7 @@ def test_entire_environment_process_together(monkeypatch):
                 "command": [
                     "/bin/sh",
                     "-c",
-                    "python -c 'from prefect.environments import FargateTaskEnvironment; FargateTaskEnvironment().run_flow()'",
+                    "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
                 ],
                 "environment": [
                     {

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -251,7 +251,7 @@ def test_setup_definition_register(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ],
             "environment": [
                 {
@@ -312,7 +312,7 @@ def test_setup_definition_register_no_defintions(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
+                "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
             ],
         }
     ]
@@ -470,7 +470,7 @@ def test_entire_environment_process_together(monkeypatch):
                 "command": [
                     "/bin/sh",
                     "-c",
-                    "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'",
+                    "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
                 ],
                 "environment": [
                     {

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -307,7 +307,7 @@ def test_populate_job_yaml():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -367,7 +367,7 @@ def test_populate_job_yaml_no_defaults():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -431,7 +431,7 @@ def test_populate_job_yaml_multiple_containers():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         # Assert Second Container
@@ -450,7 +450,7 @@ def test_populate_job_yaml_multiple_containers():
         )
 
         assert yaml_obj["spec"]["template"]["spec"]["containers"][1]["args"] != [
-            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -307,7 +307,7 @@ def test_populate_job_yaml():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -367,7 +367,7 @@ def test_populate_job_yaml_no_defaults():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -431,7 +431,7 @@ def test_populate_job_yaml_multiple_containers():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         # Assert Second Container
@@ -450,7 +450,7 @@ def test_populate_job_yaml_multiple_containers():
         )
 
         assert yaml_obj["spec"]["template"]["spec"]["containers"][1]["args"] != [
-            "python -c 'from prefect.environments import KubernetesJobEnvironment; KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; from prefect.environments.storage import Docker; Docker().get_flow(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -307,7 +307,7 @@ def test_populate_job_yaml():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -367,7 +367,7 @@ def test_populate_job_yaml_no_defaults():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 
@@ -431,7 +431,7 @@ def test_populate_job_yaml_multiple_containers():
             "-c",
         ]
         assert yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] == [
-            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
         # Assert Second Container
@@ -450,7 +450,7 @@ def test_populate_job_yaml_multiple_containers():
         )
 
         assert yaml_obj["spec"]["template"]["spec"]["containers"][1]["args"] != [
-            "python -c 'import prefect; from prefect import Flow; Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+            "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
         ]
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updated the commands for a few environments which were calling `run_flow` on a new Environment object


## Why is this PR important?
If a new Environment object is created on each run then some of the information stored on the environment won't persist. This is mainly an issue in specifying things like `min_workers` and `max_workers` on the `DaskKubernetesEnvironment`. 

