### PR TITLE
S3 storage: accept additional boto3 kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Improve error handling for unsupported callables - [#1993](https://github.com/PrefectHQ/prefect/pull/1993)
+- Accept additional `boto3` client parameters in S3 storage - [#2000](https://github.com/PrefectHQ/prefect/pull/2000)
 
 ### Task Library
 

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -39,6 +39,7 @@ class S3(Storage):
             `AWS_SESSION_TOKEN` or `None`
         - key (str, optional): a unique key to use for uploading a Flow to S3. This
             is only useful when storing a single Flow using this storage object.
+        - client_options (dict, optional): Additional options for the `boto3` client.
     """
 
     def __init__(
@@ -47,6 +48,7 @@ class S3(Storage):
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: str = None,
+        client_options: dict = None,
         key: str = None,
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
@@ -57,6 +59,7 @@ class S3(Storage):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token
+        self.client_options = client_options
 
         result_handler = S3ResultHandler(bucket=bucket)
         super().__init__(result_handler=result_handler)
@@ -192,6 +195,7 @@ class S3(Storage):
 
         return boto3_client(
             "s3",
+            **(self.client_options or {}),
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -14,7 +14,7 @@ from prefect.environments.storage import (
     Storage,
     S3,
 )
-from prefect.utilities.serialization import Bytes as BytesField
+from prefect.utilities.serialization import Bytes as BytesField, JSONCompatible
 from prefect.utilities.serialization import ObjectSchema, OneOfSchema
 
 
@@ -111,6 +111,9 @@ class S3Schema(ObjectSchema):
     bucket = fields.String(allow_none=False)
     key = fields.String(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
+    client_options = fields.Dict(
+        key=fields.Str(), values=JSONCompatible(), allow_none=True
+    )
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> S3:

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -26,6 +26,7 @@ def test_create_s3_storage_init_args():
         aws_session_token="session",
         bucket="bucket",
         key="key",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False,},
     )
     assert storage
     assert storage.flows == dict()
@@ -34,13 +35,25 @@ def test_create_s3_storage_init_args():
     assert storage.aws_session_token == "session"
     assert storage.bucket == "bucket"
     assert storage.key == "key"
+    assert storage.client_options == {
+        "endpoint_url": "http://some-endpoint",
+        "use_ssl": False,
+    }
 
 
 def test_serialize_s3_storage():
-    storage = S3(bucket="bucket")
+    storage = S3(
+        bucket="bucket",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False},
+    )
     serialized_storage = storage.serialize()
 
     assert serialized_storage["type"] == "S3"
+    assert serialized_storage["bucket"] == "bucket"
+    assert serialized_storage["client_options"] == {
+        "endpoint_url": "http://some-endpoint",
+        "use_ssl": False,
+    }
 
 
 def test_boto3_client_property(monkeypatch):
@@ -53,6 +66,7 @@ def test_boto3_client_property(monkeypatch):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="session",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False,},
     )
 
     boto3_client = storage._boto3_client
@@ -62,6 +76,8 @@ def test_boto3_client_property(monkeypatch):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="session",
+        endpoint_url="http://some-endpoint",
+        use_ssl=False,
     )
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Add a `client_options` optional dict parameter to `prefect.environments.storage.s3.S3` for passing additional parameters when instantiating the `boto3` client; also serialize it as `JSONCompatible` in `prefect.serialization.storage.S3Schema`.

## Why is this PR important?

Passing additional parameters to the `boto3` client (like `endpoint_url` and `use_ssl`) allows storing and fetching Flows from any S3-compatible service, for example a local Minio cluster or alternative services ([list of S3-compatible and competing services on Wikipedia](https://en.wikipedia.org/wiki/Amazon_S3#S3_API_and_competing_services)).
