### PR TITLE
Closes #2168 Update taskrunner pipelines to use newstyle Results

### DIFF
--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -25,6 +25,7 @@ import prefect.triggers
 from prefect.utilities import logging
 from prefect.utilities.notifications import callback_factory
 from prefect.utilities.tasks import unmapped
+from prefect.engine.result import Result
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
@@ -252,6 +253,8 @@ class Task(metaclass=SignatureValidator):
         self.cache_validator = cache_validator or default_validator
         self.checkpoint = checkpoint
         self.result_handler = result_handler
+
+        self.result = result or Result()
 
         if state_handlers and not isinstance(state_handlers, collections.Sequence):
             raise TypeError("state_handlers should be iterable.")

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -25,7 +25,7 @@ import prefect.triggers
 from prefect.utilities import logging
 from prefect.utilities.notifications import callback_factory
 from prefect.utilities.tasks import unmapped
-from prefect.engine.result import Result
+from prefect.engine.results import PrefectResult
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
@@ -254,7 +254,7 @@ class Task(metaclass=SignatureValidator):
         self.checkpoint = checkpoint
         self.result_handler = result_handler
 
-        self.result = result or Result()
+        self.result = result or PrefectResult()  # todo: actually use CustomResult
 
         if state_handlers and not isinstance(state_handlers, collections.Sequence):
             raise TypeError("state_handlers should be iterable.")

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -215,15 +215,15 @@ class CloudTaskRunner(TaskRunner):
             for candidate_state in cached_states:
                 assert isinstance(candidate_state, Cached)  # mypy assert
                 candidate_state.cached_inputs = {
-                    key: res.to_result(inputs[key].result_handler)  # type: ignore
+                    key: res.populate_result(inputs[key])  # type: ignore
                     for key, res in (candidate_state.cached_inputs or {}).items()
                 }
                 sanitized_inputs = {key: res.value for key, res in inputs.items()}
                 if self.task.cache_validator(
                     candidate_state, sanitized_inputs, prefect.context.get("parameters")
                 ):
-                    candidate_state._result = candidate_state._result.to_result(
-                        self.task.result_handler
+                    candidate_state._result = candidate_state._result.populate_result(
+                        self.task.result
                     )
                     return candidate_state
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -46,16 +46,9 @@ class CloudTaskRunner(TaskRunner):
             retrieving and storing state results during execution (if the Task doesn't already have one)
     """
 
-    def __init__(
-        self,
-        task: Task,
-        state_handlers: Iterable[Callable] = None,
-        result_handler: ResultHandler = None,
-    ) -> None:
+    def __init__(self, task: Task, state_handlers: Iterable[Callable] = None) -> None:
         self.client = Client()
-        super().__init__(
-            task=task, state_handlers=state_handlers, result_handler=result_handler
-        )
+        super().__init__(task=task, state_handlers=state_handlers)
 
     def _heartbeat(self) -> bool:
         try:

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -566,11 +566,9 @@ class FlowRunner(Runner):
 
         """
         with prefect.context(self.context):
-            default_handler = task.result_handler or self.flow.result_handler
             task_runner = self.task_runner_cls(
                 task=task,
                 state_handlers=task_runner_state_handlers,
-                result_handler=default_handler,
             )
 
             # if this task reduces over a mapped state, make sure its children have finished

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -567,8 +567,7 @@ class FlowRunner(Runner):
         """
         with prefect.context(self.context):
             task_runner = self.task_runner_cls(
-                task=task,
-                state_handlers=task_runner_state_handlers,
+                task=task, state_handlers=task_runner_state_handlers,
             )
 
             # if this task reduces over a mapped state, make sure its children have finished

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -118,13 +118,7 @@ class Result(ResultInterface):
         if self.value is None:
             return
         if self.safe_value == NoResult:
-            assert isinstance(
-                self.result_handler, ResultHandler
-            ), "Result has no ResultHandler"  # mypy assert
-            value = self.result_handler.write(self.value)
-            self.safe_value = SafeResult(
-                value=value, result_handler=self.result_handler
-            )
+            self.safe_value = SafeResult(value=self.filepath)
 
     def populate_result(self, result: "Result") -> "Result":
         """
@@ -267,7 +261,7 @@ class SafeResult(ResultInterface):
         - result_handler (ResultHandler): the result handler to use when reading this result's value
     """
 
-    def __init__(self, value: Any, result_handler: ResultHandler):
+    def __init__(self, value: Any, result_handler: ResultHandler = None):
         self.value = value
         self.result_handler = result_handler
 

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -48,7 +48,7 @@ class ResultInterface:
         val = self.value  # type: ignore
         return "<{type}: {val}>".format(type=type(self).__name__, val=repr(val))
 
-    def to_result(self, result_handler: ResultHandler = None) -> "ResultInterface":
+    def populate_result(self, result: "Result") -> "ResultInterface":
         """
         If no result handler provided, returns self.  If a ResultHandler is provided, however,
         it will become the new result handler for this result.
@@ -59,8 +59,6 @@ class ResultInterface:
         Returns:
             - ResultInterface: a potentially new Result object
         """
-        if result_handler is not None:
-            self.result_handler = result_handler
         return self
 
     def store_safe_value(self) -> None:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -23,7 +23,7 @@ from prefect import config
 from prefect.core import Edge, Task
 from prefect.engine import signals
 from prefect.engine.result import NoResult, Result
-from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
+from prefect.engine.results import PrefectResult
 from prefect.engine.runner import ENDRUN, Runner, call_state_handlers
 from prefect.engine.state import (
     Cached,
@@ -969,11 +969,12 @@ class TaskRunner(Runner):
             run_count = prefect.context.get("task_run_count", 1)
             if prefect.context.get("task_loop_count") is not None:
                 loop_context = {
-                    "_loop_count": Result(  # todo: here
+                    "_loop_count": PrefectResult(
                         value=prefect.context["task_loop_count"],
                     ),
-                    "_loop_result": Result(  # todo: here
+                    "_loop_result": self.task.result.write(
                         value=prefect.context.get("task_loop_result"),
+                        **prefect.context
                     ),
                 }
                 inputs.update(loop_context)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -81,9 +81,7 @@ class TaskRunner(Runner):
     """
 
     def __init__(
-        self,
-        task: Task,
-        state_handlers: Iterable[Callable] = None,
+        self, task: Task, state_handlers: Iterable[Callable] = None,
     ):
         self.context = prefect.context.to_dict()
         self.task = task
@@ -150,12 +148,12 @@ class TaskRunner(Runner):
                 "task_loop_count": state.cached_inputs.pop(  # type: ignore
                     "_loop_count"
                 )  # type: ignore
-                .populate_result(self.task.result) # todo: here
+                .populate_result(self.task.result)  # todo: here
                 .value,
                 "task_loop_result": state.cached_inputs.pop(  # type: ignore
                     "_loop_result"
                 )  # type: ignore
-                .populate_result(self.task.result) # todo: here
+                .populate_result(self.task.result)  # todo: here
                 .value,
             }
             context.update(loop_context)
@@ -572,7 +570,7 @@ class TaskRunner(Runner):
             # construct task inputs
             if edge.key is not None:
                 handlers[edge.key] = result_skeleton = getattr(
-                    edge.upstream_task, "result", None # todo: here
+                    edge.upstream_task, "result", None  # todo: here
                 )
                 task_inputs[  # type: ignore
                     edge.key
@@ -583,9 +581,9 @@ class TaskRunner(Runner):
         if state.is_pending() and state.cached_inputs:
             task_inputs.update(
                 {
-                    k: r.to_result(handlers.get(k))  # type: ignore # todo: here
+                    k: r.populate_result(handlers.get(k))  # type: ignore # todo: here
                     for k, r in state.cached_inputs.items()
-                    if task_inputs.get(k, NoResult) == NoResult # todo: here
+                    if task_inputs.get(k, NoResult) == NoResult  # todo: here
                 }
             )
         return task_inputs
@@ -711,7 +709,7 @@ class TaskRunner(Runner):
                                         preview=repr(upstream_state.result)[:10],
                                     )
                                 )
-                            upstream_result = Result( # todo: here
+                            upstream_result = Result(  # todo: here
                                 upstream_state.result[i],
                                 result_handler=upstream_state._result.result_handler,  # type: ignore # todo: here
                             )
@@ -905,14 +903,13 @@ class TaskRunner(Runner):
             result=result, message="Task run succeeded.", cached_inputs=inputs
         )
 
-        ## checkpoint tasks if a result_handler is present, except for when the user has opted out by disabling checkpointing
-        # if (
-        #     state.is_successful()
-        #     and prefect.context.get("checkpointing") is True
-        #     and self.task.checkpoint is not False
-        #     and self.result_handler is not None # todo: here
-        # ):
-        #     state._result.store_safe_value() # todo: here
+        # checkpoint tasks if a result_handler is present, except for when the user has opted out by disabling checkpointing
+        if (
+            state.is_successful()
+            and prefect.context.get("checkpointing") is True
+            and self.task.checkpoint is not False
+        ):
+            state._result.store_safe_value()  # todo: here
 
         return state
 
@@ -972,10 +969,10 @@ class TaskRunner(Runner):
             run_count = prefect.context.get("task_run_count", 1)
             if prefect.context.get("task_loop_count") is not None:
                 loop_context = {
-                    "_loop_count": Result( # todo: here
+                    "_loop_count": Result(  # todo: here
                         value=prefect.context["task_loop_count"],
                     ),
-                    "_loop_result": Result( # todo: here
+                    "_loop_result": Result(  # todo: here
                         value=prefect.context.get("task_loop_result"),
                     ),
                 }

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -84,11 +84,9 @@ class TaskRunner(Runner):
         self,
         task: Task,
         state_handlers: Iterable[Callable] = None,
-        result_handler: "ResultHandler" = None, # todo: here
     ):
         self.context = prefect.context.to_dict()
         self.task = task
-        self.result_handler = task.result_handler or result_handler # todo: here
         super().__init__(state_handlers=state_handlers)
 
     def __repr__(self) -> str:
@@ -152,12 +150,12 @@ class TaskRunner(Runner):
                 "task_loop_count": state.cached_inputs.pop(  # type: ignore
                     "_loop_count"
                 )  # type: ignore
-                .to_result() # todo: here
+                .populate_result(self.task.result) # todo: here
                 .value,
                 "task_loop_result": state.cached_inputs.pop(  # type: ignore
                     "_loop_result"
                 )  # type: ignore
-                .to_result() # todo: here
+                .populate_result(self.task.result) # todo: here
                 .value,
             }
             context.update(loop_context)
@@ -573,13 +571,13 @@ class TaskRunner(Runner):
         for edge, upstream_state in upstream_states.items():
             # construct task inputs
             if edge.key is not None:
-                handlers[edge.key] = handler = getattr(
-                    edge.upstream_task, "result_handler", None # todo: here
+                handlers[edge.key] = result_skeleton = getattr(
+                    edge.upstream_task, "result", None # todo: here
                 )
                 task_inputs[  # type: ignore
                     edge.key
-                ] = upstream_state._result.to_result(  # type: ignore # todo: here
-                    handler
+                ] = upstream_state._result.populate_result(  # type: ignore # todo: here
+                    result_skeleton
                 )  # type: ignore
 
         if state.is_pending() and state.cached_inputs:
@@ -614,7 +612,7 @@ class TaskRunner(Runner):
             if self.task.cache_validator(
                 state, sanitized_inputs, prefect.context.get("parameters")
             ):
-                state._result = state._result.to_result(self.task.result_handler) # todo: here
+                state._result = state._result.populate_result(self.task.result)
                 return state
             else:
                 state = Pending("Cache was invalid; ready to run.")
@@ -628,8 +626,8 @@ class TaskRunner(Runner):
                 if self.task.cache_validator(
                     candidate, sanitized_inputs, prefect.context.get("parameters")
                 ):
-                    candidate._result = candidate._result.to_result(
-                        self.task.result_handler # todo: here
+                    candidate._result = candidate._result.populate_result(
+                        self.task.result
                     )
                     return candidate
 
@@ -868,11 +866,11 @@ class TaskRunner(Runner):
 
             if getattr(self.task, "log_stdout", False):
                 with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
-                    result = timeout_handler(
+                    return_value = timeout_handler(
                         self.task.run, timeout=self.task.timeout, **raw_inputs
                     )
             else:
-                result = timeout_handler(
+                return_value = timeout_handler(
                     self.task.run, timeout=self.task.timeout, **raw_inputs
                 )
 
@@ -893,8 +891,8 @@ class TaskRunner(Runner):
         except signals.LOOP as exc:
             new_state = exc.state
             assert isinstance(new_state, Looped)
-            new_state.result = Result( # todo: here
-                value=new_state.result, result_handler=self.result_handler # todo: here
+            new_state.result = self.task.result.write(
+                value=new_state.result, **prefect.context
             )
             new_state.cached_inputs = inputs
             new_state.message = exc.state.message or "Task is looping ({})".format(
@@ -902,19 +900,19 @@ class TaskRunner(Runner):
             )
             return new_state
 
-        result = Result(value=result, result_handler=self.result_handler) # todo: here
+        result = self.task.result.write(return_value, **prefect.context)
         state = Success(
-            result=result, message="Task run succeeded.", cached_inputs=inputs # todo: here
+            result=result, message="Task run succeeded.", cached_inputs=inputs
         )
 
         ## checkpoint tasks if a result_handler is present, except for when the user has opted out by disabling checkpointing
-        if (
-            state.is_successful()
-            and prefect.context.get("checkpointing") is True
-            and self.task.checkpoint is not False
-            and self.result_handler is not None # todo: here
-        ):
-            state._result.store_safe_value() # todo: here
+        # if (
+        #     state.is_successful()
+        #     and prefect.context.get("checkpointing") is True
+        #     and self.task.checkpoint is not False
+        #     and self.result_handler is not None # todo: here
+        # ):
+        #     state._result.store_safe_value() # todo: here
 
         return state
 
@@ -976,11 +974,9 @@ class TaskRunner(Runner):
                 loop_context = {
                     "_loop_count": Result( # todo: here
                         value=prefect.context["task_loop_count"],
-                        result_handler=JSONResultHandler(), # todo: here
                     ),
                     "_loop_result": Result( # todo: here
                         value=prefect.context.get("task_loop_result"),
-                        result_handler=self.result_handler, # todo: here
                     ),
                 }
                 inputs.update(loop_context)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -890,7 +890,7 @@ class TaskRunner(Runner):
             new_state = exc.state
             assert isinstance(new_state, Looped)
             new_state.result = self.task.result.write(
-                value=new_state.result, **prefect.context
+                new_state.result, **prefect.context
             )
             new_state.cached_inputs = inputs
             new_state.message = exc.state.message or "Task is looping ({})".format(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -564,26 +564,26 @@ class TaskRunner(Runner):
 
         """
         task_inputs = {}  # type: Dict[str, Result]
-        handlers = {}  # type: Dict[str, ResultHandler]
+        result_skeletons = {}  # type: Dict[str, Result]
 
         for edge, upstream_state in upstream_states.items():
             # construct task inputs
             if edge.key is not None:
-                handlers[edge.key] = result_skeleton = getattr(
-                    edge.upstream_task, "result", None  # todo: here
+                result_skeletons[edge.key] = result_skeleton = getattr(
+                    edge.upstream_task, "result", None
                 )
                 task_inputs[  # type: ignore
                     edge.key
-                ] = upstream_state._result.populate_result(  # type: ignore # todo: here
+                ] = upstream_state._result.populate_result(  # type: ignore
                     result_skeleton
                 )  # type: ignore
 
         if state.is_pending() and state.cached_inputs:
             task_inputs.update(
                 {
-                    k: r.populate_result(handlers.get(k))  # type: ignore # todo: here
+                    k: r.populate_result(result_skeletons.get(k))  # type: ignore
                     for k, r in state.cached_inputs.items()
-                    if task_inputs.get(k, NoResult) == NoResult  # todo: here
+                    if task_inputs.get(k, NoResult) == NoResult
                 }
             )
         return task_inputs

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -84,11 +84,11 @@ class TaskRunner(Runner):
         self,
         task: Task,
         state_handlers: Iterable[Callable] = None,
-        result_handler: "ResultHandler" = None,
+        result_handler: "ResultHandler" = None, # todo: here
     ):
         self.context = prefect.context.to_dict()
         self.task = task
-        self.result_handler = task.result_handler or result_handler
+        self.result_handler = task.result_handler or result_handler # todo: here
         super().__init__(state_handlers=state_handlers)
 
     def __repr__(self) -> str:
@@ -152,12 +152,12 @@ class TaskRunner(Runner):
                 "task_loop_count": state.cached_inputs.pop(  # type: ignore
                     "_loop_count"
                 )  # type: ignore
-                .to_result()
+                .to_result() # todo: here
                 .value,
                 "task_loop_result": state.cached_inputs.pop(  # type: ignore
                     "_loop_result"
                 )  # type: ignore
-                .to_result()
+                .to_result() # todo: here
                 .value,
             }
             context.update(loop_context)
@@ -574,20 +574,20 @@ class TaskRunner(Runner):
             # construct task inputs
             if edge.key is not None:
                 handlers[edge.key] = handler = getattr(
-                    edge.upstream_task, "result_handler", None
+                    edge.upstream_task, "result_handler", None # todo: here
                 )
                 task_inputs[  # type: ignore
                     edge.key
-                ] = upstream_state._result.to_result(  # type: ignore
+                ] = upstream_state._result.to_result(  # type: ignore # todo: here
                     handler
                 )  # type: ignore
 
         if state.is_pending() and state.cached_inputs:
             task_inputs.update(
                 {
-                    k: r.to_result(handlers.get(k))  # type: ignore
+                    k: r.to_result(handlers.get(k))  # type: ignore # todo: here
                     for k, r in state.cached_inputs.items()
-                    if task_inputs.get(k, NoResult) == NoResult
+                    if task_inputs.get(k, NoResult) == NoResult # todo: here
                 }
             )
         return task_inputs
@@ -614,7 +614,7 @@ class TaskRunner(Runner):
             if self.task.cache_validator(
                 state, sanitized_inputs, prefect.context.get("parameters")
             ):
-                state._result = state._result.to_result(self.task.result_handler)
+                state._result = state._result.to_result(self.task.result_handler) # todo: here
                 return state
             else:
                 state = Pending("Cache was invalid; ready to run.")
@@ -629,7 +629,7 @@ class TaskRunner(Runner):
                     candidate, sanitized_inputs, prefect.context.get("parameters")
                 ):
                     candidate._result = candidate._result.to_result(
-                        self.task.result_handler
+                        self.task.result_handler # todo: here
                     )
                     return candidate
 
@@ -713,9 +713,9 @@ class TaskRunner(Runner):
                                         preview=repr(upstream_state.result)[:10],
                                     )
                                 )
-                            upstream_result = Result(
+                            upstream_result = Result( # todo: here
                                 upstream_state.result[i],
-                                result_handler=upstream_state._result.result_handler,  # type: ignore
+                                result_handler=upstream_state._result.result_handler,  # type: ignore # todo: here
                             )
                             states[edge].result = upstream_result
                         elif state.is_mapped():
@@ -893,8 +893,8 @@ class TaskRunner(Runner):
         except signals.LOOP as exc:
             new_state = exc.state
             assert isinstance(new_state, Looped)
-            new_state.result = Result(
-                value=new_state.result, result_handler=self.result_handler
+            new_state.result = Result( # todo: here
+                value=new_state.result, result_handler=self.result_handler # todo: here
             )
             new_state.cached_inputs = inputs
             new_state.message = exc.state.message or "Task is looping ({})".format(
@@ -902,9 +902,9 @@ class TaskRunner(Runner):
             )
             return new_state
 
-        result = Result(value=result, result_handler=self.result_handler)
+        result = Result(value=result, result_handler=self.result_handler) # todo: here
         state = Success(
-            result=result, message="Task run succeeded.", cached_inputs=inputs
+            result=result, message="Task run succeeded.", cached_inputs=inputs # todo: here
         )
 
         ## checkpoint tasks if a result_handler is present, except for when the user has opted out by disabling checkpointing
@@ -912,9 +912,9 @@ class TaskRunner(Runner):
             state.is_successful()
             and prefect.context.get("checkpointing") is True
             and self.task.checkpoint is not False
-            and self.result_handler is not None
+            and self.result_handler is not None # todo: here
         ):
-            state._result.store_safe_value()
+            state._result.store_safe_value() # todo: here
 
         return state
 
@@ -974,13 +974,13 @@ class TaskRunner(Runner):
             run_count = prefect.context.get("task_run_count", 1)
             if prefect.context.get("task_loop_count") is not None:
                 loop_context = {
-                    "_loop_count": Result(
+                    "_loop_count": Result( # todo: here
                         value=prefect.context["task_loop_count"],
-                        result_handler=JSONResultHandler(),
+                        result_handler=JSONResultHandler(), # todo: here
                     ),
-                    "_loop_result": Result(
+                    "_loop_result": Result( # todo: here
                         value=prefect.context.get("task_loop_result"),
-                        result_handler=self.result_handler,
+                        result_handler=self.result_handler, # todo: here
                     ),
                 }
                 inputs.update(loop_context)

--- a/src/prefect/serialization/result.py
+++ b/src/prefect/serialization/result.py
@@ -37,7 +37,7 @@ class ConstantResultSchema(ObjectSchema):
 
 class ResultSchema(ObjectSchema):
     class Meta:
-        object_class = results.ConstantResult
+        object_class = result.Result
 
 
 class SafeResultSchema(ObjectSchema):

--- a/src/prefect/serialization/result.py
+++ b/src/prefect/serialization/result.py
@@ -1,8 +1,43 @@
 from marshmallow import fields
 
-from prefect.engine import result
+from prefect.engine import result, results
 from prefect.serialization.result_handlers import ResultHandlerSchema
 from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
+
+
+class GCSResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.GCSResult
+
+    filepath = fields.String(allow_none=False)
+    bucket = fields.String(allow_none=False)
+    credentials_secret = fields.String(allow_none=True)
+
+
+class PrefectResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.PrefectResult
+
+    value = fields.String(allow_none=True)
+
+
+class S3ResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.S3Result
+
+    filepath = fields.String(allow_none=False)
+    bucket = fields.String(allow_none=False)
+    credentials_secret = fields.String(allow_none=True)
+
+
+class ConstantResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.ConstantResult
+
+
+class ResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.ConstantResult
 
 
 class SafeResultSchema(ObjectSchema):
@@ -10,7 +45,6 @@ class SafeResultSchema(ObjectSchema):
         object_class = result.SafeResult
 
     value = JSONCompatible(allow_none=True)
-    result_handler = fields.Nested(ResultHandlerSchema, allow_none=False)
 
 
 class NoResultSchema(ObjectSchema):
@@ -24,4 +58,12 @@ class StateResultSchema(OneOfSchema):
     """
 
     # map class name to schema
-    type_schemas = {"SafeResult": SafeResultSchema, "NoResultType": NoResultSchema}
+    type_schemas = {
+        "SafeResult": SafeResultSchema,
+        "NoResultType": NoResultSchema,
+        "GCSResult": GCSResultSchema,
+        "PrefectResult": PrefectResultSchema,
+        "S3Result": S3ResultSchema,
+        "ConstantResult": ConstantResultSchema,
+        "Result": ResultSchema,
+    }

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -36,10 +36,10 @@ class BaseStateSchema(ObjectSchema):
 
     context = fields.Dict(key=fields.Str(), values=JSONCompatible(), allow_none=True)
     message = fields.String(allow_none=True)
-    _result = Nested(StateResultSchema, allow_none=False, value_selection_fn=get_safe)
+    _result = Nested(StateResultSchema, allow_none=False, value_selection_fn=None)
     cached_inputs = fields.Dict(
         key=fields.Str(),
-        values=Nested(StateResultSchema, value_selection_fn=get_safe),
+        values=Nested(StateResultSchema, value_selection_fn=None),
         allow_none=True,
     )
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updates the taskrunner pipelines (normal `TaskRunner` and `CloudTaskRunner`) to use newstyle Results and their methods everywhere, and also add Result subclass serializers so they can be serialized to Cloud/Server.


## Why is this PR important?
This sets newstyle Results to be the default used by the pipeline. (Notably, backwards compatibility with result handlers is separated in #2300.)

