### PR TITLE
Allow for dask work stealing to be toggles in Dask Kubernetes Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Add option to specify a run name for `cloud run` CLI command - [#1756](https://github.com/PrefectHQ/prefect/pull/1756)
+- Add `work_stealing` option to `DaskKubernetesEnvironment` - [#1760](https://github.com/PrefectHQ/prefect/pull/1760)
 
 ### Task Library
 

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -46,6 +46,9 @@ class DaskKubernetesEnvironment(Environment):
     Args:
         - min_workers (int, optional): the minimum allowed number of Dask worker pods; defaults to 1
         - max_workers (int, optional): the maximum allowed number of Dask worker pods; defaults to 1
+        - work_stealing (bool, optional): toggle Dask Distributed scheduler work stealing; defaults to False
+            Only used when a custom scheduler spec is not provided. Enabling this may cause ClientErrors
+            to appear when multiple Dask workers try to run the same Prefect Task.
         - private_registry (bool, optional): a boolean specifying whether your Flow's Docker container will be in a private
             Docker registry; if so, requires a Prefect Secret containing your docker credentials to be set.
             Defaults to `False`.
@@ -64,6 +67,7 @@ class DaskKubernetesEnvironment(Environment):
         self,
         min_workers: int = 1,
         max_workers: int = 2,
+        work_stealing: bool = False,
         private_registry: bool = False,
         docker_secret: str = None,
         labels: List[str] = None,
@@ -74,6 +78,7 @@ class DaskKubernetesEnvironment(Environment):
     ) -> None:
         self.min_workers = min_workers
         self.max_workers = max_workers
+        self.work_stealing = work_stealing
         self.private_registry = private_registry
         if self.private_registry:
             self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
@@ -343,6 +348,7 @@ class DaskKubernetesEnvironment(Environment):
         env[3]["value"] = prefect.context.get("namespace", "")
         env[4]["value"] = docker_name
         env[5]["value"] = flow_file_path
+        env[13]["value"] = str(self.work_stealing)
 
         # set image
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"] = docker_name

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -17,12 +17,31 @@ from prefect.utilities.configuration import set_temporary_config
 def test_create_dask_environment():
     environment = DaskKubernetesEnvironment()
     assert environment
+    assert environment.min_workers == 1
+    assert environment.max_workers == 2
+    assert environment.work_stealing is False
     assert environment.private_registry is False
     assert environment.docker_secret is None
     assert environment.labels == set()
     assert environment.on_start is None
     assert environment.on_exit is None
     assert environment.logger.name == "prefect.DaskKubernetesEnvironment"
+
+
+def test_create_dask_environment_args():
+    environment = DaskKubernetesEnvironment(
+        min_workers=5,
+        max_workers=6,
+        work_stealing=True,
+        private_registry=True,
+        docker_secret="docker",
+    )
+    assert environment
+    assert environment.min_workers == 5
+    assert environment.max_workers == 6
+    assert environment.work_stealing is True
+    assert environment.private_registry is True
+    assert environment.docker_secret == "docker"
 
 
 def test_create_dask_environment_labels():
@@ -233,7 +252,7 @@ def test_run_flow_calls_callbacks(monkeypatch):
 
 
 def test_populate_job_yaml():
-    environment = DaskKubernetesEnvironment()
+    environment = DaskKubernetesEnvironment(work_stealing=True)
 
     file_path = os.path.dirname(prefect.environments.execution.dask.k8s.__file__)
 
@@ -266,6 +285,7 @@ def test_populate_job_yaml():
     assert env[3]["value"] == "namespace_test"
     assert env[4]["value"] == "test1/test2:test3"
     assert env[5]["value"] == "test4"
+    assert env[13]["value"] == "True"
 
     assert (
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"]


### PR DESCRIPTION

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a kwarg for `work_stealing` to the Dask Kubernetes Environment. Previously this _always_ defaulted to 'False'


## Why is this PR important?
There are some cases in which users want to enable work stealing.

