### PR TITLE
remove unused imports

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -17,9 +17,7 @@ import inspect
 import os
 import re
 import shutil
-import subprocess
 import textwrap
-import warnings
 from contextlib import contextmanager
 from functools import partial
 from unittest.mock import MagicMock

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 import sys
 import textwrap
@@ -22,7 +21,6 @@ try:
         format_subheader,
         get_call_signature,
         get_class_methods,
-        get_source,
         patch_imports,
     )
 

--- a/docs/tokenizer.py
+++ b/docs/tokenizer.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 
 from pygments.lexers import Python3Lexer
 from pygments.token import Comment, Keyword, Name, Number, Operator, Punctuation, String

--- a/docs/tokenizer.py
+++ b/docs/tokenizer.py
@@ -1,4 +1,3 @@
-
 from pygments.lexers import Python3Lexer
 from pygments.token import Comment, Keyword, Name, Number, Operator, Punctuation, String
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,7 +1,6 @@
 # Licensed under the Prefect Community License, available at
 # https://www.prefect.io/legal/prefect-community-license
 
-import sys
 
 from setuptools import find_packages, setup
 

--- a/server/src/prefect_server/api/flows.py
+++ b/server/src/prefect_server/api/flows.py
@@ -6,8 +6,6 @@ import asyncio
 import copy
 import uuid
 
-import pendulum
-
 import prefect
 from prefect.engine.state import Finished
 from prefect.utilities.graphql import EnumValue, with_args
@@ -15,8 +13,6 @@ from prefect.utilities.serialization import to_qualified_name
 from prefect_server import api, config
 from prefect_server.database import hasura, models
 from prefect_server.utilities import context
-
-import warnings
 
 
 async def _update_flow_setting(flow_id: str, key: str, value: any) -> bool:

--- a/server/src/prefect_server/api/logs.py
+++ b/server/src/prefect_server/api/logs.py
@@ -4,7 +4,6 @@
 
 import pydantic
 import asyncio
-import datetime
 from typing import Any, List, Dict
 
 import pendulum

--- a/server/src/prefect_server/api/runs.py
+++ b/server/src/prefect_server/api/runs.py
@@ -2,9 +2,8 @@
 # https://www.prefect.io/legal/prefect-community-license
 
 
-import ujson
 import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Iterable, List
 
 import pendulum
 

--- a/server/src/prefect_server/api/states.py
+++ b/server/src/prefect_server/api/states.py
@@ -3,13 +3,8 @@
 
 
 import asyncio
-import datetime
-import json
-from dataclasses import dataclass
-from typing import Any, Optional
 
 import pendulum
-from box import Box
 
 import prefect
 

--- a/server/src/prefect_server/cli/database.py
+++ b/server/src/prefect_server/cli/database.py
@@ -3,12 +3,9 @@
 
 
 import argparse
-import uuid
 from pathlib import Path
-from typing import Iterator
 
 import click
-import requests
 from click.testing import CliRunner
 
 import prefect

--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -3,7 +3,6 @@
 
 
 import glob
-import json
 import os
 import shutil
 import signal
@@ -12,10 +11,6 @@ import time
 from pathlib import Path
 
 import click
-import pendulum
-import toml
-import yaml
-from click.testing import CliRunner
 
 import prefect
 import prefect_server

--- a/server/src/prefect_server/cli/hasura.py
+++ b/server/src/prefect_server/cli/hasura.py
@@ -5,7 +5,6 @@
 import os
 import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 import click

--- a/server/src/prefect_server/cli/services.py
+++ b/server/src/prefect_server/cli/services.py
@@ -9,7 +9,6 @@ import time
 from pathlib import Path
 
 import click
-import pendulum
 
 import prefect_server
 from prefect_server import config

--- a/server/src/prefect_server/database/hasura.py
+++ b/server/src/prefect_server/database/hasura.py
@@ -3,11 +3,8 @@
 
 
 import asyncio
-import os
-from contextlib import contextmanager
 from typing import Any, Dict, Iterable, List, Union
 
-import httpx
 from box import Box
 
 import prefect_server

--- a/server/src/prefect_server/database/orm.py
+++ b/server/src/prefect_server/database/orm.py
@@ -8,7 +8,6 @@ import uuid
 from typing import List, Union, cast
 
 import pendulum
-from box import Box
 
 import psycopg2
 import prefect

--- a/server/src/prefect_server/graphql/logs.py
+++ b/server/src/prefect_server/graphql/logs.py
@@ -3,7 +3,6 @@
 
 
 import asyncio
-import warnings
 from typing import Any
 
 from graphql import GraphQLResolveInfo

--- a/server/src/prefect_server/graphql/runs.py
+++ b/server/src/prefect_server/graphql/runs.py
@@ -3,7 +3,6 @@
 
 
 import asyncio
-import json
 from typing import Any
 
 from graphql import GraphQLResolveInfo

--- a/server/src/prefect_server/graphql/states.py
+++ b/server/src/prefect_server/graphql/states.py
@@ -3,9 +3,6 @@
 
 
 import asyncio
-import json
-import sys
-import warnings
 from typing import Any
 
 from graphql import GraphQLResolveInfo

--- a/server/src/prefect_server/utilities/graphql.py
+++ b/server/src/prefect_server/utilities/graphql.py
@@ -2,15 +2,12 @@
 # https://www.prefect.io/legal/prefect-community-license
 
 
-import functools
 import json
 import textwrap
-from typing import Any, Callable, Dict, Union
+from typing import Any, Dict, Union
 
 import ariadne
-import graphql
 import httpx
-import re
 from box import Box
 
 import prefect_server

--- a/server/src/prefect_server/utilities/graphql_tools.py
+++ b/server/src/prefect_server/utilities/graphql_tools.py
@@ -6,12 +6,10 @@
 This module requires graphql-core-next
 """
 
-import itertools
 from typing import Any, Dict, List
 
 import ariadne
 import graphql
-import requests
 
 import prefect_server
 from prefect.utilities.graphql import parse_graphql, with_args

--- a/server/tests/api/test_flows.py
+++ b/server/tests/api/test_flows.py
@@ -2,10 +2,8 @@
 # https://www.prefect.io/legal/prefect-community-license
 
 
-import datetime
 import uuid
 
-import pendulum
 import pytest
 
 import prefect

--- a/server/tests/api/test_logs.py
+++ b/server/tests/api/test_logs.py
@@ -3,11 +3,9 @@
 
 
 import asyncio
-import uuid
 
 import pendulum
 import pytest
-from asynctest import CoroutineMock
 
 from prefect_server import api, config, utilities
 from prefect_server.database import models

--- a/server/tests/api/test_runs.py
+++ b/server/tests/api/test_runs.py
@@ -3,12 +3,10 @@
 
 
 import asyncio
-import json
 import uuid
 
 import pendulum
 import pytest
-from asynctest import CoroutineMock
 
 import prefect
 import prefect_server

--- a/server/tests/api/test_states.py
+++ b/server/tests/api/test_states.py
@@ -3,14 +3,9 @@
 
 
 import asyncio
-import datetime
-import json
-import time
 import uuid
 
-import pendulum
 import pytest
-from asynctest import CoroutineMock
 from box import Box
 
 import prefect

--- a/server/tests/cli/test_dev.py
+++ b/server/tests/cli/test_dev.py
@@ -5,7 +5,6 @@
 import os
 import tempfile
 
-import click
 import pytest
 from click.testing import CliRunner
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -3,16 +3,9 @@
 
 
 import asyncio
-import datetime
 import inspect
-import uuid
-import warnings
-from box import Box
 
-import pendulum
 import pytest
-from asynctest import CoroutineMock
-from click.testing import CliRunner
 
 import prefect
 import prefect_server

--- a/server/tests/database/test_flow_run_insert_trigger.py
+++ b/server/tests/database/test_flow_run_insert_trigger.py
@@ -2,8 +2,6 @@
 # https://www.prefect.io/legal/prefect-community-license
 
 
-import datetime
-import pendulum
 import pytest
 
 import prefect

--- a/server/tests/database/test_migrations.py
+++ b/server/tests/database/test_migrations.py
@@ -3,8 +3,6 @@
 
 
 import prefect
-import uuid
-import pendulum
 import alembic
 import subprocess
 

--- a/server/tests/fixtures/database_fixtures.py
+++ b/server/tests/fixtures/database_fixtures.py
@@ -3,15 +3,9 @@
 
 
 import datetime
-import inspect
-import uuid
-import warnings
-from box import Box
 
 import pendulum
 import pytest
-from asynctest import CoroutineMock
-from click.testing import CliRunner
 
 import prefect
 import prefect_server

--- a/server/tests/graphql/conftest.py
+++ b/server/tests/graphql/conftest.py
@@ -3,7 +3,6 @@
 
 
 import httpx
-import pendulum
 import pytest
 from box import Box
 

--- a/server/tests/graphql/test_flows.py
+++ b/server/tests/graphql/test_flows.py
@@ -4,7 +4,6 @@
 
 import uuid
 
-import pendulum
 import pytest
 
 import prefect

--- a/server/tests/graphql/test_logs.py
+++ b/server/tests/graphql/test_logs.py
@@ -3,7 +3,6 @@
 
 
 import asyncio
-import uuid
 
 import pendulum
 import pytest

--- a/server/tests/graphql/test_runs.py
+++ b/server/tests/graphql/test_runs.py
@@ -3,9 +3,7 @@
 
 
 import asyncio
-import time
 import uuid
-from unittest.mock import MagicMock
 
 import pendulum
 import pytest

--- a/server/tests/graphql/test_server.py
+++ b/server/tests/graphql/test_server.py
@@ -9,9 +9,7 @@ from typing import Any
 
 import ariadne
 import httpx
-import json
 import pytest
-import uuid
 from ariadne import make_executable_schema
 from ariadne.asgi import GraphQL
 from graphql import GraphQLResolveInfo

--- a/server/tests/graphql/test_states.py
+++ b/server/tests/graphql/test_states.py
@@ -2,8 +2,6 @@
 # https://www.prefect.io/legal/prefect-community-license
 
 
-import os
-import pendulum
 import pytest
 
 import prefect

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -20,7 +20,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Union,
     cast,
 )
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -12,9 +12,6 @@ from typing import (
     Iterable,
     List,
     Mapping,
-    Set,
-    Tuple,
-    Union,
     Optional,
 )
 

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -3,11 +3,9 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Set,
-    Tuple,
     Union,
 )
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -3,18 +3,13 @@ from contextlib import redirect_stdout
 import itertools
 import json
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Set,
-    Sized,
-    Tuple,
-    Union,
 )
 
 import pendulum

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     NamedTuple,
     Optional,
     Set,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -10,6 +10,7 @@ from typing import (
     NamedTuple,
     Optional,
     Set,
+    Tuple,
 )
 
 import pendulum

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -1,10 +1,8 @@
-import os
 import socket
 from unittest.mock import MagicMock
 
 import pytest
 from marshmallow.exceptions import ValidationError
-from testfixtures.mock import call
 from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 from click.testing import CliRunner
 
 from prefect.cli.create import create

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -1,7 +1,5 @@
-import sys
 from unittest.mock import MagicMock
 
-import click
 import pytest
 import requests
 from click.testing import CliRunner

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -1,4 +1,3 @@
-
 from click.testing import CliRunner
 import pytest
 

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -1,4 +1,3 @@
-from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 import pytest

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,4 +1,3 @@
-import click
 from click.testing import CliRunner
 
 import prefect

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,11 +1,9 @@
 import json
 import os
 import re
-import sys
 import tempfile
 from unittest.mock import MagicMock
 
-import click
 import pytest
 import requests
 from click.testing import CliRunner

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,9 +1,7 @@
 import datetime
 import json
-import os
-import tempfile
 import uuid
-from unittest.mock import MagicMock, mock_open
+from unittest.mock import MagicMock
 
 import marshmallow
 import pendulum

--- a/tests/client/test_client_auth.py
+++ b/tests/client/test_client_auth.py
@@ -1,12 +1,10 @@
-import datetime
 import json
 import os
 import tempfile
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open
+from unittest.mock import MagicMock
 
-import marshmallow
 import pendulum
 import pytest
 import requests

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import MagicMock
 
 import box

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tempfile
 from unittest.mock import MagicMock
 
@@ -8,7 +7,7 @@ from distributed import Client
 
 import prefect
 from prefect.engine.executors import DaskExecutor, LocalDaskExecutor, LocalExecutor
-from prefect.utilities import configuration, debug
+from prefect.utilities import configuration
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -7,7 +7,6 @@ import random
 import sys
 import tempfile
 import time
-import uuid
 from unittest.mock import MagicMock, patch
 
 import cloudpickle

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -1,9 +1,7 @@
-from unittest.mock import MagicMock
-import json
 import logging
 import uuid
 from datetime import timedelta
-from typing import Any, Union
+from typing import Any
 
 import pytest
 

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -1,7 +1,5 @@
 import datetime
 import time
-import uuid
-from box import Box
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -1,7 +1,6 @@
 import datetime
-import sys
 import uuid
-from collections import Counter, namedtuple
+from collections import Counter
 from unittest.mock import MagicMock
 
 import pendulum

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1,17 +1,9 @@
 import datetime
 import json
-import os
-import sys
-import tempfile
-import time
-import uuid
 from unittest.mock import MagicMock
 
-import cloudpickle
 import pendulum
 import pytest
-import requests
-from box import Box
 
 import prefect
 from prefect.client import Client

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -1,13 +1,10 @@
-import datetime
 import logging
 import random
 import sys
-import tempfile
 import time
 from unittest.mock import MagicMock
 
 import cloudpickle
-import dask
 import distributed
 import pytest
 

--- a/tests/engine/result/test_base.py
+++ b/tests/engine/result/test_base.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 import cloudpickle

--- a/tests/engine/result_handlers/test_result_handlers.py
+++ b/tests/engine/result_handlers/test_result_handlers.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from unittest.mock import MagicMock, patch

--- a/tests/engine/results/test_azure_result.py
+++ b/tests/engine/results/test_azure_result.py
@@ -1,10 +1,6 @@
-import json
-import os
-import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import cloudpickle
-import pendulum
 import pytest
 
 import prefect

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock, patch
 
 import cloudpickle
 import pytest

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -1,10 +1,5 @@
-import json
-import os
-import tempfile
-from unittest.mock import MagicMock, patch
 
 import cloudpickle
-import pendulum
 import pytest
 
 import prefect

--- a/tests/engine/results/test_result_handler_result.py
+++ b/tests/engine/results/test_result_handler_result.py
@@ -1,10 +1,5 @@
-import os
-import json
-import tempfile
 import uuid
-from typing import Union
 
-import cloudpickle
 import pytest
 
 import prefect

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -2,9 +2,7 @@ import collections
 import datetime
 import queue
 import random
-import sys
 import time
-from distutils.version import LooseVersion
 from unittest.mock import MagicMock
 
 import cloudpickle

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,9 +1,6 @@
 import datetime
 import json
-import tempfile
-import uuid
 
-import cloudpickle
 import pendulum
 import pytest
 

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from os import path

--- a/tests/environments/storage/test_azure_storage.py
+++ b/tests/environments/storage/test_azure_storage.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-import cloudpickle
 import pytest
 
 from prefect import Flow

--- a/tests/environments/storage/test_docker_healthcheck.py
+++ b/tests/environments/storage/test_docker_healthcheck.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import sys
 import tempfile
-from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest

--- a/tests/environments/storage/test_gcs_storage.py
+++ b/tests/environments/storage/test_gcs_storage.py
@@ -1,6 +1,4 @@
-import io
 from unittest.mock import MagicMock, patch, call
-import warnings
 
 import cloudpickle
 import pytest

--- a/tests/schedules/test_filters.py
+++ b/tests/schedules/test_filters.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 
 import pendulum
 import pytest

--- a/tests/schedules/test_filters.py
+++ b/tests/schedules/test_filters.py
@@ -1,4 +1,3 @@
-
 import pendulum
 import pytest
 

--- a/tests/serialization/test_edges.py
+++ b/tests/serialization/test_edges.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import prefect

--- a/tests/serialization/test_edges.py
+++ b/tests/serialization/test_edges.py
@@ -1,5 +1,3 @@
-import datetime
-import json
 
 import pytest
 

--- a/tests/serialization/test_flows.py
+++ b/tests/serialization/test_flows.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 
 import pytest
 

--- a/tests/serialization/test_results.py
+++ b/tests/serialization/test_results.py
@@ -1,4 +1,3 @@
-import marshmallow
 import pytest
 
 import prefect

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -1,7 +1,6 @@
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-import marshmallow
 import pendulum
 import pytest
 

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -1,8 +1,5 @@
-import base64
 import datetime
-import json
 
-import cloudpickle
 import marshmallow
 import pendulum
 import pytest

--- a/tests/tasks/airtable/test_airtable.py
+++ b/tests/tasks/airtable/test_airtable.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 import prefect

--- a/tests/tasks/dbt/test_dbt.py
+++ b/tests/tasks/dbt/test_dbt.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import sys
 
 import pytest

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from unittest.mock import MagicMock
 

--- a/tests/tasks/gcp/test_gcs_copy.py
+++ b/tests/tasks/gcp/test_gcs_copy.py
@@ -1,7 +1,4 @@
-from unittest.mock import MagicMock
-
 import pytest
-from google.cloud.exceptions import NotFound
 
 import prefect
 from prefect.tasks.gcp import GCSCopy

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import prefect

--- a/tests/tasks/github/test_issues.py
+++ b/tests/tasks/github/test_issues.py
@@ -1,7 +1,5 @@
-from unittest.mock import MagicMock
 
 import pytest
-import requests
 
 import prefect
 from prefect.tasks.github import OpenGitHubIssue

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import prefect

--- a/tests/tasks/github/test_prs.py
+++ b/tests/tasks/github/test_prs.py
@@ -1,7 +1,5 @@
-from unittest.mock import MagicMock
 
 import pytest
-import requests
 
 import prefect
 from prefect.tasks.github import CreateGitHubPR

--- a/tests/tasks/templates/test_jinja.py
+++ b/tests/tasks/templates/test_jinja.py
@@ -1,6 +1,3 @@
-import os
-import subprocess
-import tempfile
 
 import cloudpickle
 import pendulum

--- a/tests/tasks/templates/test_jinja.py
+++ b/tests/tasks/templates/test_jinja.py
@@ -1,4 +1,3 @@
-
 import cloudpickle
 import pendulum
 import pytest

--- a/tests/tasks/templates/test_strings.py
+++ b/tests/tasks/templates/test_strings.py
@@ -1,15 +1,7 @@
-import os
-import subprocess
-import tempfile
-
-import cloudpickle
-import pendulum
 import pytest
 
 from prefect import Flow, context
-from prefect.engine import signals
 from prefect.tasks.templates import StringFormatter
-from prefect.utilities.debug import raise_on_exception
 
 
 def test_string_formatter_simply_formats():

--- a/tests/tasks/twitter/test_twitter.py
+++ b/tests/tasks/twitter/test_twitter.py
@@ -1,4 +1,3 @@
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/tasks/twitter/test_twitter.py
+++ b/tests/tasks/twitter/test_twitter.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import prefect

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,10 +1,7 @@
 import datetime
 import os
-import shlex
-import subprocess
 import sys
 import tempfile
-import uuid
 
 import pytest
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from pathlib import Path
 
 import pytest

--- a/tests/utilities/test_debug.py
+++ b/tests/utilities/test_debug.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from datetime import timedelta
 
 import pytest
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -4,8 +4,6 @@ import sys
 import threading
 import tempfile
 import time
-from datetime import timedelta
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import uuid
 from collections import OrderedDict
 from textwrap import dedent

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import sys
 import time
 from unittest.mock import MagicMock
 

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 import uuid
 
 import marshmallow

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -1,4 +1,3 @@
-import inspect
 
 import pytest
 

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from prefect.core import Flow, Task


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Thanks for this great project! I've been getting familiar with `prefect` and really liking it, so I wanted to contribute back. Similar to #2567 , this PR proposes fixing another class of problem I saw running `flake8` on this repo: unused imports.

The "unused imports" detection in `flake8` can lead to a lot of false positives, for example in `__init__.py` files, so I tried to limit the changes I made here to things I'm fairly confident can be removed. You can generate the list of things I changed with this command:

```shell
flake8 \
    --ignore=E501,E231,E503,E266,W503 \
    | grep "F401" \
    | grep -v "__init" \
    | grep -v "'prefect" \
    | grep -v "'pytest'" \
    | grep -v "'asyncio" \
    | grep -v "sqlalchemy" \
    | grep -v "alembic" \
    | grep -v "'docker" \
    | grep -v "'azure\.stoorage" \
    | grep -v "'google\.cloud" \
    | grep -v "'graphviz" \
    | grep -v "\.fixtures\.database_fixtures" \
    | grep -v "'blig" \
    > flake.txt
```

Most of those ignored things are from these common false positive cases:

* things in `__init__.py` files
* things that need to be defined because they're mocked or patched
* imports used to test the availability of a library

I also avoided `sqlalchemy` and `alembic` just because I don't understand the full magic of `sqlalchemy` and didn't know if some of the things `flake8` turned about were actually unused.

## Why is this PR important?

Imports add to the time it takes to load modules.

Unused imports can also make it seem like some dependencies are more widely used in the project than they really are, which can prevent maintainers from noticing limited-use dependencies and trying to factor them out.

To be clear...this PR removes _imports_, but it doesn't change the dependencies for `prefect` at all. All of the things I'm proposing removing come from libraries that are imported elsewhere in the project.

Thanks for your time and consideration!
