### PR TITLE
Add flow run name to env vars set by Docker Agent

### DIFF
--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -126,6 +126,7 @@ class DockerAgent(Agent):
             "PREFECT__CLOUD__AUTH_TOKEN": config.cloud.agent.auth_token,
             "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
             "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
+            "PREFECT__CONTEXT__FLOW_RUN_NAME": flow_run.name,  # type: ignore
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
             "PREFECT__LOGGING__LEVEL": "DEBUG",

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -111,13 +111,14 @@ def test_populate_env_vars(monkeypatch, runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "token", "cloud.api": "api"}):
         agent = DockerAgent()
 
-        env_vars = agent.populate_env_vars(GraphQLResult({"id": "id"}))
+        env_vars = agent.populate_env_vars(GraphQLResult({"id": "id", "name": "name"}))
 
         expected_vars = {
             "PREFECT__CLOUD__API": "api",
             "PREFECT__CLOUD__AUTH_TOKEN": "token",
             "PREFECT__CLOUD__AGENT__LABELS": "[]",
             "PREFECT__CONTEXT__FLOW_RUN_ID": "id",
+            "PREFECT__CONTEXT__FLOW_RUN_NAME": "name",
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
             "PREFECT__LOGGING__LEVEL": "DEBUG",
@@ -135,13 +136,14 @@ def test_populate_env_vars_includes_agent_labels(monkeypatch, runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "token", "cloud.api": "api"}):
         agent = DockerAgent(labels=["42", "marvin"])
 
-        env_vars = agent.populate_env_vars(GraphQLResult({"id": "id"}))
+        env_vars = agent.populate_env_vars(GraphQLResult({"id": "id", "name": "name"}))
 
         expected_vars = {
             "PREFECT__CLOUD__API": "api",
             "PREFECT__CLOUD__AGENT__LABELS": "['42', 'marvin']",
             "PREFECT__CLOUD__AUTH_TOKEN": "token",
             "PREFECT__CONTEXT__FLOW_RUN_ID": "id",
+            "PREFECT__CONTEXT__FLOW_RUN_NAME": "name",
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
             "PREFECT__LOGGING__LEVEL": "DEBUG",
@@ -174,6 +176,7 @@ def test_docker_agent_deploy_flows(monkeypatch, runner_token):
                         }
                     ),
                     "id": "id",
+                    "name": "name",
                 }
             )
         ]
@@ -204,6 +207,7 @@ def test_docker_agent_deploy_flows_storage_continues(monkeypatch, runner_token):
                 {
                     "flow": GraphQLResult({"storage": Local().serialize()}),
                     "id": "id",
+                    "name": "name",
                     "version": "version",
                 }
             )
@@ -235,6 +239,7 @@ def test_docker_agent_deploy_flows_no_pull(monkeypatch, runner_token):
                         }
                     ),
                     "id": "id",
+                    "name": "name",
                 }
             )
         ]
@@ -267,6 +272,7 @@ def test_docker_agent_deploy_flows_no_registry_does_not_pull(monkeypatch, runner
                         }
                     ),
                     "id": "id",
+                    "name": "name",
                 }
             )
         ]


### PR DESCRIPTION
After #1815 there was one missing place where the Flow Run name was not specified on the Docker Agent