### PR TITLE
Fix windows path check

### DIFF
--- a/changes/pr2685.yaml
+++ b/changes/pr2685.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with instantiating LocalResult on Windows with dir from other drive - [#2685](https://github.com/PrefectHQ/prefect/pull/2685)"

--- a/changes/pr2685.yaml
+++ b/changes/pr2685.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Fix issue with instantiating LocalResult on Windows with dir from other drive - [#2685](https://github.com/PrefectHQ/prefect/pull/2685)"
+  - "Fix issue with instantiating LocalResult on Windows with dir from other drive - [#2683](https://github.com/PrefectHQ/prefect/issues/2683)"

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -30,10 +30,14 @@ class LocalResult(Result):
         self, dir: str = None, validate_dir: bool = True, **kwargs: Any
     ) -> None:
         full_prefect_path = os.path.abspath(config.home_dir)
+        try:
+            common_path = os.path.commonpath([full_prefect_path, os.path.abspath(dir)])
+        except ValueError:
+            # ValueError is raised if comparing two paths in Windows from different drives, e.g., E:/ and C:/
+            common_path = ""
         if (
             dir is None
-            or os.path.commonpath([full_prefect_path, os.path.abspath(dir)])
-            == full_prefect_path
+            common_path == full_prefect_path
         ):
             directory = os.path.join(config.home_dir, "results")
         else:

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -30,11 +30,15 @@ class LocalResult(Result):
         self, dir: str = None, validate_dir: bool = True, **kwargs: Any
     ) -> None:
         full_prefect_path = os.path.abspath(config.home_dir)
+        common_path = ""
         try:
-            common_path = os.path.commonpath([full_prefect_path, os.path.abspath(dir)])
+            if dir is not None:
+                common_path = os.path.commonpath(
+                    [full_prefect_path, os.path.abspath(dir)]
+                )
         except ValueError:
             # ValueError is raised if comparing two paths in Windows from different drives, e.g., E:/ and C:/
-            common_path = ""
+            pass
         if dir is None or common_path == full_prefect_path:
             directory = os.path.join(config.home_dir, "results")
         else:

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -35,10 +35,7 @@ class LocalResult(Result):
         except ValueError:
             # ValueError is raised if comparing two paths in Windows from different drives, e.g., E:/ and C:/
             common_path = ""
-        if (
-            dir is None
-            common_path == full_prefect_path
-        ):
+        if dir is None or common_path == full_prefect_path:
             directory = os.path.join(config.home_dir, "results")
         else:
             directory = dir

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys
 import tempfile
 from typing import Union
 
@@ -198,3 +199,8 @@ class TestLocalResult:
         new_result = result.write("so-much-data", thing=44)
         assert result.exists("44.txt") is True
         assert result.exists(os.path.join(tmp_dir, "44.txt")) is True
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+    def test_local_init_with_different_drive_works_on_windows(self):
+        result = LocalResult(dir="E:/location", validate=False)
+        assert result.dir == "E:/location"

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -202,5 +202,5 @@ class TestLocalResult:
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
     def test_local_init_with_different_drive_works_on_windows(self):
-        result = LocalResult(dir="E:/location", validate=False)
+        result = LocalResult(dir="E:/location", validate_dir=False)
         assert result.dir == "E:/location"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR handles the `ValueError` that can sometimes be raised when instantiating a `LocalResult` on Windows with a drive other than `C:/`

## Why is this PR important?
Windows compatibility.  Closes #2683 