### PR TITLE
Don't warn on tasks defined inline and copied

### DIFF
--- a/changes/issue-2677.yaml
+++ b/changes/issue-2677.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Don't warn about unused tasks defined inline and copied - [#2677](https://github.com/PrefectHQ/prefect/issues/2677)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -327,25 +327,20 @@ class Flow:
         """
         When entering a flow context, the Prefect context is modified to include:
             - `flow`: the flow itself
-            - `_new_task_tracker`: a set of all tasks created while the context is
+            - `_unused_task_tracker`: a set of all tasks created while the context is
                 open, in order to provide user friendly warnings if they aren't added
                 to the flow itself. This is purely for user experience.
         """
-        new_task_tracker = set()  # type: Set[Task]
+        unused_task_tracker = set()  # type: Set[Task]
 
-        with prefect.context(flow=self, _new_task_tracker=new_task_tracker):
+        with prefect.context(flow=self, _unused_task_tracker=unused_task_tracker):
             yield self
 
         # constants are not tracked at the flow level
-        new_tasks = {
-            t
-            for t in new_task_tracker
-            if not isinstance(t, prefect.tasks.core.constants.Constant)
-        }
-        if new_tasks.difference(self.tasks):
+        if unused_task_tracker.difference(self.tasks):
             warnings.warn(
                 "Tasks were created but not added to the flow: "
-                f"{new_task_tracker.difference(self.tasks)}. This can occur "
+                f"{unused_task_tracker.difference(self.tasks)}. This can occur "
                 "when `Task` classes, including `Parameters`, are instantiated "
                 "inside a `with flow:` block but not added to the flow either "
                 "explicitly or as the input to another task. For more information, "

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -403,8 +403,11 @@ class Task(metaclass=SignatureValidator):
 
         # if new task creations are being tracked, add this task
         # this makes it possible to give guidance to users that forget
-        # to add tasks to a flow
+        # to add tasks to a flow. We also remove the original task,
+        # as it has been "interacted" with and don't want spurious
+        # warnings
         if "_new_task_tracker" in prefect.context:
+            prefect.context._new_task_tracker.remove(self)
             prefect.context._new_task_tracker.add(new)
 
         return new

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -301,8 +301,9 @@ class Task(metaclass=SignatureValidator):
         # if new task creations are being tracked, add this task
         # this makes it possible to give guidance to users that forget
         # to add tasks to a flow
-        if "_new_task_tracker" in prefect.context:
-            prefect.context._new_task_tracker.add(self)
+        if "_unused_task_tracker" in prefect.context:
+            if not isinstance(self, prefect.tasks.core.constants.Constant):
+                prefect.context._unused_task_tracker.add(self)
 
     def __repr__(self) -> str:
         return "<Task: {self.name}>".format(self=self)
@@ -406,9 +407,11 @@ class Task(metaclass=SignatureValidator):
         # to add tasks to a flow. We also remove the original task,
         # as it has been "interacted" with and don't want spurious
         # warnings
-        if "_new_task_tracker" in prefect.context:
-            prefect.context._new_task_tracker.remove(self)
-            prefect.context._new_task_tracker.add(new)
+        if "_unused_task_tracker" in prefect.context:
+            if self in prefect.context._unused_task_tracker:
+                prefect.context._unused_task_tracker.remove(self)
+            if not isinstance(new, prefect.tasks.core.constants.Constant):
+                prefect.context._unused_task_tracker.add(new)
 
         return new
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -784,6 +784,21 @@ def test_warning_not_raised_for_tasks_defined_in_flow_context():
     assert len(record) == 0
 
 
+def test_warning_raised_for_tasks_defined_in_flow_context_and_unused():
+    # https://github.com/PrefectHQ/prefect/issues/2677
+
+    with pytest.warns(UserWarning, match="Tasks were created but not added"):
+        with Flow(name="test") as flow:
+
+            @task
+            def ten():
+                return 10
+
+            @task
+            def add(x, y):
+                return x + y
+
+
 def test_warning_not_raised_for_lambda_tasks_defined_in_flow_context():
     # https://github.com/PrefectHQ/prefect/issues/2677
 
@@ -794,6 +809,13 @@ def test_warning_not_raised_for_lambda_tasks_defined_in_flow_context():
 
     # no warnings
     assert len(record) == 0
+
+
+def test_warning_raised_for_lambda_tasks_defined_in_flow_context_and_unused():
+    # https://github.com/PrefectHQ/prefect/issues/2677
+    with pytest.warns(UserWarning, match="Tasks were created but not added"):
+        with Flow(name="test") as flow:
+            x = task(lambda: 10)
 
 
 def test_context_is_scoped_to_flow_context():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
#2677 identified that the warning about unused tasks fired spuriously when tasks were defined inside the flow context. This is because the task is defined (which adds it to the task tracker) then copied, and the copy is added to the flow. The original, unused task triggers the warning.

To solve this, we relax the "new task tracker" slightly to reflect "unused tasks", and the act of copying a task counts as "using" it. This way, tasks defined inline are able to trigger the warning unless 1) added to the flow or 2) copied. This still covers all cases that originally motivated the warning, while being less intrusive to users who know what they're doing. The only tasks that will fire the warning now are tasks that are created and never interacted with again.


## Why is this PR important?

Closes #2677 
Closes #2678 

