### PR TITLE
AWS Auth changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Breaking Changes
 
-- None
+- Remove default value for `aws_credentials_secret` on all S3 hooks - [#1886](https://github.com/PrefectHQ/prefect/issues/1886)
 
 ### Contributors
 

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -181,7 +181,9 @@ class TestS3ResultHandler:
             yield client
 
     def test_s3_client_init_uses_secrets(self, s3_client):
-        handler = S3ResultHandler(bucket="bob")
+        handler = S3ResultHandler(
+            bucket="bob", aws_credentials_secret="AWS_CREDENTIALS"
+        )
         assert handler.bucket == "bob"
         assert s3_client.called is False
 

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -219,7 +219,7 @@ class TestS3ResultHandler:
         )
         assert isinstance(handler, S3ResultHandler)
         assert handler.bucket == "foo-bar"
-        assert handler.aws_credentials_secret == "AWS_CREDENTIALS"
+        assert handler.aws_credentials_secret is None
 
     def test_roundtrip(self):
         schema = ResultHandlerSchema()

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -10,7 +10,7 @@ from prefect.utilities.configuration import set_temporary_config
 class TestS3Download:
     def test_initialization(self):
         task = S3Download()
-        assert task.aws_credentials_secret == "AWS_CREDENTIALS"
+        assert task.aws_credentials_secret is None
 
     def test_initialization_passes_to_task_constructor(self):
         task = S3Download(name="test", tags=["AWS"])
@@ -23,7 +23,7 @@ class TestS3Download:
             task.run(key="")
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
-        task = S3Download(bucket="bob")
+        task = S3Download(bucket="bob", aws_credentials_secret="AWS_CREDENTIALS")
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.tasks.aws.s3.boto3", boto3)
@@ -37,11 +37,20 @@ class TestS3Download:
         kwargs = client.call_args[1]
         assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
 
+    def test_creds_default_to_environment(self, monkeypatch):
+        task = S3Download(bucket="bob")
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.tasks.aws.s3.boto3", boto3)
+        task.run(key="")
+        kwargs = client.call_args[1]
+        assert kwargs == {"aws_access_key_id": None, "aws_secret_access_key": None}
+
 
 class TestS3Upload:
     def test_initialization(self):
         task = S3Upload()
-        assert task.aws_credentials_secret == "AWS_CREDENTIALS"
+        assert task.aws_credentials_secret is None
 
     def test_initialization_passes_to_task_constructor(self):
         task = S3Upload(name="test", tags=["AWS"])
@@ -54,7 +63,7 @@ class TestS3Upload:
             task.run(data="")
 
     def test_generated_key_is_str(self, monkeypatch):
-        task = S3Upload(bucket="test")
+        task = S3Upload(bucket="test", aws_credentials_secret="AWS_CREDENTIALS")
         client = MagicMock()
         boto3 = MagicMock(client=MagicMock(return_value=client))
         monkeypatch.setattr("prefect.tasks.aws.s3.boto3", boto3)
@@ -68,7 +77,7 @@ class TestS3Upload:
         assert type(client.upload_fileobj.call_args[1]["Key"]) == str
 
     def test_creds_are_pulled_from_secret(self, monkeypatch):
-        task = S3Upload(bucket="bob")
+        task = S3Upload(bucket="bob", aws_credentials_secret="AWS_CREDENTIALS")
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.tasks.aws.s3.boto3", boto3)
@@ -81,3 +90,12 @@ class TestS3Upload:
                 task.run(data="")
         kwargs = client.call_args[1]
         assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+
+    def test_creds_default_to_environment(self, monkeypatch):
+        task = S3Upload(bucket="bob")
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.tasks.aws.s3.boto3", boto3)
+        task.run(data="")
+        kwargs = client.call_args[1]
+        assert kwargs == {"aws_access_key_id": None, "aws_secret_access_key": None}


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR changes how all S3 hooks authenticate with AWS; in particular, it removes the requirement that users store their AWS credentials in a Prefect Cloud Secret and allows for the standard boto3 auth chain.  Note that this resulted in a breaking change - S3 tasks and handlers that relied on the default value for `aws_credentials_secret` will need to explicitly provide it.


## Why is this PR important?
Gives users control over how the authenticate with AWS and allows for a more natural authentication strategy, especially when running Flows in AWS.