### PR TITLE
Improve import time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
       - checkout
 
       - run:
-          name: Install packages for static analysis
-          command: pip install black mypy mypy_extensions autoflake
+          name: Install python packages for static analysis
+          command: pip install black mypy mypy_extensions autoflake profimp
 
       - run:
           name: Run Black
@@ -36,6 +36,27 @@ jobs:
               echo "Potentially unused imports found"
               cat .unused-imports.txt
               exit 2
+            fi
+
+      - run:
+          name: Quick installation of Prefect
+          command: pip install -e .
+
+      - run:
+          name: Ensure 'import prefect' is under 1 second
+          command: |
+            apt update && apt install jq bc -y
+
+            # generate pycache
+            python -c 'import prefect'
+
+            if [[ $(echo "$(profimp 'import prefect'  | jq '.duration' | tee .import-time.txt ) < 1000" | bc -l) -ne 1 ]]; then
+              echo "Prefect import time is too slow"
+              cat .import-time.txt
+              # exit 3
+            else
+              echo "Prefect import time (ms):"
+              cat .import-time.txt
             fi
 
   check_documentation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             if [[ $(echo "$(profimp 'import prefect'  | jq '.duration' | tee .import-time.txt ) < 1000" | bc -l) -ne 1 ]]; then
               echo "Prefect import time is too slow"
               cat .import-time.txt
-              # exit 3
+              exit 3
             else
               echo "Prefect import time (ms):"
               cat .import-time.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,33 +11,32 @@ jobs:
   # Check formatting
   # ----------------------------------
 
-  check_black_formatting:
+  check_static_analysis:
     docker:
       - image: python:3.6
     steps:
       - checkout
 
       - run:
-          name: Install Black
-          command: pip install black
+          name: Install packages for static analysis
+          command: pip install black mypy mypy_extensions autoflake
 
       - run:
           name: Run Black
           command: black --check .
 
-  check_mypy_typing:
-    docker:
-      - image: python:3.6
-    steps:
-      - checkout
-
-      - run:
-          name: Install mypy
-          command: pip install mypy mypy_extensions
-
       - run:
           name: Run mypy
           command: mypy src/
+
+      - run:
+          name: Check for potentially unused imports
+          command: |
+            if [[ $(autoflake --remove-all-unused-imports -r --exclude __init__.py src | tee .unused-imports.txt | wc -c ) -ne 0 ]]; then
+              echo "Potentially unused imports found"
+              cat .unused-imports.txt
+              exit 2
+            fi
 
   check_documentation:
     docker:
@@ -370,8 +369,7 @@ workflows:
 
   "Check code style and docs":
     jobs:
-      - check_black_formatting
-      - check_mypy_typing
+      - check_static_analysis
       - check_documentation
 
   "Build docker images":

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 
 .unused-imports.txt
+.import-time.txt
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.unused-imports.txt
+
 # C extensions
 *.so
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 - repo: local
   hooks:
-      - id: black
-        name: black
-        entry: black
-        language: python
-        language_version: python3
-        types: [python]
+    - id: black
+      name: black
+      entry: black
+      language: python
+      language_version: python3
+      types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Better exception for unsubscriptable mapping arguments - [#1821](https://github.com/PrefectHQ/prefect/issues/1821)
 - Add DaskGateway tip to docs - [#1959](https://github.com/PrefectHQ/prefect/issues/1959)
+- Improve package import time - [#2046](https://github.com/PrefectHQ/prefect/issues/2046)
 
 ### Task Library
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -1,14 +1,14 @@
-import os
 import ast
 import functools
 import logging
+import os
 import signal
 import sys
-import time
 import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from concurrent.futures import ThreadPoolExecutor, Future
-from typing import Any, Generator, Iterable, Union, Set
+from typing import Any, Generator, Iterable, Set, Union
 
 import pendulum
 
@@ -16,9 +16,9 @@ from prefect import config
 from prefect.client import Client
 from prefect.engine.state import Failed, Submitted
 from prefect.serialization import state
+from prefect.utilities.context import context
 from prefect.utilities.exceptions import AuthorizationError
 from prefect.utilities.graphql import GraphQLResult, with_args
-from prefect.utilities.context import context
 
 ascii_name = r"""
  ____            __           _        _                    _
@@ -166,7 +166,6 @@ class Agent:
         Invoked when the event loop is exiting and the agent is shutting down. Intended
         as a hook for child classes to optionally implement.
         """
-        pass
 
     def agent_connect(self) -> str:
         """
@@ -500,7 +499,6 @@ class Agent:
         """
         Meant to be overridden by a platform specific heartbeat option
         """
-        pass
 
 
 if __name__ == "__main__":

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -1,14 +1,16 @@
-from sys import platform
-from typing import Iterable, List
 import multiprocessing
-
-import docker
+from sys import platform
+from typing import Iterable, List, TYPE_CHECKING
 
 from prefect import config, context
 from prefect.agent import Agent
 from prefect.environments.storage import Docker
 from prefect.serialization.storage import StorageSchema
 from prefect.utilities.graphql import GraphQLResult
+
+
+if TYPE_CHECKING:
+    import docker
 
 
 class DockerAgent(Agent):
@@ -52,7 +54,6 @@ class DockerAgent(Agent):
         show_flow_logs: bool = False,
     ) -> None:
         super().__init__(name=name, labels=labels, env_vars=env_vars)
-
         if platform == "win32":
             default_url = "npipe:////./pipe/docker_engine"
         else:
@@ -70,7 +71,7 @@ class DockerAgent(Agent):
         self.logger.debug("no_pull set to {}".format(self.no_pull))
 
         self.failed_connections = 0
-        self.docker_client = docker.APIClient(base_url=self.base_url, version="auto")
+        self.docker_client = self._get_docker_client()
         self.show_flow_logs = show_flow_logs
         self.processes = []  # type: List[multiprocessing.Process]
 
@@ -83,6 +84,13 @@ class DockerAgent(Agent):
                 "Issue connecting to the Docker daemon. Make sure it is running."
             )
             raise exc
+
+    def _get_docker_client(self) -> "docker.APIClient":
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
+        return docker.APIClient(base_url=self.base_url, version="auto")
 
     def heartbeat(self) -> None:
         try:

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -1,13 +1,12 @@
 import multiprocessing
 from sys import platform
-from typing import Iterable, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, List
 
 from prefect import config, context
 from prefect.agent import Agent
 from prefect.environments.storage import Docker
 from prefect.serialization.storage import StorageSchema
 from prefect.utilities.graphql import GraphQLResult
-
 
 if TYPE_CHECKING:
     import docker

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -1,15 +1,16 @@
-from ast import literal_eval
-import os
 import copy
 import json
+import os
+from ast import literal_eval
 from typing import Iterable
+
+from slugify import slugify
 
 from prefect import config
 from prefect.agent import Agent
 from prefect.environments.storage import Docker
 from prefect.serialization.storage import StorageSchema
 from prefect.utilities.graphql import GraphQLResult
-from slugify import slugify
 
 
 class FargateAgent(Agent):

--- a/src/prefect/agent/kubernetes/resource_manager.py
+++ b/src/prefect/agent/kubernetes/resource_manager.py
@@ -5,7 +5,6 @@ import time
 from typing import TYPE_CHECKING
 
 import pendulum
-from requests.exceptions import HTTPError
 
 from prefect import Client
 from prefect import config as prefect_config
@@ -242,6 +241,9 @@ class ResourceManager:
         """
         Report pods that failed for reasons outside of a flow run. Write cloud log
         """
+        # deferred import to reduce import time for prefect
+        from requests.exceptions import HTTPError
+
         core_client = self.k8s_client.CoreV1Api()
         name = pod.metadata.name
 
@@ -280,6 +282,9 @@ class ResourceManager:
         """
         Write cloud log of pods that entered unknonw states
         """
+        # deferred import to reduce import time for prefect
+        from requests.exceptions import HTTPError
+
         name = pod.metadata.name
         self.logger.info(
             "Reporting unknown pod {} in namespace {}".format(name, self.namespace)
@@ -303,6 +308,9 @@ class ResourceManager:
         """
         Write cloud log of pods that ahd image pull errors
         """
+        # deferred import to reduce import time for prefect
+        from requests.exceptions import HTTPError
+
         for status in pod.status.container_statuses:
             waiting = status.state.waiting
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -1,13 +1,12 @@
 import os
-import sys
 import socket
+import sys
 from subprocess import PIPE, STDOUT, Popen
 from typing import Iterable, List
 
-from prefect import config, context
+from prefect import config
 from prefect.agent import Agent
-from prefect.engine.state import Failed
-from prefect.environments.storage import Azure, GCS, Local, S3
+from prefect.environments.storage import GCS, S3, Azure, Local
 from prefect.serialization.storage import StorageSchema
 from prefect.utilities.graphql import GraphQLResult
 

--- a/src/prefect/agent/nomad/agent.py
+++ b/src/prefect/agent/nomad/agent.py
@@ -4,8 +4,6 @@ import uuid
 from os import path
 from typing import Iterable
 
-import requests
-
 from prefect import config
 from prefect.agent import Agent
 from prefect.environments.storage import Docker
@@ -50,6 +48,10 @@ class NomadAgent(Agent):
                 "Storage for flow run {} is not of type Docker.".format(flow_run.id)
             )
             raise ValueError("Unsupported Storage type")
+
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
 
         job_spec = self.replace_job_spec_json(flow_run)
         nomad_host = os.getenv("NOMAD_HOST", "http://127.0.0.1:4646")

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -40,7 +40,6 @@ def agent():
         $ prefect agent install kubernetes --token MY_TOKEN --namespace metrics
         ...k8s yaml output...
     """
-    pass
 
 
 @agent.command(

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -52,7 +52,6 @@ def auth():
         $ prefect auth create-token -n MyToken -r RUNNER
         ...token output...
     """
-    pass
 
 
 @auth.command(hidden=True)

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -26,7 +26,6 @@ def create():
         $ prefect create project My-Project --description "My description"
         My-Project created
     """
-    pass
 
 
 @create.command(hidden=True)

--- a/src/prefect/cli/describe.py
+++ b/src/prefect/cli/describe.py
@@ -1,6 +1,4 @@
 import click
-import pendulum
-from tabulate import tabulate
 
 from prefect.client import Client
 from prefect.utilities.graphql import EnumValue, with_args
@@ -50,7 +48,6 @@ def describe():
             }
         }
     """
-    pass
 
 
 @describe.command(hidden=True)

--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -25,7 +25,6 @@ def execute():
     \b
         $ prefect execute local-flow ~/.prefect/flows/my_flow.prefect
     """
-    pass
 
 
 @execute.command(hidden=True)

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -2,7 +2,6 @@ import click
 import pendulum
 from tabulate import tabulate
 
-from prefect import config
 from prefect.client import Client
 from prefect.utilities.graphql import EnumValue, with_args
 
@@ -42,7 +41,6 @@ def get():
         first_task    Test-Flow   1              5 days ago   False    prefect.tasks.core.function.FunctionTask
         second_task   Test-Flow   1              5 days ago   True     prefect.tasks.core.function.FunctionTask
     """
-    pass
 
 
 @get.command(hidden=True)

--- a/src/prefect/cli/heartbeat.py
+++ b/src/prefect/cli/heartbeat.py
@@ -20,7 +20,6 @@ def heartbeat():
         task-run   Send heartbeat for a given task run ID
         flow-run   Send heartbeat for a given flow run ID
     """
-    pass
 
 
 @heartbeat.command(hidden=True)

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -31,7 +31,6 @@ def run():
         Flow Run ID: 2ba3rrfd-411c-4d99-bb2a-f64a6dea78f9
         Scheduled -> Submitted -> Running -> Success
     """
-    pass
 
 
 @run.command(hidden=True)

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -48,7 +48,6 @@ When settings secrets via `.toml` config files, you can use the [TOML Keys](http
 """
 
 import json
-import os
 from typing import Any, Optional
 
 import prefect

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -1,9 +1,7 @@
 import datetime
-import inspect
-import logging
 import os
 import re
-from typing import Any, Optional, Union, cast
+from typing import Optional, Union, cast
 
 import toml
 from box import Box

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -2,14 +2,10 @@ import collections
 import copy
 import functools
 import inspect
-import json
 import os
-import socket
 import tempfile
 import time
-import uuid
 import warnings
-from collections import Counter
 from pathlib import Path
 from typing import (
     Any,
@@ -36,12 +32,11 @@ from prefect.core.edge import Edge
 from prefect.core.task import Parameter, Task
 from prefect.engine.result import NoResult
 from prefect.engine.result_handlers import ResultHandler
-from prefect.environments import Environment, RemoteEnvironment
+from prefect.environments import Environment
 from prefect.environments.storage import Storage, get_default_storage_class
 from prefect.utilities import logging
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.notifications import callback_factory
-from prefect.utilities.serialization import to_qualified_name
 from prefect.utilities.tasks import as_task, unmapped
 
 ParameterDetails = TypedDict("ParameterDetails", {"default": Any, "required": bool})

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -22,13 +22,13 @@ import prefect.engine.cache_validators
 import prefect.engine.signals
 import prefect.triggers
 from prefect.utilities import logging
-from prefect.utilities.tasks import unmapped
 from prefect.utilities.notifications import callback_factory
+from prefect.utilities.tasks import unmapped
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
     from prefect.engine.result_handlers import ResultHandler
-    from prefect.engine.state import State
+    from prefect.engine.state import State  # pylint: disable=W0611
 
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
 
@@ -290,7 +290,6 @@ class Task(metaclass=SignatureValidator):
                     flow, depending on whether downstream tasks have `skip_on_upstream_skip=True`. </li></ul>
         </li></ul>
         """
-        pass
 
     # Dependencies -------------------------------------------------------------
 

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -1,6 +1,4 @@
-import _thread
-import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import prefect
 from prefect.client import Client

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -1,18 +1,14 @@
-import copy
 import datetime
-import _thread
 import time
-import warnings
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import pendulum
 
 import prefect
 from prefect.client import Client
 from prefect.core import Edge, Task
-from prefect.utilities.executors import tail_recursive
 from prefect.engine.cloud.utilities import prepare_state_for_cloud
-from prefect.engine.result import NoResult, Result
+from prefect.engine.result import Result
 from prefect.engine.result_handlers import ResultHandler
 from prefect.engine.runner import ENDRUN, call_state_handlers
 from prefect.engine.state import (
@@ -20,11 +16,12 @@ from prefect.engine.state import (
     ClientFailed,
     Failed,
     Mapped,
-    Retrying,
     Queued,
+    Retrying,
     State,
 )
 from prefect.engine.task_runner import TaskRunner, TaskRunnerInitializeResult
+from prefect.utilities.executors import tail_recursive
 from prefect.utilities.graphql import with_args
 
 

--- a/src/prefect/engine/cloud/utilities.py
+++ b/src/prefect/engine/cloud/utilities.py
@@ -1,4 +1,4 @@
-from prefect.engine.state import State, Failed
+from prefect.engine.state import State
 
 
 def prepare_state_for_cloud(state: State) -> State:

--- a/src/prefect/engine/executors/base.py
+++ b/src/prefect/engine/executors/base.py
@@ -1,9 +1,7 @@
-import datetime
 import uuid
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterator, List
+from typing import Any, Callable, Iterator, List
 
-import prefect
 from prefect.utilities.executors import timeout_handler
 
 

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List
 
 from prefect import context
 from prefect.engine.executors.base import Executor

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -1,13 +1,14 @@
 import logging
 import uuid
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, List
-
-import dask
-from distributed import Client, Future, fire_and_forget, worker_client
+from typing import Any, Callable, Iterator, List, TYPE_CHECKING
 
 from prefect import context
 from prefect.engine.executors.base import Executor
+
+if TYPE_CHECKING:
+    import dask
+    from distributed import Future
 
 
 class DaskExecutor(Executor):
@@ -65,6 +66,9 @@ class DaskExecutor(Executor):
 
         Creates a `dask.distributed.Client` and yields it.
         """
+        # import dask client here to decrease our import times
+        from distributed import Client
+
         try:
             if self.address is None:
                 self.kwargs.update(
@@ -111,7 +115,7 @@ class DaskExecutor(Executor):
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
 
-    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> Future:
+    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> "Future":
         """
         Submit a function to the executor for execution. Returns a Future object.
 
@@ -123,6 +127,8 @@ class DaskExecutor(Executor):
         Returns:
             - Future: a Future-like object that represents the computation of `fn(*args, **kwargs)`
         """
+        # import dask functions here to decrease our import times
+        from distributed import fire_and_forget, worker_client
 
         dask_kwargs = self._prep_dask_kwargs()
         kwargs.update(dask_kwargs)
@@ -138,7 +144,7 @@ class DaskExecutor(Executor):
         fire_and_forget(future)
         return future
 
-    def map(self, fn: Callable, *args: Any, **kwargs: Any) -> List[Future]:
+    def map(self, fn: Callable, *args: Any, **kwargs: Any) -> List["Future"]:
         """
         Submit a function to be mapped over its iterable arguments.
 
@@ -154,6 +160,9 @@ class DaskExecutor(Executor):
         """
         if not args:
             return []
+
+        # import dask functions here to decrease our import times
+        from distributed import fire_and_forget, worker_client
 
         dask_kwargs = self._prep_dask_kwargs()
         kwargs.update(dask_kwargs)
@@ -180,6 +189,9 @@ class DaskExecutor(Executor):
         Returns:
             - Any: an iterable of resolved futures with similar shape to the input
         """
+        # import dask functions here to decrease our import times
+        from distributed import worker_client
+
         if self.is_started and hasattr(self, "client"):
             return self.client.gather(futures)
         elif self.is_started:
@@ -213,10 +225,13 @@ class LocalDaskExecutor(Executor):
 
         Configures `dask` and yields the `dask.config` contextmanager.
         """
+        # import dask here to reduce prefect import times
+        import dask
+
         with dask.config.set(scheduler=self.scheduler, **self.kwargs) as cfg:
             yield cfg
 
-    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> dask.delayed:
+    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> "dask.delayed":
         """
         Submit a function to the executor for execution. Returns a `dask.delayed` object.
 
@@ -228,9 +243,12 @@ class LocalDaskExecutor(Executor):
         Returns:
             - dask.delayed: a `dask.delayed` object that represents the computation of `fn(*args, **kwargs)`
         """
+        # import dask here to reduce prefect import times
+        import dask
+
         return dask.delayed(fn)(*args, **kwargs)
 
-    def map(self, fn: Callable, *args: Any) -> List[dask.delayed]:
+    def map(self, fn: Callable, *args: Any) -> List["dask.delayed"]:
         """
         Submit a function to be mapped over its iterable arguments.
 
@@ -262,5 +280,8 @@ class LocalDaskExecutor(Executor):
         Returns:
             - Any: an iterable of resolved futures
         """
+        # import dask here to reduce prefect import times
+        import dask
+
         with dask.config.set(scheduler=self.scheduler, **self.kwargs) as cfg:
             return dask.compute(futures)[0]

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -1,10 +1,7 @@
-import datetime
 import logging
-import queue
 import uuid
-import warnings
 from contextlib import contextmanager
-from typing import Any, Callable, Iterable, Iterator, List
+from typing import Any, Callable, Iterator, List
 
 import dask
 from distributed import Client, Future, fire_and_forget, worker_client

--- a/src/prefect/engine/executors/local.py
+++ b/src/prefect/engine/executors/local.py
@@ -1,5 +1,4 @@
-import datetime
-from typing import Any, Callable, Iterable, List
+from typing import Any, Callable, List
 
 from prefect.engine.executors.base import Executor
 

--- a/src/prefect/engine/executors/sync.py
+++ b/src/prefect/engine/executors/sync.py
@@ -1,10 +1,5 @@
-import datetime
 import warnings
-from contextlib import contextmanager
-from typing import Any, Callable, Iterable, Iterator, List
 
-import dask
-import dask.bag
 
 from prefect.engine.executors.dask import LocalDaskExecutor
 

--- a/src/prefect/engine/executors/sync.py
+++ b/src/prefect/engine/executors/sync.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 from prefect.engine.executors.dask import LocalDaskExecutor
 
 

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -15,7 +15,6 @@ import pendulum
 
 import prefect
 from prefect.core import Edge, Flow, Task
-from prefect.engine import signals
 from prefect.engine.result import Result
 from prefect.engine.result_handlers import ConstantResultHandler
 from prefect.engine.runner import ENDRUN, Runner, call_state_handlers
@@ -30,7 +29,6 @@ from prefect.engine.state import (
     State,
     Success,
 )
-from prefect.engine.task_runner import TaskRunner
 from prefect.utilities.collections import flatten_seq
 from prefect.utilities.executors import run_with_heartbeat
 

--- a/src/prefect/engine/result.py
+++ b/src/prefect/engine/result.py
@@ -17,7 +17,7 @@ also provides a `NoResult` object representing the _absence_ of computation / da
 whose value is `None`.
 """
 
-from typing import Any, Union
+from typing import Any
 
 from prefect.engine.result_handlers import ResultHandler
 
@@ -59,7 +59,6 @@ class ResultInterface:
 
     def store_safe_value(self) -> None:
         """Performs no computation."""
-        pass
 
 
 class Result(ResultInterface):

--- a/src/prefect/engine/result_handlers/local_result_handler.py
+++ b/src/prefect/engine/result_handlers/local_result_handler.py
@@ -3,13 +3,12 @@ Result Handlers provide the hooks that Prefect uses to store task results in pro
 
 Anytime a task needs its output or inputs stored, a result handler is used to determine where this data should be stored (and how it can be retrieved).
 """
-import base64
-import cloudpickle
 import os
-import pendulum
-
-from slugify import slugify
 from typing import Any
+
+import cloudpickle
+import pendulum
+from slugify import slugify
 
 import prefect
 from prefect.engine.result_handlers import ResultHandler

--- a/src/prefect/engine/result_handlers/result_handler.py
+++ b/src/prefect/engine/result_handlers/result_handler.py
@@ -5,7 +5,6 @@ Anytime a task needs its output or inputs stored, a result handler is used to de
 """
 from typing import Any
 
-
 from prefect.utilities import logging
 
 

--- a/src/prefect/engine/result_handlers/result_handler.py
+++ b/src/prefect/engine/result_handlers/result_handler.py
@@ -3,14 +3,9 @@ Result Handlers provide the hooks that Prefect uses to store task results in pro
 
 Anytime a task needs its output or inputs stored, a result handler is used to determine where this data should be stored (and how it can be retrieved).
 """
-import base64
-import tempfile
 from typing import Any
 
-import cloudpickle
 
-from prefect import config
-from prefect.client.client import Client
 from prefect.utilities import logging
 
 

--- a/src/prefect/engine/result_handlers/secret_result_handler.py
+++ b/src/prefect/engine/result_handlers/secret_result_handler.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import prefect

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -10,14 +10,12 @@ Every run is initialized with the `Pending` state, meaning that it is waiting fo
 execution. During execution a run will enter a `Running` state. Finally, runs become `Finished`.
 """
 import datetime
-from collections import defaultdict
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
 import pendulum
 
 import prefect
-from prefect.engine.result import NoResult, Result, ResultInterface, SafeResult
-from prefect.engine.result_handlers import ResultHandler
+from prefect.engine.result import NoResult, Result, ResultInterface
 
 
 class State:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1,8 +1,5 @@
-import collections
 import copy
 import itertools
-import threading
-from functools import partial, wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -47,9 +44,9 @@ from prefect.engine.state import (
     TriggerFailed,
 )
 from prefect.utilities.executors import (
+    RecursiveCall,
     run_with_heartbeat,
     tail_recursive,
-    RecursiveCall,
 )
 
 if TYPE_CHECKING:

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -63,7 +63,6 @@ class Environment:
         Args:
             - storage (Storage): the Storage object that contains the flow
         """
-        pass
 
     def execute(self, storage: "Storage", flow_location: str, **kwargs: Any) -> None:
         """
@@ -74,7 +73,6 @@ class Environment:
             - flow_location (str): the location of the Flow to execute
             - **kwargs (Any): additional keyword arguments to pass to the runner
         """
-        pass
 
     def serialize(self) -> dict:
         """

--- a/src/prefect/environments/storage/azure.py
+++ b/src/prefect/environments/storage/azure.py
@@ -5,7 +5,6 @@ import cloudpickle
 import pendulum
 from slugify import slugify
 
-import prefect
 from prefect.engine.result_handlers import AzureResultHandler
 from prefect.environments.storage import Storage
 
@@ -38,7 +37,7 @@ class Azure(Storage):
         self, container: str, connection_string: str = None, blob_name: str = None
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
-        self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
+        self._flows = dict()  # type: Dict[str, "Flow"]
 
         self.connection_string = connection_string or os.getenv(
             "AZURE_STORAGE_CONNECTION_STRING"

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -1,5 +1,5 @@
-from abc import ABCMeta, abstractmethod
 import logging
+from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, List
 
 import prefect
@@ -68,7 +68,6 @@ class Storage(metaclass=ABCMeta):
         Returns:
             - str: the location of the newly added flow in this Storage object
         """
-        pass
 
     @property
     def name(self) -> str:
@@ -89,7 +88,6 @@ class Storage(metaclass=ABCMeta):
         """
         Method for determining whether an object is contained within this storage.
         """
-        pass
 
     @abstractmethod
     def build(self) -> "Storage":

--- a/src/prefect/environments/storage/bytes.py
+++ b/src/prefect/environments/storage/bytes.py
@@ -1,8 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
+from typing import Any, Dict, TYPE_CHECKING
 
 import cloudpickle
 
-import prefect
 from prefect.engine.result_handlers import ResultHandler
 from prefect.environments.storage import Storage
 

--- a/src/prefect/environments/storage/bytes.py
+++ b/src/prefect/environments/storage/bytes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 import cloudpickle
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -9,7 +9,7 @@ import textwrap
 import uuid
 import warnings
 from pathlib import PurePosixPath
-from typing import Any, Callable, Dict, Iterable, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List
 
 import cloudpickle
 import pendulum
@@ -17,7 +17,6 @@ from slugify import slugify
 
 import prefect
 from prefect.environments.storage import Storage
-
 
 if TYPE_CHECKING:
     import docker

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -9,15 +9,18 @@ import textwrap
 import uuid
 import warnings
 from pathlib import PurePosixPath
-from typing import Any, Callable, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List, TYPE_CHECKING
 
 import cloudpickle
-import docker
 import pendulum
 from slugify import slugify
 
 import prefect
 from prefect.environments.storage import Storage
+
+
+if TYPE_CHECKING:
+    import docker
 
 
 class Docker(Storage):
@@ -157,7 +160,7 @@ class Docker(Storage):
             environment variables set.
             """
             image = "{}:{}".format(self.image_name, self.image_tag)
-            client = docker.APIClient(base_url=self.base_url, version="auto")
+            client = self._get_client()
             container = client.create_container(image, command="tail -f /dev/null")
             client.start(container=container.get("Id"))
             python_script = "import cloudpickle; f = open('{}', 'rb'); flow = cloudpickle.load(f); f.close(); flow.run()".format(
@@ -291,7 +294,7 @@ class Docker(Storage):
                 self.pull_image()
 
             dockerfile_path = self.create_dockerfile_object(directory=tempdir)
-            client = docker.APIClient(base_url=self.base_url, version="auto")
+            client = self._get_client()
 
             # Verify that a registry url has been provided for images that should be pushed
             if self.registry_url:
@@ -461,6 +464,13 @@ class Docker(Storage):
     # Docker Utilities
     ########################
 
+    def _get_client(self) -> "docker.APIClient":
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
+        return docker.APIClient(base_url=self.base_url, version="auto")
+
     def pull_image(self) -> None:
         """Pull the image specified so it can be built.
 
@@ -471,7 +481,7 @@ class Docker(Storage):
         Raises:
             - InterruptedError: if either pulling the image fails
         """
-        client = docker.APIClient(base_url=self.base_url, version="auto")
+        client = self._get_client()
 
         output = client.pull(self.base_image, stream=True, decode=True)
         for line in output:
@@ -491,7 +501,7 @@ class Docker(Storage):
         Raises:
             - InterruptedError: if either pushing the image fails
         """
-        client = docker.APIClient(base_url=self.base_url, version="auto")
+        client = self._get_client()
 
         self.logger.info("Pushing image to the registry...")
 

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -1,11 +1,9 @@
-import io
 from typing import TYPE_CHECKING, Any, Dict, List
 
 import cloudpickle
 import pendulum
 from slugify import slugify
 
-import prefect
 from prefect.engine.result_handlers import GCSResultHandler
 from prefect.environments.storage import Storage
 from prefect.utilities.exceptions import StorageError
@@ -38,7 +36,7 @@ class GCS(Storage):
 
     def __init__(self, bucket: str, key: str = None, project: str = None) -> None:
         self.flows = dict()  # type: Dict[str, str]
-        self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
+        self._flows = dict()  # type: Dict[str, "Flow"]
 
         self.bucket = bucket
         self.key = key

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -1,8 +1,7 @@
 import os
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
-
-import cloudpickle
 import socket
+from typing import Any, Dict, List, TYPE_CHECKING
+
 from slugify import slugify
 
 import prefect

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -1,6 +1,6 @@
 import os
 import socket
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from slugify import slugify
 

--- a/src/prefect/environments/storage/memory.py
+++ b/src/prefect/environments/storage/memory.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 import prefect
 from prefect.engine.result_handlers import ResultHandler

--- a/src/prefect/environments/storage/memory.py
+++ b/src/prefect/environments/storage/memory.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union
+from typing import Any, Dict, TYPE_CHECKING
 
 import prefect
 from prefect.engine.result_handlers import ResultHandler

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -1,12 +1,10 @@
 import io
 from typing import TYPE_CHECKING, Any, Dict, List
 
-
 import cloudpickle
 import pendulum
 from slugify import slugify
 
-import prefect
 from prefect.engine.result_handlers import S3ResultHandler
 from prefect.environments.storage import Storage
 
@@ -52,7 +50,7 @@ class S3(Storage):
         key: str = None,
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
-        self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
+        self._flows = dict()  # type: Dict[str, "Flow"]
         self.bucket = bucket
         self.key = key
 

--- a/src/prefect/serialization/result_handlers.py
+++ b/src/prefect/serialization/result_handlers.py
@@ -1,7 +1,6 @@
-import json
-from typing import Any, Dict, Optional
+from typing import Any
 
-from marshmallow import ValidationError, fields, post_load
+from marshmallow import fields, post_load
 
 from prefect.engine.result_handlers import (
     AzureResultHandler,

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import marshmallow
-from marshmallow import fields, post_load, post_dump
+from marshmallow import fields, post_dump, post_load
 
 import prefect
 from prefect.serialization import schedule_compat

--- a/src/prefect/serialization/schedule_compat.py
+++ b/src/prefect/serialization/schedule_compat.py
@@ -2,9 +2,8 @@
 This module ensures that old-style schedules (pre-0.6.1) can be deserialized as new-style
 schedules. It is deprecated.
 """
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import marshmallow
 from marshmallow import fields, post_load
 
 import prefect

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -1,7 +1,6 @@
-import json
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
-from marshmallow import ValidationError, fields, post_load
+from marshmallow import fields, post_load
 
 from prefect.engine import result, state
 from prefect.serialization.result import StateResultSchema
@@ -14,7 +13,7 @@ from prefect.utilities.serialization import (
 )
 
 if TYPE_CHECKING:
-    import prefect
+    pass
 
 
 def get_safe(obj: state.State, context: dict) -> Any:

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -1,4 +1,4 @@
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from marshmallow import fields, post_load
 

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -1,21 +1,19 @@
 from typing import Any
 
-import marshmallow
 from marshmallow import fields, post_load
 
-import prefect
 from prefect.environments.storage import (
+    GCS,
+    S3,
     Azure,
     Bytes,
     Docker,
-    GCS,
     Local,
     Memory,
     Storage,
-    S3,
 )
-from prefect.utilities.serialization import Bytes as BytesField, JSONCompatible
-from prefect.utilities.serialization import ObjectSchema, OneOfSchema
+from prefect.utilities.serialization import Bytes as BytesField
+from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
 
 
 class AzureSchema(ObjectSchema):

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -1,9 +1,6 @@
-import uuid
-from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Callable, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
-import marshmallow
-from marshmallow import ValidationError, fields, post_load
+from marshmallow import fields, post_load
 
 import prefect
 from prefect.utilities.serialization import (

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 from marshmallow import fields, post_load
 

--- a/src/prefect/tasks/airtable/airtable.py
+++ b/src/prefect/tasks/airtable/airtable.py
@@ -1,5 +1,5 @@
-from typing import Any
 import warnings
+from typing import Any
 
 import airtable
 

--- a/src/prefect/tasks/azure/blobstorage.py
+++ b/src/prefect/tasks/azure/blobstorage.py
@@ -1,6 +1,7 @@
 import uuid
 
 import azure.storage.blob
+
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs

--- a/src/prefect/tasks/azure/cosmosdb.py
+++ b/src/prefect/tasks/azure/cosmosdb.py
@@ -1,8 +1,6 @@
-from typing import Dict, Any, Union, List
+from typing import Any, Dict, List, Union
 
 import azure.cosmos.cosmos_client
-from azure.cosmos.query_iterable import QueryIterable
-
 
 from prefect import Task
 from prefect.client import Secret

--- a/src/prefect/tasks/azureml/dataset.py
+++ b/src/prefect/tasks/azureml/dataset.py
@@ -1,11 +1,9 @@
-from typing import Union, List, Dict
+from typing import Dict, List, Union
 
 import azureml.core.dataset
 from azureml.core.datastore import Datastore
-from azureml.data import DataType, TabularDataset, FileDataset
+from azureml.data import DataType, TabularDataset
 from azureml.data.dataset_type_definitions import PromoteHeadersBehavior
-from azureml.data.azure_sql_database_datastore import AzureSqlDatabaseDatastore
-
 
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs

--- a/src/prefect/tasks/azureml/datastore.py
+++ b/src/prefect/tasks/azureml/datastore.py
@@ -1,11 +1,11 @@
 import os
-from typing import List, Dict, Union
+from typing import Dict, List, Union
 
 import azureml.core.datastore
 from azureml.core.workspace import Workspace
 from azureml.data.azure_storage_datastore import (
-    AzureBlobDatastore,
     AbstractAzureStorageDatastore,
+    AzureBlobDatastore,
 )
 from azureml.data.data_reference import DataReference
 

--- a/src/prefect/tasks/cloud/flow_run.py
+++ b/src/prefect/tasks/cloud/flow_run.py
@@ -1,9 +1,9 @@
 from typing import Any
-from prefect import Task
 
+from prefect import Task
 from prefect.client import Client
+from prefect.utilities.graphql import EnumValue, with_args
 from prefect.utilities.tasks import defaults_from_attrs
-from prefect.utilities.graphql import with_args, EnumValue
 
 
 class FlowRunTask(Task):

--- a/src/prefect/tasks/control_flow/filter.py
+++ b/src/prefect/tasks/control_flow/filter.py
@@ -1,7 +1,5 @@
-import warnings
 from typing import Any, Callable, List
 
-import prefect
 from prefect import Task
 from prefect.engine.result import NoResultType
 from prefect.triggers import all_finished

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -5,7 +5,6 @@ In general, users will not instantiate these tasks by hand; they will automatica
 applied when users apply the `@task` decorator.
 """
 
-import inspect
 from typing import Any, Callable
 
 import prefect

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -2,7 +2,6 @@ import sqlite3 as sql
 from contextlib import closing
 from typing import Any, cast
 
-import prefect
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -1,7 +1,5 @@
 from typing import Any, Union
 
-import docker
-
 from prefect import Task
 from prefect.engine.signals import FAIL
 from prefect.utilities.tasks import defaults_from_attrs
@@ -85,6 +83,10 @@ class CreateContainer(Task):
         if not image_name:
             raise ValueError("An image name must be provided.")
 
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
         client = docker.APIClient(base_url=docker_server_url, version="auto")
         self.logger.debug(
             "Starting to create container {} with command {}".format(
@@ -154,11 +156,16 @@ class GetContainerLogs(Task):
         if not container_id:
             raise ValueError("A container id must be provided.")
 
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
         self.logger.debug(
             "Starting fetching container logs from container with id {}".format(
                 container_id
             )
         )
+
         client = docker.APIClient(base_url=docker_server_url, version="auto")
         api_result = client.logs(container=container_id).decode()
         self.logger.debug(
@@ -212,6 +219,10 @@ class ListContainers(Task):
         Returns:
             - list: A list of dicts, one per container
         """
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
         self.logger.debug("Starting to list containers")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
         api_result = client.containers(all=all_containers)
@@ -264,6 +275,10 @@ class StartContainer(Task):
         """
         if not container_id:
             raise ValueError("A container id must be provided.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug("Starting container with id {}".format(container_id))
         client = docker.APIClient(base_url=docker_server_url, version="auto")
@@ -319,6 +334,10 @@ class StopContainer(Task):
         """
         if not container_id:
             raise ValueError("A container id must be provided.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug("Starting to stop container with id {}".format(container_id))
         client = docker.APIClient(base_url=docker_server_url, version="auto")
@@ -385,6 +404,10 @@ class WaitOnContainer(Task):
         """
         if not container_id:
             raise ValueError("A container id must be provided.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug(
             "Starting to wait on container with id {}".format(container_id)

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -1,8 +1,6 @@
 import json
 from typing import Any
 
-import docker
-
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 
@@ -57,6 +55,10 @@ class ListImages(Task):
         Returns:
             - list: A list of dictionaries containing information about the images found
         """
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
         self.logger.debug(
             "Starting docker pull for repository {}...".format(repository_name)
         )
@@ -124,6 +126,10 @@ class PullImage(Task):
         """
         if not repository:
             raise ValueError("A repository to pull the image from must be specified.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         client = docker.APIClient(base_url=docker_server_url, version="auto")
         self.logger.debug(
@@ -197,6 +203,10 @@ class PushImage(Task):
         if not repository:
             raise ValueError("A repository to push the image to must be specified.")
 
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
+
         self.logger.debug(
             "Starting docker image push for repo {repo} and tag {tag}".format(
                 repo=repository, tag=tag
@@ -262,6 +272,10 @@ class RemoveImage(Task):
         """
         if not image:
             raise ValueError("The name of an image to remove must be provided.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug("Starting to remove Docker images: {}".format(image))
         client = docker.APIClient(base_url=docker_server_url, version="auto")
@@ -333,6 +347,10 @@ class TagImage(Task):
         """
         if not image or not repository:
             raise ValueError("Both image and repository must be provided.")
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug(
             "Starting to tagging Docker image {image} with tag {tag} in repo {repo}".format(
@@ -424,6 +442,10 @@ class BuildImage(Task):
             raise ValueError(
                 "A path to a directory containing a Dockerfile must be provided."
             )
+
+        # 'import docker' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import docker
 
         self.logger.debug(
             "Starting docker build with path {path} and tag {tag}".format(

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -3,7 +3,6 @@ from typing import List
 
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
-from google.oauth2.service_account import Credentials
 
 from prefect.client import Secret
 from prefect.core import Task

--- a/src/prefect/tasks/github/issues.py
+++ b/src/prefect/tasks/github/issues.py
@@ -1,6 +1,6 @@
 import json
-from typing import Any, List
 import warnings
+from typing import Any, List
 
 import requests
 

--- a/src/prefect/tasks/github/issues.py
+++ b/src/prefect/tasks/github/issues.py
@@ -2,8 +2,6 @@ import json
 import warnings
 from typing import Any, List
 
-import requests
-
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
@@ -86,6 +84,10 @@ class OpenGitHubIssue(Task):
                 UserWarning,
             )
             token = Secret(self.token_secret).get()
+
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
 
         url = "https://api.github.com/repos/{}/issues".format(repo)
         headers = {

--- a/src/prefect/tasks/github/prs.py
+++ b/src/prefect/tasks/github/prs.py
@@ -1,8 +1,9 @@
 import json
 import warnings
-from typing import Any, List
+from typing import Any
 
 import requests
+
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs

--- a/src/prefect/tasks/github/prs.py
+++ b/src/prefect/tasks/github/prs.py
@@ -2,8 +2,6 @@ import json
 import warnings
 from typing import Any
 
-import requests
-
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
@@ -93,6 +91,11 @@ class CreateGitHubPR(Task):
                 UserWarning,
             )
             token = Secret(self.token_secret).get()
+
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
+
         url = "https://api.github.com/repos/{}/pulls".format(repo)
         headers = {
             "AUTHORIZATION": "token {}".format(token),

--- a/src/prefect/tasks/github/repos.py
+++ b/src/prefect/tasks/github/repos.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Any, List
 
-import requests
-
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
@@ -74,6 +72,11 @@ class GetRepoInfo(Task):
                 UserWarning,
             )
             token = Secret(self.token_secret).get()
+
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
+
         url = "https://api.github.com/repos/{}".format(repo)
         headers = {
             "AUTHORIZATION": "token {}".format(token),
@@ -165,6 +168,11 @@ class CreateBranch(Task):
                 UserWarning,
             )
             token = Secret(self.token_secret).get()
+
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
+
         url = "https://api.github.com/repos/{}/git/refs".format(repo)
         headers = {
             "AUTHORIZATION": "token {}".format(token),

--- a/src/prefect/tasks/github/repos.py
+++ b/src/prefect/tasks/github/repos.py
@@ -1,5 +1,4 @@
 import warnings
-import json
 from typing import Any, List
 
 import requests

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -1,7 +1,5 @@
 from typing import Any, cast
 
-import requests
-
 from prefect import Task
 from prefect.client import Secret
 from prefect.utilities.tasks import defaults_from_attrs
@@ -42,6 +40,9 @@ class SlackTask(Task):
         Returns:
             - None
         """
+        # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+        # the 'import prefect' time low
+        import requests
 
         webhook_url = cast(str, Secret(self.webhook_secret).get())
         r = requests.post(webhook_url, json={"text": message})

--- a/src/prefect/tasks/secrets/base.py
+++ b/src/prefect/tasks/secrets/base.py
@@ -1,7 +1,7 @@
 import datetime
 
-from prefect.core.task import Task
 from prefect.client.secrets import Secret as _Secret
+from prefect.core.task import Task
 from prefect.engine.result_handlers import SecretResultHandler
 
 

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -1,4 +1,5 @@
 import snowflake.connector as sf
+
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 

--- a/src/prefect/tasks/twitter/twitter.py
+++ b/src/prefect/tasks/twitter/twitter.py
@@ -1,5 +1,5 @@
-from typing import Any
 import warnings
+from typing import Any
 
 import tweepy
 

--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -42,10 +42,14 @@ flow.set_reference_tasks([success])
 flow.run()
 ```
 """
-from typing import Callable, Set, Union
+from typing import Callable, Set, TYPE_CHECKING, Union
+
 
 from prefect import context
-from prefect.engine import signals, state
+from prefect.engine import signals
+
+if TYPE_CHECKING:
+    from prefect.engine import state  # pylint: disable=W0611
 
 
 def all_finished(upstream_states: Set["state.State"]) -> bool:

--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -42,8 +42,7 @@ flow.set_reference_tasks([success])
 flow.run()
 ```
 """
-from typing import Callable, Set, TYPE_CHECKING, Union
-
+from typing import TYPE_CHECKING, Callable, Set, Union
 
 from prefect import context
 from prefect.engine import signals

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -1,5 +1,4 @@
 import collections
-import json
 from collections.abc import MutableMapping
 from typing import Any, Generator, Iterable, Iterator, Union, cast
 

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -59,7 +59,7 @@ import contextlib
 import threading
 from typing import Any, Iterator, MutableMapping
 
-from prefect.configuration import Config, config
+from prefect.configuration import config
 from prefect.utilities.collections import DotDict, merge_dicts
 
 

--- a/src/prefect/utilities/datetimes.py
+++ b/src/prefect/utilities/datetimes.py
@@ -1,8 +1,6 @@
 import datetime
 from typing import Any, Callable
 
-import pendulum
-
 
 def retry_delay(
     interval: datetime.timedelta = None,

--- a/src/prefect/utilities/debug.py
+++ b/src/prefect/utilities/debug.py
@@ -4,12 +4,11 @@ import sys
 import tempfile
 import textwrap
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator
+from typing import Any, Iterator
 
 import cloudpickle
 
 import prefect
-from prefect.engine import state
 
 
 def is_serializable(obj: Any, raise_on_error: bool = False) -> bool:

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -1,29 +1,23 @@
-import datetime
 import multiprocessing
 import os
 import signal
 import subprocess
 import sys
 import threading
-import time
 import warnings
-
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
 from functools import wraps
-from logging import Logger
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
+from typing import Any, Callable, List, TYPE_CHECKING, Union
 
-import dask
-import dask.bag
 
 import prefect
-from prefect.core.edge import Edge
 
 if TYPE_CHECKING:
     import prefect.engine.runner
     import prefect.engine.state
-    from prefect.engine.state import State
+    from prefect.engine.state import State  # pylint: disable=W0611
+
 StateList = Union["State", List["State"]]
 
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -8,8 +8,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
 from functools import wraps
-from typing import Any, Callable, List, TYPE_CHECKING, Union
-
+from typing import TYPE_CHECKING, Any, Callable, List, Union
 
 import prefect
 

--- a/src/prefect/utilities/gcp.py
+++ b/src/prefect/utilities/gcp.py
@@ -1,8 +1,7 @@
 """
 Utility functions for interacting with Google Cloud.
 """
-from google.cloud import bigquery
-from google.cloud import storage
+from google.cloud import bigquery, storage
 from google.oauth2.service_account import Credentials
 
 

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -1,11 +1,10 @@
 import base64
 import gzip
 import json
-import re
 import textwrap
 import uuid
 from collections.abc import KeysView, ValuesView
-from typing import Any, Union
+from typing import Any
 
 from box import Box
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -14,14 +14,13 @@ import logging
 import sys
 import threading
 import time
-from queue import Queue, Empty
+from queue import Empty, Queue
 from typing import Any
 
 import pendulum
 
 import prefect
 from prefect.utilities.context import context
-
 
 _original_log_record_factory = logging.getLogRecordFactory()
 

--- a/src/prefect/utilities/notifications.py
+++ b/src/prefect/utilities/notifications.py
@@ -9,7 +9,6 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import TYPE_CHECKING, Any, Callable, Union, cast
 
-import requests
 from toolz import curry
 
 import prefect
@@ -276,6 +275,10 @@ def slack_notifier(
         [isinstance(new_state, included) for included in only_states]
     ):
         return new_state
+
+    # 'import requests' is expensive time-wise, we should do this just-in-time to keep
+    # the 'import prefect' time low
+    import requests
 
     form_data = slack_message_formatter(tracked_obj, new_state)
     r = requests.post(webhook_url, json=form_data)

--- a/src/prefect/utilities/notifications.py
+++ b/src/prefect/utilities/notifications.py
@@ -17,10 +17,11 @@ import prefect
 if TYPE_CHECKING:
     import prefect.engine.state
     import prefect.client
-    from prefect import Flow, Task
+    from prefect import Flow, Task  # pylint: disable=W0611
+
+TrackedObjectType = Union["Flow", "Task"]
 
 __all__ = ["callback_factory", "gmail_notifier", "slack_notifier"]
-TrackedObjectType = Union["Flow", "Task"]
 
 
 def callback_factory(

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import sys
 import types
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List
 
 import marshmallow_oneofschema
 import pendulum
@@ -21,7 +21,6 @@ from marshmallow import (
 )
 
 import prefect
-from prefect.utilities.collections import as_nested_dict
 
 
 def to_qualified_name(obj: Any) -> str:

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -11,7 +11,10 @@ from prefect.utilities.graphql import GraphQLResult
 
 def test_docker_agent_init(monkeypatch, runner_token):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     agent = DockerAgent()
     assert agent
@@ -20,8 +23,12 @@ def test_docker_agent_init(monkeypatch, runner_token):
 
 
 def test_docker_agent_config_options(monkeypatch, runner_token):
+    import docker  # DockerAgent imports docker within the constructor
+
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "docker.APIClient", api,
+    )
     monkeypatch.setattr("prefect.agent.docker.agent.platform", "osx")
 
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
@@ -34,8 +41,12 @@ def test_docker_agent_config_options(monkeypatch, runner_token):
 
 
 def test_docker_agent_daemon_url_responds_to_system(monkeypatch, runner_token):
+    import docker  # DockerAgent imports docker within the constructor
+
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "docker.APIClient", api,
+    )
     monkeypatch.setattr("prefect.agent.docker.agent.platform", "win32")
 
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
@@ -47,8 +58,12 @@ def test_docker_agent_daemon_url_responds_to_system(monkeypatch, runner_token):
 
 
 def test_docker_agent_config_options_populated(monkeypatch, runner_token):
+    import docker  # DockerAgent imports docker within the constructor
+
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "docker.APIClient", api,
+    )
 
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
         agent = DockerAgent(base_url="url", no_pull=True)
@@ -60,7 +75,10 @@ def test_docker_agent_config_options_populated(monkeypatch, runner_token):
 
 def test_docker_agent_no_pull(monkeypatch, runner_token):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     agent = DockerAgent()
     assert not agent.no_pull
@@ -85,7 +103,8 @@ def test_docker_agent_ping(monkeypatch, runner_token):
     api = MagicMock()
     api.ping.return_value = True
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -97,7 +116,8 @@ def test_docker_agent_ping_exception(monkeypatch, runner_token):
     api.ping.return_value = True
     api.ping.side_effect = Exception()
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     with pytest.raises(Exception):
@@ -106,7 +126,10 @@ def test_docker_agent_ping_exception(monkeypatch, runner_token):
 
 def test_populate_env_vars_uses_user_provided_env_vars(monkeypatch, runner_token):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     with set_temporary_config(
         {
@@ -124,7 +147,10 @@ def test_populate_env_vars_uses_user_provided_env_vars(monkeypatch, runner_token
 
 def test_populate_env_vars(monkeypatch, runner_token):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     with set_temporary_config(
         {
@@ -154,7 +180,10 @@ def test_populate_env_vars(monkeypatch, runner_token):
 
 def test_populate_env_vars_includes_agent_labels(monkeypatch, runner_token):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     with set_temporary_config(
         {
@@ -187,7 +216,10 @@ def test_populate_env_vars_is_responsive_to_logging_config(
     monkeypatch, runner_token, flag
 ):
     api = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", api)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
 
     with set_temporary_config(
         {
@@ -207,7 +239,8 @@ def test_docker_agent_deploy_flow(monkeypatch, runner_token):
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -242,7 +275,8 @@ def test_docker_agent_deploy_flow_storage_raises(monkeypatch, runner_token):
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -268,7 +302,8 @@ def test_docker_agent_deploy_flow_no_pull(monkeypatch, runner_token):
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent(no_pull=True)
@@ -302,7 +337,8 @@ def test_docker_agent_deploy_flow_show_flow_logs(monkeypatch, runner_token):
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent(show_flow_logs=True)
@@ -336,7 +372,8 @@ def test_docker_agent_shutdown_terminates_child_processes(monkeypatch, runner_to
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     proc = MagicMock(is_alive=MagicMock(return_value=True))
@@ -354,7 +391,8 @@ def test_docker_agent_deploy_flow_no_registry_does_not_pull(monkeypatch, runner_
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -383,7 +421,8 @@ def test_docker_agent_heartbeat_gocase(monkeypatch, runner_token):
     api = MagicMock()
     api.ping.return_value = True
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -395,7 +434,8 @@ def test_docker_agent_heartbeat_exits_on_failure(monkeypatch, runner_token, capl
     api = MagicMock()
     api.ping.return_value = True
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -415,7 +455,8 @@ def test_docker_agent_heartbeat_logs_reconnect(monkeypatch, runner_token, caplog
     api = MagicMock()
     api.ping.return_value = True
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()
@@ -432,7 +473,8 @@ def test_docker_agent_heartbeat_resets_fail_count(monkeypatch, runner_token, cap
     api = MagicMock()
     api.ping.return_value = True
     monkeypatch.setattr(
-        "prefect.agent.docker.agent.docker.APIClient", MagicMock(return_value=api)
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
     )
 
     agent = DockerAgent()

--- a/tests/agent/test_nomad_agent.py
+++ b/tests/agent/test_nomad_agent.py
@@ -25,8 +25,10 @@ def test_nomad_agent_config_options(runner_token):
 
 
 def test_nomad_agent_deploy_flow(monkeypatch, runner_token):
-    requests = MagicMock()
-    monkeypatch.setattr("prefect.agent.nomad.agent.requests", requests)
+    post = MagicMock()
+    import requests  # this is imported within the agent's constructor
+
+    monkeypatch.setattr(requests, "post", post)
 
     agent = NomadAgent()
     agent.deploy_flow(
@@ -45,13 +47,15 @@ def test_nomad_agent_deploy_flow(monkeypatch, runner_token):
         )
     )
 
-    assert requests.post.called
-    assert requests.post.call_args[1]["json"]
+    assert post.called
+    assert post.call_args[1]["json"]
 
 
 def test_nomad_agent_deploy_flow_raises(monkeypatch, runner_token):
-    requests = MagicMock()
-    monkeypatch.setattr("prefect.agent.nomad.agent.requests", requests)
+    post = MagicMock()
+    import requests  # this is imported within the agent's constructor
+
+    monkeypatch.setattr(requests, "post", post)
 
     agent = NomadAgent()
 
@@ -65,7 +69,7 @@ def test_nomad_agent_deploy_flow_raises(monkeypatch, runner_token):
             )
         )
 
-    assert not requests.post.called
+    assert not post.called
 
 
 @pytest.mark.parametrize("flag", [True, False])

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -38,7 +38,10 @@ def test_docker_agent_start_token(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(agent, ["start", "docker", "-t", "test"])
@@ -50,7 +53,10 @@ def test_docker_agent_start_verbose(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(agent, ["start", "docker", "-v"])
@@ -80,7 +86,10 @@ def test_agent_start_docker(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(agent, ["start", "docker"])
@@ -194,7 +203,10 @@ def test_agent_start_name(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(agent, ["start", "docker", "--name", "test_agent"])
@@ -206,7 +218,10 @@ def test_agent_start_docker_vars(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(
@@ -220,7 +235,10 @@ def test_agent_start_docker_labels(monkeypatch, runner_token):
     monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
 
     docker_client = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.agent.docker.APIClient", docker_client)
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest
+import requests
 
 import prefect
 from prefect.client import Client
@@ -107,9 +108,7 @@ def test_task_runner_places_task_tags_in_state_context_and_serializes_them(monke
     task = Task(name="test", tags=["1", "2", "tag"])
     session = MagicMock()
     monkeypatch.setattr("prefect.client.client.GraphQLResult", MagicMock())
-    monkeypatch.setattr(
-        "prefect.client.client.requests.Session", MagicMock(return_value=session)
-    )
+    monkeypatch.setattr("requests.Session", MagicMock(return_value=session))
 
     res = CloudTaskRunner(task=task).run()
     assert res.is_successful()

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -5,12 +5,12 @@ import sys
 import tempfile
 import time
 import uuid
-from box import Box
 from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest
 import requests
+from box import Box
 
 import prefect
 from prefect.client import Client
@@ -27,10 +27,10 @@ from prefect.engine.state import (
     ClientFailed,
     Failed,
     Finished,
-    Queued,
     Mapped,
     Paused,
     Pending,
+    Queued,
     Retrying,
     Running,
     Skipped,

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import cloudpickle
 import dask
+import distributed
 import pytest
 
 import prefect
@@ -267,7 +268,7 @@ class TestDaskExecutor:
 
     def test_init_kwargs_are_passed_to_init(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
         executor = DaskExecutor(test_kwarg="test_value")
         with executor.start():
             pass
@@ -276,7 +277,7 @@ class TestDaskExecutor:
 
     def test_task_names_are_passed_to_submit(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
         executor = DaskExecutor()
         with executor.start():
             with prefect.context(task_full_name="FISH!"):
@@ -286,7 +287,7 @@ class TestDaskExecutor:
 
     def test_task_names_are_passed_to_map(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
         executor = DaskExecutor()
         with executor.start():
             with prefect.context(task_full_name="FISH![0]"):
@@ -296,7 +297,7 @@ class TestDaskExecutor:
 
     def test_context_tags_are_passed_to_submit(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
         executor = DaskExecutor()
         with executor.start():
             with prefect.context(task_tags=["dask-resource:GPU=1"]):
@@ -306,7 +307,7 @@ class TestDaskExecutor:
 
     def test_context_tags_are_passed_to_map(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
         executor = DaskExecutor()
         with executor.start():
             with prefect.context(task_tags=["dask-resource:GPU=1"]):
@@ -316,7 +317,7 @@ class TestDaskExecutor:
 
     def test_debug_is_converted_to_silence_logs(self, monkeypatch):
         client = MagicMock()
-        monkeypatch.setattr(prefect.engine.executors.dask, "Client", client)
+        monkeypatch.setattr(distributed, "Client", client)
 
         # debug False
         executor = DaskExecutor(debug=False)

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -89,7 +89,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
         task = CreateContainer(image_name="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -98,7 +98,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
         task = CreateContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image_name="test")
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -107,7 +107,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
         task = CreateContainer(image_name="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image_name="test")
         assert api.return_value.create_container.call_args[1]["image"] == "test"
@@ -117,7 +117,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
         task = CreateContainer(image_name=image_name)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_twice_on_success(task, caplog)
 
@@ -131,7 +131,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("A docker specific exception")
         )
         api.return_value.create_container = create_container_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
@@ -141,7 +141,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
 
         api = MagicMock()
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
 
@@ -170,7 +170,7 @@ class TestGetContainerLogsTask(DockerLoggingTestingUtilityMixin):
         task = GetContainerLogs(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -179,7 +179,7 @@ class TestGetContainerLogsTask(DockerLoggingTestingUtilityMixin):
         task = GetContainerLogs()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -188,7 +188,7 @@ class TestGetContainerLogsTask(DockerLoggingTestingUtilityMixin):
         task = GetContainerLogs(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.logs.call_args[1]["container"] == "test"
@@ -197,7 +197,7 @@ class TestGetContainerLogsTask(DockerLoggingTestingUtilityMixin):
 
         task = GetContainerLogs(container_id="test")
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_twice_on_success(task, caplog)
 
@@ -215,7 +215,7 @@ class TestGetContainerLogsTask(DockerLoggingTestingUtilityMixin):
 
         task = GetContainerLogs()
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
@@ -235,7 +235,7 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
         task = ListContainers(all_containers=True)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.containers.call_args[1]["all"]
@@ -244,7 +244,7 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
         task = ListContainers()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(all_containers=True)
         assert api.return_value.containers.call_args[1]["all"]
@@ -253,7 +253,7 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
         task = ListContainers(all_containers=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(all_containers=True)
         assert api.return_value.containers.call_args[1]["all"]
@@ -263,7 +263,7 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
         task = ListContainers(all_containers=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_twice_on_success(task, caplog)
 
@@ -275,7 +275,7 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("A docker specific exception")
         )
         api.return_value.containers = list_containers_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
 
@@ -304,7 +304,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
         task = StartContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -313,7 +313,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
         task = StartContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -322,7 +322,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
         task = StartContainer(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.start.call_args[1]["container"] == "test"
@@ -331,7 +331,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
         task = StartContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_twice_on_success(task, caplog)
 
@@ -344,7 +344,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("A docker specific exception")
         )
         api.return_value.start = start_container_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
@@ -353,7 +353,7 @@ class TestStartContainerTask(DockerLoggingTestingUtilityMixin):
         task = StartContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
@@ -383,7 +383,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
         task = StopContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -392,7 +392,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
         task = StopContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -401,7 +401,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
         task = StopContainer(container_id="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(container_id="test")
         assert api.return_value.stop.call_args[1]["container"] == "test"
@@ -411,7 +411,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
         task = StopContainer(container_id="test")
         api = MagicMock()
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_twice_on_success(task, caplog)
 
@@ -424,7 +424,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("A docker specific exception")
         )
         api.return_value.stop = stop_container_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
@@ -432,7 +432,7 @@ class TestStopContainerTask(DockerLoggingTestingUtilityMixin):
 
         task = StopContainer()
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
@@ -466,7 +466,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {}
 
         task.run()
@@ -476,7 +476,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="init")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {}
 
         task.run(container_id="test")
@@ -486,7 +486,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="noise")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"StatusCode": 1}
 
         with pytest.raises(FAIL):
@@ -496,7 +496,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="noise")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"Error": "oops!"}
 
         with pytest.raises(FAIL):
@@ -506,7 +506,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="noise", raise_on_exit_code=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         api.return_value.wait.return_value = {"StatusCode": 1, "Error": "oops!"}
 
         task.run()
@@ -516,7 +516,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer(container_id="noise", raise_on_exit_code=False)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -528,7 +528,7 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("A docker specific exception")
         )
         api.return_value.wait = wait_container_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
@@ -537,5 +537,5 @@ class TestWaitOnContainerTask(DockerLoggingTestingUtilityMixin):
         task = WaitOnContainer()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -67,7 +67,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         task = ListImages(repository_name="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.images.call_args[1]["name"] == "test"
@@ -76,7 +76,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         task = ListImages()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository_name="test")
         assert api.return_value.images.call_args[1]["name"] == "test"
@@ -85,7 +85,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         task = ListImages(repository_name="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository_name="test")
         assert api.return_value.images.call_args[1]["name"] == "test"
@@ -98,7 +98,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         expected_docker_output = ["A real image", "A second, equally real image"]
 
         api.return_value.images = MagicMock(return_value=expected_docker_output)
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         with caplog.at_level(logging.DEBUG, logger=task.logger.name):
 
@@ -112,7 +112,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         task = ListImages(repository_name=repo_name)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -125,7 +125,7 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
         )
         api.return_value.images = images_mock
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
 
@@ -156,7 +156,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         task = PullImage(repository="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.pull.call_args[1]["repository"] == "test"
@@ -165,7 +165,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         task = PullImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository="test")
         assert api.return_value.pull.call_args[1]["repository"] == "test"
@@ -174,7 +174,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         task = PullImage(repository="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository="test")
         assert api.return_value.pull.call_args[1]["repository"] == "test"
@@ -187,7 +187,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         expected_docker_output = "A real output from docker's api"
 
         api.return_value.pull = MagicMock(return_value=expected_docker_output)
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         with caplog.at_level(logging.DEBUG, logger=task.logger.name):
 
@@ -200,7 +200,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         task = PullImage(repository=repository, tag=tag)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_doesnt_log_on_param_failure(self, monkeypatch, caplog):
@@ -208,7 +208,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         task = PullImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -221,7 +221,7 @@ class TestPullImageTask(DockerLoggingTestingUtilityMixin):
         )
         api.return_value.pull = pull_mock
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
 
@@ -252,7 +252,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         task = PushImage(repository="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.push.call_args[1]["repository"] == "test"
@@ -261,7 +261,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         task = PushImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository="test")
         assert api.return_value.push.call_args[1]["repository"] == "test"
@@ -270,7 +270,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         task = PushImage(repository="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(repository="test")
         assert api.return_value.push.call_args[1]["repository"] == "test"
@@ -282,7 +282,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         expected_docker_output = "An example push API response"
 
         api.return_value.push = MagicMock(return_value=expected_docker_output)
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         with caplog.at_level(logging.DEBUG, logger=task.logger.name):
 
@@ -294,7 +294,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         task = PushImage(repository=repository)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -307,7 +307,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         )
 
         api.return_value.push = push_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
     def test_doesnt_log_on_param_failure(self, monkeypatch, caplog):
@@ -315,7 +315,7 @@ class TestPushImageTask(DockerLoggingTestingUtilityMixin):
         task = PushImage()
         api = MagicMock()
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
 
@@ -346,7 +346,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
         task = RemoveImage(image="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.remove_image.call_args[1]["image"] == "test"
@@ -355,7 +355,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
         task = RemoveImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image="test")
         assert api.return_value.remove_image.call_args[1]["image"] == "test"
@@ -364,7 +364,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
         task = RemoveImage(image="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image="test")
         assert api.return_value.remove_image.call_args[1]["image"] == "test"
@@ -375,7 +375,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
         task = RemoveImage(image=image)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_doesnt_log_on_param_failure(self, monkeypatch, caplog):
@@ -383,7 +383,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
         task = RemoveImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -395,7 +395,7 @@ class TestRemoveImageTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("Docker specific error")
         )
         api.return_value.remove_image = remove_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
 
@@ -436,7 +436,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         task = TagImage(image="test", repository="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.tag.call_args[1]["image"] == "test"
@@ -446,7 +446,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         task = TagImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image="test", repository="test")
         assert api.return_value.tag.call_args[1]["image"] == "test"
@@ -456,7 +456,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         task = TagImage(image="original", repository="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(image="test", repository="test")
         assert api.return_value.tag.call_args[1]["image"] == "test"
@@ -468,7 +468,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         expected_docker_output = image
         api = MagicMock()
         api.return_value.tag = MagicMock(return_value=expected_docker_output)
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         with caplog.at_level(logging.DEBUG, logger=task.logger.name):
 
@@ -484,7 +484,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
             side_effect=docker.errors.DockerException("Docker specific error")
         )
         api.return_value.tag = tag_mock
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
     def test_doesnt_log_on_param_failure(self, monkeypatch, caplog):
@@ -492,7 +492,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         task = TagImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         self.assert_doesnt_log_on_param_failure(task, caplog)
 
@@ -501,7 +501,7 @@ class TestTagImageTask(DockerLoggingTestingUtilityMixin):
         task = TagImage(image="test", repository="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         tag = "test tag"
         image = "test image"
@@ -550,7 +550,7 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         task = BuildImage(path="test")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run()
         assert api.return_value.build.call_args[1]["path"] == "test"
@@ -559,7 +559,7 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         task = BuildImage()
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(path="test")
         assert api.return_value.build.call_args[1]["path"] == "test"
@@ -574,7 +574,7 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         ]
         api = MagicMock()
         api.return_value.build.return_value = output
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         return_value = task.run(path="test")
         assert all([isinstance(value, dict) for value in return_value])
@@ -585,7 +585,7 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         task = BuildImage(path="original")
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
 
         task.run(path="test")
         assert api.return_value.build.call_args[1]["path"] == "test"
@@ -595,7 +595,7 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         task = BuildImage(path=path)
 
         api = MagicMock()
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_twice_on_success(task, caplog)
 
     def test_logs_once_on_docker_api_failure(self, monkeypatch, caplog):
@@ -609,12 +609,12 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
 
         api.return_value.build = build_mock
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_logs_once_on_docker_api_failure(task, caplog)
 
     def test_doesnt_log_on_param_failure(self, monkeypatch, caplog):
         task = BuildImage()
         api = MagicMock()
 
-        monkeypatch.setattr("prefect.tasks.docker.containers.docker.APIClient", api)
+        monkeypatch.setattr("docker.APIClient", api)
         self.assert_doesnt_log_on_param_failure(task, caplog)

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 import prefect
 from prefect.tasks.github import OpenGitHubIssue
@@ -37,9 +38,9 @@ class TestCredentialsandProjects:
         task = OpenGitHubIssue(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.issues.requests", req)
+        monkeypatch.setattr(requests, "post", req)
 
         with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
             task.run(repo="org/repo")
 
-        assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
+        assert req.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 import prefect
 from prefect.tasks.github import CreateGitHubPR
@@ -38,9 +39,9 @@ class TestCredentialsandProjects:
         task = CreateGitHubPR(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.prs.requests", req)
+        monkeypatch.setattr(requests, "post", req)
 
         with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
             task.run(repo="org/repo")
 
-        assert req.post.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
+        assert req.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"

--- a/tests/tasks/github/test_repos.py
+++ b/tests/tasks/github/test_repos.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 import prefect
 from prefect.tasks.github import CreateBranch, GetRepoInfo
@@ -65,38 +66,40 @@ class TestCredentialsSecret:
         task = GetRepoInfo(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
+        monkeypatch.setattr(requests, "get", req)
 
         with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
             task.run(repo="org/repo")
 
-        assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
+        assert req.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
 
     def test_creds_are_pulled_from_secret_at_runtime_create_branch(self, monkeypatch):
         task = CreateBranch(token_secret="GITHUB_ACCESS_TOKEN")
 
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
+        monkeypatch.setattr(requests, "get", req)
 
         with prefect.context(secrets=dict(GITHUB_ACCESS_TOKEN={"key": 42})):
             with pytest.raises(ValueError, match="not found"):
                 task.run(repo="org/repo", branch_name="new")
 
-        assert req.get.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
+        assert req.call_args[1]["headers"]["AUTHORIZATION"] == "token {'key': 42}"
 
 
 def test_base_name_is_filtered_for(monkeypatch):
     task = CreateBranch(base="BOB", branch_name="NEWBRANCH")
 
     payload = [{"ref": "refs/heads/BOB", "object": {"sha": "salty"}}]
-    req = MagicMock(
-        get=MagicMock(return_value=MagicMock(json=MagicMock(return_value=payload)))
-    )
-    monkeypatch.setattr("prefect.tasks.github.repos.requests", req)
+
+    get = MagicMock(return_value=MagicMock(json=MagicMock(return_value=payload)))
+    post = MagicMock()
+
+    monkeypatch.setattr(requests, "get", get)
+    monkeypatch.setattr(requests, "post", post)
 
     task.run(repo="org/repo", token={"key": 42})
 
-    assert req.post.call_args[1]["json"] == {
+    assert post.call_args[1]["json"] == {
         "ref": "refs/heads/NEWBRANCH",
         "sha": "salty",
     }

--- a/tests/tasks/notifications/test_slack_task.py
+++ b/tests/tasks/notifications/test_slack_task.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from prefect import context
 from prefect.tasks.notifications import SlackTask
@@ -20,20 +21,20 @@ class TestInitialization:
 
     def test_webhook_url_pulled_from_secrets(self, monkeypatch):
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.notifications.slack_task.requests", req)
+        monkeypatch.setattr(requests, "post", req)
         t = SlackTask()
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with context({"secrets": dict(SLACK_WEBHOOK_URL="http://foo/bar")}):
                 res = t.run(message="o hai mark")
-        assert req.post.call_args[0] == ("http://foo/bar",)
-        assert req.post.call_args[1]["json"]["text"] == "o hai mark"
+        assert req.call_args[0] == ("http://foo/bar",)
+        assert req.call_args[1]["json"]["text"] == "o hai mark"
 
     def test_custom_webhook_url_pulled_from_secrets(self, monkeypatch):
         req = MagicMock()
-        monkeypatch.setattr("prefect.tasks.notifications.slack_task.requests", req)
+        monkeypatch.setattr(requests, "post", req)
         t = SlackTask(webhook_secret="MY_URL")
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with context({"secrets": dict(MY_URL="http://foo/bar")}):
                 res = t.run(message="o hai mark")
-        assert req.post.call_args[0] == ("http://foo/bar",)
-        assert req.post.call_args[1]["json"]["text"] == "o hai mark"
+        assert req.call_args[0] == ("http://foo/bar",)
+        assert req.call_args[1]["json"]["text"] == "o hai mark"

--- a/tests/utilities/test_notifications.py
+++ b/tests/utilities/test_notifications.py
@@ -5,6 +5,7 @@ import tempfile
 from multiprocessing.pool import ThreadPool
 from unittest.mock import MagicMock
 
+import requests
 import cloudpickle
 import pytest
 
@@ -155,7 +156,7 @@ def test_every_state_gets_a_unique_color():
 
 def test_slack_notifier_returns_new_state_and_old_state_is_ignored(monkeypatch):
     ok = MagicMock(ok=True)
-    monkeypatch.setattr(prefect.utilities.notifications.requests, "post", ok)
+    monkeypatch.setattr(requests, "post", ok)
     new_state = Failed(message="1", result=0)
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(SLACK_WEBHOOK_URL="")):
@@ -164,7 +165,7 @@ def test_slack_notifier_returns_new_state_and_old_state_is_ignored(monkeypatch):
 
 def test_slack_notifier_pulls_url_from_secret(monkeypatch):
     post = MagicMock(ok=True)
-    monkeypatch.setattr("prefect.utilities.notifications.requests.post", post)
+    monkeypatch.setattr("requests.post", post)
     state = Failed(message="1", result=0)
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with pytest.raises(ValueError, match="SLACK_WEBHOOK_URL"):
@@ -195,7 +196,7 @@ def test_slack_notifier_ignores_ignore_states(monkeypatch):
         Skipped,
     ]
     ok = MagicMock(ok=True)
-    monkeypatch.setattr(prefect.utilities.notifications.requests, "post", ok)
+    monkeypatch.setattr(requests, "post", ok)
     for state in all_states:
         s = state()
         with set_temporary_config({"cloud.use_local_secrets": True}):
@@ -223,7 +224,7 @@ def test_slack_notifier_ignores_ignore_states(monkeypatch):
 def test_slack_notifier_is_curried_and_ignores_ignore_states(monkeypatch, state):
     state = state()
     ok = MagicMock(ok=True)
-    monkeypatch.setattr(prefect.utilities.notifications.requests, "post", ok)
+    monkeypatch.setattr(requests, "post", ok)
     handler = slack_notifier(ignore_states=[Finished])
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(SLACK_WEBHOOK_URL="")):
@@ -250,7 +251,7 @@ def test_slack_notifier_is_curried_and_ignores_ignore_states(monkeypatch, state)
 def test_slack_notifier_is_curried_and_uses_only_states(monkeypatch, state):
     state = state()
     ok = MagicMock(ok=True)
-    monkeypatch.setattr(prefect.utilities.notifications.requests, "post", ok)
+    monkeypatch.setattr(requests, "post", ok)
     handler = slack_notifier(only_states=[TriggerFailed])
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(SLACK_WEBHOOK_URL="")):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
- Reduces the the import time from ~1.1 seconds to ~0.3 seconds. This is accomplished by deferring importing larger 3rd party modules until they are needed (docker, dask, distributed, and requests).
- Add CI check for import time < 1 second
- Remove unused imports (and migrated type check only imports under `typing.TYPE_CHECKING` condition)
- Add CI check to fail if potentially unused imports are discovered (ignores exceptional  imports with `# pylint: disable=W0611` annotation)
- Sorted existing imports (via `isort`)

Closes #2046 

## Why is this PR important?
This makes the CLI more responsive and reduces the time to start running a flow (from interpreter startup).

