### PR TITLE
Pin msgpack distributed dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ distributed >= 1.26.1, < 3.0
 docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 3.3.1
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
-msgpack < 1.0.0
+msgpack >= 0.6.0, < 1.0
 mypy_extensions >= 0.4.0, <1.0
 pendulum >= 2.0.4, < 3.0
 python-dateutil ~= 2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ distributed >= 1.26.1, < 3.0
 docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 3.3.1
 marshmallow-oneofschema >= 2.0.0b2, < 3.0
+msgpack < 1.0.0
 mypy_extensions >= 0.4.0, <1.0
 pendulum >= 2.0.4, < 3.0
 python-dateutil ~= 2.7


### PR DESCRIPTION
Until https://github.com/dask/distributed/pull/3494 is merged let's pin msgpack `<1.0.0` to fix failing tests