### PR TITLE
Dont issue warning for constant tasks

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -328,7 +328,7 @@ class Flow:
         """
         When entering a flow context, the Prefect context is modified to include:
             - `flow`: the flow itself
-            - `_new_task_tracker`: a set of all tasks created while the context is 
+            - `_new_task_tracker`: a set of all tasks created while the context is
                 open, in order to provide user friendly warnings if they aren't added
                 to the flow itself. This is purely for user experience.
         """
@@ -337,7 +337,13 @@ class Flow:
         with prefect.context(flow=self, _new_task_tracker=new_task_tracker):
             yield self
 
-        if new_task_tracker.difference(self.tasks):
+        # constants are not tracked at the flow level
+        new_tasks = {
+            t
+            for t in new_task_tracker
+            if not isinstance(t, prefect.tasks.core.constants.Constant)
+        }
+        if new_tasks.difference(self.tasks):
             warnings.warn(
                 "Tasks were created but not added to the flow: "
                 f"{new_task_tracker.difference(self.tasks)}. This can occur "

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -728,6 +728,18 @@ def test_warning_not_raised_if_tasks_are_created_and_added_to_flow():
     assert len(record) == 0
 
 
+def test_warning_not_raised_for_constant_tasks():
+    with pytest.warns(None) as record:
+        with Flow(name="test") as f:
+            tt = Task()[0]
+
+    # confirm tasks were added
+    assert len(f.tasks) == 2
+
+    # no warnings
+    assert len(record) == 0
+
+
 def test_warning_raised_if_tasks_are_copied_but_not_added_to_flow():
     x = Parameter("x")
     with pytest.warns(UserWarning, match="Tasks were created but not added"):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
#2584 added a very convenient warning whenever tasks are initialized within a Flow context but not added to `flow.tasks`.  `Constant` tasks are a special type of task that are created whenever constants are referenced within a Task call -- one way in which they are special is that they are _not_ tracked by the `Flow` but instead are stored directly on the `Task` object.  This was causing the new warning to incorrectly be issued anytime a Constant was created under the hood.


## Why is this PR important?
Prevent confusing users.

**cc:** @kingsleyb 