### PR TITLE
Add extra-requirements.txt file for dependabot version tracking

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,0 +1,20 @@
+# Extra requirements file for dependabot PRs to check dependency versions
+
+airtable-python-wrapper >= 0.11, < 0.12
+azure-cosmos >= 3.1.1, <3.2
+azure-storage-blob >= 12.1.0, < 13.0
+azureml-sdk >= 1.0.65, < 1.1
+boto3 >= 1.9, < 2.0
+dask-kubernetes >= 0.8.0
+dropbox ~= 9.0
+feedparser >= 5.0.1, < 6.0
+google-cloud-bigquery >= 1.6.0, < 2.0
+google-cloud-storage >= 1.13, < 2.0
+graphviz >= 0.8.3
+jinja2 >= 2.0, < 3.0
+kubernetes >= 9.0.0a1, <= 11.0.0b2
+psycopg2-binary >= 2.8.2
+redis >= 3.2.1
+snowflake-connector-python >= 1.8.2, < 2.0
+spacy >= 2.0.0, < 3.0.0
+tweepy >= 3.5, < 4.0


### PR DESCRIPTION
After looking into the dependabot source (notably [here](https://github.com/dependabot/dependabot-core/blob/master/python/lib/dependabot/python/file_fetcher.rb#L19)) we can have dependabot track the _extra_ dependencies by putting them into their own `*-requirements.txt` file. This is in an effort to keep extra packages for things like the task library and agents from getting stale. I believe this would mean that when dependabot opens a PR for a dependency in this file then we would have to add an extra commit to that PR to update setup.py (not strongly opposed to that). Unless we found some way to refactor the `extras = {...}` dictionary in the setup.py

**Open for discussion**

Closes #2087 
