### PR TITLE
A few cleanups to the k8s agent resource manager

### DIFF
--- a/changes/issue1588.yaml
+++ b/changes/issue1588.yaml
@@ -1,0 +1,2 @@
+fix:
+  - Kubernetes agent resource manager is more strict about what resources it manages - [#2641](https://github.com/PrefectHQ/prefect/pull/2641)

--- a/changes/issue1588.yaml
+++ b/changes/issue1588.yaml
@@ -1,2 +1,5 @@
 fix:
   - Kubernetes agent resource manager is more strict about what resources it manages - [#2641](https://github.com/PrefectHQ/prefect/pull/2641)
+
+breaking:
+  - Kubernetes labels associated with Prefect flow runs now have a `prefect.io/` prefix (e.g. `prefect.io/identifier`) - [#2641](https://github.com/PrefectHQ/prefect/pull/2641)

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -140,7 +140,6 @@ class KubernetesAgent(Agent):
 
         # Populate job metadata for identification
         k8s_labels = {
-            "prefect.io/app": job_name,
             "prefect.io/identifier": identifier,
             "prefect.io/flow_run_id": flow_run.id,  # type: ignore
             "prefect.io/flow_id": flow_run.flow.id,  # type: ignore

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -139,16 +139,15 @@ class KubernetesAgent(Agent):
         job_name = "prefect-job-{}".format(identifier)
 
         # Populate job metadata for identification
+        k8s_labels = {
+            "prefect.io/app": job_name,
+            "prefect.io/identifier": identifier,
+            "prefect.io/flow_run_id": flow_run.id,  # type: ignore
+            "prefect.io/flow_id": flow_run.flow.id,  # type: ignore
+        }
         job["metadata"]["name"] = job_name
-        job["metadata"]["labels"]["app"] = job_name
-        job["metadata"]["labels"]["identifier"] = identifier
-        job["metadata"]["labels"]["flow_run_id"] = flow_run.id  # type: ignore
-        job["metadata"]["labels"]["flow_id"] = flow_run.flow.id  # type: ignore
-        job["spec"]["template"]["metadata"]["labels"]["app"] = job_name
-        job["spec"]["template"]["metadata"]["labels"][
-            "flow_run_id"
-        ] = flow_run.id  # type: ignore
-        job["spec"]["template"]["metadata"]["labels"]["identifier"] = identifier
+        job["metadata"]["labels"].update(**k8s_labels)
+        job["spec"]["template"]["metadata"]["labels"].update(**k8s_labels)
 
         # Use flow storage image for job
         job["spec"]["template"]["spec"]["containers"][0]["image"] = (

--- a/src/prefect/agent/kubernetes/resource_manager.py
+++ b/src/prefect/agent/kubernetes/resource_manager.py
@@ -70,7 +70,9 @@ class ResourceManager:
         batch_client = self.k8s_client.BatchV1Api()
 
         try:
-            jobs = batch_client.list_namespaced_job(namespace=self.namespace)
+            jobs = batch_client.list_namespaced_job(
+                namespace=self.namespace, label_selector="prefect.io/identifier",
+            )
         except self.k8s_client.rest.ApiException:
             self.logger.exception(
                 "Error attempting to list jobs in namespace {}".format(self.namespace)
@@ -80,7 +82,7 @@ class ResourceManager:
         for job in jobs.items:
             if job.status.succeeded or job.status.failed:
 
-                identifier = job.metadata.labels.get("identifier")
+                identifier = job.metadata.labels.get("prefect.io/identifier")
                 name = job.metadata.name
 
                 if job.status.failed:
@@ -121,7 +123,7 @@ class ResourceManager:
         try:
             pods = core_client.list_namespaced_pod(
                 namespace=self.namespace,
-                label_selector="identifier={}".format(identifier),
+                label_selector="prefect.io/identifier={}".format(identifier),
             )
         except self.k8s_client.rest.ApiException:
             self.logger.exception(
@@ -167,7 +169,7 @@ class ResourceManager:
             self.client.write_run_logs(
                 [
                     dict(
-                        flow_run_id=pod.metadata.labels.get("flow_run_id"),
+                        flow_run_id=pod.metadata.labels.get("prefect.io/flow_run_id"),
                         timestamp=pendulum.now("UTC").isoformat(),
                         name="resource-manager",
                         message=logs,
@@ -178,71 +180,6 @@ class ResourceManager:
             )
         except HTTPError as exc:
             self.logger.exception(exc)
-
-    def report_unknown_pod(self, pod: "kubernetes.client.V1Pod") -> None:
-        """
-        Write cloud log of pods that entered unknonw states
-        """
-        # deferred import to reduce import time for prefect
-        from requests.exceptions import HTTPError
-
-        name = pod.metadata.name
-        self.logger.info(
-            "Reporting unknown pod {} in namespace {}".format(name, self.namespace)
-        )
-
-        try:
-            self.client.write_run_logs(
-                [
-                    dict(
-                        flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                        timestamp=pendulum.now("UTC").isoformat(),
-                        name="resource-manager",
-                        message="Flow run pod {} entered an unknown state in namespace {}".format(
-                            name, self.namespace
-                        ),
-                        level="ERROR",
-                        info={},
-                    )
-                ]
-            )
-        except HTTPError as exc:
-            self.logger.exception(exc)
-
-    def report_pod_image_pull_error(self, pod: "kubernetes.client.V1Pod") -> None:
-        """
-        Write cloud log of pods that ahd image pull errors
-        """
-        # deferred import to reduce import time for prefect
-        from requests.exceptions import HTTPError
-
-        for status in pod.status.container_statuses:
-            waiting = status.state.waiting
-
-            if waiting and waiting.reason == "ImagePullBackoff":
-                self.logger.info(
-                    "Reporting image pull error for pod {} in namespace {}".format(
-                        pod.metadata.name, self.namespace
-                    )
-                )
-
-                try:
-                    self.client.write_run_logs(
-                        [
-                            dict(
-                                flow_run_id=pod.metadata.labels.get("flow_run_id"),
-                                timestamp=pendulum.now("UTC").isoformat(),
-                                name="resource-manager",
-                                message="Flow run image pull error for pod {} in namespace {}".format(
-                                    pod.metadata.name, self.namespace
-                                ),
-                                level="ERROR",
-                                info={},
-                            )
-                        ]
-                    )
-                except HTTPError as exc:
-                    self.logger.exception(exc)
 
 
 if __name__ == "__main__":

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -226,11 +226,12 @@ class KubernetesJobEnvironment(Environment):
             yaml_obj["spec"]["template"]["metadata"]["labels"] = {}
 
         # Populate metadata label fields
-        yaml_obj["metadata"]["labels"]["identifier"] = self.identifier_label
-        yaml_obj["metadata"]["labels"]["flow_run_id"] = flow_run_id
-        yaml_obj["spec"]["template"]["metadata"]["labels"][
-            "identifier"
-        ] = self.identifier_label
+        k8s_labels = {
+            "prefect.io/identifier": self.identifier_label,
+            "prefect.io/flow_run_id": flow_run_id,
+        }
+        yaml_obj["metadata"]["labels"].update(k8s_labels)
+        yaml_obj["spec"]["template"]["metadata"]["labels"].update(k8s_labels)
 
         # Required Cloud environment variables
         env_values = [

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -132,9 +132,12 @@ def test_k8s_agent_replace_yaml_uses_user_env_vars(
         agent = KubernetesAgent(env_vars=dict(AUTH_THING="foo", PKG_SETTING="bar"))
         job = agent.replace_job_spec_yaml(flow_run)
 
-        assert job["metadata"]["labels"]["flow_run_id"] == "id"
-        assert job["metadata"]["labels"]["flow_id"] == "new_id"
-        assert job["spec"]["template"]["metadata"]["labels"]["flow_run_id"] == "id"
+        assert job["metadata"]["labels"]["prefect.io/flow_run_id"] == "id"
+        assert job["metadata"]["labels"]["prefect.io/flow_id"] == "new_id"
+        assert (
+            job["spec"]["template"]["metadata"]["labels"]["prefect.io/flow_run_id"]
+            == "id"
+        )
         assert (
             job["spec"]["template"]["spec"]["containers"][0]["image"] == "test/name:tag"
         )
@@ -187,9 +190,12 @@ def test_k8s_agent_replace_yaml(monkeypatch, runner_token, cloud_api):
         agent = KubernetesAgent()
         job = agent.replace_job_spec_yaml(flow_run)
 
-        assert job["metadata"]["labels"]["flow_run_id"] == "id"
-        assert job["metadata"]["labels"]["flow_id"] == "new_id"
-        assert job["spec"]["template"]["metadata"]["labels"]["flow_run_id"] == "id"
+        assert job["metadata"]["labels"]["prefect.io/flow_run_id"] == "id"
+        assert job["metadata"]["labels"]["prefect.io/flow_id"] == "new_id"
+        assert (
+            job["spec"]["template"]["metadata"]["labels"]["prefect.io/flow_run_id"]
+            == "id"
+        )
         assert (
             job["spec"]["template"]["spec"]["containers"][0]["image"] == "test/name:tag"
         )

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -280,10 +280,13 @@ def test_populate_job_yaml():
     assert yaml_obj["metadata"]["name"] == "prefect-dask-job-{}".format(
         environment.identifier_label
     )
-    assert yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
-    assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
     assert (
-        yaml_obj["spec"]["template"]["metadata"]["labels"]["identifier"]
+        yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+        == environment.identifier_label
+    )
+    assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
+    assert (
+        yaml_obj["spec"]["template"]["metadata"]["labels"]["prefect.io/identifier"]
         == environment.identifier_label
     )
 
@@ -325,8 +328,11 @@ def test_populate_worker_pod_yaml():
         with prefect.context(flow_run_id="id_test", image="my_image"):
             yaml_obj = environment._populate_worker_pod_yaml(yaml_obj=pod)
 
-    assert yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
-    assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
+    assert (
+        yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+        == environment.identifier_label
+    )
+    assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
 
     env = yaml_obj["spec"]["containers"][0]["env"]
 
@@ -399,8 +405,11 @@ def test_populate_custom_worker_spec_yaml(log_flag):
         with prefect.context(flow_run_id="id_test", image="my_image"):
             yaml_obj = environment._populate_worker_spec_yaml(yaml_obj=pod)
 
-    assert yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
-    assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
+    assert (
+        yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+        == environment.identifier_label
+    )
+    assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
 
     env = yaml_obj["spec"]["containers"][0]["env"]
 

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -313,11 +313,12 @@ def test_populate_job_yaml():
         assert len(yaml_obj["metadata"]["name"]) == 25
 
         assert (
-            yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
+            yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+            == environment.identifier_label
         )
-        assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
+        assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
         assert (
-            yaml_obj["spec"]["template"]["metadata"]["labels"]["identifier"]
+            yaml_obj["spec"]["template"]["metadata"]["labels"]["prefect.io/identifier"]
             == environment.identifier_label
         )
 
@@ -374,11 +375,12 @@ def test_populate_job_yaml_no_defaults():
                 )
 
         assert (
-            yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
+            yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+            == environment.identifier_label
         )
-        assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
+        assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
         assert (
-            yaml_obj["spec"]["template"]["metadata"]["labels"]["identifier"]
+            yaml_obj["spec"]["template"]["metadata"]["labels"]["prefect.io/identifier"]
             == environment.identifier_label
         )
 
@@ -442,11 +444,12 @@ def test_populate_job_yaml_multiple_containers():
                 )
 
         assert (
-            yaml_obj["metadata"]["labels"]["identifier"] == environment.identifier_label
+            yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+            == environment.identifier_label
         )
-        assert yaml_obj["metadata"]["labels"]["flow_run_id"] == "id_test"
+        assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
         assert (
-            yaml_obj["spec"]["template"]["metadata"]["labels"]["identifier"]
+            yaml_obj["spec"]["template"]["metadata"]["labels"]["prefect.io/identifier"]
             == environment.identifier_label
         )
 


### PR DESCRIPTION
A few fixes to the k8s agent resource manager

- No longer delete pods explicitly. Deleting a job deletes any directly associated pods, which is all the resource manager should be concerned with. Previously this also had the fun behavior of deleting any non-running pod in a namespace (including pods that were pending or not associated with prefect).
- Only manage jobs that have a `prefect.io/identifier` label. Previously this managed all jobs in a namespace, including those not associated with prefect.
- Update our k8s labels to use a `prefect.io/` prefix, following kubernetes best practices.

Fixes #1588.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)