### PR TITLE
Forward heartbeat utility output to subprocess.DEVNULL instead of subprocess.PIPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fix possible `LocalAgent` subprocess deadlocks when logging to `subprocess.PIPE` - [#2293](https://github.com/PrefectHQ/prefect/pull/2293)
+- Fix possible subprocess deadlocks when sending stdout to `subprocess.PIPE` - [#2293](https://github.com/PrefectHQ/prefect/pull/2293), [#2295](https://github.com/PrefectHQ/prefect/pull/2295)
 - Fix issue with Flow registration to non-standard Cloud backends - [#2292](https://github.com/PrefectHQ/prefect/pull/2292)
 
 ### Deprecations

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -52,8 +52,8 @@ def run_with_heartbeat(
                     p = subprocess.Popen(
                         self.heartbeat_cmd,
                         env=clean_env,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
                     )
             except Exception as exc:
                 self.logger.exception(
@@ -66,8 +66,6 @@ def run_with_heartbeat(
                 if exit_code is not None:
                     out, err = p.communicate()
                     msg = "Heartbeat process died with exit code {}".format(exit_code)
-                    msg += "\nSTDOUT: {}".format(out.decode() if out else None)
-                    msg += "\nSTDERR: {}".format(err.decode() if err else None)
                     self.logger.error(msg)
                 p.kill()
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -64,7 +64,6 @@ def run_with_heartbeat(
             if p is not None:
                 exit_code = p.poll()
                 if exit_code is not None:
-                    out, err = p.communicate()
                     msg = "Heartbeat process died with exit code {}".format(exit_code)
                     self.logger.error(msg)
                 p.kill()


### PR DESCRIPTION
Related to #2293, a "just in case" for forwarding stdout to `DEVNULL` instead of `PIPE`. This PR makes the change in the heartbeat subprocess since the output was never used in a meaningful way and only gathered on error. (status code is still reported)