### PR TITLE
prefer sets to lists for membership tests

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -216,7 +216,7 @@ def get_call_signature(obj):
     if args == []:
         standalone, kwargs = [], []
     else:
-        if args[0] in ["cls", "self"]:
+        if args[0] in {"cls", "self"}:
             args = args[1:]  # remove cls or self from displayed signature
 
         standalone = args[: -len(defaults)] if defaults else args  # true args

--- a/examples/tutorial/aircraftlib/analysis.py
+++ b/examples/tutorial/aircraftlib/analysis.py
@@ -21,7 +21,7 @@ FIELS_OF_INTEREST = (
 def clean_vector(raw_vector: List[Any]):
     clean = dict(zip(AIRCRAFT_VECTOR_FIELDS, raw_vector[:]))
 
-    if None in (clean["longitude"], clean["latitude"]):
+    if None in {clean["longitude"], clean["latitude"]}:
         # this is an invalid vector, ignore it
         return None
 

--- a/server/src/prefect_server/utilities/graphql_tools.py
+++ b/server/src/prefect_server/utilities/graphql_tools.py
@@ -212,7 +212,7 @@ def type_to_ast(graphql_type):
     """
     if isinstance(graphql_type, graphql.GraphQLNonNull):
         inner_type = type_to_ast(graphql_type.of_type)
-        if inner_type.kind in ("list_type", "named_type"):
+        if inner_type.kind in {"list_type", "named_type"}:
             return graphql.NonNullTypeNode(type=inner_type)
         else:
             raise ValueError("Incorrect inner non-null type.")

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -199,7 +199,7 @@ class DockerAgent(Agent):
         for volume_spec in volume_specs:
             fields = volume_spec.split(":")
 
-            if fields[-1] in ("ro", "rw"):
+            if fields[-1] in {"ro", "rw"}:
                 mode = fields.pop()
             else:
                 mode = "rw"

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -115,7 +115,7 @@ def backend(api):
     """
     Switch Prefect API backend to either `server` or `cloud`
     """
-    if api not in ["server", "cloud"]:
+    if api not in {"server", "cloud"}:
         click.secho("{} is not a valid backend API".format(api), fg="red")
         return
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -154,7 +154,7 @@ class CloudTaskRunner(TaskRunner):
         # if the map_index is not None, this is a dynamic task and we need to load
         # task run info for it
         map_index = context.get("map_index")
-        if map_index not in [-1, None]:
+        if map_index not in {-1, None}:
             try:
                 task_run_info = self.client.get_task_run_info(
                     flow_run_id=context.get("flow_run_id", ""),
@@ -309,7 +309,7 @@ class CloudTaskRunner(TaskRunner):
             ## entire upstream array that is being mapped over, instead we need store the
             ## individual pieces of data separately for more efficient retries
             map_index = prefect.context.get("map_index")
-            if map_index not in [-1, None]:
+            if map_index not in {-1, None}:
                 for edge, upstream_state in upstream_states.items():
                     if (
                         edge.key

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -69,7 +69,7 @@ class State:
             assert isinstance(other, State)  # this assertion is here for MyPy only
             eq = self.result == other.result  # type: ignore
             for attr in self.__dict__:
-                if attr.startswith("_") or attr in ["context", "message", "result"]:
+                if attr.startswith("_") or attr in {"context", "message", "result"}:
                     continue
                 eq &= getattr(self, attr, object()) == getattr(other, attr, object())
             return eq

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -241,7 +241,7 @@ class Docker(Storage):
         """
         Full name of the Docker image.
         """
-        if None in [self.image_name, self.image_tag]:
+        if None in {self.image_name, self.image_tag}:
             raise ValueError("Docker storage is missing required fields")
 
         return "{}:{}".format(

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -386,7 +386,7 @@ def test_create_dockerfile_from_dockerfile():
 
     # test proper indentation
     assert all(
-        line == line.lstrip() for line in output.split("\n") if line not in ["\n", " "]
+        line == line.lstrip() for line in output.split("\n") if line not in {"\n", " "}
     )
 
 
@@ -432,7 +432,7 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
 
     # test proper indentation
     assert all(
-        line == line.lstrip() for line in output.split("\n") if line not in ["\n", " "]
+        line == line.lstrip() for line in output.split("\n") if line not in {"\n", " "}
     )
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

For some memberships tests (`in` and `not in`) in Python code, this PR proposes replacing lists and tuples with set objects. 

## Why is this PR important?

For the cases touched in this PR, I think using sets will offer a very tiny speedup relative to the lists and tuples currently used.

From the [Python wiki](https://wiki.python.org/moin/PythonSpeed#Use_the_best_algorithms_and_fastest_tools):

> Membership testing with sets and dictionaries is much faster, O(1), than searching sequences, O(n). When testing "a in b", b should be a set or dictionary instead of a list or tuple.

Thanks for your time and consideration!
