### PR TITLE
take docker daemon url in docker storage from DOCKER_HOST env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Released on May 5, 2020.
 - Add `flow_id` to context for Flow runs - [#2461](https://github.com/PrefectHQ/prefect/pull/2461)
 - Allow users to inject custom context variables into their logger formats - [#2462](https://github.com/PrefectHQ/prefect/issues/2462)
 - Add option to set backend on `agent install` CLI command - [#2478](https://github.com/PrefectHQ/prefect/pull/2478)
+- Allow for setting docker daemon at build time using DOCKER_HOST env var to override base_url in docker storage - [#2482](https://github.com/PrefectHQ/prefect/pull/2482)
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 ### Breaking Changes
 
+- Allow for setting docker daemon at build time using DOCKER_HOST env var to override base_url in docker storage - [#2482](https://github.com/PrefectHQ/prefect/pull/2482)
 - Triggers now accept a dictionary of upstream edges and states instead of a set of states - [#2289](https://github.com/PrefectHQ/prefect/issues/2298)
 - Ensure all calls to `flow.run()` use the same execution logic - [#1994](https://github.com/PrefectHQ/prefect/pull/1994)
 - Moved `prefect.tasks.cloud` to `prefect.tasks.prefect` - [#2404](https://github.com/PrefectHQ/prefect/pull/2404)
@@ -121,7 +122,6 @@ Released on May 5, 2020.
 - Add `flow_id` to context for Flow runs - [#2461](https://github.com/PrefectHQ/prefect/pull/2461)
 - Allow users to inject custom context variables into their logger formats - [#2462](https://github.com/PrefectHQ/prefect/issues/2462)
 - Add option to set backend on `agent install` CLI command - [#2478](https://github.com/PrefectHQ/prefect/pull/2478)
-- Allow for setting docker daemon at build time using DOCKER_HOST env var to override base_url in docker storage - [#2482](https://github.com/PrefectHQ/prefect/pull/2482)
 
 ### Task Library
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -105,9 +105,11 @@ class Docker(Storage):
         self.files = files or {}
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
-        self.base_url = environ.get(
+        self.base_url = os.environ.get(
             "DOCKER_HOST",
-            "unix://var/run/docker.sock"
+            base_url
+            if base_url
+            else "unix://var/run/docker.sock"
             if sys.platform != "win32"
             else "npipe:////./pipe/docker_engine",
         )

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -92,6 +92,10 @@ class Docker(Storage):
         secrets: List[str] = None,
     ) -> None:
         self.registry_url = registry_url
+        if sys.platform == "win32":
+            default_url = "npipe:////./pipe/docker_engine"
+        else:
+            default_url = "unix://var/run/docker.sock"
         self.image_name = image_name
         self.image_tag = image_tag
         self.python_dependencies = python_dependencies or []
@@ -105,14 +109,7 @@ class Docker(Storage):
         self.files = files or {}
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
-        self.base_url = os.environ.get(
-            "DOCKER_HOST",
-            base_url
-            if base_url
-            else "unix://var/run/docker.sock"
-            if sys.platform != "win32"
-            else "npipe:////./pipe/docker_engine",
-        )
+        self.base_url = os.environ.get("DOCKER_HOST", base_url or default_url)
         self.local_image = local_image
         self.extra_commands = []  # type: List[str]
         self.ignore_healthchecks = ignore_healthchecks

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -109,7 +109,7 @@ class Docker(Storage):
         self.files = files or {}
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
-        self.base_url = os.environ.get("DOCKER_HOST", base_url or default_url)
+        self.base_url = base_url or os.environ.get("DOCKER_HOST", default_url)
         self.local_image = local_image
         self.extra_commands = []  # type: List[str]
         self.ignore_healthchecks = ignore_healthchecks

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -57,7 +57,7 @@ class Docker(Storage):
         - files (dict, optional): a dictionary of files to copy into the image
             when building
         - base_url: (str, optional): a URL of a Docker daemon to use when for
-            Docker related functionality.  DOCKER_HOST env var takes precedence
+            Docker related functionality.  Defaults to DOCKER_HOST env var if not set
         - prefect_version (str, optional): an optional branch, tag, or commit
             specifying the version of prefect you want installed into the container;
             defaults to the version you are currently using or `"master"` if your

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -149,6 +149,14 @@ def test_initialized_docker_storage():
     assert storage.local_image
 
 
+def test_env_var_precedence_docker_storage(monkeypatch):
+    storage = Docker(base_url="foo")
+    assert storage.base_url == "foo"
+    monkeypatch.setenv("DOCKER_HOST", "bar")
+    storage = Docker(base_url="foo")
+    assert storage.base_url == "bar"
+
+
 def test_docker_storage_allows_for_user_provided_config_locations():
     storage = Docker(env_vars={"PREFECT__USER_CONFIG_PATH": "1"})
 

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -13,6 +13,11 @@ from prefect import Flow
 from prefect.environments.storage import Docker
 
 
+@pytest.fixture
+def no_docker_host_var(monkeypatch):
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+
+
 def test_create_docker_storage():
     storage = Docker(secrets=["cloud_creds"])
     assert storage
@@ -49,7 +54,7 @@ def test_add_flow_to_docker():
         ("darwn", "unix://var/run/docker.sock"),
     ],
 )
-def test_empty_docker_storage(monkeypatch, platform, url):
+def test_empty_docker_storage(monkeypatch, platform, url, no_docker_host_var):
     monkeypatch.setattr("prefect.environments.storage.docker.sys.platform", platform)
     monkeypatch.setattr(sys, "version_info", MagicMock(major=3, minor=6))
     monkeypatch.setattr(prefect, "__version__", "0.9.2+c2394823")
@@ -78,7 +83,9 @@ def test_empty_docker_storage(monkeypatch, platform, url):
         ("darwn", "unix://var/run/docker.sock"),
     ],
 )
-def test_empty_docker_storage_on_tagged_commit(monkeypatch, platform, url):
+def test_empty_docker_storage_on_tagged_commit(
+    monkeypatch, platform, url, no_docker_host_var
+):
     monkeypatch.setattr("prefect.environments.storage.docker.sys.platform", platform)
     monkeypatch.setattr(sys, "version_info", MagicMock(major=3, minor=6))
     monkeypatch.setattr(prefect, "__version__", "0.9.2")
@@ -122,7 +129,7 @@ def test_docker_init_responds_to_prefect_version(monkeypatch, version):
     assert storage.prefect_version == version[1]
 
 
-def test_initialized_docker_storage():
+def test_initialized_docker_storage(no_docker_host_var):
     storage = Docker(
         registry_url="test1",
         base_image="test3",
@@ -149,7 +156,7 @@ def test_initialized_docker_storage():
     assert storage.local_image
 
 
-def test_env_var_precedence_docker_storage(monkeypatch):
+def test_env_var_precedence_docker_storage(monkeypatch, no_docker_host_var):
     storage = Docker(base_url="foo")
     assert storage.base_url == "foo"
     monkeypatch.setenv("DOCKER_HOST", "bar")
@@ -485,7 +492,7 @@ def test_create_dockerfile_with_weird_flow_name():
             )
 
 
-def test_create_dockerfile_from_everything():
+def test_create_dockerfile_from_everything(no_docker_host_var):
 
     with tempfile.TemporaryDirectory() as tempdir_outside:
 

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -15,6 +15,10 @@ from prefect.environments.storage import Docker
 
 @pytest.fixture
 def no_docker_host_var(monkeypatch):
+    """
+    This fixture is for tests that assert an unset DOCKER_HOST variable
+    to avoid muddying test results from running Docker in Docker (e.g. in CI)
+    """
     monkeypatch.delenv("DOCKER_HOST", raising=False)
 
 

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -161,11 +161,13 @@ def test_initialized_docker_storage(no_docker_host_var):
 
 
 def test_env_var_precedence_docker_storage(monkeypatch, no_docker_host_var):
+    monkeypatch.setenv("DOCKER_HOST", "bar")
+    storage = Docker()
+    assert storage.base_url
+    assert storage.base_url == "bar"
     storage = Docker(base_url="foo")
     assert storage.base_url == "foo"
-    monkeypatch.setenv("DOCKER_HOST", "bar")
     storage = Docker(base_url="foo")
-    assert storage.base_url == "bar"
 
 
 def test_docker_storage_allows_for_user_provided_config_locations():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Take in DOCKER_HOST env var with precedence over base_url parameter in docs


## Why is this PR important?
closes #2157 
Allows for docker-in-docker/ remote docker daemon setup at buildtime