### PR TITLE
Bugfix: DeleteNamespacedJob K8s task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix the DeleteNamespacedJob, DeleteNamespacedDeployment, DeleteNamespacedService and DeleteNamespacedPod tasks. 
 
 ### Deprecations
 
@@ -31,7 +31,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- [Romain Thalineau](https://github.com/romaintha)
 
 ## 0.9.4 <Badge text="beta" type="success"/>
 

--- a/src/prefect/tasks/kubernetes/deployment.py
+++ b/src/prefect/tasks/kubernetes/deployment.py
@@ -215,7 +215,7 @@ class DeleteNamespacedDeployment(Task):
         api_client.delete_namespaced_deployment(
             name=deployment_name,
             namespace=namespace,
-            body=api_client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -211,7 +211,7 @@ class DeleteNamespacedJob(Task):
         api_client.delete_namespaced_job(
             name=job_name,
             namespace=namespace,
-            body=api_client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/pod.py
+++ b/src/prefect/tasks/kubernetes/pod.py
@@ -211,7 +211,7 @@ class DeleteNamespacedPod(Task):
         api_client.delete_namespaced_pod(
             name=pod_name,
             namespace=namespace,
-            body=api_client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/service.py
+++ b/src/prefect/tasks/kubernetes/service.py
@@ -213,7 +213,7 @@ class DeleteNamespacedService(Task):
         api_client.delete_namespaced_service(
             name=service_name,
             namespace=namespace,
-            body=api_client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(),
             **kube_kwargs
         )
 


### PR DESCRIPTION
There is a bug in the DeleteNamespacedJob K8s task. in the api_client delete_namespaced_job call, api_client is used instead of client.
Fixed it here
