### PR TITLE
Update s3 result handler to check for _client attribute before retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fix `S3ResultHandler` check to use `hasattr` of `_client` attribute - [#2232](https://github.com/PrefectHQ/prefect/issues/2232)
+- Fix `S3ResultHandler` safe retrieval of `_client` attribute - [#2232](https://github.com/PrefectHQ/prefect/issues/2232)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix `S3ResultHandler` check to use `hasattr` of `_client` attribute - [#2232](https://github.com/PrefectHQ/prefect/issues/2232)
 
 ### Deprecations
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -72,7 +72,7 @@ class S3ResultHandler(ResultHandler):
         Initializes a client if we believe we are in a new thread.
         We consider ourselves in a new thread if we haven't stored a client yet in the current context.
         """
-        if not prefect.context.get("boto3client") or not self._client:
+        if not prefect.context.get("boto3client") or not hasattr(self, "_client"):
             self.initialize_client()
             prefect.context["boto3client"] = self._client
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -72,11 +72,7 @@ class S3ResultHandler(ResultHandler):
         Initializes a client if we believe we are in a new thread.
         We consider ourselves in a new thread if we haven't stored a client yet in the current context.
         """
-        if (
-            not prefect.context.get("boto3client")
-            or not hasattr(self, "_client")
-            or not self._client
-        ):
+        if not prefect.context.get("boto3client") or not getattr(self, "_client", None):
             self.initialize_client()
             prefect.context["boto3client"] = self._client
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -72,7 +72,11 @@ class S3ResultHandler(ResultHandler):
         Initializes a client if we believe we are in a new thread.
         We consider ourselves in a new thread if we haven't stored a client yet in the current context.
         """
-        if not prefect.context.get("boto3client") or not hasattr(self, "_client"):
+        if (
+            not prefect.context.get("boto3client")
+            or not hasattr(self, "_client")
+            or not self._client
+        ):
             self.initialize_client()
             prefect.context["boto3client"] = self._client
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2232 


## Why is this PR important?
There is still a chance where the s3 result handler `_client` attribute does not exist and this uses the hasattr function for that case.

