### PR TITLE
Add note about using prefect diagnostics to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,3 +27,5 @@ assignees: ''
 
 ## Environment
 *Any additional information about your environment*
+
+You may optionally run `prefect diagnostics` from the command line and paste the information here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,4 +28,4 @@ assignees: ''
 ## Environment
 *Any additional information about your environment*
 
-You may optionally run `prefect diagnostics` from the command line and paste the information here.
+*Optionally run `prefect diagnostics` from the command line and paste the information here*


### PR DESCRIPTION
Updates the github bug template to make note of the `prefect diagnostics` command line option to retrieve environment information