### PR TITLE
Minor AWS creds refactor

### DIFF
--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -26,15 +26,6 @@ class S3(Storage):
 
     Args:
         - bucket (str): the name of the S3 Bucket to store Flows
-        - aws_access_key_id (str, optional): AWS access key id for connecting to S3.
-            Defaults to the value set in the environment variable
-            `AWS_ACCESS_KEY_ID` or `None`
-        - aws_secret_access_key (str, optional): AWS secret access key for connecting to S3.
-            Defaults to the value set in the environment variable
-            `AWS_SECRET_ACCESS_KEY` or `None`
-        - aws_session_token (str, optional): AWS session key for connecting to S3
-            Defaults to the value set in the environment variable
-            `AWS_SESSION_TOKEN` or `None`
         - key (str, optional): a unique key to use for uploading a Flow to S3. This
             is only useful when storing a single Flow using this storage object.
         - client_options (dict, optional): Additional options for the `boto3` client.
@@ -45,9 +36,6 @@ class S3(Storage):
     def __init__(
         self,
         bucket: str,
-        aws_access_key_id: str = None,
-        aws_secret_access_key: str = None,
-        aws_session_token: str = None,
         client_options: dict = None,
         key: str = None,
         secrets: List[str] = None,
@@ -57,9 +45,6 @@ class S3(Storage):
         self.bucket = bucket
         self.key = key
 
-        self.aws_access_key_id = aws_access_key_id
-        self.aws_secret_access_key = aws_secret_access_key
-        self.aws_session_token = aws_session_token
         self.client_options = client_options
 
         result_handler = S3ResultHandler(bucket=bucket)
@@ -194,13 +179,7 @@ class S3(Storage):
     def _boto3_client(self):  # type: ignore
         from prefect.utilities.aws import get_boto_client
 
-        creds = dict(
-            ACCESS_KEY=self.aws_access_key_id,
-            SECRET_ACCESS_KEY=self.aws_secret_access_key,
-        )
-        kwargs = dict(
-            aws_session_token=self.aws_session_token, **(self.client_options or {})
-        )
+        kwargs = self.client_options or {}
         return get_boto_client(
-            resource="s3", credentials=creds, use_session=False, **kwargs
+            resource="s3", credentials=None, use_session=False, **kwargs
         )

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -26,14 +26,17 @@ def get_boto_client(
     """
     aws_access_key = None
     aws_secret_access_key = None
+    aws_session_token = None
 
     if credentials:
         aws_access_key = credentials["ACCESS_KEY"]
         aws_secret_access_key = credentials["SECRET_ACCESS_KEY"]
+        aws_session_token = credentials.get("SESSION_TOKEN")
     else:
         ctx_credentials = prefect.context.get("secrets", {}).get("AWS_CREDENTIALS", {})
         aws_access_key = ctx_credentials.get("ACCESS_KEY")
         aws_secret_access_key = ctx_credentials.get("SECRET_ACCESS_KEY")
+        aws_session_token = ctx_credentials.get("SESSION_TOKEN")
 
     if use_session:
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
@@ -42,6 +45,7 @@ def get_boto_client(
             resource,
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             **kwargs
         )
     else:
@@ -49,5 +53,6 @@ def get_boto_client(
             resource,
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             **kwargs
         )

--- a/tests/engine/results/test_s3_result.py
+++ b/tests/engine/results/test_s3_result.py
@@ -33,6 +33,7 @@ class TestS3Result:
                 result.initialize_client()
         assert session.Session().client.call_args[1] == {
             "aws_access_key_id": 1,
+            "aws_session_token": None,
             "aws_secret_access_key": 42,
         }
 

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import cloudpickle
 import pytest
 
-from prefect import Flow
+from prefect import context, Flow
 from prefect.environments.storage import S3
 
 pytest.importorskip("boto3")
@@ -21,9 +21,6 @@ def test_create_s3_storage():
 
 def test_create_s3_storage_init_args():
     storage = S3(
-        aws_access_key_id="id",
-        aws_secret_access_key="secret",
-        aws_session_token="session",
         bucket="bucket",
         key="key",
         client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False,},
@@ -31,9 +28,6 @@ def test_create_s3_storage_init_args():
     )
     assert storage
     assert storage.flows == dict()
-    assert storage.aws_access_key_id == "id"
-    assert storage.aws_secret_access_key == "secret"
-    assert storage.aws_session_token == "session"
     assert storage.bucket == "bucket"
     assert storage.key == "key"
     assert storage.client_options == {
@@ -65,13 +59,14 @@ def test_boto3_client_property(monkeypatch):
 
     storage = S3(
         bucket="bucket",
-        aws_access_key_id="id",
-        aws_secret_access_key="secret",
-        aws_session_token="session",
         client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False,},
     )
 
-    boto3_client = storage._boto3_client
+    credentials = dict(
+        ACCESS_KEY="id", SECRET_ACCESS_KEY="secret", SESSION_TOKEN="session"
+    )
+    with context(secrets=dict(AWS_CREDENTIALS=credentials)):
+        boto3_client = storage._boto3_client
     assert boto3_client
     boto3.assert_called_with(
         "s3",

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -90,14 +90,7 @@ def test_s3_empty_serialize():
 
 
 def test_s3_full_serialize():
-    s3 = storage.S3(
-        aws_access_key_id="id",
-        aws_secret_access_key="secret",
-        aws_session_token="session",
-        bucket="bucket",
-        key="key",
-        secrets=["hidden", "auth"],
-    )
+    s3 = storage.S3(bucket="bucket", key="key", secrets=["hidden", "auth"],)
     serialized = S3Schema().dump(s3)
 
     assert serialized
@@ -107,34 +100,8 @@ def test_s3_full_serialize():
     assert serialized["secrets"] == ["hidden", "auth"]
 
 
-def test_s3_aws_creds_not_serialized():
-    s3 = storage.S3(
-        aws_access_key_id="id",
-        aws_secret_access_key="secret",
-        aws_session_token="session",
-        bucket="bucket",
-        key="key",
-    )
-    serialized = S3Schema().dump(s3)
-
-    assert serialized
-    assert serialized["__version__"] == prefect.__version__
-    assert serialized["bucket"] == "bucket"
-    assert serialized["key"] == "key"
-    assert serialized.get("aws_access_key_id") is None
-    assert serialized.get("aws_secret_access_key") is None
-    assert serialized.get("aws_session_token") is None
-
-
 def test_s3_serialize_with_flows():
-    s3 = storage.S3(
-        aws_access_key_id="id",
-        aws_secret_access_key="secret",
-        aws_session_token="session",
-        bucket="bucket",
-        key="key",
-        secrets=["hidden", "auth"],
-    )
+    s3 = storage.S3(bucket="bucket", key="key", secrets=["hidden", "auth"],)
     f = prefect.Flow("test")
     s3.flows["test"] = "key"
     serialized = S3Schema().dump(s3)

--- a/tests/tasks/aws/test_lambda.py
+++ b/tests/tasks/aws/test_lambda.py
@@ -34,12 +34,20 @@ class TestLambdaCreate:
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
                 )
             ):
                 task.run()
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
 
 
 class TestLambdaDelete:
@@ -54,12 +62,20 @@ class TestLambdaDelete:
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
                 )
             ):
                 task.run()
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
 
 
 class TestLambdaInvoke:
@@ -74,12 +90,20 @@ class TestLambdaInvoke:
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
                 )
             ):
                 task.run()
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
 
 
 class TestLambdaList:
@@ -94,9 +118,17 @@ class TestLambdaList:
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
                 )
             ):
                 task.run()
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -34,7 +34,11 @@ class TestS3Download:
             ):
                 task.run(key="")
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": None,
+        }
 
     def test_creds_default_to_environment(self, monkeypatch):
         task = S3Download(bucket="bob")
@@ -43,7 +47,11 @@ class TestS3Download:
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
         task.run(key="")
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": None, "aws_secret_access_key": None}
+        assert kwargs == {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+        }
 
 
 class TestS3Upload:
@@ -87,7 +95,11 @@ class TestS3Upload:
             ):
                 task.run(data="")
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": None,
+        }
 
     def test_creds_default_to_environment(self, monkeypatch):
         task = S3Upload(bucket="bob")
@@ -96,4 +108,8 @@ class TestS3Upload:
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
         task.run(data="")
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": None, "aws_secret_access_key": None}
+        assert kwargs == {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+        }

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -26,9 +26,17 @@ class TestStepActivate:
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
                 )
             ):
                 task.run()
         kwargs = client.call_args[1]
-        assert kwargs == {"aws_access_key_id": "42", "aws_secret_access_key": "99"}
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }


### PR DESCRIPTION
This PR will address https://github.com/PrefectHQ/prefect/issues/2272 once it's released with 0.11.0.  

In particular:
- adds `SESSION_TOKEN` as a possible key for AWS credentials stored in secrets
- removes the credentials kwargs on S3 Storage.  Storage classes are _always_ deserialized from Cloud and as such, cannot access non-serialized attributes so these kwargs were non-functional 