### PR TITLE
update set_flow_run_state signature for flow meta state future use

### DIFF
--- a/changes/pr2725.yaml
+++ b/changes/pr2725.yaml
@@ -1,0 +1,25 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - server
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+    - "Update set_flow_run_state for future meta state use - [#2725](https://github.com/PrefectHQ/prefect/pull/2725)"
+  
+  contributor:
+    - "[Alex Cano](https://github.com/alexisprince1994)"
+  

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 import re
+import time
 import uuid
 import warnings
 from pathlib import Path
@@ -10,7 +11,6 @@ from urllib.parse import urljoin
 
 import pendulum
 import toml
-import time
 from slugify import slugify
 
 import prefect
@@ -952,7 +952,7 @@ class Client:
 
     def set_flow_run_state(
         self, flow_run_id: str, version: int, state: "prefect.engine.state.State"
-    ) -> None:
+    ) -> "prefect.engine.state.State":
         """
         Sets new state for a flow run in the database.
 
@@ -960,6 +960,9 @@ class Client:
             - flow_run_id (str): the id of the flow run to set state for
             - version (int): the current version of the flow run state
             - state (State): the new state for this flow run
+
+        Returns:
+            - State: the state the current flow run should be considered in
 
         Raises:
             - ClientError: if the GraphQL mutation is bad for any reason
@@ -986,6 +989,8 @@ class Client:
                 )
             ),
         )  # type: Any
+
+        return state
 
     def get_latest_cached_states(
         self, task_id: str, cache_key: Optional[str], created_after: datetime.datetime

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -114,7 +114,7 @@ class CloudFlowRunner(FlowRunner):
 
         try:
             cloud_state = new_state
-            self.client.set_flow_run_state(
+            state = self.client.set_flow_run_state(
                 flow_run_id=flow_run_id, version=version, state=cloud_state
             )
         except Exception as exc:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -11,7 +11,7 @@ import requests
 import prefect
 from prefect.client.client import Client, FlowRunInfoResult, TaskRunInfoResult
 from prefect.engine.result import NoResult, Result, SafeResult
-from prefect.engine.state import Pending
+from prefect.engine.state import Pending, State
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.exceptions import AuthorizationError, ClientError
 from prefect.utilities.graphql import GraphQLResult, decompress
@@ -670,10 +670,11 @@ def test_set_flow_run_state(patch_post):
         {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
     ):
         client = Client()
-    result = client.set_flow_run_state(
-        flow_run_id="74-salt", version=0, state=Pending()
-    )
-    assert result is None
+
+    state = Pending()
+    result = client.set_flow_run_state(flow_run_id="74-salt", version=0, state=state)
+    assert isinstance(result, State)
+    assert isinstance(result, Pending)
 
 
 def test_set_flow_run_state_with_error(patch_post):

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -9,15 +9,15 @@ import pytest
 import prefect
 from prefect.client.client import Client, FlowRunInfoResult
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
-from prefect.engine.signals import LOOP
 from prefect.engine.result import NoResult, Result, SafeResult
-from prefect.engine.results import PrefectResult, SecretResult
 from prefect.engine.result_handlers import (
     ConstantResultHandler,
     JSONResultHandler,
     ResultHandler,
     SecretResultHandler,
 )
+from prefect.engine.results import PrefectResult, SecretResult
+from prefect.engine.signals import LOOP
 from prefect.engine.state import (
     Cancelled,
     Failed,
@@ -52,7 +52,9 @@ def cloud_settings():
 def client(monkeypatch):
     cloud_client = MagicMock(
         get_flow_run_info=MagicMock(return_value=MagicMock(state=None, parameters={})),
-        set_flow_run_state=MagicMock(),
+        set_flow_run_state=MagicMock(
+            side_effect=lambda flow_run_id, version, state: state
+        ),
         get_task_run_info=MagicMock(return_value=MagicMock(state=None)),
         set_task_run_state=MagicMock(
             side_effect=lambda task_run_id, version, state, cache_for: state
@@ -540,7 +542,6 @@ def test_starting_at_arbitrary_loop_index_from_cloud_context(client):
     client.get_flow_run_info = MagicMock(
         return_value=MagicMock(context={"task_loop_count": 20})
     )
-    client.set_flow_run_state = MagicMock()
 
     flow_state = CloudFlowRunner(flow=f).run(return_tasks=[inter, final])
 
@@ -602,6 +603,9 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
             calls.append(args)
 
         def set_task_run_state(self, *args, **kwargs):
+            return kwargs.get("state")
+
+        def set_flow_run_state(self, *args, **kwargs):
             return kwargs.get("state")
 
         def get_flow_run_info(self, *args, **kwargs):

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -171,6 +171,7 @@ class MockedCloudClient(MagicMock):
             fr.version += 1
         else:
             raise ValueError("Invalid flow run update")
+        return state
 
     def set_task_run_state(self, task_run_id, version, state, **kwargs):
         self.call_count["set_task_run_state"] += 1


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

closes #2724 

## What does this PR change?
This PR will update the `Client.set_flow_run_state` signature to return the new `State`, as opposed to `None`.


## Why is this PR important?
This PR allows future extensibility by allowing logic to be placed between receiving a response from Cloud and the cloud flow runner reacting to it.

