### PR TITLE
Add CI jobs for building versioned server images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,14 +445,14 @@ workflows:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
 
-  'Build Server Images':
+  'Build and publish development server artifacts':
     jobs:
       - docker/publish:
           docker-password: DOCKER_HUB_PW
           docker-username: DOCKER_HUB_USER
           image: 'prefecthq/apollo'
           path: 'server/services/apollo'
-          tag: $CIRCLE_SHA1,latest,master
+          tag: master
           filters:
             branches:
               only: master
@@ -462,7 +462,7 @@ workflows:
           docker-username: DOCKER_HUB_USER
           image: 'prefecthq/server'
           path: 'server'
-          tag: $CIRCLE_SHA1,latest,master
+          tag: master
           filters:
             branches:
               only: master
@@ -472,7 +472,45 @@ workflows:
           docker-username: DOCKER_HUB_USER
           image: 'prefecthq/ui'
           path: 'server/services/ui'
-          tag: $CIRCLE_SHA1,latest,master
+          tag: master
           filters:
             branches:
               only: master
+
+  'Build and publish versioned server artifacts':
+    jobs:
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/apollo'
+          path: 'server/services/apollo'
+          tag: $CIRCLE_TAG,latest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/server'
+          path: 'server'
+          tag: $CIRCLE_TAG,latest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+
+      - docker/publish:
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/ui'
+          path: 'server/services/ui'
+          tag: $CIRCLE_SHA1,latest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Features
 
-- CI build for prefect server images - [#2229](https://github.com/PrefectHQ/prefect/pull/2229)
+- CI build for prefect server images - [#2229](https://github.com/PrefectHQ/prefect/pull/2229), [#2275](https://github.com/PrefectHQ/prefect/issues/2275)
 - Allow kwargs to boto3 in S3ResultHandler - [#2240](https://github.com/PrefectHQ/prefect/issues/2240)
 
 ### Enhancements


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2275 by adding steps to CI for building versioned server, ui, apollo images. This fits with the same tagging scheme of the `prefecthq/prefect` images by releasing `latest` and `X.Y.Z` on released and `master` on merges to the master branch.


