### PR TITLE
Slight refactor of how agents deploy and submit flow runs for execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- More graceful handling of Agents competing for work - [#1956](https://github.com/PrefectHQ/prefect/issues/1956)
 
 ### Task Library
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -209,16 +209,19 @@ class Agent:
         try:
             self.update_state(flow_run)
             deployment_info = self.deploy_flow(flow_run)
-            self.client.write_run_logs(
-                [
-                    dict(
-                        flowRunId=getattr(flow_run, "id", "UNKNOWN"),  # type: ignore
-                        name=self.name,
-                        message="Submitted for execution: {}".format(deployment_info),
-                        level="INFO",
-                    )
-                ]
-            )
+            if getattr(flow_run, "id", None):
+                self.client.write_run_logs(
+                    [
+                        dict(
+                            flowRunId=getattr(flow_run, "id"),  # type: ignore
+                            name=self.name,
+                            message="Submitted for execution: {}".format(
+                                deployment_info
+                            ),
+                            level="INFO",
+                        )
+                    ]
+                )
         except Exception as exc:
             ## if the state update failed, we don't want to follow up with another state update
             if "State update failed" in str(exc):
@@ -229,16 +232,17 @@ class Agent:
                     getattr(flow_run, "id", "UNKNOWN")  # type: ignore
                 )
             )
-            self.client.write_run_logs(
-                [
-                    dict(
-                        flowRunId=getattr(flow_run, "id", "UNKNOWN"),  # type: ignore
-                        name=self.name,
-                        message=str(exc),
-                        level="ERROR",
-                    )
-                ]
-            )
+            if getattr(flow_run, "id", None):
+                self.client.write_run_logs(
+                    [
+                        dict(
+                            flowRunId=getattr(flow_run, "id"),  # type: ignore
+                            name=self.name,
+                            message=str(exc),
+                            level="ERROR",
+                        )
+                    ]
+                )
             self.mark_failed(flow_run=flow_run, exc=exc)
 
     def on_flow_run_deploy_attempt(self, fut: "Future", flow_run_id: str) -> None:

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -213,7 +213,7 @@ class Agent:
                 [
                     dict(
                         flowRunId=getattr(flow_run, "id", "UNKNOWN"),  # type: ignore
-                        name="agent",
+                        name=self.name,
                         message="Submitted for execution: {}".format(deployment_info),
                         level="INFO",
                     )
@@ -233,7 +233,7 @@ class Agent:
                 [
                     dict(
                         flowRunId=getattr(flow_run, "id", "UNKNOWN"),  # type: ignore
-                        name="agent",
+                        name=self.name,
                         message=str(exc),
                         level="ERROR",
                     )

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -407,7 +407,7 @@ class Agent:
             }
         }
 
-        if flow_run_ids:
+        if target_flow_run_ids:
             self.logger.debug("Querying flow run metadata")
             result = self.client.graphql(query)
             return result.data.flow_run  # type: ignore

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -199,8 +199,7 @@ def test_update_states_passes_no_task_runs(monkeypatch, runner_token):
                 "version": 1,
                 "task_runs": [],
             }
-        ),
-        deployment_info="test",
+        )
     )
 
 
@@ -231,8 +230,7 @@ def test_update_states_passes_task_runs(monkeypatch, runner_token):
                     )
                 ],
             }
-        ),
-        deployment_info="test",
+        )
     )
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR does two things:
- puts Flow Runs in submitted states _prior_ to deploying them; this ensures that jobs / resources aren't created for Flow Runs which have already been submitted by other agents.  Putting them in Submitted _first_ allows Cloud to version lock appropriately
- in the event that placing the Flow Run into a Submitted state fails, we no longer attempt to mark the flow run failed; instead we log the error and continue on our way


## Why is this PR important?
Closes #1956 