### PR TITLE
Handle possible malformed evals in agent labels parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fix agents not being able to parse label list provided via environment variable - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
+- Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fix agents not being able to parse label list provided vie environment variable - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
+- Fix agents not being able to parse label list provided via environment variable - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- None
+- Fix agents not being able to parse label list provided vie environment variable - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 
 ### Deprecations
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -100,10 +100,9 @@ class Agent:
         self.name = name or config.cloud.agent.get("name", "agent")
 
         self.labels = labels or config.cloud.agent.get("labels", [])
-        try:
+        # quick hack in case config has not been evaluated to a list yet
+        if isinstance(self.labels, str):
             self.labels = ast.literal_eval(self.labels)
-        except ValueError:
-            pass
         self.env_vars = env_vars or config.cloud.agent.get("env_vars", dict())
         self.max_polls = max_polls
         self.log_to_cloud = False if no_cloud_logs else True

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -98,9 +98,16 @@ class Agent:
         no_cloud_logs: bool = False,
     ) -> None:
         self.name = name or config.cloud.agent.get("name", "agent")
-        self.labels = list(
-            labels or ast.literal_eval(config.cloud.agent.get("labels", "[]"))
-        )
+
+        # Handle possible malformed evals
+        if labels:
+            self.labels = labels
+        else:
+            try:
+                self.labels = ast.literal_eval(config.cloud.agent.get("labels", "[]"))
+            except Exception:
+                self.labels = config.cloud.agent.get("labels", "[]")
+
         self.env_vars = env_vars or config.cloud.agent.get("env_vars", dict())
         self.max_polls = max_polls
         self.log_to_cloud = False if no_cloud_logs else True

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -100,6 +100,10 @@ class Agent:
         self.name = name or config.cloud.agent.get("name", "agent")
 
         self.labels = labels or config.cloud.agent.get("labels", [])
+        try:
+            self.labels = ast.literal_eval(self.labels)
+        except ValueError:
+            pass
         self.env_vars = env_vars or config.cloud.agent.get("env_vars", dict())
         self.max_polls = max_polls
         self.log_to_cloud = False if no_cloud_logs else True

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -173,7 +173,7 @@ class Agent:
             - The agent ID as a string
         """
         agent_id = self.client.register_agent(
-            agent_type=type(self).__name__, name=self.name, labels=self.labels
+            agent_type=type(self).__name__, name=self.name, labels=self.labels  # type: ignore
         )
 
         self.logger.debug(f"Agent ID: {agent_id}")

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -99,15 +99,7 @@ class Agent:
     ) -> None:
         self.name = name or config.cloud.agent.get("name", "agent")
 
-        # Handle possible malformed evals
-        if labels:
-            self.labels = labels
-        else:
-            try:
-                self.labels = ast.literal_eval(config.cloud.agent.get("labels", "[]"))
-            except Exception:
-                self.labels = config.cloud.agent.get("labels", "[]")
-
+        self.labels = labels or config.cloud.agent.get("labels", [])
         self.env_vars = env_vars or config.cloud.agent.get("env_vars", dict())
         self.max_polls = max_polls
         self.log_to_cloud = False if no_cloud_logs else True

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -75,7 +75,7 @@ class LocalAgent(Agent):
         )
         hostname = socket.gethostname()
         if hostname_label and (hostname not in self.labels):
-            assert isinstance(self.labels, list)
+            # assert isinstance(self.labels, list)
             self.labels.append(hostname)
         self.labels.extend(
             ["azure-flow-storage", "gcs-flow-storage", "s3-flow-storage"]

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -75,7 +75,7 @@ class LocalAgent(Agent):
         )
         hostname = socket.gethostname()
         if hostname_label and (hostname not in self.labels):
-            # assert isinstance(self.labels, list)
+            assert isinstance(self.labels, list)
             self.labels.append(hostname)
         self.labels.extend(
             ["azure-flow-storage", "gcs-flow-storage", "s3-flow-storage"]


### PR DESCRIPTION
Now that #2558 allows for providing a more rich set of env vars via config we were attempting to double parse `config.cloud.agent.labels`. 

Closes #2569