### PR TITLE
Fix task runner pipeline retrieving of log_stdout attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix `task.log_stdout` attribute retieval for patch versions - [#2120](https://github.com/PrefectHQ/prefect/pull/2120)
 
 ### Deprecations
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -874,7 +874,7 @@ class TaskRunner(Runner):
             )
             raw_inputs = {k: r.value for k, r in inputs.items()}
 
-            if self.task.log_stdout:
+            if getattr(self.task, "log_stdout", False):
                 with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
                     result = timeout_handler(
                         self.task.run, timeout=self.task.timeout, **raw_inputs


### PR DESCRIPTION
Fix retrieval of `task.log_stdout` by making it a `getattr` to preserve compatibility between patch release versions