### PR TITLE
Isoformat timestamps before passing them to log writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix `server start` CLI command not respecting `version` kwarg on tagged releases - [#2435](https://github.com/PrefectHQ/prefect/pull/2435)
 - Fix issue with non-JSON serializable args being used to format log messages preventing them from shipping to Cloud - [#2407](https://github.com/PrefectHQ/prefect/issues/2407)
 - Fix issue where ordered Prefect collections use lexical sorting, not numerical sorting, which can result in unexpected ordering - [#2452](https://github.com/PrefectHQ/prefect/pull/2452)
+- Fix issue where Resource Manager was failing due to non-JSON timestamp in log writing - [#2474](https://github.com/PrefectHQ/prefect/issues/2474)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/resource_manager.py
+++ b/src/prefect/agent/kubernetes/resource_manager.py
@@ -271,7 +271,7 @@ class ResourceManager:
                 [
                     dict(
                         flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                        timestamp=pendulum.now(),
+                        timestamp=pendulum.now("UTC").isoformat(),
                         name="resource-manager",
                         message=logs,
                         level="ERROR",
@@ -299,7 +299,7 @@ class ResourceManager:
                 [
                     dict(
                         flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                        timestamp=pendulum.now(),
+                        timestamp=pendulum.now("UTC").isoformat(),
                         name="resource-manager",
                         message="Flow run pod {} entered an unknown state in namespace {}".format(
                             name, self.namespace
@@ -334,7 +334,7 @@ class ResourceManager:
                         [
                             dict(
                                 flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                                timestamp=pendulum.now(),
+                                timestamp=pendulum.now("UTC").isoformat(),
                                 name="resource-manager",
                                 message="Flow run image pull error for pod {} in namespace {}".format(
                                     pod.metadata.name, self.namespace


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Calls `.isoformat()` prior to passing a log timestamp in the k8s resource manager.


## Why is this PR important?
Was preventing the resource manager from doing its job.  Closes #2474 