### PR TITLE
Validate interval clocks for cloud deployment

### DIFF
--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -40,7 +40,8 @@ class IntervalClock(Clock):
     """
     A clock formed by adding `timedelta` increments to a start_date.
 
-    IntervalClocks only support intervals of one minute or greater.
+    IntervalClocks support any interval, but if deployed to Prefect Cloud only
+    intervals of one minute or greater are allowed.
 
     NOTE: If the `IntervalClock` start time is provided with a DST-observing timezone,
     then the clock will adjust itself appropriately. Intervals greater than 24

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 import marshmallow
-from marshmallow import fields, post_load
+from marshmallow import fields, post_load, post_dump
 
 import prefect
 from prefect.serialization import schedule_compat
@@ -38,6 +38,17 @@ class IntervalClockSchema(ObjectSchema):
     start_date = DateTimeTZ(allow_none=True)
     end_date = DateTimeTZ(allow_none=True)
     interval = fields.TimeDelta(precision="microseconds", required=True)
+
+    @post_dump
+    def _interval_validation(self, data: dict, **kwargs: Any) -> dict:
+        """
+        Ensures interval is at least one minute in length
+        """
+        if data["interval"] / 1e6 < 60:
+            raise ValueError(
+                "Interval can not be less than one minute when deploying to Prefect Cloud."
+            )
+        return data
 
 
 class CronClockSchema(ObjectSchema):

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -50,6 +50,15 @@ class IntervalClockSchema(ObjectSchema):
             )
         return data
 
+    @post_load
+    def create_object(self, data: dict, **kwargs: Any):
+        if data["interval"].total_seconds() < 60:
+            raise ValueError(
+                "Interval can not be less than one minute when deploying to Prefect Cloud."
+            )
+        base_obj = super().create_object(data)
+        return base_obj
+
 
 class CronClockSchema(ObjectSchema):
     class Meta:

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -48,13 +48,11 @@ class TestIntervalClock:
         assert c.end_date == pendulum.datetime(2020, 1, 1)
 
     def test_interval_clock_interval_must_be_positive(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="greater than 0"):
             clocks.IntervalClock(interval=timedelta(hours=-1))
-
-    def test_interval_clock_interval_must_be_more_than_one_minute(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="greater than 0"):
             clocks.IntervalClock(interval=timedelta(seconds=-1))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="greater than 0"):
             clocks.IntervalClock(interval=timedelta(0))
 
     def test_interval_clock_events(self):

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -50,6 +50,27 @@ def test_serialize_complex_schedule():
     ]
 
 
+def test_interval_clocks_with_sub_minute_intervals_cant_be_serialized():
+    schema = ScheduleSchema()
+    s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(seconds=59))])
+    with pytest.raises(ValueError, match="can not be less than one minute"):
+        schema.dump(s)
+
+
+def test_interval_clocks_with_exactly_one_minute_intervals_can_be_serialized():
+    s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(seconds=60))])
+    t = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(minutes=1))])
+    s2 = serialize_and_deserialize(s)
+    t2 = serialize_and_deserialize(t)
+
+    assert s2.next(1, after=pendulum.datetime(2019, 1, 1)) == [
+        pendulum.datetime(2019, 1, 1, 0, 1)
+    ]
+    assert t2.next(1, after=pendulum.datetime(2019, 1, 1)) == [
+        pendulum.datetime(2019, 1, 1, 0, 1)
+    ]
+
+
 def test_serialize_multiple_clocks():
 
     dt = pendulum.datetime(2019, 1, 1)

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -57,6 +57,15 @@ def test_interval_clocks_with_sub_minute_intervals_cant_be_serialized():
         schema.dump(s)
 
 
+def test_interval_clocks_with_sub_minute_intervals_cant_be_deserialized():
+    schema = ScheduleSchema()
+    s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(seconds=100))])
+    data = schema.dump(s)
+    data["clocks"][0]["interval"] = 59 * 1e6
+    with pytest.raises(ValueError, match="can not be less than one minute"):
+        schema.load(data)
+
+
 def test_interval_clocks_with_exactly_one_minute_intervals_can_be_serialized():
     s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(seconds=60))])
     t = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(minutes=1))])


### PR DESCRIPTION
Follows up on https://github.com/PrefectHQ/prefect/pull/1880 with some doc / serialization changes to ensure Prefect Cloud requirements are unchanged.