### PR TITLE
Fix retrieval of unset S3ResultHandler attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix issue with heartbeat failing if any Cloud config var is not present - [#2190](https://github.com/PrefectHQ/prefect/issues/2190)
 - Fix issue where `run cloud` CLI command would pull final state before last batch of logs - [#2192](https://github.com/PrefectHQ/prefect/pull/2192)
+- Fix issue where the `S3ResultHandler` would attempt to access uninitialized attribute - [#2204](https://github.com/PrefectHQ/prefect/issues/2204)
 
 ### Deprecations
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -36,6 +36,7 @@ class S3ResultHandler(ResultHandler):
     def __init__(self, bucket: str, aws_credentials_secret: str = None) -> None:
         self.bucket = bucket
         self.aws_credentials_secret = aws_credentials_secret
+        self._client = None
         super().__init__()
 
     def initialize_client(self) -> None:
@@ -71,9 +72,10 @@ class S3ResultHandler(ResultHandler):
         Initializes a client if we believe we are in a new thread.
         We consider ourselves in a new thread if we haven't stored a client yet in the current context.
         """
-        if not prefect.context.get("boto3client"):
+        if not prefect.context.get("boto3client") or not self._client:
             self.initialize_client()
             prefect.context["boto3client"] = self._client
+
         return self._client
 
     @client.setter

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -243,6 +243,19 @@ class TestS3ResultHandler:
             res = cloudpickle.loads(cloudpickle.dumps(handler))
             assert isinstance(res, S3ResultHandler)
 
+    def test_s3_uninitialized_client(self, session):
+        handler = S3ResultHandler(
+            bucket="bob", aws_credentials_secret="AWS_CREDENTIALS"
+        )
+        assert handler.bucket == "bob"
+
+        with prefect.context(
+            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
+            boto3client="test",
+        ):
+            with set_temporary_config({"cloud.use_local_secrets": True}):
+                assert handler.client is not None
+
 
 @pytest.mark.xfail(raises=ImportError, reason="azure extras not installed.")
 class TestAzureResultHandler:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2204 

There was a possibility where a thread contained a `boto3client` in context however did not have the `_client` attribute set. This updates the `client` property to check if `_client` is set before returning.

## Why is this PR important?
Fix the potential failures that could arise from using the `S3ResultHandler`.

