### PR TITLE
Result location updates

### DIFF
--- a/changes/pr2698.yaml
+++ b/changes/pr2698.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - server
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Allow for custom callables for Result locations - [#2577](https://github.com/PrefectHQ/prefect/issues/2577)"
+  - "Ensure all Parameter values, included non-required defaults, are present in context - [#2698](https://github.com/PrefectHQ/prefect/pull/2698)"
+  - "Use absolute path for `LocalResult` location for disambiguation - [#2698](https://github.com/PrefectHQ/prefect/pull/2698)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -147,10 +147,12 @@ class FlowRunner(Runner):
         """
 
         # overwrite context parameters one-by-one
-        if parameters:
-            context_params = context.setdefault("parameters", {})
-            for param, value in parameters.items():
-                context_params[param] = value
+        context_params = context.setdefault("parameters", {})
+        for p in self.flow.parameters():
+            if not p.required:
+                context_params.setdefault(p.name, p.default)
+        for param, value in (parameters or {}).items():
+            context_params[param] = value
 
         context.update(flow_name=self.flow.name)
         context.setdefault("scheduled_start_time", pendulum.now("utc"))

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -80,8 +80,10 @@ class Result(ResultInterface):
         - validators (Iterable[Callable], optional): Iterable of validation functions to apply to
             the result to ensure it is `valid`.
         - run_validators (bool): Whether the result value should be validated.
-        - location (str, optional): Possibly templated location to be used for saving the
-            result to the destination.
+        - location (Union[str, Callable], optional): Possibly templated location to be used for saving the
+            result to the destination. If a callable function is provided, it should have signature `callable(**kwargs) -> str`
+            and at write time all formatting kwargs will be passed and a fully formatted location is expected
+            as the return value.  Can be used for string formatting logic that `.format(**kwargs)` doesn't support
     """
 
     def __init__(

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -97,7 +97,12 @@ class Result(ResultInterface):
         self.result_handler = result_handler  # type: ignore
         self.validators = validators
         self.run_validators = run_validators
-        self.location = location
+        if isinstance(location, (str, type(None))):
+            self.location = location
+            self._formatter = None
+        else:
+            self._formatter = location
+            self.location = None
         self.logger = logging.get_logger(type(self).__name__)
 
     def store_safe_value(self) -> None:
@@ -207,9 +212,11 @@ class Result(ResultInterface):
             - Result: a new result instance with the appropriately formatted location
         """
         new = self.copy()
-        if new.location is not None:
+        if isinstance(new.location, str):
             assert new.location is not None
             new.location = new.location.format(**kwargs)
+        elif new._formatter is not None:
+            new.location = new._formatter(**kwargs)
         else:
             new.location = new.default_location
         return new

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -104,9 +104,11 @@ class LocalResult(Result):
 
         full_path = os.path.join(self.dir, new.location)
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
+
         with open(full_path, "wb") as f:
             f.write(cloudpickle.dumps(new.value))
 
+        new.location = full_path
         self.logger.debug("Finished uploading result to {}...".format(new.location))
 
         return new

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -986,8 +986,8 @@ class TaskRunner(Runner):
                 result = self.result.write(
                     value,
                     filename="output",
-                    **raw_inputs,
                     **prefect.context.get("parameters", {}),
+                    **raw_inputs,
                     **prefect.context,
                 )
             except NotImplementedError:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -795,9 +795,7 @@ class TaskRunner(Runner):
                     name=prefect.context.get("task_full_name", self.task.name)
                 )
             )
-            timeout_handler = (
-                timeout_handler or prefect.utilities.executors.timeout_handler
-            )
+            timeout_handler = prefect.utilities.executors.timeout_handler
             if getattr(self.task, "log_stdout", False):
                 with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
                     value = timeout_handler(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -931,6 +931,7 @@ class TaskRunner(Runner):
             raise ENDRUN(state)
 
         value = None
+        raw_inputs = {k: r.value for k, r in inputs.items()}
         try:
             self.logger.debug(
                 "Task '{name}': Calling task.run() method...".format(
@@ -940,7 +941,6 @@ class TaskRunner(Runner):
             timeout_handler = (
                 timeout_handler or prefect.utilities.executors.timeout_handler
             )
-            raw_inputs = {k: r.value for k, r in inputs.items()}
 
             if getattr(self.task, "log_stdout", False):
                 with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
@@ -983,7 +983,13 @@ class TaskRunner(Runner):
             and value is not None
         ):
             try:
-                result = self.result.write(value, filename="output", **prefect.context)
+                result = self.result.write(
+                    value,
+                    filename="output",
+                    **raw_inputs,
+                    **prefect.context.get("parameters", {}),
+                    **prefect.context,
+                )
             except NotImplementedError:
                 result = self.result.from_value(value=value)
         else:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -983,13 +983,12 @@ class TaskRunner(Runner):
             and value is not None
         ):
             try:
-                formatting_kwargs = prefect.context.get("parameters", {}).copy()
-                formatting_kwargs.update(
-                    raw_inputs
-                )  # inputs take precedence over flow-level parameters
-                formatting_kwargs.update(
-                    prefect.context
-                )  # context has ultimate precedence
+                # precedence for keys is task context > task inputs > flow parameters
+                formatting_kwargs = {
+                    **prefect.context.get("parameters", {}).copy(),
+                    **raw_inputs,
+                    **prefect.context,
+                }
                 result = self.result.write(
                     value, filename="output", **formatting_kwargs,
                 )

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -983,12 +983,15 @@ class TaskRunner(Runner):
             and value is not None
         ):
             try:
+                formatting_kwargs = prefect.context.get("parameters", {}).copy()
+                formatting_kwargs.update(
+                    raw_inputs
+                )  # inputs take precedence over flow-level parameters
+                formatting_kwargs.update(
+                    prefect.context
+                )  # context has ultimate precedence
                 result = self.result.write(
-                    value,
-                    filename="output",
-                    **prefect.context.get("parameters", {}),
-                    **raw_inputs,
-                    **prefect.context,
+                    value, filename="output", **formatting_kwargs,
                 )
             except NotImplementedError:
                 result = self.result.from_value(value=value)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2886,15 +2886,15 @@ def test_results_write_to_formatted_locations(tmpdir):
 def test_results_write_to_custom_formatters(tmpdir):
     result = LocalResult(dir=tmpdir, location="{map_index}-{x}-{param}.txt")
 
-    with Flow(
-        "results", result=result, tasks=[Parameter("param", default="book")]
-    ) as flow:
+    with Flow("results", result=result) as flow:
+
+        p = Parameter("param", default="book")
 
         @task()
-        def return_x(x):
+        def return_x(x, param):
             return x
 
-        vals = return_x.map(x=[1, 42, None, "string-type"])
+        vals = return_x.map(x=[1, 42, None, "string-type"], param=unmapped(p))
 
     with set_temporary_config({"flows.checkpointing": True}):
         flow_state = flow.run()

--- a/tests/engine/results/test_results.py
+++ b/tests/engine/results/test_results.py
@@ -151,14 +151,14 @@ class TestLocalResult:
     def test_local_result_writes_using_rendered_template_name(self, tmp_dir):
         result = LocalResult(dir=tmp_dir, location="{thing}.txt")
         new_result = result.write("so-much-data", thing=42)
-        assert new_result.location == "42.txt"
+        assert new_result.location.endswith("42.txt")
         assert new_result.value == "so-much-data"
 
     def test_local_result_creates_necessary_dirs(self, tmp_dir):
         os_independent_template = os.path.join("mydir", "mysubdir", "{thing}.txt")
         result = LocalResult(dir=tmp_dir, location=os_independent_template)
         new_result = result.write("so-much-data", thing=42)
-        assert new_result.location == os.path.join("mydir", "mysubdir", "42.txt")
+        assert new_result.location.endswith(os.path.join("mydir", "mysubdir", "42.txt"))
         assert new_result.value == "so-much-data"
 
     def test_local_result_cleverly_redirects_prefect_defaults(self):
@@ -170,7 +170,7 @@ class TestLocalResult:
         result = LocalResult(dir=tmp_dir, location="test.txt")
         fpath = result.write(res).location
         assert isinstance(fpath, str)
-        assert fpath == "test.txt"
+        assert fpath.endswith("test.txt")
 
         with open(os.path.join(tmp_dir, fpath), "rb") as f:
             val = f.read()
@@ -204,3 +204,17 @@ class TestLocalResult:
     def test_local_init_with_different_drive_works_on_windows(self):
         result = LocalResult(dir="E:/location", validate_dir=False)
         assert result.dir == "E:/location"
+
+
+class TestResultFormatting:
+    def test_result_accepts_callable_for_location(self, tmpdir):
+        result = LocalResult(dir=tmpdir, location=lambda **kwargs: "special_val")
+        assert result.location is None
+        new_result = result.format()
+        assert new_result.location.endswith("special_val")
+
+    def test_result_callable_accepts_kwargs(self, tmpdir):
+        result = LocalResult(dir=tmpdir, location=lambda **kwargs: kwargs["key"])
+        assert result.location is None
+        new_result = result.format(key="42")
+        assert new_result.location.endswith("42")

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -320,6 +320,21 @@ def test_parameters_are_placed_into_context():
     assert flow_state.result[y].result == 42
 
 
+def test_parameters_are_placed_into_context_including_defaults():
+    @prefect.task
+    def whats_in_ctx():
+        return prefect.context.parameters
+
+    y = prefect.Parameter("y", default=99)
+    z = prefect.Parameter("z", default=19)
+    flow = Flow(name="test", tasks=[y, z, whats_in_ctx])
+    flow_state = FlowRunner(flow=flow).run(
+        return_tasks=[whats_in_ctx], parameters=dict(y=42)
+    )
+    assert isinstance(flow_state, Success)
+    assert flow_state.result[whats_in_ctx].result == dict(y=42, z=19)
+
+
 def test_parameters_are_placed_into_context_and_override_current_context():
     flow = Flow(name="test")
     y = prefect.Parameter("y", default=99)

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1189,6 +1189,38 @@ class TestRunTaskStep:
         assert new_state.is_successful()
         assert new_state._result.location == "3"
 
+    def test_result_formatting_with_checkpointing(self, tmpdir):
+        result = LocalResult(dir=tmpdir, location="{task_slug}.txt")
+
+        @prefect.task(checkpoint=True, result=result, slug="boo")
+        def fn(x):
+            return x + 1
+
+        edge = Edge(Task(), fn, key="x")
+        with set_temporary_config({"flows.checkpointing": True}):
+            new_state = TaskRunner(task=fn).run(
+                state=None, upstream_states={edge: Success(result=Result(2))}
+            )
+        assert new_state.is_successful()
+        assert new_state._result.location.endswith("boo.txt")
+
+    def test_result_formatting_with_custom_formatter(self, tmpdir):
+        result = LocalResult(
+            dir=tmpdir, location=lambda **kwargs: kwargs["task_slug"][:2] + ".txt"
+        )
+
+        @prefect.task(checkpoint=True, result=result, slug="1234567")
+        def fn(x):
+            return x + 1
+
+        edge = Edge(Task(), fn, key="x")
+        with set_temporary_config({"flows.checkpointing": True}):
+            new_state = TaskRunner(task=fn).run(
+                state=None, upstream_states={edge: Success(result=Result(2))}
+            )
+        assert new_state.is_successful()
+        assert new_state._result.location.endswith("12.txt")
+
     @pytest.mark.parametrize("checkpoint", [True, None])
     def test_success_state_with_checkpointing_in_context(self, checkpoint):
         @prefect.task(checkpoint=checkpoint, result=PrefectResult())


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR does a few things:
- stores the full absolute path to the result location for `LocalResult` (note that this change _should_ have no bearing on implementation, but instead makes sure the full path is visible in the UI)
- makes sure that `prefect.context.parameters` now also includes unprovided parameter defaults (previously this dictionary only included parameters that were explicitly passed)
- passes flow `parameters`, task `inputs` _and_ `context` to `result.write(**kwargs)` call for richer templating possibilities
- allows for users to (optionally) provide a callable location for their `Result` locations which will passed _all_ formatting kwargs.  This callable should return a `str` which will be used as the location.

## Why is this PR important?
Closes https://github.com/PrefectHQ/prefect/issues/2577 and provides more expressive result interactions

