### PR TITLE
Kubernetes Agent install default RBAC option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add convenience `parents()` and `children()` classmethods to all State objects for navigating the hierarchy - [#1784](https://github.com/PrefectHQ/prefect/pull/1784)
+- Add `--rbac` flag to `prefect agent install` for Kubernetes Agent - [#1822](https://github.com/PrefectHQ/prefect/pull/1822)
 - Add `prefect agent install` option to output `supervisord.conf` file for Local Agent - [#1819](https://github.com/PrefectHQ/prefect/pull/1819)
+- Add convenience `parents()` and `children()` classmethods to all State objects for navigating the hierarchy - [#1784](https://github.com/PrefectHQ/prefect/pull/1784)
 - Add new `not_all_skipped` trigger and set it as the default for merge tasks - [#1768](https://github.com/PrefectHQ/prefect/issues/1768)
+
 
 ### Task Library
 
@@ -24,8 +26,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with `flow.visualize()` for mapped tasks which are skipped - [#1765](https://github.com/PrefectHQ/prefect/issues/1765)
 - Fix issue with timeouts only being softly enforced - [#1145](https://github.com/PrefectHQ/prefect/issues/1145), [#1686](https://github.com/PrefectHQ/prefect/issues/1686)
-- Fix issue with `flow.update()` not transferring constants - [#1785](https://github.com/PrefectHQ/prefect/pull/1785)
 - Log agent errors using `write_run_logs` instead of the deprecated `write_run_log` - [#1791](https://github.com/PrefectHQ/prefect/pull/1791)
+- Fix issue with `flow.update()` not transferring constants - [#1785](https://github.com/PrefectHQ/prefect/pull/1785)
 
 ### Deprecations
 

--- a/docs/cloud/agent/local.md
+++ b/docs/cloud/agent/local.md
@@ -107,6 +107,7 @@ Usage: prefect agent install [OPTIONS] NAME
       --namespace, -n             TEXT    Agent namespace to launch workloads
       --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
       --resource-manager                  Enable resource manager on install
+      --rbac                              Enable default RBAC on install
 
   Local Agent Options:
       --import-path, -p           TEXT    Absolute import paths to provide to the local agent.

--- a/docs/cloud/tutorial/k8s.md
+++ b/docs/cloud/tutorial/k8s.md
@@ -43,11 +43,26 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: default
-  name: prefect-agent-jobs
+  name: prefect-agent-rbac
 rules:
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: default
+  name: prefect-agent-rbac
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  kind: Role
+  name: prefect-agent-rbac
+  apiGroup: rbac.authorization.k8s.io
 ```
 
 :::
@@ -57,7 +72,7 @@ rules:
 For a high availability set up you should install the Kubernetes Agent into your cluster.
 
 ```bash
-prefect agent install kubernetes -t <YOUR_RUNNER_TOKEN> | kubectl apply -f -
+prefect agent install kubernetes -t <YOUR_RUNNER_TOKEN> --rbac | kubectl apply -f -
 ```
 
 Once the Agent has been created on your cluster it create Jobs on that cluster for each Flow Run. For more information on the Kubernetes Agent visit the [documentation](/cloud/agent/kubernetes.html).

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -150,6 +150,7 @@ class KubernetesAgent(Agent):
         namespace: str = None,
         image_pull_secrets: str = None,
         resource_manager_enabled: bool = False,
+        rbac: bool = False,
         labels: Iterable[str] = None,
     ) -> str:
         """
@@ -223,7 +224,21 @@ class KubernetesAgent(Agent):
         else:
             del deployment["spec"]["template"]["spec"]["imagePullSecrets"]
 
-        return yaml.safe_dump(deployment)
+        # Load RBAC if specified
+        rbac_yaml = []
+        if rbac:
+            with open(
+                path.join(path.dirname(__file__), "rbac.yaml"), "r"
+            ) as rbac_file:
+                rbac_generator = yaml.safe_load_all(rbac_file)
+
+                for document in rbac_generator:
+                    document["metadata"]["namespace"] = namespace
+                    rbac_yaml.append(document)
+
+        output_yaml = [deployment]
+        output_yaml.extend(rbac_yaml)
+        return yaml.safe_dump_all(output_yaml, explicit_start=True)
 
     def heartbeat(self) -> None:
         """

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -166,6 +166,8 @@ class KubernetesAgent(Agent):
                 for Prefect jobs
             - resource_manager_enabled (bool, optional): Whether to include the resource
                 manager as part of the YAML. Defaults to `False`
+            - rbac (bool, optional): Whether to include default RBAC configuration as
+                part of the YAML. Defaults to `False`
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -227,9 +227,7 @@ class KubernetesAgent(Agent):
         # Load RBAC if specified
         rbac_yaml = []
         if rbac:
-            with open(
-                path.join(path.dirname(__file__), "rbac.yaml"), "r"
-            ) as rbac_file:
+            with open(path.join(path.dirname(__file__), "rbac.yaml"), "r") as rbac_file:
                 rbac_generator = yaml.safe_load_all(rbac_file)
 
                 for document in rbac_generator:

--- a/src/prefect/agent/kubernetes/rbac.yaml
+++ b/src/prefect/agent/kubernetes/rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: prefect-agent
+rules:
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: default
+  name: prefect-agent
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  kind: Role
+  name: prefect-agent
+  apiGroup: rbac.authorization.k8s.io

--- a/src/prefect/agent/kubernetes/rbac.yaml
+++ b/src/prefect/agent/kubernetes/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: default
-  name: prefect-agent
+  name: prefect-agent-rbac
 rules:
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
@@ -14,11 +14,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   namespace: default
-  name: prefect-agent
+  name: prefect-agent-rbac
 subjects:
   - kind: ServiceAccount
     name: default
 roleRef:
   kind: Role
-  name: prefect-agent
+  name: prefect-agent-rbac
   apiGroup: rbac.authorization.k8s.io

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -198,9 +198,7 @@ def start(
 @click.option(
     "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
 )
-@click.option(
-    "--rbac", is_flag=True, help="Enable default RBAC.", hidden=True
-)
+@click.option("--rbac", is_flag=True, help="Enable default RBAC.", hidden=True)
 @click.option(
     "--label",
     "-l",

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -199,6 +199,9 @@ def start(
     "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
 )
 @click.option(
+    "--rbac", is_flag=True, help="Enable default RBAC.", hidden=True
+)
+@click.option(
     "--label",
     "-l",
     multiple=True,
@@ -226,6 +229,7 @@ def install(
     namespace,
     image_pull_secrets,
     resource_manager,
+    rbac,
     label,
     import_path,
     show_flow_logs,
@@ -250,6 +254,7 @@ def install(
         --namespace, -n             TEXT    Agent namespace to launch workloads
         --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
         --resource-manager                  Enable resource manager on install
+        --rbac                              Enable default RBAC on install
 
     \b
     Local Agent Options:
@@ -276,6 +281,7 @@ def install(
             namespace=namespace,
             image_pull_secrets=image_pull_secrets,
             resource_manager_enabled=resource_manager,
+            rbac=rbac,
             labels=list(label),
         )
         click.echo(deployment)

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -343,6 +343,24 @@ def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
     )
 
 
+def test_k8s_agent_generate_deployment_yaml_rbac(monkeypatch, runner_token):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    agent = KubernetesAgent()
+    deployment = agent.generate_deployment_yaml(
+        token="test_token", api="test_api", namespace="test_namespace", rbac=True
+    )
+
+    deployment = yaml.safe_load_all(deployment)
+
+    for document in deployment:
+        if "rbac" in document:
+            assert "rbac" in document["apiVersion"]
+            assert document["metadata"]["namespace"] == "test_namespace"
+            assert document["metadata"]["name"] == "prefect-agent-rbac"
+
+
 def test_k8s_agent_heartbeat_creates_file(monkeypatch, runner_token):
     k8s_config = MagicMock()
     monkeypatch.setattr("kubernetes.config", k8s_config)

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -283,7 +283,7 @@ def test_agent_install_k8s_no_resource_manager():
             "TEST_NAMESPACE",
             "--image-pull-secrets",
             "secret-test",
-            "--rbac"
+            "--rbac",
         ],
     )
     assert result.exit_code == 0

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -248,6 +248,7 @@ def test_agent_install_k8s_asses_args():
             "--namespace",
             "TEST_NAMESPACE",
             "--resource-manager",
+            "--rbac",
             "--image-pull-secrets",
             "secret-test",
             "--label",
@@ -261,6 +262,7 @@ def test_agent_install_k8s_asses_args():
     assert "TEST_API" in result.output
     assert "TEST_NAMESPACE" in result.output
     assert "resource-manager" in result.output
+    assert "rbac" in result.output
     assert "secret-test" in result.output
     assert "test_label1" in result.output
     assert "test_label2" in result.output
@@ -281,6 +283,7 @@ def test_agent_install_k8s_no_resource_manager():
             "TEST_NAMESPACE",
             "--image-pull-secrets",
             "secret-test",
+            "--rbac"
         ],
     )
     assert result.exit_code == 0
@@ -288,6 +291,7 @@ def test_agent_install_k8s_no_resource_manager():
     assert "TEST_API" in result.output
     assert "TEST_NAMESPACE" in result.output
     assert not "resource-manager" in result.output
+    assert "rbac" in result.output
     assert "secret-test" in result.output
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a `--rbac` flag to the `prefect agent install kubernetes` command for a default RBAC configuration. Also updated the documentation with the proper Role and RoleBinding YAML.

Closes #1487 


## Why is this PR important?
This makes it easier and more clear on the RBAC required to use the Kubernetes Agent

