### PR TITLE
Dynamic `__doc__`/`__signature__` on tasks

### DIFF
--- a/changes/pr2602.yaml
+++ b/changes/pr2602.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "Task instances define a `__signature__` attribute, for improved introspection and tab-completion - [#2602](https://github.com/PrefectHQ/prefect/pull/2602)"
+  - "Tasks created with `@task` forward the wrapped function's docstring - [#2602](https://github.com/PrefectHQ/prefect/pull/2602)"

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -10,9 +10,20 @@ from typing import Any, Callable
 import prefect
 
 
+class _DocProxy(object):
+    def __init__(self, source):
+        self._source = source
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self._source
+        else:
+            return obj.run.__doc__
+
+
 class FunctionTask(prefect.Task):
-    """
-    A convenience Task for functionally creating Task instances with
+    __doc__ = _DocProxy(
+        """A convenience Task for functionally creating Task instances with
     arbitrary callable `run` methods.
 
     Args:
@@ -33,6 +44,7 @@ class FunctionTask(prefect.Task):
         result = task(42)
     ```
     """
+    )
 
     def __init__(self, fn: Callable, name: str = None, **kwargs: Any):
         if not callable(fn):

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -26,8 +26,7 @@ class _DocProxy(object):
 
 class FunctionTask(prefect.Task):
     __doc__ = _DocProxy(
-        """
-    A convenience Task for functionally creating Task instances with
+        """A convenience Task for functionally creating Task instances with
     arbitrary callable `run` methods.
 
     Args:
@@ -63,7 +62,7 @@ class FunctionTask(prefect.Task):
 
         super().__init__(name=name, **kwargs)
 
-    @property
-    def __wrapped__(self):
-        """Propogates information about the wrapped function"""
-        return self.run
+    def __getattr__(self, k):
+        if k == "__wrapped__":
+            return self.run
+        raise AttributeError(f"'FunctionTask' object has no attribute {k}")

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import uuid
 from datetime import timedelta
@@ -231,6 +232,23 @@ class TestCreateTask:
     def test_class_instantiation_raises_helpful_warning_for_unsupported_callables(self):
         with pytest.raises(ValueError, match="This function can not be inspected"):
             task(zip)
+
+    def test_task_signature_generation(self):
+        class Test(Task):
+            def run(self, x: int, y: bool, z: int = 1):
+                pass
+
+        t = Test()
+
+        sig = inspect.signature(t)
+        # signature is a superset of the `run` method
+        for k, p in inspect.signature(t.run).parameters.items():
+            assert sig.parameters[k] == p
+        # extra kwonly args to __call__ also in sig
+        assert set(sig.parameters).issuperset(
+            {"mapped", "task_args", "upstream_tasks", "flow"}
+        )
+        assert sig.return_annotation == "Task"
 
     def test_create_task_with_and_without_cache_for(self):
         t1 = Task()

--- a/tests/tasks/test_core.py
+++ b/tests/tasks/test_core.py
@@ -69,6 +69,7 @@ class TestFunctionTask:
 
         t = FunctionTask(fn=my_fn)
         assert t.__wrapped__ == my_fn
+        assert not hasattr(FunctionTask, "__wrapped__")
 
 
 class TestCollections:

--- a/tests/tasks/test_core.py
+++ b/tests/tasks/test_core.py
@@ -46,6 +46,30 @@ class TestFunctionTask:
         f = FunctionTask(fn=my_fn, name="test")
         assert f.name == "test"
 
+    def test_function_task_docstring(self):
+        def my_fn():
+            """An example docstring."""
+            pass
+
+        # Original docstring available on class
+        assert "FunctionTask" in FunctionTask.__doc__
+
+        # Wrapped function is docstring on instance
+        f = FunctionTask(fn=my_fn)
+        assert f.__doc__ == my_fn.__doc__
+
+        # Except when no docstring on wrapped function
+        f = FunctionTask(fn=lambda x: x + 1)
+        assert "FunctionTask" in f.__doc__
+
+    def test_function_task_sets__wrapped__(self):
+        def my_fn():
+            """An example function"""
+            pass
+
+        t = FunctionTask(fn=my_fn)
+        assert t.__wrapped__ == my_fn
+
 
 class TestCollections:
     def test_list_returns_a_list(self):


### PR DESCRIPTION
This is possibly too much magic.

It does two things:

- On tasks created with `@task`, the docstring is now the original
  function docstring. The `__call__` and `__class__` docstrings are
  still the same.
- All tasks dynamically generate a `__signature__` attribute, which
  provides nicer tab completion and signature inspection when calling a
  task directly (e.g. `mytask(param, other_param=1)`).

Mostly putting this up for discussion, the implementation can be cleaned
up for sure.

Fixes #2551.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)