### PR TITLE
Fix running server on Ubuntu using a rootless Docker setup

### DIFF
--- a/changes/pr2691.yaml
+++ b/changes/pr2691.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix invalid IP address error when running `server start` on Ubuntu using rootless Docker - [#2691](https://github.com/PrefectHQ/prefect/pull/2691)"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -250,7 +250,6 @@ def start(
         or no_graphql_port
         or no_ui_port
         or no_server_port
-        or platform_is_linux()
         or not use_volume
     ):
         temp_dir = tempfile.gettempdir()
@@ -274,13 +273,6 @@ def start(
 
             if no_server_port:
                 del y["services"]["apollo"]["ports"]
-
-            # if platform_is_linux():
-            #     docker_internal_ip = get_docker_ip()
-            #     for service in list(y["services"]):
-            #         y["services"][service]["extra_hosts"] = [
-            #             "host.docker.internal:{}".format(docker_internal_ip)
-            #         ]
 
             if not use_volume:
                 del y["services"]["postgres"]["volumes"]

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -11,7 +11,6 @@ import yaml
 import prefect
 from prefect import config
 from prefect.utilities.configuration import set_temporary_config
-from prefect.utilities.docker_util import platform_is_linux, get_docker_ip
 
 
 def make_env(fname=None):

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -275,12 +275,12 @@ def start(
             if no_server_port:
                 del y["services"]["apollo"]["ports"]
 
-            if platform_is_linux():
-                docker_internal_ip = get_docker_ip()
-                for service in list(y["services"]):
-                    y["services"][service]["extra_hosts"] = [
-                        "host.docker.internal:{}".format(docker_internal_ip)
-                    ]
+            # if platform_is_linux():
+            #     docker_internal_ip = get_docker_ip()
+            #     for service in list(y["services"]):
+            #         y["services"][service]["extra_hosts"] = [
+            #             "host.docker.internal:{}".format(docker_internal_ip)
+            #         ]
 
             if not use_volume:
                 del y["services"]["postgres"]["volumes"]

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -236,37 +236,6 @@ def test_server_start_disable_port_mapping(monkeypatch, macos_platform):
     assert check_output.call_args[1].get("env")
 
 
-def test_server_start_linux_host(monkeypatch, linux_platform):
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-
-    sys_platform = MagicMock()
-    sys_platform.return_value = "linux"
-    monkeypatch.setattr("sys.platform", sys_platform)
-
-    get_docker_ip = MagicMock()
-    get_docker_ip.return_value = "172.17.0.1"
-    monkeypatch.setattr("prefect.cli.server.get_docker_ip", get_docker_ip)
-
-    yaml_dump = MagicMock()
-    monkeypatch.setattr("yaml.safe_dump", yaml_dump)
-
-    runner = CliRunner()
-    result = runner.invoke(server, ["start", "--skip-pull",],)
-    assert result.exit_code == 1
-
-    assert popen.called
-    assert check_output.called
-
-    call_arg = yaml_dump.call_args[0][0]
-    for svc in ("postgres", "hasura", "graphql", "apollo", "scheduler", "ui"):
-        assert call_arg["services"][svc]["extra_hosts"] == [
-            "host.docker.internal:172.17.0.1"
-        ]
-
-
 def test_server_start_volume_options(monkeypatch, macos_platform):
     check_call = MagicMock()
     popen = MagicMock(side_effect=KeyboardInterrupt())


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
There is an extra_hosts addition that is added during `prefect server start` when running on Linux. This was added in #2328 however I don't think it is needed for the server as it does not need to communicate outside of its own network anyway. The PR was intended to add this option to containers created by the docker agent but it also added it to the server containers.

Removing this change as it was causing issues on some platforms when running Docker in a rootless setup. The error that commonly arose was: `invalid IP address in add-host: ""`

Link to slack thread: https://prefect-community.slack.com/archives/CL09KU1K7/p1590673237089100

^ Had someone test out this branch before I made this PR and it appears to have fixed their issue

