### PR TITLE
Closes #2333. Add contrib directories and READMEs for prefect core and server

### DIFF
--- a/server/contrib/README.md
+++ b/server/contrib/README.md
@@ -1,0 +1,3 @@
+## Server contrib
+
+The `/server/contrib` package is a deciated place for community contributed code to Prefect Core's open source orchestration server.

--- a/src/prefect/contrib/README.md
+++ b/src/prefect/contrib/README.md
@@ -1,0 +1,5 @@
+## Contrib
+
+The `/src/prefect/contrib` package is a dedicated place for community contributed code related to the core Prefect library or Prefect task library. Code here might not be owned or supported fully by the core Prefect developers, though as contributed software expands it is possible that features in `contrib` may move into the core codebase. Feel free to PR into `contrib` at any stage in development, even if it doesn't meet exact the exact style, testing, or documentation conventions of the core codebase.
+
+The `contrib` package structure is not specifically mandated at this time, but the intention is that the subpackages in here will mirror those in `/src/prefect/` incrementally as code is added. Any tests for contributed code should be placed in the analogous `/tests/contrib` subdirectory.

--- a/tests/contrib/README.md
+++ b/tests/contrib/README.md
@@ -1,0 +1,3 @@
+## Contrib tests
+
+Tests for code in `/src/prefect/contrib` should be placed in this folder, using a directory structure that mirrors the analogous `contrib` subdirectory. This way we can more easily enforce separate testing enforcement (e.g. github checks) on contributed code.


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [n/a] adds new tests (if appropriate)
- [n/a] updates `CHANGELOG.md` (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2333. Adds in a `contrib` folder with a basic readme for `/src/prefect` (and an analogous spot for `/tests/`) and another one in `/server/`. For the latter, I imagine we might split this more over time depending what type of contributions really go into server (for example, a contrib folder specifically for UI in `/server/services/ui/src`) but this felt like a safe starting point there while we still get a sense for what contributions to expect.


## Why is this PR important?
Makes it easier to distinguish between core supported code and community supported code, and make it easier for contributors to merge PRs while we continue to sophisticate our published contributing guidelines and design principles.

