### PR TITLE
Move worker stealing warning in docs

### DIFF
--- a/docs/core/advanced_tutorials/dask-cluster.md
+++ b/docs/core/advanced_tutorials/dask-cluster.md
@@ -28,16 +28,6 @@ If you'd like to kick the tires on Dask locally, you can [install Dask distribut
 > dask-worker tcp://10.0.0.41:8786
 ```
 
-::: warning Work Stealing
-We highly recommend turning off [Dask work stealing](https://distributed.dask.org/en/latest/work-stealing.html) in your Dask Cluster when executing Prefect flows. This can be done via a environment variable in your Dask Cluster:
-
-```
-DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING="False" # case sensitive
-```
-
-On rare occasions, work stealing can result in tasks attempting to run twice.
-:::
-
 Once you have a cluster up and running, let's deploy a very basic flow that runs on this cluster. This example was repurposed from the [distributed documentation](https://distributed.readthedocs.io/en/latest/web.html#example-computation):
 
 ```python

--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -153,9 +153,9 @@ mutation {
 ```
 
 ::: warning Dask Work Stealing with Version Locking
-**If you are using Dask**, we recommend turning off [Dask work stealing](https://distributed.dask.org/en/latest/work-stealing.html) if you enable version locking, as in rare occasions work stealing can result in tasks attempting to run twice which breaks the idempotency constraint of version locking.
+**If you are using Dask**, you might consider turning off [Dask work stealing](https://distributed.dask.org/en/latest/work-stealing.html) if you enable version locking. In rare occasions work stealing can result in tasks attempting to run twice. Though the version locking feature will prevent this from happening, you may experience a lot of log noise and inefficient re-submissions of the flow run when it occurs.
 
-This can be done via an environment variable in your Dask Cluster:
+You can turn off Dask worker stealing via an environment variable in your Dask Cluster:
 
 ```DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING="False" # case sensitive```
 :::

--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -152,6 +152,14 @@ mutation {
 }
 ```
 
+::: warning Dask Work Stealing with Version Locking
+**If you are using Dask**, we recommend turning off [Dask work stealing](https://distributed.dask.org/en/latest/work-stealing.html) if you enable version locking, as in rare occasions work stealing can result in tasks attempting to run twice which breaks the idempotency constraint of version locking.
+
+This can be done via an environment variable in your Dask Cluster:
+
+```DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING="False" # case sensitive```
+:::
+
 ## Scheduling
 
 If a flow has a `schedule` attached, then the Prefect API can [automatically](services.html#scheduler) create new flow runs according to that schedule. In addition, if any of the schedule's clocks have `parameter_defaults` set they will be passed to each flow run generated from that clock (see the corresponding [Schedule documentation here](../../core/concepts/schedules.html#varying-parameter-values)).


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [n/a] adds new tests (if appropriate)
- [n/a] add a changelog entry in the `changes/` directory (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Move the warning about dask worker stealing to under the docs on version locking, since it is only relevant in that case.


## Why is this PR important?
People deploying on Dask are probably reading our deployment tutorial first, but are unsure if enabling worker stealing (which they are likely prefer to optimize their Dask cluster later) is the source of any other issues they might have.

