### PR TITLE
Fix LocalAgent registration with default labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix issue with `log_stdout` not correctly storing returned data on the task run state - [#2585](https://github.com/PrefectHQ/prefect/pull/2585)
 - Fix `S3Result` exists function handling of `NoSuchKey` error - [#2585](https://github.com/PrefectHQ/prefect/issues/2585)
 - Fix confusing language in Telemetry documentation - [#2593](https://github.com/PrefectHQ/prefect/pull/2593)
+- Fix `LocalAgent` not registering with Cloud using default labels - [#2587](https://github.com/PrefectHQ/prefect/issues/2587)
 
 ### Deprecations
 

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -133,9 +133,6 @@ class Agent:
         self.logger.debug(f"Prefect backend: {config.backend}")
 
         self.client = Client(api_token=token)
-        if config.backend == "cloud":
-            self._verify_token(token)
-            self.client.attach_headers({"X-PREFECT-AGENT-ID": self._register_agent()})
 
     def _verify_token(self, token: str) -> None:
         """
@@ -176,6 +173,10 @@ class Agent:
         The main entrypoint to the agent. This function loops and constantly polls for
         new flow runs to deploy
         """
+        if config.backend == "cloud":
+            self._verify_token(self.client.get_auth_token())
+            self.client.attach_headers({"X-PREFECT-AGENT-ID": self._register_agent()})
+
         try:
             self.setup()
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -116,7 +116,7 @@ def test_agent_log_level_debug(runner_token):
 
 def test_agent_fails_no_auth_token(cloud_api):
     with pytest.raises(AuthorizationError):
-        agent = Agent()
+        agent = Agent().start()
 
 
 def test_agent_fails_no_runner_token(monkeypatch, cloud_api):
@@ -134,7 +134,7 @@ def test_agent_fails_no_runner_token(monkeypatch, cloud_api):
     monkeypatch.setattr("requests.Session", session)
 
     with pytest.raises(AuthorizationError):
-        agent = Agent()
+        agent = Agent().start()
 
 
 def test_query_flow_runs(monkeypatch, runner_token, cloud_api):
@@ -506,7 +506,8 @@ def test_agent_registration_and_id(monkeypatch, cloud_api):
         "prefect.agent.agent.Client.register_agent", MagicMock(return_value="ID")
     )
 
-    agent = Agent()
+    agent = Agent(max_polls=1)
+    agent.start()
     assert agent._register_agent() == "ID"
     assert agent.client._attached_headers == {"X-PREFECT-AGENT-ID": "ID"}
 

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -24,10 +24,7 @@ def test_agent_help():
     assert "Manage Prefect agents." in result.output
 
 
-def test_agent_start_fails_no_token(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)
-
+def test_agent_start_fails_no_token(cloud_api):
     runner = CliRunner()
     result = runner.invoke(agent, ["start"])
     assert result.exit_code == 1


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2587 


## Why is this PR important?
By moving the registration step to `start` all agents will be initialized with whatever necessary information (such as default label)

