### PR TITLE
Undefined name: from prefect.engine.signals import LOOP

### DIFF
--- a/tests/client/test_client_auth.py
+++ b/tests/client/test_client_auth.py
@@ -339,8 +339,8 @@ class TestTenantAuth:
         # add buffer because Windows doesn't compare milliseconds
         assert client._access_token_expires_at < pendulum.now().add(seconds=1)
         client._refresh_access_token()
-        assert client._access_token is "ACCESS_TOKEN"
-        assert client._refresh_token is "REFRESH_TOKEN"
+        assert client._access_token == "ACCESS_TOKEN"
+        assert client._refresh_token == "REFRESH_TOKEN"
         assert client._access_token_expires_at > pendulum.now().add(seconds=599)
 
     def test_refresh_token_passes_access_token_as_arg(self, patch_post):

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -11,6 +11,7 @@ import pytest
 import prefect
 from prefect.client.client import Client, FlowRunInfoResult
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
+from prefect.engine.signals import LOOP
 from prefect.engine.result import NoResult, Result, SafeResult
 from prefect.engine.result_handlers import (
     ConstantResultHandler,


### PR DESCRIPTION
Import LOOP so that line 536 will not raise NameError at runtime.

Related to #1199

[flake8](http://flake8.pycqa.org) testing of https://github.com/PrefectHQ/prefect on Python 3.8.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tests/client/test_client_auth.py:342:16: F632 use ==/!= to compare str, bytes, and int literals
        assert client._access_token is "ACCESS_TOKEN"
               ^
./tests/client/test_client_auth.py:343:16: F632 use ==/!= to compare str, bytes, and int literals
        assert client._refresh_token is "REFRESH_TOKEN"
               ^
./tests/engine/cloud/test_cloud_flow_runner.py:536:19: F821 undefined name 'LOOP'
            raise LOOP(result=prefect.context.get("task_loop_result", 0) + x)
                  ^
2     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'LOOP'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> 1 is 1
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?



## Why is this PR important?


