### PR TITLE
Diagnostic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Return `flow_run_id` from CLI `run` methods for programmatic use - [#2242](https://github.com/PrefectHQ/prefect/pull/2242)
 - Add JSON output option to `describe` CLI commands - [#1813](https://github.com/PrefectHQ/prefect/issues/1813)
 - Add ConstantResult for eventually replacing ConstantResultHandler - [#2145](https://github.com/PrefectHQ/prefect/issues/2145)
+- Add new `diagnostics` mode for timing requests made to Cloud - [#2283](https://github.com/PrefectHQ/prefect/pull/2283)
 
 ### Task Library
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -51,6 +51,7 @@ endpoint = "https://api.prefect.io"
 graphql = "${cloud.api}/graphql/alpha"
 use_local_secrets = true
 heartbeat_interval = 30.0
+diagnostic = false
 
 # rate at which to batch upload logs
 logging_heartbeat = 5

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -51,7 +51,7 @@ endpoint = "https://api.prefect.io"
 graphql = "${cloud.api}/graphql/alpha"
 use_local_secrets = true
 heartbeat_interval = 30.0
-diagnostic = false
+diagnostics = false
 
 # rate at which to batch upload logs
 logging_heartbeat = 5

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -243,7 +243,17 @@ def configure_extra_loggers() -> None:
 configure_extra_loggers()
 
 
-def get_logger(name: str = None, remove_cloud_handler: bool = False) -> logging.Logger:
+def create_diagnostic_logger(name: str) -> logging.Logger:
+    """
+    Create a logger that does not use the `CloudHandler` but preserves all other
+    Prefect logging configuration.  For diagnostic / debugging / internal use only.
+    """
+    logger = _create_logger(name)
+    logger.handlers = [h for h in logger.handlers if not isinstance(h, CloudHandler)]
+    return logger
+
+
+def get_logger(name: str = None) -> logging.Logger:
     """
     Returns a "prefect" logger.
 
@@ -251,9 +261,6 @@ def get_logger(name: str = None, remove_cloud_handler: bool = False) -> logging.
         - name (str): if `None`, the root Prefect logger is returned. If provided, a child
             logger of the name `"prefect.{name}"` is returned. The child logger inherits
             the root logger's settings.
-        - remove_cloud_handler (bool, optional): a boolean specifying whether to remove the
-            `CloudHandler` from the returned logger; intended mainly for internal use.  Defaults
-            to `False`.
 
     Returns:
         - logging.Logger: a configured logging object with the appropriate name
@@ -262,11 +269,7 @@ def get_logger(name: str = None, remove_cloud_handler: bool = False) -> logging.
     if name is None:
         return prefect_logger
     else:
-        logger = prefect_logger.getChild(name)
-        logger.handlers = [
-            h for h in logger.handlers if not isinstance(h, CloudHandler)
-        ]
-        return logger
+        return prefect_logger.getChild(name)
 
 
 class RedirectToLog:

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -243,7 +243,7 @@ def configure_extra_loggers() -> None:
 configure_extra_loggers()
 
 
-def get_logger(name: str = None) -> logging.Logger:
+def get_logger(name: str = None, remove_cloud_handler: bool = False) -> logging.Logger:
     """
     Returns a "prefect" logger.
 
@@ -251,6 +251,9 @@ def get_logger(name: str = None) -> logging.Logger:
         - name (str): if `None`, the root Prefect logger is returned. If provided, a child
             logger of the name `"prefect.{name}"` is returned. The child logger inherits
             the root logger's settings.
+        - remove_cloud_handler (bool, optional): a boolean specifying whether to remove the
+            `CloudHandler` from the returned logger; intended mainly for internal use.  Defaults
+            to `False`.
 
     Returns:
         - logging.Logger: a configured logging object with the appropriate name
@@ -259,7 +262,11 @@ def get_logger(name: str = None) -> logging.Logger:
     if name is None:
         return prefect_logger
     else:
-        return prefect_logger.getChild(name)
+        logger = prefect_logger.getChild(name)
+        logger.handlers = [
+            h for h in logger.handlers if not isinstance(h, CloudHandler)
+        ]
+        return logger
 
 
 class RedirectToLog:

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -39,6 +39,25 @@ def test_remote_handler_is_configured_for_cloud():
         logger.handlers = []
 
 
+def test_diagnostic_logger_has_no_cloud_handler():
+    try:
+        with utilities.configuration.set_temporary_config(
+            {"logging.log_to_cloud": True}
+        ):
+            logger = utilities.logging.create_diagnostic_logger(name="diagnostic-test")
+            assert logger.handlers
+            assert all(
+                [
+                    not isinstance(h, utilities.logging.CloudHandler)
+                    for h in logger.handlers
+                ]
+            )
+    finally:
+        # reset logger
+        logger = utilities.logging.create_diagnostic_logger(name="diagnostic-test")
+        logger.handlers = []
+
+
 def test_remote_handler_captures_errors_and_logs_them(caplog, monkeypatch):
     try:
         with utilities.configuration.set_temporary_config(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a new "diagnostic" mode for analyzing all requests made to Prefect Cloud.  To turn this mode on for your flows either:
- set `PREFECT__CLOUD__DIAGNOSTICS=true` locally and run a local agent
- start your agent with `prefect agent start -e PREFECT__CLOUD__DIAGNOSTICS=true` so that all flows submitted through that agent have diagnostics on
- set the corresponding value to `true` in your user `config.toml`

Every request made to Cloud will then be timed and logged.

## Why is this PR important?
Some users experience slow downs when running flows on Cloud and this PR adds a tool to help them self diagnose where there issue might be.

Some example output:

```python
from prefect import Client; c = Client()
c.graphql("query{hello}")
```

```
[2020-04-07 01:26:41,721] 291-- DEBUG - Diagnostics | Preparing request to https://api.prefect.io/graphql/alpha
[2020-04-07 01:26:41,721] 293-- DEBUG - Diagnostics | Headers: {'Authorization': 'Bearer XXXX', 'X-PREFECT-CORE-VERSION': '0.10.0+118.g9ed87df3.dirty'}
[2020-04-07 01:26:41,721] 294-- DEBUG - Diagnostics | Request: {'query': 'query{hello}', 'variables': 'null'}
[2020-04-07 01:26:41,954] 308-- DEBUG - Diagnostics | Response: {'data': {'hello': '👋'}, 'extensions': {'tracing': {'version': 1, 'startTime': '2020-04-07T01:26:41.889Z', 'endTime': '2020-04-07T01:26:41.899Z', 'duration': 9120195, 'execution': {'resolvers': [{'path': ['hello'], 'parentType': 'Query', 'fieldName': 'hello', 'returnType': 'String', 'startOffset': 287767, 'duration': 8821555}]}}}}
[2020-04-07 01:26:41,955] 309-- DEBUG - Diagnostics | Request duration: 0.2327 seconds
```