### PR TITLE
Try to parse all config values using literal_eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Add option to [set secrets on Storage objects](https://docs.prefect.io/orchestration/recipes/third_party_auth.html#declaring-secrets-on-storage) - [#2507](https://github.com/PrefectHQ/prefect/pull/2507)
 - Add reserved [default Secret names](https://docs.prefect.io/orchestration/recipes/third_party_auth.html#list-of-default-secret-names) and formats for working with cloud platforms - [#2507](https://github.com/PrefectHQ/prefect/pull/2507)
 - Add unique naming option to the jobs created by the `KubernetesJobEnvironment` - [#2553](https://github.com/PrefectHQ/prefect/pull/2553)
+- Use `ast.literal_eval` for configuration values - [#2536](https://github.com/PrefectHQ/prefect/issues/2536)
 
 ### Server
 

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -58,7 +58,7 @@ def string_to_type(val: str) -> Union[bool, int, float, str]:
     elif val.upper() == "FALSE":
         return False
 
-    # dicts
+    # dicts, ints, floats, or any other literal Python syntax
     try:
         val_as_obj = literal_eval(val)
         return val_as_obj

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -42,14 +42,13 @@ def string_to_type(val: str) -> Union[bool, int, float, str]:
     Maps:
         - "true" (any capitalization) to `True`
         - "false" (any capitalization) to `False`
-        - integers to `int`
-        - floats to `float`
-
+        - any other valid literal Python syntax interpretable by ast.literal_eval
+        
     Arguments:
         - val (str): the string value of an environment variable
 
     Returns:
-        Union[bool, int, float, str]: the type-cast env var value
+        Union[bool, int, float, str, dict, list, None, tuple]: the type-cast env var value
     """
 
     # bool

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+from ast import literal_eval
 from typing import Optional, Union, cast
 
 import toml
@@ -57,19 +58,10 @@ def string_to_type(val: str) -> Union[bool, int, float, str]:
     elif val.upper() == "FALSE":
         return False
 
-    # int
+    # dicts
     try:
-        val_as_int = int(val)
-        if str(val_as_int) == val:
-            return val_as_int
-    except Exception:
-        pass
-
-    # float
-    try:
-        val_as_float = float(val)
-        if str(val_as_float) == val:
-            return val_as_float
+        val_as_obj = literal_eval(val)
+        return val_as_obj
     except Exception:
         pass
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -64,6 +64,10 @@ def config(test_config_file_path, monkeypatch):
     monkeypatch.setenv("PREFECT_TEST__ENV_VARS__NEGATIVE_INT", "-10")
     monkeypatch.setenv("PREFECT_TEST__ENV_VARS__FLOAT", "7.5")
     monkeypatch.setenv("PREFECT_TEST__ENV_VARS__NEGATIVE_FLOAT", "-7.5")
+    monkeypatch.setenv(
+        "PREFECT_TEST__CONTEXT__SECRETS__AWS_CREDENTIALS",
+        '{"ACCESS_KEY": "abcdef", "SECRET_ACCESS_KEY": "ghijklmn"}',
+    )
     monkeypatch.setenv("PATH", "1/2/3")
     monkeypatch.setenv(
         "PREFECT_TEST__ENV_VARS__ESCAPED_CHARACTERS", r"line 1\nline 2\rand 3\tand 4"
@@ -79,6 +83,12 @@ def test_keys(config):
     assert "general" in config
     assert "nested" in config.general
     assert "x" not in config
+
+
+def test_dicts_are_created(config):
+    val = config.context.secrets.AWS_CREDENTIALS
+    assert isinstance(val, dict)
+    assert val["ACCESS_KEY"] == "abcdef"
 
 
 def test_getattr_missing(config):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR introduces a better implementation for parsing config values that will handle secrets passed in through env var in a much more natural way.


## Why is this PR important?
Mainly for secrets, but also for configuration consistency.  Closes #2536 