### PR TITLE
Add backend toggle to k8s agent install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add support for EC2 launch type in Fargate Agent and `FargateTaskEnvironment` - [#2421](https://github.com/PrefectHQ/prefect/pull/2421)
 - Add `flow_id` to context for Flow runs - [#2461](https://github.com/PrefectHQ/prefect/pull/2461)
 - Allow users to inject custom context variables into their logger formats - [#2462](https://github.com/PrefectHQ/prefect/issues/2462)
+- Add option to set backend on `agent install` CLI command - [#2478](https://github.com/PrefectHQ/prefect/pull/2478)
 
 ### Task Library
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -210,6 +210,7 @@ class KubernetesAgent(Agent):
         cpu_request: str = None,
         cpu_limit: str = None,
         labels: Iterable[str] = None,
+        backend: str = None,
     ) -> str:
         """
         Generate and output an installable YAML spec for the agent.
@@ -248,6 +249,7 @@ class KubernetesAgent(Agent):
         mem_limit = mem_limit or ""
         cpu_request = cpu_request or ""
         cpu_limit = cpu_limit or ""
+        backend = backend or "cloud"
 
         version = prefect.__version__.split("+")
         image_version = (
@@ -267,6 +269,7 @@ class KubernetesAgent(Agent):
         agent_env[2]["value"] = namespace
         agent_env[3]["value"] = image_pull_secrets or ""
         agent_env[4]["value"] = str(labels)
+        agent_env[9]["value"] = backend
 
         # Populate job resource env vars
         agent_env[5]["value"] = mem_request

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -235,6 +235,8 @@ class KubernetesAgent(Agent):
             - cpu_limit (str, optional): Limit CPU for Prefect init job.
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
+            - backend (str, optional): toggle which backend to use for this agent.
+                Defaults to "cloud".
 
         Returns:
             - str: A string representation of the generated YAML

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -236,7 +236,7 @@ class KubernetesAgent(Agent):
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
             - backend (str, optional): toggle which backend to use for this agent.
-                Defaults to "cloud".
+                Defaults to backend currently set in config.
 
         Returns:
             - str: A string representation of the generated YAML
@@ -251,7 +251,7 @@ class KubernetesAgent(Agent):
         mem_limit = mem_limit or ""
         cpu_request = cpu_request or ""
         cpu_limit = cpu_limit or ""
-        backend = backend or "cloud"
+        backend = backend or config.backend
 
         version = prefect.__version__.split("+")
         image_version = (

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: ""
             - name: JOB_CPU_LIMIT
               value: ""
+            - name: PREFECT__BACKEND
+              value: "cloud"
           resources:
             limits:
               memory: "128Mi"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -389,6 +389,7 @@ def install(
         --cpu-request               TEXT    Requested CPU for Prefect init job
         --cpu-limit                 TEXT    Limit CPU for Prefect init job
         --backend                   TEST    Prefect backend to use for this agent
+                                            Defaults to the backend currently set in config.
 
     \b
     Local Agent Options:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -422,7 +422,7 @@ def install(
             cpu_request=cpu_request,
             cpu_limit=cpu_limit,
             labels=list(label),
-            backend=backend
+            backend=backend,
         )
         click.echo(deployment)
     elif name == "local":

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -337,6 +337,13 @@ def start(
     hidden=True,
     is_flag=True,
 )
+@click.option(
+    "--backend",
+    "-b",
+    required=False,
+    help="Prefect backend to use for this agent.",
+    hidden=True,
+)
 def install(
     name,
     token,
@@ -353,6 +360,7 @@ def install(
     label,
     import_path,
     show_flow_logs,
+    backend,
 ):
     """
     Install an agent. Outputs configuration text which can be used to install on various
@@ -380,6 +388,7 @@ def install(
         --mem-limit                 TEXT    Limit memory for Prefect init job
         --cpu-request               TEXT    Requested CPU for Prefect init job
         --cpu-limit                 TEXT    Limit CPU for Prefect init job
+        --backend                   TEST    Prefect backend to use for this agent
 
     \b
     Local Agent Options:
@@ -413,6 +422,7 @@ def install(
             cpu_request=cpu_request,
             cpu_limit=cpu_limit,
             labels=list(label),
+            backend=backend
         )
         click.echo(deployment)
     elif name == "local":

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -328,6 +328,20 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, runner_token):
     assert resource_manager_env[3]["value"] == "test_namespace"
 
 
+def test_k8s_agent_generate_deployment_yaml_backend_default(monkeypatch, server_api):
+    k8s_config = MagicMock()
+    monkeypatch.setattr("kubernetes.config", k8s_config)
+
+    agent = KubernetesAgent()
+    deployment = agent.generate_deployment_yaml()
+
+    deployment = yaml.safe_load(deployment)
+
+    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+
+    assert agent_env[9]["value"] == "server"
+
+
 @pytest.mark.parametrize(
     "version",
     [

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -308,6 +308,7 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, runner_token):
         api="test_api",
         namespace="test_namespace",
         resource_manager_enabled=True,
+        backend="backend-test",
     )
 
     deployment = yaml.safe_load(deployment)
@@ -320,6 +321,7 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, runner_token):
     assert agent_env[0]["value"] == "test_token"
     assert agent_env[1]["value"] == "test_api"
     assert agent_env[2]["value"] == "test_namespace"
+    assert agent_env[9]["value"] == "backend-test"
 
     assert resource_manager_env[0]["value"] == "test_token"
     assert resource_manager_env[1]["value"] == "test_api"

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -354,6 +354,8 @@ def test_agent_install_k8s_asses_args():
             "test_label1",
             "-l",
             "test_label2",
+            "-b",
+            "backend-test",
         ],
     )
     assert result.exit_code == 0
@@ -370,6 +372,7 @@ def test_agent_install_k8s_asses_args():
     assert "secret-test" in result.output
     assert "test_label1" in result.output
     assert "test_label2" in result.output
+    assert "backend-test" in result.output
 
 
 def test_agent_install_k8s_no_resource_manager():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a toggle for `config.backend` when installing the k8s agent.


## Why is this PR important?
When using the k8s agent against Core's server would cause an issue where a token was expected because it didn't know it wasn't communicating with cloud.

