### PR TITLE
Reuse prefect.context for flow context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
 
 ### Server
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -218,8 +219,6 @@ class Flow:
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
-        # remove _cache
-        state.pop("_cache", None)
         # remove _ctx since it is an active generator
         state.pop("_ctx", None)
         return state
@@ -331,7 +330,7 @@ class Flow:
     # Context Manager ----------------------------------------------------------
 
     @contextmanager
-    def _flow_context(self) -> "Flow":
+    def _flow_context(self) -> Iterator["Flow"]:
         with prefect.context(flow=self):
             yield self
 
@@ -339,11 +338,10 @@ class Flow:
         self._ctx = self._flow_context()
         return self._ctx.__enter__()
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         result = self._ctx.__exit__(exc_type, exc_value, traceback)
         # delete _ctx because it's an active generator
         del self._ctx
-        return result
 
     # Introspection ------------------------------------------------------------
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -217,12 +217,6 @@ class Flow:
     def __iter__(self) -> Iterable[Task]:
         yield from self.sorted_tasks()
 
-    def __getstate__(self) -> Dict[str, Any]:
-        state = self.__dict__.copy()
-        # remove _ctx since it is an active generator
-        state.pop("_ctx", None)
-        return state
-
     def copy(self) -> "Flow":
         """
         Create and returns a copy of the current Flow.
@@ -340,7 +334,7 @@ class Flow:
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         result = self._ctx.__exit__(exc_type, exc_value, traceback)
-        # delete _ctx because it's an active generator
+        # delete _ctx because it's an active generator, which prevents pickling
         del self._ctx
 
     # Introspection ------------------------------------------------------------

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -693,6 +693,16 @@ def test_key_states_raises_error_if_not_iterable():
             f.set_reference_tasks(t1)
 
 
+def test_context_is_scoped_to_flow_context():
+    with Flow(name="f"):
+        prefect.context.name = "f"
+        with Flow(name="g"):
+            prefect.context.name = "g"
+            assert prefect.context.name == "g"
+        assert prefect.context.name == "f"
+    assert "name" not in prefect.context
+
+
 class TestEquality:
     def test_equality_based_on_tasks(self):
         f1 = Flow(name="test")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

The `Flow` context manager works by explicitly placing and removing itself into context on enter and exit, in order to make sure it works across various nesting levels. However, this replicates (better-tested) functionality in the `prefect.context` class itself, so it is preferable to reuse `prefect.context` as a context manager rather than as a manually-manipulated object. 

Specifically, while entering a `with Flow:` block modifies the active `prefect.context`, it is NOT equivalent to entering a new `with prefect.context():` block. This can lead to surprising behaviors. For example, modifying context from inside a `with Flow` block will persist once the `Flow` block is exited, even though the flow itself will be removed from context.

This PR tweaks the `Flow` class so it uses a `contextlib.contextmanger`-style generator to reuse Prefect's existing `context` implementation. This reduces complexity because both `__enter__` and `__exit__` are now boilerplate and all application logic is in `Flow._flow_context`.

## Why is this PR important?


