### PR TITLE
Support for Docker volumes and list filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Add support for Docker volumes and filtering in `prefect.tasks.docker`.
+- None
 
 ### Task Library
 
-- None
+- Add support for Docker volumes and filtering in `prefect.tasks.docker`.
 
 ### Fixes
 
@@ -30,7 +30,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- [Nelson Cornet](https://github.com/sk4la)
 
 ## 0.10.4 <Badge text="beta" type="success"/>
 

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -38,7 +38,9 @@ class ListImages(Task):
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("repository_name", "all_layers", "filters", "docker_server_url")
+    @defaults_from_attrs(
+        "repository_name", "all_layers", "filters", "docker_server_url"
+    )
     def run(
         self,
         repository_name: str = None,
@@ -70,7 +72,9 @@ class ListImages(Task):
             "Starting docker pull for repository {}...".format(repository_name)
         )
         client = docker.APIClient(base_url=docker_server_url, version="auto")
-        api_result = client.images(name=repository_name, all=all_layers, filters=filters)
+        api_result = client.images(
+            name=repository_name, all=all_layers, filters=filters
+        )
         self.logger.debug(
             "Completed docker pull for repository {}...".format(repository_name)
         )

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -232,7 +232,9 @@ class TestListContainersTask(DockerLoggingTestingUtilityMixin):
         assert task.docker_server_url == "unix:///var/run/docker.sock"
 
     def test_filled_initialization(self):
-        task = ListContainers(all_containers=True, filters={"name": "test"}, docker_server_url="test")
+        task = ListContainers(
+            all_containers=True, filters={"name": "test"}, docker_server_url="test"
+        )
         assert task.all_containers == True
         assert task.filters == {"name": "test"}
         assert task.docker_server_url == "test"

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -67,7 +67,7 @@ class TestCreateContainerTask(DockerLoggingTestingUtilityMixin):
             detach=True,
             entrypoint=["test"],
             environment=["test"],
-            volumes=["/tmp/test:/tmp/test:ro"]
+            volumes=["/tmp/test:/tmp/test:ro"],
             name="test",
             docker_server_url="test",
         )

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -58,7 +58,10 @@ class TestListImagesTask(DockerLoggingTestingUtilityMixin):
 
     def test_filled_initialization(self):
         task = ListImages(
-            repository_name="test", all_layers=True, filters={"name": "test"}, docker_server_url="test"
+            repository_name="test",
+            all_layers=True,
+            filters={"name": "test"},
+            docker_server_url="test",
         )
         assert task.repository_name == "test"
         assert task.all_layers == True


### PR DESCRIPTION
## What does this PR change?

At the moment, only a subset of the Docker API is supported by Prefect's [Docker tasks](https://github.com/PrefectHQ/prefect/tree/master/src/prefect/tasks/docker).

Nothing too fancy, I simply added some code to the current tasks (respectively `CreateContainer`, `ListContainers` and `ListImages`) in order to allow the following optional arguments when calling the `run` method:

* `volumes` ;
* `filters`.

I invite you to refer to the [documentation](https://docker-py.readthedocs.io/en/stable/index.html) in case you're not familiar with Docker-related concepts.

## Why is this PR important?

I plan to use Prefect at my workplace to manage Docker-based ETL jobs (heavily relying on disk I/O), but the lack of support for Docker volumes and list filtering is sadly a no-go.