### PR TITLE
Enforce max_retries if retry_delay specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Enforce provision of `max_retries` if specifying `retry_delay` for a `Task` - [#1875](https://github.com/PrefectHQ/prefect/pull/1875)
 
 ### Deprecations
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -198,6 +198,11 @@ class Task(metaclass=SignatureValidator):
             raise ValueError(
                 "A datetime.timedelta `retry_delay` must be provided if max_retries > 0"
             )
+        # specify not max retries because the default is false
+        if retry_delay is not None and not max_retries:
+            raise ValueError(
+                "A `max_retries` argument greater than 0 must be provided if specifying a retry delay."
+            )
         if timeout is not None and not isinstance(timeout, int):
             raise TypeError(
                 "Only integer timeouts (representing seconds) are supported."

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -66,6 +66,21 @@ class TestCreateTask:
         with pytest.raises(ValueError):
             Task(max_retries=1, retry_delay=None)
 
+    def test_create_task_with_retry_delay_and_no_max_retries(self):
+        with pytest.raises(
+            ValueError,
+            match="A `max_retries` argument greater than 0 must be provided if specifying a retry delay",
+        ):
+            Task(retry_delay=timedelta(seconds=30))
+
+    @pytest.mark.parametrize("max_retries", [None, 0, False])
+    def test_create_task_with_retry_delay_and_invalid_max_retries(self, max_retries):
+        with pytest.raises(
+            ValueError,
+            match="A `max_retries` argument greater than 0 must be provided if specifying a retry delay",
+        ):
+            Task(retry_delay=timedelta(seconds=30), max_retries=max_retries)
+
     def test_create_task_with_timeout(self):
         t1 = Task()
         assert t1.timeout == None

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -59,7 +59,7 @@ class TestCreateTask:
         assert t2.max_retries == 5
 
     def test_create_task_with_retry_delay(self):
-        t2 = Task(retry_delay=timedelta(seconds=30))
+        t2 = Task(retry_delay=timedelta(seconds=30), max_retries=1)
         assert t2.retry_delay == timedelta(seconds=30)
 
     def test_create_task_with_max_retries_and_no_retry_delay(self):

--- a/tests/utilities/test_configuration.py
+++ b/tests/utilities/test_configuration.py
@@ -17,8 +17,8 @@ def test_set_temporary_config_is_temporary():
                 assert t1.max_retries == 1
             t2 = Task()
             assert t2.max_retries == 5
-        t3 = Task()
-        assert t3.max_retries == 0
+    t3 = Task()
+    assert t3.max_retries == 0
 
 
 def test_set_temporary_config_can_invent_new_settings():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR enforces the provision of a `max_retries` argument if `retry_delay` is specified for a task.

## Why is this PR important?

If a user is specifying a retry delay, they're probably expecting their task to retry. The current default behavior of setting max retries to 0 if not provided isn't sensible.
