### PR TITLE
Closes #2702. Fix mistakes re: result/result_handler in persistence docs

### DIFF
--- a/docs/core/concepts/persistence.md
+++ b/docs/core/concepts/persistence.md
@@ -21,7 +21,7 @@ Input caching is an automatic caching. Prefect will automatically apply it whene
 
 Sometimes, it's desirable to cache the output of a task to avoid recomputing it in the future. Common examples of this pattern include expensive or time-consuming computations that are unlikely to change. In this case, users can indicate that a task should be cached for a certain duration or as long as certain conditions are met.
 
-Prefect even supports caching output by a a shared key, which can be accessed between flow runs. This mechanism is sometimes called "Time Travel" because it makes results computed in one flow run available to other runs.
+Prefect even supports caching output by a shared key, which can be accessed between flow runs. This mechanism is sometimes called "Time Travel" because it makes results computed in one flow run available to other runs.
 
 Output caching is controlled with three `Task` arguments: `cache_for`, `cache_validator` and `cache_key`.
 

--- a/docs/core/concepts/persistence.md
+++ b/docs/core/concepts/persistence.md
@@ -21,7 +21,7 @@ Input caching is an automatic caching. Prefect will automatically apply it whene
 
 Sometimes, it's desirable to cache the output of a task to avoid recomputing it in the future. Common examples of this pattern include expensive or time-consuming computations that are unlikely to change. In this case, users can indicate that a task should be cached for a certain duration or as long as certain conditions are met.
 
-This mechanism is sometimes called "Time Travel" because it makes results computed in one flow run available to other runs.
+Prefect even supports caching output by a a shared key, which can be accessed between flow runs. This mechanism is sometimes called "Time Travel" because it makes results computed in one flow run available to other runs.
 
 Output caching is controlled with three `Task` arguments: `cache_for`, `cache_validator` and `cache_key`.
 
@@ -65,7 +65,7 @@ class_task = MyTask(
 
 
 # create a task via the task decorator
-@task(checkpoint=True, result_handler=LocalResult(dir="~/.prefect"))
+@task(checkpoint=True, result=LocalResult(dir="~/.prefect"))
 def func_task():
     return 99
 ```
@@ -88,7 +88,7 @@ from prefect import task, Task
 
 
 # create a task via the task decorator
-@task(target="func_task_target.txt", checkpoint=True, result_handler=LocalResult(dir="~/.prefect"))
+@task(target="func_task_target.txt", checkpoint=True, result=LocalResult(dir="~/.prefect"))
 def func_task():
     return 99
 ```
@@ -102,7 +102,7 @@ from prefect import task, Task
 
 
 # create a task via the task decorator
-@task(target="{date:%A}/{task_name}.txt", checkpoint=True, result_handler=LocalResult(dir="~/.prefect"))
+@task(target="{date:%A}/{task_name}.txt", checkpoint=True, result=LocalResult(dir="~/.prefect"))
 def func_task():
     return 99
 ```


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [n/a] adds new tests (if appropriate)
- [n/a] add a changelog entry in the `changes/` directory (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Fix some leftover references to `result_handler` kwarg in our docs. On a reread also felt like we needed another sentence in here about the 'time travel' desgination for cache_key.


## Why is this PR important?
Not confuse new users re: result handlers!
Closes #2702

