### PR TITLE
Fix log_stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 - Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 - Fix type for Dask Security in RemoteDaskEnvironment - [#2571](https://github.com/PrefectHQ/prefect/pull/2571)
+- Fix issue with `log_stdout` not correctly storing returned data on the task run state - [#2585](https://github.com/PrefectHQ/prefect/pull/2585)
 
 ### Deprecations
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -935,7 +935,7 @@ class TaskRunner(Runner):
 
             if getattr(self.task, "log_stdout", False):
                 with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
-                    result = timeout_handler(
+                    value = timeout_handler(
                         self.task.run, timeout=self.task.timeout, **raw_inputs
                     )
             else:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -2167,10 +2167,14 @@ def test_task_runner_logs_stdout(caplog):
     class MyTask(Task):
         def run(self):
             print("TEST_HERE")
+            return 42
 
     task = MyTask(log_stdout=True)
-    TaskRunner(task=task).run()
+    state = TaskRunner(task=task).run()
 
+    # there was a bug previously with log_stdout where
+    # data was not being passed on correctly
+    assert state.result == 42
     logs = [r.message for r in caplog.records]
     assert logs[1] == "TEST_HERE"
 

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -339,8 +339,15 @@ def test_context_attributes():
     assert test_filter.called
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Test randomly fails on Windows")
-def test_users_can_specify_additional_context_attributes(caplog):
+def test_users_can_specify_additional_context_attributes():
+    class MyHandler(logging.StreamHandler):
+        log_traces = []
+
+        def emit(self, record):
+            self.log_traces.append(getattr(record, "trace_id", None))
+
+    handler = MyHandler()
+
     items = {
         "flow_run_id": "fri",
         "flow_name": "fn",
@@ -354,15 +361,23 @@ def test_users_can_specify_additional_context_attributes(caplog):
         {"logging.log_attributes": '["trace_id"]'}
     ):
         logger = logging.getLogger("test-logger")
+        logger.addHandler(handler)
 
         with context(items):
             logger.critical("log entry!")
 
-    assert caplog.records[0].trace_id == "ID"
+    assert handler.log_traces[0] == "ID"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Test randomly fails on Windows")
-def test_users_can_specify_additional_context_attributes_and_fails_gracefully(caplog):
+def test_users_can_specify_additional_context_attributes_and_fails_gracefully():
+    class MyHandler(logging.StreamHandler):
+        log_attrs = []
+
+        def emit(self, record):
+            data = dict(trace_id=record.trace_id, foo=record.foo)
+            self.log_attrs.append(data)
+
+    handler = MyHandler()
     items = {
         "flow_run_id": "fri",
         "flow_name": "fn",
@@ -376,12 +391,13 @@ def test_users_can_specify_additional_context_attributes_and_fails_gracefully(ca
         {"logging.log_attributes": '["trace_id", "foo"]'}
     ):
         logger = logging.getLogger("test-logger")
+        logger.addHandler(handler)
 
         with context(items):
             logger.critical("log entry!")
 
-    assert caplog.records[0].foo is None
-    assert caplog.records[0].trace_id == "ID"
+    assert handler.log_attrs[0]["foo"] is None
+    assert handler.log_attrs[0]["trace_id"] == "ID"
 
 
 def test_context_only_specified_attributes():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Introduced in 0.11.0, if users set `log_stdout=True` on a task that returns non-trivial data, that data was not stored on the task run state and consequently was not checkpointed / passed to downstream tasks.  


## Why is this PR important?
Dataflow is critical functionality in prefect