### PR TITLE
Fix merge issue from #1918 and #1921

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -39,6 +39,8 @@ def exit_handler(agent: "Agent") -> Generator:
     try:
         signal.signal(signal.SIGINT, _exit_handler)
         yield exit_event
+    except SystemExit:
+        pass
     finally:
         signal.signal(signal.SIGINT, original)
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -83,7 +83,7 @@ class DockerAgent(Agent):
             self.logger.error(
                 "Cannot reconnect to Docker daemon. Agent is shutting down."
             )
-            self.is_running = False
+            raise SystemExit()
 
     def deploy_flow(self, flow_run: GraphQLResult) -> str:
         """

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -344,16 +344,14 @@ def test_docker_agent_heartbeat_exits_on_failure(monkeypatch, runner_token, capl
     )
 
     agent = DockerAgent()
-    agent.is_running = True  # this is only set on start()
     api.ping.return_value = False
     agent.heartbeat()
     agent.heartbeat()
     agent.heartbeat()
     agent.heartbeat()
     agent.heartbeat()
-    assert agent.is_running
-    agent.heartbeat()
-    assert not agent.is_running
+    with pytest.raises(SystemExit):
+        agent.heartbeat()
     assert "Cannot reconnect to Docker daemon. Agent is shutting down." in caplog.text
     assert api.ping.call_count == 7
 
@@ -366,7 +364,6 @@ def test_docker_agent_heartbeat_logs_reconnect(monkeypatch, runner_token, caplog
     )
 
     agent = DockerAgent()
-    agent.is_running = True  # this is only set on start()
     api.ping.return_value = False
     agent.heartbeat()
     agent.heartbeat()


### PR DESCRIPTION
#1918 and #1921 had conflicting changes which was not apparent due to implied base class behavior that had changed. Without this PR the Docker agent will fail to exit after the allotted reconnect attempts have expired.


