### PR TITLE
Update "deploying flow" log level in k8s and fargate agents

### DIFF
--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -333,7 +333,7 @@ class FargateAgent(Agent):
         Raises:
             - ValueError: if deployment attempted on unsupported Storage type
         """
-        self.logger.debug(
+        self.logger.info(
             "Deploying flow run {}".format(flow_run.id)  # type: ignore
         )
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -95,7 +95,7 @@ class KubernetesAgent(Agent):
         Raises:
             - ValueError: if deployment attempted on unsupported Storage type
         """
-        self.logger.debug(
+        self.logger.info(
             "Deploying flow run {}".format(flow_run.id)  # type: ignore
         )
 


### PR DESCRIPTION
Local and Docker agents already log this at the `INFO` level. Informative to track runs that are being deployed and witness activity.