### PR TITLE
[Server] Prevent tasks from entering a running state if flow run is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 - None
 
+### Server
+
+- Add "cancellation-lite" semantic by preventing task runs from running if the flow run isn't running - [#2535](https://github.com/PrefectHQ/prefect/pull/2535)
+
 ### Task Library
 
 - None

--- a/server/tests/api/test_runs.py
+++ b/server/tests/api/test_runs.py
@@ -317,9 +317,9 @@ class TestGetTaskRunInfo:
         assert all(tr.state == "Pending" for tr in trs)
         assert all(tr.serialized_state["type"] == "Pending" for tr in trs)
 
-    async def test_task_run_pulls_current_state(self, flow_run_id, task_id):
+    async def test_task_run_pulls_current_state(self, running_flow_run_id, task_id):
         tr_id = await runs.get_or_create_task_run(
-            flow_run_id=flow_run_id, task_id=task_id, map_index=None
+            flow_run_id=running_flow_run_id, task_id=task_id, map_index=None
         )
         await states.set_task_run_state(tr_id, state=Running())
 

--- a/server/tests/fixtures/database_fixtures.py
+++ b/server/tests/fixtures/database_fixtures.py
@@ -113,6 +113,7 @@ async def edge_id(flow_id):
 async def flow_run_id(flow_id):
     return await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=1))
 
+
 @pytest.fixture
 async def running_flow_run_id(flow_run_id):
     await api.states.set_flow_run_state(flow_run_id, state=Running())

--- a/server/tests/fixtures/database_fixtures.py
+++ b/server/tests/fixtures/database_fixtures.py
@@ -113,6 +113,11 @@ async def edge_id(flow_id):
 async def flow_run_id(flow_id):
     return await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=1))
 
+@pytest.fixture
+async def running_flow_run_id(flow_run_id):
+    await api.states.set_flow_run_state(flow_run_id, state=Running())
+    return flow_run_id
+
 
 @pytest.fixture
 async def labeled_flow_run_id(labeled_flow_id):

--- a/server/tests/graphql/test_states.py
+++ b/server/tests/graphql/test_states.py
@@ -169,7 +169,7 @@ class TestSetTaskRunStates:
     """
 
     async def test_set_multiple_task_run_states(
-        self, run_query, task_run_id, task_run_id_2, task_run_id_3
+        self, run_query, running_flow_run_id, task_run_id, task_run_id_2, task_run_id_3
     ):
         result = await run_query(
             query=self.mutation,
@@ -264,7 +264,7 @@ class TestSetTaskRunStates:
         assert tr.version == 1
         assert tr.state == "Success"
 
-    async def test_set_task_run_state(self, run_query, task_run_id):
+    async def test_set_task_run_state(self, run_query,  running_flow_run_id, task_run_id):
         result = await run_query(
             query=self.mutation,
             variables=dict(

--- a/server/tests/graphql/test_states.py
+++ b/server/tests/graphql/test_states.py
@@ -264,7 +264,9 @@ class TestSetTaskRunStates:
         assert tr.version == 1
         assert tr.state == "Success"
 
-    async def test_set_task_run_state(self, run_query,  running_flow_run_id, task_run_id):
+    async def test_set_task_run_state(
+        self, run_query, running_flow_run_id, task_run_id
+    ):
         result = await run_query(
             query=self.mutation,
             variables=dict(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR brings a new behavior from Prefect Cloud to server: task runs can not enter a running state if the flow run isn't running. The enables a "cancellation lite" semantic.


## Why is this PR important?


