### PR TITLE
Better timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with `flow.visualize()` for mapped tasks which are skipped - [#1765](https://github.com/PrefectHQ/prefect/issues/1765)
+- Fix issue with timeouts only being softly enforced - [#1145](https://github.com/PrefectHQ/prefect/issues/1145), [#1686](https://github.com/PrefectHQ/prefect/issues/1686)
 
 ### Deprecations
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -4,6 +4,8 @@ import signal
 import sys
 import threading
 import time
+import warnings
+
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
 from functools import wraps
@@ -247,6 +249,13 @@ def timeout_handler(
     elif multiprocessing.current_process().daemon is False:
         return multiprocessing_timeout(fn, *args, timeout=timeout, **kwargs)
 
+    msg = (
+        "This task is running in a daemonic subprocess; "
+        "consequently Prefect can only enforce a soft timeout limit, i.e., "
+        "if your Task reaches its timeout limit it will entire a TimedOut state "
+        "but continue running in the background."
+    )
+    warnings.warn(msg)
     executor = ThreadPoolExecutor()
 
     def run_with_ctx(*args: Any, _ctx_dict: dict, **kwargs: Any) -> Any:

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -223,7 +223,11 @@ def timeout_handler(
 ) -> Any:
     """
     Helper function for implementing timeouts on function executions.
-    Implemented via `concurrent.futures.ThreadPoolExecutor`.
+
+    The exact implementation varies depending on whether this function is being run
+    in the main thread or a non-daemonic subprocess.  If this is run from a daemonic subprocess,
+    the task is run in a `ThreadPoolExecutor` and only a soft timeout is enforced, meaning
+    a `TimeoutError` is raised at the appropriate time but the task continues running in the background.
 
     Args:
         - fn (callable): the function to execute

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -248,7 +248,9 @@ def timeout_handler(
 
     # if we are running the main thread, use a signal to stop execution at the appropriate time;
     # else if we are running in a non-daemonic process, spawn a subprocess to kill at the appropriate time
-    if threading.current_thread() is threading.main_thread():
+    if threading.current_thread() is threading.main_thread() and not sys.platform.startswith(
+        "win"
+    ):
         return main_thread_timeout(fn, *args, timeout=timeout, **kwargs)
     elif multiprocessing.current_process().daemon is False:
         return multiprocessing_timeout(fn, *args, timeout=timeout, **kwargs)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2495,9 +2495,7 @@ def test_auto_generation_of_collection_tasks_is_robust():
     assert flow_state.is_successful()
 
 
-@pytest.mark.parametrize(
-    "executor", ["local", "sync", "mthread", "mproc"], indirect=True
-)
+@pytest.mark.parametrize("executor", ["local", "sync", "mthread"], indirect=True)
 def test_timeout_actually_stops_execution(executor):
     with tempfile.TemporaryDirectory() as call_dir:
         FILE = os.path.join(call_dir, "test.txt")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2495,6 +2495,9 @@ def test_auto_generation_of_collection_tasks_is_robust():
     assert flow_state.is_successful()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("executor", ["local", "sync", "mthread"], indirect=True)
 def test_timeout_actually_stops_execution(executor):
     with tempfile.TemporaryDirectory() as call_dir:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -300,6 +300,9 @@ def test_task_runner_accepts_dictionary_of_edges():
     assert state.result == 2
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize(
     "executor", ["local", "sync", "mproc", "mthread"], indirect=True
 )

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1,10 +1,12 @@
 import collections
+import os
+import pendulum
+import pytest
+import tempfile
+
 from datetime import datetime, timedelta
 from time import sleep
 from unittest.mock import MagicMock
-
-import pendulum
-import pytest
 
 import prefect
 from prefect.client import Secret
@@ -296,6 +298,34 @@ def test_task_runner_accepts_dictionary_of_edges():
     state = runner.run(upstream_states={ex: Success(result=1), ey: Success(result=1)})
     assert state.is_successful()
     assert state.result == 2
+
+
+@pytest.mark.parametrize(
+    "executor", ["local", "sync", "mproc", "mthread"], indirect=True
+)
+def test_timeout_actually_stops_execution(executor):
+    with tempfile.TemporaryDirectory() as call_dir:
+        FILE = os.path.join(call_dir, "test.txt")
+
+        @prefect.task(timeout=1)
+        def slow_fn():
+            "Runs for 1.5 seconds, writes to file 6 times"
+            iters = 0
+            while iters < 6:
+                with open(FILE, "a") as f:
+                    f.write("called\n")
+                iters += 1
+                sleep(0.25)
+
+        state = TaskRunner(slow_fn).run(executor=executor)
+
+        # if it continued running, would run for 1 more second
+        sleep(0.5)
+        with open(FILE, "r") as g:
+            contents = g.read()
+
+    assert len(contents.split("\n")) <= 4
+    assert state.is_failed()
 
 
 def test_task_runner_can_handle_timeouts_by_default():

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -2,6 +2,7 @@ import collections
 import os
 import pendulum
 import pytest
+import sys
 import tempfile
 
 from datetime import datetime, timedelta

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -312,10 +312,10 @@ def test_timeout_actually_stops_execution(executor):
             "Runs for 1.5 seconds, writes to file 6 times"
             iters = 0
             while iters < 6:
+                sleep(0.25)
                 with open(FILE, "a") as f:
                     f.write("called\n")
                 iters += 1
-                sleep(0.25)
 
         state = TaskRunner(slow_fn).run(executor=executor)
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -137,21 +137,20 @@ def test_timeout_handler_actually_stops_execution():
             "Runs for 1.5 seconds, writes to file 6 times"
             iters = 0
             while iters < 6:
+                time.sleep(0.26)
                 with open(FILE, "a") as f:
                     f.write("called\n")
                 iters += 1
-                time.sleep(0.25)
 
         with pytest.raises(TimeoutError):
             # allow for at most 3 writes
-            timeout_handler(slow_fn, timeout=0.6)
+            timeout_handler(slow_fn, timeout=1)
 
-        # if it continued running, would run for 1 more second
-        time.sleep(1)
+        time.sleep(0.5)
         with open(FILE, "r") as g:
             contents = g.read()
 
-    assert len(contents.split("\n")) <= 3
+    assert len(contents.split("\n")) <= 4
 
 
 def test_timeout_handler_passes_args_and_kwargs_and_returns():
@@ -205,9 +204,7 @@ def test_timeout_handler_allows_function_to_spawn_new_thread():
 
 
 def test_timeout_handler_doesnt_do_anything_if_no_timeout(monkeypatch):
-    monkeypatch.delattr(prefect.utilities.executors, "ThreadPoolExecutor")
-    with pytest.raises(NameError):  # to test the test's usefulness...
-        timeout_handler(lambda: 4, timeout=1)
+    assert timeout_handler(lambda: 4, timeout=1) == 4
     assert timeout_handler(lambda: 4) == 4
 
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -129,6 +129,9 @@ def test_timeout_handler_times_out():
         timeout_handler(slow_fn, timeout=1)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 def test_timeout_handler_actually_stops_execution():
     with tempfile.TemporaryDirectory() as call_dir:
         FILE = os.path.join(call_dir, "test.txt")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR revisits our old timeout code with some smarter detection of when each handler is the appropriate choice.  In particular, this PR returns to the hard enforcement of timeouts in most situations, except for those where the task was submitted to run in a daemonic subprocess (in which case we don't have a good way of "managing" the run and killing it).  In this event, I added a helpful warning and I recommend any users to use a state handler which detects the `TimedOut` state and takes any necessary action (which will vary from use case to use case).


## Why is this PR important?
Soft timeout enforcement was unexpected.

Closes #1145 
Closes #1686 

**cc:** @occoder - this will fix your timeout situations using the `LocalExecutor`