### PR TITLE
Ensure target locations are updated when tasks are copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
-- Create `initialize_task()` method for abstracting initialization logic across new task instances and copies - [#2590](https://github.com/PrefectHQ/prefect/pull/2590)
 
 ### Server
 
@@ -26,6 +25,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 - Fix type for Dask Security in RemoteDaskEnvironment - [#2571](https://github.com/PrefectHQ/prefect/pull/2571)
 - Fix issue with `log_stdout` not correctly storing returned data on the task run state - [#2585](https://github.com/PrefectHQ/prefect/pull/2585)
+- Ensure result locations are updated from targets when copying tasks with `task_args` - [#2590](https://github.com/PrefectHQ/prefect/pull/2590)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 ### Enhancements
 
 - Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
+- Create `initialize_task()` method for abstracting initialization logic across new task instances and copies - [#2590](https://github.com/PrefectHQ/prefect/pull/2590)
 
 ### Server
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -125,33 +125,40 @@ class Task(metaclass=SignatureValidator):
         - max_retries (int, optional): The maximum amount of times this task can be retried
         - retry_delay (timedelta, optional): The amount of time to wait until task is retried
         - timeout (int, optional): The amount of time (in seconds) to wait while
-            running this task before a timeout occurs; note that sub-second resolution is not supported
-        - trigger (callable, optional): a function that determines whether the task should run, based
-                on the states of any upstream tasks.
+            running this task before a timeout occurs; note that sub-second
+            resolution is not supported
+        - trigger (callable, optional): a function that determines whether the
+            task should run, based on the states of any upstream tasks.
         - skip_on_upstream_skip (bool, optional): if `True`, if any immediately
-                upstream tasks are skipped, this task will automatically be skipped as well,
-                regardless of trigger. By default, this prevents tasks from attempting to use either state or data
-                from tasks that didn't run. If `False`, the task's trigger will be called as normal,
-                with skips considered successes. Defaults to `True`.
+            upstream tasks are skipped, this task will automatically be skipped as
+            well, regardless of trigger. By default, this prevents tasks from
+            attempting to use either state or data from tasks that didn't run. If
+            `False`, the task's trigger will be called as normal, with skips
+            considered successes. Defaults to `True`.
         - cache_for (timedelta, optional, DEPRECATED): The amount of time to maintain a cache
             of the outputs of this task.  Useful for situations where the containing Flow
             will be rerun multiple times, but this task doesn't need to be.
         - cache_validator (Callable, optional, DEPRECATED): Validator that will determine
             whether the cache for this task is still valid (only required if `cache_for`
             is provided; defaults to `prefect.engine.cache_validators.duration_only`)
-        - cache_key (str, optional, DEPRECATED): if provided, a `cache_key` serves as a unique identifier for this Task's cache, and can
-            be shared across both Tasks _and_ Flows; if not provided, the Task's _name_ will be used if running locally, or the
-            Task's database ID if running in Cloud
+        - cache_key (str, optional, DEPRECATED): if provided, a `cache_key`
+            serves as a unique identifier for this Task's cache, and can be shared
+            across both Tasks _and_ Flows; if not provided, the Task's _name_ will
+            be used if running locally, or the Task's database ID if running in
+            Cloud 
         - checkpoint (bool, optional): if this Task is successful, whether to
-            store its result using the `result_handler` available during the run; Also note that
-            checkpointing will only occur locally if `prefect.config.flows.checkpointing` is set to `True`
-        - result_handler (ResultHandler, optional, DEPRECATED): the handler to use for
-            retrieving and storing state results during execution; if not provided, will default to the
-            one attached to the Flow
-        - result (Result, optional): the result instance used to retrieve and store task results during execution
-        - target (str, optional): location to check for task Result. If a result exists at that location then
-            the task run will enter a cached state.  `target` strings can be templated formatting strings which will be formatted
-            at runtime with values from `prefect.context`
+            store its result using the `result_handler` available during the run;
+            Also note that checkpointing will only occur locally if
+            `prefect.config.flows.checkpointing` is set to `True`
+        - result_handler (ResultHandler, optional, DEPRECATED): the handler to
+            use for retrieving and storing state results during execution; if not
+            provided, will default to the one attached to the Flow
+        - result (Result, optional): the result instance used to retrieve and
+            store task results during execution
+        - target (str, optional): location to check for task Result. If a result
+            exists at that location then the task run will enter a cached state.
+            `target` strings can be templated formatting strings which will be
+            formatted at runtime with values from `prefect.context`
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
             that will be called whenever the task changes state, providing an
             opportunity to inspect or modify the new state. The handler
@@ -160,8 +167,9 @@ class Task(metaclass=SignatureValidator):
                 `state_handler(task: Task, old_state: State, new_state: State) -> Optional[State]`
             If multiple functions are passed, then the `new_state` argument will be the
             result of the previous handler.
-        - on_failure (Callable, optional): A function with signature `fn(task: Task, state: State) -> None`
-            with will be called anytime this Task enters a failure state
+        - on_failure (Callable, optional): A function with signature 
+            `fn(task: Task, state: State) -> None` that will be called anytime this 
+            Task enters a failure state
         - log_stdout (bool, optional): Toggle whether or not to send stdout messages to
             the Prefect logger. Defaults to `False`.
 
@@ -268,6 +276,19 @@ class Task(metaclass=SignatureValidator):
 
         self.target = target
 
+        # if both a target and a result were provided, update the result location
+        # to point at the target
+        if self.target and self.result:
+            if (
+                getattr(self.result, "location", None)
+                and self.result.location != self.target
+            ):
+                warnings.warn(
+                    "Both `result.location` and `target` were provided. The `target` value will be used."
+                )
+            self.result = self.result.copy()
+            self.result.location = target
+
         if state_handlers and not isinstance(state_handlers, collections.abc.Sequence):
             raise TypeError("state_handlers should be iterable.")
         self.state_handlers = state_handlers or []
@@ -278,30 +299,6 @@ class Task(metaclass=SignatureValidator):
         self.auto_generated = False
 
         self.log_stdout = log_stdout
-
-        self.initialize_task()
-
-    def initialize_task(self) -> None:
-        """
-        There are two places that task attributes can be set: `Task.__init__()`
-        and `Task.copy()`, which is frequently used for creating tasks in the
-        functional API. Therefore, we need a common place for any initialization
-        logic (other than assigning attributes) to avoid repition and ensure
-        task instances are created in a uniform way. 
-
-        Any initialization logic that doesn't involve simple assignments should
-        be put in this method.
-        """
-        # if a target and a result are provided, update the result location
-        # to point at the target
-        if self.target and self.result:
-            self.result = self.result.copy()
-            self.result.location = self.target
-
-            if getattr(self.result, "location", None):
-                warnings.warn(
-                    "Both `result.location` and `target` set on task. Task result will use target as location."
-                )
 
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)
@@ -382,11 +379,23 @@ class Task(metaclass=SignatureValidator):
             else:
                 setattr(new, attr, val)
 
+        # if both a target and a result were provided, update the result location
+        # to point at the target
+        if new.target and new.result:
+            if (
+                getattr(new.result, "location", None)
+                and new.result.location != new.target
+            ):
+                warnings.warn(
+                    "Both `result.location` and `target` were provided. "
+                    "The `target` value will be used."
+                )
+            new.result = new.result.copy()
+            new.result.location = new.target
+
         new.tags = copy.deepcopy(self.tags).union(set(new.tags))
         tags = set(prefect.context.get("tags", set()))
         new.tags.update(tags)
-
-        new.initialize_task()
 
         return new
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -284,10 +284,11 @@ class Task(metaclass=SignatureValidator):
                 and self.result.location != self.target
             ):
                 warnings.warn(
-                    "Both `result.location` and `target` were provided. The `target` value will be used."
+                    "Both `result.location` and `target` were provided. "
+                    "The `target` value will be used."
                 )
             self.result = self.result.copy()
-            self.result.location = target
+            self.result.location = self.target
 
         if state_handlers and not isinstance(state_handlers, collections.abc.Sequence):
             raise TypeError("state_handlers should be iterable.")

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -419,13 +419,6 @@ class TestTaskCopy:
         assert t.slug == "test"
         assert t2.slug == "test-2"
 
-    def test_copy_calls_initialize_task(self, monkeypatch):
-        t = Task()
-        mock = MagicMock()
-        monkeypatch.setattr("prefect.Task.initialize_task", mock)
-        t.copy()
-        mock.assert_called_once()
-
     def test_copy_appropriately_sets_result_target_if_target_provided(self):
         # https://github.com/PrefectHQ/prefect/issues/2588
         @task(target="target", result=LocalResult(dir="."))

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 import json
 import logging
 import uuid
@@ -10,7 +11,7 @@ import prefect
 from prefect.core import Edge, Flow, Parameter, Task
 from prefect.engine.cache_validators import all_inputs, duration_only, never_use
 from prefect.engine.result_handlers import JSONResultHandler, ResultHandler
-from prefect.engine.results import PrefectResult
+from prefect.engine.results import PrefectResult, LocalResult
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.tasks import task
 
@@ -417,6 +418,30 @@ class TestTaskCopy:
         t2 = t.copy(slug="test-2")
         assert t.slug == "test"
         assert t2.slug == "test-2"
+
+    def test_copy_calls_initialize_task(self, monkeypatch):
+        t = Task()
+        mock = MagicMock()
+        monkeypatch.setattr("prefect.Task.initialize_task", mock)
+        t.copy()
+        mock.assert_called_once()
+
+    def test_copy_appropriately_sets_result_target_if_target_provided(self):
+        # https://github.com/PrefectHQ/prefect/issues/2588
+        @task(target="target", result=LocalResult(dir="."))
+        def X():
+            pass
+
+        @task
+        def Y():
+            pass
+
+        with Flow("test"):
+            x = X()
+            y = Y(task_args=dict(target="target", result=LocalResult(dir=".")))
+
+        assert x.result.location == "target"
+        assert y.result.location == "target"
 
 
 def test_task_has_slug():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
When tasks are copied, which happens often in the functional API via `Task.bind()`, their attributes are carried over to the new copy. In addition, users have the opportunity to set new attributes via the `task_args` kwarg. However, any initialization logic that takes place in `Task.__init__()` based on the values of those attributes is unavailable to the copy method. This leads to inconsistencies like the one described in #2588. In the issue described in #2588, the task `Result` is modified based on the presence of a `target` attribute. When copying the task, that step doesn't take place.

Closes #2588


## Why is this PR important?
We want to ensure consistent behavior across both the functional and imperative APIs.

