### PR TITLE
Support creating temporary clusters within DaskExecutor

### DIFF
--- a/changes/pr2667.yaml
+++ b/changes/pr2667.yaml
@@ -1,0 +1,6 @@
+enhancement:
+  - "Support creating temporary dask clusters from within a `DaskExecutor` - [#2667](https://github.com/PrefectHQ/prefect/pull/2667)"
+  
+deprecation:
+  - "Deprecate `local_processes` and `**kwargs` arguments for `DaskExecutor` - [#2667](https://github.com/PrefectHQ/prefect/pull/2667)"
+  - "Deprecate `address='local'` for `DaskExecutor` - [#2667](https://github.com/PrefectHQ/prefect/pull/2667)"

--- a/docs/core/advanced_tutorials/advanced-mapping.md
+++ b/docs/core/advanced_tutorials/advanced-mapping.md
@@ -237,7 +237,10 @@ print('\n'.join([f'{s.result[0]}: {s}' for s in dialogue_state.map_states[:5]]))
 
 Great - 5 minutes isn't so bad! An astute reader might notice that each mapped task is ["embarrassingly parallel"](https://en.wikipedia.org/wiki/Embarrassingly_parallel). When running locally, Prefect will default to synchronous execution (with the `Synchronous` executor), so this property was not taken advantage of during execution.
 
-In order to allow for parallel execution of tasks, we don't need to "recompile" our flow: we provide an executor which can handle parallelism in our call to `run`. In the local case, Prefect offers the `DaskExecutor` for executing parallel flows. These execution pipelines can either spawn new processes (`local_processes=True`), or only use threads; we have chosen to use `local_processes=True` in our example below.
+In order to allow for parallel execution of tasks, we don't need to "recompile"
+our flow: we provide an executor which can handle parallelism in our call to
+`run`. In the local case, Prefect offers the `DaskExecutor` for executing
+parallel flows.
 
 :::tip What is an executor, anyway?
 A Prefect executor is the core driver of computation - an executor specifies _how_ and _where_ each task in a flow should be run.
@@ -252,7 +255,7 @@ If you are following along and executing the code locally, it is recommended you
 ```python
 from prefect.engine.executors import DaskExecutor
 
-executor = DaskExecutor(local_processes=True)
+executor = DaskExecutor()
 
 %%time
 scraped_state = flow.run(parameters={"url": "http://www.insidethex.co.uk/"},

--- a/docs/core/advanced_tutorials/dask-cluster.md
+++ b/docs/core/advanced_tutorials/dask-cluster.md
@@ -101,7 +101,10 @@ from prefect.engine.executors import DaskExecutor
 
 gateway = Gateway()
 cluster = gateway.new_cluster()
-executor = DaskExecutor(address=cluster.scheduler_address, security=cluster.security)
+executor = DaskExecutor(
+    address=cluster.scheduler_address,
+    client_kwargs={"security": cluster.security}
+)
 flow.run(executor=executor)
 ```
 
@@ -114,7 +117,10 @@ from prefect.engine.executors import DaskExecutor
 # ...flow definition...
 
 security = GatewaySecurity(tls_cert="path-to-cert", tls_key="path-to-key")
-executor = DaskExecutor(address="a-scheduler-address", security=security)
+executor = DaskExecutor(
+    address="a-scheduler-address",
+    client_kwargs={"security": security}
+)
 flow.run(executor=executor)
 ```
 

--- a/docs/core/advanced_tutorials/local-debugging.md
+++ b/docs/core/advanced_tutorials/local-debugging.md
@@ -52,10 +52,9 @@ You can set the `LocalDaskExecutor` to be the default executor on your local mac
 
 #### `DaskExecutor`
 
-Lastly, if your issue is actually related to parallelism, you'll _need_ to use the `DaskExecutor`. There are two initialization keyword arguments that are useful to know about when debugging:
-
-- `local_processes`, which is a boolean specifying whether you want to use multiprocessing or not. The default for this flag is `False`. Try toggling it to see if your issue is related to multiprocessing or multithreading!
-- `debug`, which is another boolean for setting the logging level of `dask.distributed`; the default value is set from your Prefect configuration file and should be `True` to get the most verbose output from `dask`'s logs.
+Lastly, if your issue is actually related to parallelism, you'll _need_ to use
+the `DaskExecutor`. By default prefect silences the Dask logs, to reenable
+them, pass `debug=True`.
 
 ### Raising Exceptions in realtime
 

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -56,22 +56,20 @@ def consistency_check(obj, obj_name):
         .union(varkwargs)
     )
 
-    # Strip `**kwargs` to allow forwarding kwargs to underlying implementations,
-    # or deprecating existing functionality
-    undocumented = actual_args.difference(doc_args).difference({"**kwargs"})
+    undocumented = actual_args.difference(doc_args)
     # If the sig contains **kwargs, any keyword is valid
     if any(k.startswith("**") for k in actual_args):
-        non_existant = {}
+        non_existent = {}
     else:
-        non_existant = doc_args.difference(actual_args)
+        non_existent = doc_args.difference(actual_args)
 
     if undocumented:
         undoc_args = ", ".join(undocumented)
         raise ValueError(
             f"{obj_name} has arguments without documentation: {undoc_args}"
         )
-    elif non_existant:
-        undoc_args = ", ".join(non_existant)
+    elif non_existent:
+        undoc_args = ", ".join(non_existent)
         raise ValueError(
             f"{obj_name} has documentation for arguments that aren't real: {undoc_args}"
         )

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -139,11 +139,11 @@ checkpointing = false
     default_class = "prefect.engine.executors.LocalExecutor"
 
         [engine.executor.dask]
-        # the default scheduler address for the DaskExecutor. Set to "local" to configure
-        # a LocalCluster
-        address = "local"
-        # whether to use multiprocessing or not (only applied if address is "local")
-        local_processes = false
+        # the default scheduler address for the DaskExecutor.
+        address = ""
+
+        # the default Cluster class to use to create a temporary dask cluster
+        cluster_class = "distributed.deploy.local.LocalCluster"
 
     [engine.flow_runner]
     # the default flow runner, specified using a full path

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Union
 
 from prefect import context
 from prefect.engine.executors.base import Executor
-from prefect.utilities.serialization import from_qualified_name
+from prefect.utilities.importtools import import_object
 
 if TYPE_CHECKING:
     import dask
@@ -127,7 +127,7 @@ class DaskExecutor(Executor):
             if cluster_class is None:
                 cluster_class = context.config.engine.executor.dask.cluster_class
             if isinstance(cluster_class, str):
-                cluster_class = from_qualified_name(cluster_class)
+                cluster_class = import_object(cluster_class)
             if cluster_kwargs is None:
                 cluster_kwargs = {}
             else:

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -1,62 +1,172 @@
 import logging
 import uuid
+import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Union
 
 from prefect import context
 from prefect.engine.executors.base import Executor
+from prefect.utilities.serialization import from_qualified_name
 
 if TYPE_CHECKING:
     import dask
     from distributed import Future
 
 
+# XXX: remove when deprecation of DaskExecutor kwargs is done
+_valid_client_kwargs = {
+    "timeout",
+    "set_as_default",
+    "scheduler_file",
+    "security",
+    "name",
+    "direct_to_workers",
+    "heartbeat_interval",
+}
+
+
 class DaskExecutor(Executor):
     """
-    An executor that runs all functions using the `dask.distributed` scheduler on
-    a (possibly local) dask cluster.  If you already have one running, provide the
-    address of the scheduler upon initialization; otherwise, one will be created
-    (and subsequently torn down) within the `start()` contextmanager.
+    An executor that runs all functions using the `dask.distributed` scheduler.
 
-    Note that if you have tasks with tags of the form `"dask-resource:KEY=NUM"` they will be parsed
-    and passed as [Worker Resources](https://distributed.dask.org/en/latest/resources.html) of the form
-    `{"KEY": float(NUM)}` to the Dask Scheduler.
+    By default a temporary `distributed.LocalCluster` is created (and
+    subsequently torn down) within the `start()` contextmanager. To use a
+    different cluster class (e.g.
+    [`dask_kubernetes.KubeCluster`](https://kubernetes.dask.org/)), you can
+    specify `cluster_class`/`cluster_kwargs`.
+
+    Alternatively, if you already have a dask cluster running, you can provide
+    the address of the scheduler via the `address` kwarg.
+
+    Note that if you have tasks with tags of the form `"dask-resource:KEY=NUM"`
+    they will be parsed and passed as
+    [Worker Resources](https://distributed.dask.org/en/latest/resources.html)
+    of the form `{"KEY": float(NUM)}` to the Dask Scheduler.
 
     Args:
         - address (string, optional): address of a currently running dask
-            scheduler; if one is not provided, a `distributed.LocalCluster()` will be created in `executor.start()`.
-            Defaults to `None`
-        - local_processes (bool, optional): whether to use multiprocessing or not
-            (computations will still be multithreaded). Ignored if address is provided.
-            Defaults to `False`.
-        - debug (bool, optional): whether to operate in debug mode; `debug=True`
-            will produce many additional dask logs. Defaults to the `debug` value in your Prefect configuration
-        - **kwargs (dict, optional): additional kwargs to be passed to the [`dask.distributed.Client`](https://distributed.dask.org/en/latest/api.html#client) upon 
-            initialization (e.g., `n_workers`, `security`, etc.), which will also pass any unmatched kwargs down to child objects such as 
-            [`distributed.deploy.local.LocalCluster`](https://docs.dask.org/en/latest/setup/single-distributed.html#distributed.deploy.local.LocalCluster).
-            Please see the Dask docs to see all of the options that child objects will respond to.
+            scheduler; if one is not provided, a temporary cluster will be
+            created in `executor.start()`.  Defaults to `None`.
+        - cluster_class (string or callable, optional): the cluster class to use
+            when creating a temporary dask cluster. Can be either the full
+            class name (e.g. `"distributed.LocalCluster"`), or the class itself.
+        - cluster_kwargs (dict, optional): addtional kwargs to pass to the
+           `cluster_class` when creating a temporary dask cluster.
+        - client_kwargs (dict, optional): additional kwargs to use when creating a
+            [`dask.distributed.Client`](https://distributed.dask.org/en/latest/api.html#client).
+        - debug (bool, optional): When running with a local cluster, setting
+            `debug=True` will increase dask's logging level, providing
+            potentially useful debug info. Defaults to the `debug` value in
+            your Prefect configuration.
+
+    Example:
+
+    Using a temporary local dask cluster:
+
+    ```python
+    executor = DaskExecutor()
+    ```
+
+    Using a temporary cluster running elsewhere. Any Dask cluster class should
+    work, here we use [dask-cloudprovider](https://cloudprovider.dask.org):
+
+    ```python
+    executor = DaskExecutor(
+        cluster_class="dask_cloudprovider.FargateCluster",
+        cluster_kwargs={"image": "prefecthq/prefect:latest", ...},
+    )
+    ```
+
+    Connecting to an existing dask cluster
+
+    ```python
+    executor = DaskExecutor(address="192.0.2.255:8786")
+    ```
     """
 
     def __init__(
         self,
         address: str = None,
-        local_processes: bool = None,
+        cluster_class: Union[str, Callable] = None,
+        cluster_kwargs: dict = None,
+        client_kwargs: dict = None,
         debug: bool = None,
         **kwargs: Any
     ):
         if address is None:
             address = context.config.engine.executor.dask.address
-        if address == "local":
+        if not address:
             address = None
+        # XXX: deprecated
+        if address == "local":
+            warnings.warn(
+                "`address='local'` is deprecated. To use a local cluster, leave the "
+                "`address` field empty."
+            )
+            address = None
+
+        # XXX: deprecated
+        local_processes = kwargs.pop("local_processes", None)
         if local_processes is None:
-            local_processes = context.config.engine.executor.dask.local_processes
-        if debug is None:
-            debug = context.config.debug
+            local_processes = context.config.engine.executor.dask.get(
+                "local_processes", None
+            )
+        if local_processes is not None:
+            warnings.warn(
+                "`local_processes` is deprecated, please use "
+                "`cluster_kwargs={'processes': local_processes}`. The default is "
+                "now `local_processes=True`."
+            )
+
+        if address is not None:
+            if cluster_class is not None or cluster_kwargs is not None:
+                raise ValueError(
+                    "Cannot specify `address` and `cluster_class`/`cluster_kwargs`"
+                )
+        else:
+            if cluster_class is None:
+                cluster_class = context.config.engine.executor.dask.cluster_class
+            if isinstance(cluster_class, str):
+                cluster_class = from_qualified_name(cluster_class)
+            if cluster_kwargs is None:
+                cluster_kwargs = {}
+            else:
+                cluster_kwargs = cluster_kwargs.copy()
+
+            from distributed.deploy.local import LocalCluster
+
+            if cluster_class == LocalCluster:
+                if debug is None:
+                    debug = context.config.debug
+                cluster_kwargs.setdefault(
+                    "silence_logs", logging.CRITICAL if not debug else logging.WARNING
+                )
+                if local_processes is not None:
+                    cluster_kwargs.setdefault("processes", local_processes)
+                for_cluster = set(kwargs).difference(_valid_client_kwargs)
+                if for_cluster:
+                    warnings.warn(
+                        "Forwarding executor kwargs to `LocalCluster` is now handled by the "
+                        "`cluster_kwargs` parameter, please update accordingly"
+                    )
+                    for k in for_cluster:
+                        cluster_kwargs[k] = kwargs.pop(k)
+
+        if client_kwargs is None:
+            client_kwargs = {}
+        if kwargs:
+            warnings.warn(
+                "Forwarding executor kwargs to `Client` is now handled by the "
+                "`client_kwargs` parameter, please update accordingly"
+            )
+            client_kwargs.update(kwargs)
+
         self.address = address
-        self.local_processes = local_processes
-        self.debug = debug
         self.is_started = False
-        self.kwargs = kwargs
+        self.cluster_class = cluster_class
+        self.cluster_kwargs = cluster_kwargs
+        self.client_kwargs = client_kwargs
+
         super().__init__()
 
     @contextmanager
@@ -70,15 +180,17 @@ class DaskExecutor(Executor):
         from distributed import Client
 
         try:
-            if self.address is None:
-                self.kwargs.update(
-                    silence_logs=logging.CRITICAL if not self.debug else logging.WARNING
-                )
-                self.kwargs.update(processes=self.local_processes)
-            with Client(self.address, **self.kwargs) as client:
-                self.client = client
-                self.is_started = True
-                yield self.client
+            if self.address is not None:
+                with Client(self.address, **self.client_kwargs) as client:
+                    self.client = client
+                    self.is_started = True
+                    yield self.client
+            else:
+                with self.cluster_class(**self.cluster_kwargs) as cluster:  # type: ignore
+                    with Client(cluster, **self.client_kwargs) as client:
+                        self.client = client
+                        self.is_started = True
+                        yield self.client
         finally:
             self.client = None
             self.is_started = False
@@ -86,12 +198,12 @@ class DaskExecutor(Executor):
     def _prep_dask_kwargs(self) -> dict:
         dask_kwargs = {"pure": False}  # type: dict
 
-        ## set a key for the dask scheduler UI
+        # set a key for the dask scheduler UI
         if context.get("task_full_name"):
             key = "{}-{}".format(context.get("task_full_name", ""), str(uuid.uuid4()))
             dask_kwargs.update(key=key)
 
-        ## infer from context if dask resources are being utilized
+        # infer from context if dask resources are being utilized
         dask_resource_tags = [
             tag
             for tag in context.get("task_tags", [])
@@ -283,5 +395,5 @@ class LocalDaskExecutor(Executor):
         # import dask here to reduce prefect import times
         import dask
 
-        with dask.config.set(scheduler=self.scheduler, **self.kwargs) as cfg:
+        with dask.config.set(scheduler=self.scheduler, **self.kwargs):
             return dask.compute(futures)[0]

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -61,6 +61,7 @@ class DaskExecutor(Executor):
             `debug=True` will increase dask's logging level, providing
             potentially useful debug info. Defaults to the `debug` value in
             your Prefect configuration.
+        - **kwargs: DEPRECATED
 
     Example:
 
@@ -102,9 +103,7 @@ class DaskExecutor(Executor):
         **kwargs: Any
     ):
         if address is None:
-            address = context.config.engine.executor.dask.address
-        if not address:
-            address = None
+            address = context.config.engine.executor.dask.address or None
         # XXX: deprecated
         if address == "local":
             warnings.warn(

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -1,0 +1,28 @@
+import importlib
+from typing import Any
+
+
+def import_object(name: str) -> Any:
+    """Import an object given a fully-qualified name.
+
+    Args:
+        - name (string): The fully-qualified name of the object to import.
+
+    Returns:
+        - obj: The object that was imported.
+
+    Example:
+
+    ```python
+    >>> obj = import_object("random.randint")
+    >>> import random
+    >>> obj == random.randint
+    True
+    ```
+    """
+    try:
+        mod_name, attr_name = name.rsplit(".", 1)
+        mod = importlib.import_module(mod_name)
+        return getattr(mod, attr_name)
+    except ValueError:
+        return importlib.import_module(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def sync():
 def mproc():
     "Multi-processing executor"
     with Client(processes=True) as client:
-        yield DaskExecutor(client.scheduler.address, local_processes=True)
+        yield DaskExecutor(client.scheduler.address)
         try:
             client.shutdown()
         except:

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -276,6 +276,7 @@ class TestDaskExecutor:
             assert res == 2
 
     def test_cluster_class_and_kwargs(self):
+        pytest.importorskip("distributed.deploy.spec.SpecCluster")
         executor = DaskExecutor(
             cluster_class="distributed.deploy.spec.SpecCluster",
             cluster_kwargs={"some_kwarg": "some_val"},

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -1,0 +1,10 @@
+from prefect.utilities.importtools import import_object
+
+
+def test_import_object():
+    rand = import_object("random")
+    randint = import_object("random.randint")
+    import random
+
+    assert rand is random
+    assert randint is random.randint


### PR DESCRIPTION
This adds support for creating a temporary dask cluster from within a `DaskExecutor`. The cluster class and kwargs can be configured by the `cluster_class` and `cluster_kwargs` keyword arguments. By default, the class is `distributed.LocalCluster`, creating a temporary local cluster.

This also deprecates a few existing arguments:

- Deprecates `local_processes` kwarg to `DaskExecutor`, in favor of `cluster_kwargs={"processes": local_processes}`
- Deprecates `address="local"` in favor of `address=None`.
- Deprecates automatic forwarding of `kwargs` to `Client` in `DaskExecutor`, in favor of `cluster_kwargs` and `client_kwargs`.


Address part of #2508

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)