### PR TITLE
Remove attempt to load data in S3Result exists function

### DIFF
--- a/changes/issue2623.yaml
+++ b/changes/issue2623.yaml
@@ -1,0 +1,2 @@
+fix:
+  - Fix `S3Result` attempting to load data when checking existence - [#2623](https://github.com/PrefectHQ/prefect/issues/2623)

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -165,7 +165,7 @@ class S3Result(Result):
         try:
             self.client.get_object(
                 Bucket=self.bucket, Key=location.format(**kwargs)
-            ).load()
+            )
         except botocore.exceptions.ClientError as exc:
             if exc.response["Error"]["Code"] == "NoSuchKey":
                 return False

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -163,9 +163,7 @@ class S3Result(Result):
         import botocore
 
         try:
-            self.client.get_object(
-                Bucket=self.bucket, Key=location.format(**kwargs)
-            )
+            self.client.get_object(Bucket=self.bucket, Key=location.format(**kwargs))
         except botocore.exceptions.ClientError as exc:
             if exc.response["Error"]["Code"] == "NoSuchKey":
                 return False


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2623 


## Why is this PR important?
We don't need to attempt to load the data at all. Only need to check existence. This call will succeed if it exists otherwise it will raise the `NoSuchKey` error that is handled.

