### PR TITLE
Add TLS configuration option to Docker storage

### DIFF
--- a/changes/issue2626.yaml
+++ b/changes/issue2626.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - Add option to set TLS configuration on client created by Docker storage - [#2626](hhttps://github.com/PrefectHQ/prefect/issues/2626)

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -9,7 +9,7 @@ import textwrap
 import uuid
 import warnings
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Union
 
 import cloudpickle
 import pendulum
@@ -69,7 +69,7 @@ class Docker(Storage):
             for each flow run.  Used primarily for providing authentication credentials.
         - base_url: (str, optional): a URL of a Docker daemon to use when for
             Docker related functionality.  Defaults to DOCKER_HOST env var if not set
-        - tls_config: (docker.tls.TLSConfig, optional): a TLS configuration to pass to the Docker
+        - tls_config: (Union[bool, docker.tls.TLSConfig], optional): a TLS configuration to pass to the Docker
             client. https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig
 
     Raises:
@@ -92,7 +92,7 @@ class Docker(Storage):
         ignore_healthchecks: bool = False,
         secrets: List[str] = None,
         base_url: str = None,
-        tls_config: "docker.tls.TLSConfig" = None,
+        tls_config: Union[bool, "docker.tls.TLSConfig"] = False,
     ) -> None:
         self.registry_url = registry_url
         if sys.platform == "win32":

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -56,8 +56,6 @@ class Docker(Storage):
             use when building
         - files (dict, optional): a dictionary of files to copy into the image
             when building
-        - base_url: (str, optional): a URL of a Docker daemon to use when for
-            Docker related functionality.  Defaults to DOCKER_HOST env var if not set
         - prefect_version (str, optional): an optional branch, tag, or commit
             specifying the version of prefect you want installed into the container;
             defaults to the version you are currently using or `"master"` if your
@@ -69,6 +67,10 @@ class Docker(Storage):
             are included.
         - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
             for each flow run.  Used primarily for providing authentication credentials.
+        - base_url: (str, optional): a URL of a Docker daemon to use when for
+            Docker related functionality.  Defaults to DOCKER_HOST env var if not set
+        - tls_config: (docker.tls.TLSConfig, optional): a TLS configuration to pass to the Docker
+            client. https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig
 
     Raises:
         - ValueError: if both `base_image` and `dockerfile` are provided
@@ -85,11 +87,12 @@ class Docker(Storage):
         image_tag: str = None,
         env_vars: dict = None,
         files: dict = None,
-        base_url: str = None,
         prefect_version: str = None,
         local_image: bool = False,
         ignore_healthchecks: bool = False,
         secrets: List[str] = None,
+        base_url: str = None,
+        tls_config: "docker.tls.TLSConfig" = None,
     ) -> None:
         self.registry_url = registry_url
         if sys.platform == "win32":
@@ -109,10 +112,12 @@ class Docker(Storage):
         self.files = files or {}
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
-        self.base_url = base_url or os.environ.get("DOCKER_HOST", default_url)
         self.local_image = local_image
         self.extra_commands = []  # type: List[str]
         self.ignore_healthchecks = ignore_healthchecks
+
+        self.base_url = base_url or os.environ.get("DOCKER_HOST", default_url)
+        self.tls_config = tls_config
 
         version = prefect.__version__.split("+")
         if prefect_version is None:
@@ -505,7 +510,9 @@ class Docker(Storage):
         # the 'import prefect' time low
         import docker
 
-        return docker.APIClient(base_url=self.base_url, version="auto")
+        return docker.APIClient(
+            base_url=self.base_url, version="auto", tls=self.tls_config
+        )
 
     def pull_image(self) -> None:
         """Pull the image specified so it can be built.

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -74,6 +74,7 @@ def test_empty_docker_storage(monkeypatch, platform, url, no_docker_host_var):
     assert not storage.files
     assert storage.prefect_version
     assert storage.base_url == url
+    assert not storage.tls_config
     assert not storage.local_image
     assert not storage.ignore_healthchecks
 
@@ -138,6 +139,7 @@ def test_initialized_docker_storage(no_docker_host_var):
         image_tag="test5",
         env_vars={"test": "1"},
         base_url="test_url",
+        tls_config={"tls": "here"},
         prefect_version="my-branch",
         local_image=True,
     )
@@ -152,8 +154,24 @@ def test_initialized_docker_storage(no_docker_host_var):
         "PREFECT__USER_CONFIG_PATH": "/opt/prefect/config.toml",
     }
     assert storage.base_url == "test_url"
+    assert storage.tls_config == {"tls": "here"}
     assert storage.prefect_version == "my-branch"
     assert storage.local_image
+
+
+def test_initialized_docker_storage_client(monkeypatch, no_docker_host_var):
+    client = MagicMock()
+    monkeypatch.setattr("docker.APIClient", client)
+
+    storage = Docker(
+        registry_url="test1", base_url="test_url", tls_config={"tls": "here"},
+    )
+
+    storage._get_client()
+
+    assert client.call_args[1]["base_url"] == "test_url"
+    assert client.call_args[1]["tls"] == {"tls": "here"}
+    assert client.call_args[1]["version"] == "auto"
 
 
 def test_env_var_precedence_docker_storage(monkeypatch, no_docker_host_var):

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -74,7 +74,7 @@ def test_empty_docker_storage(monkeypatch, platform, url, no_docker_host_var):
     assert not storage.files
     assert storage.prefect_version
     assert storage.base_url == url
-    assert not storage.tls_config
+    assert storage.tls_config == False
     assert not storage.local_image
     assert not storage.ignore_healthchecks
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2626 


## Why is this PR important?
Now a TLS config can be passed directly to Docker storage (https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig). This is very useful for CI related processes that build flows

