### PR TITLE
Fix type for Dask Security in RemoteDaskEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
+- Fix type for Dask Security in RemoteDaskEnvironment - [#2571](https://github.com/PrefectHQ/prefect/pull/2571)
 
 ### Deprecations
 

--- a/src/prefect/environments/execution/dask/remote.py
+++ b/src/prefect/environments/execution/dask/remote.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Type
+from typing import Callable, List
 
 from distributed.security import Security
 

--- a/src/prefect/environments/execution/dask/remote.py
+++ b/src/prefect/environments/execution/dask/remote.py
@@ -36,7 +36,7 @@ class RemoteDaskEnvironment(RemoteEnvironment):
     Args:
         - address (str): an address of the scheduler of a Dask cluster in URL form,
             e.g. `tcp://172.33.17.28:8786`
-        - security (Type[Security], optional): a Dask Security object from `distributed.security.Security`.
+        - security (Security, optional): a Dask Security object from `distributed.security.Security`.
             Use this to connect to a Dask cluster that is enabled with TLS encryption.
         - executor_kwargs (dict, optional): a dictionary of kwargs to be passed to
             the executor; defaults to an empty dictionary
@@ -49,7 +49,7 @@ class RemoteDaskEnvironment(RemoteEnvironment):
     def __init__(
         self,
         address: str,
-        security: Type[Security] = None,
+        security: Security = None,
         executor_kwargs: dict = None,
         labels: List[str] = None,
         on_start: Callable = None,

--- a/tests/environments/execution/test_remote_dask_environment.py
+++ b/tests/environments/execution/test_remote_dask_environment.py
@@ -31,6 +31,7 @@ def test_create_remote_environment_populated():
     arbitrary_kwargs = {"arbitrary": "value"}
     environment = RemoteDaskEnvironment(
         address=address_kwargs["address"],
+        security=security,
         executor_kwargs=arbitrary_kwargs,
         labels=["foo", "bar", "good"],
         on_start=f,


### PR DESCRIPTION
This is a minor change to fix the type of the optional Dask Security parameter in RemoteDaskEnvironment for those using TLS.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
Change the type of the security parameter from `Type[Security]` to `Security`.

## Why is this PR important?
Without this change, those using TLS with Dask will get an annoying and incorrect type error.
