### PR TITLE
Change some tests around given the new boto3 utility function in 0.11.0

### DIFF
--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -22,7 +22,7 @@ def get_boto_client(
         - **kwargs (Any, optional): additional keyword arguments to pass to boto3
 
     Returns:
-        - Client: an initialized and authenticated Google Client
+        - Client: an initialized and authenticated boto3 Client
     """
     aws_access_key = None
     aws_secret_access_key = None

--- a/tests/tasks/aws/test_lambda.py
+++ b/tests/tasks/aws/test_lambda.py
@@ -49,6 +49,32 @@ class TestLambdaCreate:
             "aws_session_token": "1",
         }
 
+    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
+        task = LambdaCreate(
+            function_name="test",
+            runtime="python3.6",
+            role="aws_role",
+            handler="file.handler",
+            bucket="s3_bucket",
+            bucket_key="bucket_key",
+        )
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        credentials = {
+            "ACCESS_KEY": "42",
+            "SECRET_ACCESS_KEY": "99",
+            "SESSION_TOKEN": "1",
+        }
+
+        task.run(credentials=credentials)
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
+
 
 class TestLambdaDelete:
     def test_initialization(self):
@@ -70,6 +96,25 @@ class TestLambdaDelete:
                 )
             ):
                 task.run()
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
+
+    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
+        task = LambdaDelete(function_name="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        credentials = {
+            "ACCESS_KEY": "42",
+            "SECRET_ACCESS_KEY": "99",
+            "SESSION_TOKEN": "1",
+        }
+
+        task.run(credentials=credentials)
         kwargs = client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "42",
@@ -105,6 +150,25 @@ class TestLambdaInvoke:
             "aws_session_token": "1",
         }
 
+    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
+        task = LambdaInvoke(function_name="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        credentials = {
+            "ACCESS_KEY": "42",
+            "SECRET_ACCESS_KEY": "99",
+            "SESSION_TOKEN": "1",
+        }
+
+        task.run(credentials=credentials)
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
+
 
 class TestLambdaList:
     def test_initialization(self):
@@ -126,6 +190,25 @@ class TestLambdaList:
                 )
             ):
                 task.run()
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
+
+    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
+        task = LambdaList()
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        credentials = {
+            "ACCESS_KEY": "42",
+            "SECRET_ACCESS_KEY": "99",
+            "SESSION_TOKEN": "1",
+        }
+
+        task.run(credentials=credentials)
         kwargs = client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "42",

--- a/tests/tasks/aws/test_lambda.py
+++ b/tests/tasks/aws/test_lambda.py
@@ -19,199 +19,68 @@ class TestLambdaCreate:
         )
         assert task.code == {"S3Bucket": "s3_bucket", "S3Key": "bucket_key"}
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
+    def test_lambda_create_exposes_boto3_create_api(self, monkeypatch):
         task = LambdaCreate(
             function_name="test",
             runtime="python3.6",
             role="aws_role",
             handler="file.handler",
-            bucket="s3_bucket",
-            bucket_key="bucket_key",
         )
         client = MagicMock()
+        client.create_function = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={
-                        "ACCESS_KEY": "42",
-                        "SECRET_ACCESS_KEY": "99",
-                        "SESSION_TOKEN": "1",
-                    }
-                )
-            ):
-                task.run()
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        task.run()
 
-    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
-        task = LambdaCreate(
-            function_name="test",
-            runtime="python3.6",
-            role="aws_role",
-            handler="file.handler",
-            bucket="s3_bucket",
-            bucket_key="bucket_key",
-        )
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        credentials = {
-            "ACCESS_KEY": "42",
-            "SECRET_ACCESS_KEY": "99",
-            "SESSION_TOKEN": "1",
-        }
-
-        task.run(credentials=credentials)
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        called_method = client.mock_calls[1]
+        assert called_method[0] == "().create_function"
+        called_method.assert_called_once_with({"FunctionName": "test"})
 
 
 class TestLambdaDelete:
     def test_initialization(self):
         task = LambdaDelete(function_name="test")
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
+    def test_lambda_delete_exposes_boto3_delete_api(self, monkeypatch):
         task = LambdaDelete(function_name="test")
         client = MagicMock()
+        client.delete_function = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={
-                        "ACCESS_KEY": "42",
-                        "SECRET_ACCESS_KEY": "99",
-                        "SESSION_TOKEN": "1",
-                    }
-                )
-            ):
-                task.run()
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        task.run()
 
-    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
-        task = LambdaDelete(function_name="test")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        credentials = {
-            "ACCESS_KEY": "42",
-            "SECRET_ACCESS_KEY": "99",
-            "SESSION_TOKEN": "1",
-        }
-
-        task.run(credentials=credentials)
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        called_method = client.mock_calls[1]
+        assert called_method[0] == "().delete_function"
+        called_method.assert_called_once_with({"FunctionName": "test"})
 
 
 class TestLambdaInvoke:
     def test_initialization(self):
         task = LambdaInvoke(function_name="test")
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
+    def test_lambda_invoke_exposes_boto3_invoke_api(self, monkeypatch):
         task = LambdaInvoke(function_name="test")
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={
-                        "ACCESS_KEY": "42",
-                        "SECRET_ACCESS_KEY": "99",
-                        "SESSION_TOKEN": "1",
-                    }
-                )
-            ):
-                task.run()
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        task.run()
 
-    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
-        task = LambdaInvoke(function_name="test")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        credentials = {
-            "ACCESS_KEY": "42",
-            "SECRET_ACCESS_KEY": "99",
-            "SESSION_TOKEN": "1",
-        }
-
-        task.run(credentials=credentials)
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        called_method = client.mock_calls[1]
+        assert called_method[0] == "().invoke"
+        called_method.assert_called_once_with({"FunctionName": "test"})
 
 
 class TestLambdaList:
     def test_initialization(self):
         task = LambdaList()
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
+    def test_lambda_list_exposes_boto3_list_api(self, monkeypatch):
         task = LambdaList()
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={
-                        "ACCESS_KEY": "42",
-                        "SECRET_ACCESS_KEY": "99",
-                        "SESSION_TOKEN": "1",
-                    }
-                )
-            ):
-                task.run()
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        task.run()
 
-    def test_credentials_are_used_when_passed_at_runtime(self, monkeypatch):
-        task = LambdaList()
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        credentials = {
-            "ACCESS_KEY": "42",
-            "SECRET_ACCESS_KEY": "99",
-            "SESSION_TOKEN": "1",
-        }
-
-        task.run(credentials=credentials)
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        called_method = client.mock_calls[1]
+        assert called_method[0] == "().list_functions"
+        called_method.assert_called_once_with({"FunctionName": "test"})

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -21,38 +21,6 @@ class TestS3Download:
         with pytest.raises(ValueError, match="bucket"):
             task.run(key="")
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
-        task = S3Download(bucket="bob")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
-                )
-            ):
-                task.run(key="")
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": None,
-        }
-
-    def test_creds_default_to_environment(self, monkeypatch):
-        task = S3Download(bucket="bob")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        task.run(key="")
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": None,
-            "aws_secret_access_key": None,
-            "aws_session_token": None,
-        }
-
 
 class TestS3Upload:
     def test_initialization(self):
@@ -81,35 +49,3 @@ class TestS3Upload:
             ):
                 task.run(data="")
         assert type(client.upload_fileobj.call_args[1]["Key"]) == str
-
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
-        task = S3Upload(bucket="bob")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
-                )
-            ):
-                task.run(data="")
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": None,
-        }
-
-    def test_creds_default_to_environment(self, monkeypatch):
-        task = S3Upload(bucket="bob")
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        task.run(data="")
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": None,
-            "aws_secret_access_key": None,
-            "aws_session_token": None,
-        }

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -18,25 +18,15 @@ class TestStepActivate:
         assert task.name == "test"
         assert task.tags == {"AWS"}
 
-    def test_creds_are_pulled_from_secret(self, monkeypatch):
+    def test_exposes_boto3_start_execution_api(self, monkeypatch):
         task = StepActivate(state_machine_arn="arn", execution_name="name")
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        with set_temporary_config({"cloud.use_local_secrets": True}):
-            with prefect.context(
-                secrets=dict(
-                    AWS_CREDENTIALS={
-                        "ACCESS_KEY": "42",
-                        "SECRET_ACCESS_KEY": "99",
-                        "SESSION_TOKEN": "1",
-                    }
-                )
-            ):
-                task.run()
-        kwargs = client.call_args[1]
-        assert kwargs == {
-            "aws_access_key_id": "42",
-            "aws_secret_access_key": "99",
-            "aws_session_token": "1",
-        }
+        task.run()
+
+        called_method = client.mock_calls[1]
+        assert called_method[0] == "().start_execution"
+        called_method.assert_called_once_with(
+            {"stateMachineArn": "arn", "name": "name", "input": {}}
+        )

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+
 import prefect
 from prefect.utilities.aws import get_boto_client
 from prefect.utilities.configuration import set_temporary_config

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import prefect
+from prefect.utilities.aws import get_boto_client
+from prefect.utilities.configuration import set_temporary_config
+
+
+class TestGetBotoClient:
+    def test_uses_context_secrets(self, monkeypatch):
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "42",
+                        "SECRET_ACCESS_KEY": "99",
+                        "SESSION_TOKEN": "1",
+                    }
+                )
+            ):
+                get_boto_client(resource="not a real resource")
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "42",
+            "aws_secret_access_key": "99",
+            "aws_session_token": "1",
+        }
+
+    def test_prefers_passed_credentials_over_secrets(self, monkeypatch):
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        desired_credentials = {
+            "ACCESS_KEY": "pick",
+            "SECRET_ACCESS_KEY": "these",
+            "SESSION_TOKEN": "please",
+        }
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={
+                        "ACCESS_KEY": "dont",
+                        "SECRET_ACCESS_KEY": "pick",
+                        "SESSION_TOKEN": "these",
+                    }
+                )
+            ):
+                get_boto_client(
+                    resource="not a real resource", credentials=desired_credentials
+                )
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "pick",
+            "aws_secret_access_key": "these",
+            "aws_session_token": "please",
+        }
+
+    def test_creds_default_to_environment(self, monkeypatch):
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        get_boto_client(resource="not a real resource")
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+        }


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [n/a] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
In release 0.11.0 there is a new utility function to create boto3 clients that honors the new rules regarding Secret authentication (`utilities.get_boto_client`). This PR fixes a typo in its docstring, and moves tests that were being repeated unevenly in AWS related tasks that had to do with the utility function to a single version of those tests only on the utility function. In doing so I decreased code coverage since the repetitive version of those tests were falsely inflating the test coverage for AWS related tasks's `run` methods, so I threw in a few basic unittests that test the run methods more directly.

I got in a tussle with getting my mock to surface method calls properly, and ended up falling into the same pattern as https://github.com/PrefectHQ/prefect/blob/f75a7f8ef97e92ef88655994eb468aaf9db6e12e/tests/tasks/azure/test_cosmosdb.py#L104-L105 as a workaround.


## Why is this PR important?
Simplify tests, and increase code coverage since secrets have changed in 0.11.0 (hopefully this actually properly did this instead of decrease in the end ;) )

