### PR TITLE
Fix bug in local agent process cleanup loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with non-JSON serializable args being used to format log messages preventing them from shipping to Cloud - [#2407](https://github.com/PrefectHQ/prefect/issues/2407)
 - Fix issue where ordered Prefect collections use lexical sorting, not numerical sorting, which can result in unexpected ordering - [#2452](https://github.com/PrefectHQ/prefect/pull/2452)
 - Fix issue where Resource Manager was failing due to non-JSON timestamp in log writing - [#2474](https://github.com/PrefectHQ/prefect/issues/2474)
+- Fix periodic error in local agent process management loop - [#2419](https://github.com/PrefectHQ/prefect/issues/2419)
 
 ### Deprecations
 
@@ -69,7 +70,6 @@ Released on Apr 28, 2020.
 - Fix Docker storage path issue when registering flows on Windows machines - [#2332](https://github.com/PrefectHQ/prefect/issues/2332)
 - Fix issue with refreshing Prefect Cloud tokens - [#2409](https://github.com/PrefectHQ/prefect/pull/2409)
 - Resolve invalid escape sequence deprecation warnings - [#2414](https://github.com/PrefectHQ/prefect/issues/2414)
-- Fix issue with list mutation while iterating - [#2419](https://github.com/PrefectHQ/prefect/issues/2419)
 
 ### Deprecations
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -57,7 +57,7 @@ class LocalAgent(Agent):
         hostname_label: bool = True,
         max_polls: int = None,
     ) -> None:
-        self.processes = []  # type: list
+        self.processes = set()
         self.import_paths = import_paths or []
         self.show_flow_logs = show_flow_logs
         super().__init__(
@@ -72,9 +72,9 @@ class LocalAgent(Agent):
         )
 
     def heartbeat(self) -> None:
-        for idx, process in enumerate(list(self.processes)):
+        for process in list(self.processes):
             if process.poll() is not None:
-                self.processes.pop(idx)
+                self.processes.remove(process)
                 if process.returncode:
                     self.logger.info(
                         "Process PID {} returned non-zero exit code".format(process.pid)
@@ -135,7 +135,7 @@ class LocalAgent(Agent):
             env=current_env,
         )
 
-        self.processes.append(p)
+        self.processes.add(p)
         self.logger.debug(
             "Submitted flow run {} to process PID {}".format(flow_run.id, p.pid)
         )

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -40,7 +40,7 @@ def test_local_agent_config_options(runner_token):
         assert agent.client.get_auth_token() == "TEST_TOKEN"
         assert agent.logger
         assert agent.log_to_cloud is True
-        assert agent.processes == []
+        assert agent.processes == set()
         assert agent.import_paths == ["test_path"]
         assert set(agent.labels) == {
             "azure-flow-storage",
@@ -438,7 +438,7 @@ def test_local_agent_heartbeat(
         )
     )
 
-    process = agent.processes[0]
+    process = list(agent.processes)[0]
     process_call = process.root_call
 
     with LogCapture() as logcap:


### PR DESCRIPTION
Previously this would loop over a list of processes, and *attempt* to
remove completed processes with `processes.pop`. Due to a bug though,
this would remove the incorrect process. We now use a set of processes,
which provides `O(1)` access to remove (more efficient than `O(n)`), and
removes the correct process.

Fixes #2419, see https://github.com/PrefectHQ/prefect/pull/2464#discussion_r419463181

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)