### PR TITLE
Closes #2108. New boto session for each thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- - Add examples to Interactive API Docs [#2122](https://github.com/PrefectHQ/prefect/pull/2122)
+- Add examples to Interactive API Docs [#2122](https://github.com/PrefectHQ/prefect/pull/2122)
+- Use a new boto3 session per thread when using S3ResultHandlers [#2108](https://github.com/PrefectHQ/prefect/issues/2108)
 
 ### Task Library
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -65,9 +65,9 @@ class S3ResultHandler(ResultHandler):
 
     @property
     def client(self) -> "boto3.client":
-        if not prefect.context.caches.get("boto3client"):
+        if not prefect.context.get("boto3client"):
             self.initialize_client()
-            prefect.context.caches["boto3client"] = self._client
+            prefect.context["boto3client"] = self._client
         return self._client
 
     @client.setter

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -54,7 +54,8 @@ class S3ResultHandler(ResultHandler):
             aws_access_key = aws_credentials["ACCESS_KEY"]
             aws_secret_access_key = aws_credentials["SECRET_ACCESS_KEY"]
 
-        s3_client = boto3.client(
+        session = boto3.session.Session()
+        s3_client = session.client(
             "s3",
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_access_key,
@@ -63,8 +64,8 @@ class S3ResultHandler(ResultHandler):
 
     @property
     def client(self) -> "boto3.client":
-        if not hasattr(self, "_client"):
-            self.initialize_client()
+        # reinitialize every time it is requested in case we are in different threads
+        self.initialize_client()
         return self._client
 
     @client.setter

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import cloudpickle
 import pendulum
 
+import prefect
 from prefect.client import Secret
 from prefect.engine.result_handlers import ResultHandler
 
@@ -64,8 +65,9 @@ class S3ResultHandler(ResultHandler):
 
     @property
     def client(self) -> "boto3.client":
-        # reinitialize every time it is requested in case we are in different threads
-        self.initialize_client()
+        if not prefect.context.caches.get("boto3client"):
+            self.initialize_client()
+            prefect.context.caches["boto3client"] = self._client
         return self._client
 
     @client.setter

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -55,6 +55,8 @@ class S3ResultHandler(ResultHandler):
             aws_access_key = aws_credentials["ACCESS_KEY"]
             aws_secret_access_key = aws_credentials["SECRET_ACCESS_KEY"]
 
+        # use a new boto session when initializing in case we are in a new thread
+        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
         session = boto3.session.Session()
         s3_client = session.client(
             "s3",
@@ -65,6 +67,10 @@ class S3ResultHandler(ResultHandler):
 
     @property
     def client(self) -> "boto3.client":
+        """
+        Initializes a client if we believe we are in a new thread.
+        We consider ourselves in a new thread if we haven't stored a client yet in the current context.
+        """
         if not prefect.context.get("boto3client"):
             self.initialize_client()
             prefect.context["boto3client"] = self._client

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -181,7 +181,8 @@ class TestS3ResultHandler:
         assert session.Session().client.called is False
 
         with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
+            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
+            caches={},
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 handler.initialize_client()
@@ -194,7 +195,7 @@ class TestS3ResultHandler:
         handler = S3ResultHandler(bucket="bob", aws_credentials_secret="MY_FOO")
 
         with prefect.context(
-            secrets=dict(MY_FOO=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=999))
+            secrets=dict(MY_FOO=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=999)), caches={}
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 handler.initialize_client()
@@ -209,7 +210,8 @@ class TestS3ResultHandler:
         handler = S3ResultHandler(bucket="foo")
 
         with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
+            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
+            caches={},
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 uri = handler.write("so-much-data")
@@ -236,7 +238,8 @@ class TestS3ResultHandler:
             boto3.session.Session().client = client
 
             with prefect.context(
-                secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
+                secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
+                caches={},
             ):
                 with set_temporary_config({"cloud.use_local_secrets": True}):
                     handler = S3ResultHandler(bucket="foo")

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -181,8 +181,7 @@ class TestS3ResultHandler:
         assert session.Session().client.called is False
 
         with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
-            caches={},
+            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 handler.initialize_client()
@@ -195,7 +194,7 @@ class TestS3ResultHandler:
         handler = S3ResultHandler(bucket="bob", aws_credentials_secret="MY_FOO")
 
         with prefect.context(
-            secrets=dict(MY_FOO=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=999)), caches={}
+            secrets=dict(MY_FOO=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=999))
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 handler.initialize_client()
@@ -210,8 +209,7 @@ class TestS3ResultHandler:
         handler = S3ResultHandler(bucket="foo")
 
         with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
-            caches={},
+            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 uri = handler.write("so-much-data")
@@ -238,8 +236,7 @@ class TestS3ResultHandler:
             boto3.session.Session().client = client
 
             with prefect.context(
-                secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
-                caches={},
+                secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
             ):
                 with set_temporary_config({"cloud.use_local_secrets": True}):
                     handler = S3ResultHandler(bucket="foo")

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -166,32 +166,31 @@ class TestGCSResultHandler:
 @pytest.mark.xfail(raises=ImportError, reason="aws extras not installed.")
 class TestS3ResultHandler:
     @pytest.fixture
-    def s3_client(self, monkeypatch):
+    def session(self, monkeypatch):
         import boto3
 
-        client = MagicMock()
-        with patch.dict("sys.modules", {"boto3": MagicMock(client=client)}):
-            yield client
+        session = MagicMock()
+        with patch.dict("sys.modules", {"boto3": MagicMock(session=session)}):
+            yield session
 
-    def test_s3_client_init_uses_secrets(self, s3_client):
+    def test_s3_client_init_uses_secrets(self, session):
         handler = S3ResultHandler(
             bucket="bob", aws_credentials_secret="AWS_CREDENTIALS"
         )
         assert handler.bucket == "bob"
-        assert s3_client.called is False
+        assert session.Session().client.called is False
 
         with prefect.context(
             secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
         ):
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 handler.initialize_client()
-
-        assert s3_client.call_args[1] == {
+        assert session.Session().client.call_args[1] == {
             "aws_access_key_id": 1,
             "aws_secret_access_key": 42,
         }
 
-    def test_s3_client_init_uses_custom_secrets(self, s3_client):
+    def test_s3_client_init_uses_custom_secrets(self, session):
         handler = S3ResultHandler(bucket="bob", aws_credentials_secret="MY_FOO")
 
         with prefect.context(
@@ -201,12 +200,12 @@ class TestS3ResultHandler:
                 handler.initialize_client()
 
         assert handler.bucket == "bob"
-        assert s3_client.call_args[1] == {
+        assert session.Session().client.call_args[1] == {
             "aws_access_key_id": 1,
             "aws_secret_access_key": 999,
         }
 
-    def test_s3_writes_to_blob_prefixed_by_date_suffixed_by_prefect(self, s3_client):
+    def test_s3_writes_to_blob_prefixed_by_date_suffixed_by_prefect(self, session):
         handler = S3ResultHandler(bucket="foo")
 
         with prefect.context(
@@ -215,7 +214,9 @@ class TestS3ResultHandler:
             with set_temporary_config({"cloud.use_local_secrets": True}):
                 uri = handler.write("so-much-data")
 
-        used_uri = s3_client.return_value.upload_fileobj.call_args[1]["Key"]
+        used_uri = session.Session().client.return_value.upload_fileobj.call_args[1][
+            "Key"
+        ]
 
         assert used_uri == uri
         assert used_uri.startswith(pendulum.now("utc").format("Y/M/D"))
@@ -229,7 +230,11 @@ class TestS3ResultHandler:
             def __getstate__(self):
                 raise ValueError("I cannot be pickled.")
 
-        with patch.dict("sys.modules", {"boto3": MagicMock(client=client)}):
+        import boto3
+
+        with patch.dict("sys.modules", {"boto3": MagicMock()}):
+            boto3.session.Session().client = client
+
             with prefect.context(
                 secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
             ):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Instantiates a new boto session (and thus boto client) if we think we are in a new thread. Closes #2108 which has a lot of context for this. In the end (see commit history for the history) I went with memoizing the boto client not on the result handler instance as before, but in `prefect.context`. Anecdotally, initializing at every call to `S3ResultHandler.client` a la 0852c2c made the [dask example flow](https://docs.prefect.io/core/advanced_tutorials/dask-cluster.html#an-example-flow) twice as slow with two local dask workers using `--nprocs 1 --nthreads 3`.


## Why is this PR important?
Tasks on multithreaded executors can now use the S3ResultHandler (before tasks would fail when initializing the boto client).

❓ **NOTE** ❓ : Should I be attempting to add an integration test testing this edge between Dask executor, mapped flows and S3?

