### PR TITLE
Fix some interpolation of config in Prefect server dev commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix possible subprocess deadlocks when sending stdout to `subprocess.PIPE` - [#2293](https://github.com/PrefectHQ/prefect/pull/2293), [#2295](https://github.com/PrefectHQ/prefect/pull/2295)
 - Fix issue with Flow registration to non-standard Cloud backends - [#2292](https://github.com/PrefectHQ/prefect/pull/2292)
+- Fix interpolation of config for dev services CLI for Apollo - [#2299](https://github.com/PrefectHQ/prefect/pull/2299)
 
 ### Deprecations
 

--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -30,7 +30,7 @@ def dev():
     """
 
 
-def make_env(fname=None):
+def make_dev_env(fname=None):
 
     # replace localhost with postgres to use docker-compose dns
     PREFECT_ENV = dict(
@@ -83,7 +83,7 @@ def infrastructure(tag, skip_pull):
     """
     docker_dir = Path(prefect_server.__file__).parents[2] / "docker"
 
-    env = make_env()
+    env = make_dev_env()
 
     proc = None
     try:
@@ -229,7 +229,7 @@ def services(include, exclude):
         procs.append(
             subprocess.Popen(
                 ["prefect-server", "services", service],
-                env=make_env(),
+                env=make_dev_env(),
                 preexec_fn=os.setsid,
             )
         )

--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -40,10 +40,10 @@ def make_env(fname=None):
     )
 
     APOLLO_ENV = dict(
-        HASURA_API_URL=f"http://hasura:{config.hasura.port}/v1alpha1/graphql",
-        HASURA_WS_URL=f"ws://hasura:{config.hasura.port}/v1alpha1/graphql",
-        PREFECT_API_URL=f"http://graphql:{config.services.graphql.port}{config.services.graphql.path}",
-        PREFECT_API_HEALTH_URL=f"http://graphql:{config.services.graphql.port}/health",
+        HASURA_API_URL=f"http://{config.hasura.host}:{config.hasura.port}/v1alpha1/graphql",
+        HASURA_WS_URL=f"ws://{config.hasura.host}:{config.hasura.port}/v1alpha1/graphql",
+        PREFECT_API_URL=f"http://{config.services.graphql.host}:{config.services.graphql.port}{config.services.graphql.path}",
+        PREFECT_API_HEALTH_URL=f"http://{config.services.graphql.host}:{config.services.graphql.port}/health",
     )
 
     POSTGRES_ENV = dict(

--- a/server/src/prefect_server/cli/services.py
+++ b/server/src/prefect_server/cli/services.py
@@ -58,6 +58,8 @@ def ui():
         or root_dir.parent / "server-web-ui"
     )
 
+    ui_path = Path(ui_path)
+
     if not ui_path.exists():
         raise RuntimeError(
             "Cannot find server-web-ui repository path. Please set PREFECT_SERVER_WEB_UI_PATH environment variable."


### PR DESCRIPTION
- Convert ui_path when read from environment variable into a Path object.
- Use config file's host and port for hasura and apollo when starting services with `dev services`.

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [n/a] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Fixes some config interpolation that wasn't happening when running services independently/not with docker.


## Why is this PR important?
Needed to dev on Apollo from Prefect Core; Apollo services could not build Apollo schema or healthcheck Apollo when running from dev services without it. Also needed to be able to build the UI from the env variable path instead of the default.


