### PR TITLE
Add new CI step for a prefect image with all_extras installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,7 +440,7 @@ jobs:
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
             docker push prefecthq/prefect:master
 
-  build_storage_docker_image:
+  build_all_extras_docker_image:
     docker:
       - image: docker
     parameters:
@@ -467,7 +467,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build storage image
+          name: Build all_extras image
           command: |
             set -u
             docker build \
@@ -476,17 +476,17 @@ jobs:
               --build-arg PREFECT_VERSION=$CIRCLE_TAG \
               --build-arg PYTHON_VERSION=$PYTHON_VERSION \
               --build-arg EXTRAS=$EXTRAS \
-              -t prefecthq/prefect:storage-${CIRCLE_TAG} \
+              -t prefecthq/prefect:all_extras-${CIRCLE_TAG} \
               .
       - run:
           name: Test image
           command: |
-            docker run -dit prefecthq/prefect:storage-${CIRCLE_TAG} /bin/bash -c 'curl -fL0 https://raw.githubusercontent.com/PrefectHQ/prefect/master/examples/retries_with_mapping.py | python'
+            docker run -dit prefecthq/prefect:all_extras-${CIRCLE_TAG} /bin/bash -c 'curl -fL0 https://raw.githubusercontent.com/PrefectHQ/prefect/master/examples/retries_with_mapping.py | python'
       - run:
-          name: Push storage tag
+          name: Push all_extras tag
           command: |
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
-            docker push prefecthq/prefect:storage-${CIRCLE_TAG}
+            docker push prefecthq/prefect:all_extras-${CIRCLE_TAG}
       - when:
           condition: << parameters.tag_latest >>
           steps:
@@ -494,7 +494,7 @@ jobs:
                 name: Push latest tag
                 command: |
                   docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
-                  docker push prefecthq/prefect:storage
+                  docker push prefecthq/prefect:all_extras
 
 
   release_to_pypi:
@@ -598,9 +598,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
-      - build_storage_docker_image:
+      - build_all_extras_docker_image:
           python_version: '3.8'
-          extras: 'aws,azure,gcp'
+          extras: 'all_extras'
           tag_latest: true
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,11 @@ jobs:
     parameters:
       python_version:
         type: string
+      extras:
+        type: string
+      tag_latest:
+        type: boolean
+        default: false
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       EXTRAS: << parameters.extras >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,6 +440,58 @@ jobs:
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
             docker push prefecthq/prefect:master
 
+  build_storage_docker_image:
+    docker:
+      - image: docker
+    parameters:
+      python_version:
+        type: string
+    environment:
+      PYTHON_VERSION: << parameters.python_version >>
+      EXTRAS: << parameters.extras >>
+    steps:
+      - checkout
+      - run:
+          name: Master branch check
+          command: |
+            apk add git
+            if [[ $(git branch --contains $CIRCLE_SHA1 --points-at master | grep master | wc -l) -ne 1 ]]; then
+              echo "commit $CIRCLE_SHA1 is not a member of the master branch"
+              exit 1
+            fi
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build storage image
+          command: |
+            set -u
+            docker build \
+              --build-arg GIT_SHA=$CIRCLE_SHA1 \
+              --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+              --build-arg PREFECT_VERSION=$CIRCLE_TAG \
+              --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+              --build-arg EXTRAS=$EXTRAS \
+              -t prefecthq/prefect:storage-${CIRCLE_TAG} \
+              .
+      - run:
+          name: Test image
+          command: |
+            docker run -dit prefecthq/prefect:storage-${CIRCLE_TAG} /bin/bash -c 'curl -fL0 https://raw.githubusercontent.com/PrefectHQ/prefect/master/examples/retries_with_mapping.py | python'
+      - run:
+          name: Push storage tag
+          command: |
+            docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
+            docker push prefecthq/prefect:storage-${CIRCLE_TAG}
+      - when:
+          condition: << parameters.tag_latest >>
+          steps:
+            - run:
+                name: Push latest tag
+                command: |
+                  docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
+                  docker push prefecthq/prefect:storage
+
+
   release_to_pypi:
     docker:
       - image: python:3.7
@@ -536,6 +588,15 @@ workflows:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - release_to_pypi:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+      - build_storage_docker_image:
+          python_version: '3.8'
+          extras: 'aws,azure,gcp'
+          tag_latest: true
           filters:
             branches:
               ignore: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:${PYTHON_VERSION}-slim
 RUN apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*
 
 ARG PREFECT_VERSION
-RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[kubernetes]
+ARG EXTRAS=kubernetes
+RUN pip install git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[${EXTRAS}]
 RUN mkdir /root/.prefect/
 
 ARG GIT_SHA

--- a/changes/pr2745.yaml
+++ b/changes/pr2745.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add CI step to build `prefecthq/prefect:all_extras` Docker image for bundling all Prefect dependencies - [#2745](https://github.com/PrefectHQ/prefect/pull/2745)"

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -91,3 +91,5 @@ Image tag breakdown:
 | X.Y.Z-python3.8  |          X.Y.Z           |            3.8 |
 | X.Y.Z-python3.7  |          X.Y.Z           |            3.7 |
 | X.Y.Z-python3.6  |          X.Y.Z           |            3.6 |
+| all_extras       | most recent PyPi version |            3.8 |
+| all_extras-X.Y.Z |          X.Y.Z           |            3.8 |


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds an `all_extras` `prefecthq/prefect` image to be built on releases of Prefect.


## Why is this PR important?
When doing something like:

```python
f.storage = S3(bucket="my-flows", secrets=["AWS_CREDENTIALS"])
f.environment = RemoteEnvironment(metadata={"image": "image/name:here"})
```

The `image` needs to have the dependencies present for the selected `storage` (in this case, prefect's `aws` extras). This adds an image with `all_extras` and it acts as a self contained image with even more packages baked in. In this case you can use the entire task library without ever having to build an image for deployment.

(edited)

-----

Original text: 
> When doing something like:

> f.storage = S3(bucket="my-flows", secrets=["AWS_CREDENTIALS"])
> f.environment = RemoteEnvironment(metadata={"image": "image/name:here"})
> The image needs to have the dependencies present for the selected storage (in this case, prefect's aws extras). This is a mini proposal to add an extra image that we build on releases which add the dependencies for the cloud storage classes (aws, azure, gcp). If we are positioning this as a way to deploy flows without building images then we need to have a base image with these dependencies or else the user will still have to build at least one image.
> 
> Another option would be to make an image with all_extras and it would act as a self contained image with even more packages baked in. In that case you could use the entire task library without ever having to build an image for deployment.
> 
> cc @cicdw~