### PR TITLE
Try to make fixtures a little more resilient to prevent nondeterminis…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
       - run:
           name: Install testing packages
-          command: pip install "pytest==5.0" pytest-cov pytest-env
+          command: pip install pytest pytest-cov pytest-env
 
       - run:
           name: Run tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
-- "%PYTHON%/Scripts/pip.exe install pytest==5.2.2"
+- "%PYTHON%/Scripts/pip.exe install pytest"
 - "%PYTHON%/Scripts/pip.exe install ."
 
 test_script:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,10 @@ def sync():
 def mproc():
     "Multi-processing executor"
     try:
-        with Client(processes=True, dashboard_address=None) as client:
+        kwargs = dict(processes=True)
+        if sys.version_info.minor != 5:
+            kwargs.update(dashboard_address=None)
+        with Client(**kwargs) as client:
             yield DaskExecutor(client.scheduler.address, local_processes=True)
     except Exception:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,11 @@ def prefect_home_dir():
 @pytest.fixture(scope="session")
 def mthread():
     "Multi-threaded executor"
-    with Client(processes=False) as client:
-        yield DaskExecutor(client.scheduler.address)
+    try:
+        with Client(processes=False, dashboard_address=None) as client:
+            yield DaskExecutor(client.scheduler.address)
+    except Exception:
+        pass
 
 
 @pytest.fixture()
@@ -56,8 +59,11 @@ def sync():
 @pytest.fixture(scope="session")
 def mproc():
     "Multi-processing executor"
-    with Client(processes=True) as client:
-        yield DaskExecutor(client.scheduler.address, local_processes=True)
+    try:
+        with Client(processes=True, dashboard_address=None) as client:
+            yield DaskExecutor(client.scheduler.address, local_processes=True)
+    except Exception:
+        pass
 
 
 @pytest.fixture()


### PR DESCRIPTION
…tic job failures

We keep seeing some appveyor builds failing, presumably because of Dask worker cleanup not being successful.