### PR TITLE
Isolated ast.literal_eval for consistency and clarity

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -1,4 +1,3 @@
-import ast
 import functools
 import logging
 import math
@@ -99,10 +98,7 @@ class Agent:
     ) -> None:
         self.name = name or config.cloud.agent.get("name", "agent")
 
-        self.labels = labels or config.cloud.agent.get("labels", [])
-        # quick hack in case config has not been evaluated to a list yet
-        if isinstance(self.labels, str):
-            self.labels = ast.literal_eval(self.labels)
+        self.labels = labels or list(config.cloud.agent.get("labels", []))
         self.env_vars = env_vars or config.cloud.agent.get("env_vars", dict())
         self.max_polls = max_polls
         self.log_to_cloud = False if no_cloud_logs else True

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -77,7 +77,6 @@ class LocalAgent(Agent):
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)
-        print(self.labels)
         self.labels.extend(
             ["azure-flow-storage", "gcs-flow-storage", "s3-flow-storage"]
         )

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -77,6 +77,7 @@ class LocalAgent(Agent):
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)
+        print(self.labels)
         self.labels.extend(
             ["azure-flow-storage", "gcs-flow-storage", "s3-flow-storage"]
         )

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -43,7 +43,7 @@ def string_to_type(val: str) -> Union[bool, int, float, str]:
         - "true" (any capitalization) to `True`
         - "false" (any capitalization) to `False`
         - any other valid literal Python syntax interpretable by ast.literal_eval
-        
+
     Arguments:
         - val (str): the string value of an environment variable
 
@@ -229,7 +229,10 @@ def interpolate_config(config: dict, env_var_prefix: str = None) -> Config:
 
     # interpolate any env vars referenced
     for k, v in list(flat_config.items()):
-        flat_config[k] = interpolate_env_vars(v)
+        val = interpolate_env_vars(v)
+        if isinstance(val, str):
+            val = string_to_type(val)
+        flat_config[k] = val
 
     # --------------------- Interpolate other config keys -----------------
     # TOML doesn't support references to other keys... but we do!

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -1,4 +1,3 @@
-from ast import literal_eval
 import base64
 import json
 import uuid
@@ -334,7 +333,7 @@ class DaskKubernetesEnvironment(Environment):
             "distributed.deploy.adaptive",
             "kubernetes",
         ]
-        config_extra_loggers = literal_eval(prefect.config.logging.extra_loggers)
+        config_extra_loggers = prefect.config.logging.extra_loggers
 
         extra_loggers = [*config_extra_loggers, *cluster_loggers]
 

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -204,7 +204,7 @@ class FargateTaskEnvironment(Environment):
                 {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
                 {
                     "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
-                    "value": config.logging.extra_loggers,
+                    "value": str(config.logging.extra_loggers),
                 },
             ]
 

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -258,7 +258,7 @@ class KubernetesJobEnvironment(Environment):
             {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
             {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
-                "value": prefect.config.logging.extra_loggers,
+                "value": str(prefect.config.logging.extra_loggers),
             },
         ]
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -8,7 +8,6 @@ Note that Prefect Tasks come equipped with their own loggers.  These can be acce
 
 When running locally, log levels and message formatting are set via your Prefect configuration file.
 """
-from ast import literal_eval
 import atexit
 import json
 import logging
@@ -180,7 +179,7 @@ def _log_record_context_injector(*args: Any, **kwargs: Any) -> logging.LogRecord
     """
     record = _original_log_record_factory(*args, **kwargs)
 
-    additional_attrs = literal_eval(context.config.logging.get("log_attributes", "[]"))
+    additional_attrs = context.config.logging.get("log_attributes", [])
 
     for attr in PREFECT_LOG_RECORD_ATTRIBUTES + tuple(additional_attrs):
         value = prefect.context.get(attr, None)
@@ -244,7 +243,7 @@ def configure_extra_loggers() -> None:
     Creates a "Prefect" configured logger for all strings in extra_loggers config list.
     The logging.extra_loggers config defaults to an empty list.
     """
-    loggers = literal_eval(context.config.logging.get("extra_loggers", "[]"))
+    loggers = context.config.logging.get("extra_loggers", [])
     for l in loggers:
         _create_logger(l)
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -101,7 +101,7 @@ def test_agent_labels(runner_token, cloud_api):
 
 
 def test_agent_labels_from_config_var(runner_token):
-    with set_temporary_config({"cloud.agent.labels": "['test', '2']"}):
+    with set_temporary_config({"cloud.agent.labels": ["test", "2"]}):
         agent = Agent()
         assert agent.labels == ["test", "2"]
 

--- a/tests/environments/execution/__init__.py
+++ b/tests/environments/execution/__init__.py
@@ -2,7 +2,6 @@ import pytest
 
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
-pytest.importorskip("dask_cloudprovider")
 pytest.importorskip("dask_kubernetes")
 pytest.importorskip("kubernetes")
 pytest.importorskip("yaml")

--- a/tests/environments/execution/test_dask_cloud_provider.py
+++ b/tests/environments/execution/test_dask_cloud_provider.py
@@ -2,6 +2,9 @@ import os
 import tempfile
 
 import cloudpickle
+import pytest
+
+pytest.importorskip("dask_cloudprovider")
 
 from distributed.deploy import Cluster
 

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -269,7 +269,7 @@ def test_populate_job_yaml():
         {
             "cloud.graphql": "gql_test",
             "cloud.auth_token": "auth_test",
-            "logging.extra_loggers": "['test_logger']",
+            "logging.extra_loggers": ["test_logger"],
         }
     ):
         with prefect.context(flow_run_id="id_test", namespace="namespace_test"):
@@ -319,7 +319,7 @@ def test_populate_worker_pod_yaml():
         {
             "cloud.graphql": "gql_test",
             "cloud.auth_token": "auth_test",
-            "logging.extra_loggers": "['test_logger']",
+            "logging.extra_loggers": ["test_logger"],
         }
     ):
         with prefect.context(flow_run_id="id_test", image="my_image"):
@@ -393,7 +393,7 @@ def test_populate_custom_worker_spec_yaml(log_flag):
             "cloud.graphql": "gql_test",
             "cloud.auth_token": "auth_test",
             "logging.log_to_cloud": log_flag,
-            "logging.extra_loggers": "['test_logger']",
+            "logging.extra_loggers": ["test_logger"],
         }
     ):
         with prefect.context(flow_run_id="id_test", image="my_image"):
@@ -435,7 +435,7 @@ def test_populate_custom_scheduler_spec_yaml(log_flag):
             "cloud.graphql": "gql_test",
             "cloud.auth_token": "auth_test",
             "logging.log_to_cloud": log_flag,
-            "logging.extra_loggers": "['test_logger']",
+            "logging.extra_loggers": ["test_logger"],
         }
     ):
         with prefect.context(flow_run_id="id_test", namespace="namespace_test"):

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -351,7 +351,7 @@ def test_users_can_specify_additional_context_attributes(caplog):
     }
 
     with utilities.configuration.set_temporary_config(
-        {"logging.log_attributes": '["trace_id"]'}
+        {"logging.log_attributes": ["trace_id"]}
     ):
         logger = logging.getLogger("test-logger")
 
@@ -373,7 +373,7 @@ def test_users_can_specify_additional_context_attributes_and_fails_gracefully(ca
     }
 
     with utilities.configuration.set_temporary_config(
-        {"logging.log_attributes": '["trace_id", "foo"]'}
+        {"logging.log_attributes": ["trace_id", "foo"]}
     ):
         logger = logging.getLogger("test-logger")
 
@@ -417,7 +417,7 @@ def test_context_only_specified_attributes():
     assert test_filter.called
 
     with utilities.configuration.set_temporary_config(
-        {"logging.extra_loggers": "['extra_logger']"}
+        {"logging.extra_loggers": ["extra_logger"]}
     ):
         utilities.logging.configure_extra_loggers()
         assert (


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR clarifies and finalizes the work of #2558 and #2570 with one well-placed `literal_eval`.  In particular, it ensures that any string values within a user's Prefect config are parsed / converted to the corresponding Python objects.  This is particularly useful for nested structures such as lists of strings (`extra_loggers`, secrets, etc.)


## Why is this PR important?
For easier debugging of our config values and consistency of typing.

