### PR TITLE
Fix S3Result exists not catching ErrorCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 
 ### Fixes
 
-- Fix duplicate agent label literal eval parsing - [#2569](https://github.com/PrefectHQ/prefect/issues/2569)
 - Fix type for Dask Security in RemoteDaskEnvironment - [#2571](https://github.com/PrefectHQ/prefect/pull/2571)
 - Fix issue with `log_stdout` not correctly storing returned data on the task run state - [#2585](https://github.com/PrefectHQ/prefect/pull/2585)
+- Fix `S3Result` exists function handling of `NoSuchKey` error - [#2585](https://github.com/PrefectHQ/prefect/issues/2585)
 
 ### Deprecations
 

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -167,7 +167,7 @@ class S3Result(Result):
                 Bucket=self.bucket, Key=location.format(**kwargs)
             ).load()
         except botocore.exceptions.ClientError as exc:
-            if exc.response["Error"]["Code"] == "404":
+            if exc.response["Error"]["Code"] == "NoSuchKey":
                 return False
             raise
         except Exception as exc:

--- a/tests/engine/results/test_s3_result.py
+++ b/tests/engine/results/test_s3_result.py
@@ -79,7 +79,7 @@ class TestS3Result:
         import botocore
 
         exc = botocore.exceptions.ClientError(
-            {"Error": {"Code": "404"}}, "list_objects"
+            {"Error": {"Code": "NoSuchKey"}}, "list_objects"
         )
 
         class _client:
@@ -98,7 +98,7 @@ class TestS3Result:
         import botocore
 
         exc = botocore.exceptions.ClientError(
-            {"Error": {"Code": "404"}}, "list_objects"
+            {"Error": {"Code": "NoSuchKey"}}, "list_objects"
         )
 
         class _client:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2585 
Was able to reproduced using code below and fixed with handling proper ErrorCode

Code used:
```python
from prefect import task, Flow
from prefect.engine.results import S3Result

@task(target="{task_name}-{today}")
def extract():
    return [1, 2, 3]

@task(target="{task_name}-{today}")
def transform(data):
    return [i * 10 for i in data]

@task
def load(data):
    print("Here's your data: {}".format(data))

with Flow("ETL", result=S3Result(bucket="MY_BUCKET")) as flow:
    e = extract()
    t = transform(e)
    l = load(t)

flow.run()
```

Results in S3:
![image](https://user-images.githubusercontent.com/40716964/82218298-b03fe200-98e9-11ea-8fc7-597bab5be945.png)


