### PR TITLE
Attempt to ship logger errors via the CloudHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Cloud logger attempts to elevate logger errors to flow run logs - [#1961](https://github.com/PrefectHQ/prefect/pull/1961)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Cloud logger now attempts to elevate logger errors to flow run logs - [#1961](https://github.com/PrefectHQ/prefect/pull/1961)
 
 ### Task Library
 
@@ -43,7 +43,6 @@ Released on Jan 30, 2020.
 
 ### Enhancements
 
-- Cloud logger attempts to elevate logger errors to flow run logs - [#1961](https://github.com/PrefectHQ/prefect/pull/1961)
 - More graceful handling of Agents competing for work - [#1956](https://github.com/PrefectHQ/prefect/issues/1956)
 
 ### Task Library

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -142,7 +142,6 @@ class CloudHandler(logging.StreamHandler):
     def _make_error_log(self, message: str) -> dict:
         log = dict()
         log["flowRunId"] = prefect.context.get("flow_run_id", None)
-        log["taskRunId"] = prefect.context.get("task_run_id", None)
         log["timestamp"] = pendulum.from_timestamp(time.time()).isoformat()
         log["name"] = self.logger.name
         log["message"] = message

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -70,7 +70,7 @@ class CloudHandler(logging.StreamHandler):
                 try:
                     assert self.client is not None
                     self.client.write_run_logs([self._make_error_log(message)])
-                except prefect.utilities.exceptions.ClientError as exc:
+                except Exception as exc:
                     self.logger.critical("Unable to write logs to Prefect Cloud")
 
     def _monitor(self) -> None:

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -63,9 +63,15 @@ class CloudHandler(logging.StreamHandler):
                 assert self.client is not None
                 self.client.write_run_logs(logs)
             except Exception as exc:
-                self.logger.critical(
-                    "Failed to write log with error: {}".format(str(exc))
-                )
+                message = "Failed to write log with error: {}".format(str(exc))
+                self.logger.critical(message)
+
+                # Attempt to write batch error log otherwise log invalid cloud communication
+                try:
+                    assert self.client is not None
+                    self.client.write_run_logs([self._make_error_log(message)])
+                except prefect.utilities.exceptions.ClientError as exc:
+                    self.logger.critical("Unable to write logs to Prefect Cloud")
 
     def _monitor(self) -> None:
         while not self._flush:
@@ -92,7 +98,10 @@ class CloudHandler(logging.StreamHandler):
             json.dumps(log)  # make sure the payload is serializable
             self.queue.put(log)
         except TypeError as exc:
-            self.logger.critical("Failed to write log with error: {}".format(str(exc)))
+            message = "Failed to write log with error: {}".format(str(exc))
+            self.logger.critical(message)
+
+            self.queue.put(self._make_error_log(message))
 
     def emit(self, record) -> None:  # type: ignore
         # if we shouldn't log to cloud, don't emit
@@ -125,7 +134,22 @@ class CloudHandler(logging.StreamHandler):
             log["info"] = record_dict
             self.put(log)
         except Exception as exc:
-            self.logger.critical("Failed to write log with error: {}".format(str(exc)))
+            message = "Failed to write log with error: {}".format(str(exc))
+            self.logger.critical(message)
+
+            self.put(self._make_error_log(message))
+
+    def _make_error_log(self, message: str) -> dict:
+        log = dict()
+        log["flowRunId"] = prefect.context.get("flow_run_id", None)
+        log["taskRunId"] = prefect.context.get("task_run_id", None)
+        log["timestamp"] = pendulum.from_timestamp(time.time()).isoformat()
+        log["name"] = self.logger.name
+        log["message"] = message
+        log["level"] = "CRITICAL"
+        log["info"] = {}
+
+        return log
 
 
 def configure_logging(testing: bool = False) -> logging.Logger:

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -192,11 +192,10 @@ def test_cloud_handler_removes_bad_logs_from_queue_and_logs_error(caplog, monkey
         time.sleep(0.75)
         assert len(calls) == 1
         msgs = [c["message"] for c in calls[0]["args"][0]]
-        assert msgs == [
-            "one",
-            "Failed to write log with error: Object of type bytes is not JSON serializable",
-            "three",
-        ]
+
+        assert msgs[0] == "one"
+        assert "is not JSON serializable" in msgs[1]
+        assert msgs[2] == "three"
     finally:
         # reset root_logger
         logger = utilities.logging.configure_logging(testing=True)

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -208,7 +208,6 @@ def test_make_error_log(caplog):
     with context({"flow_run_id": "f_id", "task_run_id": "t_id"}):
         log = utilities.logging.CloudHandler()._make_error_log("test_message")
         assert log["flowRunId"] == "f_id"
-        assert log["taskRunId"] == "t_id"
         assert log["timestamp"]
         assert log["name"] == "CloudHandler"
         assert log["message"] == "test_message"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a step to the CloudHandler to attempt to log possible logger errors to Cloud for visibility. For example if the payload is too large or something non-json serializable is attempted the error will be raised in the flow process but not elevated for visibility.

Example logger issue being elevated as a cloud log:
![image](https://user-images.githubusercontent.com/40716964/73385870-e5bdb280-429b-11ea-9918-6b84a3d8f397.png) 

Closes #1943 

## Why is this PR important?
Improves user visibility into otherwise hidden logger exceptions.

