### PR TITLE
Pause states have no "start_time"

### DIFF
--- a/changes/pr-2617.yaml
+++ b/changes/pr-2617.yaml
@@ -1,0 +1,4 @@
+
+enhancement:
+  - "The `start_time` of a `Paused` state defaults to `None` - [#2617](https://github.com/PrefectHQ/prefect/pull/2617)"
+

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -941,7 +941,11 @@ class Flow:
                 for s in filter(lambda x: x.is_mapped(), task_states):
                     task_states.extend(s.map_states)
                 earliest_start = min(
-                    [s.start_time for s in task_states if s.is_scheduled()],
+                    [
+                        s.start_time
+                        for s in task_states
+                        if s.is_scheduled() and s.start_time is not None
+                    ],
                     default=pendulum.now("utc"),
                 )
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -418,8 +418,6 @@ class Paused(Scheduled):
         cached_inputs: Dict[str, Result] = None,
         context: Dict[str, Any] = None,
     ):
-        if start_time is None:
-            start_time = pendulum.now().add(years=10)
 
         super().__init__(
             message=message,
@@ -428,6 +426,11 @@ class Paused(Scheduled):
             cached_inputs=cached_inputs,
             context=context,
         )
+
+        # override default logic to set start_time = now();
+        # have indefinite start_time instead
+        if start_time is None:
+            self.start_time = None
 
 
 class _MetaState(State):

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -373,6 +373,7 @@ class Scheduled(Pending):
     """
 
     color = "#ffab00"
+    start_time: Optional[datetime.datetime]
 
     def __init__(
         self,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -559,7 +559,9 @@ class TaskRunner(Runner):
     def check_task_reached_start_time(self, state: State) -> State:
         """
         Checks if a task is in a Scheduled state and, if it is, ensures that the scheduled
-        time has been reached. Note: Scheduled states include Retry states.
+        time has been reached. Note: Scheduled states include Retry states. Scheduled
+        states with no start time (`start_time = None`) are never considered ready;
+        they must be manually placed in another state.
 
         Args:
             - state (State): the current state of this task
@@ -571,13 +573,24 @@ class TaskRunner(Runner):
             - ENDRUN: if the task is Scheduled with a future scheduled time
         """
         if isinstance(state, Scheduled):
-            if state.start_time and state.start_time > pendulum.now("utc"):
+            # handle case where no start_time is set
+            if state.start_time is None:
+                self.logger.debug(
+                    "Task '{name}' is scheduled without a known start_time; ending run.".format(
+                        name=prefect.context.get("task_full_name", self.task.name)
+                    )
+                )
+                raise ENDRUN(state)
+
+            # handle case where start time is in the future
+            elif state.start_time and state.start_time > pendulum.now("utc"):
                 self.logger.debug(
                     "Task '{name}': start_time has not been reached; ending run.".format(
                         name=prefect.context.get("task_full_name", self.task.name)
                     )
                 )
                 raise ENDRUN(state)
+
         return state
 
     def get_task_inputs(

--- a/src/prefect/environments/execution/local.py
+++ b/src/prefect/environments/execution/local.py
@@ -49,8 +49,11 @@ class LocalEnvironment(Environment):
 
         env = kwargs.pop("env", dict())
         try:
-            runner = storage.get_flow(flow_location)
-            runner.run(**kwargs)
+            from prefect.engine import get_default_flow_runner_class
+
+            flow = storage.get_flow(flow_location)
+            runner_cls = get_default_flow_runner_class()
+            runner_cls(flow=flow).run(**kwargs)
         except NotImplementedError:
             env_runner = storage.get_env_runner(flow_location)
             current_env = os.environ.copy()

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1699,6 +1699,8 @@ class TestFlowRunMethod:
 
     def test_flow_dot_run_with_paused_states_hangs(self, monkeypatch):
         """
+        Tests that running a flow with a Paused state hangs forever... 
+        not recommended behavior but possible.
         https://github.com/PrefectHQ/prefect/issues/2615
         """
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -139,6 +139,22 @@ def test_scheduled_states_have_default_times():
     assert now - Retrying().start_time < datetime.timedelta(seconds=0.1)
 
 
+def test_paused_state_has_no_default_start_time():
+    state = Paused()
+    assert state.start_time is None
+
+
+def test_passing_none_to_paused_state_has_no_default_start_time():
+    state = Paused(start_time=None)
+    assert state.start_time is None
+
+
+def test_paused_state_can_have_start_time():
+    dt = pendulum.now().add(years=1)
+    state = Paused(start_time=dt)
+    assert state.start_time == dt
+
+
 def test_queued_states_have_start_times():
     now = pendulum.now("utc")
     assert now - Queued().start_time < datetime.timedelta(seconds=0.1)
@@ -389,6 +405,9 @@ class TestStateHierarchy:
 
     def test_validation_failed_is_failed(self):
         assert issubclass(ValidationFailed, Failed)
+
+    def test_paused_is_scheduled(self):
+        assert issubclass(Paused, Scheduled)
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1495,9 +1495,10 @@ class TestCheckScheduledStep:
         )
 
     @pytest.mark.parametrize(
-        "state", [Scheduled(start_time=None), Retrying(start_time=None)]
+        "state", [Scheduled(start_time=None), Retrying(start_time=None), Paused()]
     )
     def test_scheduled_states_without_start_time(self, state):
+        assert state.start_time is None
         assert (
             TaskRunner(task=Task()).check_task_reached_start_time(state=state) is state
         )

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1495,21 +1495,26 @@ class TestCheckScheduledStep:
         )
 
     @pytest.mark.parametrize(
-        "state", [Scheduled(start_time=None), Retrying(start_time=None), Paused()]
+        "state", [Scheduled(start_time=None), Retrying(start_time=None),],
     )
-    def test_scheduled_states_without_start_time(self, state):
-        assert state.start_time is None
+    def test_scheduled_states_with_default_start_time(self, state):
+        assert state.start_time is not None
         assert (
             TaskRunner(task=Task()).check_task_reached_start_time(state=state) is state
         )
+
+    @pytest.mark.parametrize(
+        "state", [Paused(start_time=None),],
+    )
+    def test_scheduled_states_with_none_start_time(self, state):
+        with pytest.raises(ENDRUN) as exc:
+            TaskRunner(task=Task()).check_task_reached_start_time(state=state)
 
     @pytest.mark.parametrize(
         "state",
         [
             Scheduled(start_time=pendulum.now("utc").add(minutes=10)),
             Retrying(start_time=pendulum.now("utc").add(minutes=10)),
-            Paused(),
-            Paused(start_time=None),
             Paused(start_time=pendulum.now("utc").add(minutes=10)),
         ],
     )

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -94,25 +94,6 @@ def test_environment_execute_with_env_runner():
     assert global_dict.get("run") is True
 
 
-def test_environment_execute_with_kwargs():
-    global_dict = {}
-
-    @prefect.task
-    def add_to_dict(x):
-        global_dict["result"] = x
-
-    environment = LocalEnvironment()
-    storage = DummyStorage()
-    with prefect.Flow("test") as flow:
-        x = prefect.Parameter("x")
-        add_to_dict(x)
-
-    flow_loc = storage.add_flow(flow)
-
-    environment.execute(storage, flow_loc, x=42)
-    assert global_dict.get("result") == 42
-
-
 def test_environment_execute_with_env_runner_with_kwargs():
     class TestStorage(DummyStorage):
         def get_flow(self, *args, **kwargs):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2615


## Why is this PR important?
`Paused` states are a subclass of `Scheduled` states, since they imply a run in a future and allow for predetermined pauses ("Pause this task for 5 minutes"). However, they currently default to a `start_time` 10 years in the future as a "hack" to simulate "pausing". While examining an error described in #2615, I began exploring whether that was even necessary - why can't a `Paused` state just have `start_time=None`, reflecting that it's likely to run in the future but at an indeterminate time?

It turns out there is only a small set of changes that had to be made to embrace this possibility, and I strongly prefer that 'Paused' is no longer equivalent to "Scheduled for 10 years from now."

@jcrist this is my first PR with the new changelog format - it felt TOO easy :)  Am I doing it correctly?