### PR TITLE
Fixes from integration testing

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -897,7 +897,11 @@ class Flow:
                     context=flow_run_context,
                     **kwargs
                 )
-                if not isinstance(flow_state.result, dict):
+
+                # if flow_state is still scheduled; this most likely means
+                # that initialize_run failed (possibly due to a connection issue)
+                # and so we want to abort instead of creating an infinite loop
+                if not isinstance(flow_state.result, dict) or flow_state.is_scheduled():
                     error = True
                     break
 
@@ -1084,7 +1088,7 @@ class Flow:
             - flow_state (State, optional): flow state object used to optionally color the nodes
             - filename (str, optional): a filename specifying a location to save this visualization to; if provided,
                 the visualization will not be rendered automatically
-            - format (str, optional): a format specifying the output file type; defaults to 'pdf'. 
+            - format (str, optional): a format specifying the output file type; defaults to 'pdf'.
               Refer to http://www.graphviz.org/doc/info/output.html for valid formats
 
         Raises:

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -571,6 +571,7 @@ class FlowRunner(Runner):
                 task=task,
                 state_handlers=task_runner_state_handlers,
                 result=default_result or Result(),
+                default_result=self.flow.result,
             )
 
             # if this task reduces over a mapped state, make sure its children have finished

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -164,9 +164,11 @@ class TaskRunner(Runner):
             else:
                 loop_result_value = loop_result.value
             loop_context = {
-                "task_loop_count": state.cached_inputs.pop(  # type: ignore
-                    "_loop_count"
-                ).value,  # type: ignore
+                "task_loop_count": json.loads(
+                    state.cached_inputs.pop(  # type: ignore
+                        "_loop_count"
+                    ).location
+                ),  # type: ignore
                 "task_loop_result": loop_result_value,
             }
             context.update(loop_context)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1,6 +1,7 @@
 import copy
 from contextlib import redirect_stdout
 import itertools
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1036,7 +1037,7 @@ class TaskRunner(Runner):
             if prefect.context.get("task_loop_count") is not None:
                 loop_context = {
                     "_loop_count": PrefectResult(
-                        value=prefect.context["task_loop_count"],
+                        location=json.dumps(prefect.context["task_loop_count"]),
                     ),
                     "_loop_result": self.result.from_value(
                         value=prefect.context.get("task_loop_result")

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -27,9 +27,7 @@ def get_safe(obj: state.State, context: dict) -> Any:
             return obj._result
         return obj._result.safe_value  # type: ignore
     value = context.get("value", result.NoResult)
-    if value is None:
-        return value
-    return value.safe_value
+    return value
 
 
 class BaseStateSchema(ObjectSchema):

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -327,3 +327,23 @@ class TestNewStyleResults:
         assert new_state._result.bucket == "foo"
         assert isinstance(new_state._result, results.S3Result)
         assert new_state._result.location == "dir/place.txt"
+
+    def test_cached_inputs_are_serialized_correctly(self):
+        s = state.Cached(
+            message="test",
+            result=results.PrefectResult(value=1, location="1"),
+            cached_inputs=dict(
+                x=results.PrefectResult(location='"foo"'),
+                y=results.PrefectResult(location='"bar"'),
+            ),
+        )
+        schema = StateSchema()
+        serialized = schema.dump(s)
+
+        assert serialized["cached_inputs"]["x"]["location"] == '"foo"'
+        assert serialized["cached_inputs"]["y"]["location"] == '"bar"'
+
+        new_state = schema.load(serialized)
+
+        assert new_state.cached_inputs["x"].location == '"foo"'
+        assert new_state.cached_inputs["y"].location == '"bar"'

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -338,6 +338,7 @@ def test_context_attributes():
     assert test_filter.called
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Test randomly fails on Windows")
 def test_users_can_specify_additional_context_attributes(caplog):
     items = {
         "flow_run_id": "fri",
@@ -359,6 +360,7 @@ def test_users_can_specify_additional_context_attributes(caplog):
     assert caplog.records[0].trace_id == "ID"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Test randomly fails on Windows")
 def test_users_can_specify_additional_context_attributes_and_fails_gracefully(caplog):
     items = {
         "flow_run_id": "fri",

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import sys
 import time
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes two issues identified in integration testing:
- an incredibly rare situation in which `flow.run()` runs on an infinite loop
- state serializers for `cached_inputs` losing information

There is still one large outstanding issue we need to address: how to handle `cached_inputs` for mapped children.  For standard situations, task outputs are checkpointed and can be safely / directly stored as a cached input to downstream tasks that request caching, retries, etc.  However, with mapping specifically, the actual input to the task is an altered version of the upstream output (in particular it's an indexed item from the upstream list).  The big question is how to store this piece of data and where?

## Why is this PR important?
For a successful release!