### PR TITLE
Use server UI endpoint when backend is server

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -650,10 +650,12 @@ class Client:
             else re.sub("api", "cloud", prefect.config.cloud.api)
         )
 
+        full_url = prefect.config.cloud.api
         if tenant_slug:
             full_url = "/".join([base_url.rstrip("/"), tenant_slug, subdirectory, id])
         elif prefect.config.backend == "server":
             full_url = "/".join([prefect.config.server.ui.endpoint, subdirectory, id,])
+
         return full_url
 
     def get_default_tenant_slug(self, as_user: bool = True) -> str:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -653,13 +653,7 @@ class Client:
         if tenant_slug:
             full_url = "/".join([base_url.rstrip("/"), tenant_slug, subdirectory, id])
         elif prefect.config.backend == "server":
-            full_url = "/".join(
-                [
-                    prefect.config.server.ui.endpoint,
-                    subdirectory,
-                    id,
-                ]
-            )
+            full_url = "/".join([prefect.config.server.ui.endpoint, subdirectory, id,])
         return full_url
 
     def get_default_tenant_slug(self, as_user: bool = True) -> str:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -652,8 +652,14 @@ class Client:
 
         if tenant_slug:
             full_url = "/".join([base_url.rstrip("/"), tenant_slug, subdirectory, id])
-        else:
-            full_url = "/".join([base_url.rstrip("/"), subdirectory, id])
+        elif prefect.config.backend == "server":
+            full_url = "/".join(
+                [
+                    prefect.config.server.ui.endpoint,
+                    subdirectory,
+                    id,
+                ]
+            )
         return full_url
 
     def get_default_tenant_slug(self, as_user: bool = True) -> str:

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -12,7 +12,9 @@ port = "4200"
 endpoint = "${server.host}:${server.port}"
 
     [server.ui]
+    host = "http://localhost"
     port = "8080"
+    endpoint = "${server.ui.host}:${server.ui.port}"
 
 [cloud]
 api = "${${backend}.endpoint}"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -47,7 +47,7 @@ def test_run_cloud(monkeypatch):
     )
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -98,7 +98,7 @@ def test_run_cloud_watch(monkeypatch):
     )
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -156,7 +156,7 @@ def test_run_cloud_logs(monkeypatch):
     )
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -188,7 +188,7 @@ def test_run_cloud_fails(monkeypatch):
     monkeypatch.setattr("requests.Session", session)
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -200,7 +200,7 @@ def test_run_cloud_fails(monkeypatch):
 
 def test_run_cloud_no_param_file(monkeypatch):
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -250,7 +250,7 @@ def test_run_cloud_param_file(monkeypatch):
             json.dump({"test": 42}, tmp)
 
         with set_temporary_config(
-            {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+            {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
         ):
             runner = CliRunner()
             result = runner.invoke(
@@ -290,7 +290,7 @@ def test_run_cloud_param_string(monkeypatch):
     )
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -330,7 +330,7 @@ def test_run_cloud_run_name(monkeypatch):
     )
 
     with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+        {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -375,7 +375,7 @@ def test_run_cloud_param_string_overwrites(monkeypatch):
             json.dump({"test": 42}, tmp)
 
         with set_temporary_config(
-            {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+            {"cloud.api": "http://api.prefect.io", "cloud.auth_token": "secret_token"}
         ):
             runner = CliRunner()
             result = runner.invoke(
@@ -403,7 +403,7 @@ def test_run_cloud_param_string_overwrites(monkeypatch):
 @pytest.mark.parametrize(
     "api,expected",
     [
-        ("https://api.foo", "https://cloud.foo/flow-run/id"),
+        ("https://api.prefect.io", "https://cloud.prefect.io/tslug/flow-run/id"),
         ("https://api-foo.prefect.io", "https://foo.prefect.io/tslug/flow-run/id"),
     ],
 )


### PR DESCRIPTION
This will output the proper UI link when registering and running flows.


Register:
```
Flow: http://localhost:8080/flow/a262196f-8bd3-4183-bfe9-4e6cb83f04d8
```

Run:
```
Flow Run: http://localhost:8080/flow-run/fdffb511-17dc-499d-b3f6-bda59a77ee49
```