### PR TITLE
Suppress deprecation warning for collections module

### DIFF
--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -25,7 +25,7 @@ def flatten_seq(seq: Iterable) -> Generator:
         - generator: a generator that yields the flattened sequence
     """
     for item in seq:
-        if isinstance(item, collections.Iterable) and not isinstance(
+        if isinstance(item, collections.abc.Iterable) and not isinstance(
             item, (str, bytes)
         ):
             yield from flatten_seq(item)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,7 +1,6 @@
 import datetime
 import tempfile
 import uuid
-from collections import defaultdict
 
 import cloudpickle
 import pendulum

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1,4 +1,3 @@
-import collections
 import os
 import pendulum
 import pytest

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import json
-from collections import defaultdict
 
 import cloudpickle
 import marshmallow


### PR DESCRIPTION
Accessing `collections.Iterable` raises a deprecation warning, but `collections.abc.Iterable` does not.