### PR TITLE
Allow intervals less than 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Allow for task looping to beyond Python's maximum recursion depth - [#1862](https://github.com/PrefectHQ/prefect/pull/1862)
 - Prevent duplication of stdout logs from multiple instantiated agents - [#1866](https://github.com/PrefectHQ/prefect/pull/1866)
+- Allow intervals less than 60 seconds - [#1880](https://github.com/PrefectHQ/prefect/pull/1880)
 
 ### Task Library
 
@@ -31,7 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- Daryll Strauss <daryll.strauss@gmail.com>
 
 ## 0.8.1 <Badge text="beta" type="success"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Allow for task looping to beyond Python's maximum recursion depth - [#1862](https://github.com/PrefectHQ/prefect/pull/1862)
 - Prevent duplication of stdout logs from multiple instantiated agents - [#1866](https://github.com/PrefectHQ/prefect/pull/1866)
-- Allow intervals less than 60 seconds - [#1880](https://github.com/PrefectHQ/prefect/pull/1880)
+- Allow intervals less than 60 seconds in `IntervalClock`s - [#1880](https://github.com/PrefectHQ/prefect/pull/1880)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- Daryll Strauss <daryll.strauss@gmail.com>
+- [Daryll Strauss](daryll.strauss@gmail.com)
 
 ## 0.8.1 <Badge text="beta" type="success"/>
 

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -75,7 +75,7 @@ class IntervalClock(Clock):
         if not isinstance(interval, timedelta):
             raise TypeError("Interval must be a timedelta.")
         elif interval.total_seconds() <= 0:
-            raise ValueError("Interval most be greater than 0.")
+            raise ValueError("Interval must be greater than 0.")
 
         self.interval = interval
         super().__init__(start_date=start_date, end_date=end_date)

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -63,7 +63,7 @@ class IntervalClock(Clock):
 
     Raises:
         - TypeError: if start_date is not a datetime
-        - ValueError: if provided interval is less than one minute
+        - ValueError: if provided interval is less than or equal to zero
     """
 
     def __init__(
@@ -74,8 +74,8 @@ class IntervalClock(Clock):
     ):
         if not isinstance(interval, timedelta):
             raise TypeError("Interval must be a timedelta.")
-        elif interval.total_seconds() < 60:
-            raise ValueError("Interval can not be less than one minute.")
+        elif interval.total_seconds() <= 0:
+            raise ValueError("Interval most be greater than 0.")
 
         self.interval = interval
         super().__init__(start_date=start_date, end_date=end_date)

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -53,16 +53,9 @@ class TestIntervalClock:
 
     def test_interval_clock_interval_must_be_more_than_one_minute(self):
         with pytest.raises(ValueError):
-            clocks.IntervalClock(interval=timedelta(seconds=59))
-        with pytest.raises(ValueError):
-            clocks.IntervalClock(interval=timedelta(microseconds=59999999))
+            clocks.IntervalClock(interval=timedelta(seconds=-1))
         with pytest.raises(ValueError):
             clocks.IntervalClock(interval=timedelta(0))
-
-    def test_interval_clock_can_be_exactly_one_minute(self):
-        assert clocks.IntervalClock(interval=timedelta(minutes=1))
-        assert clocks.IntervalClock(interval=timedelta(seconds=60))
-        assert clocks.IntervalClock(interval=timedelta(microseconds=60000000))
 
     def test_interval_clock_events(self):
         """Test that default after is *now*"""


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
IntervalClock should allow any interval greater than 0.


## Why is this PR important?
60 seconds was an arbitrary time period. Some applications can use short intervals.

