### PR TITLE
Relax result handler requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Introduce new `-e` CLI options on agent start commands to allow passing environment variables to flow runs - [#1878](https://github.com/PrefectHQ/prefect/issues/1878)
 - Stop persisting `None` when calling result handlers - [#1894](https://github.com/PrefectHQ/prefect/pull/1894)
 - All States now store `cached_inputs` for easier recovery from failure - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
-- ALways checkpoint tasks which have result handlers - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
+- Always checkpoint tasks which have result handlers - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Remove default value for `aws_credentials_secret` on all S3 hooks - [#1886](https://github.com/PrefectHQ/prefect/issues/1886)
 - Remove `config.engine.result_handler` section of Prefect config - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
-- Require Flow result handler when registering with Prefect Cloud - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
 - Remove default value for `aws_credentials_secret` on `GCSResultHandler` - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
 - Remove default value for `azure_credentials_secret` on `AzureResultHandler` - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
 - Checkpointing for all tasks is now the default - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Introduce new `-e` CLI options on agent start commands to allow passing environment variables to flow runs - [#1878](https://github.com/PrefectHQ/prefect/issues/1878)
 - Stop persisting `None` when calling result handlers - [#1894](https://github.com/PrefectHQ/prefect/pull/1894)
 - All States now store `cached_inputs` for easier recovery from failure - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
+- ALways checkpoint tasks which have result handlers - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
 
 ### Task Library
 
@@ -38,7 +39,6 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Remove `config.engine.result_handler` section of Prefect config - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
 - Remove default value for `aws_credentials_secret` on `GCSResultHandler` - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
 - Remove default value for `azure_credentials_secret` on `AzureResultHandler` - [#1888](https://github.com/PrefectHQ/prefect/issues/1888)
-- Checkpointing for all tasks is now the default - [#1898](https://github.com/PrefectHQ/prefect/issues/1898)
 
 ### Contributors
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -573,8 +573,8 @@ class Client:
                 "Flows with required parameters can not be scheduled automatically."
             )
         if any(e.key for e in flow.edges) and flow.result_handler is None:
-            raise ClientError(
-                "Flows are required to have a result handler for storing inputs and outputs."
+            warnings.warn(
+                "It is strongly recommended you include a result handler on your Flow for certain Cloud features to work properly."
             )
         if compressed:
             create_mutation = {

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -65,7 +65,7 @@ checkpointing = false
     [tasks.defaults]
 
     # whether all tasks should checkpoint their outputs
-    checkpoint = true
+    checkpoint = false
 
     # the number of times tasks retry before they fail.
     # false indicates that tasks should never retry (equivalent to max_retries = 0)

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -127,7 +127,9 @@ class Task(metaclass=SignatureValidator):
             Task's database ID if running in Cloud
         - checkpoint (bool, optional, DEPRECATED): if this Task is successful, whether to
             store its result using the `result_handler` available during the run; defaults to the value of
-            `tasks.defaults.checkpoint` in your user config
+            `tasks.defaults.checkpoint` in your user config.  Note that in the future, all tasks with result handlers
+            will be checkpointed.  Also note that checkpointing will only occur locally if `prefect.config.flows.checkpointing` is
+            set to `True`
         - result_handler (ResultHandler, optional): the handler to use for
             retrieving and storing state results during execution; if not provided, will default to the
             one attached to the Flow

--- a/src/prefect/engine/cloud/utilities.py
+++ b/src/prefect/engine/cloud/utilities.py
@@ -17,6 +17,7 @@ def prepare_state_for_cloud(state: State) -> State:
 
     if state.cached_inputs:
         for res in state.cached_inputs.values():
-            res.store_safe_value()
+            if res.result_handler:
+                res.store_safe_value()
 
     return state

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -904,11 +904,11 @@ class TaskRunner(Runner):
             result=result, message="Task run succeeded.", cached_inputs=inputs
         )
 
-        ## only checkpoint tasks if checkpointing is turned on
+        ## checkpoint tasks if a result_handler is present
         if (
             state.is_successful()
             and prefect.context.get("checkpointing") is True
-            and self.task.checkpoint is True
+            and self.result_handler is not None
         ):
             state._result.store_safe_value()
 

--- a/src/prefect/environments/storage/_healthcheck.py
+++ b/src/prefect/environments/storage/_healthcheck.py
@@ -42,6 +42,58 @@ def cloudpickle_deserialization_check(flow_file_paths: str):
     return flows
 
 
+def result_handler_check(flows: list):
+    for flow in flows:
+        if flow.result_handler is not None:
+            continue
+
+        ## test for tasks which are checkpointed with no result handler
+        if any([(t.checkpoint and t.result_handler is None) for t in flow.tasks]):
+            raise ValueError(
+                "Some tasks request to be checkpointed but do not have a result handler. See https://docs.prefect.io/core/concepts/results.html for more details."
+            )
+
+        ## test for tasks which might retry without upstream result handlers
+        retry_tasks = [t for t in flow.tasks if t.max_retries > 0]
+        upstream_edges = flow.all_upstream_edges()
+        for task in retry_tasks:
+            if any(
+                [
+                    e.upstream_task.result_handler is None
+                    for e in upstream_edges[task]
+                    if e.key is not None
+                ]
+            ):
+                raise ValueError(
+                    "Task {} has retry settings but some upstream dependencies do not have result handlers. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
+                        task
+                    )
+                )
+
+        ## test for tasks which request caching with no result handler or no upstream result handlers
+        cached_tasks = [t for t in flow.tasks if t.cache_for is not None]
+        for task in cached_tasks:
+            if task.result_handler is None:
+                raise ValueError(
+                    "Task {} has cache settings but does not have a result handler. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
+                        task
+                    )
+                )
+            if any(
+                [
+                    e.upstream_task.result_handler is None
+                    for e in upstream_edges[task]
+                    if e.key is not None
+                ]
+            ):
+                raise ValueError(
+                    "Task {} has cache settings but some upstream dependencies do not have result handlers. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
+                        task
+                    )
+                )
+    print("Result Handler check: OK")
+
+
 def environment_dependency_check(flows: list):
     # Test for imports that are required by certain environments
     for flow in flows:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -154,6 +154,19 @@ def test_client_register(patch_post, compressed):
 def test_client_register_raises_for_keyed_flows_with_no_result_handler(
     patch_post, compressed
 ):
+    if compressed:
+        response = {
+            "data": {
+                "project": [{"id": "proj-id"}],
+                "createFlowFromCompressedString": {"id": "long-id"},
+            }
+        }
+    else:
+        response = {
+            "data": {"project": [{"id": "proj-id"}], "createFlow": {"id": "long-id"}}
+        }
+    patch_post(response)
+
     @prefect.task
     def a(x):
         pass
@@ -169,7 +182,7 @@ def test_client_register_raises_for_keyed_flows_with_no_result_handler(
 
     flow.result_handler = None
 
-    with pytest.raises(ClientError, match="required to have a result handler"):
+    with pytest.warns(UserWarning, match="result handler"):
         flow_id = client.register(
             flow,
             project_name="my-default-project",

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -253,17 +253,11 @@ class TestCreateTask:
 
     def test_create_task_with_and_without_checkpoint(self):
         t = Task()
-        assert t.checkpoint is True
+        assert t.checkpoint is False
 
         with pytest.warns(UserWarning, match="deprecated"):
-            s = Task(checkpoint=False)
-            assert s.checkpoint is False
-
-    @pytest.mark.xfail(reason="UX improvement for Core")
-    def test_create_parameter_always_checkpoints(self):
-        with set_temporary_config({"tasks.defaults.checkpoint": False}):
-            p = Parameter("p")
-        assert p.checkpoint is True
+            s = Task(checkpoint=True)
+            assert s.checkpoint is True
 
 
 def test_task_has_logger():

--- a/tests/engine/cloud/test_utilities.py
+++ b/tests/engine/cloud/test_utilities.py
@@ -30,6 +30,19 @@ def test_preparing_state_for_cloud_replaces_cached_inputs_with_safe(cls):
 
 
 @pytest.mark.parametrize("cls", [s for s in all_states if s.__name__ != "State"])
+def test_preparing_state_for_cloud_ignores_the_lack_of_result_handlers_for_cached_inputs(
+    cls,
+):
+    xres = Result(3, result_handler=None)
+    state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
+    assert isinstance(state, cls)
+    assert state.result is None
+    assert state._result == NoResult
+    assert state.cached_inputs == dict(x=xres)
+    assert state.serialize()["cached_inputs"]["x"]["type"] == "NoResultType"
+
+
+@pytest.mark.parametrize("cls", [s for s in all_states if s.__name__ != "State"])
 def test_preparing_state_for_cloud_does_nothing_if_result_is_none(cls):
     xres = Result(None, result_handler=JSONResultHandler())
     state = prepare_state_for_cloud(cls(cached_inputs=dict(x=xres)))
@@ -40,6 +53,7 @@ def test_preparing_state_for_cloud_does_nothing_if_result_is_none(cls):
     assert state.serialize()["cached_inputs"]["x"]["type"] == "NoResultType"
 
 
+@pytest.mark.skip(reason="Result Handlers are not required to exist currently")
 @pytest.mark.parametrize("cls", [s for s in all_states if s.__name__ != "State"])
 def test_preparing_state_for_cloud_fails_if_cached_inputs_have_no_handler(cls):
     xres = Result(3, result_handler=None)


### PR DESCRIPTION
**NOTE**: PR'ing into #1898 

This PR:
- reverts checkpointing behavior _essentially_ to its defaults, with one change: if checkpointing is turned on (which occurs in Core with an env var setting and in Cloud always), any task with a result handler will be checkpointed
- updates cached inputs to gracefully pass in the absence of a result handler
- removes the strict requirement that _all_ Flows have result handlers in favor of a warning
