### PR TITLE
Fix parameter first usage with case

### DIFF
--- a/changes/issue2604.yaml
+++ b/changes/issue2604.yaml
@@ -1,0 +1,2 @@
+fix:
+  - Fix error when adding `Parameter` to flow under `case` statement - [#2608](https://github.com/PrefectHQ/prefect/pull/2608)

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -469,9 +469,12 @@ class Flow:
             self.tasks.add(task)
             self._cache.clear()
 
-            case = prefect.context.get("case", None)
-            if case is not None:
-                case.add_task(task, self)
+            # Parameters must be root tasks
+            # All other new tasks should be added to the current case (if any)
+            if not isinstance(task, Parameter):
+                case = prefect.context.get("case", None)
+                if case is not None:
+                    case.add_task(task, self)
 
         return task
 

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -1,7 +1,7 @@
 import pytest
 
 import prefect
-from prefect import Flow, Task, task
+from prefect import Flow, Task, task, Parameter
 from prefect.engine.result import NoResult
 from prefect.engine.state import Skipped, Success
 from prefect.tasks.control_flow import FilterTask, ifelse, merge, switch, case
@@ -514,3 +514,16 @@ class TestCase:
         elif branch == "c":
             for t in [a, b, c, d]:
                 assert state.result[t].is_skipped()
+
+    def test_case_with_parameters(self):
+        with Flow("test") as flow:
+            x = Parameter("x")
+            cond = identity(True)
+            with case(cond, True):
+                y1 = x + 1
+            with case(cond, False):
+                y2 = x - 1
+
+        state = flow.run(x=1)
+        assert state.result[y1].result == 2
+        assert state.result[y2].is_skipped()


### PR DESCRIPTION
Previously adding a parameter to a flow under a `case` statement would
error if the parameter hadn't been already used (since all new tasks
under the case statment had the case set as an upstream task, and
parameters can't have upstream tasks). This fixes that.

Fixes #2604.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

