### PR TITLE
Update `prefect server start` command to specify and disable port mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Add flags to `prefect server start` for disabling service port mapping - [#2228](https://github.com/PrefectHQ/prefect/pull/2228)
+- Add options to `prefect server start` for mapping to host ports - [#2228](https://github.com/PrefectHQ/prefect/pull/2228)
 
 ### Task Library
 

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: "postgres:11"
     ports:
-      - "5432:5432"
+      - "5432:${POSTGRES_HOST_PORT}"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +20,7 @@ services:
   hasura:
     image: "hasura/graphql-engine:v1.1.0"
     ports:
-      - "3000:3000"
+      - "3000:${HASURA_HOST_PORT}"
     command: "graphql-engine serve"
     environment:
       HASURA_GRAPHQL_DATABASE_URL: ${DB_CONNECTION_URL}
@@ -35,7 +35,7 @@ services:
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4201:4201"
+      - "4201:${GRAPHQL_HOST_PORT}"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
     environment:
       PREFECT_SERVER_DB_CMD: ${PREFECT_SERVER_DB_CMD:-"echo 'DATABASE MIGRATIONS SKIPPED'"}
@@ -61,7 +61,7 @@ services:
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4200:4200"
+      - "4200:${APOLLO_HOST_PORT}"
     command: "npm run serve"
     environment:
       HASURA_API_URL: ${HASURA_API_URL:-http://hasura:3000/v1alpha1/graphql}
@@ -75,7 +75,7 @@ services:
   ui:
     image: "prefecthq/ui:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "8080:8080"
+      - "8080:${UI_HOST_PORT}"
     command: "/intercept.sh"
     networks:
       - prefect-server

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: "postgres:11"
     ports:
-      - "5432:${POSTGRES_HOST_PORT:-5432}"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +20,7 @@ services:
   hasura:
     image: "hasura/graphql-engine:v1.1.0"
     ports:
-      - "3000:${HASURA_HOST_PORT:-3000}"
+      - "${HASURA_HOST_PORT:-3000}:3000"
     command: "graphql-engine serve"
     environment:
       HASURA_GRAPHQL_DATABASE_URL: ${DB_CONNECTION_URL}
@@ -35,7 +35,7 @@ services:
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4201:${GRAPHQL_HOST_PORT:-4201}"
+      - "${GRAPHQL_HOST_PORT:-4201}:4201"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
     environment:
       PREFECT_SERVER_DB_CMD: ${PREFECT_SERVER_DB_CMD:-"echo 'DATABASE MIGRATIONS SKIPPED'"}
@@ -61,7 +61,7 @@ services:
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4200:${APOLLO_HOST_PORT:-4200}"
+      - "${APOLLO_HOST_PORT:-4200}:4200"
     command: "npm run serve"
     environment:
       HASURA_API_URL: ${HASURA_API_URL:-http://hasura:3000/v1alpha1/graphql}
@@ -75,7 +75,7 @@ services:
   ui:
     image: "prefecthq/ui:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "8080:${UI_HOST_PORT:-8080}"
+      - "${UI_HOST_PORT:-8080}:8080"
     command: "/intercept.sh"
     networks:
       - prefect-server

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: "postgres:11"
     ports:
-      - "5432:${POSTGRES_HOST_PORT}"
+      - "5432:${POSTGRES_HOST_PORT:-5432}"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -20,7 +20,7 @@ services:
   hasura:
     image: "hasura/graphql-engine:v1.1.0"
     ports:
-      - "3000:${HASURA_HOST_PORT}"
+      - "3000:${HASURA_HOST_PORT:-3000}"
     command: "graphql-engine serve"
     environment:
       HASURA_GRAPHQL_DATABASE_URL: ${DB_CONNECTION_URL}
@@ -35,7 +35,7 @@ services:
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4201:${GRAPHQL_HOST_PORT}"
+      - "4201:${GRAPHQL_HOST_PORT:-4201}"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
     environment:
       PREFECT_SERVER_DB_CMD: ${PREFECT_SERVER_DB_CMD:-"echo 'DATABASE MIGRATIONS SKIPPED'"}
@@ -61,7 +61,7 @@ services:
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "4200:${APOLLO_HOST_PORT}"
+      - "4200:${APOLLO_HOST_PORT:-4200}"
     command: "npm run serve"
     environment:
       HASURA_API_URL: ${HASURA_API_URL:-http://hasura:3000/v1alpha1/graphql}
@@ -75,7 +75,7 @@ services:
   ui:
     image: "prefecthq/ui:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "8080:${UI_HOST_PORT}"
+      - "8080:${UI_HOST_PORT:-8080}"
     command: "/intercept.sh"
     networks:
       - prefect-server

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -261,7 +261,7 @@ def start(
             "server.hasura.host_port": hasura_port,
             "server.graphql.host_port": graphql_port,
             "server.ui.host_port": ui_port,
-            "server.port": server_port,
+            "server.host_port": server_port,
         }
     ):
         env = make_env()

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -154,7 +154,7 @@ def start(
             "server.hasura.host_port": hasura_port,
             "server.graphql.host_port": graphql_port,
             "server.ui.host_port": ui_port,
-            "server.host_port": server_port,
+            "server.port": server_port,
         }
     ):
         env = make_env()

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -90,67 +90,89 @@ def server():
     help="The server image versions to use (for example, '0.10.0' or 'master')",
     # TODO: update this default to use prefect.__version__ logic
     default="latest",
+    hidden=True,
 )
 @click.option(
     "--skip-pull",
     help="Pass this flag to skip pulling new images (if available)",
     is_flag=True,
+    hidden=True,
 )
 @click.option(
     "--no-upgrade",
     "-n",
     help="Pass this flag to avoid running a database upgrade when the database spins up",
     is_flag=True,
+    hidden=True,
 )
 @click.option(
-    "--no-ui", "-u", help="Pass this flag to avoid starting the UI", is_flag=True,
+    "--no-ui",
+    "-u",
+    help="Pass this flag to avoid starting the UI",
+    is_flag=True,
+    hidden=True,
 )
 @click.option(
     "--postgres-port",
     help="The port used to serve Postgres",
     default=config.server.database.host_port,
     type=str,
+    hidden=True,
 )
 @click.option(
     "--hasura-port",
     help="The port used to serve Hasura",
     default=config.server.hasura.host_port,
     type=str,
+    hidden=True,
 )
 @click.option(
     "--graphql-port",
     help="The port used to serve the GraphQL API",
     default=config.server.graphql.host_port,
     type=str,
+    hidden=True,
 )
 @click.option(
     "--ui-port",
     help="The port used to serve the UI",
     default=config.server.ui.host_port,
     type=str,
+    hidden=True,
 )
 @click.option(
     "--server-port",
     help="The port used to serve the Core server",
     default=config.server.host_port,
     type=str,
+    hidden=True,
 )
 @click.option(
-    "--no-postgres-port", help="Disable port map of Postgres to host", is_flag=True,
+    "--no-postgres-port",
+    help="Disable port map of Postgres to host",
+    is_flag=True,
+    hidden=True,
 )
 @click.option(
-    "--no-hasura-port", help="Disable port map of Hasura to host", is_flag=True,
+    "--no-hasura-port",
+    help="Disable port map of Hasura to host",
+    is_flag=True,
+    hidden=True,
 )
 @click.option(
-    "--no-graphql-port", help="Disable port map of GraphqlAPI to host", is_flag=True,
+    "--no-graphql-port",
+    help="Disable port map of the GraphqlAPI to host",
+    is_flag=True,
+    hidden=True,
 )
 @click.option(
-    "--no-ui-port", help="Disable port map of UI to host", is_flag=True,
+    "--no-ui-port", help="Disable port map of the UI to host", is_flag=True, hidden=True
 )
 @click.option(
     "--no-server-port",
     help="Disable port map of the Core server to host",
     is_flag=True,
+    hidden=True,
 )
 def start(
     version,
@@ -169,8 +191,31 @@ def start(
     no_server_port,
 ):
     """
-    This command spins up all infrastructure and services for Prefect Server
+    This command spins up all infrastructure and services for the Prefect Core server
+
+    \b
+    Options:
+        --version, -v   TEXT    The server image versions to use (for example, '0.10.0' or 'master')
+                                Defaults to 'latest'
+        --skip-pull             Flag to skip pulling new images (if available)
+        --no-upgrade, -n        Flag to avoid running a database upgrade when the database spins up
+        --no-ui, -u             Flag to avoid starting the UI
+
+    \b
+        --postgres-port TEXT    Port used to serve Postgres, defaults to '5432'
+        --hasura-port   TEXT    Port used to serve Hasura, defaults to '3001'
+        --graphql-port  TEXT    Port used to serve the GraphQL API, defaults to '4001'
+        --ui-port       TEXT    Port used to serve the UI, defaults to '8080'
+        --server-port   TEXT    Port used to serve the Core server, defaults to '4200'
+
+    \b
+        --no-postgres-port      Disable port map of Postgres to host
+        --no-hasura-port        Disable port map of Hasura to host
+        --no-graphql-port       Disable port map of the GraphQL API to host
+        --no-ui-port            Disable port map of the UI to host
+        --no-server-port        Disable port map of the Core server to host
     """
+
     docker_dir = Path(__file__).parents[0]
     compose_dir_path = docker_dir
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -16,7 +16,7 @@ def make_env(fname=None):
             "localhost", "postgres"
         ),
         GRAPHQL_HOST_PORT=config.server.graphql.host_port,
-        UI_HOST_PORT=config.server.ui.port,
+        UI_HOST_PORT=config.server.ui.host_port,
     )
 
     APOLLO_ENV = dict(
@@ -32,7 +32,7 @@ def make_env(fname=None):
         PREFECT_API_HEALTH_URL="http://graphql:{port}/health".format(
             port=config.server.graphql.port
         ),
-        APOLLO_HOST_PORT=config.server.port,
+        APOLLO_HOST_PORT=config.server.host_port,
     )
 
     POSTGRES_ENV = dict(
@@ -122,13 +122,13 @@ def server():
 @click.option(
     "--ui-port",
     help="The port used to serve the UI",
-    default=config.server.ui.port,
+    default=config.server.ui.host_port,
     type=str,
 )
 @click.option(
     "--server-port",
     help="The port used to serve the Core server",
-    default=config.server.port,
+    default=config.server.host_port,
     type=str,
 )
 def start(
@@ -153,8 +153,8 @@ def start(
             "server.database.host_port": postgres_port,
             "server.hasura.host_port": hasura_port,
             "server.graphql.host_port": graphql_port,
-            "server.ui.port": ui_port,
-            "server.port": server_port,
+            "server.ui.host_port": ui_port,
+            "server.host_port": server_port,
         }
     ):
         env = make_env()

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -66,7 +66,7 @@ def make_env(fname=None):
 @click.group(hidden=True)
 def server():
     """
-    Commands for interacting with the Prefect Server
+    Commands for interacting with the Prefect Core server
 
     \b
     Usage:

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -12,9 +12,9 @@ port = "4200"
 endpoint = "${server.host}:${server.port}"
 
     [server.database]
-
     host = "localhost"
-    port = 5432
+    port = "5432"
+    host_port = "5432"
     name = "prefect_server"
     username = "prefect"
     # set to "" to generate a random password each time the database starts
@@ -23,14 +23,15 @@ endpoint = "${server.host}:${server.port}"
 
     [server.graphql]
     host = "0.0.0.0"
-    port = 4201
+    port = "4201"
+    host_port = "4201"
     debug = false
     path = "/graphql/"
 
     [server.hasura]
-
     host = "localhost"
-    port = 3000
+    port = "3000"
+    host_port = "3000"
     admin_secret = "" # a string. One will be automatically generated if not provided.
     claims_namespace = "hasura-claims"
     graphql_url = "http://${server.hasura.host}:${server.hasura.port}/v1alpha1/graphql"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -9,6 +9,7 @@ backend = "cloud"
 [server]
 host = "http://localhost"
 port = "4200"
+host_port = "4200"
 endpoint = "${server.host}:${server.port}"
 
     [server.database]
@@ -41,6 +42,7 @@ endpoint = "${server.host}:${server.port}"
     [server.ui]
     host = "http://localhost"
     port = "8080"
+    host_port = "8080"
     endpoint = "${server.ui.host}:${server.ui.port}"
 
 [cloud]

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from prefect.cli.server import server, make_env
+from prefect.utilities.configuration import set_temporary_config
+
+
+def test_server_init():
+    runner = CliRunner()
+    result = runner.invoke(server)
+    assert result.exit_code == 0
+    assert "Commands for interacting with the Prefect Core server" in result.output
+
+
+def test_server_help():
+    runner = CliRunner()
+    result = runner.invoke(server, ["--help"])
+    assert result.exit_code == 0
+    assert "Commands for interacting with the Prefect Core server" in result.output
+
+
+def test_make_env():
+    env = make_env()
+    assert env
+
+
+def test_make_env_config_vars():
+    with set_temporary_config(
+        {
+            "config.server.database.connection_url": "connect",
+            "config.server.graphql.host_port": "1",
+            "config.server.ui.host_port": "2",
+            "config.server.hasura.port": "3",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+            "config.server.graphql.host_port": "1",
+        }
+    ):
+        pass

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
@@ -28,20 +29,174 @@ def test_make_env():
 def test_make_env_config_vars():
     with set_temporary_config(
         {
-            "config.server.database.connection_url": "connect",
-            "config.server.graphql.host_port": "1",
-            "config.server.ui.host_port": "2",
-            "config.server.hasura.port": "3",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
-            "config.server.graphql.host_port": "1",
+            "server.database.connection_url": "localhost",
+            "server.graphql.host_port": "1",
+            "server.ui.host_port": "2",
+            "server.hasura.port": "3",
+            "server.graphql.port": "4",
+            "server.graphql.path": "/path",
+            "server.host_port": "5",
+            "server.database.host_port": "6",
+            "server.database.username": "username",
+            "server.database.password": "password",
+            "server.database.name": "db",
+            "server.hasura.host_port": "7",
         }
     ):
-        pass
+        env = make_env()
+
+        assert env["DB_CONNECTION_URL"] == "postgres"
+        assert env["GRAPHQL_HOST_PORT"] == "1"
+        assert env["UI_HOST_PORT"] == "2"
+        assert env["HASURA_API_URL"] == "http://hasura:3/v1alpha1/graphql"
+        assert env["HASURA_WS_URL"] == "ws://hasura:3/v1alpha1/graphql"
+        assert env["PREFECT_API_URL"] == "http://graphql:4/path"
+        assert env["PREFECT_API_HEALTH_URL"] == "http://graphql:4/health"
+        assert env["APOLLO_HOST_PORT"] == "5"
+        assert env["POSTGRES_HOST_PORT"] == "6"
+        assert env["POSTGRES_USER"] == "username"
+        assert env["POSTGRES_PASSWORD"] == "password"
+        assert env["POSTGRES_DB"] == "db"
+        assert env["HASURA_HOST_PORT"] == "7"
+
+
+def test_server_start(monkeypatch):
+    check_call = MagicMock()
+    popen = MagicMock(side_effect=KeyboardInterrupt())
+    check_output = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen)
+    monkeypatch.setattr("subprocess.check_call", check_call)
+    monkeypatch.setattr("subprocess.check_output", check_output)
+
+    runner = CliRunner()
+    result = runner.invoke(server, ["start"])
+    assert result.exit_code == 1
+
+    assert check_call.called
+    assert popen.called
+    assert check_output.called
+
+    assert check_call.call_args[0][0] == ["docker-compose", "pull"]
+    assert check_call.call_args[1].get("cwd")
+    assert check_call.call_args[1].get("env")
+
+    assert popen.call_args[0][0] == ["docker-compose", "up"]
+    assert popen.call_args[1].get("cwd")
+    assert popen.call_args[1].get("env")
+
+    assert check_output.call_args[0][0] == ["docker-compose", "down"]
+    assert check_output.call_args[1].get("cwd")
+    assert check_output.call_args[1].get("env")
+
+
+def test_server_start_options_and_flags(monkeypatch):
+    check_call = MagicMock()
+    popen = MagicMock(side_effect=KeyboardInterrupt())
+    check_output = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen)
+    monkeypatch.setattr("subprocess.check_call", check_call)
+    monkeypatch.setattr("subprocess.check_output", check_output)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        server,
+        ["start", "--version", "version", "--skip-pull", "--no-upgrade", "--no-ui"],
+    )
+    assert result.exit_code == 1
+
+    assert not check_call.called
+    assert popen.called
+    assert check_output.called
+
+    assert popen.call_args[0][0] == ["docker-compose", "up", "--scale", "ui=0"]
+    assert popen.call_args[1].get("cwd")
+    assert popen.call_args[1].get("env")
+    assert popen.call_args[1]["env"].get("PREFECT_SERVER_TAG") == "version"
+    assert (
+        popen.call_args[1]["env"].get("PREFECT_SERVER_DB_CMD")
+        == "echo 'DATABASE MIGRATIONS SKIPPED'"
+    )
+
+    assert check_output.call_args[0][0] == ["docker-compose", "down"]
+    assert check_output.call_args[1].get("cwd")
+    assert check_output.call_args[1].get("env")
+
+
+def test_server_start_port_options(monkeypatch):
+    check_call = MagicMock()
+    popen = MagicMock(side_effect=KeyboardInterrupt())
+    check_output = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen)
+    monkeypatch.setattr("subprocess.check_call", check_call)
+    monkeypatch.setattr("subprocess.check_output", check_output)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        server,
+        [
+            "start",
+            "--postgres-port",
+            "1",
+            "--hasura-port",
+            "2",
+            "--graphql-port",
+            "3",
+            "--ui-port",
+            "4",
+            "--server-port",
+            "5",
+        ],
+    )
+    assert result.exit_code == 1
+
+    assert check_call.called
+    assert popen.called
+    assert check_output.called
+
+    assert popen.call_args[0][0] == ["docker-compose", "up"]
+    assert popen.call_args[1].get("cwd")
+    assert popen.call_args[1].get("env")
+    assert popen.call_args[1]["env"].get("POSTGRES_HOST_PORT") == "1"
+    assert popen.call_args[1]["env"].get("HASURA_HOST_PORT") == "2"
+    assert popen.call_args[1]["env"].get("GRAPHQL_HOST_PORT") == "3"
+    assert popen.call_args[1]["env"].get("UI_HOST_PORT") == "4"
+    assert popen.call_args[1]["env"].get("APOLLO_HOST_PORT") == "5"
+
+
+def test_server_start_disable_port_mapping(monkeypatch):
+    check_call = MagicMock()
+    popen = MagicMock(side_effect=KeyboardInterrupt())
+    check_output = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen)
+    monkeypatch.setattr("subprocess.check_call", check_call)
+    monkeypatch.setattr("subprocess.check_output", check_output)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        server,
+        [
+            "start",
+            "--no-postgres-port",
+            "--no-hasura-port",
+            "--no-graphql-port",
+            "--no-ui-port",
+            "--no-server-port",
+        ],
+    )
+    assert result.exit_code == 1
+
+    assert check_call.called
+    assert popen.called
+    assert check_output.called
+
+    assert check_call.call_args[0][0] == ["docker-compose", "pull"]
+    assert check_call.call_args[1].get("cwd")
+    assert check_call.call_args[1].get("env")
+
+    assert popen.call_args[0][0] == ["docker-compose", "up"]
+    assert popen.call_args[1].get("cwd")
+    assert popen.call_args[1].get("env")
+
+    assert check_output.call_args[0][0] == ["docker-compose", "down"]
+    assert check_output.call_args[1].get("cwd")
+    assert check_output.call_args[1].get("env")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1605,7 +1605,7 @@ class TestFlowRunMethod:
             [pendulum.now("UTC").add(seconds=0.1)], parameter_defaults=dict(x=1)
         )
         b = prefect.schedules.clocks.DatesClock(
-            [pendulum.now("UTC").add(seconds=0.25)], parameter_defaults=dict(x=2)
+            [pendulum.now("UTC").add(seconds=0.5)], parameter_defaults=dict(x=2)
         )
 
         x = prefect.Parameter("x", default=None, required=False)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Open PR up for discussion if this is how we want optional port allocations to work when running `prefect server start`. This allows ports from the server services to be binded to different ports on the host machine. For this to work I had to add `__HOST_PORT` options to some of the services in `config.toml`. I'm guessing this is due to some hardcoded ports that these services use inside their containers. (e.g. overwriting `config.server.hasura.port` broke communication inside the containers when they ran)

This implementation allows us to set ports through CLI `--postgres-port` or environment variables `PREFECT__SERVER__DATABASE__HOST_PORT` however we can definitely go a different route.

This PR also adds the options to disable port mappings on a per-service basis. (e.g. `--no-postgres-port`)

Closes #2225 

## Why is this PR important?
Port customization for the start command is a nice convenience to have.

