### PR TITLE
Add direct option to set imagePullSecrets on DaskKubernetesEnvironment

### DIFF
--- a/changes/pr2657.yaml
+++ b/changes/pr2657.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add option to set `image_pull_secret` directly on `DaskKubernetesEnvironment` - [#2657](https://github.com/PrefectHQ/prefect/pull/2657)"
+
+fix:
+  - "Fix `DaskKubernetesEnvironment` requiring that an `env` block is set when using custom specs - [#2657](https://github.com/PrefectHQ/prefect/pull/2657)"

--- a/docs/orchestration/execution/dask_k8s_environment.md
+++ b/docs/orchestration/execution/dask_k8s_environment.md
@@ -20,9 +20,9 @@ The `DaskKubernetesEnvironment` can optionally accept two worker-dependent argum
 If you do not want your Dask cluster to automatically scale the number of workers between the bounds of `min_workers` and `max_workers` then set the two options to the same value.
 :::
 
-When deploying your flows to a private container registry, you should set the `private_registry` kwarg to `True`. You should also provide the name of a Prefect Secret to the `docker_secret` kwarg, which otherwise defaults to _DOCKER_REGISTRY_CREDENTIALS_. This secret should be a dictionary containing the following keys: `"docker-server"`, `"docker-username"`, `"docker-password"`, and `"docker-email"`. This is necessary because the relevant Kubernetes `imagePullSecret` will be automatically created if it does not already exist.
-
-_For more information on setting Prefect Secrets visit the relevant [concept documentation](/core/concepts/secrets.html#overview)._
+:::warning Private Registries
+When running your flows that are registered with a private container registry, you should either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment` or directly set the `imagePullSecrets` on your custom worker/scheduler specs.
+:::
 
 **Custom Configuration:**
 
@@ -77,7 +77,7 @@ roleRef:
 #### Setup
 
 ::: warning Deprecated
-As of version `0.11.3` setting `docker_secret` and `private_registry` is deprecated. Image pull secrets should be set on custom YAML for the scheduler and worker pods. For more information on Kubernetes imagePullSecets go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
+As of version `0.11.3` setting `docker_secret` and `private_registry` is deprecated. Image pull secrets should be set on custom YAML for the scheduler and worker pods or directly through the `image_pull_secret` kwarg. For more information on Kubernetes imagePullSecets go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
 :::
 
 The Dask Kubernetes environment setup step is responsible for checking the [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for a provided `docker_secret` only if `private_registry=True`. If the Kubernetes Secret is not found then it will attempt to create one based off of the value set in the Prefect Secret matching the name specified for `docker_secret`.

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -510,7 +510,11 @@ class DaskKubernetesEnvironment(Environment):
         ]
 
         # set environment variables
-        env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
+        env = yaml_obj["spec"]["template"]["spec"]["containers"][0].get("env")
+        if not env:
+            yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"] = {}
+            env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
+
         env.extend(env_values)
 
         # set image
@@ -566,7 +570,11 @@ class DaskKubernetesEnvironment(Environment):
         ]
 
         # set environment variables
-        env = yaml_obj["spec"]["containers"][0]["env"]
+        env = yaml_obj["spec"]["containers"][0].get("env")
+        if not env:
+            yaml_obj["spec"]["containers"][0]["env"] = {}
+            env = yaml_obj["spec"]["containers"][0]["env"]
+
         env.extend(env_values)
 
         # set image

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -20,11 +20,9 @@ class DaskKubernetesEnvironment(Environment):
     on Kubernetes by spinning up a temporary Dask Cluster (using [dask-kubernetes](https://kubernetes.dask.org/en/latest/))
     and running the Prefect `DaskExecutor` on this cluster.
 
-    If pulling from a private docker registry, `setup` will ensure the appropriate
-    kubernetes secret exists; `execute` creates a single job that has the role
-    of spinning up a dask executor and running the flow. The job created in the execute
-    function does have the requirement in that it needs to have an `identifier_label`
-    set with a UUID so resources can be cleaned up independently of other deployments.
+    When running your flows that are registered with a private container registry, you
+    should either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment`
+    or directly set the `imagePullSecrets` on your custom worker/scheduler specs.
 
     It is possible to provide a custom scheduler and worker spec YAML files through the `scheduler_spec_file` and
     `worker_spec_file` arguments. These specs (if provided) will be used in place of the defaults. Your spec files
@@ -65,7 +63,7 @@ class DaskKubernetesEnvironment(Environment):
         - scheduler_spec_file (str, optional): Path to a scheduler spec YAML file
         - worker_spec_file (str, optional): Path to a worker spec YAML file
         - image_pull_secret (str, optional): optional name of an `imagePullSecret` to use for the scheduler and worker
-            pods. https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+            pods. For more information go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     """
 
     def __init__(
@@ -389,11 +387,12 @@ class DaskKubernetesEnvironment(Environment):
 
         # set environment variables
         env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
+        pod_spec = yaml_obj["spec"]["template"]["spec"]
         if self.private_registry:
-            pod_spec = yaml_obj["spec"]["template"]["spec"]
             pod_spec["imagePullSecrets"] = []
             pod_spec["imagePullSecrets"].append({"name": namespace + "-docker"})
         elif self.image_pull_secret:
+            pod_spec["imagePullSecrets"] = []
             pod_spec["imagePullSecrets"].append({"name": self.image_pull_secret})
 
         env[0]["value"] = prefect.config.cloud.graphql
@@ -431,12 +430,13 @@ class DaskKubernetesEnvironment(Environment):
         env[2]["value"] = prefect.context.get("flow_run_id", "")
         env[11]["value"] = self._extra_loggers()
 
+        pod_spec = yaml_obj["spec"]
         if self.private_registry:
             namespace = prefect.context.get("namespace", "default")
-            pod_spec = yaml_obj["spec"]
             pod_spec["imagePullSecrets"] = []
             pod_spec["imagePullSecrets"].append({"name": namespace + "-docker"})
         elif self.image_pull_secret:
+            pod_spec["imagePullSecrets"] = []
             pod_spec["imagePullSecrets"].append({"name": self.image_pull_secret})
 
         # set image
@@ -512,7 +512,7 @@ class DaskKubernetesEnvironment(Environment):
         # set environment variables
         env = yaml_obj["spec"]["template"]["spec"]["containers"][0].get("env")
         if not env:
-            yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"] = {}
+            yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"] = []
             env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
 
         env.extend(env_values)
@@ -572,7 +572,7 @@ class DaskKubernetesEnvironment(Environment):
         # set environment variables
         env = yaml_obj["spec"]["containers"][0].get("env")
         if not env:
-            yaml_obj["spec"]["containers"][0]["env"] = {}
+            yaml_obj["spec"]["containers"][0]["env"] = []
             env = yaml_obj["spec"]["containers"][0]["env"]
 
         env.extend(env_values)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
It is now easier to directly specify the name of an `imagePullSecret` to be used for the scheduler and worker pods. *Note* this is only for the quick configuration options and has no effect on custom specs.


## Why is this PR important?
This is a point of confusion and sometimes users do not want to provide custom worker & scheduler specs.

