### PR TITLE
Fix agent kubernetes liveness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 ### Fixes
 
-- None
+- Fix bug in Kubernetes agent ``deployment.yaml`` with a misconfigured liveness probe - [#2519](https://github.com/PrefectHQ/prefect/pull/2519)
 
 ### Deprecations
 

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: PREFECT__BACKEND
               value: "cloud"
             - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
-              value: "http://127.0.0.1:8080"
+              value: "http://:8080"
           resources:
             limits:
               memory: "128Mi"


### PR DESCRIPTION
The health check server can't listen on localhost in kubernetes.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)