### PR TITLE
Reimplement client.deploy w/ deprecation warning

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -486,6 +486,54 @@ class Client:
     # Actions
     # -------------------------------------------------------------------------
 
+    def deploy(
+        self,
+        flow: "Flow",
+        project_name: str,
+        build: bool = True,
+        set_schedule_active: bool = True,
+        version_group_id: str = None,
+        compressed: bool = True,
+    ) -> str:
+        """
+        *Note*: This function will be deprecated soon and should be replaced with `client.register`
+
+        Push a new flow to Prefect Cloud
+
+        Args:
+            - flow (Flow): a flow to register
+            - project_name (str): the project that should contain this flow.
+            - build (bool, optional): if `True`, the flow's environment is built
+                prior to serialization; defaults to `True`
+            - set_schedule_active (bool, optional): if `False`, will set the
+                schedule to inactive in the database to prevent auto-scheduling runs (if the Flow has a schedule).
+                Defaults to `True`. This can be changed later.
+            - version_group_id (str, optional): the UUID version group ID to use for versioning this Flow
+                in Cloud; if not provided, the version group ID associated with this Flow's project and name
+                will be used.
+            - compressed (bool, optional): if `True`, the serialized flow will be; defaults to `True`
+                compressed
+
+        Returns:
+            - str: the ID of the newly-registered flow
+
+        Raises:
+            - ClientError: if the register failed
+        """
+        warnings.warn(
+            "client.deploy() will be deprecated in an upcoming release. Please use client.register()",
+            UserWarning,
+        )
+
+        return self.register(
+            flow=flow,
+            project_name=project_name,
+            build=build,
+            set_schedule_active=set_schedule_active,
+            version_group_id=version_group_id,
+            compressed=compressed,
+        )
+
     def register(
         self,
         flow: "Flow",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -107,13 +107,15 @@ def test_client_deploy(patch_post, compressed):
     ):
         client = Client()
     flow = prefect.Flow(name="test", storage=prefect.environments.storage.Memory())
-    flow_id = client.deploy(
-        flow,
-        project_name="my-default-project",
-        compressed=compressed,
-        version_group_id=str(uuid.uuid4()),
-    )
-    assert flow_id == "long-id"
+
+    with pytest.warns(expected_warning=UserWarning):
+        flow_id = client.deploy(
+            flow,
+            project_name="my-default-project",
+            compressed=compressed,
+            version_group_id=str(uuid.uuid4()),
+        )
+        assert flow_id == "long-id"
 
 
 @pytest.mark.parametrize("compressed", [True, False])

--- a/tests/environments/storage/test_gcs_storage.py
+++ b/tests/environments/storage/test_gcs_storage.py
@@ -97,7 +97,6 @@ class TestGCSStorage:
         fetched_flow = storage.get_flow("a-place")
 
         assert fetched_flow.name == f.name
-        assert cloudpickle.dumps(fetched_flow) == flow_content
         bucket_mock.get_blob.assert_called_with("a-place")
         assert blob_mock.download_as_string.call_count == 1
 


### PR DESCRIPTION
Quick fix to readd `client.deploy` w/ a deprecation warning