### PR TITLE
NoResult returns None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Allow intervals less than 60 seconds in `IntervalClock`s - [#1880](https://github.com/PrefectHQ/prefect/pull/1880)
 - Introduce new `Secret.exists` method for checking whether a Secret is available - [#1882](https://github.com/PrefectHQ/prefect/pull/1882)
 - Introduce new `-e` CLI options on agent start commands to allow passing environment variables to flow runs - [#1878](https://github.com/PrefectHQ/prefect/issues/1878)
+- Stop persisting `None` when calling result handlers - [#1894](https://github.com/PrefectHQ/prefect/pull/1894)
 
 ### Task Library
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 7.0, < 8.0
 cloudpickle >=0.6.0, <1.3
-croniter >= 0.3.24, <1.0
+croniter >= 0.3.24, <0.3.31
 dask[bag] >=0.19.3, <3.0
 distributed >= 1.26.1, < 3.0
 docker >=3.4.1, <5.0

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1024,7 +1024,7 @@ class Flow:
 
         # state always should return a dict of tasks. If it's NoResult (meaning the run was
         # interrupted before any tasks were executed), we set the dict manually.
-        if state.result == NoResult:
+        if state._result == NoResult:
             state.result = {}
         elif isinstance(state.result, Exception):
             self.logger.error(

--- a/src/prefect/engine/result.py
+++ b/src/prefect/engine/result.py
@@ -138,7 +138,7 @@ class NoResultType(SafeResult):
     """
 
     def __init__(self) -> None:
-        pass
+        super().__init__(value=None, result_handler=ResultHandler())
 
     def __eq__(self, other: Any) -> bool:
         if type(self) == type(other):
@@ -151,10 +151,6 @@ class NoResultType(SafeResult):
 
     def __str__(self) -> str:
         return "NoResult"
-
-    @property
-    def value(self) -> "ResultInterface":
-        return self
 
     def to_result(self, result_handler: ResultHandler = None) -> "ResultInterface":
         """

--- a/src/prefect/engine/result.py
+++ b/src/prefect/engine/result.py
@@ -83,6 +83,9 @@ class Result(ResultInterface):
         """
         Populate the `safe_value` attribute with a `SafeResult` using the result handler
         """
+        # don't bother with `None` values
+        if self.value is None:
+            return
         if self.safe_value == NoResult:
             assert isinstance(
                 self.result_handler, ResultHandler

--- a/src/prefect/engine/result_handlers/result_handler.py
+++ b/src/prefect/engine/result_handlers/result_handler.py
@@ -22,10 +22,10 @@ class ResultHandler:
         return "<ResultHandler: {}>".format(type(self).__name__)
 
     def write(self, result: Any) -> Any:
-        return result
+        return None
 
-    def read(self, loc: str) -> str:
-        return loc
+    def read(self, loc: str) -> Any:
+        return None
 
     def __eq__(self, other: object) -> bool:
         """

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -718,7 +718,7 @@ class TaskRunner(Runner):
                         # in the `cached_inputs` attribute of one of the child states).
                         # Therefore, we only try to get a result if EITHER this task's
                         # state is not already mapped OR the upstream result is not None.
-                        if not state.is_mapped() or upstream_state.result != NoResult:
+                        if not state.is_mapped() or upstream_state._result != NoResult:
                             upstream_result = Result(
                                 upstream_state.result[i],
                                 result_handler=upstream_state._result.result_handler,  # type: ignore

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -17,12 +17,7 @@ class Merge(Task):
 
     def run(self, **task_results: Any) -> Any:
         return next(
-            (
-                v
-                for k, v in sorted(task_results.items())
-                if not isinstance(v, NoResultType)
-            ),
-            None,
+            (v for k, v in sorted(task_results.items()) if v is not None), None,
         )
 
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 import prefect
 from prefect import Task
 from prefect.engine import signals
-from prefect.engine.result import NoResultType
 
 __all__ = ["switch", "ifelse"]
 

--- a/src/prefect/tasks/control_flow/filter.py
+++ b/src/prefect/tasks/control_flow/filter.py
@@ -9,7 +9,7 @@ from prefect.triggers import all_finished
 
 class FilterTask(Task):
     """
-    Task for filtering lists of results.  The default filter removes `NoResult`s and
+    Task for filtering lists of results.  The default filter removes `NoResult`s, `None`s and
     Exceptions, intended to be used for filtering out mapped results.  Note that this task has a default trigger of
     `all_finished` and `skip_on_upstream_skip=False`.
 

--- a/src/prefect/tasks/control_flow/filter.py
+++ b/src/prefect/tasks/control_flow/filter.py
@@ -53,7 +53,7 @@ class FilterTask(Task):
         kwargs.setdefault("skip_on_upstream_skip", False)
         kwargs.setdefault("trigger", all_finished)
         self.filter_func = filter_func or (
-            lambda r: not isinstance(r, (NoResultType, Exception))
+            lambda r: not isinstance(r, (type(None), NoResultType, Exception))
         )
         super().__init__(**kwargs)
 

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -287,7 +287,7 @@ def test_map_skips_dont_leak_out(executor):
     assert s.is_successful()
     assert isinstance(m.map_states, list)
     assert len(m.result) == 3
-    assert m.result == [NoResult, 4, 5]
+    assert m.result == [None, 4, 5]
     assert isinstance(m.map_states[0], prefect.engine.state.Skipped)
 
 

--- a/tests/engine/cloud/test_utilities.py
+++ b/tests/engine/cloud/test_utilities.py
@@ -28,7 +28,8 @@ def test_preparing_state_for_cloud_replaces_cached_inputs_with_safe(cls):
     xres = Result(3, result_handler=JSONResultHandler())
     state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
     assert isinstance(state, cls)
-    assert state.result == NoResult
+    assert state.result is None
+    assert state._result == NoResult
     assert state.cached_inputs == dict(x=xres)
 
 
@@ -47,7 +48,8 @@ def test_preparing_state_for_cloud_fails_if_cached_inputs_have_no_handler(cls):
 def test_preparing_state_for_cloud_passes_if_cached_inputs_dont_exist(cls):
     state = prepare_state_for_cloud(cls())
     assert isinstance(state, cls)
-    assert state.result == NoResult
+    assert state.result is None
+    assert state._result == NoResult
     assert state.cached_inputs is None
 
 
@@ -60,7 +62,8 @@ def test_preparing_state_for_cloud_passes_if_cached_inputs_have_no_handler_for_f
     xres = Result(3, result_handler=None)
     state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
     assert isinstance(state, cls)
-    assert state.result == NoResult
+    assert state.result is None
+    assert state._result == NoResult
     assert state.cached_inputs == dict(x=xres)
 
 

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -92,8 +92,8 @@ class TestLocalHandler:
 
 def test_result_handler_base_class_is_a_passthrough():
     handler = ResultHandler()
-    assert handler.write("foo") == "foo"
-    assert handler.read(99) == 99
+    assert handler.write("foo") is None
+    assert handler.read(99) is None
 
 
 @pytest.mark.xfail(raises=ImportError, reason="google extras not installed.")

--- a/tests/engine/test_result.py
+++ b/tests/engine/test_result.py
@@ -77,10 +77,9 @@ def test_basic_result_repr():
     assert repr(r) == "<Result: 2>"
 
 
-def test_noresult_has_no_handler_attrs():
+def test_noresult_has_base_handler():
     n = NoResult
-    with pytest.raises(AttributeError):
-        n.result_handler
+    n.result_handler == ResultHandler()
 
 
 def test_noresult_returns_itself_for_safe_value():
@@ -88,9 +87,9 @@ def test_noresult_returns_itself_for_safe_value():
     assert n is n.safe_value
 
 
-def test_noresult_returns_itself_for_value():
+def test_noresult_returns_none_for_value():
     n = NoResult
-    assert n is n.value
+    assert n.value is None
 
 
 def test_no_results_are_all_the_same():

--- a/tests/engine/test_result.py
+++ b/tests/engine/test_result.py
@@ -38,6 +38,15 @@ class TestInitialization:
         assert r.safe_value is NoResult
         assert r.result_handler == handler
 
+    def test_result_ignores_none_values(self):
+        handler = JSONResultHandler()
+        r = Result(value=None, result_handler=handler)
+        assert r.value is None
+        assert r.safe_value is NoResult
+        r.store_safe_value()
+        assert r.safe_value is NoResult
+        assert r.value is None
+
     def test_safe_result_requires_both_init_args(self):
         with pytest.raises(TypeError, match="2 required positional arguments"):
             SafeResult()

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -57,7 +57,7 @@ cached_input_states = sorted(
 def test_create_state_with_no_args(cls):
     state = cls()
     assert state.message is None
-    assert state.result == NoResult
+    assert state.result is None
     assert state.context == dict()
 
 
@@ -118,7 +118,7 @@ def test_create_state_with_tags_in_context(cls):
     with prefect.context(task_tags=set("abcdef")):
         state = cls()
     assert state.message is None
-    assert state.result == NoResult
+    assert state.result is None
     assert state.context == dict(tags=list(set("abcdef")))
 
     with prefect.context(task_tags=set("abcdef")):
@@ -226,7 +226,7 @@ def test_serialize_and_deserialize_on_raw_cached_state():
     new_state = State.deserialize(serialized)
     assert isinstance(new_state, Cached)
     assert new_state.color == state.color
-    assert new_state.result == NoResult
+    assert new_state.result is None
     assert new_state.cached_result_expiration == state.cached_result_expiration
     assert new_state.cached_inputs == dict.fromkeys(["x", "p"], NoResult)
 

--- a/tests/serialization/test_result_handlers.py
+++ b/tests/serialization/test_result_handlers.py
@@ -60,7 +60,7 @@ class TestCustomSchema:
         schema = CustomResultHandlerSchema()
         obj = schema.load(schema.dump(Dummy()))
         assert isinstance(obj, ResultHandler)
-        assert obj.read(42) == 42  # just the base class, not the Dummy class
+        assert obj.read(42) is None  # just the base class, not the Dummy class
 
     def test_custom_schema_roundtrip_on_stateful_class(self):
         class Stateful(ResultHandler):
@@ -76,7 +76,7 @@ class TestCustomSchema:
         schema = CustomResultHandlerSchema()
         obj = schema.load(schema.dump(Stateful(42)))
         assert isinstance(obj, ResultHandler)
-        assert obj.write("foo") == "foo"  # just the base class, not the Stateful class
+        assert obj.write("foo") is None  # just the base class, not the Stateful class
 
     def test_result_handler_schema_defaults_to_custom(self):
         class Weird(ResultHandler):
@@ -96,7 +96,7 @@ class TestCustomSchema:
 
         obj = schema.load(serialized)
         assert isinstance(obj, ResultHandler)
-        assert obj.write("foo") == "foo"  # just the base class, not the Weird class
+        assert obj.write("foo") is None  # just the base class, not the Weird class
 
     def test_cloud_can_deserialize_custom_handlers(self):
         schema = ResultHandlerSchema()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR alters the behavior of both the base `ResultHandler` class as well as the `NoResult` sentinel object.  In particular, `ResultHandler` now returns `None` for both read and write, and `NoResult` returns `None` as its "value".  


## Why is this PR important?
This PR is another step towards greedy persistence of results; in particular, we will ultimately never checkpoint / persist tasks which return `None`, and this change simplifies our logic in that space.

