### PR TITLE
Allow log configuration in Fargate Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Fixes
 
 - Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
+- Fix type for Dask Security in RemoteDaskEnvironment - [#2571](https://github.com/PrefectHQ/prefect/pull/2571)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Enhancements
 
-- None
+- Allow log configuration in Fargate Agent - [#2589](https://github.com/PrefectHQ/prefect/pull/2589)
 
 ### Server
 
@@ -35,7 +35,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Contributors
 
-- None
+- [Joe Schmid](https://github.com/joeschmid)
 
 ## 0.11.1 <Badge text="beta" type="success"/>
 

--- a/docs/orchestration/agents/fargate.md
+++ b/docs/orchestration/agents/fargate.md
@@ -139,6 +139,7 @@ We have also added the ability to select items to the `containerDefinitions` kwa
 environments               list
 secrets                    list
 mountPoints                list
+logConfiguration           dict
 ```
 
 Environment was added to support adding flow level environment variables via the `use_external_kwargs` described later on in the documentation.  
@@ -183,7 +184,16 @@ agent = FargateAgent(
             "sourceVolume": "myEfsVolume",
             "containerPath": "/data",
             "readOnly": False
-        }]
+        }],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/my/log/group",
+                "awslogs-region": "us-east-1",
+                "awslogs-stream-prefix": "prefect-flow-runs",
+                "awslogs-create-group": "true",
+            },
+        },
     }],
     volumes=[
         {

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -321,7 +321,7 @@ class FargateAgent(Agent):
             "propagateTags",
         ]
 
-        container_definitions_kwarg_list = ["mountPoints", "secrets", "environment"]
+        container_definitions_kwarg_list = ["mountPoints", "secrets", "environment", "logConfiguration"]
 
         task_definition_kwargs = {}
         definition_kwarg_list_eval = {

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -321,7 +321,12 @@ class FargateAgent(Agent):
             "propagateTags",
         ]
 
-        container_definitions_kwarg_list = ["mountPoints", "secrets", "environment", "logConfiguration"]
+        container_definitions_kwarg_list = [
+            "mountPoints",
+            "secrets",
+            "environment",
+            "logConfiguration",
+        ]
 
         task_definition_kwargs = {}
         definition_kwarg_list_eval = {
@@ -593,6 +598,7 @@ class FargateAgent(Agent):
                 ],
                 "secrets": [],
                 "mountPoints": [],
+                "logConfiguration": {},
                 "essential": True,
             }
         ]
@@ -621,6 +627,9 @@ class FargateAgent(Agent):
         )
         container_definitions[0]["mountPoints"] = container_definitions_kwargs.get(
             "mountPoints", []
+        )
+        container_definitions[0]["logConfiguration"] = container_definitions_kwargs.get(
+            "logConfiguration", {}
         )
 
         # Register task definition

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -162,7 +162,12 @@ def test_parse_container_definition_kwargs(monkeypatch, runner_token):
 
     kwarg_dict = {
         "containerDefinitions": [
-            {"environment": "test", "secrets": "test", "mountPoints": "test"}
+            {
+                "environment": "test",
+                "secrets": "test",
+                "mountPoints": "test",
+                "logConfiguration": "test",
+            }
         ]
     }
 
@@ -176,6 +181,7 @@ def test_parse_container_definition_kwargs(monkeypatch, runner_token):
         "environment": "test",
         "secrets": "test",
         "mountPoints": "test",
+        "logConfiguration": "test",
     }
 
 
@@ -339,6 +345,7 @@ def test_fargate_agent_config_options_init(monkeypatch, runner_token):
         "environment": "test",
         "secrets": "test",
         "mountPoints": "test",
+        "logConfiguration": "test",
     }
 
     kwarg_dict = {
@@ -363,7 +370,12 @@ def test_fargate_agent_config_options_init(monkeypatch, runner_token):
         "enableECSManagedTags": "test",
         "propagateTags": "test",
         "containerDefinitions": [
-            {"environment": "test", "secrets": "test", "mountPoints": "test"}
+            {
+                "environment": "test",
+                "secrets": "test",
+                "mountPoints": "test",
+                "logConfiguration": "test",
+            }
         ],
     }
 
@@ -431,6 +443,7 @@ def test_fargate_agent_config_env_vars(monkeypatch, runner_token):
         "environment": "test",
         "secrets": "test",
         "mountPoints": "test",
+        "logConfiguration": "test",
     }
 
     # Client args
@@ -463,6 +476,7 @@ def test_fargate_agent_config_env_vars(monkeypatch, runner_token):
     monkeypatch.setenv("containerDefinitions_environment", "test")
     monkeypatch.setenv("containerDefinitions_secrets", "test")
     monkeypatch.setenv("containerDefinitions_mountPoints", "test")
+    monkeypatch.setenv("containerDefinitions_logConfiguration", "test")
 
     agent = FargateAgent(subnets=["subnet"])
     assert agent
@@ -821,6 +835,15 @@ def test_deploy_flow_register_task_definition_all_args(
                         "readOnly": False,
                     }
                 ],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "prefect",
+                        "awslogs-region": "us-east-1",
+                        "awslogs-stream-prefix": "flow-runs",
+                        "awslogs-create-group": "true",
+                    },
+                },
             }
         ],
     }
@@ -896,6 +919,15 @@ def test_deploy_flow_register_task_definition_all_args(
                     "readOnly": False,
                 }
             ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "prefect",
+                    "awslogs-region": "us-east-1",
+                    "awslogs-stream-prefix": "flow-runs",
+                    "awslogs-create-group": "true",
+                },
+            },
         }
     ]
     assert boto3_client.register_task_definition.call_args[1][
@@ -1009,6 +1041,7 @@ def test_deploy_flows_includes_agent_labels_in_environment(
             "essential": True,
             "secrets": [],
             "mountPoints": [],
+            "logConfiguration": {},
         }
     ]
     assert boto3_client.register_task_definition.call_args[1][
@@ -1076,6 +1109,7 @@ def test_deploy_flow_register_task_definition_no_repo_credentials(
             "essential": True,
             "secrets": [],
             "mountPoints": [],
+            "logConfiguration": {},
         }
     ]
 
@@ -1168,6 +1202,7 @@ def test_deploy_flows_enable_task_revisions_no_tags(
                 "essential": True,
                 "secrets": [],
                 "mountPoints": [],
+                "logConfiguration": {},
             }
         ],
         family="name",
@@ -1541,6 +1576,7 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
                 "essential": True,
                 "secrets": [],
                 "mountPoints": [],
+                "logConfiguration": {},
             }
         ],
         cpu="256",


### PR DESCRIPTION
It's not currently possible to enable AWS logging for Flow Runs launched with the Fargate Agent. This is a small change to allow `logConfiguration` in `containerDefinitions`, which enables logging, e.g. with AWS CloudWatch.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
Adds the ability to include `logConfiguration` inside `containerDefinitions`.

## Why is this PR important?
The Fargate Agent can be complex to configure, especially when using it with an environment like `DaskCloudProviderEnvironment`. Being able to examine logs for Flow runs can help with debugging configuration issues. Some users may also wish to capture and store logs for Flow runs in AWS CloudWatch.
