### PR TITLE
Add `--latest` flag for Kubernetes Agent CLI install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Add `--latest` flag for Kubernetes Agent install CLI command - [#1842](https://github.com/PrefectHQ/prefect/pull/1842)
 
 ### Task Library
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -153,6 +153,7 @@ class KubernetesAgent(Agent):
         image_pull_secrets: str = None,
         resource_manager_enabled: bool = False,
         rbac: bool = False,
+        latest: bool = False,
         labels: Iterable[str] = None,
     ) -> str:
         """
@@ -170,6 +171,8 @@ class KubernetesAgent(Agent):
                 manager as part of the YAML. Defaults to `False`
             - rbac (bool, optional): Whether to include default RBAC configuration as
                 part of the YAML. Defaults to `False`
+            - rbac (bool, optional): Whether to use the `latest` Prefect image.
+                Defaults to `False`
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
 
@@ -184,7 +187,7 @@ class KubernetesAgent(Agent):
         labels = labels or []
 
         version = prefect.__version__.split("+")
-        image_version = "latest" if len(version) > 1 else (version[0] + "-python3.6")
+        image_version = "latest" if len(version) > 1 or latest else (version[0] + "-python3.6")
 
         with open(
             path.join(path.dirname(__file__), "deployment.yaml"), "r"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -187,7 +187,9 @@ class KubernetesAgent(Agent):
         labels = labels or []
 
         version = prefect.__version__.split("+")
-        image_version = "latest" if len(version) > 1 or latest else (version[0] + "-python3.6")
+        image_version = (
+            "latest" if len(version) > 1 or latest else (version[0] + "-python3.6")
+        )
 
         with open(
             path.join(path.dirname(__file__), "deployment.yaml"), "r"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -171,7 +171,7 @@ class KubernetesAgent(Agent):
                 manager as part of the YAML. Defaults to `False`
             - rbac (bool, optional): Whether to include default RBAC configuration as
                 part of the YAML. Defaults to `False`
-            - rbac (bool, optional): Whether to use the `latest` Prefect image.
+            - latest (bool, optional): Whether to use the `latest` Prefect image.
                 Defaults to `False`
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -196,7 +196,9 @@ def start(
     "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
 )
 @click.option("--rbac", is_flag=True, help="Enable default RBAC.", hidden=True)
-@click.option("--latest", is_flag=True, help="Use the latest Prefect image.", hidden=True)
+@click.option(
+    "--latest", is_flag=True, help="Use the latest Prefect image.", hidden=True
+)
 @click.option(
     "--label",
     "-l",

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -196,6 +196,7 @@ def start(
     "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
 )
 @click.option("--rbac", is_flag=True, help="Enable default RBAC.", hidden=True)
+@click.option("--latest", is_flag=True, help="Use the latest Prefect image.", hidden=True)
 @click.option(
     "--label",
     "-l",
@@ -225,6 +226,7 @@ def install(
     image_pull_secrets,
     resource_manager,
     rbac,
+    latest,
     label,
     import_path,
     show_flow_logs,
@@ -250,6 +252,7 @@ def install(
         --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
         --resource-manager                  Enable resource manager on install
         --rbac                              Enable default RBAC on install
+        --latest                            Use the `latest` Prefect image
 
     \b
     Local Agent Options:
@@ -277,6 +280,7 @@ def install(
             image_pull_secrets=image_pull_secrets,
             resource_manager_enabled=resource_manager,
             rbac=rbac,
+            latest=latest,
             labels=list(label),
         )
         click.echo(deployment)

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -264,6 +264,28 @@ def test_k8s_agent_generate_deployment_yaml_local_version(
     assert resource_manager_yaml["image"] == "prefecthq/prefect:{}".format(version[1])
 
 
+def test_k8s_agent_generate_deployment_yaml_latest(monkeypatch, runner_token):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    agent = KubernetesAgent()
+    deployment = agent.generate_deployment_yaml(
+        token="test_token",
+        api="test_api",
+        namespace="test_namespace",
+        resource_manager_enabled=True,
+        latest=True,
+    )
+
+    deployment = yaml.safe_load(deployment)
+
+    agent_yaml = deployment["spec"]["template"]["spec"]["containers"][0]
+    resource_manager_yaml = deployment["spec"]["template"]["spec"]["containers"][1]
+
+    assert agent_yaml["image"] == "prefecthq/prefect:latest"
+    assert resource_manager_yaml["image"] == "prefecthq/prefect:latest"
+
+
 def test_k8s_agent_generate_deployment_yaml_no_resource_manager(
     monkeypatch, runner_token
 ):

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -249,6 +249,7 @@ def test_agent_install_k8s_asses_args():
             "TEST_NAMESPACE",
             "--resource-manager",
             "--rbac",
+            "--latest",
             "--image-pull-secrets",
             "secret-test",
             "--label",
@@ -263,6 +264,7 @@ def test_agent_install_k8s_asses_args():
     assert "TEST_NAMESPACE" in result.output
     assert "resource-manager" in result.output
     assert "rbac" in result.output
+    assert "latest" in result.output
     assert "secret-test" in result.output
     assert "test_label1" in result.output
     assert "test_label2" in result.output


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a `--latest` flag for the `prefect agent install kubernetes` command to use the latest Prefect image


## Why is this PR important?
Adds the option to use the most recent image if desired

