### PR TITLE
Dont spuriously create None task when using ifelse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Don't create a `None` task for the `False` condition when using `ifelse` - [#2449](https://github.com/PrefectHQ/prefect/pull/2449)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- Don't create a `None` task for the `False` condition when using `ifelse` - [#2449](https://github.com/PrefectHQ/prefect/pull/2449)
+- Don't create a `None` task for a null condition when using `ifelse` - [#2449](https://github.com/PrefectHQ/prefect/pull/2449)
 
 ### Task Library
 

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -114,7 +114,10 @@ def ifelse(condition: Task, true_task: Task, false_task: Task) -> None:
     def as_bool(x):
         return bool(x)
 
-    switch(condition=as_bool(condition), cases={True: true_task, False: false_task})
+    cases = {True: true_task}
+    if false_task is not None:
+        cases.update({False: false_task})
+    switch(condition=as_bool(condition), cases=cases)
 
 
 def merge(*tasks: Task) -> Task:

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -114,10 +114,9 @@ def ifelse(condition: Task, true_task: Task, false_task: Task) -> None:
     def as_bool(x):
         return bool(x)
 
-    cases = {True: true_task}
-    if false_task is not None:
-        cases.update({False: false_task})
-    switch(condition=as_bool(condition), cases=cases)
+    cases = {c: t for c, t in [(True, true_task), (False, false_task)] if t is not None}
+    if cases:
+        switch(condition=as_bool(condition), cases=cases)
 
 
 def merge(*tasks: Task) -> Task:

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -39,6 +39,23 @@ def test_ifelse(condition_value):
     )
 
 
+@pytest.mark.parametrize("condition_value", [True, False])
+def test_ifelse_doesnt_add_None_task(condition_value):
+    condition = Condition()
+    true_branch = SuccessTask(name="true branch")
+
+    with Flow(name="test") as flow:
+        cnd = ifelse(condition, true_branch, None)
+        assert len(flow.tasks) == 4
+
+    with prefect.context(CONDITION=condition_value):
+        state = flow.run()
+
+    assert isinstance(
+        state.result[true_branch], Success if condition_value is True else Skipped
+    )
+
+
 @pytest.mark.parametrize("condition_value", [1, "a", "False", True, [1], {1: 2}])
 def test_ifelse_with_truthy_conditions(condition_value):
     condition = Condition()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR prevents the creation of a task whenever the `false_task` is `None`.  This is a minor optimization that allows for a cleaner DAG when the intent is just using a basic "if".

## Why is this PR important?
Minor UX improvement.

**cc:** @jcrist / @znicholasbrown 