### PR TITLE
Ensure that ordered collections maintain numerical order for > 10 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix `server start` CLI command not respecting `version` kwarg on tagged releases - [#2435](https://github.com/PrefectHQ/prefect/pull/2435)
 - Fix issue with non-JSON serializable args being used to format log messages preventing them from shipping to Cloud - [#2407](https://github.com/PrefectHQ/prefect/issues/2407)
+- Fix issue where ordered Prefect collections use lexical sorting, not numerical sorting, which can result in unexpected ordering - [#2452](https://github.com/PrefectHQ/prefect/pull/2452)
 
 ### Deprecations
 

--- a/src/prefect/tasks/core/collections.py
+++ b/src/prefect/tasks/core/collections.py
@@ -70,7 +70,15 @@ class List(VarArgsTask):
         Returns:
             - list: a list of task results
         """
-        return [v for (k, v) in sorted(task_results.items())]
+        return [
+            v
+            for (k, v) in sorted(
+                task_results.items(),
+                # extract the integer index of the key to maintain sort order
+                # arg_1, arg_2, etc.
+                key=lambda item: int(item[0].split("_")[-1]),
+            )
+        ]
 
 
 class Tuple(VarArgsTask):
@@ -93,7 +101,17 @@ class Tuple(VarArgsTask):
         Returns:
             - tuple: a tuple of task results
         """
-        return tuple([v for (k, v) in sorted(task_results.items())])
+        return tuple(
+            [
+                v
+                for (k, v) in sorted(
+                    task_results.items(),
+                    # extract the integer index of the key to maintain sort order
+                    # arg_1, arg_2, etc.
+                    key=lambda item: int(item[0].split("_")[-1]),
+                )
+            ]
+        )
 
 
 class Set(VarArgsTask):

--- a/tests/tasks/test_core.py
+++ b/tests/tasks/test_core.py
@@ -241,3 +241,17 @@ class TestCollections:
 
         assert len(f.tasks) == 10
         assert state.result[identity].result == dict(a=[1, dict(y=2)], b=(2, set([1])))
+
+    def test_list_maintains_sort_order_for_more_than_10_items(self):
+        # https://github.com/PrefectHQ/prefect/issues/2451
+        l = collections.List()
+        with Flow(name="test") as f:
+            l.bind(*list(range(15)))
+        assert f.run().result[l].result == list(range(15))
+
+    def test_tuple_maintains_sort_order_for_more_than_10_items(self):
+        # https://github.com/PrefectHQ/prefect/issues/2451
+        t = collections.Tuple()
+        with Flow(name="test") as f:
+            t.bind(*list(range(15)))
+        assert f.run().result[t].result == tuple(range(15))


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR closes https://github.com/PrefectHQ/prefect/issues/2451, which identified a bug in which ordered Prefect collections implicitly relied on string (lexical) ordering rather than numerical ordering. Since collections maintain a dictionary keyed by `arg_{n}`, where n is the sort order, lexical ordering would result in `arg_0, arg_1, arg_10, arg_11, arg_2, arg_3, ...` for a list of 12 items. This PR adds an explicit key function to the sort of `collections.List` and `collections.Tuple` which extracts the integer part of the key name for numerical sorting.


## Why is this PR important?


