### PR TITLE
Control flow tasks return executed branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Task logical operators (e.g. `And`, `Or`, ...) no longer implicitly cast to `bool` - [#2303](https://github.com/PrefectHQ/prefect/pull/2303)
 - Allow for dynamically changing secret names at runtime - [#2302](https://github.com/PrefectHQ/prefect/pull/2302)
+- Update `ifelse` and `switch` to return tasks representing the output of the run branch - [#2310](https://github.com/PrefectHQ/prefect/pull/2310)
 
 ### Task Library
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -82,11 +82,16 @@ def switch(condition: Task, cases: Dict[Any, Task]) -> None:
             The value of the `condition` task will be compared to the keys of this dict, and
             the matching task will be executed.
 
+    Returns:
+        - Task: a task whose result is the output from the task executed by this switch
+
     Raises:
         - PrefectWarning: if any of the tasks in "cases" have upstream dependencies,
-            then this task will warn that those upstream tasks may run whether or not the switch condition matches their branch. The most common cause of this
-            is passing a list of tasks as one of the cases, which adds the `List` task
-            to the switch condition but leaves the tasks themselves upstream.
+            then this task will warn that those upstream tasks may run whether
+            or not the switch condition matches their branch. The most common
+            cause of this is passing a list of tasks as one of the cases, which
+            adds the `List` task to the switch condition but leaves the tasks
+            themselves upstream.
     """
 
     with prefect.tags("switch"):
@@ -94,6 +99,7 @@ def switch(condition: Task, cases: Dict[Any, Task]) -> None:
             task = prefect.utilities.tasks.as_task(task)
             match_condition = CompareValue(value=value).bind(value=condition)
             task.set_dependencies(upstream_tasks=[match_condition])
+        return merge(*cases.values())
 
 
 def ifelse(condition: Task, true_task: Task, false_task: Task) -> None:
@@ -101,20 +107,26 @@ def ifelse(condition: Task, true_task: Task, false_task: Task) -> None:
     Builds a conditional branch into a workflow.
 
     If the condition evaluates True(ish), the true_task will run. If it
-    evaluates False(ish), the false_task will run. The task doesn't run is Skipped, as are
-    all downstream tasks that don't set `skip_on_upstream_skip=False`.
+    evaluates False(ish), the false_task will run. The task that doesn't run is
+    Skipped, as are all downstream tasks that don't set
+    `skip_on_upstream_skip=False`.
 
     Args:
         - condition (Task): a task whose boolean result forms the condition for the ifelse
         - true_task (Task): a task that will be executed if the condition is True
         - false_task (Task): a task that will be executed if the condition is False
+
+    Returns:
+        - Task: a task whose result is the output from the task executed by this ifelse
     """
 
     @prefect.task
     def as_bool(x):
         return bool(x)
 
-    switch(condition=as_bool(condition), cases={True: true_task, False: false_task})
+    return switch(
+        condition=as_bool(condition), cases={True: true_task, False: false_task}
+    )
 
 
 def merge(*tasks: Task) -> Task:


### PR DESCRIPTION
This modifies `ifelse` and `switch` to return a task for the branch that
was run. Previously users had to explicitly use `merge` to achieve the
same behavior.

Fixes #1735.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)