### PR TITLE
Hardening the Result interface

### DIFF
--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -215,14 +215,14 @@ class Result(ResultInterface):
         new.filepath = new.filepath.format(**kwargs)
         return new
 
-    def exists(self, loc: str) -> bool:
+    def exists(self, filepath: str) -> bool:
         """
         Checks whether the target result exists.
 
         Does not validate whether the result is `valid`, only that it is present.
 
         Args:
-            - loc (str, optional): Location of the result in the specific result target.
+            - filepath (str, optional): Location of the result in the specific result target.
                 If provided, will check whether the provided location exists;
                 otherwise, will use `self.filepath`
 
@@ -231,12 +231,12 @@ class Result(ResultInterface):
         """
         raise NotImplementedError()
 
-    def read(self, loc: str) -> "Result":
+    def read(self, filepath: str) -> "Result":
         """
         Reads from the target result and returns a corresponding `Result` instance.
 
         Args:
-            - loc (str): Location of the result in the specific result target.
+            - filepath (str): Location of the result in the specific result target.
 
         Returns:
             - Any: The value saved to the result.

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -166,6 +166,9 @@ class Result(ResultInterface):
         """
         Serializes the provided value into bytes.
 
+        Args:
+            - value (Any): the value to serialize to bytes
+
         Returns:
             - bytes: the serialized result value
         """

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -128,6 +128,20 @@ class Result(ResultInterface):
                 value=value, result_handler=self.result_handler
             )
 
+    def populate_result(self, result: "Result") -> "Result":
+        """
+        Given another Result instance, uses `self.filepath` to create a fully hydrated `Result`
+        using the logic of the provided result.  This method is mainly intended to be used
+        by `TaskRunner` methods to hydrate deserialized Cloud results into fully functional `Result` instances.
+
+        Args:
+            - result (Result): the result instance to hydrate with `self.filepath`
+
+        Returns:
+            - Result: a new result instance
+        """
+        return result.read(self.filepath)
+
     def validate(self) -> bool:
         """
         Run any validator functions associated with this result and return whether the result is valid or not.
@@ -217,9 +231,9 @@ class Result(ResultInterface):
         """
         raise NotImplementedError()
 
-    def read(self, loc: str = None) -> Any:
+    def read(self, loc: str = None) -> "Result":
         """
-        Reads from the target result.
+        Reads from the target result and returns a corresponding `Result` instance.
 
         Args:
             - loc (str): Location of the result in the specific result target.

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -19,7 +19,7 @@ whose value is `None`.
 import base64
 import copy
 import datetime
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable, Union
 
 import cloudpickle
 

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -215,7 +215,7 @@ class Result(ResultInterface):
         new.filepath = new.filepath.format(**kwargs)
         return new
 
-    def exists(self, loc: str = None) -> bool:
+    def exists(self, loc: str) -> bool:
         """
         Checks whether the target result exists.
 
@@ -231,7 +231,7 @@ class Result(ResultInterface):
         """
         raise NotImplementedError()
 
-    def read(self, loc: str = None) -> "Result":
+    def read(self, loc: str) -> "Result":
         """
         Reads from the target result and returns a corresponding `Result` instance.
 
@@ -243,11 +243,13 @@ class Result(ResultInterface):
         """
         raise NotImplementedError()
 
-    def write(self, **kwargs: Any) -> "Result":
+    def write(self, value: Any, **kwargs: Any) -> "Result":
         """
         Serialize and write the result to the target location.
 
         Args:
+            - value (Any): the value to write; will then be stored as the `value` attribute
+                of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the filepath template
                 to determine the location to write to
 

--- a/src/prefect/engine/results/__init__.py
+++ b/src/prefect/engine/results/__init__.py
@@ -1,3 +1,4 @@
 from prefect.engine.results.constant_result import ConstantResult
 from prefect.engine.results.gcs_result import GCSResult
+from prefect.engine.results.prefect_result import PrefectResult
 from prefect.engine.results.s3_result import S3Result

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -16,12 +16,12 @@ class ConstantResult(Result):
         self.value = value
         super().__init__(value=value, **kwargs)
 
-    def read(self, loc: str) -> Result:
+    def read(self, filepath: str) -> Result:
         """
         Returns the underlying value regardless of the argument passed.
 
         Args:
-            - loc (str): an unused argument
+            - filepath (str): an unused argument
         """
         return self
 
@@ -40,12 +40,12 @@ class ConstantResult(Result):
         self.filepath = repr(self.value)
         return self
 
-    def exists(self, loc: str) -> bool:
+    def exists(self, filepath: str) -> bool:
         """
         As all Python objects are valid constants, always returns `True`.
 
         Args:
-             - loc (str): for interface compatibility
+             - filepath (str): for interface compatibility
 
         Returns:
             - bool: True, confirming the constant exists.

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -1,5 +1,4 @@
 from typing import Any
-
 from prefect.engine.result import Result
 
 
@@ -30,13 +29,18 @@ class ConstantResult(Result):
         Returns the repr of the underlying value, purely for convenience.
 
         Args:
-            - value (Any): the new value to store on the class
+            - value (Any): the value to store on the class; must be the same as `self.value`
+                and is exposed purely for interface compatibility
             - **kwargs (optional): unused, for compatibility with the interface
 
         Returns:
             - Result: returns self
+
+        Raises:
+            ValueError: if the provided result is distinct from `self.value`
         """
-        self.value = value
+        if self.value != value:
+            raise ValueError("Cannot write new values to `ConstantResult` types.")
         self.filepath = repr(self.value)
         return self
 

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from prefect.engine.result import Result
 
@@ -35,6 +35,7 @@ class ConstantResult(Result):
         Returns:
             - Result: returns self
         """
+        self.filepath = repr(self.value)
         return self
 
     def exists(self, loc: str = None) -> bool:
@@ -49,5 +50,4 @@ class ConstantResult(Result):
         Returns:
             - bool: True, confirming the constant exists.
         """
-
         return True

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -16,31 +16,36 @@ class ConstantResult(Result):
         self.value = value
         super().__init__(value=value, **kwargs)
 
-    def read(self, arg: Optional[str] = None) -> Any:
+    def read(self, loc: str = None) -> Any:
         """
         Returns the underlying value regardless of the argument passed.
 
         Args:
-            - arg (str): an unused argument
+            - loc (str): an unused argument
         """
         return self.value
 
-    def write(self) -> str:
+    def write(self, **kwargs: Any) -> Result:
         """
         Returns the repr of the underlying value, purely for convenience.
 
-        Returns:
-            - str: the repr of the result
-        """
-        return repr(self.value)
+        Args:
+            - **kwargs (optional): unused, for compatibility with the interface
 
-    def exists(self) -> bool:
+        Returns:
+            - Result: returns self
+        """
+        return self
+
+    def exists(self, loc: str = None) -> bool:
         """
         Confirms the existence of the Constant value stored in the Result.
 
         The value stored within a Constant is logically always present,
         so `True` is returned.
 
+        Args:
+             - loc (optional): for interface compatibility
         Returns:
             - bool: True, confirming the constant exists.
         """

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -6,7 +6,7 @@ from prefect.engine.result import Result
 class ConstantResult(Result):
     """
     Hook for storing and retrieving constant Python objects. Only intended to be used
-    internally.
+    internally.  The "backend" in this instance is the class instance itself.
 
     Args:
         - value (Any): the underlying value this Result should represent
@@ -16,7 +16,7 @@ class ConstantResult(Result):
         self.value = value
         super().__init__(value=value, **kwargs)
 
-    def read(self, loc: str = None) -> Result:
+    def read(self, loc: str) -> Result:
         """
         Returns the underlying value regardless of the argument passed.
 
@@ -25,28 +25,28 @@ class ConstantResult(Result):
         """
         return self
 
-    def write(self, **kwargs: Any) -> Result:
+    def write(self, value: Any, **kwargs: Any) -> Result:
         """
         Returns the repr of the underlying value, purely for convenience.
 
         Args:
+            - value (Any): the new value to store on the class
             - **kwargs (optional): unused, for compatibility with the interface
 
         Returns:
             - Result: returns self
         """
+        self.value = value
         self.filepath = repr(self.value)
         return self
 
-    def exists(self, loc: str = None) -> bool:
+    def exists(self, loc: str) -> bool:
         """
-        Confirms the existence of the Constant value stored in the Result.
-
-        The value stored within a Constant is logically always present,
-        so `True` is returned.
+        As all Python objects are valid constants, always returns `True`.
 
         Args:
-             - loc (optional): for interface compatibility
+             - loc (str): for interface compatibility
+
         Returns:
             - bool: True, confirming the constant exists.
         """

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -86,9 +86,9 @@ class GCSResult(Result):
 
         return new
 
-    def read(self, loc: str = None) -> Any:
+    def read(self, loc: str = None) -> Result:
         """
-        Reads a result from a GCS bucket
+        Reads a result from a GCS bucket and returns a corresponding `Result` instance.
 
         Args:
             - loc (str, optional): the GCS URI; if not provided, `self.filepath` will be used
@@ -97,14 +97,15 @@ class GCSResult(Result):
             - Any: the read result
         """
         uri = loc or self.filepath
+        new = self.copy()
 
         try:
             self.logger.debug("Starting to download result from {}...".format(uri))
             serialized_value = self.gcs_bucket.blob(uri).download_as_string()
             try:
-                self.value = self.deserialize_from_bytes(serialized_value)
+                new.value = new.deserialize_from_bytes(serialized_value)
             except EOFError:
-                self.value = None
+                new.value = None
             self.logger.debug("Finished downloading result from {}.".format(uri))
         except Exception as exc:
             self.logger.exception(
@@ -112,8 +113,8 @@ class GCSResult(Result):
                     repr(exc)
                 )
             )
-            self.value = None
-        return self.value
+            new.value = None
+        return new
 
     def exists(self, loc: str = None) -> bool:
         """

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -90,12 +90,12 @@ class GCSResult(Result):
 
         return new
 
-    def read(self, loc: str) -> Result:
+    def read(self, filepath: str) -> Result:
         """
         Reads a result from a GCS bucket and returns a corresponding `Result` instance.
 
         Args:
-            - loc (str): the GCS URI to read from
+            - filepath (str): the GCS URI to read from
 
         Returns:
             - Any: the read result
@@ -103,13 +103,13 @@ class GCSResult(Result):
         new = self.copy()
 
         try:
-            self.logger.debug("Starting to download result from {}...".format(loc))
-            serialized_value = self.gcs_bucket.blob(loc).download_as_string()
+            self.logger.debug("Starting to download result from {}...".format(filepath))
+            serialized_value = self.gcs_bucket.blob(filepath).download_as_string()
             try:
                 new.value = new.deserialize_from_bytes(serialized_value)
             except EOFError:
                 new.value = None
-            self.logger.debug("Finished downloading result from {}.".format(loc))
+            self.logger.debug("Finished downloading result from {}.".format(filepath))
         except Exception as exc:
             self.logger.exception(
                 "Unexpected error while reading from result handler: {}".format(
@@ -119,17 +119,17 @@ class GCSResult(Result):
             new.value = None
         return new
 
-    def exists(self, loc: str) -> bool:
+    def exists(self, filepath: str) -> bool:
         """
         Checks whether the target result exists.
 
         Does not validate whether the result is `valid`, only that it is present.
 
         Args:
-            - loc (str): Location of the result in the specific result target.
-                Will check whether the provided location exists
+            - filepath (str): Location of the result in the specific result target.
+                Will check whether the provided filepath exists
 
         Returns:
             - bool: whether or not the target result exists.
         """
-        return self.gcs_bucket.blob(loc).exists()
+        return self.gcs_bucket.blob(filepath).exists()

--- a/src/prefect/engine/results/json_result.py
+++ b/src/prefect/engine/results/json_result.py
@@ -54,4 +54,4 @@ class JSONResult(Result):
         Returns:
             - bool: True, confirming the constant exists.
         """
-        return True
+        return self.filepath is not ""

--- a/src/prefect/engine/results/json_result.py
+++ b/src/prefect/engine/results/json_result.py
@@ -1,12 +1,14 @@
+import json
+
 from typing import Any
 
 from prefect.engine.result import Result
 
 
-class ConstantResult(Result):
+class JSONResult(Result):
     """
-    Hook for storing and retrieving constant Python objects. Only intended to be used
-    internally.
+    Hook for storing and retrieving JSON serializable Python objects that can
+    safely be stored directly in a Prefect database.
 
     Args:
         - value (Any): the underlying value this Result should represent
@@ -23,7 +25,9 @@ class ConstantResult(Result):
         Args:
             - loc (str): an unused argument
         """
-        return self
+        new = self.copy()
+        new.value = json.loads(loc or new.filepath)
+        return new
 
     def write(self, **kwargs: Any) -> Result:
         """
@@ -35,7 +39,7 @@ class ConstantResult(Result):
         Returns:
             - Result: returns self
         """
-        self.filepath = repr(self.value)
+        self.filepath = json.dumps(self.value)
         return self
 
     def exists(self, loc: str = None) -> bool:

--- a/src/prefect/engine/results/prefect_result.py
+++ b/src/prefect/engine/results/prefect_result.py
@@ -18,16 +18,19 @@ class PrefectResult(Result):
         self.value = value
         super().__init__(value=value, **kwargs)
 
-    def read(self, loc: str) -> Result:
+    def read(self, filepath: str) -> Result:
         """
         Returns the underlying value regardless of the argument passed.
 
         Args:
-            - loc (str): an unused argument
+            - filepath (str): an unused argument
+
+        Returns:
+            - Result: a new result instance with the data represented by the filepath
         """
         new = self.copy()
-        new.value = json.loads(loc)
-        new.filepath = loc
+        new.value = json.loads(filepath)
+        new.filepath = filepath
         return new
 
     def write(self, value: Any, **kwargs: Any) -> Result:
@@ -47,18 +50,18 @@ class PrefectResult(Result):
         new.filepath = json.dumps(new.value)
         return new
 
-    def exists(self, loc: str) -> bool:
+    def exists(self, filepath: str) -> bool:
         """
         Confirms that the provided value is JSON deserializable.
 
         Args:
-             - loc (str): the value to test
+             - filepath (str): the value to test
 
         Returns:
             - bool: whether the provided string can be deserialized
         """
         try:
-            json.loads(loc)
+            json.loads(filepath)
             return True
         except:
             return False

--- a/src/prefect/engine/results/prefect_result.py
+++ b/src/prefect/engine/results/prefect_result.py
@@ -44,7 +44,7 @@ class PrefectResult(Result):
 
     def exists(self, loc: str = None) -> bool:
         """
-        Confirms the existence of the Constant value stored in the Result.
+        Confirms the existence of the `filepath` stored on the Result.
 
         The value stored within a Constant is logically always present,
         so `True` is returned.

--- a/src/prefect/engine/results/prefect_result.py
+++ b/src/prefect/engine/results/prefect_result.py
@@ -18,7 +18,7 @@ class PrefectResult(Result):
         self.value = value
         super().__init__(value=value, **kwargs)
 
-    def read(self, loc: str = None) -> Result:
+    def read(self, loc: str) -> Result:
         """
         Returns the underlying value regardless of the argument passed.
 
@@ -26,32 +26,39 @@ class PrefectResult(Result):
             - loc (str): an unused argument
         """
         new = self.copy()
-        new.value = json.loads(loc or new.filepath)
+        new.value = json.loads(loc)
+        new.filepath = loc
         return new
 
-    def write(self, **kwargs: Any) -> Result:
+    def write(self, value: Any, **kwargs: Any) -> Result:
         """
-        Returns the repr of the underlying value, purely for convenience.
+        JSON serializes `self.value` and returns `self`.
 
         Args:
+            - value (Any): the value to write; will then be stored as the `value` attribute
+                of the returned `Result` instance
             - **kwargs (optional): unused, for compatibility with the interface
 
         Returns:
-            - Result: returns self
+            - Result: returns a new `Result` with both `value` and `filepath` attributes
         """
-        self.filepath = json.dumps(self.value)
-        return self
+        new = self.copy()
+        new.value = value
+        new.filepath = json.dumps(new.value)
+        return new
 
-    def exists(self, loc: str = None) -> bool:
+    def exists(self, loc: str) -> bool:
         """
-        Confirms the existence of the `filepath` stored on the Result.
-
-        The value stored within a Constant is logically always present,
-        so `True` is returned.
+        Confirms that the provided value is JSON deserializable.
 
         Args:
-             - loc (optional): for interface compatibility
+             - loc (str): the value to test
+
         Returns:
-            - bool: True, confirming the constant exists.
+            - bool: whether the provided string can be deserialized
         """
-        return self.filepath is not ""
+        try:
+            json.loads(loc)
+            return True
+        except:
+            return False

--- a/src/prefect/engine/results/prefect_result.py
+++ b/src/prefect/engine/results/prefect_result.py
@@ -5,7 +5,7 @@ from typing import Any
 from prefect.engine.result import Result
 
 
-class JSONResult(Result):
+class PrefectResult(Result):
     """
     Hook for storing and retrieving JSON serializable Python objects that can
     safely be stored directly in a Prefect database.

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -134,7 +134,7 @@ class S3Result(Result):
         Reads a result from S3, reads it and returns it
 
         Args:
-            - loc (str, optional): the S3 URI
+            - loc (str, optional): the S3 URI; if not provided, `self.filepath` will be used
 
         Returns:
             - Any: the read result

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -127,9 +127,15 @@ class S3Result(Result):
         stream = io.BytesIO(binary_data)
 
         ## upload
-        self.client.upload_fileobj(stream, Bucket=self.bucket, Key=new.filepath)
-        self.logger.debug("Finished uploading result to {}.".format(new.filepath))
+        from botocore.exceptions import ClientError
 
+        try:
+            self.client.upload_fileobj(stream, Bucket=self.bucket, Key=new.filepath)
+        except ClientError as err:
+            self.logger.error("Error uploading to S3: {}".format(err))
+            raise err
+
+        self.logger.debug("Finished uploading result to {}.".format(new.filepath))
         return new
 
     def read(self, filepath: str) -> Result:
@@ -167,7 +173,7 @@ class S3Result(Result):
                     repr(exc)
                 )
             )
-            new.value = None
+            raise exc
 
         return new
 

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -34,7 +34,7 @@ class TestInitialization:
         assert r.validators is None
         assert r.cache_for is None
         assert r.cache_validator is None
-        assert r.filepath_template is None
+        assert r.filepath == ""
         assert r.run_validators is True
 
         s = Result(value=5)
@@ -44,7 +44,7 @@ class TestInitialization:
         assert s.validators is None
         assert s.cache_for is None
         assert s.cache_validator is None
-        assert s.filepath_template is None
+        assert s.filepath == ""
         assert r.run_validators is True
 
     def test_result_inits_with_handled_and_result_handler(self):
@@ -297,17 +297,11 @@ def test_results_are_pickleable_with_their_safe_values():
 
 
 def test_result_format_template_from_context():
-    res = Result(filepath_template="{this}/{works}/yes?")
+    res = Result(filepath="{this}/{works}/yes?")
     with prefect.context(this="indeed", works="functional"):
         new = res.format(**prefect.context)
-        assert new._rendered_filepath == "indeed/functional/yes?"
-        assert res._rendered_filepath == None
-
-
-def test_result_render_fails_on_no_template_given():
-    with pytest.raises(ValueError):
-        res = Result()
-        res.format()
+        assert new.filepath == "indeed/functional/yes?"
+        assert res.filepath == "{this}/{works}/yes?"
 
 
 class TestResultValidate:

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -302,6 +302,7 @@ def test_result_format_template_from_context():
         new = res.format(**prefect.context)
         assert new.filepath == "indeed/functional/yes?"
         assert res.filepath == "{this}/{works}/yes?"
+        assert new != res
 
 
 class TestResultValidate:

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -111,7 +111,7 @@ def test_has_abstract_interfaces(abstract_interface: str):
 
     func = getattr(r, abstract_interface)
     with pytest.raises(NotImplementedError):
-        func()
+        func(None)
 
 
 def test_noresult_is_safe():

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -40,9 +40,7 @@ class TestGCSResult:
         bucket = MagicMock()
         google_client.return_value.bucket = MagicMock(return_value=bucket)
         result = GCSResult(bucket="foo", filepath="{thing}/here.txt")
-        result.value = "so-much-data"
-        new_result = result.format(thing=42)
-        new_result.write()
+        new_result = result.write("so-much-data", thing=42)
         assert bucket.blob.called
         assert bucket.blob.call_args[0][0] == "42/here.txt"
 
@@ -61,9 +59,7 @@ class TestGCSResult:
             return_value=MagicMock(blob=MagicMock(return_value=blob))
         )
         result = GCSResult(bucket="foo", filepath="nothing/here.txt")
-        result.value = None
-        new_result = result.format()
-        new_result.write()
+        new_result = result.write(None)
         assert blob.upload_from_string.called
         assert isinstance(blob.upload_from_string.call_args[0][0], str)
 

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -39,7 +39,7 @@ class TestGCSResult:
     def test_gcs_writes_to_blob_using_rendered_template_name(self, google_client):
         bucket = MagicMock()
         google_client.return_value.bucket = MagicMock(return_value=bucket)
-        result = GCSResult(bucket="foo", filepath_template="{thing}/here.txt")
+        result = GCSResult(bucket="foo", filepath="{thing}/here.txt")
         result.value = "so-much-data"
         new_result = result.format(thing=42)
         new_result.write()
@@ -60,7 +60,7 @@ class TestGCSResult:
         google_client.return_value.bucket = MagicMock(
             return_value=MagicMock(blob=MagicMock(return_value=blob))
         )
-        result = GCSResult(bucket="foo", filepath_template="nothing/here.txt")
+        result = GCSResult(bucket="foo", filepath="nothing/here.txt")
         result.value = None
         new_result = result.format()
         new_result.write()
@@ -78,18 +78,3 @@ class TestGCSResult:
         result = GCSResult("foo")
         res = cloudpickle.loads(cloudpickle.dumps(result))
         assert isinstance(res, GCSResult)
-
-    def test_gcs_write_fails_if_format_not_called_first(self, google_client):
-        result = GCSResult(bucket="foo", filepath_template="nothing/here.txt")
-        with pytest.raises(ValueError):
-            result.write()
-
-    def test_gcs_read_fails_if_format_not_called_first(self, google_client):
-        result = GCSResult(bucket="foo", filepath_template="nothing/here.txt")
-        with pytest.raises(ValueError):
-            result.read()
-
-    def test_gcs_exists_fails_if_format_not_called_first(self, google_client):
-        result = GCSResult(bucket="foo", filepath_template="nothing/here.txt")
-        with pytest.raises(ValueError):
-            result.exists()

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -29,14 +29,14 @@ class TestConstantResult:
         constant_result = ConstantResult("constant value")
 
         output = constant_result.write()
-        assert output == "'constant value'"
+        assert output is output
 
     def test_handles_none_as_constant(self):
 
         constant_result = ConstantResult(None)
         assert constant_result.read("still not used") is None
         output = constant_result.write()
-        assert output == "None"
+        assert output is output
 
     @pytest.mark.parametrize(
         "constant_value", [3, "text", 5.0, Constant(3), Constant("text"), Constant(5.0)]

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -1,8 +1,9 @@
+import json
 from typing import Union
 
 import pytest
 
-from prefect.engine.results import ConstantResult
+from prefect.engine.results import ConstantResult, PrefectResult
 from prefect.tasks.core.constants import Constant
 
 
@@ -14,28 +15,27 @@ class TestConstantResult:
         constant_result = ConstantResult(value=10)
         assert constant_result.value == 10
 
-    def test_read_returns_value(self):
+    def test_read_returns_self(self):
         constant_result = ConstantResult("hello world")
         assert constant_result.read("this param isn't used") is constant_result
 
-    def test_write_doesnt_overwrite_value(self):
+    def test_write_overwrites_value(self):
         constant_result = ConstantResult("untouchable!")
 
-        constant_result.write()
-        assert constant_result.value == "untouchable!"
+        constant_result.write("nvm")
+        assert constant_result.value == "nvm"
         assert constant_result.read("still unused") is constant_result
 
     def test_write_returns_value(self):
         constant_result = ConstantResult("constant value")
 
-        output = constant_result.write()
+        output = constant_result.write(None)
         assert output is output
 
     def test_handles_none_as_constant(self):
-
         constant_result = ConstantResult(None)
         assert constant_result.read("still not used") is constant_result
-        output = constant_result.write()
+        output = constant_result.write(None)
         assert output is output
 
     @pytest.mark.parametrize(
@@ -44,6 +44,44 @@ class TestConstantResult:
     def test_exists(self, constant_value: Union[str, Constant]):
 
         result = ConstantResult(constant_value)
-        result_exists = result.exists()
+        result_exists = result.exists("")
 
         assert result_exists is True
+
+
+class TestPrefectResult:
+    def test_instantiates_with_value(self):
+        result = PrefectResult(5)
+        assert result.value == 5
+        assert result.filepath == ""
+
+        result = PrefectResult(value=10)
+        assert result.value == 10
+        assert result.filepath == ""
+
+    def test_read_returns_new_result(self):
+        result = PrefectResult("hello world")
+        res = result.read('"bl00p"')
+
+        assert res.filepath == '"bl00p"'
+        assert res.value == "bl00p"
+        assert result.value == "hello world"
+
+    def test_write_doesnt_overwrite_value(self):
+        result = PrefectResult(42)
+
+        new_result = result.write(99)
+
+        assert result.value == 42
+        assert result.filepath == ""
+
+        assert new_result.value == 99
+        assert new_result.filepath == "99"
+
+    @pytest.mark.parametrize(
+        "value", [42, [0, 1], "x,y", (9, 10), dict(x=[55], y=None)]
+    )
+    def test_exists_for_json_objs(self, value):
+        result = PrefectResult()
+        assert result.exists(json.dumps(value)) is True
+        assert result.exists(value) is False

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -19,17 +19,16 @@ class TestConstantResult:
         constant_result = ConstantResult("hello world")
         assert constant_result.read("this param isn't used") is constant_result
 
-    def test_write_overwrites_value(self):
+    def test_write_doesnt_write_new_value(self):
         constant_result = ConstantResult("untouchable!")
 
-        constant_result.write("nvm")
-        assert constant_result.value == "nvm"
-        assert constant_result.read("still unused") is constant_result
+        with pytest.raises(ValueError):
+            constant_result.write("nvm")
 
     def test_write_returns_value(self):
         constant_result = ConstantResult("constant value")
 
-        output = constant_result.write(None)
+        output = constant_result.write("constant value")
         assert output is output
 
     def test_handles_none_as_constant(self):

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -16,14 +16,14 @@ class TestConstantResult:
 
     def test_read_returns_value(self):
         constant_result = ConstantResult("hello world")
-        assert constant_result.read("this param isn't used") == "hello world"
+        assert constant_result.read("this param isn't used") is constant_result
 
     def test_write_doesnt_overwrite_value(self):
         constant_result = ConstantResult("untouchable!")
 
         constant_result.write()
         assert constant_result.value == "untouchable!"
-        assert constant_result.read("still unused") == "untouchable!"
+        assert constant_result.read("still unused") is constant_result
 
     def test_write_returns_value(self):
         constant_result = ConstantResult("constant value")
@@ -34,7 +34,7 @@ class TestConstantResult:
     def test_handles_none_as_constant(self):
 
         constant_result = ConstantResult(None)
-        assert constant_result.read("still not used") is None
+        assert constant_result.read("still not used") is constant_result
         output = constant_result.write()
         assert output is output
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR hardens the new PIN-16 `Result` interface to better match our intended way of using it.  Additionally, this PR introduces a new `JSONResult` type for interacting with data which can safely be stored directly in the database.

There are a few ways this PR could be improved:

- [ ] better tests
- [ ] better docstrings describing and explaining what each of the `Result` methods is intended to be used for

I wanted to open the PR for any comments before addressing the two points above.