### PR TITLE
Add executor_kwargs to KubernetesJobEnvironment and FargateTaskEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Add option to set `executor_kwargs` on `KubernetesJobEnvironment` and `FargateTaskEnvironment` - [#2258](https://github.com/PrefectHQ/prefect/issues/2258)
 
 ### Task Library
 

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -25,6 +25,26 @@ def test_create_k8s_job_environment():
         )
         assert environment
         assert environment.job_spec_file == os.path.join(directory, "job.yaml")
+        assert environment.executor_kwargs == {}
+        assert environment.labels == set()
+        assert environment.on_start is None
+        assert environment.on_exit is None
+        assert environment.logger.name == "prefect.KubernetesJobEnvironment"
+
+
+def test_create_k8s_job_environment_with_executor_kwargs():
+    with tempfile.TemporaryDirectory() as directory:
+
+        with open(os.path.join(directory, "job.yaml"), "w+") as file:
+            file.write("job")
+
+        environment = KubernetesJobEnvironment(
+            job_spec_file=os.path.join(directory, "job.yaml"),
+            executor_kwargs={"test": "here"},
+        )
+        assert environment
+        assert environment.job_spec_file == os.path.join(directory, "job.yaml")
+        assert environment.executor_kwargs == {"test": "here"}
         assert environment.labels == set()
         assert environment.on_start is None
         assert environment.on_exit is None

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -43,12 +43,7 @@ def test_create_k8s_job_environment_with_executor_kwargs():
             executor_kwargs={"test": "here"},
         )
         assert environment
-        assert environment.job_spec_file == os.path.join(directory, "job.yaml")
         assert environment.executor_kwargs == {"test": "here"}
-        assert environment.labels == set()
-        assert environment.on_start is None
-        assert environment.on_exit is None
-        assert environment.logger.name == "prefect.KubernetesJobEnvironment"
 
 
 def test_create_k8s_job_environment_labels():
@@ -215,12 +210,19 @@ def test_create_flow_run_job_fails_outside_cluster():
 
 def test_run_flow(monkeypatch):
     file_path = os.path.dirname(prefect.environments.execution.dask.k8s.__file__)
-    environment = KubernetesJobEnvironment(path.join(file_path, "job.yaml"))
+    environment = KubernetesJobEnvironment(
+        path.join(file_path, "job.yaml"), executor_kwargs={"test": "here"}
+    )
 
     flow_runner = MagicMock()
     monkeypatch.setattr(
         "prefect.engine.get_default_flow_runner_class",
         MagicMock(return_value=flow_runner),
+    )
+
+    executor = MagicMock()
+    monkeypatch.setattr(
+        "prefect.engine.get_default_executor_class", MagicMock(return_value=executor),
     )
 
     with tempfile.TemporaryDirectory() as directory:
@@ -237,6 +239,7 @@ def test_run_flow(monkeypatch):
                 environment.run_flow()
 
         assert flow_runner.call_args[1]["flow"].name == "test"
+        assert executor.call_args[1] == {"test": "here"}
 
 
 def test_run_flow_calls_callbacks(monkeypatch):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2258 


## Why is this PR important?
This allows optional executor kwargs to be set on these environments where previously it was not possible to pass arguments to the executors they used.

