### PR TITLE
Fix issue with flow.update not transferring constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with `flow.visualize()` for mapped tasks which are skipped - [#1765](https://github.com/PrefectHQ/prefect/issues/1765)
+- Fix issue with `flow.update()` not transferring constants - [#1785](https://github.com/PrefectHQ/prefect/pull/1785)
 
 ### Deprecations
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -557,6 +557,8 @@ class Flow:
                     validate=validate,
                 )
 
+        self.constants.update(flow.constants or {})
+
     @cache
     def all_upstream_edges(self) -> Dict[Task, Set[Edge]]:
         """

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -725,6 +725,19 @@ def test_update():
     assert len(f2.edges) == 2
 
 
+def test_update_with_constants():
+    with Flow("math") as f:
+        x = Parameter("x")
+        d = x["d"] + 4
+
+    new_flow = Flow("test")
+    new_flow.update(f)
+
+    flow_state = new_flow.run(x=dict(d=42))
+    assert flow_state.is_successful()
+    assert flow_state.result[d].result == 46
+
+
 def test_update_with_mapped_edges():
     t1 = Task()
     t2 = Task()

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import sys
 import tempfile
 import time
 import uuid
@@ -560,6 +561,10 @@ class TestHeartBeats:
         assert isinstance(res, TimedOut)
         assert len(results.split()) >= 30
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Randomly fails on Windows and Windows is not currently fully supported for Cloud Deployments",
+    )
     @pytest.mark.parametrize(
         "executor", ["local", "sync", "mproc", "mthread"], indirect=True
     )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes an issue caused by the latest refactor to how Prefect handles constants: in short, now that constants are stored as a flow attribute we need to also transfer these over when calling `flow.update`.


## Why is this PR important?
Fixes an issue raised by a user in Slack.