### PR TITLE
Sets dask scheduler default to "threads" on LocalDaskExecutor so by d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Agents now support an optional HTTP health check, for use by their backing orchestration layer (e.g. k8s, docker, supervisord, ...) - [#2406](https://github.com/PrefectHQ/prefect/pull/2406)
+- Sets dask scheduler default to "threads" on LocalDaskExecutor to provide parallelism [#2485](https://github.com/PrefectHQ/prefect/issues/2485) 
 
 ### Task Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Agents now support an optional HTTP health check, for use by their backing orchestration layer (e.g. k8s, docker, supervisord, ...) - [#2406](https://github.com/PrefectHQ/prefect/pull/2406)
-- Sets dask scheduler default to "threads" on LocalDaskExecutor to provide parallelism [#2485](https://github.com/PrefectHQ/prefect/issues/2485) 
+- Sets dask scheduler default to "threads" on LocalDaskExecutor to provide parallelism [#2494](https://github.com/PrefectHQ/prefect/pull/2494) 
 
 ### Task Library
 

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -209,11 +209,11 @@ class LocalDaskExecutor(Executor):
     Prefect's mapping feature will not work in conjunction with setting `scheduler="processes"`.
 
     Args:
-        - scheduler (str): The local dask scheduler to use; common options are "synchronous", "threads" and "processes".  Defaults to "synchronous".
+        - scheduler (str): The local dask scheduler to use; common options are "synchronous", "threads" and "processes".  Defaults to "threads".
         - **kwargs (Any): Additional keyword arguments to pass to dask config
     """
 
-    def __init__(self, scheduler: str = "synchronous", **kwargs: Any):
+    def __init__(self, scheduler: str = "threads", **kwargs: Any):
         self.scheduler = scheduler
         self.kwargs = kwargs
         super().__init__()

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -62,6 +62,10 @@ class TestSyncExecutor:
 
 
 class TestLocalDaskExecutor:
+    def test_scheduler_defaults_to_threads(self):
+        e = LocalDaskExecutor()
+        assert e.scheduler == "threads"
+
     def test_responds_to_kwargs(self):
         e = LocalDaskExecutor(scheduler="threads")
         assert e.scheduler == "threads"


### PR DESCRIPTION
…efault LocalDaskExecutor provides parallelism,

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] updates `CHANGELOG.md` (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2485 


## Why is this PR important?
Sets the default dask scheduler on the LocalDaskExecutor to provide parallelism

