### PR TITLE
Add serializer for custom Results

### DIFF
--- a/src/prefect/serialization/result.py
+++ b/src/prefect/serialization/result.py
@@ -38,14 +38,14 @@ class CustomResultSchema(ObjectSchema):
         object_class = lambda: result.Result
         exclude_fields = ["type"]
 
-    type = fields.Function(
-        lambda handler: to_qualified_name(type(handler)), lambda x: x
-    )
+    location = fields.Str(allow_none=True)
+
+    type = fields.Function(lambda result: to_qualified_name(type(result)), lambda x: x)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> result.Result:
-        """Because we cannot deserialize a custom class, return `None`"""
-        return result.Result()
+        """Because we cannot deserialize a custom class, return a base `Result`"""
+        return result.Result(location=data.get("location"))
 
 
 class AzureResultSchema(ObjectSchema):

--- a/tests/serialization/test_results.py
+++ b/tests/serialization/test_results.py
@@ -153,7 +153,7 @@ def test_result_handler_result():
 
 
 def test_custom_result():
-    class CustomResult(Result):
+    class MySuperAwesomeAmazingTopOfTheLineCustomResult(Result):
         def __init__(self, test_kwarg=None, **kwargs):
             self.test_kwarg = test_kwarg
             self.read_result = False
@@ -177,7 +177,9 @@ def test_custom_result():
             return new
 
     schema = StateResultSchema()
-    result = CustomResult(test_kwarg="yes", value=42, location="bar")
+    result = MySuperAwesomeAmazingTopOfTheLineCustomResult(
+        test_kwarg="yes", value=42, location="bar"
+    )
     serialized = schema.dump(result)
 
     assert serialized["type"] == "CustomResult"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a serializer for custom results


## Why is this PR important?
So users can write their own result handlers and orchestrate them with a backend

