### PR TITLE
Allow slack_task to accept a dictionary as a specially-strctured JSON 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 ### Enhancements
 
-- None
+- Allow slack_task to accept a dictionary for the message parameter to build a specially-strctured JSON Block
 
 ### Server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 ### Enhancements
 
-- Allow slack_task to accept a dictionary for the message parameter to build a specially-structured JSON Block
+- Allow slack_task to accept a dictionary for the message parameter to build a specially-structured JSON Block - [#2541](https://github.com/PrefectHQ/prefect/pull/2541)
 
 ### Server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 
 ### Enhancements
 
-- Allow slack_task to accept a dictionary for the message parameter to build a specially-strctured JSON Block
+- Allow slack_task to accept a dictionary for the message parameter to build a specially-structured JSON Block
 
 ### Server
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR change allows **slack_task** to accept a dictionary for the message parameter to build a specially-strctured JSON Block. It would give users flexibility to send a text or a JSON block. The original slack_task only accepted message as a plain text by setting `json = {"text":message}`.


## Why is this PR important?
Users would able to customize and their own slack message with a structured JSON block. Here is the documentation of [Slack Block](https://api.slack.com/block-kit/building) which provides better formatting, layouts and visualization. In our case, we used slack block kit to send informative alert message when the flow is done
![our enhanced slack alert](https://github.com/JLouSRM/srm_dev/blob/master/slack_info.png?raw=true)
