### PR TITLE
Parse Fargate Agent kwargs as literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix the Fargate Agent not parsing kwargs as literals - [#1926](https://github.com/PrefectHQ/prefect/pull/1926)
 
 ### Deprecations
 

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -261,13 +261,13 @@ class FargateAgent(Agent):
         task_definition_kwargs = {}
         for key, item in user_kwargs.items():
             if key in definition_kwarg_list:
-                task_definition_kwargs.update({key: item})
+                task_definition_kwargs.update({key: literal_eval(item)})
                 self.logger.debug("{} = {}".format(key, item))
 
         task_run_kwargs = {}
         for key, item in user_kwargs.items():
             if key in run_kwarg_list:
-                task_run_kwargs.update({key: item})
+                task_run_kwargs.update({key: literal_eval(item)})
                 self.logger.debug("{} = {}".format(key, item))
 
         # Check environment if keys were not provided
@@ -513,6 +513,10 @@ class FargateAgent(Agent):
                 task_definition_name  # type: ignore
             )
         )
+
+        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+        print(flow_task_run_kwargs)
+
         task = self.boto3_client.run_task(
             taskDefinition=task_definition_name,
             overrides={"containerOverrides": container_overrides},

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -258,16 +258,27 @@ class FargateAgent(Agent):
             "enableECSManagedTags",
             "propagateTags",
         ]
+
         task_definition_kwargs = {}
         for key, item in user_kwargs.items():
             if key in definition_kwarg_list:
-                task_definition_kwargs.update({key: literal_eval(item)})
+                try:
+                    # Parse kwarg if needed
+                    item = literal_eval(item)
+                except ValueError:
+                    pass
+                task_definition_kwargs.update({key: item})
                 self.logger.debug("{} = {}".format(key, item))
 
         task_run_kwargs = {}
         for key, item in user_kwargs.items():
             if key in run_kwarg_list:
-                task_run_kwargs.update({key: literal_eval(item)})
+                try:
+                    # Parse kwarg if needed
+                    item = literal_eval(item)
+                except ValueError:
+                    pass
+                task_run_kwargs.update({key: item})
                 self.logger.debug("{} = {}".format(key, item))
 
         # Check environment if keys were not provided
@@ -513,9 +524,6 @@ class FargateAgent(Agent):
                 task_definition_name  # type: ignore
             )
         )
-
-        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        print(flow_task_run_kwargs)
 
         task = self.boto3_client.run_task(
             taskDefinition=task_definition_name,

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -704,8 +704,8 @@ def test_deploy_flow_register_task_definition_all_args(monkeypatch, runner_token
         "requiresCompatibilities"
     ] == ["FARGATE"]
     assert boto3_client.register_task_definition.call_args[1]["networkMode"] == "awsvpc"
-    assert boto3_client.register_task_definition.call_args[1]["cpu"] == "1"
-    assert boto3_client.register_task_definition.call_args[1]["memory"] == "2"
+    assert boto3_client.register_task_definition.call_args[1]["cpu"] == 1
+    assert boto3_client.register_task_definition.call_args[1]["memory"] == 2
 
 
 @pytest.mark.parametrize("flag", [True, False])
@@ -812,8 +812,8 @@ def test_deploy_flows_includes_agent_labels_in_environment(
         "requiresCompatibilities"
     ] == ["FARGATE"]
     assert boto3_client.register_task_definition.call_args[1]["networkMode"] == "awsvpc"
-    assert boto3_client.register_task_definition.call_args[1]["cpu"] == "1"
-    assert boto3_client.register_task_definition.call_args[1]["memory"] == "2"
+    assert boto3_client.register_task_definition.call_args[1]["cpu"] == 1
+    assert boto3_client.register_task_definition.call_args[1]["memory"] == 2
 
 
 def test_deploy_flow_register_task_definition_no_repo_credentials(
@@ -1108,7 +1108,7 @@ def test_override_kwargs(monkeypatch, runner_token):
 
     assert boto3_resource.called
     assert streaming_body.read().decode.called
-    assert definition_kwargs == {"cpu": "256"}
+    assert definition_kwargs == {"cpu": 256}
     assert run_kwargs == {"networkConfiguration": "test"}
 
 
@@ -1292,7 +1292,7 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
                 "essential": True,
             }
         ],
-        cpu="256",
+        cpu=256,
         family="name",
         networkMode="awsvpc",
         requiresCompatibilities=["FARGATE"],


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
The Fargate Agent checks values read in through environment variables to see if they need to be taken literally. For example:

```bash
export networkConfiguration="{'awsvpcConfiguration':{'assignPublicIp':'DISABLED','subnets':['my_subnet'],'securityGroups':['sg-12345']}}"
```

Will be interpreted as a dictionary (as it should be). Previously any kwargs passed in to the `FargateAgent` object itself were not subjected to this literal eval. This was an issue because the CLI `prefect agent start fargate` accepts strings and passes them directly to the `FargateAgent`. Therefore the parse step needed to occur on those kwargs to check whether or not a string needed to be interpreted literally.

This would address ParameterValidation errors similar to:
```
ERROR - agent | Error while deploying flow: ParamValidationError("Parameter validation failed:\nInvalid type for parameter networkConfiguration, value: {'awsvpcConfiguration':{'assignPublicIp':'DISABLED','subnets':['my_subnet'],'securityGroups':['sg-12345']}}, type: <class 'str'>, valid types: <class 'dict'>")
```

## Why is this PR important?
So the CLI can parse Fargate Agent kwargs properly :)