### PR TITLE
Recast server service ports to strings

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -269,11 +269,11 @@ def start(
     # Temporary config set for port allocation
     with set_temporary_config(
         {
-            "server.database.host_port": postgres_port,
-            "server.hasura.host_port": hasura_port,
-            "server.graphql.host_port": graphql_port,
-            "server.ui.host_port": ui_port,
-            "server.host_port": server_port,
+            "server.database.host_port": str(postgres_port),
+            "server.hasura.host_port": str(hasura_port),
+            "server.graphql.host_port": str(graphql_port),
+            "server.ui.host_port": str(ui_port),
+            "server.host_port": str(server_port),
         }
     ):
         env = make_env()


### PR DESCRIPTION
If specific ports aren't specified then they are read from config. In config they are strings but literal eval converts them to integers. Docker compose wants _all_ strings and no integers so we have to cast these back to strings. Otherwise we get this error:

```
Traceback (most recent call last):
  File "/Users/josh/Desktop/code/prefect/src/prefect/cli/server.py", line 308, in start
    ["docker-compose", "pull"], cwd=compose_dir_path, env=env
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 342, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 323, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 1432, in _execute_child
    env_list.append(k + b'=' + os.fsencode(v))
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/os.py", line 809, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not int

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/josh/miniconda3/envs/prefect/bin/prefect", line 11, in <module>
    load_entry_point('prefect', 'console_scripts', 'prefect')()
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/josh/Desktop/code/prefect/src/prefect/cli/server.py", line 324, in start
    ["docker-compose", "down"], cwd=compose_dir_path, env=env
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/subprocess.py", line 1432, in _execute_child
    env_list.append(k + b'=' + os.fsencode(v))
  File "/Users/josh/miniconda3/envs/prefect/lib/python3.7/os.py", line 809, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not int
```