### PR TITLE
Populate prefect job imagePullSecrets if provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix uncaught Fargate Agent kwarg parse SyntaxError from `literal_eval` - [#1968](https://github.com/PrefectHQ/prefect/pull/1968)
 - Fix FargateTaskEnvironment passing empty auth token to run task - [#1976](https://github.com/PrefectHQ/prefect/pull/1976)
+- Fix imagePullSecrets not being automatically passed to jobs created by Kubernetes Agent - [#1982](https://github.com/PrefectHQ/prefect/pull/1982)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -249,6 +249,7 @@ class KubernetesAgent(Agent):
         agent_env[0]["value"] = token
         agent_env[1]["value"] = api
         agent_env[2]["value"] = namespace
+        agent_env[3]["value"] = image_pull_secrets or ""
         agent_env[4]["value"] = str(labels)
 
         # Populate job resource env vars

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -437,6 +437,8 @@ def test_k8s_agent_generate_deployment_yaml_no_image_pull_secrets(
     deployment = yaml.safe_load(deployment)
 
     assert deployment["spec"]["template"]["spec"].get("imagePullSecrets") is None
+    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert agent_env[3]["value"] == ""
 
 
 def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
@@ -459,6 +461,8 @@ def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
         deployment["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
         == "secrets"
     )
+    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert agent_env[3]["value"] == "secrets"
 
 
 def test_k8s_agent_generate_deployment_yaml_contains_resources(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Previously providing an `image_pull_secrets` to the Kubernetes agent install did not automatically use them for the jobs created by the agent.


## Why is this PR important?
This reduces user need to manually update the yaml outputted by the install command.

