### PR TITLE
add docker publish jobs for server images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,7 @@ workflows:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
 
-  'Build Earth Images':
+  'Build Server Images':
     jobs:
       - docker/publish:
           docker-password: DOCKER_HUB_PW

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,7 +455,7 @@ workflows:
           tag: $CIRCLE_SHA1,latest,master
           filters:
             branches:
-              only: ci-server-images
+              only: master
 
       - docker/publish:
           docker-password: DOCKER_HUB_PW
@@ -465,15 +465,14 @@ workflows:
           tag: $CIRCLE_SHA1,latest,master
           filters:
             branches:
-              only: ci-server-images
+              only: master
 
       - docker/publish:
           docker-password: DOCKER_HUB_PW
           docker-username: DOCKER_HUB_USER
-          registry: gcr.io
           image: 'prefecthq/ui'
           path: 'server/services/ui'
           tag: $CIRCLE_SHA1,latest,master
           filters:
             branches:
-              only: ci-server-images
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,9 @@ jobs:
           name: Upload Package to PyPI
           command: twine upload dist/*
 
+orbs:
+  docker: circleci/docker@1.0.0
+
 workflows:
   version: 2
 
@@ -441,3 +444,36 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+
+  'Build Earth Images':
+    jobs:
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/apollo'
+          path: 'server/services/apollo'
+          tag: $CIRCLE_SHA1,latest,master
+          filters:
+            branches:
+              only: ci-server-images
+
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/server'
+          path: 'server'
+          tag: $CIRCLE_SHA1,latest,master
+          filters:
+            branches:
+              only: ci-server-images
+
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          registry: gcr.io
+          image: 'prefecthq/ui'
+          path: 'server/services/ui'
+          tag: $CIRCLE_SHA1,latest,master
+          filters:
+            branches:
+              only: ci-server-images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Features
 
-- None
+- CI build for prefect server images - [#2229](https://github.com/PrefectHQ/prefect/pull/2229)
 
 ### Enhancements
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
adds a circle orb to docker publish prefect server images


## Why is this PR important?
versioned images published to docker hub for open use on each merge to master

