### PR TITLE
Fix AzureResultHandler choosing an empty Secret over provided connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with registering Flows with Server that have required scheduled Parameters - [#2296](https://github.com/PrefectHQ/prefect/issues/2296)
 - Fix interpolation of config for dev services CLI for Apollo - [#2299](https://github.com/PrefectHQ/prefect/pull/2299)
 - Fix pytest Cloud and Core server backend fixtures - [#2319](https://github.com/PrefectHQ/prefect/issues/2319)
+- Fix `AzureResultHandler` choosing an empty Secret over provided connection string - [#2316](https://github.com/PrefectHQ/prefect/issues/2316)
 
 ### Deprecations
 

--- a/src/prefect/engine/result_handlers/azure_result_handler.py
+++ b/src/prefect/engine/result_handlers/azure_result_handler.py
@@ -55,7 +55,9 @@ class AzureResultHandler(ResultHandler):
         import azure.storage.blob
 
         kwargs = dict()
-        if self.azure_credentials_secret:
+        if self.connection_string:
+            kwargs["connection_string"] = self.connection_string
+        else:
             azure_credentials = Secret(self.azure_credentials_secret).get()
             if isinstance(azure_credentials, str):
                 azure_credentials = json.loads(azure_credentials)
@@ -63,8 +65,6 @@ class AzureResultHandler(ResultHandler):
             kwargs["account_name"] = azure_credentials["ACCOUNT_NAME"]
             kwargs["account_key"] = azure_credentials.get("ACCOUNT_KEY")
             kwargs["sas_token"] = azure_credentials.get("SAS_TOKEN")
-        else:
-            kwargs["connection_string"] = self.connection_string
 
         blob_service = azure.storage.blob.BlockBlobService(**kwargs)
         self.service = blob_service

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -441,6 +441,22 @@ class TestAzureResultHandler:
             "sas_token": None,
         }
 
+    def test_azure_service_init_uses_connection_string_over_secret(self, azure_service):
+        handler = AzureResultHandler(
+            container="bob", azure_credentials_secret="MY_FOO", connection_string="TEST"
+        )
+
+        with prefect.context(
+            secrets=dict(MY_FOO=dict(ACCOUNT_NAME=1, ACCOUNT_KEY=999))
+        ):
+            with set_temporary_config({"cloud.use_local_secrets": True}):
+                handler.initialize_service()
+
+        assert handler.container == "bob"
+        assert azure_service.call_args[1] == {
+            "connection_string": "TEST",
+        }
+
     def test_azure_service_writes_to_blob_prefixed_by_date_suffixed_by_prefect(
         self, azure_service
     ):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2316 
This PR fixes the Azure result handler's use of an empty Prefect Secret over a provided connection string (either directly or through env var). A provided connection string should take precedence over looking for a Prefect Secret.


## Why is this PR important?
Previously the Prefect Secret was always used unless specified as `None`.

