### PR TITLE
Bound graphql-core

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "coolname >= 1.1, < 2.0",
     "cryptography >= 2.2, < 3.0",
     "docker >= 3.4,< 5.0",
+    "graphql-core < 3.1",
     "gunicorn >= 19.9,< 20.1",
     "httpx >= 0.9.6, < 0.11.0",
     "pendulum >= 2.0, < 3.0",


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR places an upper bound on `graphql-core`. 

## Why is this PR important?

A recent release of `graphql-core` broke some server dependencies-- this should pin them back up. 
