### PR TITLE
Fix Stateful Function Reference deserialization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with stateful function reference deserialization logic mutating state - [#2159](https://github.com/PrefectHQ/prefect/pull/2159)
 
 ### Deprecations
 

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -429,7 +429,7 @@ class StatefulFunctionReference(fields.Field):
             return None
 
         # call function on state
-        kwargs = value.get("kwargs")
+        kwargs = value.get("kwargs", {}).copy()
 
         # if there are no kwargs, then this function isn't stateful
         if not kwargs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def mthread():
     with Client(processes=False) as client:
         yield DaskExecutor(client.scheduler.address)
         try:
-            client.close()
+            client.shutdown()
         except:
             pass
 
@@ -63,7 +63,7 @@ def mproc():
     with Client(processes=True) as client:
         yield DaskExecutor(client.scheduler.address, local_processes=True)
         try:
-            client.close()
+            client.shutdown()
         except:
             pass
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1626,7 +1626,7 @@ class TestFlowRunMethod:
         a = prefect.schedules.clocks.DatesClock(
             [pendulum.now("UTC").add(seconds=0.1)], parameter_defaults=dict(x=1)
         )
-        b = prefect.schedules.clocks.DatesClock([pendulum.now("UTC").add(seconds=0.25)])
+        b = prefect.schedules.clocks.DatesClock([pendulum.now("UTC").add(seconds=0.35)])
 
         x = prefect.Parameter("x", default=3, required=False)
         outputs = []

--- a/tests/serialization/test_flows.py
+++ b/tests/serialization/test_flows.py
@@ -45,6 +45,21 @@ def test_deserialize_schedule():
     assert deserialized.schedule.next(5) == f.schedule.next(5)
 
 
+def test_deserialize_schedule_doesnt_mutate_original():
+    schedule = prefect.schedules.Schedule(
+        clocks=[],
+        filters=[
+            prefect.schedules.filters.between_times(datetime.time(1), datetime.time(2))
+        ],
+    )
+    f = Flow(name="test", schedule=schedule)
+    serialized = FlowSchema().dump(f)
+    deserialized = FlowSchema().load(serialized)
+    kwargs = serialized["schedule"]["filters"][0]["kwargs"]
+    assert isinstance(kwargs["start"], str)
+    assert isinstance(kwargs["end"], str)
+
+
 def test_deserialize_tasks():
     tasks = [Task(n) for n in ["a", "b", "c"]]
     f = Flow(name="test", tasks=tasks)

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -263,6 +263,13 @@ class TestStatefulFunctionReferenceField:
         )
         assert deserialized["f"](100) == outer(x=1, y=2, z=99)(100)
 
+    def test_deserialize_outer_with_state_doesnt_mutate_payload(self):
+        payload = self.Schema().dump(dict(f=outer(x=1, y=2, z=datetime.time(4))))
+        deserialized = self.Schema().load(payload)
+        assert payload["f"]["kwargs"]["x"] == 1
+        assert payload["f"]["kwargs"]["y"] == 2
+        assert isinstance(payload["f"]["kwargs"]["z"], str)
+
     def test_deserialize_invalid_fn(self):
         with pytest.raises(marshmallow.ValidationError):
             self.Schema().load({"f": {"fn": "hello"}})


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes an issue in which some deserialization logic accidentally mutated the state of the original serialized payload. 


## Why is this PR important?
This bug prevented some specific types of Schedules from being registered with Prefect Cloud.

**cc:** @znicholasbrown 