### PR TITLE
Add show_flow_logs to the Docker agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Docker daemon reconnect attempts + exit on heartbeat failure -[#1918](https://github.com/PrefectHQ/prefect/pull/1918)
 - More responsive agent shutdown - [#1921](https://github.com/PrefectHQ/prefect/issues/1921)
+- Add show_flow_logs to Docker agent [#1929](https://github.com/PrefectHQ/prefect/issues/1929)
 
 ### Task Library
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -108,6 +108,11 @@ class LocalAgent(Agent):
 
         stdout = sys.stdout if self.show_flow_logs else PIPE
 
+        # note: we will allow these processes to be orphaned if the agent were to exit
+        # before the flow runs have completed. The lifecycle of the agent should not
+        # dictate the lifecycle of the flow run. However, if the user has elected to
+        # show flow logs, these log entries will continue to stream to the users terminal
+        # until these child processes exit, even if the agent has already exited.
         p = Popen(
             ["prefect", "execute", "cloud-flow"],
             stdout=stdout,

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -147,7 +147,7 @@ def start(
         --import-path, -p   TEXT    Import paths which will be provided to each Flow's runtime environment.
                                     Used for Flows which might import from scripts or local packages.
                                     Multiple values supported e.g. `-p /root/my_scripts -p /utilities`
-        --show-flow-logs, -f        Display logging output from flows run by the agent
+        --show-flow-logs, -f        Display logging output from flows run by the agent (available for Local and Docker agents only)
 
     \b
     Docker Agent Options:
@@ -206,6 +206,7 @@ def start(
                 env_vars=env_vars,
                 base_url=base_url,
                 no_pull=no_pull,
+                show_flow_logs=show_flow_logs,
             ).start()
         elif agent_option == "fargate":
             from_qualified_name(retrieved_agent)(

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -185,6 +185,7 @@ def test_agent_start_with_env_vars(monkeypatch, runner_token):
         labels=[],
         name=None,
         no_pull=False,
+        show_flow_logs=False,
     )
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds the `show_flow_logs` agent option to the `DockerAgent`, forwarding all subprocess flow logs to the agent's standard output. 


