### PR TITLE
Support using `case` with the imperative api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [release/0.11.0 branch](https://github.com/Pr
 ### Enhancements
 
 - Allow slack_task to accept a dictionary for the message parameter to build a specially-structured JSON Block - [#2541](https://github.com/PrefectHQ/prefect/pull/2541)
+- Support using `case` for control flow with the imperative api - [#2546](https://github.com/PrefectHQ/prefect/pull/2546)
 
 ### Server
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -437,9 +437,12 @@ class Flow:
                     "flow.".format(task.slug)
                 )
 
-        if task not in self.tasks:
             self.tasks.add(task)
             self._cache.clear()
+
+            case = prefect.context.get("case", None)
+            if case is not None:
+                case.add_task(task, self)
 
         return task
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -461,10 +461,6 @@ class Task(metaclass=SignatureValidator):
         if not flow:
             raise ValueError("Could not infer an active Flow context.")
 
-        case = prefect.context.get("case", None)
-        if case is not None:
-            case.add_task(self)
-
         self.set_dependencies(
             flow=flow,
             upstream_tasks=upstream_tasks,

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -464,3 +464,53 @@ class TestCase:
                 assert state.result[t].result == sol[t]
             else:
                 assert state.result[t].is_skipped()
+
+    def test_case_imperative_errors(self):
+        flow = Flow("test")
+        flow2 = Flow("test2")
+        cond = identity.copy()
+        a = identity.copy()
+        with pytest.raises(ValueError, match="Multiple flows"):
+            with case(cond, True):
+                flow.add_task(a)
+                flow2.add_task(a)
+
+    @pytest.mark.parametrize("branch", ["a", "b", "c"])
+    def test_case_imperative_api(self, branch):
+        flow = Flow("test")
+
+        cond = identity.copy()
+        a = identity.copy()
+        b = inc.copy()
+        c = identity.copy()
+        d = inc.copy()
+
+        cond.bind(branch, flow=flow)
+        flow.add_task(cond)
+        with case(cond, "a"):
+            a.bind(1, flow=flow)
+            b.bind(a, flow=flow)
+            flow.add_task(a)
+            flow.add_task(b)
+
+        with case(cond, "b"):
+            c.bind(3, flow=flow)
+            d.bind(c, flow=flow)
+            flow.add_task(c)
+            flow.add_task(d)
+
+        state = flow.run()
+
+        if branch == "a":
+            assert state.result[a].result == 1
+            assert state.result[b].result == 2
+            assert state.result[c].is_skipped()
+            assert state.result[d].is_skipped()
+        elif branch == "b":
+            assert state.result[a].is_skipped()
+            assert state.result[b].is_skipped()
+            assert state.result[c].result == 3
+            assert state.result[d].result == 4
+        elif branch == "c":
+            for t in [a, b, c, d]:
+                assert state.result[t].is_skipped()


### PR DESCRIPTION
Previously this only worked with the functional api.

Fixes #2538.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)