### PR TITLE
Fix LocalAgent subprocess using PIPE to buffer logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix possible `LocalAgent` subprocess deadlocks when logging to `subprocess.PIPE` - [#2293](https://github.com/PrefectHQ/prefect/pull/2293)
 
 ### Deprecations
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import sys
-from subprocess import PIPE, STDOUT, Popen
+from subprocess import STDOUT, Popen, DEVNULL
 from typing import Iterable, List
 
 from prefect import config
@@ -124,7 +124,7 @@ class LocalAgent(Agent):
 
         current_env["PYTHONPATH"] = ":".join(python_path)
 
-        stdout = sys.stdout if self.show_flow_logs else PIPE
+        stdout = sys.stdout if self.show_flow_logs else DEVNULL
 
         # note: we will allow these processes to be orphaned if the agent were to exit
         # before the flow runs have completed. The lifecycle of the agent should not

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -79,9 +79,6 @@ class LocalAgent(Agent):
                     self.logger.info(
                         "Process PID {} returned non-zero exit code".format(process.pid)
                     )
-                    if not self.show_flow_logs:
-                        for raw_line in iter(process.stdout.readline, b""):
-                            self.logger.info(raw_line.decode("utf-8").rstrip())
         super().heartbeat()
 
     def deploy_flow(self, flow_run: GraphQLResult) -> str:

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -377,10 +377,7 @@ def test_generate_supervisor_conf(runner_token):
         (
             1,
             False,
-            (
-                ("agent", "INFO", "Process PID 1234 returned non-zero exit code"),
-                ("agent", "INFO", "awesome output!blerg, eRroR!"),
-            ),
+            (("agent", "INFO", "Process PID 1234 returned non-zero exit code"),),
         ),
         (1, True, (("agent", "INFO", "Process PID 1234 returned non-zero exit code"),)),
     ),


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
When not using `show_flow_logs` the LocalAgent subprocesses were previously holding on to logs in a `PIPE` which on longer runs could cause the subprocess to deadlock if too many logs were buffered. Since these logs are not used it makes more sense to send them to `subprocess.DEVNULL` (**note:** logs are still sent to the Prefect API when in use).

Also updates the LocalAgent heartbeat to no longer attempt to log the stdout on an unexpected error since stderr is already by default redirected to stdout if an error were to occur.

I believe there is a chance this is related to #2270 

## Why is this PR important?
Prevent subprocesses from filling up with logs

