### PR TITLE
Add `case` to toplevel `prefect` namespace

### DIFF
--- a/changes/issue2568.yaml
+++ b/changes/issue2568.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - Add `case` to top-level namespace - [#2609](https://github.com/PrefectHQ/prefect/pull/2609)

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -11,6 +11,7 @@ import prefect.environments
 from prefect.core import Task, Flow, Parameter
 import prefect.engine
 import prefect.tasks
+from prefect.tasks.control_flow import case
 from prefect.utilities.tasks import task, tags, unmapped
 
 import prefect.serialization


### PR DESCRIPTION
This is common enough that we should elevate it to the toplevel
namespace.

Fixes #2568.

- [x] adds new tests (if appropriate)
- [x] updates `CHANGELOG.md` (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)