### PR TITLE
Use fully-qualified path to avoid conflicts with other registered schemas

### DIFF
--- a/changes/pr2738.yaml
+++ b/changes/pr2738.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Ensure state deserialization works even when another StateSchema exists - [#2738](https://github.com/PrefectHQ/prefect/pull/2738)"

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -57,7 +57,7 @@ class PendingSchema(BaseStateSchema):
 
 
 class MetaStateSchema(BaseStateSchema):
-    state = fields.Nested("StateSchema", allow_none=True)
+    state = fields.Nested("prefect.serialization.state.StateSchema", allow_none=True)
 
 
 class ClientFailedSchema(MetaStateSchema):
@@ -132,7 +132,7 @@ class MappedSchema(SuccessSchema):
         object_class = state.Mapped
 
     # though this field is excluded from serialization, it must be present in the schema
-    map_states = fields.Nested("StateSchema", many=True)
+    map_states = fields.Nested("prefect.serialization.state.StateSchema", many=True)
     n_map_states = fields.Integer()
 
     @post_load

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -21,6 +21,8 @@ all_states = sorted(
     key=lambda c: c.__name__,
 )
 
+from marshmallow import Schema
+
 
 def complex_states():
     res1 = SafeResult(1, result_handler=JSONResultHandler())

--- a/tests/serialization/test_states_shadow_schema.py
+++ b/tests/serialization/test_states_shadow_schema.py
@@ -1,0 +1,19 @@
+import prefect
+from prefect.engine import state
+from marshmallow import Schema
+
+
+class StateSchema(Schema):
+    pass
+
+
+def test_state():
+    """
+    This test ensures that deserialization works even when
+    another Marshmallow serializer called "StateSchema" has been
+    created.
+
+    https://github.com/PrefectHQ/prefect/pull/2738
+    """
+    a = state.Submitted(state=state.Success())
+    prefect.serialization.state.StateSchema().load(a.serialize())


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Uses a fully-qualified path to the Marshmallow schema for States in order to avoid conflicts with any user-registered schemas by the same name (since Marshmallow doesn't know how to disambiguate)


## Why is this PR important?
See for example https://prefect-community.slack.com/archives/CL09KU1K7/p1591564929493200?thread_ts=1591186834.311100&cid=CL09KU1K7

