### PR TITLE
Add `--output` option to describe CLI commands for JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add flags to `prefect server start` for disabling service port mapping - [#2228](https://github.com/PrefectHQ/prefect/pull/2228)
 - Add options to `prefect server start` for mapping to host ports - [#2228](https://github.com/PrefectHQ/prefect/pull/2228)
 - Return `flow_run_id` from CLI `run` methods for programmatic use - [#2242](https://github.com/PrefectHQ/prefect/pull/2242)
+- Add JSON output option to `describe` CLI commands - [#1813](https://github.com/PrefectHQ/prefect/issues/1813)
 
 ### Task Library
 

--- a/src/prefect/cli/describe.py
+++ b/src/prefect/cli/describe.py
@@ -1,3 +1,5 @@
+import json
+
 import click
 
 from prefect.client import Client
@@ -21,7 +23,7 @@ def describe():
 
     \b
     Examples:
-        $ prefect describe flows --name My-Flow --version 2
+        $ prefect describe flows --name My-Flow --version 2 -o json
         {
             "name": "My-Flow",
             "version": 2,
@@ -54,7 +56,8 @@ def describe():
 @click.option("--name", "-n", required=True, help="A flow name to query.", hidden=True)
 @click.option("--version", "-v", type=int, help="A flow version to query.", hidden=True)
 @click.option("--project", "-p", help="The name of a project to query.", hidden=True)
-def flows(name, version, project):
+@click.option("--output", "-o", type=click.Choice(["json"]), hidden=True)
+def flows(name, version, project, output):
     """
     Describe a Prefect flow.
 
@@ -63,6 +66,8 @@ def flows(name, version, project):
         --name, -n      TEXT    A flow name to query                [required]
         --version, -v   INTEGER A flow version to query
         --project, -p   TEXT    The name of a project to query
+        --output, -o    TEXT    Output style, currently supports `json`.
+                                Defaults to Python dictionary format.
     """
 
     where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
@@ -100,9 +105,11 @@ def flows(name, version, project):
     result = Client().graphql(query)
 
     flow_data = result.data.flow
-
     if flow_data:
-        click.echo(flow_data[0])
+        if output == "json":
+            click.echo(json.dumps(flow_data[0]))
+        else:
+            click.echo(flow_data[0])
     else:
         click.secho("{} not found".format(name), fg="red")
 
@@ -111,7 +118,8 @@ def flows(name, version, project):
 @click.option("--name", "-n", required=True, help="A flow name to query.", hidden=True)
 @click.option("--version", "-v", type=int, help="A flow version to query.", hidden=True)
 @click.option("--project", "-p", help="The name of a project to query.", hidden=True)
-def tasks(name, version, project):
+@click.option("--output", "-o", type=click.Choice(["json"]), hidden=True)
+def tasks(name, version, project, output):
     """
     Describe tasks from a Prefect flow. This command is similar to `prefect describe flow`
     but instead of flow metadata it outputs task metadata.
@@ -121,6 +129,8 @@ def tasks(name, version, project):
         --name, -n      TEXT    A flow name to query                [required]
         --version, -v   INTEGER A flow version to query
         --project, -p   TEXT    The name of a project to query
+        --output, -o    TEXT    Output style, currently supports `json`.
+                                Defaults to Python dictionary format.
     """
 
     where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
@@ -166,7 +176,10 @@ def tasks(name, version, project):
 
     if task_data:
         for item in task_data:
-            click.echo(item)
+            if output == "json":
+                click.echo(json.dumps(item))
+            else:
+                click.echo(item)
     else:
         click.secho("No tasks found for flow {}".format(name), fg="red")
 
@@ -176,7 +189,8 @@ def tasks(name, version, project):
     "--name", "-n", required=True, help="A flow run name to query", hidden=True
 )
 @click.option("--flow-name", "-fn", help="A flow name to query", hidden=True)
-def flow_runs(name, flow_name):
+@click.option("--output", "-o", type=click.Choice(["json"]), hidden=True)
+def flow_runs(name, flow_name, output):
     """
     Describe a Prefect flow run.
 
@@ -184,6 +198,8 @@ def flow_runs(name, flow_name):
     Options:
         --name, -n          TEXT    A flow run name to query            [required]
         --flow-name, -fn    TEXT    A flow name to query
+        --output, -o    TEXT    Output style, currently supports `json`.
+                                Defaults to Python dictionary format.
     """
     query = {
         "query": {
@@ -218,6 +234,9 @@ def flow_runs(name, flow_name):
     flow_run_data = result.data.flow_run
 
     if flow_run_data:
-        click.echo(flow_run_data[0])
+        if output == "json":
+            click.echo(json.dumps(flow_run_data[0]))
+        else:
+            click.echo(flow_run_data[0])
     else:
         click.secho("{} not found".format(name), fg="red")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #1813
Adds a new `--output/-o` option to `prefect describe` CLI commands. Currently only supports `json` but could be expanded in the future to support other options if requested.

## Why is this PR important?
Allows for more programmatic use of the describe CLI commands.

