### PR TITLE
Query for state on flow run logs query for run CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix issue with heartbeat failing if any Cloud config var is not present - [#2190](https://github.com/PrefectHQ/prefect/issues/2190)
+- Fix issue where `run cloud` CLI command would pull final state before last batch of logs - [#2192](https://github.com/PrefectHQ/prefect/pull/2192)
 
 ### Deprecations
 

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -207,6 +207,7 @@ def cloud(
                 "logs", {"order_by": {EnumValue("timestamp"): EnumValue("asc")}}
             ): {"timestamp": True, "message": True, "level": True},
             "start_time": True,
+            "state": True,
         }
 
         query = {
@@ -257,18 +258,7 @@ def cloud(
                     tabulate(output, tablefmt="plain", numalign="left", stralign="left")
                 )
 
-            # Check if state is either Success or Failed, exit if it is
-            pk_query = {
-                "query": {
-                    with_args("flow_run_by_pk", {"id": flow_run_id}): {"state": True}
-                }
-            }
-            result = client.graphql(pk_query)
-
-            if (
-                result.data.flow_run_by_pk.state == "Success"
-                or result.data.flow_run_by_pk.state == "Failed"
-            ):
+            if new_run.state == "Success" or new_run.state == "Failed":
                 return
 
             time.sleep(3)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -135,10 +135,10 @@ def test_run_cloud_logs(monkeypatch):
                                         "message": "test_message",
                                         "level": "test_level",
                                     }
-                                ]
+                                ],
+                                "state": "Success",
                             }
                         ],
-                        flow_run_by_pk=dict(state="Success"),
                     )
                 )
             )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
By querying for a flow run state in the `run cloud --logs` option after the initial log query it allowed for a potential condition where the state was retrieved before all of the batch logs had arrived.


## Why is this PR important?
So possible tracebacks aren't missing in failed runs

cc @bnaul 

