### PR TITLE
Relax bool cast on operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Task logical operators (e.g. `And`, `Or`, ...) no longer implicitly cast to `bool` - [#2303](https://github.com/PrefectHQ/prefect/pull/2303)
 
 ### Task Library
 

--- a/src/prefect/tasks/core/operators.py
+++ b/src/prefect/tasks/core/operators.py
@@ -218,16 +218,16 @@ class And(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x and y)
+        return x and y
 
 
 class Or(Task):
@@ -242,16 +242,16 @@ class Or(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x or y)
+        return x or y
 
 
 class Not(Task):
@@ -274,7 +274,7 @@ class Not(Task):
         Returns:
             - bool
         """
-        return bool(not (x))
+        return not x
 
 
 class Equal(Task):
@@ -289,16 +289,16 @@ class Equal(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x == y)
+        return x == y
 
 
 class NotEqual(Task):
@@ -313,16 +313,16 @@ class NotEqual(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x != y)
+        return x != y
 
 
 class GreaterThanOrEqual(Task):
@@ -337,16 +337,16 @@ class GreaterThanOrEqual(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x >= y)
+        return x >= y
 
 
 class GreaterThan(Task):
@@ -361,16 +361,16 @@ class GreaterThan(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x > y)
+        return x > y
 
 
 class LessThanOrEqual(Task):
@@ -385,16 +385,16 @@ class LessThanOrEqual(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x <= y)
+        return x <= y
 
 
 class LessThan(Task):
@@ -409,13 +409,13 @@ class LessThan(Task):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-    def run(self, x: Any, y: Any) -> bool:  # type: ignore
+    def run(self, x: Any, y: Any) -> Any:  # type: ignore
         """
         Args:
             - x (Any): a value
             - y (Any): a value
 
         Returns:
-            - bool
+            - Any
         """
-        return bool(x < y)
+        return x < y


### PR DESCRIPTION
Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Previously conditional operators also cast their result to `bool`. This
relaxes that constraint. Note that `Not` still returns bool, since
this is required in Python by `__bool__` (which `not x` calls).

Fixes #2271.