### PR TITLE
Raise informative error for mapping over processes w/ LocalDaskExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add `work_stealing` option to `DaskKubernetesEnvironment` - [#1760](https://github.com/PrefectHQ/prefect/pull/1760)
 - Improve heartbeat thread management - [#1770](https://github.com/PrefectHQ/prefect/pull/1770)
 - Add unique scheduler Job name to `DaskKubernetesEnvironment` - [#1772](https://github.com/PrefectHQ/prefect/pull/1772)
+- Add informative error when trying to map with the `LocalDaskExecutor` using processes - [#1777](https://github.com/PrefectHQ/prefect/pull/1777)
 
 ### Task Library
 

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -195,6 +195,8 @@ class LocalDaskExecutor(Executor):
     An executor that runs all functions locally using `dask` and a configurable dask scheduler.  Note that
     this executor is known to occasionally run tasks twice when using multi-level mapping.
 
+    Prefect's mapping feature will not work in conjunction with setting `scheduler="processes"`.
+
     Args:
         - scheduler (str): The local dask scheduler to use; common options are "synchronous", "threads" and "processes".  Defaults to "synchronous".
         - **kwargs (Any): Additional keyword arguments to pass to dask config

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -241,6 +241,11 @@ class LocalDaskExecutor(Executor):
             - List[dask.delayed]: the result of computating the function over the arguments
 
         """
+        if self.scheduler == "processes":
+            raise RuntimeError(
+                "LocalDaskExecutor cannot map if scheduler='processes'. Please set to either 'synchronous' or 'threads'."
+            )
+
         results = []
         for args_i in zip(*args):
             results.append(self.submit(fn, *args_i))

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -116,6 +116,33 @@ class TestLocalDaskExecutor:
             res = e.wait(e.map(map_fn))
         assert res == []
 
+    def test_map_with_synchronous_scheduler(self):
+        def map_fn(x, y):
+            return x + y
+
+        e = LocalDaskExecutor(scheduler="synchronous")
+        with e.start():
+            res = e.wait(e.map(map_fn, [1, 2], [1, 3]))
+        assert res == [2, 5]
+
+    def test_map_with_threads_scheduler(self):
+        def map_fn(x, y):
+            return x + y
+
+        e = LocalDaskExecutor(scheduler="threads")
+        with e.start():
+            res = e.wait(e.map(map_fn, [1, 2], [1, 3]))
+        assert res == [2, 5]
+
+    def test_map_fails_with_processes_executor(self):
+        def map_fn(x, y):
+            return x + y
+
+        e = LocalDaskExecutor(scheduler="processes")
+        with pytest.raises(RuntimeError):
+            with e.start():
+                res = e.wait(e.map(map_fn, [1, 2], [1, 3]))
+
 
 class TestLocalExecutor:
     def test_submit(self):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Mapping using the `LocalDaskExecutor` w/ _scheduler='processes'_ was causing the multithreading error `'daemonic processes are not allowed to have children'`. This updates the executor to raise a more informative error.


## Why is this PR important?
`'daemonic processes are not allowed to have children'` is pretty vague and this now raises and error which offers a solution.

