### PR TITLE
Don't mutate data during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Don't mutate data when serializing or deserializing - [#2098](https://github.com/PrefectHQ/prefect/issues/2098)
 
 ### Deprecations
 

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -102,6 +102,8 @@ class ObjectSchema(Schema):
         Returns:
             - dict: the data dict, without its __version__ field
         """
+        # don't mutate data
+        data = data.copy()
         data.pop("__version__", None)
         return data
 
@@ -116,6 +118,8 @@ class ObjectSchema(Schema):
         Returns:
             - dict: the data dict, with an additional __version__ field
         """
+        # don't mutate data
+        data = data.copy()
         data.setdefault("__version__", prefect.__version__)
         return data
 

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -299,6 +299,22 @@ class TestObjectSchema:
         serialized = Schema().dump(TestObject(x=5))
         assert serialized == {"__version__": prefect.__version__, "x": 5}
 
+    def test_schema_doesnt_mutate_object_on_load(self):
+        class TestObject:
+            def __init__(self, x):
+                self.x = x
+
+        class Schema(ObjectSchema):
+            class Meta:
+                object_class = TestObject
+
+            x = marshmallow.fields.Int()
+
+        serialized = Schema().dump(TestObject(x=5))
+
+        Schema().load(serialized)
+        assert serialized == {"__version__": prefect.__version__, "x": 5}
+
     def test_schema_creates_object(self):
         class TestObject:
             def __init__(self, x):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR ensures that serialization and deserialization do not mutate their payloads, but create and manipulate (shallow) copies instead.


## Why is this PR important?

Closes #2098 
