### PR TITLE
Add early check for mapping argument type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Better exception for unsubscriptable mapping arguments - [#1821](https://github.com/PrefectHQ/prefect/issues/1821)
 
 ### Task Library
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -22,6 +22,7 @@ import prefect.engine.cache_validators
 import prefect.engine.signals
 import prefect.triggers
 from prefect.utilities import logging
+from prefect.utilities.tasks import unmapped
 from prefect.utilities.notifications import callback_factory
 
 if TYPE_CHECKING:
@@ -476,7 +477,7 @@ class Task(metaclass=SignatureValidator):
             - Task: a new Task instance
         """
         for arg in args:
-            if not hasattr(arg, "__getitem__"):
+            if not hasattr(arg, "__getitem__") and not isinstance(arg, unmapped):
                 raise TypeError(
                     "cannot map over an unsubscriptable object ({})".format(arg)
                 )

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -479,7 +479,7 @@ class Task(metaclass=SignatureValidator):
         for arg in args:
             if not hasattr(arg, "__getitem__") and not isinstance(arg, unmapped):
                 raise TypeError(
-                    "cannot map over an unsubscriptable object ({})".format(arg)
+                    "Cannot map over an unsubscriptable object ({})".format(arg)
                 )
         new = self.copy(**(task_args or {}))
         return new.bind(

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -475,6 +475,11 @@ class Task(metaclass=SignatureValidator):
         Returns:
             - Task: a new Task instance
         """
+        for arg in args:
+            if not hasattr(arg, "__getitem__"):
+                raise TypeError(
+                    "cannot map over an unsubscriptable object ({})".format(arg)
+                )
         new = self.copy(**(task_args or {}))
         return new.bind(
             *args, mapped=True, upstream_tasks=upstream_tasks, flow=flow, **kwargs

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -479,7 +479,9 @@ class Task(metaclass=SignatureValidator):
         for arg in args:
             if not hasattr(arg, "__getitem__") and not isinstance(arg, unmapped):
                 raise TypeError(
-                    "Cannot map over an unsubscriptable object ({})".format(arg)
+                    "Cannot map over unsubscriptable object of type {t}: {preview}...".format(
+                        t=type(arg), preview=repr(arg)[:10]
+                    )
                 )
         new = self.copy(**(task_args or {}))
         return new.bind(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -719,7 +719,7 @@ class TaskRunner(Runner):
                         if not state.is_mapped() or upstream_state._result != NoResult:
                             if not hasattr(upstream_state.result, "__getitem__"):
                                 raise TypeError(
-                                    "cannot map over an unsubscriptable object ({})".format(
+                                    "Cannot map over an unsubscriptable object ({})".format(
                                         upstream_state.result
                                     )
                                 )

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -717,6 +717,12 @@ class TaskRunner(Runner):
                         # Therefore, we only try to get a result if EITHER this task's
                         # state is not already mapped OR the upstream result is not None.
                         if not state.is_mapped() or upstream_state._result != NoResult:
+                            if not hasattr(upstream_state.result, "__getitem__"):
+                                raise TypeError(
+                                    "cannot map over an unsubscriptable object ({})".format(
+                                        upstream_state.result
+                                    )
+                                )
                             upstream_result = Result(
                                 upstream_state.result[i],
                                 result_handler=upstream_state._result.result_handler,  # type: ignore

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -719,8 +719,9 @@ class TaskRunner(Runner):
                         if not state.is_mapped() or upstream_state._result != NoResult:
                             if not hasattr(upstream_state.result, "__getitem__"):
                                 raise TypeError(
-                                    "Cannot map over an unsubscriptable object ({})".format(
-                                        upstream_state.result
+                                    "Cannot map over unsubscriptable object of type {t}: {preview}...".format(
+                                        t=type(upstream_state.result),
+                                        preview=repr(upstream_state.result)[:10],
                                     )
                                 )
                             upstream_result = Result(

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -581,3 +581,9 @@ class TestTaskArgs:
                 t2 = t(1, 2, task_args={"name": "test-tags", "tags": ["new-tag"]})
 
         assert t2.tags == {"math", "test", "new-tag"}
+
+    def test_task_check_mapped_args_are_subscriptable_in_advance(self):
+        t = Task()
+        with pytest.raises(TypeError):
+            with Flow(name="test") as f:
+                res = t.map({1, 2, 3, 4})


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a better exception around unsubscriptable mapped arguments, both within a Flow context and at runtime. Until there is a large mapping refactor, this only addresses the message raised by #1821 .

## Why is this PR important?
Brings forth mapping argument Type issues as early as possible.

