### PR TITLE
add flag to include hostname on local storage

### DIFF
--- a/changes/pr2653.yaml
+++ b/changes/pr2653.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - 'Add flag to include hostname on local storage [#2653](https://github.com/PrefectHQ/prefect/issues/2653)'
+
+contributor:
+  - '[Alex Cano](https://github.com/alexisprince1994)'

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -115,7 +115,8 @@ checkpointing = false
 
     [flows.defaults]
         [flows.defaults.storage]
-
+        # Whether to inclu
+        add_default_labels = true
         # the default storage class, specified using a full path
         default_class = "prefect.environments.storage.Local"
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -115,7 +115,8 @@ checkpointing = false
 
     [flows.defaults]
         [flows.defaults.storage]
-        # Whether to inclu
+        # Whether to include a storage's default labels. Useful for
+        # controlling Agent's workflows.
         add_default_labels = true
         # the default storage class, specified using a full path
         default_class = "prefect.environments.storage.Local"

--- a/src/prefect/environments/storage/azure.py
+++ b/src/prefect/environments/storage/azure.py
@@ -31,8 +31,7 @@ class Azure(Storage):
             will be used
         - blob_name (str, optional): a unique key to use for uploading this Flow to Azure. This
             is only useful when storing a single Flow using this storage object.
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
+        - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
     def __init__(
@@ -40,7 +39,7 @@ class Azure(Storage):
         container: str,
         connection_string: str = None,
         blob_name: str = None,
-        secrets: List[str] = None,
+        **kwargs: Any
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "Flow"]
@@ -55,10 +54,10 @@ class Azure(Storage):
         result = AzureResult(
             connection_string=self.connection_string, container=container
         )
-        super().__init__(result=result, secrets=secrets)
+        super().__init__(result=result, **kwargs)
 
     @property
-    def labels(self) -> List[str]:
+    def default_labels(self) -> List[str]:
         return ["azure-flow-storage"]
 
     def get_flow(self, flow_location: str) -> "Flow":

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, List
 
 import prefect
+from prefect import config
 from prefect.engine.result import Result
 from prefect.environments.storage import _healthcheck
 from prefect.utilities import logging as prefect_logging
@@ -22,7 +23,8 @@ class Storage(metaclass=ABCMeta):
             for each flow run.  Used primarily for providing authentication credentials.
         - labels (List[str], optional): a list of labels to associate with this `Storage`.
         - add_default_labels (bool): If `True`, adds the storage specific default label (if applicable)
-            to the storage labels. Defaults to `True`.
+            to the storage labels. Defaults to the value specified in the configuration at
+            `flows.defaults.storage.add_default_labels`.
     """
 
     def __init__(
@@ -30,12 +32,15 @@ class Storage(metaclass=ABCMeta):
         result: Result = None,
         secrets: List[str] = None,
         labels: List[str] = None,
-        add_default_labels: bool = True,
+        add_default_labels: bool = None,
     ) -> None:
         self.result = result
         self.secrets = secrets or []
         self._labels = labels or []
-        self.add_default_labels = add_default_labels
+        if add_default_labels is None:
+            self.add_default_labels = config.flows.defaults.storage.add_default_labels
+        else:
+            self.add_default_labels = add_default_labels
 
     @property
     def labels(self) -> List[str]:

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -20,14 +20,42 @@ class Storage(metaclass=ABCMeta):
             all flows which utilize this storage class
         - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
             for each flow run.  Used primarily for providing authentication credentials.
+        - labels (List[str], optional): a list of labels to associate with this `Storage`.
+        - add_default_labels (bool): If `True`, adds the storage specific default label (if applicable)
+            to the storage labels. Defaults to `True`.
     """
 
-    def __init__(self, result: Result = None, secrets: List[str] = None,) -> None:
+    def __init__(
+        self,
+        result: Result = None,
+        secrets: List[str] = None,
+        labels: List[str] = None,
+        add_default_labels: bool = True,
+    ) -> None:
         self.result = result
         self.secrets = secrets or []
+        self._labels = labels or []
+        self.add_default_labels = add_default_labels
 
     @property
     def labels(self) -> List[str]:
+        """
+        Concatenates user provided labels and optionally the storage's
+        default labels.
+        """
+        if not self.add_default_labels:
+            return self._labels
+
+        all_labels = set(self._labels)
+        all_labels.update(self.default_labels)
+
+        return list(all_labels)
+
+    @property
+    def default_labels(self) -> List[str]:
+        """
+        Holds the default storage labels for a given storage.
+        """
         return []
 
     def __repr__(self) -> str:

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -65,12 +65,11 @@ class Docker(Storage):
         - ignore_healthchecks (bool, optional): if True, the Docker healthchecks
             are not added to the Dockerfile. If False (default), healthchecks
             are included.
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
         - base_url: (str, optional): a URL of a Docker daemon to use when for
             Docker related functionality.  Defaults to DOCKER_HOST env var if not set
         - tls_config: (Union[bool, docker.tls.TLSConfig], optional): a TLS configuration to pass to the Docker
             client. https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig
+        - **kwargs (Any, optional): any additional `Storage` initialization options
 
     Raises:
         - ValueError: if both `base_image` and `dockerfile` are provided
@@ -90,9 +89,9 @@ class Docker(Storage):
         prefect_version: str = None,
         local_image: bool = False,
         ignore_healthchecks: bool = False,
-        secrets: List[str] = None,
         base_url: str = None,
         tls_config: Union[bool, "docker.tls.TLSConfig"] = False,
+        **kwargs: Any
     ) -> None:
         self.registry_url = registry_url
         if sys.platform == "win32":
@@ -164,7 +163,7 @@ class Docker(Storage):
                     ", ".join(not_absolute)
                 )
             )
-        super().__init__(secrets=secrets)
+        super().__init__(**kwargs)
 
     def get_env_runner(self, flow_location: str) -> Callable[[Dict[str, str]], None]:
         """

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -32,16 +32,11 @@ class GCS(Storage):
             is only useful when storing a single Flow using this storage object.
         - project (str, optional): the google project where any GCS API requests are billed to;
             if not provided, the project will be inferred from your Google Cloud credentials.
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
+        - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
     def __init__(
-        self,
-        bucket: str,
-        key: str = None,
-        project: str = None,
-        secrets: List[str] = None,
+        self, bucket: str, key: str = None, project: str = None, **kwargs: Any
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "Flow"]
@@ -51,10 +46,10 @@ class GCS(Storage):
         self.project = project
 
         result = GCSResult(bucket=bucket)
-        super().__init__(result=result, secrets=secrets)
+        super().__init__(result=result, **kwargs)
 
     @property
-    def labels(self) -> List[str]:
+    def default_labels(self) -> List[str]:
         return ["gcs-flow-storage"]
 
     def get_flow(self, flow_location: str) -> "Flow":

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -31,14 +31,21 @@ class Local(Storage):
             absolute path and created.  Defaults to `True`
         - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
             for each flow run.  Used primarily for providing authentication credentials.
+        - add_hostname_label (bool): if `True`, include the current host's hostname
+            as a label for storage. Defaults to `True`.
     """
 
     def __init__(
-        self, directory: str = None, validate: bool = True, secrets: List[str] = None,
+        self,
+        directory: str = None,
+        validate: bool = True,
+        secrets: List[str] = None,
+        add_hostname_label: bool = True,
     ) -> None:
         directory = directory or os.path.join(prefect.config.home_dir, "flows")
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
+        self.add_hostname_label = add_hostname_label
 
         if validate:
             abs_directory = os.path.abspath(os.path.expanduser(directory))
@@ -53,7 +60,10 @@ class Local(Storage):
 
     @property
     def labels(self) -> List[str]:
-        return [socket.gethostname()]
+        if self.add_hostname_label:
+            return [socket.gethostname()]
+        else:
+            return []
 
     def get_flow(self, flow_location: str) -> "Flow":
         """

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -29,23 +29,15 @@ class Local(Storage):
         - validate (bool, optional): a boolean specifying whether to validate the
             provided directory path; if `True`, the directory will be converted to an
             absolute path and created.  Defaults to `True`
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
-        - add_hostname_label (bool): if `True`, include the current host's hostname
-            as a label for storage. Defaults to `True`.
+        - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
     def __init__(
-        self,
-        directory: str = None,
-        validate: bool = True,
-        secrets: List[str] = None,
-        add_hostname_label: bool = True,
+        self, directory: str = None, validate: bool = True, **kwargs: Any
     ) -> None:
         directory = directory or os.path.join(prefect.config.home_dir, "flows")
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "prefect.core.flow.Flow"]
-        self.add_hostname_label = add_hostname_label
 
         if validate:
             abs_directory = os.path.abspath(os.path.expanduser(directory))
@@ -56,11 +48,11 @@ class Local(Storage):
 
         self.directory = abs_directory
         result = LocalResult(self.directory, validate_dir=validate)
-        super().__init__(result=result, secrets=secrets)
+        super().__init__(result=result, **kwargs)
 
     @property
-    def labels(self) -> List[str]:
-        if self.add_hostname_label:
+    def default_labels(self) -> List[str]:
+        if self.add_default_labels:
             return [socket.gethostname()]
         else:
             return []

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -29,16 +29,11 @@ class S3(Storage):
         - key (str, optional): a unique key to use for uploading a Flow to S3. This
             is only useful when storing a single Flow using this storage object.
         - client_options (dict, optional): Additional options for the `boto3` client.
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
+        - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
     def __init__(
-        self,
-        bucket: str,
-        client_options: dict = None,
-        key: str = None,
-        secrets: List[str] = None,
+        self, bucket: str, client_options: dict = None, key: str = None, **kwargs: Any
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "Flow"]
@@ -48,10 +43,10 @@ class S3(Storage):
         self.client_options = client_options
 
         result = S3Result(bucket=bucket)
-        super().__init__(result=result, secrets=secrets)
+        super().__init__(result=result, **kwargs)
 
     @property
-    def labels(self) -> List[str]:
+    def default_labels(self) -> List[str]:
         return ["s3-flow-storage"]
 
     def get_flow(self, flow_location: str) -> "Flow":

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -14,8 +14,6 @@ class AzureSchema(ObjectSchema):
     blob_name = fields.String(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
-    labels = fields.List(fields.Str(), allow_none=True)
-    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Azure:
@@ -40,8 +38,6 @@ class DockerSchema(ObjectSchema):
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     prefect_version = fields.String(allow_none=False)
     secrets = fields.List(fields.Str(), allow_none=True)
-    labels = fields.List(fields.Str(), allow_none=True)
-    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Docker:
@@ -60,8 +56,6 @@ class GCSSchema(ObjectSchema):
     project = fields.Str(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
-    labels = fields.List(fields.Str(), allow_none=True)
-    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> GCS:
@@ -78,8 +72,6 @@ class LocalSchema(ObjectSchema):
     directory = fields.Str(allow_none=False)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
-    labels = fields.List(fields.Str(), allow_none=True)
-    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Docker:
@@ -101,8 +93,6 @@ class S3Schema(ObjectSchema):
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     secrets = fields.List(fields.Str(), allow_none=True)
-    labels = fields.List(fields.Str(), allow_none=True)
-    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> S3:

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -2,19 +2,8 @@ from typing import Any
 
 from marshmallow import fields, post_load
 
-from prefect.environments.storage import (
-    GCS,
-    S3,
-    Azure,
-    Docker,
-    Local,
-    Storage,
-)
-from prefect.utilities.serialization import (
-    JSONCompatible,
-    ObjectSchema,
-    OneOfSchema,
-)
+from prefect.environments.storage import GCS, S3, Azure, Docker, Local, Storage
+from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
 
 
 class AzureSchema(ObjectSchema):
@@ -25,6 +14,8 @@ class AzureSchema(ObjectSchema):
     blob_name = fields.String(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
+    labels = fields.List(fields.Str(), allow_none=True)
+    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Azure:
@@ -49,6 +40,8 @@ class DockerSchema(ObjectSchema):
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     prefect_version = fields.String(allow_none=False)
     secrets = fields.List(fields.Str(), allow_none=True)
+    labels = fields.List(fields.Str(), allow_none=True)
+    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Docker:
@@ -67,6 +60,8 @@ class GCSSchema(ObjectSchema):
     project = fields.Str(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
+    labels = fields.List(fields.Str(), allow_none=True)
+    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> GCS:
@@ -83,6 +78,8 @@ class LocalSchema(ObjectSchema):
     directory = fields.Str(allow_none=False)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
+    labels = fields.List(fields.Str(), allow_none=True)
+    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Docker:
@@ -104,6 +101,8 @@ class S3Schema(ObjectSchema):
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     secrets = fields.List(fields.Str(), allow_none=True)
+    labels = fields.List(fields.Str(), allow_none=True)
+    add_default_labels = fields.Bool(allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> S3:

--- a/tests/environments/storage/test_base_storage.py
+++ b/tests/environments/storage/test_base_storage.py
@@ -5,6 +5,7 @@ import pytest
 
 import prefect
 from prefect.environments.storage import Storage
+from prefect.utilities.configuration import set_temporary_config
 
 
 @pytest.fixture
@@ -63,3 +64,19 @@ class TestStorageLabels:
 
     def test_no_default_labels(self, inst):
         assert inst.default_labels == []
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_uses_provided_default_label_flag(self, sub, flag: bool):
+        inst = sub(add_default_labels=flag)
+        assert inst.add_default_labels == flag
+
+    @pytest.mark.parametrize("config_value", [True, "test", "hello, world!"])
+    def test_uses_config_value_if_not_provided(self, sub, config_value):
+        with set_temporary_config(
+            {"flows.defaults.storage.add_default_labels": config_value}
+        ):
+            inst = sub()
+            assert inst.add_default_labels == config_value
+
+    def test_add_default_labels_default_true(self, inst):
+        assert inst.add_default_labels == True

--- a/tests/environments/storage/test_base_storage.py
+++ b/tests/environments/storage/test_base_storage.py
@@ -1,17 +1,29 @@
-from typing import Type
+from typing import List, Type
 from unittest.mock import PropertyMock
 
 import pytest
 
 import prefect
-from prefect.environments.storage import Storage
+from prefect.environments.storage import Local, Storage
 from prefect.utilities.configuration import set_temporary_config
 
 
 @pytest.fixture
 def sub() -> Type[Storage]:
-    class Subclass(Storage):
+    class Subclass(Local):
+        """
+        Subclassing `Local` storage instead of `Base` to avoid
+        other test failures that ensure all subclasses of the `Base`
+        have an accompanying serialization Schema.
+
+        The goal of this subclass is to test all methods of `Base`
+        that don't require actual implementation details, so
+        we override those methods to ensure we don't interact
+        with the external world.
+        """
+
         def __contains__(self, other):
+
             return False
 
         def add_flow(self, flow):
@@ -19,6 +31,10 @@ def sub() -> Type[Storage]:
 
         def build(self, flow):
             pass
+
+        @property
+        def default_labels(self) -> List[str]:
+            return []
 
     return Subclass
 

--- a/tests/environments/storage/test_base_storage.py
+++ b/tests/environments/storage/test_base_storage.py
@@ -1,9 +1,65 @@
+from typing import Type
+from unittest.mock import PropertyMock
+
 import pytest
 
 import prefect
 from prefect.environments.storage import Storage
 
 
+@pytest.fixture
+def sub() -> Type[Storage]:
+    class Subclass(Storage):
+        def __contains__(self, other):
+            return False
+
+        def add_flow(self, flow):
+            pass
+
+        def build(self, flow):
+            pass
+
+    return Subclass
+
+
+@pytest.fixture
+def inst(sub) -> Storage:
+    return sub(
+        secrets=["secret1", "secret2"],
+        labels=["label1", "label2"],
+        add_default_labels=True,
+    )
+
+
 def test_create_base_storage():
     with pytest.raises(TypeError):
         storage = Storage()
+
+
+class TestStorageLabels:
+    def test_doesnt_include_default_labels(self, inst):
+
+        type(inst).default_labels = PropertyMock(
+            return_value=["default_1", "default_2"]
+        )
+
+        inst.add_default_labels = False
+
+        assert inst.labels == inst._labels
+
+    def test_includes_default_labels(self, inst):
+
+        type(inst).default_labels = PropertyMock(
+            return_value=["default_1", "default_2"]
+        )
+
+        assert sorted(inst.labels) == sorted(
+            ["label1", "label2", "default_1", "default_2"]
+        )
+
+    def test_deduplicates_labels(self, inst):
+        type(inst).default_labels = PropertyMock(return_value=["label1"])
+        assert sorted(inst.labels) == ["label1", "label2"]
+
+    def test_no_default_labels(self, inst):
+        assert inst.default_labels == []

--- a/tests/environments/storage/test_local_storage.py
+++ b/tests/environments/storage/test_local_storage.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import tempfile
 
 import cloudpickle
@@ -154,3 +155,15 @@ def test_build_healthcheck_returns_on_no_flows():
     with tempfile.TemporaryDirectory() as tmpdir:
         s = Local(directory=tmpdir)
         assert s.build()
+
+
+def test_labels_includes_hostname():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        s = Local(directory=tmpdir)
+        assert socket.gethostname() in s.labels
+
+
+def test_opt_out_of_hostname_label():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        s = Local(directory=tmpdir, add_hostname_label=False)
+        assert socket.gethostname() not in s.labels

--- a/tests/environments/storage/test_local_storage.py
+++ b/tests/environments/storage/test_local_storage.py
@@ -165,5 +165,5 @@ def test_labels_includes_hostname():
 
 def test_opt_out_of_hostname_label():
     with tempfile.TemporaryDirectory() as tmpdir:
-        s = Local(directory=tmpdir, add_hostname_label=False)
+        s = Local(directory=tmpdir, add_default_labels=False)
         assert socket.gethostname() not in s.labels

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -36,8 +36,6 @@ def test_docker_empty_serialize():
     assert not serialized["image_tag"]
     assert not serialized["registry_url"]
     assert serialized["secrets"] == []
-    assert serialized["labels"] == []
-    assert serialized["add_default_labels"] == True
 
 
 def test_docker_full_serialize():
@@ -60,8 +58,6 @@ def test_docker_full_serialize():
     assert serialized["flows"] == dict()
     assert serialized["prefect_version"] == "0.5.2"
     assert serialized["secrets"] == ["bar", "creds"]
-    assert serialized["labels"] == ["foo"]
-    assert serialized["add_default_labels"] == False
 
 
 def test_docker_serialize_with_flows():
@@ -94,8 +90,6 @@ def test_s3_empty_serialize():
     assert serialized["bucket"]
     assert not serialized["key"]
     assert serialized["secrets"] == []
-    assert serialized["labels"] == ["s3-flow-storage"]
-    assert serialized["add_default_labels"] == True
 
 
 def test_s3_full_serialize():
@@ -113,8 +107,6 @@ def test_s3_full_serialize():
     assert serialized["bucket"] == "bucket"
     assert serialized["key"] == "key"
     assert serialized["secrets"] == ["hidden", "auth"]
-    assert serialized["labels"] == ["foo", "bar"]
-    assert serialized["add_default_labels"] == False
 
 
 def test_s3_serialize_with_flows():
@@ -143,8 +135,6 @@ def test_azure_empty_serialize():
     assert serialized["container"] == "container"
     assert serialized["blob_name"] is None
     assert serialized["secrets"] == []
-    assert serialized["labels"] == ["azure-flow-storage"]
-    assert serialized["add_default_labels"] == True
 
 
 def test_azure_full_serialize():
@@ -163,8 +153,6 @@ def test_azure_full_serialize():
     assert serialized["container"] == "container"
     assert serialized["blob_name"] == "name"
     assert serialized["secrets"] == ["foo"]
-    assert serialized["labels"] == ["bar", "baz"]
-    assert serialized["add_default_labels"] == False
 
 
 def test_azure_creds_not_serialized():
@@ -212,8 +200,6 @@ def test_local_empty_serialize():
     assert serialized["flows"] == dict()
     assert serialized["directory"].endswith(os.path.join(".prefect", "flows"))
     assert serialized["secrets"] == []
-    assert serialized["labels"] == [socket.gethostname()]
-    assert serialized["add_default_labels"] == True
 
 
 def test_local_roundtrip():
@@ -250,8 +236,6 @@ def test_gcs_empty_serialize():
     assert serialized["bucket"]
     assert not serialized["key"]
     assert serialized["secrets"] == []
-    assert serialized["labels"] == ["gcs-flow-storage"]
-    assert serialized["add_default_labels"] == True
 
 
 def test_gcs_full_serialize():
@@ -271,8 +255,6 @@ def test_gcs_full_serialize():
     assert serialized["key"] == "key"
     assert serialized["project"] == "project"
     assert serialized["secrets"] == ["CREDS"]
-    assert serialized["labels"] == ["foo", "bar"]
-    assert serialized["add_default_labels"] == False
 
 
 def test_gcs_serialize_with_flows():

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import tempfile
 
 import pytest
@@ -35,6 +36,8 @@ def test_docker_empty_serialize():
     assert not serialized["image_tag"]
     assert not serialized["registry_url"]
     assert serialized["secrets"] == []
+    assert serialized["labels"] == []
+    assert serialized["add_default_labels"] == True
 
 
 def test_docker_full_serialize():
@@ -44,6 +47,8 @@ def test_docker_full_serialize():
         image_tag="tag",
         prefect_version="0.5.2",
         secrets=["bar", "creds"],
+        labels=["foo"],
+        add_default_labels=False,
     )
     serialized = DockerSchema().dump(docker)
 
@@ -55,6 +60,8 @@ def test_docker_full_serialize():
     assert serialized["flows"] == dict()
     assert serialized["prefect_version"] == "0.5.2"
     assert serialized["secrets"] == ["bar", "creds"]
+    assert serialized["labels"] == ["foo"]
+    assert serialized["add_default_labels"] == False
 
 
 def test_docker_serialize_with_flows():
@@ -87,10 +94,18 @@ def test_s3_empty_serialize():
     assert serialized["bucket"]
     assert not serialized["key"]
     assert serialized["secrets"] == []
+    assert serialized["labels"] == ["s3-flow-storage"]
+    assert serialized["add_default_labels"] == True
 
 
 def test_s3_full_serialize():
-    s3 = storage.S3(bucket="bucket", key="key", secrets=["hidden", "auth"],)
+    s3 = storage.S3(
+        bucket="bucket",
+        key="key",
+        secrets=["hidden", "auth"],
+        labels=["foo", "bar"],
+        add_default_labels=False,
+    )
     serialized = S3Schema().dump(s3)
 
     assert serialized
@@ -98,6 +113,8 @@ def test_s3_full_serialize():
     assert serialized["bucket"] == "bucket"
     assert serialized["key"] == "key"
     assert serialized["secrets"] == ["hidden", "auth"]
+    assert serialized["labels"] == ["foo", "bar"]
+    assert serialized["add_default_labels"] == False
 
 
 def test_s3_serialize_with_flows():
@@ -126,6 +143,8 @@ def test_azure_empty_serialize():
     assert serialized["container"] == "container"
     assert serialized["blob_name"] is None
     assert serialized["secrets"] == []
+    assert serialized["labels"] == ["azure-flow-storage"]
+    assert serialized["add_default_labels"] == True
 
 
 def test_azure_full_serialize():
@@ -134,6 +153,8 @@ def test_azure_full_serialize():
         connection_string="conn",
         blob_name="name",
         secrets=["foo"],
+        labels=["bar", "baz"],
+        add_default_labels=False,
     )
     serialized = AzureSchema().dump(azure)
 
@@ -142,6 +163,8 @@ def test_azure_full_serialize():
     assert serialized["container"] == "container"
     assert serialized["blob_name"] == "name"
     assert serialized["secrets"] == ["foo"]
+    assert serialized["labels"] == ["bar", "baz"]
+    assert serialized["add_default_labels"] == False
 
 
 def test_azure_creds_not_serialized():
@@ -189,6 +212,8 @@ def test_local_empty_serialize():
     assert serialized["flows"] == dict()
     assert serialized["directory"].endswith(os.path.join(".prefect", "flows"))
     assert serialized["secrets"] == []
+    assert serialized["labels"] == [socket.gethostname()]
+    assert serialized["add_default_labels"] == True
 
 
 def test_local_roundtrip():
@@ -225,10 +250,19 @@ def test_gcs_empty_serialize():
     assert serialized["bucket"]
     assert not serialized["key"]
     assert serialized["secrets"] == []
+    assert serialized["labels"] == ["gcs-flow-storage"]
+    assert serialized["add_default_labels"] == True
 
 
 def test_gcs_full_serialize():
-    gcs = storage.GCS(bucket="bucket", key="key", project="project", secrets=["CREDS"])
+    gcs = storage.GCS(
+        bucket="bucket",
+        key="key",
+        project="project",
+        secrets=["CREDS"],
+        labels=["foo", "bar"],
+        add_default_labels=False,
+    )
     serialized = GCSSchema().dump(gcs)
 
     assert serialized
@@ -237,6 +271,8 @@ def test_gcs_full_serialize():
     assert serialized["key"] == "key"
     assert serialized["project"] == "project"
     assert serialized["secrets"] == ["CREDS"]
+    assert serialized["labels"] == ["foo", "bar"]
+    assert serialized["add_default_labels"] == False
 
 
 def test_gcs_serialize_with_flows():


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

closes #2653 

## What does this PR change?
This PR includes a flag on `LocalStorage` which will disable including hostname as the default label. By default, the `add_hostname_label` flag defaults to `True`, maintaining backwards compatibility.

## Why is this PR important?
See issue.

