### PR TITLE
Fix issue with None values in heartbeat subprocess environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix issue with heartbeat failing if any Cloud config var is not present - [#2190](https://github.com/PrefectHQ/prefect/issues/2190)
 
 ### Deprecations
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -48,9 +48,10 @@ def run_with_heartbeat(
                     api_url = prefect.context.config.cloud.get("api")
                     current_env.setdefault("PREFECT__CLOUD__AUTH_TOKEN", auth_token)
                     current_env.setdefault("PREFECT__CLOUD__API", api_url)
+                    clean_env = {k: v for k, v in current_env.items() if v is not None}
                     p = subprocess.Popen(
                         self.heartbeat_cmd,
-                        env=current_env,
+                        env=clean_env,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -13,7 +13,6 @@ import prefect
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.executors import (
     timeout_handler,
-    run_with_heartbeat,
     tail_recursive,
     RecursiveCall,
 )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes a new issue that crops up in local development situations wherein certain Cloud environment / configuration variables are not present causing the background heartbeat process to fail to start.


## Why is this PR important?
Local dev is important.

