### PR TITLE
Add flag for toggling Docker interface check on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Task Library
 
-- Add Pushbullet notification task to send notifications to mobile [#2366](https://github.com/PrefectHQ/prefect/pull/2366)
-- Add support for Docker volumes and filtering in `prefect.tasks.docker`.
+- Add Pushbullet notification task to send notifications to mobile - [#2366](https://github.com/PrefectHQ/prefect/pull/2366)
+- Add support for Docker volumes and filtering in `prefect.tasks.docker` - [#2384](https://github.com/PrefectHQ/prefect/pull/2384)
 
 ### Fixes
 
@@ -42,6 +42,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - [Nelson Cornet](https://github.com/sk4la)
 - [Braun Reyes](https://github.com/braunreyes)
 - [Fraznist](https://github.com/Fraznist)
+- [sk4la](https://github.com/sk4la)
 
 ## 0.10.4 <Badge text="beta" type="success"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add map index to task logs for mapped task runs - [#2402](https://github.com/PrefectHQ/prefect/pull/2402)
 - Agents can now register themselves with Cloud for better management - [#2312](https://github.com/PrefectHQ/prefect/issues/2312)
 - Adding support for `environment`, `secrets`, and `mountPoints` via configurable `containerDefinitions` to the Fargate Agent - [#2397](https://github.com/PrefectHQ/prefect/pull/2397)
+- Add flag for disabling Docker agent interface check on Linux - [#2361](https://github.com/PrefectHQ/prefect/issues/2361)
 
 ### Task Library
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -50,6 +50,9 @@ class DockerAgent(Agent):
             to stdout; defaults to `False`
         - volumes (List[str], optional): a list of Docker volume mounts to be attached to any and all created containers.
         - network (str, optional): Add containers to an existing docker network
+        - docker_interface (bool, optional): Toggle whether or not a `docker0` interface is present on this machine.
+            Defaults to `True`. **Note**: This is mostly relevant for some Docker-in-Docker setups that users may be
+            running their agent with.
     """
 
     def __init__(
@@ -63,6 +66,7 @@ class DockerAgent(Agent):
         volumes: List[str] = None,
         show_flow_logs: bool = False,
         network: str = None,
+        docker_interface: bool = True,
     ) -> None:
         super().__init__(
             name=name, labels=labels, env_vars=env_vars, max_polls=max_polls
@@ -93,6 +97,11 @@ class DockerAgent(Agent):
         # Add containers to a docker network
         self.network = network
         self.logger.debug("Docker network set to {}".format(self.network))
+
+        self.docker_interface = docker_interface
+        self.logger.debug(
+            "Docker interface toggle set to {}".format(self.docker_interface)
+        )
 
         self.failed_connections = 0
         self.docker_client = self._get_docker_client()
@@ -339,7 +348,7 @@ class DockerAgent(Agent):
         if container_mount_paths:
             host_config.update(binds=self.host_spec)
 
-        if sys.platform.startswith("linux"):
+        if sys.platform.startswith("linux") and self.docker_interface:
             docker_internal_ip = get_docker_ip()
             host_config.update(extra_hosts={"host.docker.internal": docker_internal_ip})
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -119,6 +119,12 @@ def agent():
 @click.option(
     "--network", help="Add containers to an existing docker network", hidden=True,
 )
+@click.option(
+    "--no-docker-interface",
+    is_flag=True,
+    help="Disable presence of a Docker interface.",
+    hidden=True,
+)
 @click.pass_context
 def start(
     ctx,
@@ -136,6 +142,7 @@ def start(
     show_flow_logs,
     volume,
     network,
+    no_docker_interface,
     max_polls,
 ):
     """
@@ -171,12 +178,15 @@ def start(
 
     \b
     Docker Agent Options:
-        --base-url, -b  TEXT    A Docker daemon host URL for a DockerAgent
-        --no-pull               Pull images for a DockerAgent
-                                Defaults to pulling if not provided
-        --volume        TEXT    Host paths for Docker bind mount volumes attached to each Flow runtime container.
-                                Multiple values supported e.g. `--volume /some/path --volume /some/other/path`
-        --network       TEXT    Add containers to an existing docker network
+        --base-url, -b      TEXT    A Docker daemon host URL for a DockerAgent
+        --no-pull                   Pull images for a DockerAgent
+                                    Defaults to pulling if not provided
+        --volume            TEXT    Host paths for Docker bind mount volumes attached to each Flow runtime container.
+                                    Multiple values supported e.g. `--volume /some/path --volume /some/other/path`
+        --network           TEXT    Add containers to an existing docker network
+        --no-docker-interface       Disable the check of a Docker interface on this machine.
+                                    **Note**: This is mostly relevant for some Docker-in-Docker setups that users may be
+                                    running their agent with.
 
     \b
     Kubernetes Agent Options:
@@ -234,6 +244,7 @@ def start(
                 show_flow_logs=show_flow_logs,
                 volumes=list(volume),
                 network=network,
+                docker_interface=not no_docker_interface,
             ).start()
         elif agent_option == "fargate":
             from_qualified_name(retrieved_agent)(

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -203,6 +203,7 @@ def test_agent_start_with_env_vars(monkeypatch, runner_token):
         show_flow_logs=False,
         volumes=[],
         network=None,
+        docker_interface=True,
     )
 
 
@@ -224,6 +225,7 @@ def test_agent_start_with_max_polls(monkeypatch, runner_token):
         show_flow_logs=False,
         volumes=[],
         network=None,
+        docker_interface=True,
     )
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a flag to disable the auto host mounting for Linux. Closes #2361 


## Why is this PR important?
In certain Docker setups (notably some Docker-in-Docker), there is no `docker0` interface present inside the container so this step of auto-attaching the internal docker daemon fails.

