### PR TITLE
Add use of ID field to `get` CLI commands

### DIFF
--- a/changes/pr2671.yaml
+++ b/changes/pr2671.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "Add flow run ID option to `get logs` CLI command - [#2671](https://github.com/PrefectHQ/prefect/pull/2671)"
+  - "Add ID to output of `get` command for `flows` and `flow-runs` - [#2671](https://github.com/PrefectHQ/prefect/pull/2671)"

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -360,18 +360,24 @@ def tasks(name, flow_name, flow_version, project, limit):
 
 @get.command(hidden=True)
 @click.option(
-    "--name", "-n", required=True, help="A flow run name to query", hidden=True
+    "--name", "-n", required=False, help="A flow run name to query", hidden=True
 )
+@click.option("--id", required=False, help="A flow run ID to query", hidden=True)
 @click.option(
     "--info", "-i", is_flag=True, help="Retrieve detailed logging info", hidden=True
 )
-def logs(name, info):
+def logs(name, id, info):
     """
     Query logs for a flow run.
 
+    Note: at least one of `name` or `id` must be specified. If only `name` is set then
+    the most recent flow run with that name will be queried.
+
+
     \b
     Options:
-        --name, -n      TEXT    A flow run name to query        [required]
+        --name, -n      TEXT    A flow run name to query
+        --id            TEXT    A flow run ID to query
         --info, -i              Retrieve detailed logging info
     """
     log_query = {
@@ -395,7 +401,7 @@ def logs(name, info):
             with_args(
                 "flow_run",
                 {
-                    "where": {"name": {"_eq": name}},
+                    "where": {"name": {"_eq": name}, "id": {"_eq": id}},
                     "order_by": {EnumValue("start_time"): EnumValue("desc")},
                 },
             ): log_query

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -77,14 +77,15 @@ def flows(name, version, project, limit, all_versions):
         "name": True,
         "version": True,
         "created": True,
+        "id": True,
     }
 
-    headers = ["NAME", "VERSION", "AGE"]
+    headers = ["NAME", "VERSION", "AGE", "ID"]
 
     if config.backend == "cloud":
         where_clause["_and"]["project"] = {"name": {"_eq": project}}
         query_results["project"] = {"name": True}
-        headers.append("PROJECT NAME")
+        headers.insert(3, "PROJECT NAME")
 
     query = {
         "query": {
@@ -113,9 +114,12 @@ def flows(name, version, project, limit, all_versions):
             item.name,
             item.version,
             pendulum.parse(item.created).diff_for_humans(),
+            item.id,
         ]
-        if project:
-            result_output.append(item.project.name,)
+        if config.backend == "cloud":
+            result_output.insert(
+                3, item.project.name,
+            )
 
         output.append(result_output)
 
@@ -236,6 +240,7 @@ def flow_runs(limit, flow, project, started):
                 "flow_run", {"where": where, "limit": limit, "order_by": order}
             ): {
                 "flow": {"name": True},
+                "id": True,
                 "created": True,
                 "state": True,
                 "name": True,
@@ -264,13 +269,22 @@ def flow_runs(limit, flow, project, started):
                 pendulum.parse(item.created).diff_for_humans(),
                 start_time,
                 item.duration,
+                item.id,
             ]
         )
 
     click.echo(
         tabulate(
             output,
-            headers=["NAME", "FLOW NAME", "STATE", "AGE", "START TIME", "DURATION"],
+            headers=[
+                "NAME",
+                "FLOW NAME",
+                "STATE",
+                "AGE",
+                "START TIME",
+                "DURATION",
+                "ID",
+            ],
             tablefmt="plain",
             numalign="left",
             stralign="left",

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -380,6 +380,10 @@ def logs(name, id, info):
         --id            TEXT    A flow run ID to query
         --info, -i              Retrieve detailed logging info
     """
+    if not name and not id:
+        click.secho("Either --name or --id must be provided", fg="red")
+        return
+
     log_query = {
         with_args("logs", {"order_by": {EnumValue("timestamp"): EnumValue("asc")}}): {
             "timestamp": True,

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -46,6 +46,7 @@ def test_get_flows_server(monkeypatch, server_api):
             name
             version
             created
+            id
         }
     }
     """
@@ -79,6 +80,7 @@ def test_get_flows_cloud(monkeypatch, cloud_api):
                 name
                 version
                 created
+                id
                 project {
                     name
                 }
@@ -123,6 +125,7 @@ def test_get_flows_populated(monkeypatch, cloud_api):
                 name
                 version
                 created
+                id
                 project {
                     name
                 }
@@ -233,6 +236,7 @@ def test_get_flow_runs_server(monkeypatch, server_api):
                 flow {
                     name
                 }
+                id
                 created
                 state
                 name
@@ -275,6 +279,7 @@ def test_get_flow_runs_cloud(monkeypatch, cloud_api):
                 flow {
                     name
                 }
+                id
                 created
                 state
                 name
@@ -321,6 +326,7 @@ def test_get_flow_runs_populated(monkeypatch, cloud_api):
                 flow {
                     name
                 }
+                id
                 created
                 state
                 name
@@ -499,7 +505,7 @@ def test_get_logs(monkeypatch, cloud_api):
 
         query = """
         query {
-            flow_run(where: { name: { _eq: "flow_run" } }, order_by: { start_time: desc }) {
+            flow_run(where: { name: { _eq: "flow_run" }, id: { _eq: null } }, order_by: { start_time: desc }) {
                 logs(order_by: { timestamp: asc }) {
                     timestamp
                     message
@@ -534,7 +540,7 @@ def test_get_logs_info(monkeypatch, cloud_api):
 
         query = """
         query {
-            flow_run(where: { name: { _eq: "flow_run" } }, order_by: { start_time: desc }) {
+            flow_run(where: { name: { _eq: "flow_run" }, id: { _eq: null } }, order_by: { start_time: desc }) {
                 logs(order_by: { timestamp: asc }) {
                     timestamp
                     info
@@ -563,3 +569,74 @@ def test_get_logs_fails(monkeypatch, cloud_api):
         result = runner.invoke(get, ["logs", "--name", "flow_run"])
         assert result.exit_code == 0
         assert "flow_run not found" in result.output
+
+
+def test_get_logs_by_id(monkeypatch, cloud_api):
+    post = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value=dict(
+                    data=dict(
+                        flow_run=[
+                            dict(
+                                logs=[
+                                    {
+                                        "timestamp": "timestamp",
+                                        "level": "level",
+                                        "message": "message",
+                                    }
+                                ]
+                            )
+                        ]
+                    )
+                )
+            )
+        )
+    )
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+
+    with set_temporary_config({"cloud.auth_token": "secret_token"}):
+        runner = CliRunner()
+        result = runner.invoke(get, ["logs", "--id", "id"])
+        assert result.exit_code == 0
+        assert (
+            "TIMESTAMP" in result.output
+            and "LEVEL" in result.output
+            and "MESSAGE" in result.output
+            and "level" in result.output
+        )
+
+        query = """
+        query {
+            flow_run(where: { name: { _eq: null }, id: { _eq: "id" } }, order_by: { start_time: desc }) {
+                logs(order_by: { timestamp: asc }) {
+                    timestamp
+                    message
+                    level
+                }
+                start_time
+            }
+        }
+        """
+
+        assert post.called
+        assert post.call_args[1]["json"]["query"].split() == query.split()
+
+
+def test_get_logs_fails_no_name_or_id(monkeypatch, cloud_api):
+    post = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(return_value=dict(data=dict(flow_run=[])))
+        )
+    )
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+
+    with set_temporary_config({"cloud.auth_token": "secret_token"}):
+        runner = CliRunner()
+        result = runner.invoke(get, ["logs"])
+        assert result.exit_code == 0
+        assert "must be provided" in result.output


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds the option to query for logs based on flow run ID. Previously only querying based on name would return the most recent run of that name. Now it can be more granular.

Also adds the ID to the output of get `flows` and `flow-runs` for more programmatic use.


## Why is this PR important?
CLI `get` usability 

