### PR TITLE
Pop args out of log messages to prevent shipping non-JSON objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix `server start` CLI command not respecting `version` kwarg on tagged releases - [#2435](https://github.com/PrefectHQ/prefect/pull/2435)
+- Fix issue with non-JSON serializable args being used to format log messages preventing them from shipping to Cloud - [#2407](https://github.com/PrefectHQ/prefect/issues/2407)
 
 ### Deprecations
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -130,6 +130,9 @@ class CloudHandler(logging.StreamHandler):
             assert isinstance(self.client, Client)  # mypy assert
 
             record_dict = record.__dict__.copy()
+            ## remove potentially non-json serializable formatting args
+            record_dict.pop("args", None)
+
             log = dict()
             log["flow_run_id"] = prefect.context.get("flow_run_id", None)
             log["task_run_id"] = prefect.context.get("task_run_id", None)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR pops `args` out of the logs record dictionary to prevent them from being sent to Cloud (under the `info` payload).  `args` are _typically_ used to format log messages and otherwise not needed for log visibility / inspection in Cloud.


## Why is this PR important?
Closes #2407 and helps ensure users don't need to change their logging code when running in Prefect.
