### PR TITLE
change default log timestamp to clock timestamp from static timestamp

### DIFF
--- a/server/Changelog.md
+++ b/server/Changelog.md
@@ -16,7 +16,7 @@
 
 ### Fixes
 
-- None
+- Change default log `timestamp` value in database to be identical to other tables instead of a hard coded value - [#2230](https://github.com/PrefectHQ/prefect/pull/2230)
 
 ### Breaking Changes
 
@@ -25,3 +25,6 @@
 ### Deprecations
 
 - None
+
+### Contributors
+- [Alex Cano](https://github.com/alexisprince1994)

--- a/server/services/postgres/alembic/versions/2020-03-30T160456_fix_log_default_timestamp.py
+++ b/server/services/postgres/alembic/versions/2020-03-30T160456_fix_log_default_timestamp.py
@@ -1,0 +1,37 @@
+"""
+fix log default timestamp
+
+Revision ID: 7e65dadba625
+Revises: 6b0389a57a0a
+Create Date: 2020-03-30 16:04:56.034089
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "7e65dadba625"
+down_revision = "6b0389a57a0a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        ALTER TABLE log ALTER COLUMN timestamp DROP DEFAULT;
+        ALTER TABLE log ALTER COLUMN timestamp SET DEFAULT clock_timestamp();
+        """
+    )
+
+
+def downgrade():
+
+    op.execute(
+        """
+        ALTER TABLE log ALTER COLUMN timestamp DROP DEFAULT;
+        ALTER TABLE log ALTER COLUMN timestamp SET DEFAULT '2020-03-18 13:42:43.118776+00'::timestamp with time zone;
+        """
+    )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR changes the default value in the `log` table from a static timestamp to `clock_timestamp()` to be in sync with the other `timestamp` default values.


## Why is this PR important?
This PR is important to make sure that default values aren't given an old static timestamp that would result in inaccurate data.

