### PR TITLE
fix start_server.sh when PREFECT_SERVER__GRAPHQL_URL undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
+- Fix `start_server.sh` script when an env var is undefined - [#2450](https://github.com/PrefectHQ/prefect/pull/2450)
 - Fix `server start` CLI command not respecting `version` kwarg on tagged releases - [#2435](https://github.com/PrefectHQ/prefect/pull/2435)
 - Fix issue with non-JSON serializable args being used to format log messages preventing them from shipping to Cloud - [#2407](https://github.com/PrefectHQ/prefect/issues/2407)
 
@@ -31,7 +32,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- [Grégory Duchatelet](https://github.com/gregorg)
 
 ## 0.10.5 <Badge text="beta" type="success"/>
 

--- a/server/services/ui/shell_scripts/start_server.sh
+++ b/server/services/ui/shell_scripts/start_server.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-if [ $PREFECT_SERVER__GRAPHQL_URL != 'http://localhost:4200/graphql' ]
+if [ "$PREFECT_SERVER__GRAPHQL_URL" != 'http://localhost:4200/graphql' ]
 then
     echo "Replacing graphql references with: $PREFECT_SERVER__GRAPHQL_URL"
     for i in /var/www/js/*.js; do


### PR DESCRIPTION
A small fix that handle undefined PREFECT_SERVER__GRAPHQL_URL env var.