### PR TITLE
Make project name optional for FlowRunTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Task Library
 
-- None
+- Make `project_name` optional for `FlowRunTask` to allow for use with Prefect Core's server - [#2266](https://github.com/PrefectHQ/prefect/pull/2266)
 
 ### Fixes
 

--- a/src/prefect/tasks/cloud/flow_run.py
+++ b/src/prefect/tasks/cloud/flow_run.py
@@ -1,5 +1,5 @@
 from typing import Any
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from prefect import config, Task
 from prefect.client import Client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,11 @@ def cloud_api():
         {"cloud.api": "https://api.prefect.io"}
     ):
         yield
+
+
+@pytest.fixture()
+def server_api():
+    with prefect.utilities.configuration.set_temporary_config(
+        {"cloud.api": "https:/localhost:4200"}
+    ):
+        yield

--- a/tests/tasks/cloud/test_flow_run.py
+++ b/tests/tasks/cloud/test_flow_run.py
@@ -76,7 +76,7 @@ class TestFlowRunTaskCloud:
 
 
 class TestFlowRunTaskCoreServer:
-    def test_initialization(self):
+    def test_initialization(self, server_api):
         # verify that the task is initialized as expected
         task = FlowRunTask(
             name="My Flow Run Task",
@@ -89,7 +89,7 @@ class TestFlowRunTaskCoreServer:
         assert task.flow_name == "Test Flow"
         assert task.parameters == {"test": "ing"}
 
-    def test_flow_run_task(self, client):
+    def test_flow_run_task(self, client, server_api):
         # verify that create_flow_run was called
         task = FlowRunTask(flow_name="Test Flow", parameters={"test": "ing"},)
         # verify that run returns the new flow run ID
@@ -103,13 +103,13 @@ class TestFlowRunTaskCoreServer:
             flow_id="abc123", parameters={"test": "ing"}
         )
 
-    def test_flow_run_task_without_flow_name(self):
+    def test_flow_run_task_without_flow_name(self, server_api):
         # verify that a ValueError is raised without a flow name
         task = FlowRunTask()
         with pytest.raises(ValueError, match="Must provide a flow name."):
             task.run()
 
-    def test_flow_run_task_with_no_matching_flow(self, client):
+    def test_flow_run_task_with_no_matching_flow(self, client, server_api):
         # verify a ValueError is raised if the client returns no flows
         task = FlowRunTask(flow_name="Test Flow")
         client.graphql = MagicMock(return_value=MagicMock(data=MagicMock(flow=[])))

--- a/tests/tasks/cloud/test_flow_run.py
+++ b/tests/tasks/cloud/test_flow_run.py
@@ -20,8 +20,8 @@ def client(monkeypatch):
     yield cloud_client
 
 
-class TestFlowRunTask:
-    def test_initialization(self):
+class TestFlowRunTaskCloud:
+    def test_initialization(self, cloud_api):
         # verify that the task is initialized as expected
         task = FlowRunTask(
             name="My Flow Run Task",
@@ -36,7 +36,7 @@ class TestFlowRunTask:
         assert task.flow_name == "Test Flow"
         assert task.parameters == {"test": "ing"}
 
-    def test_flow_run_task(self, client):
+    def test_flow_run_task(self, client, cloud_api):
         # verify that create_flow_run was called
         task = FlowRunTask(
             project_name="Test Project",
@@ -55,21 +55,63 @@ class TestFlowRunTask:
             flow_id="abc123", parameters={"test": "ing"}
         )
 
-    def test_flow_run_task_without_flow_name(self):
+    def test_flow_run_task_without_flow_name(self, cloud_api):
         # verify that a ValueError is raised without a flow name
         task = FlowRunTask(project_name="Test Project")
         with pytest.raises(ValueError, match="Must provide a flow name."):
             task.run()
 
-    def test_flow_run_task_without_project_name(self):
+    def test_flow_run_task_without_project_name(self, cloud_api):
         # verify that a ValueError is raised without a project name
         task = FlowRunTask(flow_name="Test Flow")
         with pytest.raises(ValueError, match="Must provide a project name."):
             task.run()
 
-    def test_flow_run_task_with_no_matching_flow(self, client):
+    def test_flow_run_task_with_no_matching_flow(self, client, cloud_api):
         # verify a ValueError is raised if the client returns no flows
         task = FlowRunTask(flow_name="Test Flow", project_name="Test Project")
         client.graphql = MagicMock(return_value=MagicMock(data=MagicMock(flow=[])))
-        with pytest.raises(ValueError, match="No flow"):
+        with pytest.raises(ValueError, match="Flow 'Test Flow' not found."):
+            task.run()
+
+
+class TestFlowRunTaskCoreServer:
+    def test_initialization(self):
+        # verify that the task is initialized as expected
+        task = FlowRunTask(
+            name="My Flow Run Task",
+            checkpoint=False,
+            flow_name="Test Flow",
+            parameters={"test": "ing"},
+        )
+        assert task.name == "My Flow Run Task"
+        assert task.checkpoint is False
+        assert task.flow_name == "Test Flow"
+        assert task.parameters == {"test": "ing"}
+
+    def test_flow_run_task(self, client):
+        # verify that create_flow_run was called
+        task = FlowRunTask(flow_name="Test Flow", parameters={"test": "ing"},)
+        # verify that run returns the new flow run ID
+        assert task.run() == "xyz890"
+        # verify the GraphQL query was called with the correct arguments
+        query_args = list(client.graphql.call_args_list[0][0][0]["query"].keys())[0]
+        assert "Test Flow" in query_args
+
+        # verify create_flow_run was called with the correct arguments
+        client.create_flow_run.assert_called_once_with(
+            flow_id="abc123", parameters={"test": "ing"}
+        )
+
+    def test_flow_run_task_without_flow_name(self):
+        # verify that a ValueError is raised without a flow name
+        task = FlowRunTask()
+        with pytest.raises(ValueError, match="Must provide a flow name."):
+            task.run()
+
+    def test_flow_run_task_with_no_matching_flow(self, client):
+        # verify a ValueError is raised if the client returns no flows
+        task = FlowRunTask(flow_name="Test Flow")
+        client.graphql = MagicMock(return_value=MagicMock(data=MagicMock(flow=[])))
+        with pytest.raises(ValueError, match="Flow 'Test Flow' not found."):
             task.run()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This updates the `FlowRunTask` in the task library to make the project name optional for running this task against Prefect Core's server.


## Why is this PR important?
Previous attempts to use this task against Prefect Core's server would raise a schema error due to the project name.
