### PR TITLE
Give a better error when trying to serialize a non-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Give a better error for non-serializable callables when registering with cloud/server - [#2491](https://github.com/PrefectHQ/prefect/pull/2491)
 
 ### Deprecations
 

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -379,10 +379,9 @@ class StatefulFunctionReference(fields.Field):
         try:
             qual_name = to_qualified_name(value)
         except:
-            if self.reject_invalid:
-                raise ValidationError("Invalid function reference: {}".format(value))
-            else:
-                return qual_name
+            raise ValidationError(
+                f"Invalid function reference, function required, got {value}"
+            )
 
         # sort matches such that the longest / most specific match comes first
         valid_bases = sorted(

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -279,6 +279,14 @@ class TestStatefulFunctionReferenceField:
         )
         assert deserialized["f_allow_invalid"] is None
 
+    def test_serialize_non_function_good_error(self):
+        class Foo(object):
+            def __call__(self, a, b):
+                return a + b
+
+        with pytest.raises(marshmallow.ValidationError, match="function required"):
+            self.Schema().dump(dict(f=Foo()))
+
     def test_serialize_none(self):
         with pytest.raises(marshmallow.ValidationError):
             self.Schema().dump({"f": None})


### PR DESCRIPTION
Prefect's serialization scheme relies on callable objects having fully
qualified names, a property that is only true (for the most part) for
true functions in importable modules. We now raise a better error
message when trying to use other callables in these locations.

Fixes #2432

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
