### PR TITLE
Results serializers

### DIFF
--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -18,14 +18,12 @@ whose value is `None`.
 """
 import base64
 import copy
-import datetime
 import pendulum
 import uuid
 from typing import Any, Callable, Iterable, Union
 
 import cloudpickle
 
-from prefect.engine.cache_validators import duration_only
 from prefect.engine.result_handlers import ResultHandler
 from prefect.utilities import logging
 

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -19,6 +19,8 @@ whose value is `None`.
 import base64
 import copy
 import datetime
+import pendulum
+import uuid
 from typing import Any, Callable, Iterable, Union
 
 import cloudpickle
@@ -80,12 +82,6 @@ class Result(ResultInterface):
         - validators (Iterable[Callable], optional): Iterable of validation functions to apply to
             the result to ensure it is `valid`.
         - run_validators (bool): Whether the result value should be validated.
-        - cache_for (timedelta, optional): The amount of time to maintain a cache
-            of this result.  Useful for situations where the containing Flow
-            will be rerun multiple times, but this task doesn't need to be.
-        - cache_validator (Callable, optional): Validator that will determine
-            whether the cache for this result is still valid (only required if `cache_for`
-            is provided; defaults to `prefect.engine.cache_validators.duration_only`)
         - location (str, optional): Possibly templated location to be used for saving the
             result to the destination.
     """
@@ -96,20 +92,14 @@ class Result(ResultInterface):
         result_handler: ResultHandler = None,
         validators: Iterable[Callable] = None,
         run_validators: bool = True,
-        cache_for: datetime.timedelta = None,
-        cache_validator: Callable = None,
-        location: str = "",
+        location: str = None,
     ):
         self.value = value
         self.safe_value = NoResult  # type: SafeResult
         self.result_handler = result_handler  # type: ignore
         self.validators = validators
         self.run_validators = run_validators
-        if cache_for is not None and cache_validator is None:
-            cache_validator = duration_only
-        self.cache_for = cache_for
-        self.cache_validator = cache_validator
-        self.location = location
+        self.location = self._template = location
         self.logger = logging.get_logger(type(self).__name__)
 
     def store_safe_value(self) -> None:
@@ -128,19 +118,20 @@ class Result(ResultInterface):
                 value=value, result_handler=self.result_handler
             )
 
-    def populate_result(self, result: "Result") -> "Result":
+    def from_value(self, value: Any) -> "Result":
         """
-        Given another Result instance, uses `self.location` to create a fully hydrated `Result`
-        using the logic of the provided result.  This method is mainly intended to be used
-        by `TaskRunner` methods to hydrate deserialized Cloud results into fully functional `Result` instances.
+        Create a new copy of the result object with the provided value.
 
         Args:
-            - result (Result): the result instance to hydrate with `self.location`
+            - value (Any): the value to use
 
         Returns:
-            - Result: a new result instance
+            - Result: a new Result instance with the given value
         """
-        return result.read(self.location)
+        new = self.copy()
+        new.location = None
+        new.value = value
+        return new
 
     def validate(self) -> bool:
         """
@@ -201,6 +192,12 @@ class Result(ResultInterface):
         """
         return cloudpickle.loads(base64.b64decode(serialized_value))
 
+    @property
+    def default_location(self) -> str:
+        date = pendulum.now("utc").format("Y/M/D")  # type: ignore
+        location = f"{date}/{uuid.uuid4()}.prefect_result"
+        return location
+
     def format(self, **kwargs: Any) -> "Result":
         """
         Takes a set of string format key-value pairs and renders the result.location to a final location string
@@ -212,7 +209,11 @@ class Result(ResultInterface):
             - Result: a new result instance with the appropriately formatted location
         """
         new = self.copy()
-        new.location = new.location.format(**kwargs)
+        if new.location is not None:
+            assert new._template is not None
+            new.location = new._template.format(**kwargs)
+        else:
+            new.location = new.default_location
         return new
 
     def exists(self, location: str) -> bool:

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -89,6 +89,7 @@ class LocalResult(Result):
         """
         new = self.format(**kwargs)
         new.value = value
+        assert new.location is not None
 
         self.logger.debug("Starting to upload result to {}...".format(new.location))
 

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -1,7 +1,9 @@
 import os
+from slugify import slugify
 from typing import Any
 
 import cloudpickle
+import pendulum
 
 from prefect import config
 from prefect.engine.result import Result
@@ -42,6 +44,12 @@ class LocalResult(Result):
         self.dir = abs_directory
 
         super().__init__(**kwargs)
+
+    @property
+    def default_location(self) -> str:
+        fname = "prefect-result-" + slugify(pendulum.now("utc").isoformat())
+        location = os.path.join(self.dir, fname)
+        return location
 
     def read(self, location: str) -> Result:
         """

--- a/src/prefect/serialization/result.py
+++ b/src/prefect/serialization/result.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from prefect.engine import result
+from prefect.engine import result, results
 from prefect.serialization.result_handlers import ResultHandlerSchema
 from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
 
@@ -13,9 +13,72 @@ class SafeResultSchema(ObjectSchema):
     result_handler = fields.Nested(ResultHandlerSchema, allow_none=False)
 
 
+class ResultSchema(ObjectSchema):
+    class Meta:
+        object_class = result.Result
+
+    location = fields.Str(allow_none=True)
+
+
 class NoResultSchema(ObjectSchema):
     class Meta:
         object_class = result.NoResultType
+
+
+class AzureResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.AzureResult
+
+    location = fields.Str(allow_none=True)
+
+
+class ConstantResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.ConstantResult
+
+    location = fields.Str(allow_none=True)
+
+
+class GCSResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.GCSResult
+
+    location = fields.Str(allow_none=True)
+
+
+class LocalResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.LocalResult
+
+    location = fields.Str(allow_none=True)
+
+
+class PrefectResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.PrefectResult
+
+    location = fields.Str(allow_none=True)
+
+
+class S3ResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.S3Result
+
+    location = fields.Str(allow_none=True)
+
+
+class SecretResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.SecretResult
+
+    location = fields.Str(allow_none=True)
+
+
+class ResultHandlerResultSchema(ObjectSchema):
+    class Meta:
+        object_class = results.ResultHandlerResult
+
+    location = fields.Str(allow_none=True)
 
 
 class StateResultSchema(OneOfSchema):
@@ -24,4 +87,16 @@ class StateResultSchema(OneOfSchema):
     """
 
     # map class name to schema
-    type_schemas = {"SafeResult": SafeResultSchema, "NoResultType": NoResultSchema}
+    type_schemas = {
+        "SafeResult": SafeResultSchema,
+        "NoResultType": NoResultSchema,
+        "Result": ResultSchema,
+        "AzureResult": AzureResultSchema,
+        "ConstantResult": ConstantResultSchema,
+        "GCSResult": GCSResultSchema,
+        "LocalResult": LocalResultSchema,
+        "PrefectResult": PrefectResultSchema,
+        "S3Result": S3ResultSchema,
+        "SecretResult": SecretResultSchema,
+        "ResultHandlerResult": ResultHandlerResultSchema,
+    }

--- a/src/prefect/serialization/result.py
+++ b/src/prefect/serialization/result.py
@@ -1,4 +1,5 @@
-from marshmallow import fields
+from marshmallow import fields, post_load
+from typing import Any
 
 from prefect.engine import result, results
 from prefect.serialization.result_handlers import ResultHandlerSchema
@@ -29,6 +30,7 @@ class AzureResultSchema(ObjectSchema):
     class Meta:
         object_class = results.AzureResult
 
+    container = fields.Str(allow_none=False)
     location = fields.Str(allow_none=True)
 
 
@@ -43,6 +45,7 @@ class GCSResultSchema(ObjectSchema):
     class Meta:
         object_class = results.GCSResult
 
+    bucket = fields.Str(allow_none=False)
     location = fields.Str(allow_none=True)
 
 
@@ -50,7 +53,14 @@ class LocalResultSchema(ObjectSchema):
     class Meta:
         object_class = results.LocalResult
 
+    dir = fields.Str(allow_none=False)
     location = fields.Str(allow_none=True)
+
+    @post_load
+    def create_object(self, data: dict, **kwargs: Any) -> results.LocalResult:
+        data["validate_dir"] = False
+        base_obj = super().create_object(data)
+        return base_obj
 
 
 class PrefectResultSchema(ObjectSchema):
@@ -64,6 +74,7 @@ class S3ResultSchema(ObjectSchema):
     class Meta:
         object_class = results.S3Result
 
+    bucket = fields.Str(allow_none=False)
     location = fields.Str(allow_none=True)
 
 

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -23,6 +23,8 @@ def get_safe(obj: state.State, context: dict) -> Any:
     safe way prior to serialization (if they want the result to be avaiable post-serialization).
     """
     if context.get("attr") == "_result":
+        if getattr(obj._result, "location", None) is not None:
+            return obj._result
         return obj._result.safe_value  # type: ignore
     value = context.get("value", result.NoResult)
     if value is None:

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -15,6 +15,11 @@ from prefect.engine.result_handlers import (
 )
 
 
+## TODO: write test that multiple writes / formats works
+## what if we allowed indexing into a result which makes a copy...
+## TODO: create from_value(value)
+
+
 class TestInitialization:
     def test_noresult_is_already_init(self):
         n = NoResult
@@ -23,8 +28,7 @@ class TestInitialization:
             n()
 
     def test_result_does_not_require_a_value(self):
-        # this may seem like a silly test, however, it is a regression to assert new result behavior
-        assert Result().value == None
+        assert Result().value is None
 
     def test_result_inits_with_value(self):
         r = Result(3)
@@ -32,9 +36,7 @@ class TestInitialization:
         assert r.safe_value is NoResult
         assert r.result_handler is None
         assert r.validators is None
-        assert r.cache_for is None
-        assert r.cache_validator is None
-        assert r.location == ""
+        assert r.location is None
         assert r.run_validators is True
 
         s = Result(value=5)
@@ -42,9 +44,7 @@ class TestInitialization:
         assert s.safe_value is NoResult
         assert s.result_handler is None
         assert s.validators is None
-        assert s.cache_for is None
-        assert s.cache_validator is None
-        assert s.location == ""
+        assert s.location is None
         assert r.run_validators is True
 
     def test_result_inits_with_handled_and_result_handler(self):
@@ -53,27 +53,6 @@ class TestInitialization:
         assert r.value == 3
         assert r.safe_value is NoResult
         assert r.result_handler == handler
-
-    def test_cache_validator_provided_if_needed(self):
-        """
-        If `cache_for` is provided, and `cache_validator` is not,
-        a `cache_validator` should be provided.
-        """
-        r = Result(value=3, cache_for=datetime.timedelta(days=2))
-        assert r.cache_validator is not None
-        assert callable(r.cache_validator)
-
-    def test_uses_provided_cache_validator(self):
-        def custom_cache_validator(*args, **kwargs):
-            # Creating a custom function for identity comparison
-            return True
-
-        r = Result(
-            value=3,
-            cache_for=datetime.timedelta(days=2),
-            cache_validator=custom_cache_validator,
-        )
-        assert r.cache_validator is custom_cache_validator
 
     def test_result_ignores_none_values(self):
         handler = JSONResultHandler()

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -15,11 +15,6 @@ from prefect.engine.result_handlers import (
 )
 
 
-## TODO: write test that multiple writes / formats works
-## what if we allowed indexing into a result which makes a copy...
-## TODO: create from_value(value)
-
-
 class TestInitialization:
     def test_noresult_is_already_init(self):
         n = NoResult

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -27,7 +27,7 @@ class TestGCSResult:
 
     def test_gcs_init(self, google_client):
         result = GCSResult(bucket="bob")
-        assert result.value == None
+        assert result.value is None
         assert result.bucket == "bob"
         assert google_client.called is False
         result.gcs_bucket()

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -97,11 +97,11 @@ class TestPrefectResult:
     def test_instantiates_with_value(self):
         result = PrefectResult(value=5)
         assert result.value == 5
-        assert result.location == ""
+        assert result.location is None
 
         result = PrefectResult(value=10)
         assert result.value == 10
-        assert result.location == ""
+        assert result.location is None
 
     def test_read_returns_new_result(self):
         result = PrefectResult(value="hello world")
@@ -117,7 +117,7 @@ class TestPrefectResult:
         new_result = result.write(99)
 
         assert result.value == 42
-        assert result.location == ""
+        assert result.location is None
 
         assert new_result.value == 99
         assert new_result.location == "99"
@@ -140,7 +140,7 @@ class TestLocalResult:
     def test_local_result_initializes_with_no_args(self):
         result = LocalResult()
         assert result.dir == os.path.join(config.home_dir, "results")
-        assert result.value == None
+        assert result.value is None
 
     def test_local_result_initializes_with_dir(self):
         root_dir = os.path.abspath(os.sep)

--- a/tests/serialization/test_result.py
+++ b/tests/serialization/test_result.py
@@ -27,12 +27,6 @@ def test_basic_noresult_serializes():
     assert handled == {}
 
 
-def test_basic_result_doesnt_serialize():
-    r = Result(3)
-    handled = StateResultSchema().dump(r)
-    assert handled[1]["_schema"] == "Unsupported object type: Result"
-
-
 def test_basic_safe_result_deserializes():
     r = SafeResultSchema().load(
         {"value": "3", "result_handler": {"type": "JSONResultHandler"}}

--- a/tests/serialization/test_results.py
+++ b/tests/serialization/test_results.py
@@ -1,0 +1,152 @@
+import marshmallow
+import pytest
+
+import prefect
+from prefect.engine import results
+from prefect.engine.result import NoResult, NoResultType, Result
+from prefect.engine.result_handlers import ResultHandler
+from prefect.serialization.result import StateResultSchema
+
+
+def test_constant_result():
+    """
+    Because ConstantResult objects have no implemented write method,
+    and therefore will never have an interesting "safe" representation,
+    we don't actually expect these to ever be serialized between Core
+    and any backend
+    """
+    schema = StateResultSchema()
+    result = results.ConstantResult(value=42)
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "ConstantResult"
+    assert serialized["location"] is None
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.ConstantResult)
+    assert new_result.location is None
+    assert new_result.value is None
+
+
+def test_azure_result():
+    schema = StateResultSchema()
+    result = results.AzureResult(value=42, container="foo", location="bar")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "AzureResult"
+    assert serialized["location"] == "bar"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.AzureResult)
+    assert new_result.container == "foo"
+    assert new_result.location == "bar"
+    assert new_result.value is None
+
+
+def test_gcs_result():
+    schema = StateResultSchema()
+    result = results.GCSResult(value=42, bucket="foo", location="bar")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "GCSResult"
+    assert serialized["location"] == "bar"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.GCSResult)
+    assert new_result.bucket == "foo"
+    assert new_result.location == "bar"
+    assert new_result.value is None
+
+
+def test_local_result():
+    schema = StateResultSchema()
+    result = results.LocalResult(value=42, location="bar")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "LocalResult"
+    assert serialized["dir"] is not None
+    assert serialized["location"] == "bar"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.LocalResult)
+    assert new_result.dir == result.dir
+    assert new_result.location == "bar"
+    assert new_result.value is None
+
+
+def test_local_result_doesnt_validate_on_deserialization():
+    schema = StateResultSchema()
+    result = results.LocalResult(validate_dir=True)
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "LocalResult"
+    serialized["dir"] = r"C:\Windows\paths\are\weird"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.LocalResult)
+    assert new_result.dir == r"C:\Windows\paths\are\weird"
+
+
+def test_prefect_result():
+    schema = StateResultSchema()
+    result = results.PrefectResult(value=42, location="42")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "PrefectResult"
+    assert "value" not in serialized
+    assert serialized["location"] == "42"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.PrefectResult)
+    assert new_result.location == "42"
+    assert new_result.value is None
+
+
+def test_s3_result():
+    schema = StateResultSchema()
+    result = results.S3Result(value=42, bucket="foo", location="bar")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "S3Result"
+    assert serialized["location"] == "bar"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.S3Result)
+    assert new_result.bucket == "foo"
+    assert new_result.location == "bar"
+    assert new_result.value is None
+
+
+def test_secret_result():
+    schema = StateResultSchema()
+    result = results.SecretResult(
+        secret_task=prefect.tasks.secrets.EnvVarSecret(name="OS")
+    )
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "SecretResult"
+    assert serialized["location"] == "OS"
+    assert serialized["secret_type"] == "EnvVarSecret"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.SecretResult)
+    assert new_result.location == "OS"
+    assert new_result.value is None
+
+
+def test_result_handler_result():
+    class MyHandler(ResultHandler):
+        pass
+
+    schema = StateResultSchema()
+    result = results.ResultHandlerResult(result_handler=MyHandler(), location="foo")
+    serialized = schema.dump(result)
+
+    assert serialized["type"] == "ResultHandlerResult"
+    assert serialized["location"] == "foo"
+    assert serialized["result_handler_type"] == "MyHandler"
+
+    new_result = schema.load(serialized)
+    assert isinstance(new_result, results.ResultHandlerResult)
+    assert new_result.location == "foo"
+    assert new_result.value is None

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -8,7 +8,7 @@ import pendulum
 import pytest
 
 import prefect
-from prefect.engine import state
+from prefect.engine import results, state
 from prefect.engine.result import NoResult, Result, SafeResult
 from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
 from prefect.serialization.state import StateSchema
@@ -296,3 +296,34 @@ def test_deserialize_handles_unknown_fields():
     )
 
     assert deserialized.is_successful()
+
+
+class TestNewStyleResults:
+    def test_new_result_with_no_location_serializes_as_no_result(self):
+        s = state.Success(message="test", result=results.S3Result(bucket="foo"))
+        serialized = StateSchema().dump(s)
+        assert serialized["message"] == "test"
+        assert serialized["_result"]["type"] == "NoResultType"
+
+    def test_new_result_with_location_serializes_correctly(self):
+        s = state.Success(
+            message="test",
+            result=results.S3Result(bucket="foo", location="dir/place.txt"),
+        )
+        serialized = StateSchema().dump(s)
+        assert serialized["message"] == "test"
+        assert serialized["_result"]["type"] == "S3Result"
+
+    def test_new_result_with_location_deserializes_correctly(self):
+        s = state.Success(
+            message="test",
+            result=results.S3Result(bucket="foo", location="dir/place.txt"),
+        )
+        schema = StateSchema()
+        new_state = schema.load(schema.dump(s))
+
+        assert new_state.is_successful()
+        assert new_state.result is None
+        assert new_state._result.bucket == "foo"
+        assert isinstance(new_state._result, results.S3Result)
+        assert new_state._result.location == "dir/place.txt"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR breaks some of the work from #2391 into it's own, independent PR for easier review.  This PR introduces new serializers for all the new-style result classes.


## Why is this PR important?
Serializers are the language by which Core and Prefect backends communicate; because the backend will need to support older versions of Core still running with old result handlers we need to be very mindful of how these serializers work.  You'll notice this implementation layers _on top_ of the serializers but doesn't change anything related to Result Handlers or SafeResult objects.

