### PR TITLE
ADD KWARGS TO `V1DeleteOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Upload package to PyPI on tag push to master - [#2030](https://github.com/PrefectHQ/prefect/issues/2030)
 - Add DaskGateway tip to docs - [#1959](https://github.com/PrefectHQ/prefect/issues/1959)
 - Improve package import time - [#2046](https://github.com/PrefectHQ/prefect/issues/2046)
+- Add kwargs to `V1DeleteOptions` for Kubernetes tasks - [#2051](https://github.com/PrefectHQ/prefect/pull/2051)
 
 ### Task Library
 

--- a/src/prefect/tasks/kubernetes/deployment.py
+++ b/src/prefect/tasks/kubernetes/deployment.py
@@ -174,6 +174,7 @@ class DeleteNamespacedDeployment(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        delete_option_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -187,6 +188,8 @@ class DeleteNamespacedDeployment(Task):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
+            - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `deployment_name` is `None`
@@ -211,11 +214,12 @@ class DeleteNamespacedDeployment(Task):
             api_client = client.ExtensionsV1beta1Api()
 
         kube_kwargs = {**self.kube_kwargs, **(kube_kwargs or {})}
+        delete_option_kwargs = delete_option_kwargs or {}
 
         api_client.delete_namespaced_deployment(
             name=deployment_name,
             namespace=namespace,
-            body=client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(delete_option_kwargs),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/deployment.py
+++ b/src/prefect/tasks/kubernetes/deployment.py
@@ -189,7 +189,8 @@ class DeleteNamespacedDeployment(Task):
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
             - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
-                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...",
+                "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `deployment_name` is `None`

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -185,7 +185,8 @@ class DeleteNamespacedJob(Task):
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
             - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
-                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...",
+                "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `job_name` is `None`

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -170,6 +170,7 @@ class DeleteNamespacedJob(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        delete_option_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -183,6 +184,8 @@ class DeleteNamespacedJob(Task):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
+            - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `job_name` is `None`
@@ -207,11 +210,12 @@ class DeleteNamespacedJob(Task):
             api_client = client.BatchV1Api()
 
         kube_kwargs = {**self.kube_kwargs, **(kube_kwargs or {})}
+        delete_option_kwargs = delete_option_kwargs or {}
 
         api_client.delete_namespaced_job(
             name=job_name,
             namespace=namespace,
-            body=client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(delete_option_kwargs),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/pod.py
+++ b/src/prefect/tasks/kubernetes/pod.py
@@ -185,7 +185,8 @@ class DeleteNamespacedPod(Task):
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
             - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
-                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...",
+                "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `pod_name` is `None`

--- a/src/prefect/tasks/kubernetes/pod.py
+++ b/src/prefect/tasks/kubernetes/pod.py
@@ -170,6 +170,7 @@ class DeleteNamespacedPod(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        delete_option_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -183,6 +184,8 @@ class DeleteNamespacedPod(Task):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
+            - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `pod_name` is `None`
@@ -207,11 +210,12 @@ class DeleteNamespacedPod(Task):
             api_client = client.CoreV1Api()
 
         kube_kwargs = {**self.kube_kwargs, **(kube_kwargs or {})}
+        delete_option_kwargs = delete_option_kwargs or {}
 
         api_client.delete_namespaced_pod(
             name=pod_name,
             namespace=namespace,
-            body=client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(delete_option_kwargs),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/service.py
+++ b/src/prefect/tasks/kubernetes/service.py
@@ -172,6 +172,7 @@ class DeleteNamespacedService(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        delete_option_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -185,6 +186,8 @@ class DeleteNamespacedService(Task):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
+            - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `service_name` is `None`
@@ -209,11 +212,12 @@ class DeleteNamespacedService(Task):
             api_client = client.CoreV1Api()
 
         kube_kwargs = {**self.kube_kwargs, **(kube_kwargs or {})}
+        delete_option_kwargs = delete_option_kwargs or {}
 
         api_client.delete_namespaced_service(
             name=service_name,
             namespace=namespace,
-            body=client.V1DeleteOptions(),
+            body=client.V1DeleteOptions(delete_option_kwargs),
             **kube_kwargs
         )
 

--- a/src/prefect/tasks/kubernetes/service.py
+++ b/src/prefect/tasks/kubernetes/service.py
@@ -187,7 +187,8 @@ class DeleteNamespacedService(Task):
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
             - delete_option_kwargs (dict, optional): Optional keyword arguments to pass to
-                the V1DeleteOptions object (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}.
+                the V1DeleteOptions object (e.g. {"propagation_policy": "...",
+                "grace_period_seconds": "..."}.
 
         Raises:
             - ValueError: if `service_name` is `None`


### PR DESCRIPTION
## What does this PR change?
Currently in delete K8s resource task (e.g. `DeleteNamespacedJob`), the propagation policy cannot be passed. This might lead to orphans.
Now we have the options to pass kwargs (e.g. {"propagation_policy": "...", "grace_period_seconds": "..."}) to the `V1DeleteOptions` object.

## Why is this PR important?
This would allow to better control the delete options, for instance garbage collection mechanism (propagation_policy).

