### PR TITLE
Attempt to close the client gracefully in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,10 @@ def mthread():
     "Multi-threaded executor"
     with Client(processes=False) as client:
         yield DaskExecutor(client.scheduler.address)
+        try:
+            client.close()
+        except:
+            pass
 
 
 @pytest.fixture()
@@ -58,6 +62,10 @@ def mproc():
     "Multi-processing executor"
     with Client(processes=True) as client:
         yield DaskExecutor(client.scheduler.address, local_processes=True)
+        try:
+            client.close()
+        except:
+            pass
 
 
 @pytest.fixture()


### PR DESCRIPTION
This is an attempt at solving for the non-deterministic appveyor job failure which isn't an actual test failure but rather a failure during Dask cleanup.