### PR TITLE
Revert "Revert "Remove reference to `graphql/alpha`""

### DIFF
--- a/changes/pr2669.yaml
+++ b/changes/pr2669.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - Update GraphQL endpoint to `/graphql` - [#2669](https://github.com/PrefectHQ/prefect/pull/2669)

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -53,7 +53,7 @@ endpoint = "${server.host}:${server.port}"
 [cloud]
 api = "${${backend}.endpoint}"
 endpoint = "https://api.prefect.io"
-graphql = "${cloud.api}/graphql/alpha"
+graphql = "${cloud.api}/graphql"
 use_local_secrets = true
 heartbeat_interval = 30.0
 diagnostics = false


### PR DESCRIPTION
This reverts commit 29f5094c71208a94b572ac53ec79ac1e34690cb1.

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
stop referring to /alpha subpath behind /graphql


## Why is this PR important?
the "official" prefect cloud api path