### PR TITLE
Remove CIRCLE_TAG for master build image step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,6 @@ jobs:
             docker build \
               --build-arg GIT_SHA=$CIRCLE_SHA1 \
               --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-              --build-arg PREFECT_VERSION=$CIRCLE_TAG \
               --build-arg PYTHON_VERSION=$PYTHON_VERSION \
               -t prefecthq/prefect:master
               .


### PR DESCRIPTION
Follow up of #1939 

@wagoodman The build fails if no `CIRCLE_TAG` is set