### PR TITLE
change to fargate agent to fix bug related to agent process threadpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Ensure `ifelse` casts its condition to `bool` prior to evaluation - [#1991](https://github.com/PrefectHQ/prefect/pull/1991)
 - Do not perform `ast.literal_eval` on cpu and memory task_definition kwargs for Fargate Agent - [#2010](https://github.com/PrefectHQ/prefect/pull/2010)
-- Fix new agent processing with Threadpool causing problem for Fargate Agent with task revisions enabled
+- Fix new agent processing with Threadpool causing problem for Fargate Agent with task revisions enabled - [#2022](https://github.com/PrefectHQ/prefect/pull/2022)
+
 ### Deprecations
 
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Ensure `ifelse` casts its condition to `bool` prior to evaluation - [#1991](https://github.com/PrefectHQ/prefect/pull/1991)
 - Do not perform `ast.literal_eval` on cpu and memory task_definition kwargs for Fargate Agent - [#2010](https://github.com/PrefectHQ/prefect/pull/2010)
-
+- Fix new agent processing with Threadpool causing problem for Fargate Agent with task revisions enabled
 ### Deprecations
 
 - None

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -105,9 +105,6 @@ class FargateAgent(Agent):
         self.external_kwargs_s3_bucket = external_kwargs_s3_bucket
         self.external_kwargs_s3_key = external_kwargs_s3_key
 
-        # populate task_definition_name as None to start
-        self.task_definition_name = None
-
         # Parse accepted kwargs for definition and run
         self.task_definition_kwargs, self.task_run_kwargs = self._parse_kwargs(
             kwargs, True
@@ -348,6 +345,9 @@ class FargateAgent(Agent):
         flow_task_definition_kwargs = copy.deepcopy(self.task_definition_kwargs)
         flow_task_run_kwargs = copy.deepcopy(self.task_run_kwargs)
 
+        # create task_definition_name dict for passing into verify method
+        task_definition_dict = {}
+
         if self.use_external_kwargs:
             # override from  external kwargs
             self._override_kwargs(
@@ -357,11 +357,11 @@ class FargateAgent(Agent):
         # set proper task_definition_name and tags based on enable_task_revisions flag
         if self.enable_task_revisions:
             # set task definition name
-            self.task_definition_name = slugify(flow_run.flow.name)
+            task_definition_dict["task_definition_name"] = slugify(flow_run.flow.name)
             self._add_flow_tags(flow_run, flow_task_definition_kwargs)
 
         else:
-            self.task_definition_name = "prefect-task-{}".format(  # type: ignore
+            task_definition_dict["task_definition_name"] = "prefect-task-{}".format(  # type: ignore
                 flow_run.flow.id[:8]  # type: ignore
             )  # type: ignore
 
@@ -374,23 +374,32 @@ class FargateAgent(Agent):
 
         # check if task definition exists
         self.logger.debug("Checking for task definition")
-        if not self._verify_task_definition_exists(flow_run):
+        if not self._verify_task_definition_exists(flow_run, task_definition_dict):
             self.logger.debug("No task definition found")
-            self._create_task_definition(flow_run, flow_task_definition_kwargs)
+            self._create_task_definition(
+                flow_run,
+                flow_task_definition_kwargs,
+                task_definition_dict["task_definition_name"],
+            )
 
         # run task
-        task_arn = self._run_task(flow_run, flow_task_run_kwargs)
+        task_arn = self._run_task(
+            flow_run, flow_task_run_kwargs, task_definition_dict["task_definition_name"]
+        )
 
         self.logger.debug("Run created for task {}".format(task_arn))
 
         return "Task ARN: {}".format(task_arn)
 
-    def _verify_task_definition_exists(self, flow_run: GraphQLResult) -> bool:
+    def _verify_task_definition_exists(
+        self, flow_run: GraphQLResult, task_definition_dict: dict
+    ) -> bool:
         """
         Check if a task definition already exists for the flow
 
         Args:
             - flow_run (GraphQLResult): A GraphQLResult representing a flow run object
+            - task_definition_dict(dict): Dictionary containing task definition name to update if needed.
 
         Returns:
             - bool: whether or not a preexisting task definition is found for this flow
@@ -399,7 +408,7 @@ class FargateAgent(Agent):
 
         try:
             definition_exists = True
-            task_definition_name = self.task_definition_name
+            task_definition_name = task_definition_dict["task_definition_name"]
             definition_response = self.boto3_client.describe_task_definition(
                 taskDefinition=task_definition_name, include=["TAGS"]
             )
@@ -424,7 +433,7 @@ class FargateAgent(Agent):
                         ResourceTypeFilters=["ecs:task-definition"],
                     )
                     if tag_search["ResourceTagMappingList"]:
-                        self.task_definition_name = [
+                        task_definition_dict["task_definition_name"] = [
                             x.get("ResourceARN")
                             for x in tag_search["ResourceTagMappingList"]
                         ][-1]
@@ -445,7 +454,10 @@ class FargateAgent(Agent):
         return definition_exists
 
     def _create_task_definition(
-        self, flow_run: GraphQLResult, flow_task_definition_kwargs: dict
+        self,
+        flow_run: GraphQLResult,
+        flow_task_definition_kwargs: dict,
+        task_definition_name: str,
     ) -> None:
         """
         Create a task definition for the flow that each flow run will use. This function
@@ -454,13 +466,13 @@ class FargateAgent(Agent):
         Args:
             - flow_runs (list): A list of GraphQLResult flow run objects
             - flow_task_definition_kwargs (dict): kwargs to use for registration
+            - task_definition_name (str): task definition name to use
         """
         self.logger.debug(
             "Using image {} for task definition".format(
                 StorageSchema().load(flow_run.flow.storage).name  # type: ignore
             )
         )
-        task_definition_name = self.task_definition_name
         container_definitions = [
             {
                 "name": "flow",
@@ -513,13 +525,19 @@ class FargateAgent(Agent):
             **flow_task_definition_kwargs
         )
 
-    def _run_task(self, flow_run: GraphQLResult, flow_task_run_kwargs: dict) -> str:
+    def _run_task(
+        self,
+        flow_run: GraphQLResult,
+        flow_task_run_kwargs: dict,
+        task_definition_name: str,
+    ) -> str:
         """
         Run a task using the flow run.
 
         Args:
             - flow_runs (list): A list of GraphQLResult flow run objects
             - flow_task_run_kwargs (dict): kwargs to use for task run
+            - task_definition_name (str): task definition name to use
         """
         container_overrides = [
             {
@@ -537,7 +555,6 @@ class FargateAgent(Agent):
             }
         ]
 
-        task_definition_name = self.task_definition_name
         # Run task
         self.logger.debug(
             "Running task using task definition {}".format(

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -422,7 +422,7 @@ def test_deploy_flow_raises(monkeypatch, runner_token):
                     "flow": GraphQLResult({"storage": Local().serialize(), "id": "id"}),
                     "id": "id",
                 }
-            )
+            ),
         )
 
     assert not boto3_client.describe_task_definition.called
@@ -988,7 +988,7 @@ def test_deploy_flows_enable_task_revisions_no_tags(monkeypatch, runner_token):
         ],
     )
     assert boto3_client.run_task.called
-    assert agent.task_definition_name == "name"
+    assert boto3_client.run_task.called_with(taskDefinition="name")
 
 
 def test_deploy_flows_enable_task_revisions_tags_current(monkeypatch, runner_token):
@@ -1026,8 +1026,7 @@ def test_deploy_flows_enable_task_revisions_tags_current(monkeypatch, runner_tok
     )
     assert boto3_client.describe_task_definition.called
     assert boto3_client.register_task_definition.not_called
-    assert boto3_client.run_task.called
-    assert agent.task_definition_name == "name-1"
+    assert boto3_client.run_task.called_with(taskDefinition="name-1")
 
 
 def test_deploy_flows_enable_task_revisions_old_version_exists(
@@ -1072,10 +1071,8 @@ def test_deploy_flows_enable_task_revisions_old_version_exists(
     assert boto3_client.describe_task_definition.called
     assert boto3_client.get_resources.called
     assert boto3_client.register_task_definition.not_called
-    assert boto3_client.run_task.called
-    assert (
-        agent.task_definition_name
-        == "arn:aws:ecs:us-east-1:12345:task-definition/flow:22"
+    assert boto3_client.run_task.called_with(
+        taskDefinition="arn:aws:ecs:us-east-1:12345:task-definition/flow:22"
     )
 
 
@@ -1224,7 +1221,7 @@ def test_deploy_flows_enable_task_revisions_tags_passed_in(monkeypatch, runner_t
     assert boto3_client.describe_task_definition.called
     assert boto3_client.register_task_definition.not_called
     assert boto3_client.run_task.called
-    assert agent.task_definition_name == "name"
+    assert boto3_client.run_task.called_with(taskDefinition="name")
 
 
 def test_deploy_flows_enable_task_revisions_with_external_kwargs(
@@ -1338,7 +1335,7 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
         taskDefinition="name",
         tags=[{"key": "test", "value": "test"}],
     )
-    assert agent.task_definition_name == "name"
+    assert boto3_client.run_task.called_with(taskDefinition="name")
 
 
 def test_deploy_flows_disable_task_revisions_with_external_kwargs(
@@ -1411,4 +1408,4 @@ def test_deploy_flows_disable_task_revisions_with_external_kwargs(
         taskDefinition="prefect-task-new_id",
         tags=[{"key": "test", "value": "test"}],
     )
-    assert agent.task_definition_name == "prefect-task-new_id"
+    assert boto3_client.run_task.called_with(taskDefinition="prefect-task-new_id")


### PR DESCRIPTION

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [X] adds new tests (if appropriate)
- [X] updates `CHANGELOG.md` (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Moving task_definition_name from class attribute to dict value, which is explicitly passed into fargate agent class methods.

## Why is this PR important?

This fixes a new bug with Fargate Agent when task revisions are enabled caused by the new ThreadPool based agent process.  Previously because the loop over flow runs was synchronous we could house the task definition name as an agent class attribute.  Now that the loop as async when there are more than 1 flows runs collected by the agent, the second flow run overrides the task definition name set by the first flow. 


