### PR TITLE
Add psycopg2 back to Server dependencies; adjust unit tests to remove "extras"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,8 +290,8 @@ jobs:
           command: pip install -U pip
 
       - run:
-          name: Install Prefect
-          command: pip install ".[all_extras]"
+          name: Install base Prefect
+          command: pip install .
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,8 +290,8 @@ jobs:
           command: pip install -U pip
 
       - run:
-          name: Install base Prefect
-          command: pip install .
+          name: Install Prefect
+          command: pip install ".[all_extras]"
 
       - run:
           name: Run tests
@@ -303,8 +303,8 @@ jobs:
       - checkout
 
       - run:
-          name: Install Prefect
-          command: pip install ".[all_extras]"
+          name: Install base Prefect
+          command: pip install .
 
       - run:
           name: Install Prefect Server (editable)

--- a/server/setup.py
+++ b/server/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     "gunicorn >= 19.9,< 20.1",
     "httpx >= 0.13.0, < 0.14.0",
     "pendulum >= 2.0, < 3.0",
+    "psycopg2-binary >= 2.7, < 3.0",
     "pydantic >= 1.5, < 2.0",
     "python-box >= 3.4, < 5.0",
     "starlette >= 0.13, < 0.14",


### PR DESCRIPTION
In #2706 I removed `psycopg2` from the Server dependencies, which appeared to be fine. However, it was only fine because Server tests included Prefect with "all extras", including psycopg2. 

This PR adds psycopg2 back to the dependencies and adjusts server tests to remove all extra installs, so server is tested with "base" Prefect only.