### PR TITLE
Handle API_ERROR codes

### DIFF
--- a/changes/pr2705.yaml
+++ b/changes/pr2705.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - server
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - 'Retry client requests when receiving an `API_ERROR` code in the response - [#2705](https://github.com/PrefectHQ/prefect/pull/2705)'

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -317,6 +317,12 @@ class Client:
         # Check if request returned a successful status
         response.raise_for_status()
 
+        # check if request returned an error key in the response
+        # response_json = response.json()
+        # if "errors" in response_json:
+        #     if response_json["errors"].get("code") == "API_ERROR":
+        #         pass
+
         return response
 
     def attach_headers(self, headers: dict) -> None:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -239,7 +239,7 @@ class Client:
             self.logger.debug(f"Preparing request to {url}")
             clean_headers = {
                 head: re.sub("Bearer .*", "Bearer XXXX", val)
-                for head, val in headers.items()
+                for head, val in headers.items()  # type: ignore
             }
             self.logger.debug(f"Headers: {clean_headers}")
             self.logger.debug(f"Request: {params}")

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -227,6 +227,44 @@ class Client:
         else:
             return GraphQLResult(result)  # type: ignore
 
+    def _send_request(
+        self,
+        session: "requests.Session",
+        method: str,
+        url: str,
+        params: Dict[str, JSONLike] = None,
+        headers: dict = None,
+    ) -> "requests.models.Response":
+        if prefect.context.config.cloud.get("diagnostics") is True:
+            self.logger.debug(f"Preparing request to {url}")
+            clean_headers = {
+                head: re.sub("Bearer .*", "Bearer XXXX", val)
+                for head, val in headers.items()
+            }
+            self.logger.debug(f"Headers: {clean_headers}")
+            self.logger.debug(f"Request: {params}")
+            start_time = time.time()
+
+        if method == "GET":
+            response = session.get(url, headers=headers, params=params, timeout=30)
+        elif method == "POST":
+            response = session.post(url, headers=headers, json=params, timeout=30)
+        elif method == "DELETE":
+            response = session.delete(url, headers=headers, timeout=30)
+        else:
+            raise ValueError("Invalid method: {}".format(method))
+
+        if prefect.context.config.cloud.get("diagnostics") is True:
+            end_time = time.time()
+            self.logger.debug(f"Response: {response.json()}")
+            self.logger.debug(
+                f"Request duration: {round(end_time - start_time, 4)} seconds"
+            )
+
+        # Check if request returned a successful status
+        response.raise_for_status()
+        return response
+
     def _request(
         self,
         method: str,
@@ -287,41 +325,27 @@ class Client:
             method_whitelist=["DELETE", "GET", "POST"],
         )
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+        response = self._send_request(
+            session=session, method=method, url=url, params=params, headers=headers
+        )
 
-        if prefect.context.config.cloud.get("diagnostics") is True:
-            self.logger.debug(f"Preparing request to {url}")
-            clean_headers = {
-                head: re.sub("Bearer .*", "Bearer XXXX", val)
-                for head, val in headers.items()
-            }
-            self.logger.debug(f"Headers: {clean_headers}")
-            self.logger.debug(f"Request: {params}")
-            start_time = time.time()
-
-        if method == "GET":
-            response = session.get(url, headers=headers, params=params, timeout=30)
-        elif method == "POST":
-            response = session.post(url, headers=headers, json=params, timeout=30)
-        elif method == "DELETE":
-            response = session.delete(url, headers=headers, timeout=30)
-        else:
-            raise ValueError("Invalid method: {}".format(method))
-
-        if prefect.context.config.cloud.get("diagnostics") is True:
-            end_time = time.time()
-            self.logger.debug(f"Response: {response.json()}")
-            self.logger.debug(
-                f"Request duration: {round(end_time - start_time, 4)} seconds"
-            )
-
-        # Check if request returned a successful status
-        response.raise_for_status()
-
-        # check if request returned an error key in the response
-        # response_json = response.json()
-        # if "errors" in response_json:
-        #     if response_json["errors"].get("code") == "API_ERROR":
-        #         pass
+        # check if there was an API_ERROR code in the response
+        if "API_ERROR" in str(response.json().get("errors")):
+            success, retry_count = False, 0
+            # retry up to six times
+            while success is False and retry_count < 6:
+                response = self._send_request(
+                    session=session,
+                    method=method,
+                    url=url,
+                    params=params,
+                    headers=headers,
+                )
+                if "API_ERROR" in str(response.json().get("errors")):
+                    retry_count += 1
+                    time.sleep(0.1 * (2 ** (retry_count - 1)))
+                else:
+                    success = True
 
         return response
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR updates the client to retry a request if it receives an `API_ERROR` code from the API. 

## Why is this PR important?

The client currently retries when it receives one of a few 500 codes. By detecting API_ERROR codes in the response, we can handle errors even when the GraphQL server returns a 200. The meat of this change is in lines 333-348, but I pulled some of the request logic into its own method to try and DRY the implementation.

Closes #2692 .