### PR TITLE
add capability to build server from source

### DIFF
--- a/server/Changelog.md
+++ b/server/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
-- None
+- new cli command--`prefect-server dev build` will build prefect server images from source locally - [#2227](https://github.com/PrefectHQ/prefect/pull/2227)
 
 ### Infrastructure
 

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - postgres
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
+    build:
+      context: '..'
     ports:
       - "4201:4201"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
@@ -49,6 +51,8 @@ services:
       - hasura
   scheduler:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
+    build:
+      context: '..'
     command: "python src/prefect_server/services/scheduler/scheduler.py"
     environment:
       PREFECT_SERVER__HASURA__ADMIN_SECRET: ${PREFECT_SERVER__HASURA__ADMIN_SECRET:-hasura-secret-admin-secret}
@@ -60,6 +64,8 @@ services:
       - graphql
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
+    build:
+      context: '../services/apollo'
     ports:
       - "4200:4200"
     command: "npm run serve"
@@ -74,6 +80,8 @@ services:
       - graphql
   ui:
     image: "prefecthq/ui:${PREFECT_SERVER_TAG:-latest}"
+    build:
+      context: '../services/ui'
     ports:
       - "8080:8080"
     command: "/intercept.sh"

--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -27,6 +27,14 @@ from prefect_server.database import models
 def dev():
     """
     Commands for developing Server
+
+    \b
+    Usage:
+        $ prefect-server ...
+    
+    \b
+    Arguments:
+        build   builds prefect server, ui, apollo from source
     """
 
 
@@ -66,10 +74,33 @@ def make_env(fname=None):
     return ENV.copy()
 
 
-@dev.command()
+@dev.command(hidden=True)
 @click.option(
-    "--tag", "-t", help="The server image/tag to use", default="latest",
+    "--version",
+    "-v",
+    help="The server image versions to build (for example, '0.10.0' or 'master')",
+    # TODO: update this default to use prefect.__version__ logic
+    default="latest",
 )
+def build(version):
+    """
+    foobar
+    """
+    docker_dir = Path(prefect_server.__file__).parents[2] / "docker"
+    print(docker_dir)
+
+    env = make_env()
+
+    if "PREFECT_SERVER_TAG" not in env:
+        env.update(PREFECT_SERVER_TAG=version)
+
+    proc = None
+    cmd = ["docker-compose", "build"]
+    proc = subprocess.Popen(cmd, cwd=docker_dir, env=env)
+
+
+@dev.command()
+@click.option("--tag", "-t", help="The server image/tag to use", default="latest")
 @click.option(
     "--skip-pull",
     help="Pass this flag to skip pulling new images (if available)",

--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -87,7 +87,6 @@ def build(version):
     foobar
     """
     docker_dir = Path(prefect_server.__file__).parents[2] / "docker"
-    print(docker_dir)
 
     env = make_env()
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
cli option for building (and using) local images from source using docker-compose
prefect-server dev build

## Why is this PR important?
enables local work on prefect-server using docker-compose
`prefect-server dev build [--version foo]`
`prefect-server dev up --no-pull [--version foo]`

