### PR TITLE
Add optional stdout logging in tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Add volume option to Docker Agent - [#2013](https://github.com/PrefectHQ/prefect/issues/2013)
+- Enable stdout logging from inside a task with the kwarg `log_stdout=True` - [#2092](https://github.com/PrefectHQ/prefect/pull/2092)
 
 ### Task Library
 

--- a/docs/core/concepts/logging.md
+++ b/docs/core/concepts/logging.md
@@ -51,16 +51,28 @@ def my_task():
     logger.warning("A warning message.")
 ```
 
+:::
+
+### Logging stdout
+
+Prefect tasks natively support forwarding the output of stdout to a logger. This can be enabled by setting `log_stdout=True` on your task.
+
+```python
+@task(log_stdout=True)
+def log_my_stdout():
+    print("I will be logged!")
+```
+
 ### Extra Loggers
 
-Many libraries like `boto3` and `snowflake.conector` are setup to emit their own internal logs when configured 
-with a logging configuration.  You may even have an internal shared library for your team with the same functionality.
+Many libraries like `boto3` and `snowflake.conector` are setup to emit their own internal logs when configured with a logging configuration. You may even have an internal shared library for your team with the same functionality.
 
 If you are doing this via the standard `logging` library you might do this:
+
 ```python
 import logging
 import sys
-for l in ['snowflake.connector', 'boto3', 'botocore']:
+for l in ['snowflake.connector', 'boto3', 'custom_lib']:
     logger = logging.getLogger(l)
     logger.setLevel('INFO')
     log_stream = logging.StreamHandler(sys.stdout)
@@ -68,17 +80,20 @@ for l in ['snowflake.connector', 'boto3', 'botocore']:
     logger.addHandler(log_stream)
 ```
 
-Given that Prefect already provides a way to configure logging for local and cloud, you can provide these 
-extra loggers to have them inherit the Prefect logging config to stream locally and also show up in cloud.
+Given that Prefect already provides a way to configure logging for local and cloud, you can provide these extra loggers to have them inherit the Prefect logging config to stream locally and also show up in cloud.
 
 In order for this to work you need to provide a list to `prefect.config.logging.extra_loggers`.
 
 Here is what the TOML config will look like:
 
-```
+```toml
 [logging]
 # Extra loggers for Prefect log configuration
-extra_loggers = ['snowflake.connector', 'boto3', 'botocore', 'custom_lib']
+extra_loggers = "['snowflake.connector', 'boto3', 'custom_lib']"
 ```
 
-:::
+As an environment variable:
+
+```bash
+export PREFECT__LOGGING__EXTRA_LOGGERS="['snowflake.connector', 'boto3', 'custom_lib']"
+```

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -154,6 +154,8 @@ class Task(metaclass=SignatureValidator):
             result of the previous handler.
         - on_failure (Callable, optional): A function with signature `fn(task: Task, state: State) -> None`
             with will be called anytime this Task enters a failure state
+        - log_stdout (bool, optional): Toggle whether or not to send stdout messages to
+            the Prefect logger. Defaults to `True`.
 
     Raises:
         - TypeError: if `tags` is of type `str`
@@ -180,8 +182,8 @@ class Task(metaclass=SignatureValidator):
         result_handler: "ResultHandler" = None,
         state_handlers: List[Callable] = None,
         on_failure: Callable = None,
+        log_stdout: bool = True,
     ):
-
         self.name = name or type(self).__name__
         self.slug = slug or str(uuid.uuid4())
 
@@ -254,6 +256,8 @@ class Task(metaclass=SignatureValidator):
                 callback_factory(on_failure, check=lambda s: s.is_failed())
             )
         self.auto_generated = False
+
+        self.log_stdout = log_stdout
 
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -155,7 +155,7 @@ class Task(metaclass=SignatureValidator):
         - on_failure (Callable, optional): A function with signature `fn(task: Task, state: State) -> None`
             with will be called anytime this Task enters a failure state
         - log_stdout (bool, optional): Toggle whether or not to send stdout messages to
-            the Prefect logger. Defaults to `True`.
+            the Prefect logger. Defaults to `False`.
 
     Raises:
         - TypeError: if `tags` is of type `str`
@@ -182,7 +182,7 @@ class Task(metaclass=SignatureValidator):
         result_handler: "ResultHandler" = None,
         state_handlers: List[Callable] = None,
         on_failure: Callable = None,
-        log_stdout: bool = True,
+        log_stdout: bool = False,
     ):
         self.name = name or type(self).__name__
         self.slug = slug or str(uuid.uuid4())

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -876,7 +876,7 @@ class TaskRunner(Runner):
             raw_inputs = {k: r.value for k, r in inputs.items()}
 
             if self.task.log_stdout:
-                with redirect_stdout(prefect.utilities.logging.log_stdout):  # type: ignore
+                with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
                     result = timeout_handler(
                         self.task.run, timeout=self.task.timeout, **raw_inputs
                     )

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1,4 +1,5 @@
 import copy
+from contextlib import redirect_stdout
 import itertools
 from typing import (
     TYPE_CHECKING,
@@ -873,9 +874,16 @@ class TaskRunner(Runner):
                 timeout_handler or prefect.utilities.executors.timeout_handler
             )
             raw_inputs = {k: r.value for k, r in inputs.items()}
-            result = timeout_handler(
-                self.task.run, timeout=self.task.timeout, **raw_inputs
-            )
+
+            if self.task.log_stdout:
+                with redirect_stdout(prefect.utilities.logging.log_stdout):  # type: ignore
+                    result = timeout_handler(
+                        self.task.run, timeout=self.task.timeout, **raw_inputs
+                    )
+            else:
+                result = timeout_handler(
+                    self.task.run, timeout=self.task.timeout, **raw_inputs
+                )
 
         except KeyboardInterrupt:
             self.logger.debug("Interrupt signal raised, cancelling task run.")

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -270,7 +270,7 @@ class RedirectToLog:
             s (str): the message from stdout to be logged
         """
         if s.strip():
-            get_logger("stdout").debug(s)
+            get_logger("stdout").info(s)
 
 
 log_stdout = RedirectToLog()

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -261,6 +261,8 @@ def get_logger(name: str = None) -> logging.Logger:
 
 
 class RedirectToLog:
+    stdout_logger = get_logger("stdout")
+
     def write(self, s: str) -> None:
         """
         Write message from stdout to a prefect logger.
@@ -270,7 +272,14 @@ class RedirectToLog:
             s (str): the message from stdout to be logged
         """
         if s.strip():
-            get_logger("stdout").info(s)
+            self.stdout_logger.info(s)
+
+    def flush(self) -> None:
+        """
+        Implemented flush operation for logger handler
+        """
+        for handler in self.stdout_logger.handlers:
+            handler.flush()
 
 
 log_stdout = RedirectToLog()

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -289,4 +289,3 @@ class RedirectToLog:
         """
         for handler in self.stdout_logger.handlers:
             handler.flush()
-

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -258,3 +258,19 @@ def get_logger(name: str = None) -> logging.Logger:
         return prefect_logger
     else:
         return prefect_logger.getChild(name)
+
+
+class RedirectToLog:
+    def write(self, s: str) -> None:
+        """
+        Write message from stdout to a prefect logger.
+        Note: blank newlines will not be logged.
+
+        Args:
+            s (str): the message from stdout to be logged
+        """
+        if s.strip():
+            get_logger("stdout").debug(s)
+
+
+log_stdout = RedirectToLog()

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -261,7 +261,16 @@ def get_logger(name: str = None) -> logging.Logger:
 
 
 class RedirectToLog:
-    stdout_logger = get_logger("stdout")
+    """
+    Custom redirect of stdout messages to logs
+
+    Args:
+        - logger (logging.Logger, optional): an optional logger to redirect stdout. If
+            not provided a logger names `stdout` will be created.
+    """
+
+    def __init__(self, logger: logging.Logger = None) -> None:
+        self.stdout_logger = logger or get_logger("stdout")
 
     def write(self, s: str) -> None:
         """

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -290,5 +290,3 @@ class RedirectToLog:
         for handler in self.stdout_logger.handlers:
             handler.flush()
 
-
-log_stdout = RedirectToLog()

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -264,10 +264,10 @@ class TestCreateTask:
 
     def test_create_task_with_and_without_log_stdout(self):
         t = Task()
-        assert t.log_stdout is True
+        assert t.log_stdout is False
 
-        s = Task(log_stdout=False)
-        assert s.log_stdout is False
+        s = Task(log_stdout=True)
+        assert s.log_stdout is True
 
 
 def test_task_has_logger():

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -262,6 +262,13 @@ class TestCreateTask:
         s = Task(checkpoint=True)
         assert s.checkpoint is True
 
+    def test_create_task_with_and_without_log_stdout(self):
+        t = Task()
+        assert t.log_stdout is True
+
+        s = Task(log_stdout=False)
+        assert s.log_stdout is False
+
 
 def test_task_has_logger():
     t = Task()

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -890,11 +890,11 @@ def test_all_tasks_only_called_once(capsys, executor):
     See https://github.com/PrefectHQ/prefect/issues/556
     """
 
-    @prefect.task
+    @prefect.task(log_stdout=False)
     def my_list():
         return list(range(5))
 
-    @prefect.task
+    @prefect.task(log_stdout=False)
     def add_one(x):
         print("adding one to {}".format(x))
         return x + 1

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -890,11 +890,11 @@ def test_all_tasks_only_called_once(capsys, executor):
     See https://github.com/PrefectHQ/prefect/issues/556
     """
 
-    @prefect.task(log_stdout=False)
+    @prefect.task
     def my_list():
         return list(range(5))
 
-    @prefect.task(log_stdout=False)
+    @prefect.task
     def add_one(x):
         print("adding one to {}".format(x))
         return x + 1

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -2249,7 +2249,7 @@ def test_task_runner_logs_stdout(caplog):
         def run(self):
             print("TEST_HERE")
 
-    task = MyTask()
+    task = MyTask(log_stdout=True)
     TaskRunner(task=task).run()
 
     logs = [r.message for r in caplog.records]
@@ -2261,7 +2261,7 @@ def test_task_runner_logs_stdout_disabled(caplog):
         def run(self):
             print("TEST_HERE")
 
-    task = MyTask(log_stdout=False)
+    task = MyTask()
     TaskRunner(task=task).run()
 
     logs = [r.message for r in caplog.records]

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -2242,3 +2242,27 @@ def test_task_runner_uses_upstream_result_handlers():
     state = TaskRunner(task=t).run(upstream_states=upstream_states)
     assert state.is_successful()
     assert state.result == "cool"
+
+
+def test_task_runner_logs_stdout(caplog):
+    class MyTask(Task):
+        def run(self):
+            print("TEST_HERE")
+
+    task = MyTask()
+    TaskRunner(task=task).run()
+
+    logs = [r.message for r in caplog.records]
+    assert logs[1] == "TEST_HERE"
+
+
+def test_task_runner_logs_stdout_disabled(caplog):
+    class MyTask(Task):
+        def run(self):
+            print("TEST_HERE")
+
+    task = MyTask(log_stdout=False)
+    TaskRunner(task=task).run()
+
+    logs = [r.message for r in caplog.records]
+    assert "TEST_HERE" not in logs

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -310,8 +310,6 @@ def test_context_only_specified_attributes():
 
     assert test_filter.called
 
-
-def test_extra_loggers():
     with utilities.configuration.set_temporary_config(
         {"logging.extra_loggers": ["extra_logger"]}
     ):
@@ -319,3 +317,14 @@ def test_extra_loggers():
         assert (
             type(logging.root.manager.loggerDict.get("extra_logger")) == logging.Logger
         )
+
+
+def test_redirect_to_log(caplog):
+    log_stdout = utilities.logging.log_stdout
+
+    log_stdout.write("TEST1")
+    log_stdout.write("")
+    log_stdout.write("TEST2")
+
+    logs = [r.message for r in caplog.records]
+    assert logs == ["TEST1", "TEST2"]

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -320,7 +320,7 @@ def test_context_only_specified_attributes():
 
 
 def test_redirect_to_log(caplog):
-    log_stdout = utilities.logging.log_stdout
+    log_stdout = utilities.logging.RedirectToLog()
 
     log_stdout.write("TEST1")
     log_stdout.write("")

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -328,3 +328,5 @@ def test_redirect_to_log(caplog):
 
     logs = [r.message for r in caplog.records]
     assert logs == ["TEST1", "TEST2"]
+
+    log_stdout.flush()

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -326,7 +326,7 @@ def test_redirect_to_log(caplog):
     log_stdout.write("")
     log_stdout.write("TEST2")
 
-    logs = [r.message for r in caplog.records]
+    logs = [r.message for r in caplog.records if r.levelname == "INFO"]
     assert logs == ["TEST1", "TEST2"]
 
     log_stdout.flush()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2040 
By default tasks now have a `log_stdout=True` kwarg which can be toggled based on whether or not to send stdout messages as Prefect logs.

Example:

```python
from prefect import task, Flow

@task
def me():
    print("@@@")

f = Flow('test', tasks=[me])
```

![image](https://user-images.githubusercontent.com/40716964/75395214-e4de6780-58bf-11ea-80ab-b15dad8d5f09.png)



## Why is this PR important?
As we have seen, logging stdout is commonly a new user assumption when it comes to using Prefect / Prefect Cloud. Having to pull the logger from context is not that intuitive to new users:
```python
from prefect import context
logger = context.get('logger')
logger.info('@@@')
```

