### PR TITLE
Add version_group_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add incremental tutorial - [#1953](https://github.com/PrefectHQ/prefect/issues/1953)
 - Improve error handling for unsupported callables - [#1993](https://github.com/PrefectHQ/prefect/pull/1993)
 - Accept additional `boto3` client parameters in S3 storage - [#2000](https://github.com/PrefectHQ/prefect/pull/2000)
+- Add optional `version_group_id` kwarg to `create_flow_run` for a stable API for flow runs - [#1987](https://github.com/PrefectHQ/prefect/issues/1987)
 
 ### Task Library
 

--- a/docs/cloud/concepts/flow_runs.md
+++ b/docs/cloud/concepts/flow_runs.md
@@ -20,6 +20,10 @@ client.create_flow_run(flow_id="<flow id>")
 
 The client method takes a number of optional arguments, including scheduled start time, parameters and an idempotency key. See the API reference for complete detail.
 
+::: tip A Stable API for Flow Runs
+For flows which update regularly, you can instead provide a `version_group_id` to `create_flow_run`.  If provided, the unique unarchived flow within the version group will be scheduled for execution.  
+:::
+
 ### Core CLI
 
 You can also create flow runs via the Prefect CLI by providing a flow name and its corresponding project name:
@@ -41,6 +45,8 @@ mutation {
   }
 }
 ```
+
+As with the Core Client, you can instead provide `versionGroupId` as an input to schedule a run for the unique unarchived flow within the provided version group.  This provides a stable API for running flows which are regularly updated.
 
 ### Idempotent run creation <Badge text="GQL"/>
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -671,15 +671,17 @@ class Client:
 
     def create_flow_run(
         self,
-        flow_id: str,
+        flow_id: str = None,
         context: dict = None,
         parameters: dict = None,
         scheduled_start_time: datetime.datetime = None,
         idempotency_key: str = None,
         run_name: str = None,
+        version_group_id: str = None,
     ) -> str:
         """
         Create a new flow run for the given flow id.  If `start_time` is not provided, the flow run will be scheduled to start immediately.
+        If both `flow_id` and `version_group_id` are provided, only the `flow_id` will be used.
 
         Args:
             - flow_id (str): the id of the Flow you wish to schedule
@@ -692,6 +694,8 @@ class Client:
                 An error will be raised if parameters or context are provided and don't match the original.
                 Each subsequent request will reset the TTL for 24 hours.
             - run_name (str, optional): The name assigned to this flow run
+            - version_group_id (str, optional): if provided, the unique unarchived flow within this version group will be scheduled
+                to run.  This input can be used as a stable API for running flows which are regularly updated.
 
         Returns:
             - str: the ID of the newly-created flow run
@@ -704,7 +708,12 @@ class Client:
                 "createFlowRun(input: $input)": {"flow_run": "id"}
             }
         }
-        inputs = dict(flowId=flow_id)
+        if not flow_id and not version_group_id:
+            raise ValueError("One of flow_id or version_group_id must be provided")
+
+        inputs = (
+            dict(flowId=flow_id) if flow_id else dict(versionGroupId=version_group_id)  # type: ignore
+        )
         if parameters is not None:
             inputs.update(parameters=parameters)  # type: ignore
         if context is not None:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -684,7 +684,7 @@ class Client:
         If both `flow_id` and `version_group_id` are provided, only the `flow_id` will be used.
 
         Args:
-            - flow_id (str): the id of the Flow you wish to schedule
+            - flow_id (str, optional): the id of the Flow you wish to schedule
             - context (dict, optional): the run context
             - parameters (dict, optional): a dictionary of parameter values to pass to the flow run
             - scheduled_start_time (datetime, optional): the time to schedule the execution for; if not provided, defaults to now


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR exposes and documents `version_group_id` as an input to `create_flow_run`.  This input provides a stable API for running flows from a version group.


## Why is this PR important?
Closes #1987 

