### PR TITLE
[docs] hide TODO from CLI docs

### DIFF
--- a/docs/orchestration/concepts/cli.md
+++ b/docs/orchestration/concepts/cli.md
@@ -14,7 +14,7 @@ The CLI is being built to comply with user demands on what is deemed useful. The
 
 ## Interacting with the CLI
 
-// TODO: Update with new CLI changes
+<!-- TODO: Update with new CLI changes -->
 
 Once you have Prefect installed (either through `pip` or `conda`) you may begin working with the CLI directly in your terminal. To see the CLI run `prefect` from the command line and you should see an output similar to the one below:
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

I noticed today that there is a `TODO` comment visible in the docs at https://docs.prefect.io/orchestration/concepts/cli.html#interacting-with-the-cli. This PR hides it.

![image](https://user-images.githubusercontent.com/7608904/82221470-a74d1180-98e5-11ea-8a86-e0ec43fa90db.png)

## Why is this PR important?

This is a minor change to remove a comment meant only for contributors from the user-facing documentation.

Thanks for your time and consideration!
