### PR TITLE
Fix server start image version not using version kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix `server start` CLI command not respecting `version` kwarg on tagged releases - [#2435](https://github.com/PrefectHQ/prefect/pull/2435)
 
 ### Deprecations
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -277,9 +277,12 @@ def start(
 
     if "PREFECT_SERVER_TAG" not in env:
         env.update(
-            PREFECT_SERVER_TAG=version or "master"
-            if len(prefect.__version__.split("+")) > 1
-            else prefect.__version__
+            PREFECT_SERVER_TAG=version
+            or (
+                "master"
+                if len(prefect.__version__.split("+")) > 1
+                else prefect.__version__
+            )
         )
     if "PREFECT_SERVER_DB_CMD" not in env:
         cmd = (


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Fixes a bug where the `version` kwarg on the `server start` CLI command wasn't being respected on tagged releases.
