### PR TITLE
Fix test fixtures by setting backend setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with Flow registration to non-standard Cloud backends - [#2292](https://github.com/PrefectHQ/prefect/pull/2292)
 - Fix issue with registering Flows with Server that have required scheduled Parameters - [#2296](https://github.com/PrefectHQ/prefect/issues/2296)
 - Fix interpolation of config for dev services CLI for Apollo - [#2299](https://github.com/PrefectHQ/prefect/pull/2299)
+- Fix pytest Cloud and Core server backend fixtures - [#2319](https://github.com/PrefectHQ/prefect/issues/2319)
 
 ### Deprecations
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -444,7 +444,7 @@ def test_run_cloud_param_string_overwrites(monkeypatch):
         ("https://api-foo.prefect.io", "https://foo.prefect.io/tslug/flow-run/id"),
     ],
 )
-def test_run_cloud_flow_run_id_link(monkeypatch, api, expected):
+def test_run_cloud_flow_run_id_link(monkeypatch, api, expected, cloud_api):
     post = MagicMock(
         return_value=MagicMock(
             json=MagicMock(return_value=dict(data=dict(flow=[{"id": "flow"}])))

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -878,7 +878,7 @@ def test_get_default_tenant_slug_not_as_user(patch_post):
         assert slug == "tslug"
 
 
-def test_get_cloud_url_as_user(patch_post):
+def test_get_cloud_url_as_user(patch_post, cloud_api):
     response = {
         "data": {"user": [{"default_membership": {"tenant": {"slug": "tslug"}}}]}
     }
@@ -897,7 +897,7 @@ def test_get_cloud_url_as_user(patch_post):
         assert url == "http://cloud.prefect.io/tslug/flow-run/id2"
 
 
-def test_get_cloud_url_not_as_user(patch_post):
+def test_get_cloud_url_not_as_user(patch_post, cloud_api):
     response = {"data": {"tenant": [{"slug": "tslug"}]}}
 
     patch_post(response)
@@ -914,7 +914,7 @@ def test_get_cloud_url_not_as_user(patch_post):
         assert url == "http://cloud.prefect.io/tslug/flow-run/id2"
 
 
-def test_get_cloud_url_different_regex(patch_post):
+def test_get_cloud_url_different_regex(patch_post, cloud_api):
     response = {
         "data": {"user": [{"default_membership": {"tenant": {"slug": "tslug"}}}]}
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def runner_token(monkeypatch):
 @pytest.fixture()
 def cloud_api():
     with prefect.utilities.configuration.set_temporary_config(
-        {"cloud.api": "https://api.prefect.io"}
+        {"cloud.api": "https://api.prefect.io", "backend": "cloud"}
     ):
         yield
 
@@ -158,6 +158,6 @@ def cloud_api():
 @pytest.fixture()
 def server_api():
     with prefect.utilities.configuration.set_temporary_config(
-        {"cloud.api": "https:/localhost:4200"}
+        {"cloud.api": "https:/localhost:4200", "backend": "server"}
     ):
         yield


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2319 

Since the client no longer determines if you are using Core's server or Cloud based on the `cloud.api` host and instead by `backend` this has to be added to the test fixtures.

## Why is this PR important?
Fix failing tests

