### PR TITLE
Use YAML safe command versions in server start CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add option to connect containers created by Docker agent to an existing Docker network - [#2334](https://github.com/PrefectHQ/prefect/pull/2334)
 - Expose `datefmt` as a configurable logging option in Prefect configuration - [#2340](https://github.com/PrefectHQ/prefect/pull/2340)
 - The Docker agent configures containers to auto-remove on completion - [#2347](https://github.com/PrefectHQ/prefect/pull/2347)
+- Use YAML's safe load and dump commands for the `server start` CLI command - [#2352](https://github.com/PrefectHQ/prefect/pull/2352)
 
 ### Task Library
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -235,7 +235,7 @@ def start(
         shutil.copy2(os.path.join(docker_dir, "docker-compose.yml"), temp_path)
 
         with open(temp_path, "r") as file:
-            y = yaml.load(file)
+            y = yaml.safe_load(file)
 
             if no_postgres_port:
                 del y["services"]["postgres"]["ports"]
@@ -260,7 +260,7 @@ def start(
                     ]
 
         with open(temp_path, "w") as f:
-            y = yaml.dump(y, f)
+            y = yaml.safe_dump(y, f)
 
         compose_dir_path = temp_dir
 

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -216,7 +216,7 @@ def test_server_start_linux_host(monkeypatch, linux_platform):
     monkeypatch.setattr("prefect.cli.server.get_docker_ip", get_docker_ip)
 
     yaml_dump = MagicMock()
-    monkeypatch.setattr("yaml.dump", yaml_dump)
+    monkeypatch.setattr("yaml.safe_dump", yaml_dump)
 
     runner = CliRunner()
     result = runner.invoke(server, ["start", "--skip-pull",],)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Changes yaml `load` and `dump` to `safe_load` and `safe_dump` in the server start CLI command.


## Why is this PR important?
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

