### PR TITLE
flow disjoint and join

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -571,28 +571,27 @@ class Flow:
                 )
             )
         return edges
-    
-  
+
     def merge_params(self, flow: "Flow", validate: bool = True) -> None:
         # TODO: Learn edges. Can lead to merging of merge params and disjoint
-        #  - merge_p: removes duplicate parameters from input flow. FIFO 
+        #  - merge_p: removes duplicate parameters from input flow. FIFO
 
-        #remove_flow = self.copy()
+        # remove_flow = self.copy()
         flow_task_lst = list(flow.tasks)
         for task in flow_task_lst:
- 
+
             # fl1_parameter = self.get_tasks(parameter.name, task_type=Parameter)
             task1 = self.get_tasks(name=task.name)
-            
-            #duped_param_list = list()
-            if len(task1)>0:
-                
+
+            # duped_param_list = list()
+            if len(task1) > 0:
+
                 print(f"Duplicate Parameter {task1}")
                 duped_task = task1[0]
                 if isinstance(task, Parameter):
 
                     # Add parameter to reappend
-                    #duped_param_list.append(task)
+                    # duped_param_list.append(task)
 
                     # Remove the task from both
                     flow.tasks.remove(task)
@@ -608,12 +607,10 @@ class Flow:
 
                     duped_task.name = f"{self.name}-{duped_task.name}"
                     duped_task.slug = f"{self.name}-{duped_task.slug}"
-            
+
         self.update(flow, validate)
 
-
         return
-
 
     def disjoint(self, flow: "Flow", validate: bool = True) -> None:
         """
@@ -635,23 +632,23 @@ class Flow:
         """
 
         for task in flow.tasks:
- 
+
             fl1_tsk = self.get_tasks(task.name)
-            
+
             # Check for duplicate names
             # TODO: Change check to compare slugs
-            if len(fl1_tsk)>0:
+            if len(fl1_tsk) > 0:
 
                 duped_task = fl1_tsk[0]
 
                 print(f"Duplicate task {duped_task}")
-       
+
                 task.name = f"{flow.name}-{task.name}"
                 task.slug = f"{flow.name}-{task.slug}"
 
                 duped_task.name = f"{self.name}-{duped_task.name}"
                 duped_task.slug = f"{self.name}-{duped_task.slug}"
-            
+
             self.add_task(task)
 
         for edge in flow.edges:
@@ -666,8 +663,7 @@ class Flow:
 
         self.constants.update(flow.constants or {})
 
-        #self.update(flow, validate)
-
+        # self.update(flow, validate)
 
     def update(self, flow: "Flow", validate: bool = None) -> None:
         """
@@ -684,7 +680,7 @@ class Flow:
         Returns:
             - None
         """
-        
+
         for task in flow.tasks:
             if task not in self.tasks:
                 self.add_task(task)

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -572,20 +572,42 @@ class Flow:
             )
         return edges
 
-    def update(self, flow: "Flow", validate: bool = None) -> None:
+    def update(self, flow: "Flow", validate: bool = None, method: str = None) -> None:
         """
         Take all tasks and edges in another flow and add it to this flow
 
         Args:
             - flow (Flow): A flow which is used to update this flow
             - validate (bool, optional): Whether or not to check the validity of the flow
+            - method (str, optional): Method to update the flow
+                - None: No duplicate tasks. Returns duplicate slug name exception
+                - disjoint: All duplicate tasks are given a new name and slug
+                - merge_p: removes duplicate parameters from input flow. FIFO 
 
         Returns:
             - None
         """
+        
         for task in flow.tasks:
-            if task not in self.tasks:
-                self.add_task(task)
+            if method is not None:
+                fl1_tsk = self.get_tasks(task.name)
+                
+                # Check for duplicate names
+                if len(fl1_tsk)>0:
+
+                    duped_task = fl1_tsk[0]
+
+                    print(f"Duplicate task {duped_task}")
+                    if method=="disjoint":
+                        task.name = f"{flow.name}-{task.name}"
+                        task.slug = f"{flow.name}-{task.name}"
+
+                        duped_task.name = f"{self.name}-{duped_task.name}"
+                        duped_task.slug = f"{self.name}-{duped_task.name}"
+                    # elif method=="merge_p":
+                    #     fl1_tsk.remove()
+            
+            self.add_task(task)
 
         for edge in flow.edges:
             if edge not in self.edges:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:
A PR to begin addressing #1745 . 

- [ ] Develop a toy example(s) for demonstration
- [ ] A method to create a disjointed flow from two flows with common parameters and tasks.

`flow1.disjoint(flow2)`

![image](https://user-images.githubusercontent.com/16763201/83481860-7da6f500-a464-11ea-80be-b29a7b2c3cc2.png)

Which might be useful for people who want to run one flow after another
```
uptask = flow1.get_tasks(name="Primary-Sources-calc_textstats")[0]
downtask = flow1.get_tasks(name="bing_search_definitions")[0]
uptask.set_downstream(downtask, flow=flow1)
```
![image](https://user-images.githubusercontent.com/16763201/83481940-a929df80-a464-11ea-88da-0ba001eb4110.png)

- [ ] Add keyword argument in `flow.dsijoint` to set edges between tasks for convenience with no bound data.
- [ ] Allow for an `edge` between tasks in a disjointed flow between `terminal tasks` and `root tasks`.
 - Involves removing certain `root tasks` in `flow2`

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?


## Why is this PR important?
This functionality paves the way for discussing use cases for merging multiple flows, and composing new flows from flows that **can** be chained together in one execution environment. 


