### PR TITLE
Add warning if tasks are created in flow context but not added to the flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
+- Show a warning when tasks are created in a flow context but not added to a flow - [#2584](https://github.com/PrefectHQ/prefect/pull/2584)
 
 ### Server
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -331,8 +331,23 @@ class Flow:
 
     @contextmanager
     def _flow_context(self) -> Iterator["Flow"]:
-        with prefect.context(flow=self):
+        """
+        When entering a flow context, the Prefect context is modified to include:
+            - `flow`: the flow itself
+            - `_new_task_tracker`: a set of all tasks created while the context is 
+                open, in order to provide user friendly warnings if they aren't added
+                to the flow itself. This is purely for user experience.
+        """
+        new_task_tracker = set()
+
+        with prefect.context(flow=self, _new_task_tracker=new_task_tracker):
             yield self
+
+        if new_task_tracker.difference(self.tasks):
+            warnings.warn(
+                "Tasks were created but not added to the flow: "
+                f"{new_task_tracker.difference(self.tasks)}"
+            )
 
     def __enter__(self) -> "Flow":
         self._ctx = self._flow_context()
@@ -852,7 +867,7 @@ class Flow:
         parameters: Dict[str, Any],
         runner_cls: type,
         run_on_schedule: bool = True,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "prefect.engine.state.State":
 
         base_parameters = parameters or dict()
@@ -908,7 +923,7 @@ class Flow:
                     state=flow_state,
                     task_states=flow_state.result,
                     context=flow_run_context,
-                    **kwargs
+                    **kwargs,
                 )
 
                 # if flow_state is still scheduled; this most likely means
@@ -985,7 +1000,7 @@ class Flow:
         parameters: Dict[str, Any] = None,
         run_on_schedule: bool = None,
         runner_cls: type = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "prefect.engine.state.State":
         """
         Run the flow on its schedule using an instance of a FlowRunner.  If the Flow has no schedule,
@@ -1062,7 +1077,7 @@ class Flow:
             parameters=parameters,
             runner_cls=runner_cls,
             run_on_schedule=run_on_schedule,
-            **kwargs
+            **kwargs,
         )
 
         # state always should return a dict of tasks. If it's NoResult (meaning the run was
@@ -1361,7 +1376,7 @@ class Flow:
         set_schedule_active: bool = True,
         version_group_id: str = None,
         no_url: bool = False,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> str:
         """
         Register the flow with Prefect Cloud; if no storage is present on the Flow, the default value from your config

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -340,7 +340,11 @@ class Flow:
         if new_task_tracker.difference(self.tasks):
             warnings.warn(
                 "Tasks were created but not added to the flow: "
-                f"{new_task_tracker.difference(self.tasks)}"
+                f"{new_task_tracker.difference(self.tasks)}. This can occur "
+                "when `Task` classes including `Parameters` are instantiated "
+                "inside a `with Flow:` block but not added to the flow either "
+                "explicitly or as the input to another task. For more information, "
+                "see https://docs.prefect.io/core/advanced_tutorials/task-guide.html#adding-tasks-to-flows."
             )
 
     def __enter__(self) -> "Flow":

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -338,7 +338,7 @@ class Flow:
                 open, in order to provide user friendly warnings if they aren't added
                 to the flow itself. This is purely for user experience.
         """
-        new_task_tracker = set()
+        new_task_tracker = set() # type: Set[Task]
 
         with prefect.context(flow=self, _new_task_tracker=new_task_tracker):
             yield self

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -341,8 +341,8 @@ class Flow:
             warnings.warn(
                 "Tasks were created but not added to the flow: "
                 f"{new_task_tracker.difference(self.tasks)}. This can occur "
-                "when `Task` classes including `Parameters` are instantiated "
-                "inside a `with Flow:` block but not added to the flow either "
+                "when `Task` classes, including `Parameters`, are instantiated "
+                "inside a `with flow:` block but not added to the flow either "
                 "explicitly or as the input to another task. For more information, "
                 "see https://docs.prefect.io/core/advanced_tutorials/task-guide.html#adding-tasks-to-flows."
             )

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -338,7 +338,7 @@ class Flow:
                 open, in order to provide user friendly warnings if they aren't added
                 to the flow itself. This is purely for user experience.
         """
-        new_task_tracker = set() # type: Set[Task]
+        new_task_tracker = set()  # type: Set[Task]
 
         with prefect.context(flow=self, _new_task_tracker=new_task_tracker):
             yield self

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -377,6 +377,12 @@ class Task(metaclass=SignatureValidator):
         tags = set(prefect.context.get("tags", set()))
         new.tags.update(tags)
 
+        # if new task creations are being tracked, add this task
+        # this makes it possible to give guidance to users that forget
+        # to add tasks to a flow
+        if "_new_task_tracker" in prefect.context:
+            prefect.context._new_task_tracker.add(new)
+
         return new
 
     def __call__(

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -288,6 +288,12 @@ class Task(metaclass=SignatureValidator):
 
         self.log_stdout = log_stdout
 
+        # if new task creations are being tracked, add this task
+        # this makes it possible to give guidance to users that forget
+        # to add tasks to a flow
+        if "_new_task_tracker" in prefect.context:
+            prefect.context._new_task_tracker.add(self)
+
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -728,6 +728,13 @@ def test_warning_not_raised_if_tasks_are_created_and_added_to_flow():
     assert len(record) == 0
 
 
+def test_warning_raised_if_tasks_are_copied_but_not_added_to_flow():
+    x = Parameter("x")
+    with pytest.warns(UserWarning, match="Tasks were created but not added"):
+        with Flow(name="test"):
+            x.copy("x2")
+
+
 def test_context_is_scoped_to_flow_context():
     with Flow(name="f"):
         prefect.context.name = "f"

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -693,6 +693,12 @@ def test_key_states_raises_error_if_not_iterable():
             f.set_reference_tasks(t1)
 
 
+def test_warning_raised_if_tasks_are_created_but_not_added_to_flow():
+    with pytest.warns(UserWarning, match="Tasks were created but not added"):
+        with Flow(name="test"):
+            x = Parameter("x")
+
+
 class TestEquality:
     def test_equality_based_on_tasks(self):
         f1 = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -696,7 +696,26 @@ def test_key_states_raises_error_if_not_iterable():
 def test_warning_raised_if_tasks_are_created_but_not_added_to_flow():
     with pytest.warns(UserWarning, match="Tasks were created but not added"):
         with Flow(name="test"):
+            tracker = prefect.context._new_task_tracker
+            assert len(tracker) == 0
             x = Parameter("x")
+            assert len(tracker) == 1
+            assert x in tracker
+        assert "_new_task_tracker" not in prefect.context
+
+
+def test_warning_raised_if_tasks_are_created_but_not_added_to_nested_flow():
+    # only one warning for nested flows
+    with pytest.warns(None) as record:
+        with Flow(name="test"):
+            tracker_1 = prefect.context._new_task_tracker
+            with Flow(name="test2"):
+                tracker_2 = prefect.context._new_task_tracker
+                x = Parameter("x")
+                assert x in tracker_2
+                assert x not in tracker_1
+
+    assert len(record) == 1
 
 
 def test_warning_not_raised_if_tasks_are_created_and_added_to_flow():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -699,6 +699,16 @@ def test_warning_raised_if_tasks_are_created_but_not_added_to_flow():
             x = Parameter("x")
 
 
+def test_warning_not_raised_if_tasks_are_created_and_added_to_flow():
+    with pytest.warns(None) as record:
+        with Flow(name="test") as f:
+            x = Parameter("x")
+            f.add_task(x)
+
+    # no warnings
+    assert len(record) == 0
+
+
 class TestEquality:
     def test_equality_based_on_tasks(self):
         f1 = Flow(name="test")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
A common stumbling block for new users is that they instantiate a `Task` class without realizing it hasn't been added to their flow. This is especially easy with `Parameters`:

```python
with Flow('example') as flow:
    x = Parameter('x')

flow.run(x=5) # error, unexpected parameter
```

This PR adds a warning when users create tasks that don't get added to the flow:

```
UserWarning: Tasks were created but not added to the flow: 
{<Parameter: x>}. This can occur when `Task` classes, 
including `Parameters`, are instantiated inside a `with flow:` 
block but not added to the flow either explicitly or as the 
input to another task. For more information, see 
https://docs.prefect.io/core/advanced_tutorials/task-guide.html#adding-tasks-to-flows.
```

(This PR is the ulterior motive for #2581, because I needed to use context and guarantee that context semantics were maintained in flow contexts)


## Why is this PR important?
UX!

