### PR TITLE
Scheduled Required Parameters Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with stateful function reference deserialization logic mutating state - [#2159](https://github.com/PrefectHQ/prefect/pull/2159)
+- Fix issue with `DateClock` serializer - [#2166](https://github.com/PrefectHQ/prefect/issues/2166)
+- Fix issue with scheduling required parameters - [#2166](https://github.com/PrefectHQ/prefect/issues/2166)
 
 ### Deprecations
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -575,9 +575,16 @@ class Client:
         """
         required_parameters = {p for p in flow.parameters() if p.required}
         if flow.schedule is not None and required_parameters:
-            raise ClientError(
-                "Flows with required parameters can not be scheduled automatically."
-            )
+            required_names = {p.name for p in required_parameters}
+            if not all(
+                [
+                    required_names == set(c.parameter_defaults.keys())
+                    for c in flow.schedule.clocks
+                ]
+            ):
+                raise ClientError(
+                    "Flows with required parameters can not be scheduled automatically."
+                )
         if any(e.key for e in flow.edges) and flow.result_handler is None:
             warnings.warn(
                 "No result handler was specified on your Flow. Cloud features such as input caching and resuming task runs from failure may not work properly.",

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -79,9 +79,7 @@ class DatesClockSchema(ObjectSchema):
     class Meta:
         object_class = prefect.schedules.clocks.DatesClock
 
-    start_date = DateTimeTZ(allow_none=True)
-    end_date = DateTimeTZ(allow_none=True)
-    dates = DateTimeTZ(required=True, many=True)
+    dates = fields.List(DateTimeTZ(), required=True)
     parameter_defaults = fields.Dict(
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -123,6 +123,100 @@ def test_client_deploy(patch_post, compressed, monkeypatch):
         assert flow_id == "long-id"
 
 
+def test_client_register_raises_if_required_param_isnt_scheduled(
+    patch_post, monkeypatch
+):
+    response = {
+        "data": {"project": [{"id": "proj-id"}], "createFlow": {"id": "long-id"}}
+    }
+    patch_post(response)
+
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+
+    with set_temporary_config(
+        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+
+    a = prefect.schedules.clocks.DatesClock(
+        [pendulum.now("UTC").add(seconds=0.1)], parameter_defaults=dict(x=1)
+    )
+    b = prefect.schedules.clocks.DatesClock(
+        [pendulum.now("UTC").add(seconds=0.25)], parameter_defaults=dict(y=2)
+    )
+
+    x = prefect.Parameter("x", required=True)
+
+    flow = prefect.Flow(
+        "test", schedule=prefect.schedules.Schedule(clocks=[a, b]), tasks=[x]
+    )
+    flow.storage = prefect.environments.storage.Memory()
+    flow.result_handler = flow.storage.result_handler
+
+    with pytest.raises(
+        ClientError,
+        match="Flows with required parameters can not be scheduled automatically",
+    ):
+        flow_id = client.register(
+            flow,
+            project_name="my-default-project",
+            compressed=False,
+            version_group_id=str(uuid.uuid4()),
+        )
+
+
+@pytest.mark.parametrize("compressed", [True, False])
+def test_client_register_doesnt_raise_for_scheduled_params(
+    patch_post, compressed, monkeypatch
+):
+    if compressed:
+        response = {
+            "data": {
+                "project": [{"id": "proj-id"}],
+                "createFlowFromCompressedString": {"id": "long-id"},
+            }
+        }
+    else:
+        response = {
+            "data": {"project": [{"id": "proj-id"}], "createFlow": {"id": "long-id"}}
+        }
+    patch_post(response)
+
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+
+    with set_temporary_config(
+        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+
+    a = prefect.schedules.clocks.DatesClock(
+        [pendulum.now("UTC").add(seconds=0.1)], parameter_defaults=dict(x=1)
+    )
+    b = prefect.schedules.clocks.DatesClock(
+        [pendulum.now("UTC").add(seconds=0.25)], parameter_defaults=dict(x=2)
+    )
+
+    x = prefect.Parameter("x", required=True)
+
+    flow = prefect.Flow(
+        "test", schedule=prefect.schedules.Schedule(clocks=[a, b]), tasks=[x]
+    )
+    flow.storage = prefect.environments.storage.Memory()
+    flow.result_handler = flow.storage.result_handler
+
+    flow_id = client.register(
+        flow,
+        project_name="my-default-project",
+        compressed=compressed,
+        version_group_id=str(uuid.uuid4()),
+    )
+    assert flow_id == "long-id"
+
+
 @pytest.mark.parametrize("compressed", [True, False])
 def test_client_register(patch_post, compressed, monkeypatch):
     if compressed:

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -16,6 +16,13 @@ def serialize_and_deserialize(schedule: schedules.Schedule):
     return schema.load(json.loads(json.dumps(schema.dump(schedule))))
 
 
+def test_serialize_schedule_with_dateclock():
+    dt = pendulum.datetime(2099, 1, 1)
+    s = schedules.Schedule(clocks=[clocks.DatesClock(dates=[dt, dt.add(days=1)])])
+    s2 = serialize_and_deserialize(s)
+    assert s2.next(2) == [dt, dt.add(days=1)]
+
+
 def test_serialize_schedule_with_parameters():
     dt = pendulum.datetime(2099, 1, 1)
     s = schedules.Schedule(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR does two independent things:
- fixes an issue with the `DateClock` serializer (this isn't a widely used clock but it still should work)
- allows users to have required parameters whose default values come entirely from their Flow's clocks

## Why is this PR important?
This PR improves the user experience for scheduling changing parameter defaults over time while still having a required parameter.

