### PR TITLE
Bump kubernetes upper bound to 11.0.0b2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
         "google-cloud-bigquery >= 1.6.0, < 2.0",
         "google-cloud-storage >= 1.13, < 2.0",
     ],
-    "kubernetes": ["kubernetes >= 9.0.0a1, < 10.0", "dask-kubernetes >= 0.8.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1, <= 11.0.0b2", "dask-kubernetes >= 0.8.0"],
     "postgres": ["psycopg2-binary >= 2.8.2"],
     "redis": ["redis >= 3.2.1"],
     "rss": ["feedparser >= 5.0.1, < 6.0"],


### PR DESCRIPTION
Bumps the upper bound of the kubernetes optional dependency. I tested deployments with newer versions and all went well 👍 

Closes #1493 