### PR TITLE
Fix flow.visualize cleanup of source files when using filename

### DIFF
--- a/changes/issue2726.yaml
+++ b/changes/issue2726.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix flow.visualize cleanup of source files when using `filename` - [#2726](https://github.com/PrefectHQ/prefect/issues/2726)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1243,7 +1243,7 @@ class Flow:
                 )
 
         if filename:
-            graph.render(filename, view=False, format=format)
+            graph.render(filename, view=False, format=format, cleanup=True)
         else:
             try:
                 from IPython import get_ipython

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1211,12 +1211,8 @@ class TestFlowVisualize:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "viz"), "wb") as tmp:
-                graph = f.visualize(filename=tmp.name)
-            with open(tmp.name, "r") as f:
-                contents = f.read()
-
-        assert "label=a_nice_task" in contents
-        assert "shape=ellipse" in contents
+                graph = f.visualize(filename=tmp.name, format="png")
+            assert os.path.exists(f"{tmp.name}.png")
 
     def test_viz_reflects_mapping(self):
         ipython = MagicMock(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1213,6 +1213,7 @@ class TestFlowVisualize:
             with open(os.path.join(tmpdir, "viz"), "wb") as tmp:
                 graph = f.visualize(filename=tmp.name, format="png")
             assert os.path.exists(f"{tmp.name}.png")
+            assert not os.path.exists(tmp.name)
 
     def test_viz_reflects_mapping(self):
         ipython = MagicMock(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2726 


## Why is this PR important?
Cleans up the intermediate source file that is kept around when visualizing the flow

