### PR TITLE
Add serializer for RemoteDaskEnvironment and add server start image version logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Agent connection step shows which endpoint it is connected to and checks API connectivity - [#2372](https://github.com/PrefectHQ/prefect/pull/2372)
+- Added serializer for `RemoteDaskEnvironment` - [#2369](https://github.com/PrefectHQ/prefect/issues/2369)
+- `server start` CLI command now defaults to image build based on current Prefect installation version - [#2375](https://github.com/PrefectHQ/prefect/issues/2375)
 
 ### Task Library
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -91,7 +91,6 @@ def server():
     "--version",
     "-v",
     help="The server image versions to use (for example, '0.10.0' or 'master')",
-    default="master" if len(prefect.__version__.split("+")) > 1 else "latest",
     hidden=True,
 )
 @click.option(
@@ -198,7 +197,7 @@ def start(
     \b
     Options:
         --version, -v   TEXT    The server image versions to use (for example, '0.10.0' or 'master')
-                                Defaults to 'latest'
+                                Defaults to the current installed Prefect version.
         --skip-pull             Flag to skip pulling new images (if available)
         --no-upgrade, -n        Flag to avoid running a database upgrade when the database spins up
         --no-ui, -u             Flag to avoid starting the UI
@@ -277,7 +276,11 @@ def start(
         env = make_env()
 
     if "PREFECT_SERVER_TAG" not in env:
-        env.update(PREFECT_SERVER_TAG=version)
+        env.update(
+            PREFECT_SERVER_TAG=version or "master"
+            if len(prefect.__version__.split("+")) > 1
+            else prefect.__version__
+        )
     if "PREFECT_SERVER_DB_CMD" not in env:
         cmd = (
             "prefect-server database upgrade -y"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 import yaml
 
+import prefect
 from prefect import config
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.docker_util import platform_is_linux, get_docker_ip
@@ -90,8 +91,7 @@ def server():
     "--version",
     "-v",
     help="The server image versions to use (for example, '0.10.0' or 'master')",
-    # TODO: update this default to use prefect.__version__ logic
-    default="latest",
+    default="master" if len(prefect.__version__.split("+")) > 1 else "latest",
     hidden=True,
 )
 @click.option(

--- a/src/prefect/environments/execution/dask/remote.py
+++ b/src/prefect/environments/execution/dask/remote.py
@@ -51,13 +51,16 @@ class RemoteDaskEnvironment(RemoteEnvironment):
         on_start: Callable = None,
         on_exit: Callable = None,
     ) -> None:
-        dask_executor_kwargs = executor_kwargs or dict()
-        dask_executor_kwargs["address"] = address
+        self.address = address
+        self.dask_executor_kwargs = executor_kwargs or dict()
+        self.dask_executor_kwargs["address"] = address
+
         if security:
-            dask_executor_kwargs["security"] = security
+            self.dask_executor_kwargs["security"] = security
+
         super().__init__(
             executor="prefect.engine.executors.DaskExecutor",
-            executor_kwargs=dask_executor_kwargs,
+            executor_kwargs=self.dask_executor_kwargs,
             labels=labels,
             on_start=on_start,
             on_exit=on_exit,

--- a/src/prefect/environments/execution/dask/remote.py
+++ b/src/prefect/environments/execution/dask/remote.py
@@ -52,15 +52,15 @@ class RemoteDaskEnvironment(RemoteEnvironment):
         on_exit: Callable = None,
     ) -> None:
         self.address = address
-        self.dask_executor_kwargs = executor_kwargs or dict()
-        self.dask_executor_kwargs["address"] = address
+        dask_executor_kwargs = executor_kwargs or dict()
+        dask_executor_kwargs["address"] = address
 
         if security:
-            self.dask_executor_kwargs["security"] = security
+            dask_executor_kwargs["security"] = security
 
         super().__init__(
             executor="prefect.engine.executors.DaskExecutor",
-            executor_kwargs=self.dask_executor_kwargs,
+            executor_kwargs=dask_executor_kwargs,
             labels=labels,
             on_start=on_start,
             on_exit=on_exit,

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -67,6 +67,7 @@ class RemoteDaskEnvironmentSchema(ObjectSchema):
         object_class = RemoteDaskEnvironment
 
     address = fields.String()
+    labels = fields.List(fields.String())
 
 
 class CustomEnvironmentSchema(ObjectSchema):

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -9,6 +9,7 @@ from prefect.environments import (
     KubernetesJobEnvironment,
     LocalEnvironment,
     RemoteEnvironment,
+    RemoteDaskEnvironment,
 )
 from prefect.utilities.serialization import ObjectSchema, OneOfSchema, to_qualified_name
 
@@ -61,6 +62,13 @@ class RemoteEnvironmentSchema(ObjectSchema):
     labels = fields.List(fields.String())
 
 
+class RemoteDaskEnvironmentSchema(ObjectSchema):
+    class Meta:
+        object_class = RemoteDaskEnvironment
+
+    address = fields.String()
+
+
 class CustomEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = lambda: Environment
@@ -94,6 +102,7 @@ class EnvironmentSchema(OneOfSchema):
         "LocalEnvironment": LocalEnvironmentSchema,
         "KubernetesJobEnvironment": KubernetesJobEnvironmentSchema,
         "RemoteEnvironment": RemoteEnvironmentSchema,
+        "RemoteDaskEnvironment": RemoteDaskEnvironmentSchema,
         "CustomEnvironment": CustomEnvironmentSchema,
     }
 

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -11,6 +11,7 @@ from prefect.serialization.environment import (
     KubernetesJobEnvironmentSchema,
     LocalEnvironmentSchema,
     RemoteEnvironmentSchema,
+    RemoteDaskEnvironmentSchema,
 )
 
 
@@ -250,6 +251,38 @@ def test_serialize_remote_environment_with_labels():
     new = schema.load(serialized)
     assert new.executor == prefect.config.engine.executor.default_class
     assert new.executor_kwargs == {}
+    assert new.labels == set(["bob", "alice"])
+
+
+def test_serialize_remote_dask_environment():
+    env = environments.RemoteDaskEnvironment(address="test")
+
+    schema = RemoteDaskEnvironmentSchema()
+    serialized = schema.dump(env)
+    assert serialized
+    assert serialized["__version__"] == prefect.__version__
+    assert serialized["address"] == "test"
+    assert serialized["labels"] == []
+
+    new = schema.load(serialized)
+    assert new.address == "test"
+    assert new.labels == set()
+
+
+def test_serialize_remote_dask_environment_with_labels():
+    env = environments.RemoteDaskEnvironment(
+        address="test", labels=["bob", "alice"], executor_kwargs={"not": "present"}
+    )
+
+    schema = RemoteDaskEnvironmentSchema()
+    serialized = schema.dump(env)
+    assert serialized
+    assert serialized["__version__"] == prefect.__version__
+    assert serialized["address"] == "test"
+    assert set(serialized["labels"]) == set(["bob", "alice"])
+
+    new = schema.load(serialized)
+    assert new.address == "test"
     assert new.labels == set(["bob", "alice"])
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2369 
Closes #2375 


## Why is this PR important?
Now the RemoteDaskEnvironment won't show up as a CustomEnvironment and the image tag selection based on Prefect version is good for local development.

