### PR TITLE
[ci] fix masked tests

### DIFF
--- a/server/tests/database/test_hasura.py
+++ b/server/tests/database/test_hasura.py
@@ -834,7 +834,7 @@ class TestExecuteResult:
         assert isinstance(result.data.y[0].a, Box)
         assert result.data.y[0].a == 1
 
-    async def test_execute_respects_as_box(self):
+    async def test_execute_respects_not_as_box(self):
         result = await HasuraClient().execute("query { x }", as_box=False)
         assert isinstance(result, dict) and not isinstance(result, Box)
         assert result["data"]["x"] == 1

--- a/server/tests/database/test_hasura.py
+++ b/server/tests/database/test_hasura.py
@@ -831,7 +831,7 @@ class TestExecuteResult:
         result = await HasuraClient().execute("query { x }")
         assert isinstance(result, Box)
         assert result.data.x == 1
-        assert isinstance(result.data.y[0].a, Box)
+        assert isinstance(result.data.y[0], Box)
         assert result.data.y[0].a == 1
 
     async def test_execute_respects_not_as_box(self):

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -542,7 +542,7 @@ def test_fargate_agent_config_env_vars_lists_dicts(monkeypatch, runner_token):
     assert botocore_config.call_args == {}
 
 
-def test_deploy_flow_raises(monkeypatch, runner_token):
+def test_deploy_flow_local_storage_raises(monkeypatch, runner_token):
     boto3_client = MagicMock()
 
     boto3_client.describe_task_definition.return_value = {}
@@ -566,7 +566,7 @@ def test_deploy_flow_raises(monkeypatch, runner_token):
     assert not boto3_client.run_task.called
 
 
-def test_deploy_flow_raises(monkeypatch, runner_token):
+def test_deploy_flow_docker_storage_raises(monkeypatch, runner_token):
     boto3_client = MagicMock()
 
     boto3_client.describe_task_definition.return_value = {}

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -120,7 +120,7 @@ def test_list_tenants(patch_post):
         assert "name" in result.output
 
 
-def test_switch_tenants(monkeypatch):
+def test_switch_tenants_success(monkeypatch):
     with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
         monkeypatch.setattr("prefect.cli.auth.Client", MagicMock())
 
@@ -130,7 +130,7 @@ def test_switch_tenants(monkeypatch):
         assert "Tenant switched" in result.output
 
 
-def test_switch_tenants(monkeypatch):
+def test_switch_tenants_failed(monkeypatch):
     with set_temporary_config({"cloud.graphql": "http://my-cloud.foo"}):
         client = MagicMock()
         client.return_value.login_to_tenant = MagicMock(return_value=False)

--- a/tests/cli/test_execute.py
+++ b/tests/cli/test_execute.py
@@ -21,7 +21,7 @@ def test_execute_help():
     assert "Execute flow environments." in result.output
 
 
-def test_execute_cloud_flow_fails():
+def test_execute_cloud_flow_fails_outside_cloud_context():
     runner = CliRunner()
     result = runner.invoke(execute, "cloud-flow")
     assert result.exit_code == 1

--- a/tests/client/test_client_auth.py
+++ b/tests/client/test_client_auth.py
@@ -115,17 +115,6 @@ class TestClientConfig:
                 client = Client(api_token="a")
                 client.save_api_token()
 
-                client = Client()
-                assert client._api_token == "a"
-
-    def test_load_local_api_token_is_called_when_the_client_is_initialized_without_token(
-        self, cloud_api
-    ):
-        with tempfile.TemporaryDirectory() as tmp:
-            with set_temporary_config({"home_dir": tmp}):
-                client = Client(api_token="a")
-                client.save_api_token()
-
                 client = Client(api_token="b")
                 assert client._api_token == "b"
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1903,7 +1903,7 @@ class TestFlowRunMethod:
 
         assert storage == dict(y=[[1, 1, 1], [1, 1, 1], [3, 3, 3]])
 
-    def test_flow_dot_run_handles_cached_states_across_runs(self, repeat_schedule):
+    def test_flow_dot_run_handles_cached_states_across_runs_with_always_run_trigger(self, repeat_schedule):
         schedule = repeat_schedule(3)
 
         class StatefulTask(Task):

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1182,33 +1182,6 @@ def test_parameters_overwrite_context_only_if_key_matches():
         context={"parameters": {"x": 5, "y": 6}},
         return_tasks=[x, y],
     )
-
-
-def test_parameters_can_be_set_in_context_if_none_passed():
-    x = prefect.Parameter("x")
-    f = FlowRunner(Flow(name="test", tasks=[x]))
-    state = f.run(parameters={}, context={"parameters": {"x": 5}}, return_tasks=[x])
-    assert state.result[x].result == 5
-
-
-def test_parameters_overwrite_context():
-    x = prefect.Parameter("x")
-    f = FlowRunner(Flow(name="test", tasks=[x]))
-    state = f.run(
-        parameters={"x": 2}, context={"parameters": {"x": 5}}, return_tasks=[x]
-    )
-    assert state.result[x].result == 2
-
-
-def test_parameters_overwrite_context_only_if_key_matches():
-    x = prefect.Parameter("x")
-    y = prefect.Parameter("y")
-    f = FlowRunner(Flow(name="test", tasks=[x, y]))
-    state = f.run(
-        parameters={"x": 2},
-        context={"parameters": {"x": 5, "y": 6}},
-        return_tasks=[x, y],
-    )
     assert state.result[x].result == 2
     assert state.result[y].result == 6
 

--- a/tests/tasks/azureml/test_datastore.py
+++ b/tests/tasks/azureml/test_datastore.py
@@ -181,14 +181,14 @@ class TestDatastoreUpload:
 
         assert task.relative_root == relative_root
 
-    def test_missing_datastore_raises_error(self):
+    def test_missing_datastore_path_raises_error(self):
         path = ""
         task = DatastoreUpload(path=path)
 
         with pytest.raises(ValueError, match="A datastore must be provided."):
             task.run()
 
-    def test_missing_datastore_raises_error(self):
+    def test_missing_datastore_datastore_raises_error(self):
         datastore = MagicMock()
         task = DatastoreUpload(datastore=datastore)
 

--- a/tests/tasks/dropbox/test_dropbox.py
+++ b/tests/tasks/dropbox/test_dropbox.py
@@ -36,7 +36,7 @@ class TestCredentials:
 
         assert dbx.call_args[0][0] == "HI"
 
-    def test_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
+    def test_non_dropbox_creds_are_pulled_from_secret_at_runtime(self, monkeypatch):
         task = DropboxDownload(path="test", access_token_secret="DROPBOX_ACCESS_TOKEN")
 
         dbx = MagicMock()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Thanks for this awesome project! I've been getting familiar with `prefect` this week, and wanted to contribute back where I could. I noticed you aren't running `flake8` in this project, so I ran that over the codebase to see if there were any issues that could be fixed.

I saw one pattern that I think it would be helpful to address...duplicated tests.

If you run this command from the root of the repo

```shell
flake8 | grep -E "F811 .*unused .*test_"
```

you'll see the following:

```text
./tests/engine/test_flow_runner.py:1187:1: F811 redefinition of unused 'test_parameters_can_be_set_in_context_if_none_passed' from line 1160
./tests/engine/test_flow_runner.py:1194:1: F811 redefinition of unused 'test_parameters_overwrite_context' from line 1167
./tests/engine/test_flow_runner.py:1203:1: F811 redefinition of unused 'test_parameters_overwrite_context_only_if_key_matches' from line 1176
./tests/cli/test_auth.py:133:1: F811 redefinition of unused 'test_switch_tenants' from line 123
./tests/cli/test_execute.py:57:1: F811 redefinition of unused 'test_execute_cloud_flow_fails' from line 24
./tests/agent/test_fargate_agent.py:569:1: F811 redefinition of unused 'test_deploy_flow_raises' from line 545
./tests/tasks/dropbox/test_dropbox.py:39:5: F811 redefinition of unused 'test_creds_are_pulled_from_secret_at_runtime' from line 28
./tests/tasks/azureml/test_datastore.py:191:5: F811 redefinition of unused 'test_missing_datastore_raises_error' from line 184
./tests/client/test_client_auth.py:121:5: F811 redefinition of unused 'test_load_local_api_token_is_called_when_the_client_is_initialized_without_token' from line 110
./tests/core/test_flow.py:1906:5: F811 redefinition of unused 'test_flow_dot_run_handles_cached_states_across_runs' from line 1815
./server/tests/database/test_hasura.py:837:5: F811 redefinition of unused 'test_execute_respects_as_box' from line 830
```

In this PR, I tried to address those warnings by fixing those test files. I saw three flavors of problem:

1. Identical test copied in two places --> **removed one of them**
2. Partial test and more-complete version of it --> **removed the partial one**
3. Two different tests with the same name --> **renamed one or both to fix the conflict**

I know that I don't have full context for what these tests are doing, so please let me know if I made any mistakes.

## Why is this PR important?

This PR makes sure that all of the project's tests are run in CI. If `pytest` finds duplicated tests methods in a file, it will only run one of them. You can test by creating a file called test_stuff.py with this content:

```python
import unittest

def test_something():
    assert False

def test_something():
    assert True
```

Run `pytest test_stuff.py` and you'll see this:

![image](https://user-images.githubusercontent.com/7608904/81989997-e3d9ee00-9603-11ea-9262-3135c4421e5e.png)

Change the first `test_something()` to `test_something_else()`, re-run `pytest test_stuff.py`, and you'll see this:

![image](https://user-images.githubusercontent.com/7608904/81990059-03711680-9604-11ea-91d8-ad12dc88be9c.png)

Thanks for your time and consideration!
