### PR TITLE
This is an update to PostgresExecute. It will rollback the transactio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Released on June 2, 2020.
 
 ### Task Library
 
-- Fix PostgresExecute task auto commit when commit is set to `False` - [#2658](https://github.com/PrefectHQ/prefect/issue/2658)
+- None
 
 ### Server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Released on June 2, 2020.
 
 ### Task Library
 
-- None
+- Fix PostgresExecute task auto commit when commit is set to `False` - [#2658](https://github.com/PrefectHQ/prefect/issue/2658)
 
 ### Server
 

--- a/changes/pr2710.yaml
+++ b/changes/pr2710.yaml
@@ -1,0 +1,3 @@
+### Task Library
+
+- Fix PostgresExecute task auto commit when commit is set to `False` - [#2658](https://github.com/PrefectHQ/prefect/issue/2658)

--- a/changes/pr2710.yaml
+++ b/changes/pr2710.yaml
@@ -1,3 +1,2 @@
-### Task Library
-
-- Fix PostgresExecute task auto commit when commit is set to `False` - [#2658](https://github.com/PrefectHQ/prefect/issue/2658)
+fix:
+  - "Fix `PostgresExecute` task auto commit when commit is set to `False` - [#2658](https://github.com/PrefectHQ/prefect/issue/2658)"

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -82,6 +82,8 @@ class PostgresExecute(Task):
                     executed = cursor.execute(query=query, vars=data)
                     if commit:
                         conn.commit()
+                    else:
+                        conn.rollback()
 
             conn.close()
             return executed


### PR DESCRIPTION
…n if commit is set to false in the task.

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:
- [ ] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Currently, if you execute a query against Postgres it will automatically commit, irrespective of the commit flag. This PR honors the commit arg on the PostgresExecute task by rolling back the transaction if commit is set to false. 

This change allows you to dry run flows without committing changes to the database. 

Any existing tasks using PostgresExecute with commit set to false will no longer commit by default with this PR. 


## Why is this PR important?
Closes #2658 


