### PR TITLE
Add unique name option to Kubernetes Job Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Docker storage now writes flows to `/opt` dir to remove need for root permissions - [#2025](https://github.com/PrefectHQ/prefect/issues/2025)
 - Add option to [set secrets on Storage objects](https://docs.prefect.io/orchestration/recipes/third_party_auth.html#declaring-secrets-on-storage) - [#2507](https://github.com/PrefectHQ/prefect/pull/2507)
 - Add reserved [default Secret names](https://docs.prefect.io/orchestration/recipes/third_party_auth.html#list-of-default-secret-names) and formats for working with cloud platforms - [#2507](https://github.com/PrefectHQ/prefect/pull/2507)
+- Add unique naming option to the jobs created by the `KubernetesJobEnvironment` - [#2553](https://github.com/PrefectHQ/prefect/pull/2553)
 
 ### Server
 

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -39,6 +39,8 @@ class KubernetesJobEnvironment(Environment):
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file
+        - unique_job_name (bool, optional): Use a unique name for each job created with this environment. Defaults
+            to `False`
         - executor_kwargs (dict, optional): a dictionary of kwargs to be passed to
             the executor; defaults to an empty dictionary
         - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -50,12 +50,14 @@ class KubernetesJobEnvironment(Environment):
     def __init__(
         self,
         job_spec_file: str = None,
+        unique_job_name: bool = False,
         executor_kwargs: dict = None,
         labels: List[str] = None,
         on_start: Callable = None,
         on_exit: Callable = None,
     ) -> None:
         self.job_spec_file = os.path.abspath(job_spec_file) if job_spec_file else None
+        self.unique_job_name = unique_job_name
         self.executor_kwargs = executor_kwargs or dict()
 
         # Load specs from file if path given, store on object
@@ -206,6 +208,11 @@ class KubernetesJobEnvironment(Environment):
         # Create metadata label fields if they do not exist
         if not yaml_obj.get("metadata"):
             yaml_obj["metadata"] = {}
+
+        if self.unique_job_name:
+            yaml_obj["metadata"][
+                "name"
+            ] = f"{yaml_obj['metadata']['name']}-{flow_run_id[:8]}"
 
         if not yaml_obj["metadata"].get("labels"):
             yaml_obj["metadata"]["labels"] = {}

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -214,7 +214,7 @@ class KubernetesJobEnvironment(Environment):
         if self.unique_job_name:
             yaml_obj["metadata"][
                 "name"
-            ] = f"{yaml_obj['metadata']['name']}-{flow_run_id[:8]}"
+            ] = f"{yaml_obj['metadata']['name']}-{str(uuid.uuid4())[:8]}"
 
         if not yaml_obj["metadata"].get("labels"):
             yaml_obj["metadata"]["labels"] = {}

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -309,7 +309,8 @@ def test_populate_job_yaml():
                     flow_file_path="test4",
                 )
 
-        assert yaml_obj["metadata"]["name"] == "prefect-dask-job-id_test"
+        assert "prefect-dask-job-" in yaml_obj["metadata"]["name"]
+        assert len(yaml_obj["metadata"]["name"]) == 25
 
         assert (
             yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -25,6 +25,7 @@ def test_create_k8s_job_environment():
         )
         assert environment
         assert environment.job_spec_file == os.path.join(directory, "job.yaml")
+        assert environment.unique_job_name == False
         assert environment.executor_kwargs == {}
         assert environment.labels == set()
         assert environment.on_start is None
@@ -285,7 +286,7 @@ def test_populate_job_yaml():
             file.write("job")
 
         environment = KubernetesJobEnvironment(
-            job_spec_file=os.path.join(directory, "job.yaml")
+            job_spec_file=os.path.join(directory, "job.yaml"), unique_job_name=True
         )
 
         file_path = os.path.dirname(prefect.environments.execution.dask.k8s.__file__)
@@ -307,6 +308,8 @@ def test_populate_job_yaml():
                     docker_name="test1/test2:test3",
                     flow_file_path="test4",
                 )
+
+        assert yaml_obj["metadata"]["name"] == "prefect-dask-job-id_test"
 
         assert (
             yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds option to use a unique name for each job created with the Kubernetes Job Environment by adding on the first eight characters from the flow run id.


## Why is this PR important?
Previously it would not be possible to run two runs of the same flow at the same time using this environment due to k8s naming collisions.

