### PR TITLE
Ability to Resume paused tasks when running locally

### DIFF
--- a/changes/issue-2693.yaml
+++ b/changes/issue-2693.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow for manual approval of locally Paused tasks - [#2693](https://github.com/PrefectHQ/prefect/issues/2693)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -937,6 +937,18 @@ class Flow:
                 task_states = list(flow_state.result.values())
                 for s in filter(lambda x: x.is_mapped(), task_states):
                     task_states.extend(s.map_states)
+
+                # handle Paused states
+                for t, s in filter(
+                    lambda tup: isinstance(tup[1], prefect.engine.state.Paused),
+                    flow_state.result.items(),
+                ):
+                    approve = input(f"{t} is currently Paused; enter 'y' to resume:\n")
+                    if approve.strip().lower() == "y":
+                        flow_state.result[t] = prefect.engine.state.Resume(
+                            "Approval given to resume."
+                        )
+
                 earliest_start = min(
                     [
                         s.start_time


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a manual approval step for tasks which enter a Paused state locally.

Example:
```python
from prefect import task, Flow
from prefect.triggers import manual_only

@task
def return_1():
    return 1

@task(trigger=manual_only)
def add(x):
    return x + 1

with Flow("pause") as flow:
    res = add(return_1)

flow_state = flow.run()
```

```...
[2020-06-02 01:47:57] 514-- INFO - prefect.FlowRunner | Flow run RUNNING: terminal tasks are incomplete.
<Task: add> is currently Paused; enter 'y' to resume:
>> y
[2020-06-02 01:47:59] 223-- INFO - prefect.FlowRunner | Beginning Flow run for 'pause'
...
```

## Why is this PR important?
Closes #2693 **cc:** @znicholasbrown 