### PR TITLE
Added to Dask cloud provider docs how to reference private vs public …

### DIFF
--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -118,6 +118,8 @@ with Flow("Dask Cloud Provider Test") as flow:
     y = times_two.map(x)
     results = get_sum(y)
 
+# cluser.scheduler.address is the private ip 
+# use cluster.scheduler_address if connecting on the public ip
 flow.run(executor=DaskExecutor(cluster.scheduler.address),
          parameters={"x": list(range(10))})
 


### PR DESCRIPTION
…ip of the scheduler

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

I added to the docstring details on how to access the external ip address of the scheduler so that it is accessible when running the flow on an external network to the cluster. 


## Why is this PR important?


