### PR TITLE
update set run state signature for extensibility

### DIFF
--- a/changes/pr2718.yaml
+++ b/changes/pr2718.yaml
@@ -1,0 +1,6 @@
+enhancement:
+    - 'Extend run state signatures for future development - [#2718](https://github.com/PrefectHQ/prefect/pull/2718)'
+  
+  contributor:
+    - '[Alex Cano](https://github.com/alexisprince1994)'
+  

--- a/server/src/prefect_server/api/states.py
+++ b/server/src/prefect_server/api/states.py
@@ -3,15 +3,15 @@
 
 
 import asyncio
+from typing import Dict, Optional
 
 import pendulum
-
 import prefect
-
 from prefect.engine.state import Failed, Queued, State
+from prefect.utilities.graphql import EnumValue, with_args
+
 from prefect_server import api, config
 from prefect_server.database import hasura, models
-from prefect.utilities.graphql import EnumValue, with_args
 from prefect_server.utilities.logging import get_logger
 
 logger = get_logger("api")
@@ -19,14 +19,16 @@ logger = get_logger("api")
 state_schema = prefect.serialization.state.StateSchema()
 
 
-async def set_flow_run_state(flow_run_id: str, state: State) -> None:
+async def set_flow_run_state(flow_run_id: str, state: State) -> Dict[str, str]:
     """
     Updates a flow run state.
 
     Args:
         - flow_run_id (str): the flow run id to update
         - state (State): the new state
-
+    Returns:
+        - Dict[str, str]: Mapping indicating status of the state
+            change operation.
     """
 
     if flow_run_id is None:
@@ -55,9 +57,12 @@ async def set_flow_run_state(flow_run_id: str, state: State) -> None:
     )
 
     await flow_run_state.insert()
+    return {"status": "SUCCESS"}
 
 
-async def set_task_run_state(task_run_id: str, state: State, force=False) -> None:
+async def set_task_run_state(
+    task_run_id: str, state: State, force: bool = False
+) -> Dict[str, str]:
     """
     Updates a task run state.
 
@@ -65,6 +70,9 @@ async def set_task_run_state(task_run_id: str, state: State, force=False) -> Non
         - task_run_id (str): the task run id to update
         - state (State): the new state
         - false (bool): if True, avoids pipeline checks
+    Returns:
+        - Dict[str, str]: Mapping indicating status of the state
+            change operation.
     """
 
     if task_run_id is None:
@@ -117,3 +125,4 @@ async def set_task_run_state(task_run_id: str, state: State, force=False) -> Non
     )
 
     await task_run_state.insert()
+    return {"status": "SUCCESS"}

--- a/server/src/prefect_server/graphql/states.py
+++ b/server/src/prefect_server/graphql/states.py
@@ -5,14 +5,14 @@
 import asyncio
 from typing import Any
 
-from graphql import GraphQLResolveInfo
-
 import prefect
+from graphql import GraphQLResolveInfo
 from prefect.utilities.graphql import EnumValue
+
 from prefect_server import api, config
 from prefect_server.database import models
-from prefect_server.utilities.graphql import mutation
 from prefect_server.utilities import context, exceptions
+from prefect_server.utilities.graphql import mutation
 
 state_schema = prefect.serialization.state.StateSchema()
 
@@ -29,15 +29,12 @@ async def resolve_set_flow_run_states(
         try:
             state = state_schema.load(state_input["state"])
 
-            await api.states.set_flow_run_state(
+            result = await api.states.set_flow_run_state(
                 flow_run_id=state_input["flow_run_id"], state=state,
             )
+            result.update({"id": state_input["flow_run_id"], "message": None})
+            return result
 
-            return {
-                "id": state_input["flow_run_id"],
-                "status": "SUCCESS",
-                "message": None,
-            }
         except Exception as exc:
             return {
                 # placing the error inside the payload will get GraphQL to return the data
@@ -69,15 +66,12 @@ async def resolve_set_task_run_states(
         try:
             state = state_schema.load(state_input["state"])
 
-            await api.states.set_task_run_state(
+            result = await api.states.set_task_run_state(
                 task_run_id=state_input["task_run_id"], state=state,
             )
+            result.update({"id": state_input["task_run_id"], "message": None})
+            return result
 
-            return {
-                "id": state_input["task_run_id"],
-                "status": "SUCCESS",
-                "message": None,
-            }
         except Exception as exc:
             return {
                 # placing the error inside the payload will get GraphQL to return the data

--- a/server/tests/api/test_states.py
+++ b/server/tests/api/test_states.py
@@ -5,10 +5,9 @@
 import asyncio
 import uuid
 
+import prefect
 import pytest
 from box import Box
-
-import prefect
 from prefect.engine.result import Result, SafeResult
 from prefect.engine.result_handlers import JSONResultHandler
 from prefect.engine.state import (
@@ -27,12 +26,19 @@ from prefect.engine.state import (
     TriggerFailed,
     _MetaState,
 )
+
 from prefect_server import api, config, utilities
 from prefect_server.api import runs, states
 from prefect_server.database import models
 
 
 class TestTaskRunStates:
+    async def test_returns_status_dict(
+        self, running_flow_run_id: str, task_run_id: str
+    ):
+        result = await states.set_task_run_state(task_run_id, state=Success())
+        assert result["status"] == "SUCCESS"
+
     @pytest.mark.parametrize(
         "state_cls", [s for s in State.children() if s not in _MetaState.children()]
     )
@@ -204,6 +210,10 @@ class TestTaskRunStates:
 
 
 class TestFlowRunStates:
+    async def test_returns_status_dict(self, flow_run_id: str):
+        result = await states.set_flow_run_state(flow_run_id, state=Success())
+        assert result["status"] == "SUCCESS"
+
     @pytest.mark.parametrize(
         "state_cls", [s for s in State.children() if s not in _MetaState.children()]
     )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR updates the signature of the state setting pipeline to return a mapping indicating the status of the update operation. Previously, the only options were returning `None`, which meant success, and raising a `ValueError`, which indicated failure.


## Why is this PR important?
This PR allows alternative options, such as indicating that instead of the desired state, the state got set to `Queued`. This PR enables both tasks and flows an avenue to enter the `Queued` status, which is a prerequisite for server successfully implementing concurrency limiting.

