### PR TITLE
Register agents with cloud

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -161,7 +161,7 @@ class Agent:
         )
         return agent_id
 
-    def deregister_agent(self) -> str:
+    def deregister_agent(self) -> None:
         """
         Removes information about the agent in Prefect Cloud.
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -30,6 +30,7 @@ def _exit(agent: "Agent") -> Callable:
     def _exit_handler(*args: Any, **kwargs: Any) -> None:
         agent.is_running = False
         agent.logger.info("Keyboard Interrupt received: Agent is shutting down.")
+        agent.deregister_agent()
 
     return _exit_handler
 
@@ -81,10 +82,9 @@ class Agent:
 
         self.client = Client(api_token=token)
         self._verify_token(token)
-        self.agent_id = self.register_agent()
-
         logger = logging.getLogger(self.name)
         logger.setLevel(config.cloud.agent.get("level"))
+
         if not any([isinstance(h, logging.StreamHandler) for h in logger.handlers]):
             ch = logging.StreamHandler(sys.stdout)
             formatter = logging.Formatter(context.config.logging.format)
@@ -93,6 +93,7 @@ class Agent:
             logger.addHandler(ch)
 
         self.logger = logger
+        self.agent_id = self.register_agent()
 
     def _verify_token(self, token: str) -> None:
         """

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -674,7 +674,7 @@ def test_create_agent_handles_error(patch_post):
 
 
 @pytest.mark.parametrize("success", [True, False])
-def test_delete_agent(patch_post):
+def test_delete_agent(patch_post, success):
     # mock the expected response
     response = {"data": {"deleteAgent": {"success": success}}}
     patch_post(response)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR updates agents to register and deregister with Prefect Cloud on startup/shutdown. This will help users track what agents they have running, what labels are being pulled, and when agents have queried for runs. 

This is a first-pass to illustrate the general pattern of how we'll be registering, and shouldn't be taken as final or merged until the corresponding API functionality is present in Cloud.

## Why is this PR important?

One of the biggest issues for Cloud users is figuring out which agents are polling for which information, and relatedly, why their flow runs aren't being picked up by agents. Coupled with the Cloud release to enable this, this will let us give greater transparency into our agent/polling system.
