### PR TITLE
Fix `auth create-token` CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix `auth create-token` CLI command specifying deprecated `role` instead of `scope` - [#2336](https://github.com/PrefectHQ/prefect/issues/2336)
 
 ### Deprecations
 

--- a/docs/orchestration/concepts/api.md
+++ b/docs/orchestration/concepts/api.md
@@ -14,7 +14,7 @@ To generate an API token, use the Cloud UI or the following GraphQL call (from a
 
 ```graphql
 mutation {
-  create_api_token(input: { name: "My API token", role: USER }) {
+  create_api_token(input: { name: "My API token", scope: USER }) {
     token
   }
 }

--- a/docs/orchestration/concepts/cli.md
+++ b/docs/orchestration/concepts/cli.md
@@ -444,7 +444,7 @@ Unable to switch tenant
 
 #### auth create-token
 
-Running `prefect auth create-token --name MY_TOKEN --role RUNNER` will generate a Prefect Cloud API token and output it to stdout. For more information on API tokens go [here](./api.html).
+Running `prefect auth create-token --name MY_TOKEN --scope RUNNER` will generate a Prefect Cloud API token and output it to stdout. For more information on API tokens go [here](./api.html).
 
 ```
 $ prefect auth create-token -n MyToken -r RUNNER

--- a/docs/orchestration/concepts/tokens.md
+++ b/docs/orchestration/concepts/tokens.md
@@ -32,7 +32,7 @@ After you click create you will be prompted with the token which you can copy an
 
 ### CLI
 
-To create a token with the CLI run the `create-token` command with the desired token name and role. For more information on how to use the CLI go [here](cli.html).
+To create a token with the CLI run the `create-token` command with the desired token name and scope. For more information on how to use the CLI go [here](cli.html).
 
 ```
 $ prefect auth create-token -n my-runner-token -r RUNNER
@@ -44,7 +44,7 @@ To create a token using GraphQL execute the `create_api_token` mutation against 
 
 ```graphql
 mutation {
-  create_api_token(input: { name: "my-runner-token", role: RUNNER }) {
+  create_api_token(input: { name: "my-runner-token", scope: RUNNER }) {
     token
   }
 }

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -187,7 +187,7 @@ def create_token(name, scope):
     """
     Create a Prefect Cloud API token.
 
-    For more info on API tokens visit https://docs.prefect.io/cloud/concepts/api.html
+    For more info on API tokens visit https://docs.prefect.io/orchestration/concepts/api.html
 
     \b
     Options:

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -182,8 +182,8 @@ def switch_tenants(id, slug):
 
 @auth.command(hidden=True)
 @click.option("--name", "-n", required=True, help="A token name.", hidden=True)
-@click.option("--role", "-r", required=True, help="A token role.", hidden=True)
-def create_token(name, role):
+@click.option("--scope", "-s", required=True, help="A token scopre.", hidden=True)
+def create_token(name, scope):
     """
     Create a Prefect Cloud API token.
 
@@ -192,7 +192,7 @@ def create_token(name, role):
     \b
     Options:
         --name, -n      TEXT    A name to give the generated token
-        --role, -r      TEXT    A role for the token
+        --scope, -r     TEXT    A scope for the token
     """
     check_override_auth_token()
 
@@ -204,7 +204,7 @@ def create_token(name, role):
                 "create_api_token(input: $input)": {"token"}
             }
         },
-        variables=dict(input=dict(name=name, role=role)),
+        variables=dict(input=dict(name=name, scope=scope)),
     )
 
     if not output.get("data", None):

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -147,7 +147,7 @@ def test_create_token(patch_post):
 
     with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
         runner = CliRunner()
-        result = runner.invoke(auth, ["create-token", "-n", "name", "-r", "role"])
+        result = runner.invoke(auth, ["create-token", "-n", "name", "-s", "scope"])
         assert result.exit_code == 0
         assert "token" in result.output
 
@@ -157,7 +157,7 @@ def test_create_token_fails(patch_post):
 
     with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
         runner = CliRunner()
-        result = runner.invoke(auth, ["create-token", "-n", "name", "-r", "role"])
+        result = runner.invoke(auth, ["create-token", "-n", "name", "-s", "scope"])
         assert result.exit_code == 0
         assert "Issue creating API token" in result.output
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2336 
The `create_api_token` mutation, when converted to snake casing convention in a recent release, switched over to using `scope` instead of `role` when creating a token.


## Why is this PR important?
Fixing a broken CLI command

