### PR TITLE
Update trigger signatures to accept a dictionary of [Edge, State]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Breaking Changes
 
-- None
+- Triggers now accept a dictionary of upstream edges and states instead of a set of states - [#2289](https://github.com/PrefectHQ/prefect/issues/2298)
 
 ### Contributors
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from prefect.engine.result import Result  # pylint: disable=W0611
     from prefect.engine.result_handlers import ResultHandler  # pylint: disable=W0611
     from prefect.engine.state import State  # pylint: disable=W0611
+    from prefect.core import Edge  # pylint: disable=W0611
 
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
 
@@ -176,7 +177,7 @@ class Task(metaclass=SignatureValidator):
         max_retries: int = None,
         retry_delay: timedelta = None,
         timeout: int = None,
-        trigger: Callable[[Set["State"]], bool] = None,
+        trigger: Callable[[Dict["Edge", "State"]], bool] = None,
         skip_on_upstream_skip: bool = True,
         cache_for: timedelta = None,
         cache_validator: Callable = None,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -430,15 +430,15 @@ class TaskRunner(Runner):
             - ENDRUN: if the trigger raises an error
         """
 
-        all_states = set()  # type: Set[State]
-        for upstream_state in upstream_states.values():
-            if isinstance(upstream_state, Mapped):
-                all_states.update(upstream_state.map_states)
-            else:
-                all_states.add(upstream_state)
+        # all_states = set()  # type: Set[State]
+        # for upstream_state in upstream_states.values():
+        #     if isinstance(upstream_state, Mapped):
+        #         all_states.update(upstream_state.map_states)
+        #     else:
+        #         all_states.add(upstream_state)
 
         try:
-            if not self.task.trigger(all_states):
+            if not self.task.trigger(upstream_states):
                 raise signals.TRIGGERFAIL(message="Trigger failed")
 
         except signals.PrefectStateSignal as exc:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -429,16 +429,8 @@ class TaskRunner(Runner):
         Raises:
             - ENDRUN: if the trigger raises an error
         """
-
-        # Deep copy upstream states and expand mapped states
-        all_states = copy.deepcopy(upstream_states)
-        for edge, upstream_state in upstream_states.items():
-            if isinstance(upstream_state, Mapped):
-                for mapped_state in upstream_state.map_states:
-                    all_states[copy.deepcopy(edge)] = mapped_state
-
         try:
-            if not self.task.trigger(all_states):
+            if not self.task.trigger(upstream_states):
                 raise signals.TRIGGERFAIL(message="Trigger failed")
 
         except signals.PrefectStateSignal as exc:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -430,15 +430,15 @@ class TaskRunner(Runner):
             - ENDRUN: if the trigger raises an error
         """
 
-        # all_states = set()  # type: Set[State]
-        # for upstream_state in upstream_states.values():
-        #     if isinstance(upstream_state, Mapped):
-        #         all_states.update(upstream_state.map_states)
-        #     else:
-        #         all_states.add(upstream_state)
+        # Deep copy upstream states and expand mapped states
+        all_states = copy.deepcopy(upstream_states)
+        for edge, upstream_state in upstream_states.items():
+            if isinstance(upstream_state, Mapped):
+                for mapped_state in upstream_state.map_states:
+                    all_states[copy.deepcopy(edge)] = mapped_state
 
         try:
-            if not self.task.trigger(upstream_states):
+            if not self.task.trigger(all_states):
                 raise signals.TRIGGERFAIL(message="Trigger failed")
 
         except signals.PrefectStateSignal as exc:

--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -42,23 +42,24 @@ flow.set_reference_tasks([success])
 flow.run()
 ```
 """
-from typing import TYPE_CHECKING, Callable, Set, Union
+from typing import TYPE_CHECKING, Callable, Dict, Union
 
 from prefect import context
 from prefect.engine import signals
 
 if TYPE_CHECKING:
     from prefect.engine import state  # pylint: disable=W0611
+    from prefect import core  # pylint: disable=W0611
 
 
-def all_finished(upstream_states: Set["state.State"]) -> bool:
+def all_finished(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     This task will run no matter what the upstream states are, as long as they are finished.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
-    if not all(s.is_finished() for s in upstream_states):
+    if not all(s.is_finished() for s in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "all_finished" but some of the upstream tasks were not finished.'
         )
@@ -66,7 +67,7 @@ def all_finished(upstream_states: Set["state.State"]) -> bool:
     return True
 
 
-def manual_only(upstream_states: Set["state.State"]) -> bool:
+def manual_only(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     This task will never run automatically, because this trigger will
     always place the task in a Paused state. The only exception is if
@@ -74,7 +75,7 @@ def manual_only(upstream_states: Set["state.State"]) -> bool:
     automatically when a task starts in a Resume state.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
     if context.get("resume"):
         return True
@@ -82,64 +83,64 @@ def manual_only(upstream_states: Set["state.State"]) -> bool:
     raise signals.PAUSE('Trigger function is "manual_only"')
 
 
-def all_successful(upstream_states: Set["state.State"]) -> bool:
+def all_successful(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     Runs if all upstream tasks were successful. Note that `SKIPPED` tasks are considered
     successes and `TRIGGER_FAILED` tasks are considered failures.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
 
-    if not all(s.is_successful() for s in upstream_states):
+    if not all(s.is_successful() for s in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "all_successful" but some of the upstream tasks failed.'
         )
     return True
 
 
-def all_failed(upstream_states: Set["state.State"]) -> bool:
+def all_failed(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     Runs if all upstream tasks failed. Note that `SKIPPED` tasks are considered successes
     and `TRIGGER_FAILED` tasks are considered failures.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
 
-    if not all(s.is_failed() for s in upstream_states):
+    if not all(s.is_failed() for s in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "all_failed" but some of the upstream tasks succeeded.'
         )
     return True
 
 
-def any_successful(upstream_states: Set["state.State"]) -> bool:
+def any_successful(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     Runs if any tasks were successful. Note that `SKIPPED` tasks are considered successes
     and `TRIGGER_FAILED` tasks are considered failures.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
 
-    if upstream_states and not any(s.is_successful() for s in upstream_states):
+    if upstream_states and not any(s.is_successful() for s in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "any_successful" but none of the upstream tasks succeeded.'
         )
     return True
 
 
-def any_failed(upstream_states: Set["state.State"]) -> bool:
+def any_failed(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     Runs if any tasks failed. Note that `SKIPPED` tasks are considered successes and
     `TRIGGER_FAILED` tasks are considered failures.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
 
-    if upstream_states and not any(s.is_failed() for s in upstream_states):
+    if upstream_states and not any(s.is_failed() for s in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "any_failed" but none of the upstream tasks failed.'
         )
@@ -148,7 +149,7 @@ def any_failed(upstream_states: Set["state.State"]) -> bool:
 
 def some_failed(
     at_least: Union[int, float] = None, at_most: Union[int, float] = None
-) -> Callable[[Set["state.State"]], bool]:
+) -> Callable[[Dict["core.Edge", "state.State"]], bool]:
     """
     Runs if some amount of upstream tasks failed. This amount can be specified as an upper bound (`at_most`) or
     a lower bound (`at_least`), and can be provided as an absolute number or a percentage of upstream tasks.
@@ -164,12 +165,12 @@ def some_failed(
             absolute number.
     """
 
-    def _some_failed(upstream_states: Set["state.State"]) -> bool:
+    def _some_failed(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
         """
         The underlying trigger function.
 
         Args:
-            - upstream_states (set[State]): the set of all upstream states
+            - upstream_states (dict[Edge, State]): the set of all upstream states
 
         Returns:
             - bool: whether the trigger thresolds were met
@@ -178,8 +179,8 @@ def some_failed(
             return True
 
         # scale conversions
-        num_failed = len([s for s in upstream_states if s.is_failed()])
-        num_states = len(upstream_states)
+        num_failed = len([s for s in upstream_states.values() if s.is_failed()])
+        num_states = len(upstream_states.values())
         if at_least is not None:
             min_num = (num_states * at_least) if at_least < 1 else at_least
         else:
@@ -200,7 +201,7 @@ def some_failed(
 
 def some_successful(
     at_least: Union[int, float] = None, at_most: Union[int, float] = None
-) -> Callable[[Set["state.State"]], bool]:
+) -> Callable[[Dict["core.Edge", "state.State"]], bool]:
     """
     Runs if some amount of upstream tasks succeed. This amount can be specified as an upper bound (`at_most`) or
     a lower bound (`at_least`), and can be provided as an absolute number or a percentage of upstream tasks.
@@ -216,12 +217,12 @@ def some_successful(
             absolute number.
     """
 
-    def _some_successful(upstream_states: Set["state.State"]) -> bool:
+    def _some_successful(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
         """
         The underlying trigger function.
 
         Args:
-            - upstream_states (set[State]): the set of all upstream states
+            - upstream_states (dict[Edge, State]): the set of all upstream states
 
         Returns:
             - bool: whether the trigger thresolds were met
@@ -230,8 +231,8 @@ def some_successful(
             return True
 
         # scale conversions
-        num_success = len([s for s in upstream_states if s.is_successful()])
-        num_states = len(upstream_states)
+        num_success = len([s for s in upstream_states.values() if s.is_successful()])
+        num_states = len(upstream_states.values())
         if at_least is not None:
             min_num = (num_states * at_least) if at_least < 1 else at_least
         else:
@@ -250,17 +251,17 @@ def some_successful(
     return _some_successful
 
 
-def not_all_skipped(upstream_states: Set["state.State"]) -> bool:
+def not_all_skipped(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
     """
     Runs if all upstream tasks were successful and were not all skipped.
 
     Args:
-        - upstream_states (set[State]): the set of all upstream states
+        - upstream_states (dict[Edge, State]): the set of all upstream states
     """
 
-    if all(state.is_skipped() for state in upstream_states):
+    if all(state.is_skipped() for state in upstream_states.values()):
         raise signals.SKIP("All upstreams were skipped", result=None)
-    elif not all(state.is_successful() for state in upstream_states):
+    elif not all(state.is_successful() for state in upstream_states.values()):
         raise signals.TRIGGERFAIL(
             'Trigger was "not_all_skipped" but some of the upstream tasks failed.'
         )
@@ -268,4 +269,4 @@ def not_all_skipped(upstream_states: Set["state.State"]) -> bool:
 
 
 # aliases
-always_run = all_finished  # type: Callable[[Set["state.State"]], bool]
+always_run = all_finished  # type: Callable[[Dict["core.Edge", "state.State"]], bool]

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -2,7 +2,7 @@ import cloudpickle
 import pytest
 
 from prefect import context, triggers
-from prefect.core.edge import Edge
+from prefect.core.edge import Edge, Task
 from prefect.engine import signals
 from prefect.engine.state import (
     Failed,
@@ -24,10 +24,11 @@ def generate_states(success=0, failed=0, skipped=0, pending=0, retrying=0) -> di
         Retrying: retrying,
     }
 
-    states = set()
+    states = dict()
     for state, count in state_counts.items():
         for _ in range(count):
-            states.add(state())
+            states[Edge(Task(), Task())] = state()
+            # states.add(state())
     return states
 
 
@@ -348,7 +349,7 @@ def test_some_successful_is_pickleable():
     ],
 )
 def test_standard_triggers_return_true_for_empty_upstream(trigger):
-    assert trigger(set()) is True
+    assert trigger(dict()) is True
 
 
 @pytest.mark.parametrize("func", [triggers.some_failed, triggers.some_successful])

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -28,7 +28,6 @@ def generate_states(success=0, failed=0, skipped=0, pending=0, retrying=0) -> di
     for state, count in state_counts.items():
         for _ in range(count):
             states[Edge(Task(), Task())] = state()
-            # states.add(state())
     return states
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Addresses #2298 by refactoring trigger signatures from a set of states to a dictionary of edges and states.

**Breaking change** so being merged into the 0.11.0 release branch

## Why is this PR important?
This will allow for more customized triggers in the future

