### PR TITLE
WIP: Hack: Local Only Logging and Exceptions

### DIFF
--- a/src/prefect/utilities/local_only.py
+++ b/src/prefect/utilities/local_only.py
@@ -1,0 +1,148 @@
+import json
+import logging
+import sys
+from abc import ABC, abstractmethod
+from logging import Formatter, LogRecord, Handler, StreamHandler, FileHandler
+from pathlib import Path
+from typing import Optional, Callable
+
+import prefect
+from prefect.utilities.logging import CloudHandler
+
+
+class LocalOnlyError(Exception):
+    """
+    Exception raised to replace uncaught exception in task with a
+    a generic exception w/o the tasks stack trace.
+    """
+
+
+class LocalOnly(ABC):
+    EXTRA_KEY = "_local_only"
+    DEBUG_LOGGER = "local_only_debug"
+
+    @abstractmethod
+    def remote_formatter(self):
+        pass
+
+    @abstractmethod
+    def remote_handler(self):
+        pass
+
+    @staticmethod
+    def apply_local_only():
+        module, cls = prefect.config.local_only.cls.rsplit(sep=".", maxsplit=1)
+        kwargs = json.loads(prefect.config.local_only.kwargs)
+        configurator = getattr(sys.modules[module], cls)(**kwargs)
+        configurator.configure()
+
+    def configure(self):
+        prefect_logger = prefect.utilities.logging.get_logger()
+        remote_handler = self.remote_handler()
+        for handler in prefect_logger.handlers:
+            if isinstance(handler, remote_handler.__class__):
+                # Already applied to logging system.
+                return
+        for handler in prefect_logger.handlers:
+            if isinstance(handler, CloudHandler):
+                # ToDo: Update CloudHandler to call some formatter.
+                handler.formatter = self.remote_formatter()
+        prefect_logger.addHandler(remote_handler)
+
+        # # Used to inspect what is going on in the formatters when exceptions are logged.
+        # for handler in prefect_logger.handlers:
+        #     if not isinstance(handler, CloudHandler) and isinstance(handler, StreamHandler):
+        #         handler.formatter = DebugFormatter()
+        #
+        # debug_formatter = Formatter(prefect.config.logging.format)
+        # debug_handler = FileHandler(
+        #     "/Users/nateatkins/projects/cake/prefect-tutorial/cloud/07-safe-hack/debug.log"
+        # )
+        # # debug_handler = StreamHandler(stream=sys.stderr)
+        # debug_handler.setFormatter(debug_formatter)
+        # debug_logger = logging.getLogger(self.DEBUG_LOGGER)
+        # debug_logger.addHandler(debug_handler)
+        # debug_logger.setLevel(logging.DEBUG)
+
+    @classmethod
+    def logger(cls, name: Optional[str] = None):
+        logger = prefect.utilities.logging.get_logger(name)
+        if not prefect.config.local_only.enabled:
+            return logger
+        cls.apply_local_only()
+        return logger
+
+    # @classmethod
+    # def get_debug_logger(cls):
+    #     return logging.getLogger(cls.DEBUG_LOGGER)
+
+
+# class DebugFormatter(Formatter):
+#     def __init__(self, **kwargs):
+#         super().__init__(**kwargs)
+#         self.formatter = Formatter(prefect.config.logging.format)
+#
+#     def format(self, record: LogRecord) -> str:
+#         msg = self.formatter.format(record)
+#         return msg
+
+
+class FileRemoteFormatter(Formatter):
+    def __init__(self, extra_key: str, url_fn: Callable[[], str], **kwargs):
+        super().__init__(**kwargs)
+        self.extra_key = extra_key
+        self.url = url_fn
+
+    def format(self, record: LogRecord) -> str:
+        message = [record.message]
+        if getattr(record, self.extra_key, None):
+            message.append(self.url())
+        msg = "\n".join(message)
+        return msg
+
+
+class FileRemoteHandler(Handler):
+    def __init__(self, extra_key: str, filename_fn: Callable[[], Path], **kwargs):
+        super().__init__(**kwargs)
+        self.extra_key = extra_key
+        self.filename = filename_fn
+
+    def handle(self, record: LogRecord):
+        # ToDo: This should be in a formatter.
+        message = [record.message]
+        try:
+            local_only_data = getattr(record, self.extra_key)
+            message.append(local_only_data)
+        except AttributeError:
+            # No local only data.
+            return
+        if record.exc_info:
+            message.append(record.exc_text)
+        msg = "\n".join(message)
+        with self.filename().open("wt") as fh:
+            fh.write(msg)
+
+
+class FileLocalOnly(LocalOnly):
+    def __init__(self, root_directory: str):
+        self.root_directory = Path(root_directory)
+
+    def _log_path(self) -> Path:
+        return (self.root_directory / prefect.context.flow_name).absolute()
+
+    def _log_filename(self) -> Path:
+        filename = f'log-{prefect.context.date.isoformat().replace(":", "-").replace("+", "-")}.txt'
+        return self._log_path() / f"{filename}"
+
+    def _log_url(self) -> str:
+        return f"file:///{self._log_filename()}"
+
+    def remote_formatter(self):
+        return FileRemoteFormatter(self.EXTRA_KEY, self._log_url)
+
+    def remote_handler(self):
+        return FileRemoteHandler(self.EXTRA_KEY, self._log_filename)
+
+    def configure(self):
+        self._log_path().mkdir(exist_ok=True, parents=True)
+        super().configure()

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -134,6 +134,8 @@ class CloudHandler(logging.StreamHandler):
                 record_dict.pop("created", time.time())
             ).isoformat()
             log["name"] = record_dict.pop("name", None)
+            # Check to see if we are logging to the cloud and in local only mode.
+            # Also make sure the handle has a formatter.  Currently it doesn't
             if (
                 prefect.context.config.logging.log_to_cloud
                 and prefect.config.local_only.enabled
@@ -141,17 +143,12 @@ class CloudHandler(logging.StreamHandler):
             ):
                 # Running in local only mode.  Replace the message with the
                 # the local file link in in this PoC case.
-                logging.getLogger("local_only_debug").debug(
-                    f"CloudHandler: formatter {self.formatter}"
-                )
                 log["message"] = self.formatter.format(record)
-                logging.getLogger("local_only_debug").debug(
-                    f"CloudHandler: message {log['message']}"
-                )
                 del record_dict["message"]
                 # Remove he exc information so it doesn't get dumped as a CRITICAL error message.
                 del record_dict["exc_info"]
                 del record_dict["exc_text"]
+
             else:
                 log["message"] = record_dict.pop("message", None)
             log["level"] = record_dict.pop("levelname", None)


### PR DESCRIPTION
This is a stab at addressing:
* https://github.com/PrefectHQ/prefect/issues/2039
* https://github.com/PrefectHQ/prefect/issues/2038

It was mostly a PoC to see what code would need to be updated.   It is still dependent on a reliable across executor hook or configuration item to turn on local only mode.  

# Changes
1. Addition off prefect/utilities/local_only.py.  This is where the work is done to replace all of the handlers and loggers to enable local only mode.
1. Updates to prefect/utilities/logging.py.  These changes check to see if we are in Log to Cloud and Local Only is enabled.   If so then the log message is replaced with a URL to a local file where the local only data is written.   The log message extra={"_local_only": <something>} must be set to trigger this formatting.   Information in this extra{_local_only} is also written to the file.
1. prefect/engine/runner.py is also updated to make the above check.   If the check is true, it adds the extra{_local_only} key to trigger local only logging of the exception.

This has only be tried with the default local executor and the cloud local executor.   On to Dask tomorrow.

Net result in cloud log:
```code
February 18th 2020 at 3:42:26pm MST | prefect.CloudTaskRunner
ERROR 
Unexpected error: ZeroDivisionError
file:////<some path>/.logs/local-only-logging/216f392f-278b-4519-8dd5-79f15a5b831d--2020-02-18T22-42-24.942057-00-00.txt
```
# Configuration
PREFECT__LOCAL_ONLY__ENABLED=True
PREFECT__LOCAL_ONLY__CLS=prefect.utilities.local_only.FileLocalOnly
PREFECT__LOCAL_ONLY__KWARGS={\"root_directory\":\".logs\"}

# Example to drive the PoC
```python
from prefect import task, Flow, Client
from prefect.engine.executors import LocalExecutor
from prefect.environments import RemoteEnvironment

from prefect.utilities.local_only import LocalOnly


@task
def uncaught_exception(numerator: int):
    # Get the special logger until the PoC has a reliable hook to
    # configure the local only logging and exception mode.
    logger = LocalOnly.logger()
    x = numerator / 0


@task
def log_info():
    # Get the special logger until the PoC has a reliable hook to
    # configure the local only logging and exception mode.
    logger = LocalOnly.logger()
    logger.info("Public message.", extra={LocalOnly.EXTRA_KEY: "private message."})


def build_flow() -> Flow:
    with Flow("local-only-logging") as flow:
        log_info()
        uncaught_exception(numerator=10)
    return flow


def run_local():
    flow = build_flow()
    executor = LocalExecutor()
    flow.run(executor=executor)


def run_cloud_local():
    flow = build_flow()
    flow_id = flow.register(project_name="tutorial")
    client = Client()
    client.create_flow_run(flow_id=flow_id)


def run_cloud_dask():
    flow = build_flow()
    flow.environment = RemoteEnvironment(
        executor="prefect.engine.executors.DaskExecutor",
        executor_kwargs={"address": "tcp://192.168.84.52:8786"},
        # on_start=apply_safe_logging,
    )
    flow_id = flow.register(project_name="tutorial")
    client = Client()
    client.create_flow_run(flow_id=flow_id)


if __name__ == "__main__":
    # run_local()
    run_cloud_local()
    # run_cloud_dask()
```