### PR TITLE
cut built size of server/ container

### DIFF
--- a/changes/pr2573.yaml
+++ b/changes/pr2573.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Clear cache, remove kubernetes dependencies to cut size of server container - [#2573](https://github.com/PrefectHQ/prefect/pull/2573)"
+
+contributor:
+  - "[James Lamb](https://github.com/jameslamb)"

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -32,10 +32,13 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+tests/
 
 # cache
 .mypy_cache/
 .pytest_cache/
+__pycache__/
+*.pyc
 
 # Flask stuff:
 instance/
@@ -54,3 +57,6 @@ instance/
 env/
 venv/
 ENV/
+
+# documentation
+*.md

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,24 +5,26 @@
 
 FROM python:3.7
 ARG VERSION
-ENV SERVER_VERSION=${VERSION}
-
-RUN apt-get -qq -y update && apt-get -qq -y install --no-install-recommends --no-install-suggests --allow-unauthenticated \
-    curl \
-    git \
-    sudo && \
-    rm -rf /var/lib/apt/lists/*
-
 ARG PREFECT_VERSION=master
 ENV PREFECT_VERSION=$PREFECT_VERSION
-
-RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect
+ENV SERVER_VERSION=${VERSION}
 
 COPY . /prefect-server
 
-RUN \
-    cd /prefect-server \
-    && pip install -e .
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install \
+        --no-install-recommends \
+        --no-install-suggests \
+        --allow-unauthenticated \
+            curl \
+            git \
+            sudo && \
+    pip install \
+        git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect && \
+    cd /prefect-server && \
+    pip install -e . && \
+    sudo apt-get remove -y --auto-remove --purge git && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /prefect-server
 CMD python

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,26 +5,24 @@
 
 FROM python:3.7
 ARG VERSION
+ENV SERVER_VERSION=${VERSION}
+
+RUN apt-get -qq -y update && apt-get -qq -y install --no-install-recommends --no-install-suggests --allow-unauthenticated \
+    curl \
+    git \
+    sudo && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG PREFECT_VERSION=master
 ENV PREFECT_VERSION=$PREFECT_VERSION
-ENV SERVER_VERSION=${VERSION}
+
+RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect
 
 COPY . /prefect-server
 
-RUN apt-get -qq -y update && \
-    apt-get -qq -y install \
-        --no-install-recommends \
-        --no-install-suggests \
-        --allow-unauthenticated \
-            curl \
-            git \
-            sudo && \
-    pip install \
-        git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect && \
-    cd /prefect-server && \
-    pip install -e . && \
-    sudo apt-get remove -y --auto-remove --purge git && \
-    rm -rf /var/lib/apt/lists/*
+RUN \
+    cd /prefect-server \
+    && pip install -e .
 
 WORKDIR /prefect-server
 CMD python

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -qq -y update && apt-get -qq -y install --no-install-recommends --no
 ARG PREFECT_VERSION=master
 ENV PREFECT_VERSION=$PREFECT_VERSION
 
-RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[kubernetes]
+RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect
 
 COPY . /prefect-server
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,7 +10,8 @@ ENV SERVER_VERSION=${VERSION}
 RUN apt-get -qq -y update && apt-get -qq -y install --no-install-recommends --no-install-suggests --allow-unauthenticated \
     curl \
     git \
-    sudo
+    sudo && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG PREFECT_VERSION=master
 ENV PREFECT_VERSION=$PREFECT_VERSION


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR proposes two small changes to reduce the built size of the `server/` docker image:

* clearing the `apt` cache with `rm -rf /var/lib/apt/lists/*`
* adding testing code, cache files, and documentation to that image's `.dockerignore`

## Why is this PR important?

If I understand correctly, the [server Dockerfile](https://github.com/PrefectHQ/prefect/blob/master/server/Dockerfile) is used to build an image that others might pull to run the Prefect Core server themselves. Cutting the size of that container reduces the amount of data that has to be transmitted to pull that image, which should make those pulls faster and less expensive.

The changes in this PR reduce the size of the built image by 2MB, tested with:

```shell
docker build \
    -t prefect-server \
    --no-cache \
    --build-arg VERSION=123 \
    -f Dockerfile \
    .
```

Thanks for your time and consideration!