### PR TITLE
Add maximum polling option to agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add ValidationFailed state and signal in anticipation of validating task outputs [#2143](https://github.com/PrefectHQ/prefect/issues/2143)
+- Add ValidationFailed state and signal in anticipation of validating task outputs - [#2143](https://github.com/PrefectHQ/prefect/issues/2143)
+- Add max polling option to all agents - [#2037](https://github.com/PrefectHQ/prefect/issues/2037)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Add ValidationFailed state and signal in anticipation of validating task outputs - [#2143](https://github.com/PrefectHQ/prefect/issues/2143)
 - Add max polling option to all agents - [#2037](https://github.com/PrefectHQ/prefect/issues/2037)
-- Add ValidationFailed state and signal in anticipation of validating task outputs [#2143](https://github.com/PrefectHQ/prefect/issues/2143)
 - Add GCSResult type [#2141](https://github.com/PrefectHQ/prefect/issues/2141)
 
 ### Task Library

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -70,6 +70,8 @@ class Agent:
             Agents when polling for work
         - env_vars (dict, optional): a dictionary of environment variables and values that will be set
             on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
+            defaults to infinite
     """
 
     def __init__(
@@ -157,7 +159,7 @@ class Agent:
                         and remaining_polls
                     ):
                         self.heartbeat()
-                        print(remaining_polls)
+
                         if self.agent_process(executor, tenant_id):
                             index = 0
                         elif index < max(loop_intervals.keys()):

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -1,6 +1,7 @@
 import ast
 import functools
 import logging
+import math
 import os
 import signal
 import sys
@@ -72,13 +73,18 @@ class Agent:
     """
 
     def __init__(
-        self, name: str = None, labels: Iterable[str] = None, env_vars: dict = None
+        self,
+        name: str = None,
+        labels: Iterable[str] = None,
+        env_vars: dict = None,
+        max_polls: int = None,
     ) -> None:
         self.name = name or config.cloud.agent.get("name", "agent")
         self.labels = list(
             labels or ast.literal_eval(config.cloud.agent.get("labels", "[]"))
         )
         self.env_vars = env_vars or dict()
+        self.max_polls = max_polls
         self.log_to_cloud = config.logging.log_to_cloud
 
         token = config.cloud.agent.get("auth_token")
@@ -138,6 +144,7 @@ class Agent:
                 }
 
                 index = 0
+                remaining_polls = math.inf if self.max_polls is None else self.max_polls
 
                 # the max workers default has changed in 3.5 and 3.8. For stable results the
                 # default 3.8 behavior is elected here.
@@ -145,13 +152,18 @@ class Agent:
 
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
                     self.logger.debug("Max Workers: {}".format(max_workers))
-                    while not exit_event.wait(timeout=loop_intervals[index]):
+                    while (
+                        not exit_event.wait(timeout=loop_intervals[index])
+                        and remaining_polls
+                    ):
                         self.heartbeat()
-
+                        print(remaining_polls)
                         if self.agent_process(executor, tenant_id):
                             index = 0
                         elif index < max(loop_intervals.keys()):
                             index += 1
+
+                        remaining_polls -= 1
 
                         self.logger.debug(
                             "Next query for flow runs in {} seconds".format(

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -37,6 +37,8 @@ class DockerAgent(Agent):
             Agents when polling for work
         - env_vars (dict, optional): a dictionary of environment variables and values that will be set
             on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
+            defaults to infinite
         - base_url (str, optional): URL for a Docker daemon server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as
             `tcp://0.0.0.0:2375` can be provided
@@ -52,12 +54,15 @@ class DockerAgent(Agent):
         name: str = None,
         labels: Iterable[str] = None,
         env_vars: dict = None,
+        max_polls: int = None,
         base_url: str = None,
         no_pull: bool = None,
         volumes: List[str] = None,
         show_flow_logs: bool = False,
     ) -> None:
-        super().__init__(name=name, labels=labels, env_vars=env_vars)
+        super().__init__(
+            name=name, labels=labels, env_vars=env_vars, max_polls=max_polls
+        )
         if platform == "win32":
             default_url = "npipe:////./pipe/docker_engine"
         else:

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -46,6 +46,8 @@ class FargateAgent(Agent):
             Agents when polling for work
         - env_vars (dict, optional): a dictionary of environment variables and values that will be set
             on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
+            defaults to infinite
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
             `AWS_ACCESS_KEY_ID` or `None`
@@ -77,6 +79,7 @@ class FargateAgent(Agent):
         name: str = None,
         labels: Iterable[str] = None,
         env_vars: dict = None,
+        max_polls: int = None,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: str = None,
@@ -87,7 +90,9 @@ class FargateAgent(Agent):
         external_kwargs_s3_key: str = None,
         **kwargs
     ) -> None:
-        super().__init__(name=name, labels=labels, env_vars=env_vars)
+        super().__init__(
+            name=name, labels=labels, env_vars=env_vars, max_polls=max_polls
+        )
 
         from boto3 import client as boto3_client
         from boto3 import resource as boto3_resource

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -67,7 +67,9 @@ class KubernetesAgent(Agent):
         env_vars: dict = None,
         max_polls: int = None,
     ) -> None:
-        super().__init__(name=name, labels=labels, env_vars=env_vars, max_polls=max_polls)
+        super().__init__(
+            name=name, labels=labels, env_vars=env_vars, max_polls=max_polls
+        )
 
         self.namespace = namespace
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -55,6 +55,8 @@ class KubernetesAgent(Agent):
             Agents when polling for work
         - env_vars (dict, optional): a dictionary of environment variables and values that will be set
             on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
+            defaults to infinite
     """
 
     def __init__(
@@ -63,8 +65,9 @@ class KubernetesAgent(Agent):
         name: str = None,
         labels: Iterable[str] = None,
         env_vars: dict = None,
+        max_polls: int = None,
     ) -> None:
-        super().__init__(name=name, labels=labels, env_vars=env_vars)
+        super().__init__(name=name, labels=labels, env_vars=env_vars, max_polls=max_polls)
 
         self.namespace = namespace
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -36,6 +36,8 @@ class LocalAgent(Agent):
             Agents when polling for work
         - env_vars (dict, optional): a dictionary of environment variables and values that will be set
             on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
+            defaults to infinite
         - import_paths (List[str], optional): system paths which will be provided to each Flow's runtime environment;
             useful for Flows which import from locally hosted scripts or packages
         - show_flow_logs (bool, optional): a boolean specifying whether the agent should re-route Flow run logs

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -53,11 +53,12 @@ class LocalAgent(Agent):
         import_paths: List[str] = None,
         show_flow_logs: bool = False,
         hostname_label: bool = True,
+        max_polls: int = None,
     ) -> None:
         self.processes = []  # type: list
         self.import_paths = import_paths or []
         self.show_flow_logs = show_flow_logs
-        super().__init__(name=name, labels=labels, env_vars=env_vars)
+        super().__init__(name=name, labels=labels, env_vars=env_vars, max_polls=max_polls)
         hostname = socket.gethostname()
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -60,7 +60,9 @@ class LocalAgent(Agent):
         self.processes = []  # type: list
         self.import_paths = import_paths or []
         self.show_flow_logs = show_flow_logs
-        super().__init__(name=name, labels=labels, env_vars=env_vars, max_polls=max_polls)
+        super().__init__(
+            name=name, labels=labels, env_vars=env_vars, max_polls=max_polls
+        )
         hostname = socket.gethostname()
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -214,15 +214,16 @@ def start(
                 name=name,
                 labels=list(label),
                 env_vars=env_vars,
+                max_polls=max_polls,
                 import_paths=list(import_path),
                 show_flow_logs=show_flow_logs,
-                max_polls=max_polls,
             ).start()
         elif agent_option == "docker":
             from_qualified_name(retrieved_agent)(
                 name=name,
                 labels=list(label),
                 env_vars=env_vars,
+                max_polls=max_polls,
                 base_url=base_url,
                 no_pull=no_pull,
                 show_flow_logs=show_flow_logs,
@@ -230,15 +231,23 @@ def start(
             ).start()
         elif agent_option == "fargate":
             from_qualified_name(retrieved_agent)(
-                name=name, labels=list(label), env_vars=env_vars, **kwargs
+                name=name,
+                labels=list(label),
+                env_vars=env_vars,
+                max_polls=max_polls,
+                **kwargs
             ).start()
         elif agent_option == "kubernetes":
             from_qualified_name(retrieved_agent)(
-                namespace=namespace, name=name, labels=list(label), env_vars=env_vars
+                namespace=namespace,
+                name=name,
+                labels=list(label),
+                env_vars=env_vars,
+                max_polls=max_polls,
             ).start()
         else:
             from_qualified_name(retrieved_agent)(
-                name=name, labels=list(label), env_vars=env_vars
+                name=name, labels=list(label), env_vars=env_vars, max_polls=max_polls,
             ).start()
 
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -109,6 +109,9 @@ def agent():
     help="Host paths for Docker bind mount volumes attached to each Flow runtime container.",
     hidden=True,
 )
+@click.option(
+    "--max-polls", required=False, help="MAX POLLS", hidden=True, type=int
+)
 @click.pass_context
 def start(
     ctx,
@@ -125,6 +128,7 @@ def start(
     import_path,
     show_flow_logs,
     volume,
+    max_polls,
 ):
     """
     Start an agent.
@@ -206,6 +210,7 @@ def start(
                 env_vars=env_vars,
                 import_paths=list(import_path),
                 show_flow_logs=show_flow_logs,
+                max_polls=max_polls,
             ).start()
         elif agent_option == "docker":
             from_qualified_name(retrieved_agent)(

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -76,6 +76,13 @@ def agent():
     hidden=True,
 )
 @click.option(
+    "--max-polls",
+    required=False,
+    help="Maximum number of polls for the agent",
+    hidden=True,
+    type=int,
+)
+@click.option(
     "--namespace",
     required=False,
     help="Kubernetes namespace to create jobs.",
@@ -108,9 +115,6 @@ def agent():
     multiple=True,
     help="Host paths for Docker bind mount volumes attached to each Flow runtime container.",
     hidden=True,
-)
-@click.option(
-    "--max-polls", required=False, help="MAX POLLS", hidden=True, type=int
 )
 @click.pass_context
 def start(
@@ -149,6 +153,8 @@ def start(
         --env, -e       TEXT    Environment variables to set on each submitted flow run.
                                 Note that equal signs in environment variable values are not currently supported from the CLI.
                                 Multiple values supported e.g. `-e AUTH=token -e PKG_SETTING=true`
+        --max-polls     INT     Maximum number of times the agent should poll Prefect Cloud for flow runs. Will run forever
+                                if not specified.
         --no-cloud-logs         Turn off logging to Prefect Cloud for all flow runs
                                 Defaults to `False`
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -25,6 +25,7 @@ def test_agent_config_options(runner_token):
         agent = Agent()
         assert agent.labels == []
         assert agent.env_vars == dict()
+        assert agent.max_polls is None
         assert agent.client.get_auth_token() == "TEST_TOKEN"
         assert agent.name == "agent"
         assert agent.logger
@@ -67,6 +68,12 @@ def test_agent_env_vars(runner_token):
     with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
         agent = Agent(env_vars=dict(AUTH_THING="foo"))
         assert agent.env_vars == dict(AUTH_THING="foo")
+
+
+def test_agent_max_polls(runner_token):
+    with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
+        agent = Agent(max_polls=10)
+        assert agent.max_polls == 10
 
 
 def test_agent_labels(runner_token):
@@ -444,3 +451,67 @@ def test_agent_process_raises_exception_and_logs(monkeypatch, runner_token):
     with pytest.raises(Exception):
         agent.agent_process(executor, "id")
         assert client.write_run_log.called
+
+
+def test_agent_start_max_polls(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.heartbeat", heartbeat)
+
+    agent = Agent(max_polls=1)
+    agent.start()
+
+    assert on_shutdown.called
+    assert agent_process.called
+    assert agent_process.call_args[0][1] == "id"
+    assert heartbeat.called
+
+
+def test_agent_start_max_polls_count(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.heartbeat", heartbeat)
+
+    agent = Agent(max_polls=2)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 2
+    assert heartbeat.call_count == 2
+
+
+def test_agent_start_max_polls_zero(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.heartbeat", heartbeat)
+
+    agent = Agent(max_polls=0)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 0
+    assert heartbeat.call_count == 0

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -728,3 +728,90 @@ def test_docker_agent_parse_volume_spec_raises_on_invalid_spec(
 
     with pytest.raises(exception_type):
         agent._parse_volume_spec([candidate])
+
+
+def test_docker_agent_start_max_polls(monkeypatch, runner_token):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.docker.agent.DockerAgent.heartbeat", heartbeat)
+
+    agent = DockerAgent(max_polls=1)
+    agent.start()
+
+    assert agent_process.called
+    assert agent_process.call_args[0][1] == "id"
+    assert heartbeat.called
+
+
+def test_docker_agent_start_max_polls_count(monkeypatch, runner_token):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.docker.agent.DockerAgent.heartbeat", heartbeat)
+
+    agent = DockerAgent(max_polls=2)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 2
+    assert heartbeat.call_count == 2
+
+
+def test_docker_agent_start_max_polls_zero(monkeypatch, runner_token):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=api),
+    )
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.docker.agent.DockerAgent.heartbeat", heartbeat)
+
+    agent = DockerAgent(max_polls=0)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 0
+    assert heartbeat.call_count == 0

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -1409,3 +1409,81 @@ def test_deploy_flows_disable_task_revisions_with_external_kwargs(
         tags=[{"key": "test", "value": "test"}],
     )
     assert boto3_client.run_task.called_with(taskDefinition="prefect-task-new_id")
+
+
+def test_fargate_agent_start_max_polls(monkeypatch, runner_token):
+    boto3_client = MagicMock()
+    monkeypatch.setattr("boto3.client", boto3_client)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.fargate.agent.FargateAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.fargate.agent.FargateAgent.heartbeat", heartbeat)
+
+    agent = FargateAgent(max_polls=1)
+    agent.start()
+
+    assert agent_process.called
+    assert agent_process.call_args[0][1] == "id"
+    assert heartbeat.called
+
+
+def test_fargate_agent_start_max_polls_count(monkeypatch, runner_token):
+    boto3_client = MagicMock()
+    monkeypatch.setattr("boto3.client", boto3_client)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.fargate.agent.FargateAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.fargate.agent.FargateAgent.heartbeat", heartbeat)
+
+    agent = FargateAgent(max_polls=2)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 2
+    assert heartbeat.call_count == 2
+
+
+def test_fargate_agent_start_max_polls_zero(monkeypatch, runner_token):
+    boto3_client = MagicMock()
+    monkeypatch.setattr("boto3.client", boto3_client)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.fargate.agent.FargateAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.fargate.agent.FargateAgent.heartbeat", heartbeat)
+
+    agent = FargateAgent(max_polls=0)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 0
+    assert heartbeat.call_count == 0

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -575,3 +575,87 @@ def test_k8s_agent_heartbeat_check(monkeypatch, runner_token):
 
         agent.heartbeat()
         assert not check_heartbeat()
+
+
+def test_k8s_agent_start_max_polls(monkeypatch, runner_token):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.heartbeat", heartbeat
+    )
+
+    agent = KubernetesAgent(max_polls=1)
+    agent.start()
+
+    assert agent_process.called
+    assert agent_process.call_args[0][1] == "id"
+    assert heartbeat.called
+
+
+def test_k8s_gent_start_max_polls_count(monkeypatch, runner_token):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.heartbeat", heartbeat
+    )
+
+    agent = KubernetesAgent(max_polls=2)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 2
+    assert heartbeat.call_count == 2
+
+
+def test_k8s_agent_start_max_polls_zero(monkeypatch, runner_token):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    on_shutdown = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.on_shutdown", on_shutdown
+    )
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.heartbeat", heartbeat
+    )
+
+    agent = KubernetesAgent(max_polls=0)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 0
+    assert heartbeat.call_count == 0

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -422,3 +422,66 @@ def test_local_agent_heartbeat(
     # the heartbeat should stop tracking upon exit
     compare(process.returncode, returncode)
     assert len(agent.processes) == 0
+
+
+def test_local_agent_start_max_polls(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.heartbeat", heartbeat)
+
+    agent = LocalAgent(max_polls=1)
+    agent.start()
+
+    assert agent_process.called
+    assert agent_process.call_args[0][1] == "id"
+    assert heartbeat.called
+
+
+def test_local_gent_start_max_polls_count(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.heartbeat", heartbeat)
+
+    agent = LocalAgent(max_polls=2)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 2
+    assert heartbeat.call_count == 2
+
+
+def test_local_agent_start_max_polls_zero(monkeypatch, runner_token):
+    on_shutdown = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.on_shutdown", on_shutdown)
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.LocalAgent.heartbeat", heartbeat)
+
+    agent = LocalAgent(max_polls=0)
+    agent.start()
+
+    assert on_shutdown.call_count == 1
+    assert agent_process.call_count == 0
+    assert heartbeat.call_count == 0

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -174,7 +174,12 @@ def test_agent_start_fargate_kwargs_received(monkeypatch, runner_token):
 
     assert fargate_agent.called
     fargate_agent.assert_called_with(
-        labels=[], env_vars=dict(), name=None, taskRoleArn="arn", volumes="vol"
+        labels=[],
+        env_vars=dict(),
+        max_polls=None,
+        name=None,
+        taskRoleArn="arn",
+        volumes="vol",
     )
 
 
@@ -191,6 +196,27 @@ def test_agent_start_with_env_vars(monkeypatch, runner_token):
     docker_agent.assert_called_with(
         base_url=None,
         env_vars={"KEY": "VAL", "SETTING": "false"},
+        max_polls=None,
+        labels=[],
+        name=None,
+        no_pull=False,
+        show_flow_logs=False,
+        volumes=[],
+    )
+
+
+def test_agent_start_with_max_polls(monkeypatch, runner_token):
+    docker_agent = MagicMock()
+    monkeypatch.setattr("prefect.agent.docker.DockerAgent", docker_agent)
+
+    runner = CliRunner()
+    result = runner.invoke(agent, ["start", "docker", "--max-polls", "5"])
+    assert result.exit_code == 0
+
+    docker_agent.assert_called_with(
+        base_url=None,
+        env_vars={},
+        max_polls=5,
         labels=[],
         name=None,
         no_pull=False,
@@ -211,6 +237,21 @@ def test_agent_start_name(monkeypatch, runner_token):
 
     runner = CliRunner()
     result = runner.invoke(agent, ["start", "docker", "--name", "test_agent"])
+    assert result.exit_code == 0
+
+
+def test_agent_start_max_polls(monkeypatch, runner_token):
+    start = MagicMock()
+    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
+
+    docker_client = MagicMock()
+    monkeypatch.setattr(
+        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
+        MagicMock(return_value=docker_client),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(agent, ["start", "docker", "--max-polls", "1"])
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2037 
Adds a `--max-polls` flag to the `prefect agent start` CLI command and a `max_polls` kwarg to all agents. This option allows users to specify the amount of times they want the agent to poll Cloud looking for flow runs. This is great for one-off and testing scenarios because the agents no longer exist as infinitely running loops.


## Why is this PR important?
Opens the door for short-lived agents that is beneficial for areas such as testing and serverless platforms.

