### PR TITLE
Use host IP for `hostname` label in cases where `LocalAgent` is in container using host network

### DIFF
--- a/changes/issue2618.yaml
+++ b/changes/issue2618.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - Use host IP for `hostname` label in cases where `LocalAgent` is in container using host network - [#2618](https://github.com/PrefectHQ/prefect/issues/2618)

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -74,6 +74,11 @@ class LocalAgent(Agent):
             no_cloud_logs=no_cloud_logs,
         )
         hostname = socket.gethostname()
+
+        # Resolve common Docker hostname by using IP
+        if hostname == "docker-desktop":
+            hostname = socket.gethostbyname(hostname)
+
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -73,6 +73,14 @@ def test_local_agent_config_options_hostname(runner_token):
         }
 
 
+def test_local_agent_uses_ip_if_dockerdesktop_hostname(monkeypatch, runner_token):
+    monkeypatch.setattr("socket.gethostname", MagicMock(return_value="docker-desktop"))
+    monkeypatch.setattr("socket.gethostbyname", MagicMock(return_value="IP"))
+
+    agent = LocalAgent()
+    assert "IP" in agent.labels
+
+
 def test_populate_env_vars_uses_user_provided_env_vars(runner_token):
     with set_temporary_config(
         {


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2618 
Uses the host IP when running LocalAgent inside of a docker container that is using the host network


## Why is this PR important?
Would lead to agents attempting to pull runs from other containers due to this constant hostname

