### PR TITLE
Fix return type annotations for switch & ifelse

### DIFF
--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -49,7 +49,7 @@ class CompareValue(Task):
             )
 
 
-def switch(condition: Task, cases: Dict[Any, Task]) -> None:
+def switch(condition: Task, cases: Dict[Any, Task]) -> Task:
     """
     Adds a SWITCH to a workflow.
 
@@ -102,7 +102,7 @@ def switch(condition: Task, cases: Dict[Any, Task]) -> None:
         return merge(*cases.values())
 
 
-def ifelse(condition: Task, true_task: Task, false_task: Task) -> None:
+def ifelse(condition: Task, true_task: Task, false_task: Task) -> Task:
     """
     Builds a conditional branch into a workflow.
 


### PR DESCRIPTION
The code and docstrings were correct, but the type annotations weren't.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

