### PR TITLE
(WIP) Closes #2168. Newstyle results pipeline logic

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -10,5 +10,25 @@ export default ({ router }) => {
       path: '/guide/*',
       redirect: '/core/*'
     },
+        // redirect any other `/cloud` route to a `/orchestration` route
+        {
+          path: '/cloud',
+          redirect: '/orchestration'
+        },
+    // redirect any other `/cloud` route to a `/orchestration` route
+    {
+      path: '/cloud/*',
+      redirect: '/orchestration/*'
+    },
+    // redirect any other `/api/unreleased` route to a `/api/latest` route
+    {
+      path: '/api/unreleased',
+      redirect: '/api/latest'
+    },
+    // redirect any other `/api/unreleased` route to a `/api/latest` route
+    {
+      path: '/api/unreleased/*',
+      redirect: '/api/latest/*'
+    },
   ])
 }

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -17,6 +17,16 @@ export default ({ router }) => {
     },
     // redirect any other `/cloud` route to a `/orchestration` route
     {
+     path: '/cloud/cloud_concepts/*',
+     redirect: '/orchestration/concepts/*'
+    },
+      // redirect any other `/cloud` route to a `/orchestration` route
+      {
+      path: '/cloud/agent/*',
+      redirect: '/orchestration/agents/*'
+    },
+    // redirect any other `/cloud` route to a `/orchestration` route
+    {
       path: '/cloud/*',
       redirect: '/orchestration/*'
     },

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -10,11 +10,11 @@ export default ({ router }) => {
       path: '/guide/*',
       redirect: '/core/*'
     },
-        // redirect any other `/cloud` route to a `/orchestration` route
-        {
-          path: '/cloud',
-          redirect: '/orchestration'
-        },
+    // redirect any other `/cloud` route to a `/orchestration` route
+    {
+      path: '/cloud',
+      redirect: '/orchestration'
+    },
     // redirect any other `/cloud` route to a `/orchestration` route
     {
       path: '/cloud/*',

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -251,6 +251,11 @@ class Task(metaclass=SignatureValidator):
         self.cache_validator = cache_validator or default_validator
         self.checkpoint = checkpoint
         self.result_handler = result_handler
+        # todo: convert result handler to a Result class that matches its type
+        # todo: instantiate a `CustomResult` object
+        # todo: later in the marshmallow serializer for the `CustomResult`, the result handler must not be serialized to Cloud
+        # self.result =  result or convert(self.result_handler)
+        # todo: ^ the thing that we make for them IF they sent us a result handler instead
 
         if state_handlers and not isinstance(state_handlers, collections.Sequence):
             raise TypeError("state_handlers should be iterable.")

--- a/src/prefect/engine/result/__init__.py
+++ b/src/prefect/engine/result/__init__.py
@@ -5,4 +5,5 @@ from prefect.engine.result.base import (
     NoResult,
     NoResultType,
     SafeResult,
+    CustomResult,
 )

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -239,6 +239,35 @@ class Result(ResultInterface):
         raise NotImplementedError()
 
 
+class CustomResult(Result):
+    """
+    Super fake custom result for testing purposes right now.
+    Throws out all excess args and kwargs.
+    """
+
+    def __init__(
+        self,
+        value: Any = None,
+        result_handler: ResultHandler = None,
+        validators: Iterable[Callable] = None,
+        run_validators: bool = True,
+        cache_for: datetime.timedelta = None,
+        cache_validator: Callable = None,
+        filepath_template: str = None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(
+            value,
+            result_handler,
+            validators,
+            run_validators,
+            cache_for,
+            cache_validator,
+            filepath_template,
+        )
+
+
 class SafeResult(ResultInterface):
     # todo: can we get Result.serialize to drop the user data ("do the right thing") every time before sending to Cloud
     # todo: part of this would be to send the filename_template as 'value' anyways so that cloud UI doesn't have to change
@@ -291,6 +320,8 @@ class NoResultType(SafeResult):
     A `SafeResult` subclass representing the _absence_ of computation / output.  A `NoResult` object
     returns itself for its `value` and its `safe_value`.
     """
+
+    RESULT_HANDLER = ResultHandler
 
     def __init__(self) -> None:
         super().__init__(value=None, result_handler=ResultHandler())

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -321,8 +321,6 @@ class NoResultType(SafeResult):
     returns itself for its `value` and its `safe_value`.
     """
 
-    RESULT_HANDLER = ResultHandler
-
     def __init__(self) -> None:
         super().__init__(value=None, result_handler=ResultHandler())
 

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from prefect.engine.result import Result
+from prefect.engine.result_handlers import ConstantResultHandler
 
 
 class ConstantResult(Result):
@@ -11,6 +12,8 @@ class ConstantResult(Result):
     Args:
         - value (Any): the underlying value this Result should represent
     """
+
+    RESULT_HANDLER = ConstantResultHandler
 
     def __init__(self, value: Any = None, **kwargs: Any) -> None:
         self.value = value

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -1,6 +1,7 @@
 from typing import Any, TYPE_CHECKING
 
 from prefect.engine.result.base import Result
+from prefect.engine.result_handlers import GCSResultHandler
 from prefect.client import Secret
 from prefect.utilities import logging
 
@@ -27,6 +28,8 @@ class GCSResult(Result):
             which stores a JSON representation of your Google Cloud credentials.
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
+
+    RESULT_HANDLER = GCSResultHandler
 
     def __init__(
         self,

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -5,6 +5,7 @@ from typing import Any, TYPE_CHECKING, Dict
 import prefect
 from prefect.client import Secret
 from prefect.engine.result import Result
+from prefect.engine.result_handlers import S3ResultHandler
 
 if TYPE_CHECKING:
     import boto3
@@ -30,6 +31,8 @@ class S3Result(Result):
             is initialized (changing the "service_name" is not permitted).
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
+
+    RESULT_HANDLER = S3ResultHandler
 
     def __init__(
         self,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -88,6 +88,7 @@ class TaskRunner(Runner):
     ):
         self.context = prefect.context.to_dict()
         self.task = task
+        # todo: this is an old thing
         self.result_handler = task.result_handler or result_handler
         super().__init__(state_handlers=state_handlers)
 
@@ -910,6 +911,7 @@ class TaskRunner(Runner):
             )
             return new_state
 
+        # todo: use the Result instance configured on the task to hold on to the return value (aka Result.value)
         result = Result(value=result, result_handler=self.result_handler)
         state = Success(
             result=result, message="Task run succeeded.", cached_inputs=inputs
@@ -922,6 +924,8 @@ class TaskRunner(Runner):
             and self.task.checkpoint is not False
             and self.result_handler is not None
         ):
+            # todo: single call to format the filename template and write it to the location
+            # todo: what to do if it has already been written
             state._result.store_safe_value()
 
         return state


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds pipeline logic changes needed to utilize new `Result` subclasses instead of Result Handlers.
This PR is still a work in progress. 

#### Status 4/6
Right now this
- has a basic conversion function during task instantiation to create a Result on the user's behalf if they sent us a result handler. So there is always a `task.result`
- has plugged in using `task.result` to store values in places that we used to create old style Result classes

Still needs to
- use `task.result` to hydrate results in places we are potentially reading from file
- need to revisiting what is special about upstream tasks? mapped tasks? looped tasks? when it comes to peeling a value out of its result (potentially in persistence)
- fix all the tests I have surely broken
- pretty sure my rebase was weird bc I thought we squashed netlify stuff

Overarching questions during implementation are:
1. what if this had just come from cloud?
2. what if we had already called the read method for this task's Result?


## Why is this PR important?


