### PR TITLE
Add run_name option to cloud run CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Add option to specify a run name for `cloud run` CLI command - [#1756](https://github.com/PrefectHQ/prefect/pull/1756)
 
 ### Task Library
 

--- a/docs/core/concepts/persistence.md
+++ b/docs/core/concepts/persistence.md
@@ -1,7 +1,7 @@
 # Persistence and Caching
 
 Out of the box, Prefect Core does not persist data in a permanent fashion.  All data, results, _and_ cached states are stored in memory within the
-Python process running the Flow.  However, Prefect Core provides all of the necssary hooks for persisting / retrieving your data in external locations.  If you require an out-of-the-box persistence layer, you might consider [Prefect Cloud](../../cloud/faq.html#what-is-the-difference-between-prefect-core-and-prefect-cloud).
+Python process running the Flow.  However, Prefect Core provides all of the necessary hooks for persisting / retrieving your data in external locations.  If you require an out-of-the-box persistence layer, you might consider [Prefect Cloud](../../cloud/faq.html#what-is-the-difference-between-prefect-core-and-prefect-cloud).
 
 
 Prefect provides a few ways to work with cached data. Wherever possible, caching is handled automatically or with minimal user input.

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -54,8 +54,9 @@ def run():
     type=click.Path(exists=True),
 )
 @click.option(
-    "--parameters-string", "--ps", help="A parameters JSON string.", hidden=True
+    "--parameters-string", "-ps", help="A parameters JSON string.", hidden=True
 )
+@click.option("--run-name", "-rn", help="A name to assign for this run.", hidden=True)
 @click.option(
     "--watch",
     "-w",
@@ -66,7 +67,9 @@ def run():
 @click.option(
     "--logs", "-l", is_flag=True, help="Live logs of the flow run.", hidden=True
 )
-def cloud(name, project, version, parameters_file, parameters_string, watch, logs):
+def cloud(
+    name, project, version, parameters_file, parameters_string, run_name, watch, logs
+):
     """
     Run a deployed flow in Prefect Cloud.
 
@@ -77,6 +80,7 @@ def cloud(name, project, version, parameters_file, parameters_string, watch, log
         --version, -v               INTEGER     A flow version to run
         --parameters-file, -pf      FILE PATH   A filepath of a JSON file containing parameters
         --parameters-string, -ps    TEXT        A string of JSON parameters
+        --run-name, -rn             TEXT        A name to assign for this run
         --watch, -w                             Watch current state of the flow run, stream output to stdout
         --logs, -l                              Get logs of the flow run, stream output to stdout
 
@@ -142,7 +146,7 @@ def cloud(name, project, version, parameters_file, parameters_string, watch, log
         string_params = json.loads(parameters_string)
 
     flow_run_id = client.create_flow_run(
-        flow_id=flow_id, parameters={**file_params, **string_params}
+        flow_id=flow_id, parameters={**file_params, **string_params}, run_name=run_name
     )
     click.echo("Flow Run ID: {}".format(flow_run_id))
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds the option to specify a `--run-name / -rn` for a Cloud Flow run.

e.g. `prefect cloud run -n Flow -p Project --run-name NAME` will create a flow run named `NAME`


## Why is this PR important?
Extra option that needed to be exposed from the CLI :)

