### PR TITLE
Remove reference to `graphql/alpha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Released on May 19, 2020.
 - Allow log configuration in Fargate Agent - [#2589](https://github.com/PrefectHQ/prefect/pull/2589)
 - Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
 - Show a warning when tasks are created in a flow context but not added to a flow - [#2584](https://github.com/PrefectHQ/prefect/pull/2584)
+- Update GraphQL endpoint to `/graphql` - [#2651](https://github.com/PrefectHQ/prefect/pull/2651)
 
 ### Server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Released on May 19, 2020.
 - Allow log configuration in Fargate Agent - [#2589](https://github.com/PrefectHQ/prefect/pull/2589)
 - Reuse `prefect.context` for opening `Flow` contexts - [#2581](https://github.com/PrefectHQ/prefect/pull/2581)
 - Show a warning when tasks are created in a flow context but not added to a flow - [#2584](https://github.com/PrefectHQ/prefect/pull/2584)
-- Update GraphQL endpoint to `/graphql` - [#2651](https://github.com/PrefectHQ/prefect/pull/2651)
 
 ### Server
 

--- a/changes/pr2651.yaml
+++ b/changes/pr2651.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - Update GraphQL endpoint to `/graphql` - [#2651](https://github.com/PrefectHQ/prefect/pull/2651)

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -53,7 +53,7 @@ endpoint = "${server.host}:${server.port}"
 [cloud]
 api = "${${backend}.endpoint}"
 endpoint = "https://api.prefect.io"
-graphql = "${cloud.api}/graphql/alpha"
+graphql = "${cloud.api}/graphql"
 use_local_secrets = true
 heartbeat_interval = 30.0
 diagnostics = false


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR removes an old reference to `graphql/alpha` endpoint in favor of `graphql`. Requests to `graphql/alpha` will still work.


## Why is this PR important?


