### PR TITLE
Update docs to reflect that version locking is opt-in

### DIFF
--- a/docs/cloud/concepts/flows.md
+++ b/docs/cloud/concepts/flows.md
@@ -4,7 +4,7 @@ Flows can be registered with Prefect Cloud for scheduling and execution, as well
 
 ## Registering a Flow from Prefect Core
 
-To register a Flow from Prefect Core, use its `register()` method:
+To register a flow from Prefect Core, use its `register()` method:
 
 ```python
 flow.register(project_name="<a project name>")
@@ -14,13 +14,13 @@ Note that this assumes you have already [authenticated](../tutorial/configure.ht
 
 ## Registering a Flow <Badge text="GQL"/>
 
-To register a Flow via the GraphQL API, first serialize the Flow to JSON:
+To register a flow via the GraphQL API, first serialize the `Flow` object to JSON:
 
 ```python
 flow.serialize()
 ```
 
-Next, use the `createFlow` GraphQL mutation to pass the serialized Flow to Prefect Cloud. You will also need to provide a project ID:
+Next, use the `createFlow` GraphQL mutation to pass the serialized `Flow` to Prefect Cloud. You will also need to provide a project ID:
 
 ```graphql
 mutation($flow: JSON!) {
@@ -39,9 +39,9 @@ mutation($flow: JSON!) {
 
 ## Flow Versions and Archiving <Badge text="GQL"/>
 
-You can control how Cloud versions your Flows by providing a `versionGroupId` whenever you register a Flow (exposed via the `version_group_id` keyword argument in `flow.register`). Flows which provide the same `versionGroupId` will be considered versions of each other. By default, Flows with the same name in the same Project will be given the same `versionGroupId` and are considered "versions" of each other. Anytime you register a new version of a Flow, Prefect Cloud will automatically "archive" the old version in place of the newly registered Flow. Archiving means that the old version's schedule is set to "Paused" and no new Flow runs can be created.
+You can control how Cloud versions your flows by providing a `versionGroupId` whenever you register a flow (exposed via the `version_group_id` keyword argument in `flow.register`). Flows which provide the same `versionGroupId` will be considered versions of each other. By default, flows with the same name in the same Project will be given the same `versionGroupId` and are considered "versions" of each other. Anytime you register a new version of a flow, Prefect Cloud will automatically "archive" the old version in place of the newly registered flow. Archiving means that the old version's schedule is set to "Paused" and no new flow runs can be created.
 
-You can always revisit old versions and unarchive them, if for example you want the same Flow to run on two distinct schedules. To archive or unarchive a Flow, use the following GraphQL mutations:
+You can always revisit old versions and unarchive them, if for example you want the same flow to run on two distinct schedules. To archive or unarchive a flow, use the following GraphQL mutations:
 
 ```graphql
 mutation {
@@ -61,21 +61,21 @@ mutation {
 
 ## Flow Settings <Badge text="GQL"/>
 
-Prefect Cloud has several insurance policies to ensure Flows run healthily and robustly. Three such policies are:
+Prefect Cloud has several insurance policies to ensure flows run healthily and robustly. Three such policies are:
 
 - Flow and task run heartbeats
 - [Lazarus resurrections](lazarus-process.html)
 - and version locking
 
-These safeguards can be disabled on a Flow-by-Flow basis using Flow settings.
+These safeguards can be toggled on a flow-by-flow basis using flow settings.
 
 ::: warning Disabling safeguards
-Disabling these safeguards can alter fundamental assumptions about how Flows run in Cloud. Be sure to read the docs and understand how each of these settings alters Flow behavior in Cloud.
+Disabling these safeguards can alter fundamental assumptions about how flows run in Cloud. Be sure to read the docs and understand how each of these settings alters flow behavior in Cloud.
 :::
 
 ### Disable Heartbeats <Badge text="0.8.1+"/>
 
-When running Flows registered with Cloud, Prefect Core sends heartbeats to Cloud every 30 seconds. These heartbeats are used to confirm the Flow run and its task runs are healthy, and runs missing four heartbeats in a row will be marked as `Failed` by the [Zombie Killer](zombie-killer.html). For most users, this is a useful safeguard. In some rare cases, however, the heartbeat falls victim to thread deadlocking and falsely registers a run as unhealthy. To prevent this, users may disable Flow heartbeats, which will disable heartbeats and the Zombie Killer for runs of this Flow. To do so, use the following GraphQL mutation:
+When running flows registered with Cloud, Prefect Core sends heartbeats to Cloud every 30 seconds. These heartbeats are used to confirm the flow run and its task runs are healthy, and runs missing four heartbeats in a row will be marked as `Failed` by the [Zombie Killer](zombie-killer.html). For most users, this is a useful safeguard. In some rare cases, however, the heartbeat falls victim to thread deadlocking and falsely registers a run as unhealthy. To prevent this, users may disable flow heartbeats, which will disable heartbeats and the Zombie Killer for runs of this flow. To do so, use the following GraphQL mutation:
 
 ```graphql
 mutation {
@@ -85,11 +85,11 @@ mutation {
 }
 ```
 
-To reenable heartbeats for a Flow, rerun this mutation with `value` set to `False`. Future runs of this Flow will resume standard heartbeat functionality.
+To reenable heartbeats for a flow, rerun this mutation with `value` set to `False`. Future runs of this flow will resume standard heartbeat functionality.
 
 ### Disable Lazarus
 
-The Lazarus process is responsible for rescheduling flow runs under the circumstances described [here](lazarus-process.html). If this is not desirable behavior for your Flow, use the following GraphQL mutation to disable it:
+The Lazarus process is responsible for rescheduling flow runs under the circumstances described [here](lazarus-process.html). If this is not desirable behavior for your flow, use the following GraphQL mutation to disable it:
 
 ```graphql
 mutation {
@@ -101,13 +101,13 @@ mutation {
 
 To reenable Lazarus resurrections for a flow, rerun this mutation with `value` set to `False`. Future runs of this flow will be subject to Lazarus resurrection.
 
-### Disable Version Locking
+### Enable Version Locking
 
-Prefect Cloud's version locking mechanism enforces the assertion that your work runs once _and only once_. For some, primarily those running highly-distributed, idempotent operations, this guarantee is less useful. To disable version locking for a flow and its tasks, use the following GraphQL mutation:
+Prefect Cloud's _opt-in_ version locking mechanism enforces the assertion that your work runs once _and only once_. To enable version locking for a flow and its tasks, use the following GraphQL mutation:
 
 ```graphql
 mutation {
-  disableFlowVersionLocking(
+  enableFlowVersionLocking(
     input: { flowId: "your-flow-id-here", value: true }
   ) {
     success
@@ -115,4 +115,4 @@ mutation {
 }
 ```
 
-To reenable version locking for a Flow, rerun this mutation with `value` set to `False`. Future runs of this Flow will resume standard version locking behavior.
+To disable this functionality again, rerun this mutation with `value` set to `False`. Future runs of this flow will once again ignore the version locking mechanism.


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR updates cloud docs for flow settings to reflect the fact that version locking is now opt-in.

## Why is this PR important?

It's important to have up-to-date and accurate docs.
