### PR TITLE
Cast environment labels to list when calling run_agent from flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These changes are available in the [master branch](https://github.com/PrefectHQ/
 - Fix `S3Result` exists function handling of `NoSuchKey` error - [#2585](https://github.com/PrefectHQ/prefect/issues/2585)
 - Fix confusing language in Telemetry documentation - [#2593](https://github.com/PrefectHQ/prefect/pull/2593)
 - Fix `LocalAgent` not registering with Cloud using default labels - [#2587](https://github.com/PrefectHQ/prefect/issues/2587)
+- Fix flow's `run_agent` function passing a `set` of labels to Agent instead of a `list` - [#2600](https://github.com/PrefectHQ/prefect/pull/2600)
 
 ### Deprecations
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1360,7 +1360,7 @@ class Flow:
             "logging.log_to_cloud": log_to_cloud,
         }
         with set_temporary_config(temp_config):
-            labels = self.environment.labels
+            labels = list(self.environment.labels) if self.environment.labels else []
             agent = prefect.agent.local.LocalAgent(
                 labels=labels, show_flow_logs=show_flow_logs
             )

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2765,3 +2765,19 @@ def test_results_write_to_formatted_locations(tmpdir):
         "1.txt",
         "3.txt",
     }
+
+
+def test_run_agent_passes_environment_labels(monkeypatch):
+    agent = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.LocalAgent", agent)
+
+    f = Flow(
+        "test",
+        environment=prefect.environments.LocalEnvironment(
+            labels=["test", "test", "test2"]
+        ),
+    )
+    f.run_agent()
+
+    assert type(agent.call_args[1]["labels"]) is list
+    assert set(agent.call_args[1]["labels"]) == set(["test", "test2"])


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Due to recent literal eval changes, running an agent off of `flow.run_agent` broke in some ways because it uses the labels found on the flow's environment which is a `set` instead of a `list` to enforce uniqueness.


