### PR TITLE
Make logging to Cloud more robust in the face of a bad log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix Kubernetes Agent passing empty default namespace - [#1839](https://github.com/PrefectHQ/prefect/pull/1839)
 - Fix missing Flow Run name on Dask Kubernetes Environment default worker pod - [#1839](https://github.com/PrefectHQ/prefect/pull/1839)
+- Fix issue with a single bad log preventing all logs from being sent to Cloud - [#1845](https://github.com/PrefectHQ/prefect/pull/1845)
 
 ### Deprecations
 

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -559,7 +559,8 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
 
         def get_flow_run_info(self, *args, **kwargs):
             return MagicMock(
-                task_runs=[MagicMock(task_slug=log_stuff.slug, id="TESTME")]
+                id="flowRunID",
+                task_runs=[MagicMock(task_slug=log_stuff.slug, id="TESTME")],
             )
 
     monkeypatch.setattr("prefect.client.Client", Client)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that a single bad non-JSON serializable log doesn't prevent further logs from arriving in Cloud.

## Why is this PR important?
A user was attempting to log bytes from a subprocess, and all logs stopped arriving in Cloud (because bytes aren't JSON serializable).  This is undesirable behavior, and as many logs as possible should be getting through.