### PR TITLE
Deprecate private_registry and docker_secret options on DaskKubernetesEnvironment

### DIFF
--- a/changes/pr2630.yaml
+++ b/changes/pr2630.yaml
@@ -1,0 +1,2 @@
+deprecation:
+  - Deprecate `private_registry` and `docker_secret` options on `DaskKubernetesEnvironment` - [#2630](https://github.com/PrefectHQ/prefect/pull/2630)

--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -1,16 +1,16 @@
-# Dask Cloud Provider Environment <Badge text="Cloud"/>
+# Dask Cloud Provider Environment
 
 [[toc]]
 
 
 ## Overview
 
-The Dask Cloud Provider Environment executes each Flow run on a dynamically created Dask cluster. It uses 
+The Dask Cloud Provider Environment executes each Flow run on a dynamically created Dask cluster. It uses
 the [Dask Cloud Provider](https://cloudprovider.dask.org/) project to create a Dask scheduler and
-workers using cloud provider services, e.g. AWS Fargate. This Environment aims to provide a very 
+workers using cloud provider services, e.g. AWS Fargate. This Environment aims to provide a very
 easy way to achieve high scalability without the complexity of Kubernetes.
 
-:::tip AWS Only    
+:::tip AWS Only
 Dask Cloud Provider currently only supports AWS using either Fargate or ECS.
 Support for AzureML is [coming soon](https://github.com/dask/dask-cloudprovider/pull/67).
 :::
@@ -28,8 +28,8 @@ network traffic. Please be conscious of security issues if you test this environ
 #### Initialization
 
 The `DaskCloudProviderEnvironment` serves largely to pass kwargs through to the specific class
-from the Dask Cloud Provider project that you're using. You can find the list of 
-available arguments in the Dask Cloud Provider 
+from the Dask Cloud Provider project that you're using. You can find the list of
+available arguments in the Dask Cloud Provider
 [API documentation](https://cloudprovider.dask.org/en/latest/api.html).
 
 ```python
@@ -63,21 +63,21 @@ time. `DaskCloudProviderEnvironment` is a particularly good fit for automated
 deployment of scheduled Flows in a CI/CD pipeline where the infrastructure for each Flow
 should be as independent as possible, e.g. each Flow could have its own docker
 image, dynamically create the Dask cluster for each Flow run, etc. However, for
-development and interactive testing, either using ECS (instead of Fargate) or 
-creating a Dask cluster manually (with Dask Cloud Provider or otherwise) and then using 
-`RemoteDaskEnvironment` or just `DaskExecutor` with your flows will result 
+development and interactive testing, either using ECS (instead of Fargate) or
+creating a Dask cluster manually (with Dask Cloud Provider or otherwise) and then using
+`RemoteDaskEnvironment` or just `DaskExecutor` with your flows will result
 in a much better and faster development experience.
 :::
 
 #### Requirements
 
 The Dask Cloud Provider environment requires sufficient privileges with your cloud provider
-in order to run Docker containers for the Dask scheduler and workers. It's a good idea to 
-test Dask Cloud Provider directly and confirm that it's working properly before using 
+in order to run Docker containers for the Dask scheduler and workers. It's a good idea to
+test Dask Cloud Provider directly and confirm that it's working properly before using
 `DaskCloudProviderEnvironment`. See [this documentation](https://cloudprovider.dask.org/)
 for more details.
 
-Here's an example of creating a Dask cluster using Dask Cloud Provider directly, 
+Here's an example of creating a Dask cluster using Dask Cloud Provider directly,
 running a Flow on it, and then closing the cluster to tear down all cloud resoures
 that were created.
 
@@ -96,12 +96,12 @@ cluster = FargateCluster(
     scheduler_mem=512,
     worker_cpu=256,
     worker_mem=512,
-    scheduler_timeout="15 minutes",  
-)         
-# Be aware of scheduler_timeout. In this case, if no Dask client (e.g. Prefect 
-# Dask Executor) has connected to the Dask scheduler in 15 minutes, the Dask 
+    scheduler_timeout="15 minutes",
+)
+# Be aware of scheduler_timeout. In this case, if no Dask client (e.g. Prefect
+# Dask Executor) has connected to the Dask scheduler in 15 minutes, the Dask
 # cluster will terminate. For development, you may want to increase this timeout.
-        
+
 
 @task
 def times_two(x):
@@ -112,17 +112,17 @@ def times_two(x):
 def get_sum(x_list):
     return sum(x_list)
 
-                        
+
 with Flow("Dask Cloud Provider Test") as flow:
     x = Parameter("x", default=[1, 2, 3])
     y = times_two.map(x)
     results = get_sum(y)
 
-flow.run(executor=DaskExecutor(cluster.scheduler.address), 
+flow.run(executor=DaskExecutor(cluster.scheduler.address),
          parameters={"x": list(range(10))})
 
 # Tear down the Dask cluster. If you're developing and testing your flow you would
-# not do this after each Flow run, but when you're done developing and testing. 
+# not do this after each Flow run, but when you're done developing and testing.
 cluster.close()
 ```
 
@@ -147,13 +147,13 @@ The Dask Cloud Provider environment has no setup step because it has no infrastr
 
 Create a new cluster consisting of one Dask scheduler and one or more Dask workers on your
 cloud provider. By default, `DaskCloudProviderEnvironment` will use the same Docker image
-as your Flow for the Dask scheduler and worker. This ensures that the Dask workers have the 
-same dependencies (python modules, etc.) as the environment where the Flow runs. This drastically 
+as your Flow for the Dask scheduler and worker. This ensures that the Dask workers have the
+same dependencies (python modules, etc.) as the environment where the Flow runs. This drastically
 simplifies dependency management and avoids the need for separately distributing softare
 to Dask workers.
 
-Following creation of the Dask cluster, the Flow will be run using the 
-[Dask Executor](/api/latest/engine/executors.html#daskexecutor) pointed 
+Following creation of the Dask cluster, the Flow will be run using the
+[Dask Executor](/api/latest/engine/executors.html#daskexecutor) pointed
 to the newly-created Dask cluster. All Task execution will take place on the
 Dask workers.
 
@@ -163,9 +163,9 @@ Dask workers.
 
 The following example will execute your Flow on a cluster that uses Dask's adaptive scaling
 to dynamically select the number of workers based on load of the Flow. The cluster
-will start with a single worker and dynamically scale up to five workers as needed. 
+will start with a single worker and dynamically scale up to five workers as needed.
 
-:::tip Dask Adaptive Mode vs. Fixed Number of Workers    
+:::tip Dask Adaptive Mode vs. Fixed Number of Workers
 While letting Dask dynamically choose the number of workers with adaptive mode is
 attractive, the slow startup time of Fargate workers may cause Dask to quickly request
 the maximum number of workers. You may find that manually specifying the number of
@@ -203,7 +203,7 @@ def times_two(x):
 def get_sum(x_list):
     return sum(x_list)
 
-                        
+
 with Flow("Dask Cloud Provider Test", environment=environment) as flow:
     x = Parameter("x", default=[1, 2, 3])
     y = times_two.map(x)
@@ -220,7 +220,7 @@ that will get passed to the constructor of the provider class from Dask Cloud Pr
 
 - TLS ecryption requires that the cert, key, and CA files are available in the Flow's Docker image
 
-- The `scheduler_extra_args` and `worker_extra_args` kwargs are not yet available in Dask Cloud Provider, 
+- The `scheduler_extra_args` and `worker_extra_args` kwargs are not yet available in Dask Cloud Provider,
 but there is an [open pull request](https://github.com/dask/dask-cloudprovider/pull/91) to include them.
 
 ```python
@@ -291,7 +291,7 @@ def times_two(x):
 def get_sum(x_list):
     return sum(x_list)
 
-                        
+
 with Flow("DaskCloudProviderEnvironment Test", environment=environment) as flow:
     x = Parameter("x", default=list(range(10)))
     y = times_two.map(x)

--- a/docs/orchestration/execution/dask_k8s_environment.md
+++ b/docs/orchestration/execution/dask_k8s_environment.md
@@ -1,4 +1,4 @@
-# Dask Kubernetes Environment <Badge text="Cloud"/>
+# Dask Kubernetes Environment
 
 [[toc]]
 
@@ -75,6 +75,10 @@ roleRef:
 ```
 
 #### Setup
+
+::: warning Deprecated
+As of version `0.11.3` setting `docker_secret` and `private_registry` is deprecated. Image pull secrets should be set on custom YAML for the scheduler and worker pods. For more information on Kubernetes imagePullSecets go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
+:::
 
 The Dask Kubernetes environment setup step is responsible for checking the [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for a provided `docker_secret` only if `private_registry=True`. If the Kubernetes Secret is not found then it will attempt to create one based off of the value set in the Prefect Secret matching the name specified for `docker_secret`.
 

--- a/docs/orchestration/execution/fargate_task_environment.md
+++ b/docs/orchestration/execution/fargate_task_environment.md
@@ -1,4 +1,4 @@
-# Fargate Task Environment <Badge text="Cloud"/>
+# Fargate Task Environment
 
 [[toc]]
 

--- a/docs/orchestration/execution/k8s_job_environment.md
+++ b/docs/orchestration/execution/k8s_job_environment.md
@@ -1,4 +1,4 @@
-# Kubernetes Job Environment <Badge text="Cloud"/>
+# Kubernetes Job Environment
 
 [[toc]]
 

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -3,6 +3,7 @@ import json
 import uuid
 from os import path
 from typing import Any, Callable, List
+import warnings
 
 import cloudpickle
 import yaml
@@ -51,10 +52,10 @@ class DaskKubernetesEnvironment(Environment):
             Only used when a custom scheduler spec is not provided. Enabling this may cause ClientErrors
             to appear when multiple Dask workers try to run the same Prefect Task.
         - scheduler_logs (bool, optional): log all Dask scheduler logs, defaults to False
-        - private_registry (bool, optional): a boolean specifying whether your Flow's Docker container will be in a private
+        - private_registry (bool, optional, DEPRECATED): a boolean specifying whether your Flow's Docker container will be in a private
             Docker registry; if so, requires a Prefect Secret containing your docker credentials to be set.
             Defaults to `False`.
-        - docker_secret (str, optional): the name of the Prefect Secret containing your Docker credentials; defaults to
+        - docker_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing your Docker credentials; defaults to
             `"DOCKER_REGISTRY_CREDENTIALS"`.  This Secret should be a dictionary containing the following keys: `"docker-server"`,
             `"docker-username"`, `"docker-password"`, and `"docker-email"`.
         - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
@@ -86,6 +87,11 @@ class DaskKubernetesEnvironment(Environment):
         self.private_registry = private_registry
         if self.private_registry:
             self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
+
+            warnings.warn(
+                "The `private_registry` and `docker_secret` options are deprecated. Please set `imagePullSecrets` on custom work and scheduler YAML manifests.",
+                stacklevel=2,
+            )
         else:
             self.docker_secret = None  # type: ignore
         self.scheduler_spec_file = scheduler_spec_file


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Deprecates kwargs used in the setup step of this environment and updates documentation.


## Why is this PR important?
This method uses an outdated secret access methodology that we do not recommend. Instead users should opt for directly adding `imagePullSecrets` to their worker and scheduler yaml.

