### PR TITLE
Makes Cloud first-page in docs more user friendly

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,26 +1,26 @@
-const sidebar64 = require('../api/0.6.4/sidebar')
-const sidebar65 = require('../api/0.6.5/sidebar')
-const sidebar66 = require('../api/0.6.6/sidebar')
-const sidebar67 = require('../api/0.6.7/sidebar')
-const sidebar70 = require('../api/0.7.0/sidebar')
-const sidebar71 = require('../api/0.7.1/sidebar')
-const sidebar72 = require('../api/0.7.2/sidebar')
-const glob = require('glob')
+const sidebar64 = require("../api/0.6.4/sidebar");
+const sidebar65 = require("../api/0.6.5/sidebar");
+const sidebar66 = require("../api/0.6.6/sidebar");
+const sidebar67 = require("../api/0.6.7/sidebar");
+const sidebar70 = require("../api/0.7.0/sidebar");
+const sidebar71 = require("../api/0.7.1/sidebar");
+const sidebar72 = require("../api/0.7.2/sidebar");
+const glob = require("glob");
 
 // function for loading all MD files in a directory
-const getChildren = function (parent_path, dir) {
+const getChildren = function(parent_path, dir) {
   return glob
-    .sync(parent_path + '/' + dir + '/**/*.md')
+    .sync(parent_path + "/" + dir + "/**/*.md")
     .map(path => {
       // remove "parent_path" and ".md"
-      path = path.slice(parent_path.length + 1, -3)
+      path = path.slice(parent_path.length + 1, -3);
       // remove README
-      if (path.endsWith('README')) {
-        path = path.slice(0, -6)
+      if (path.endsWith("README")) {
+        path = path.slice(0, -6);
       }
-      return path
+      return path;
     })
-    .sort()
+    .sort();
 };
 
 module.exports = {
@@ -44,8 +44,8 @@ module.exports = {
   ],
   themeConfig: {
     algolia: {
-      apiKey: '553c75634e1d4f09c84f7a513f9cc4f9',
-      indexName: 'prefect'
+      apiKey: "553c75634e1d4f09c84f7a513f9cc4f9",
+      indexName: "prefect"
     },
     repo: "PrefectHQ/prefect",
     docsDir: "docs",
@@ -71,7 +71,7 @@ module.exports = {
           { text: "0.6.7", link: "/api/0.6.7/" },
           { text: "0.6.6", link: "/api/0.6.6/" },
           { text: "0.6.5", link: "/api/0.6.5/" },
-          { text: "0.6.4", link: "/api/0.6.4/" },
+          { text: "0.6.4", link: "/api/0.6.4/" }
         ]
       }
     ],
@@ -86,7 +86,10 @@ module.exports = {
       "/api/unreleased/": [
         { title: "API Reference", path: "/api/unreleased/" },
         "changelog",
-        { title: "Test Coverage", path: "https://codecov.io/gh/PrefectHQ/prefect" },
+        {
+          title: "Test Coverage",
+          path: "https://codecov.io/gh/PrefectHQ/prefect"
+        },
         {
           title: "prefect",
           collapsable: true,
@@ -137,12 +140,20 @@ module.exports = {
         {
           title: "Welcome",
           collapsable: false,
-          children: ["the-basics", "upandrunning", "flow-deploy", "dataflow", "deployment", "faq"]
+          children: [
+            "the-basics",
+            "upandrunning",
+            "flow-deploy",
+            "dataflow",
+            "deployment",
+            "other-considerations",
+            "faq"
+          ]
         },
         {
           title: "Cloud Concepts",
           collapsable: true,
-          children: getChildren('docs/cloud', 'concepts')
+          children: getChildren("docs/cloud", "concepts")
         },
         {
           title: "Cloud Execution",
@@ -153,17 +164,17 @@ module.exports = {
             "execution/dask_k8s_environment",
             "execution/k8s_job_environment",
             "execution/fargate_task_environment",
-            "execution/custom_environment",
+            "execution/custom_environment"
           ]
         },
         {
-          title: 'Agent',
+          title: "Agent",
           collapsable: true,
           children: [
-            'agent/overview',
-            'agent/local',
-            'agent/kubernetes',
-            'agent/fargate',
+            "agent/overview",
+            "agent/local",
+            "agent/kubernetes",
+            "agent/fargate"
           ]
         },
         {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,269 +1,269 @@
-const sidebar64 = require("../api/0.6.4/sidebar");
-const sidebar65 = require("../api/0.6.5/sidebar");
-const sidebar66 = require("../api/0.6.6/sidebar");
-const sidebar67 = require("../api/0.6.7/sidebar");
-const sidebar70 = require("../api/0.7.0/sidebar");
-const sidebar71 = require("../api/0.7.1/sidebar");
-const sidebar72 = require("../api/0.7.2/sidebar");
-const glob = require("glob");
+const sidebar64 = require('../api/0.6.4/sidebar')
+const sidebar65 = require('../api/0.6.5/sidebar')
+const sidebar66 = require('../api/0.6.6/sidebar')
+const sidebar67 = require('../api/0.6.7/sidebar')
+const sidebar70 = require('../api/0.7.0/sidebar')
+const sidebar71 = require('../api/0.7.1/sidebar')
+const sidebar72 = require('../api/0.7.2/sidebar')
+const glob = require('glob')
 
 // function for loading all MD files in a directory
 const getChildren = function(parent_path, dir) {
   return glob
-    .sync(parent_path + "/" + dir + "/**/*.md")
+    .sync(parent_path + '/' + dir + '/**/*.md')
     .map(path => {
       // remove "parent_path" and ".md"
-      path = path.slice(parent_path.length + 1, -3);
+      path = path.slice(parent_path.length + 1, -3)
       // remove README
-      if (path.endsWith("README")) {
-        path = path.slice(0, -6);
+      if (path.endsWith('README')) {
+        path = path.slice(0, -6)
       }
-      return path;
+      return path
     })
-    .sort();
-};
+    .sort()
+}
 
 module.exports = {
-  title: "Prefect Docs",
+  title: 'Prefect Docs',
   description: "Don't Panic.",
   head: [
-    "link",
+    'link',
     {
-      rel: "icon",
-      href: "/favicon.ico"
+      rel: 'icon',
+      href: '/favicon.ico'
     }
   ],
   plugins: [
     [
-      "@vuepress/google-analytics",
+      '@vuepress/google-analytics',
       {
-        ga: "UA-115585378-1"
+        ga: 'UA-115585378-1'
       }
     ],
-    ["vuepress-plugin-code-copy", true]
+    ['vuepress-plugin-code-copy', true]
   ],
   themeConfig: {
     algolia: {
-      apiKey: "553c75634e1d4f09c84f7a513f9cc4f9",
-      indexName: "prefect"
+      apiKey: '553c75634e1d4f09c84f7a513f9cc4f9',
+      indexName: 'prefect'
     },
-    repo: "PrefectHQ/prefect",
-    docsDir: "docs",
+    repo: 'PrefectHQ/prefect',
+    docsDir: 'docs',
     editLinks: true,
     // repoLabel: 'GitHub',
-    logo: "/assets/logomark-color.svg",
+    logo: '/assets/logomark-color.svg',
     nav: [
       {
-        text: "Prefect Core",
-        link: "/core/"
+        text: 'Prefect Core',
+        link: '/core/'
       },
       {
-        text: "Prefect Cloud",
-        link: "/cloud/the-basics"
+        text: 'Prefect Cloud',
+        link: '/cloud/the-basics'
       },
       {
-        text: "API Reference",
+        text: 'API Reference',
         items: [
-          { text: "Unreleased", link: "/api/unreleased/" },
-          { text: "0.7.2", link: "/api/0.7.2/" },
-          { text: "0.7.1", link: "/api/0.7.1/" },
-          { text: "0.7.0", link: "/api/0.7.0/" },
-          { text: "0.6.7", link: "/api/0.6.7/" },
-          { text: "0.6.6", link: "/api/0.6.6/" },
-          { text: "0.6.5", link: "/api/0.6.5/" },
-          { text: "0.6.4", link: "/api/0.6.4/" }
+          { text: 'Unreleased', link: '/api/unreleased/' },
+          { text: '0.7.2', link: '/api/0.7.2/' },
+          { text: '0.7.1', link: '/api/0.7.1/' },
+          { text: '0.7.0', link: '/api/0.7.0/' },
+          { text: '0.6.7', link: '/api/0.6.7/' },
+          { text: '0.6.6', link: '/api/0.6.6/' },
+          { text: '0.6.5', link: '/api/0.6.5/' },
+          { text: '0.6.4', link: '/api/0.6.4/' }
         ]
       }
     ],
     sidebar: {
-      "/api/0.6.4/": sidebar64.sidebar,
-      "/api/0.6.5/": sidebar65.sidebar,
-      "/api/0.6.6/": sidebar66.sidebar,
-      "/api/0.6.7/": sidebar67.sidebar,
-      "/api/0.7.0/": sidebar70.sidebar,
-      "/api/0.7.1/": sidebar71.sidebar,
-      "/api/0.7.2/": sidebar72.sidebar,
-      "/api/unreleased/": [
-        { title: "API Reference", path: "/api/unreleased/" },
-        "changelog",
+      '/api/0.6.4/': sidebar64.sidebar,
+      '/api/0.6.5/': sidebar65.sidebar,
+      '/api/0.6.6/': sidebar66.sidebar,
+      '/api/0.6.7/': sidebar67.sidebar,
+      '/api/0.7.0/': sidebar70.sidebar,
+      '/api/0.7.1/': sidebar71.sidebar,
+      '/api/0.7.2/': sidebar72.sidebar,
+      '/api/unreleased/': [
+        { title: 'API Reference', path: '/api/unreleased/' },
+        'changelog',
         {
-          title: "Test Coverage",
-          path: "https://codecov.io/gh/PrefectHQ/prefect"
+          title: 'Test Coverage',
+          path: 'https://codecov.io/gh/PrefectHQ/prefect'
         },
         {
-          title: "prefect",
+          title: 'prefect',
           collapsable: true,
-          children: ["triggers"]
+          children: ['triggers']
         },
         {
-          title: "prefect.client",
+          title: 'prefect.client',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "client")
+          children: getChildren('docs/api/unreleased', 'client')
         },
         {
-          title: "prefect.core",
+          title: 'prefect.core',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "core")
+          children: getChildren('docs/api/unreleased', 'core')
         },
         {
-          title: "prefect.engine",
+          title: 'prefect.engine',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "engine")
+          children: getChildren('docs/api/unreleased', 'engine')
         },
         {
-          title: "prefect.environments",
+          title: 'prefect.environments',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "environments")
+          children: getChildren('docs/api/unreleased', 'environments')
         },
         {
-          title: "prefect.tasks",
+          title: 'prefect.tasks',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "tasks")
+          children: getChildren('docs/api/unreleased', 'tasks')
         },
         {
-          title: "prefect.schedules",
+          title: 'prefect.schedules',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "schedules")
+          children: getChildren('docs/api/unreleased', 'schedules')
         },
         {
-          title: "prefect.agent",
+          title: 'prefect.agent',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "agent")
+          children: getChildren('docs/api/unreleased', 'agent')
         },
         {
-          title: "prefect.utilities",
+          title: 'prefect.utilities',
           collapsable: true,
-          children: getChildren("docs/api/unreleased", "utilities")
+          children: getChildren('docs/api/unreleased', 'utilities')
         }
       ],
-      "/cloud/": [
+      '/cloud/': [
         {
-          title: "Welcome",
+          title: 'Welcome',
           collapsable: false,
           children: [
-            "the-basics",
-            "upandrunning",
-            "flow-deploy",
-            "dataflow",
-            "deployment",
-            "other-considerations",
-            "faq"
+            'the-basics',
+            'upandrunning',
+            'flow-deploy',
+            'dataflow',
+            'deployment',
+            'other-considerations',
+            'faq'
           ]
         },
         {
-          title: "Cloud Concepts",
+          title: 'Cloud Concepts',
           collapsable: true,
-          children: getChildren("docs/cloud", "concepts")
+          children: getChildren('docs/cloud', 'concepts')
         },
         {
-          title: "Cloud Execution",
+          title: 'Cloud Execution',
           collapsable: true,
           children: [
-            "execution/overview",
-            "execution/remote_environment",
-            "execution/dask_k8s_environment",
-            "execution/k8s_job_environment",
-            "execution/fargate_task_environment",
-            "execution/custom_environment"
+            'execution/overview',
+            'execution/remote_environment',
+            'execution/dask_k8s_environment',
+            'execution/k8s_job_environment',
+            'execution/fargate_task_environment',
+            'execution/custom_environment'
           ]
         },
         {
-          title: "Agent",
+          title: 'Agent',
           collapsable: true,
           children: [
-            "agent/overview",
-            "agent/local",
-            "agent/kubernetes",
-            "agent/fargate"
+            'agent/overview',
+            'agent/local',
+            'agent/kubernetes',
+            'agent/fargate'
           ]
         },
         {
-          title: "Deployment Recipes",
+          title: 'Deployment Recipes',
           collapsable: true,
-          children: getChildren("docs/cloud", "recipes")
+          children: getChildren('docs/cloud', 'recipes')
         }
       ],
-      "/core/": [
-        "/core/",
+      '/core/': [
+        '/core/',
         {
-          title: "Welcome",
+          title: 'Welcome',
           collapsable: false,
           children: [
-            "welcome/what_is_prefect",
-            "welcome/why_prefect",
-            "welcome/why_not_airflow",
-            "welcome/community",
-            "welcome/code_of_conduct"
+            'welcome/what_is_prefect',
+            'welcome/why_prefect',
+            'welcome/why_not_airflow',
+            'welcome/community',
+            'welcome/code_of_conduct'
           ]
         },
         {
-          title: "Getting Started",
+          title: 'Getting Started',
           collapsable: true,
           children: [
-            "getting_started/installation",
-            "getting_started/first-steps",
-            "getting_started/next-steps"
+            'getting_started/installation',
+            'getting_started/first-steps',
+            'getting_started/next-steps'
           ]
         },
         {
-          title: "Tutorials",
+          title: 'Tutorials',
           collapsable: true,
-          children: getChildren("docs/core", "tutorials")
+          children: getChildren('docs/core', 'tutorials')
         },
         {
-          title: "Task Library",
+          title: 'Task Library',
           collapsable: true,
-          children: getChildren("docs/core", "task_library")
+          children: getChildren('docs/core', 'task_library')
         },
         {
-          title: "Core Concepts",
+          title: 'Core Concepts',
           collapsable: true,
           children: [
-            "concepts/tasks",
-            "concepts/flows",
-            "concepts/parameters",
-            "concepts/states",
-            "concepts/engine",
-            "concepts/execution",
-            "concepts/logging",
-            "concepts/mapping",
-            "concepts/notifications",
-            "concepts/persistence",
-            "concepts/results",
-            "concepts/schedules",
-            "concepts/secrets",
-            "concepts/configuration",
-            "concepts/best-practices",
-            "concepts/common-pitfalls"
+            'concepts/tasks',
+            'concepts/flows',
+            'concepts/parameters',
+            'concepts/states',
+            'concepts/engine',
+            'concepts/execution',
+            'concepts/logging',
+            'concepts/mapping',
+            'concepts/notifications',
+            'concepts/persistence',
+            'concepts/results',
+            'concepts/schedules',
+            'concepts/secrets',
+            'concepts/configuration',
+            'concepts/best-practices',
+            'concepts/common-pitfalls'
           ]
         },
         {
-          title: "Examples",
+          title: 'Examples',
           collapsable: true,
-          children: getChildren("docs/core", "examples")
+          children: getChildren('docs/core', 'examples')
         },
         {
-          title: "PINs",
+          title: 'PINs',
           collapsable: true,
-          children: getChildren("docs/core", "PINs")
+          children: getChildren('docs/core', 'PINs')
         },
         {
-          title: "Development",
+          title: 'Development',
           collapsable: true,
           children: [
-            "development/overview",
-            "development/style",
-            "development/documentation",
-            "development/tests",
-            "development/contributing",
-            "development/release-checklist"
+            'development/overview',
+            'development/style',
+            'development/documentation',
+            'development/tests',
+            'development/contributing',
+            'development/release-checklist'
           ]
         }
       ]
     }
   },
   extendMarkdown(md) {
-    md.use(require("markdown-it-attrs"));
-    md.use(require("markdown-it-checkbox"));
+    md.use(require('markdown-it-attrs'))
+    md.use(require('markdown-it-checkbox'))
   }
-};
+}

--- a/docs/cloud/other-considerations.md
+++ b/docs/cloud/other-considerations.md
@@ -10,15 +10,18 @@ Now that you have an account, this guide will talk you through the components of
 
 Before you can deploy Prefect flows from Prefect Cloud you must stand up a Prefect Agent on your desired platform. For more agent documentation visit the [Agent](agent/overview.html) section of the Cloud docs.
 
-## Create a Project
+## Authentication
 
 Before you can interact with Prefect Cloud you need to be able to authenticate with Prefect Cloud's API. To do so, visit the Cloud UI and retrieve an Authorization Token from the upper right hand corner menu. You can use [Prefect's CLI](https://docs.prefect.io/core/concepts/cli.html#auth) to persist your token locally.
+
+## Create a Project
 
 Prior to deploying your first Flow you should create a Project in Prefect Cloud. Recall that Projects are simply an organizational tool for your Flows, and can be thought of as a directory structure.
 
 There are three simple ways of creating projects, depending on your personal preference:
 
 **The UI**
+
 Simply head to the dashboard page of the UI and click on the projects page. Select "New Project" and enter a name.
 
 **Python**
@@ -29,6 +32,10 @@ from prefect import Client
 c = Client()
 c.create_project(project_name="My Project")
 ```
+
+**CLI**
+
+`prefect create project "My Project"`
 
 **GraphQL**
 

--- a/docs/cloud/other-considerations.md
+++ b/docs/cloud/other-considerations.md
@@ -1,0 +1,156 @@
+---
+sidebarDepth: 0
+---
+
+# Prefect Cloud: Other Things to Consider
+
+Now that you have an account, this guide will talk you through the components of Prefect Cloud and the parts you need to deploy and run your flows.
+
+## Prefect Agent
+
+Before you can deploy Prefect flows from Prefect Cloud you must stand up a Prefect Agent on your desired platform. For more agent documentation visit the [Agent](agent/overview.html) section of the Cloud docs.
+
+## Create a Project
+
+Before you can interact with Prefect Cloud you need to be able to authenticate with Prefect Cloud's API. To do so, visit the Cloud UI and retrieve an Authorization Token from the upper right hand corner menu. You can use [Prefect's CLI](https://docs.prefect.io/core/concepts/cli.html#auth) to persist your token locally.
+
+Prior to deploying your first Flow you should create a Project in Prefect Cloud. Recall that Projects are simply an organizational tool for your Flows, and can be thought of as a directory structure.
+
+There are three simple ways of creating projects, depending on your personal preference:
+
+**The UI**
+Simply head to the dashboard page of the UI and click on the projects page. Select "New Project" and enter a name.
+
+**Python**
+
+```python
+from prefect import Client
+
+c = Client()
+c.create_project(project_name="My Project")
+```
+
+**GraphQL**
+
+```graphql
+mutation {
+  createProject(input: { name: "My Project" }) {
+    project {
+      id
+      name
+    }
+  }
+}
+```
+
+## Deployment
+
+To deploy your Flow to Cloud requires that you have [Docker](https://www.docker.com/) running locally and that you have have access to a Docker registry that you are comfortable pushing your code to. Additionally, note that your Prefect Agent (which runs within your infrastructure and _not_ within Prefect Cloud) will require access to this registry as well.
+
+Remember that to deploy your flow you need to specify an _execution environment_ and your _Docker storage metadata_. See [Deploying A Flow](https://docs.prefect.io/cloud/flow-deploy.html#dockerize-your-flow)for an example.
+
+### Execution Environments
+
+[Prefect execution environments](https://docs.prefect.io/api/unreleased/environments/execution.html) specify execution information about _how your Flow should be run_. For example, what executor should be used and are there any auxiliary infrastructure requirements for your Flow's execution? At this exact moment, the only supported execution environment is the [Remote Environment](https://docs.prefect.io/api/unreleased/environments/execution.html#remoteenvironment) which allows you to specify which Prefect Executor to use, but this will soon expand into a richer library.
+
+By default, Prefect will attach a `RemoteEnvironment` with your local default executor to every Flow you create. To specify a different environment, simply provide it to your Flow at initialization:
+
+```python
+from prefect.environments import RemoteEnvironment
+
+f = Flow("example-env", environment=RemoteEnvironment(executor="prefect.engine.executors.LocalExecutor"))
+```
+
+or assign it directly:
+
+```python
+from prefect.environments import RemoteEnvironment
+
+f = Flow("example-env")
+f.environment = RemoteEnvironment(executor="prefect.engine.executors.LocalExecutor")
+```
+
+### Storage
+
+The [Prefect Storage interface](https://docs.prefect.io/api/unreleased/environments/storage.html#docker) provides a way to specify (via metadata) _where_ your Flow code is actually stored. Currently the only supported Storage class in Prefect Cloud is [Docker storage](https://docs.prefect.io/api/unreleased/environments/storage.html#docker). The only _required_ piece of information to include when creating your Docker storage class is the `registry_url` of the Docker registry where your image will live. All other keyword arguments are optional and "smart" defaults will be inferred.
+
+Similar to environments above, simply provide your storage at initialization:
+
+```python
+from prefect.environments.storage import Docker
+
+f = Flow("example-storage", storage=Docker(registry_url="prefecthq/storage-example"))
+```
+
+or assign it directly:
+
+```python
+from prefect.environments.storage import Docker
+
+f = Flow("example-storage")
+f.storage = Docker(registry_url="prefecthq/storage-example")
+```
+
+For added convenience, `flow.deploy` will accept arbitrary keyword arguments which will then be passed to the initialization method of your configured default storage class (which is `Docker` by default). Consequently, the following code will actually create a `Docker` object for you at deploy-time:
+
+```python
+from prefect import Flow
+
+f = Flow("example-easy-storage")
+
+# all other init kwargs to `Docker` are accepted here
+f.deploy("My First Project", registry_url="prefecthq/storage-example")
+```
+
+::: warning Serialization
+A common issue when first onboarding to Cloud is understanding how Flow serialization into your Docker image works. Two common issues are:
+
+- ensuring all Python package dependences are provided (this is usually fixed via a judicious choice of `base_image` or the `python_dependencies` kwarg)
+- ensuring all utility functions / scripts are importable at runtime via the same Python path (this usually requires understanding [`cloudpickle`](https://github.com/cloudpipe/cloudpickle) a little deeper)
+
+A tutorial on how to debug such issues can be found [here](https://docs.prefect.io/core/tutorials/local-debugging.html#locally-check-your-flow-s-docker-storage).
+:::
+
+### More about `flow.deploy`
+
+Now that your Flow has all the required attributes, it's time to deploy to Cloud! All that you have to do now is:
+
+[The flow.deploy() convenience method](https://docs.prefect.io/api/unreleased/core/flow.html#prefect-core-flow-flow-deploy) will proceed to build your Docker image, layer Prefect on top, serialize your Flow into the image, perform a "health check" that your Flow can be properly deserialized within the image and finally push the image to your registry of choice. It will then send the corresponding _metadata_ to Prefect Cloud. As above, note that `flow.deploy` also accepts initialization keyword arguments for `Docker` storage if you want to avoid creating that object yourself.
+
+::: tip GraphQL
+Advanced users who manually build their own images and perform their own serialization can actually deploy Flows via pure GraphQL (assuming they have pushed their image already). Most people will never do this, but it highlights the minimal amount of information that Cloud requires to function. Using our storage example above, the corresponding GraphQL call is simply:
+
+```graphql
+mutation($input: createFlowInput!) {
+  createFlow(input: $input) {
+    id
+  }
+}
+```
+
+where `$input` is:
+
+```python
+{"name": "example-env",
+ "type": "prefect.core.flow.Flow",
+ "schedule": null,
+ "parameters": [],
+ "tasks": [],
+ "edges": [],
+ "reference_tasks": [],
+ "environment": {"executor_kwargs": {},
+  "executor": "prefect.engine.executors.LocalExecutor",
+  "__version__": "0.6.1",
+  "type": "RemoteEnvironment"},
+ "__version__": "0.6.1",
+ "storage": {"image_tag": "latest",
+  "flows": {"storage-example": "/root/.prefect/storage-example.prefect"},
+  "registry_url": "prefecthq/storage-example",
+  "image_name": "storage-example",
+  "prefect_version": "0.6.1",
+  "__version__": "0.6.1",
+  "type": "Docker"}}
+```
+
+which you may recognize as the output of `f.serialize()`
+:::

--- a/docs/cloud/the-basics.md
+++ b/docs/cloud/the-basics.md
@@ -11,12 +11,12 @@ Prefect Cloud automatically extends the Prefect Core engine with:
 - a full GraphQL API
 - a complete UI for flows and jobs
 - remote execution clusters
-- automatic scheduling
+- automatic and asynchronous scheduling
 - permissions and authorization
 - projects for flow organization
 - secure runtime secrets and parameters
-- ...and a few things we're not ready to talk about yet!
+- many more features...
 
-If you are new to Prefect, we recommend learning more about [Prefect](https://docs.prefect.io/core/welcome/what_is_prefect.html) and our open source product, [Prefect Core](https://docs.prefect.io/core/) in the Prefect Core section of the docs.
+If you are new to Prefect, we recommend learning more about [Prefect](docs.prefect.io/core/welcome/what_is_prefect.html) and our open source product, [Prefect Core](docs.prefect.io/core/) in the Prefect Core section of the docs.
 
-To start running your first flow, we suggest following the Flow Run Tutorial in the [UI](cloud.prefect.io). (You'll find tutorials in the Side Menu that you can access by clicking the menu button on the top left corner of the dashboard.) Then follow the instructions and the examples in [Up And Running](https://docs.prefect.io/cloud/upandrunning.html) and [Deploying A Flow](https://docs.prefect.io/cloud/flow-deploy.html) to start running your own flows.
+To start running your first flow, we suggest following the Flow Run Tutorial in the [UI](https://cloud.prefect.io). (You'll find tutorials in the Side Menu that you can access by clicking the menu button on the top left corner of the dashboard.) Then follow the instructions and the examples in [Up And Running](docs.prefect.io/cloud/upandrunning.html) and [Deploying A Flow](docs.prefect.io/cloud/flow-deploy.html) to start running your own flows.

--- a/docs/cloud/the-basics.md
+++ b/docs/cloud/the-basics.md
@@ -4,156 +4,19 @@ sidebarDepth: 0
 
 # Prefect Cloud: The Basics
 
-Welcome to Prefect Cloud! Now that you have an account, this guide will help you orient yourself and understand the minor adjustments required to deploy your Flows to Cloud.
+Welcome to Prefect Cloud!
 
-## Prefect Agent
+Prefect Cloud automatically extends the Prefect Core engine with:
 
-Before you can deploy Prefect flows from Prefect Cloud you must stand up a Prefect Agent on your desired platform. For more agent documentation visit the [Agent](agent/overview.html) section of the Cloud docs.
+- a full GraphQL API
+- a complete UI for flows and jobs
+- remote execution clusters
+- automatic scheduling
+- permissions and authorization
+- projects for flow organization
+- secure runtime secrets and parameters
+- ...and a few things we're not ready to talk about yet!
 
-## Create a Project
+If you are new to Prefect, we recommend learning more about [Prefect](https://docs.prefect.io/core/welcome/what_is_prefect.html) and our open source product, [Prefect Core](https://docs.prefect.io/core/) in the Prefect Core section of the docs.
 
-Before you can interact with Prefect Cloud you need to be able to authenticate with Prefect Cloud's API. To do so, visit the Cloud UI and retrieve an Authorization Token from the upper right hand corner menu. Either follow the instructions from the UI, or use [Prefect's CLI](https://docs.prefect.io/core/concepts/cli.html#auth) to persist your token locally.
-
-Prior to deploying your first Flow you should create a Project in Prefect Cloud. Recall that Projects are simply an organizational tool for your Flows, and can be thought of as a directory structure.
-
-There are two simple ways of creating projects, depending on your personal preference:
-
-**Python**
-
-```python
-from prefect import Client
-
-c = Client()
-c.create_project(project_name="My Project")
-```
-
-**GraphQL**
-
-```graphql
-mutation {
-  createProject(input: { name: "My Project" }) {
-    project {
-      id
-      name
-    }
-  }
-}
-```
-
-## Deployment
-
-To deploy your Flow to Cloud requires that you have [Docker](https://www.docker.com/) running locally and that you have have access to a Docker registry that you are comfortable pushing your code to. Additionally, note that your Prefect Agent (which runs within your infrastructure and _not_ within Prefect Cloud) will require access to this registry as well.
-
-Now that you have Docker running and have your Prefect Cloud auth token ready, there are two small changes to your Flow that are required prior to deployment: specifying an _execution environment_ and your _Docker storage metadata_.
-
-### Execution Environments
-
-[Prefect execution environments](https://docs.prefect.io/api/unreleased/environments/execution.html) specify execution information about _how your Flow should be run_. For example, what executor should be used and are there any auxiliary infrastructure requirements for your Flow's execution? At this exact moment, the only supported execution environment is the [Remote Environment](https://docs.prefect.io/api/unreleased/environments/execution.html#remoteenvironment) which allows you to specify which Prefect Executor to use, but this will soon expand into a richer library.
-
-By default, Prefect will attach a `RemoteEnvironment` with your local default executor to every Flow you create. To specify a different environment, simply provide it to your Flow at initialization:
-
-```python
-from prefect.environments import RemoteEnvironment
-
-f = Flow("example-env", environment=RemoteEnvironment(executor="prefect.engine.executors.LocalExecutor"))
-```
-
-or assign it directly:
-
-```python
-from prefect.environments import RemoteEnvironment
-
-f = Flow("example-env")
-f.environment = RemoteEnvironment(executor="prefect.engine.executors.LocalExecutor")
-```
-
-### Storage
-
-The [Prefect Storage interface](https://docs.prefect.io/api/unreleased/environments/storage.html#docker) provides a way to specify (via metadata) _where_ your Flow code is actually stored. Currently the only supported Storage class in Prefect Cloud is [Docker storage](https://docs.prefect.io/api/unreleased/environments/storage.html#docker). The only _required_ piece of information to include when creating your Docker storage class is the `registry_url` of the Docker registry where your image will live. All other keyword arguments are optional and "smart" defaults will be inferred.
-
-Similar to environments above, simply provide your storage at initialization:
-
-```python
-from prefect.environments.storage import Docker
-
-f = Flow("example-storage", storage=Docker(registry_url="prefecthq/storage-example"))
-```
-
-or assign it directly:
-
-```python
-from prefect.environments.storage import Docker
-
-f = Flow("example-storage")
-f.storage = Docker(registry_url="prefecthq/storage-example")
-```
-
-For added convenience, `flow.deploy` will accept arbitrary keyword arguments which will then be passed to the initialization method of your configured default storage class (which is `Docker` by default). Consequently, the following code will actually create a `Docker` object for you at deploy-time:
-
-```python
-from prefect import Flow
-
-f = Flow("example-easy-storage")
-
-# all other init kwargs to `Docker` are accepted here
-f.deploy("My First Project", registry_url="prefecthq/storage-example")
-```
-
-::: warning Serialization
-A common issue when first onboarding to Cloud is understanding how Flow serialization into your Docker image works. Two common issues are:
-
-- ensuring all Python package dependences are provided (this is usually fixed via a judicious choice of `base_image` or the `python_dependencies` kwarg)
-- ensuring all utility functions / scripts are importable at runtime via the same Python path (this usually requires understanding [`cloudpickle`](https://github.com/cloudpipe/cloudpickle) a little deeper)
-
-A tutorial on how to debug such issues can be found [here](https://docs.prefect.io/core/tutorials/local-debugging.html#locally-check-your-flow-s-docker-storage).
-:::
-
-### `flow.deploy`
-
-Now that your Flow has all the required attributes, it's time to deploy to Cloud! All that you have to do now is:
-
-```python
-flow.deploy(project_name="My Prefect Cloud Project Name")
-```
-
-[This convenience method](https://docs.prefect.io/api/unreleased/core/flow.html#prefect-core-flow-flow-deploy) will proceed to build your Docker image, layer Prefect on top, serialize your Flow into the image, perform a "health check" that your Flow can be properly deserialized within the image and finally push the image to your registry of choice. It will then send the corresponding _metadata_ to Prefect Cloud. As above, note that `flow.deploy` also accepts initialization keyword arguments for `Docker` storage if you want to avoid creating that object yourself.
-
-::: tip GraphQL
-Advanced users who manually build their own images and perform their own serialization can actually deploy Flows via pure GraphQL (assuming they have pushed their image already). Most people will never do this, but it highlights the minimal amount of information that Cloud requires to function. Using our storage example above, the corresponding GraphQL call is simply:
-
-```graphql
-mutation($input: createFlowInput!) {
-  createFlow(input: $input) {
-    id
-  }
-}
-```
-
-where `$input` is:
-
-```python
-{"name": "example-env",
- "type": "prefect.core.flow.Flow",
- "schedule": null,
- "parameters": [],
- "tasks": [],
- "edges": [],
- "reference_tasks": [],
- "environment": {"executor_kwargs": {},
-  "executor": "prefect.engine.executors.LocalExecutor",
-  "__version__": "0.6.1",
-  "type": "RemoteEnvironment"},
- "__version__": "0.6.1",
- "storage": {"image_tag": "latest",
-  "flows": {"storage-example": "/root/.prefect/storage-example.prefect"},
-  "registry_url": "prefecthq/storage-example",
-  "image_name": "storage-example",
-  "prefect_version": "0.6.1",
-  "__version__": "0.6.1",
-  "type": "Docker"}}
-```
-
-which you may recognize as the output of `f.serialize()`
-:::
-
-Congratulations, you have now deployed your first Flow!
+To start running your first flow, we suggest following the Flow Run Tutorial in the [UI](cloud.prefect.io). (You'll find tutorials in the Side Menu that you can access by clicking the menu button on the top left corner of the dashboard.) Then follow the instructions and the examples in [Up And Running](https://docs.prefect.io/cloud/upandrunning.html) and [Deploying A Flow](https://docs.prefect.io/cloud/flow-deploy.html) to start running your own flows.

--- a/docs/cloud/upandrunning.md
+++ b/docs/cloud/upandrunning.md
@@ -2,24 +2,30 @@
 
 In this guide, we will look at a minimal and quick way to get Prefect Cloud flow deployments up and running on your local machine. We will write a simple flow, build its Docker storage, deploy to Prefect Cloud, and orchestrate a run with the Local Agent. No extra infrastructure required!
 
+You might also want to look at the Running A Flow tutorial that is in the "Tutorials" section of the UI. (Accessed via the menu button at the top-left of the dashboard.)
+
 ### Prerequisites
 
-In order to start using Prefect Cloud we need to set up our authentication. Head to the UI and retrieve a `USER` API token which we will use to log into Prefect Cloud. We are also going to want to generate a `RUNNER` token and save that in a secure place because we will use it later when creating our Local Agent. 
+In order to start using Prefect Cloud we need to set up our authentication. Head to the UI and retrieve a `USER` API token from the user settings section (click on the button at the top left of the dashboard to find it). We will use the `USER` token to log into Prefect Cloud. We are also going to want to generate a `RUNNER` token (available in the team settings section of the UI) and save that in a secure place because we will use it later when creating our Local Agent.
 
-For information on how to create a `RUNNER` token visit the [Tokens](concepts/tokens.html) page.
+For more information on how to create a `USER` or `RUNNER` token visit the [Tokens](concepts/tokens.html) page.
 
 Let's use the Prefect CLI to log into Cloud. Run this command, replacing `$PREFECT_USER_TOKEN` with the `USER` token you generated a moment ago:
+
 ```
 $ prefect auth login --token $PREFECT_USER_TOKEN
 Login successful!
 ```
 
 Now you should be able to begin working with Prefect Cloud! Verify that you have a default project by running:
+
 ```
 $ prefect get projects
 NAME            FLOW COUNT  AGE         DESCRIPTION
 Hello, World!   0           1 day ago
 ```
+
+If you don't have a project set up, you can do so from the dashboard in the UI.
 
 ### Write a Flow
 
@@ -91,18 +97,22 @@ Flow Run ID: 43a6624a-c5ce-43f3-a652-55e9c0b20527
 ```
 
 Our flow run has been created! We should be able to see this picked up in the agent logs:
+
 ```
 2019-09-01 13:11:58,716 - agent - INFO - Found 1 flow run(s) to submit for execution.
 2019-09-01 13:12:00,534 - agent - INFO - Submitted 1 flow run(s) for execution.
 ```
 
-Now the agent has submitted the flow run and created a Docker container locally. We may be able to catch it in the act with `docker ps` but our flow doesn't do anything so it may run too fast for us! (Another option: Kitematic is a great tool for interacting with containers while they are live)
-
 You can check on your flow run using Prefect Cloud:
+
 ```
 $ prefect get flow-runs
 NAME                FLOW NAME       STATE    AGE                START TIME
 super-bat           my-flow         Success  a few seconds ago  2019-09-01 13:12:02
 ```
 
-Congratulations! You ran a flow using Prefect Cloud! Now you can take it a step further and deploy a Prefect Agent on a high availability platform such as [Kubernetes](agent/kubernetes.html).
+You should also be able to see your flow in the UI.
+
+Congratulations! You ran a flow using Prefect Cloud! Now you can take it a step further and follow our example for deploying a flow.
+
+You could also deploy a Prefect Agent on a high availability platform such as [Kubernetes](agent/kubernetes.html).

--- a/docs/cloud/upandrunning.md
+++ b/docs/cloud/upandrunning.md
@@ -25,7 +25,7 @@ NAME            FLOW COUNT  AGE         DESCRIPTION
 Hello, World!   0           1 day ago
 ```
 
-If you don't have a project set up, you can do so from the dashboard in the UI.
+If you don't have a project set up, you can do so from the dashboard in the UI or by using the create command in the CLI `prefect create project "My Project"` (where "My Project" is your project name).
 
 ### Write a Flow
 

--- a/docs/core/welcome/community.md
+++ b/docs/core/welcome/community.md
@@ -14,22 +14,22 @@ Please consider [Chris White](https://github.com/cicdw) the main point of contac
 - For feature requests or bug reports, please open a [new GitHub issue](https://github.com/PrefectHQ/prefect/issues/new).
 - Important architectural and design decisions are memorialized in [Prefect Improvement Notices (PINs)](../PINs/PIN-01-Introduce-PINs.html).
 
-
 ## Contributing
 
 Prefect encourages users to contribute in any way they can!
 
 There are a number of ways you can get started contributing:
+
 - **closing issues**: the [issue board](https://github.com/PrefectHQ/prefect/issues) contains issues with the tag ["good first issue"](https://github.com/PrefectHQ/prefect/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) which should be approachable for first time contributors
-- **documentation**: Prefect prioritizes its documentation, as this is usually the first place users go to look for help.  If you find any typos, or want to update something for clarity, users everywhere will thank you!
-- **the task library**: Prefect's task library helps users build workflows even quicker by abstracting away common boilerplate.  If you know of a common operation that isn't represented, open a Pull Request to add a new task to the library!
+- **documentation**: Prefect prioritizes its documentation, as this is usually the first place users go to look for help. If you find any typos, or want to update something for clarity, users everywhere will thank you!
+- **the task library**: Prefect's task library helps users build workflows even quicker by abstracting away common boilerplate. If you know of a common operation that isn't represented, open a Pull Request to add a new task to the library!
 
 See our [Development Guide](../development/overview.html) for more information on how to get started.
 
+## The Prefect Cloud Platform
 
-## The Prefect Platform
+The "Prefect Core" engine is maintained by [Prefect Technologies, Inc.](https://www.prefect.io/) and is the driving engine of the Prefect Cloud Platform, which extends Prefect Core to include:
 
-The "Prefect Core" engine is maintained by [Prefect Technologies, Inc.](https://www.prefect.io/) and is the driving engine of the Prefect Platform, which extends Prefect Core to include:
 - a full GraphQL API
 - a complete UI for flows and jobs
 - remote execution clusters
@@ -37,6 +37,6 @@ The "Prefect Core" engine is maintained by [Prefect Technologies, Inc.](https://
 - permissions and authorization
 - projects for flow organization
 - secure runtime secrets and parameters
-- any many more features...
+- many more features...
 
 Please [get in touch](mailto:hello@prefect.io) to apply for access.


### PR DESCRIPTION


**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- Adds some basic info about Prefect Cloud and links to info about Prefect and Prefect Core in the first page of the Prefect Cloud Docs.  
- Moves the current content of "the basics" to a new page called "other things to consider" as it's not really the basics and as a new user it contained information that was slightly confusing/superfluous to what I needed to get up and running. 

## Why is this PR important?
- Although most users come through Prefect Core, if a user is interested in Prefect Cloud and goes straight to the Prefect Cloud section of the docs, we should give them some sort of introduction and make them feel that getting started is simple. 

