### PR TITLE
[docs] fix grammatical error in Environments overview

### DIFF
--- a/docs/orchestration/execution/overview.md
+++ b/docs/orchestration/execution/overview.md
@@ -60,7 +60,7 @@ f.register("My First Project", build=False)
 
 ## Environments
 
-While Storage objects provide a way to save and retrieve Flows, [Environments](https://docs.prefect.io/api/latest/environments/execution.html) specify _how your Flow should be run_ e.g., which executor to and whether there are any auxiliary infrastructure requirements for your Flow's execution. For example, if you want to run your Flow on Kubernetes using an auto-scaling Dask cluster then you're going to want to use an environment for that!
+While Storage objects provide a way to save and retrieve Flows, [Environments](https://docs.prefect.io/api/latest/environments/execution.html) specify _how your Flow should be run_ e.g., which executor to use and whether there are any auxiliary infrastructure requirements for your Flow's execution. For example, if you want to run your Flow on Kubernetes using an auto-scaling Dask cluster then you're going to want to use an environment for that!
 
 ### How Environments are Used
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Reading through https://docs.prefect.io/orchestration/execution/overview.html#environments this morning, I noticed what I think is a grammatical error.

> ...should be run e.g., which executor to and whether there are any..

I think this was supposed to be:

> ...should be run e.g., which executor to [use] and whether there are any...

This PR proposes that fix to that sentence.

## Why is this PR important?

This is a minor fix to a grammatical error that makes one sentence in the Environments overview ambiguous.
