### PR TITLE
[docs] fix indentation for parentheses in Dask example

### DIFF
--- a/docs/core/tutorial/06-parallel-execution.md
+++ b/docs/core/tutorial/06-parallel-execution.md
@@ -30,8 +30,8 @@ This will spin up a [Local Dask Cluster](http://distributed.dask.org/en/latest/l
 flow.run(
     executor=DaskExecutor(
         address='some-ip:port/to-your-dask-scheduler'
-        )
     )
+)
 ```
 
 Furthermore, you can implement your own `Executor` for use with any Prefect `Flow`, as long as the object provided satisfies [the `Executor` interface](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/engine/executors/base.py) (i.e. appropriate `submit`, `map`, and `wait` functions, similar to Python's [`concurrent.futures.Executor`](https://docs.python.org/3/library/concurrent.futures.html#executor-objects) interface). In this way, the sky is the limit!


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR proposes fixing mis-aligned parentheses in the Dask example at https://docs.prefect.io/core/tutorial/06-parallel-execution.html to match style in the rest of the documentation.

## Why is this PR important?

This PR is a minor change to improve the consistency and readability of the documentation. In its current form, at first glance I thought that there was a `)` missing and this was distracting while reading the documentation.

