### PR TITLE
Fix env metadata not having access to name of Docker storage

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -648,8 +648,14 @@ class Client:
 
         serialized_flow = flow.serialize(build=build)  # type: Any
 
-        if isinstance(flow.storage, prefect.environments.storage.Docker):
-            flow.environment.metadata["image"] = flow.storage.name
+        try:
+            if isinstance(flow.storage, prefect.environments.storage.Docker):
+                flow.environment.metadata["image"] = flow.storage.name
+        except ValueError:
+            warnings.warn(
+                "Flow's Docker storage was not built so `image` will not be present in `environment.metadata`.",
+                UserWarning,
+            )
 
         # verify that the serialized flow can be deserialized
         try:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -648,6 +648,9 @@ class Client:
 
         serialized_flow = flow.serialize(build=build)  # type: Any
 
+        if isinstance(flow.storage, prefect.environments.storage.Docker):
+            flow.environment.metadata["image"] = flow.storage.name
+
         # verify that the serialized flow can be deserialized
         try:
             prefect.serialization.flow.FlowSchema().load(serialized_flow)

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -648,14 +648,8 @@ class Client:
 
         serialized_flow = flow.serialize(build=build)  # type: Any
 
-        try:
-            if isinstance(flow.storage, prefect.environments.storage.Docker):
-                flow.environment.metadata["image"] = flow.storage.name
-        except ValueError:
-            warnings.warn(
-                "Flow's Docker storage was not built so `image` will not be present in `environment.metadata`.",
-                UserWarning,
-            )
+        if isinstance(flow.storage, prefect.environments.storage.Docker):
+            flow.environment.metadata["image"] = flow.storage.name
 
         # verify that the serialized flow can be deserialized
         try:

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1428,9 +1428,6 @@ class Flow:
         if labels:
             self.environment.labels.update(labels)
 
-        if isinstance(self.storage, prefect.environments.storage.Docker):
-            self.environment.metadata["image"] = self.storage.name
-
         # register the flow with a default result handler if one not provided
         if not self.result:
             self.result = self.storage.result

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -250,7 +250,9 @@ class Docker(Storage):
         Full name of the Docker image.
         """
         if None in [self.image_name, self.image_tag]:
-            raise ValueError("Docker storage is missing required fields")
+            raise ValueError(
+                "Docker storage is missing required fields image_name and image_tag"
+            )
 
         return "{}:{}".format(
             PurePosixPath(self.registry_url or "", self.image_name),  # type: ignore

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -358,6 +358,55 @@ def test_client_register_builds_flow(patch_post, compressed, monkeypatch, tmpdir
 
 
 @pytest.mark.parametrize("compressed", [True, False])
+def test_client_register_docker_image_name(patch_post, compressed, monkeypatch, tmpdir):
+    if compressed:
+        response = {
+            "data": {
+                "project": [{"id": "proj-id"}],
+                "create_flow_from_compressed_string": {"id": "long-id"},
+            }
+        }
+    else:
+        response = {
+            "data": {"project": [{"id": "proj-id"}], "create_flow": {"id": "long-id"}}
+        }
+    post = patch_post(response)
+
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+    monkeypatch.setattr("prefect.environments.storage.Docker._build_image", MagicMock())
+
+    with set_temporary_config(
+        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+    flow = prefect.Flow(
+        name="test",
+        storage=prefect.environments.storage.Docker(image_name="test_image"),
+    )
+    flow.result = flow.storage.result
+
+    flow_id = client.register(
+        flow, project_name="my-default-project", compressed=compressed, build=True
+    )
+
+    ## extract POST info
+    if compressed:
+        serialized_flow = decompress(
+            json.loads(post.call_args[1]["json"]["variables"])["input"][
+                "serialized_flow"
+            ]
+        )
+    else:
+        serialized_flow = json.loads(post.call_args[1]["json"]["variables"])["input"][
+            "serialized_flow"
+        ]
+    assert serialized_flow["storage"] is not None
+    assert "test_image" in serialized_flow["environment"]["metadata"]["image"]
+
+
+@pytest.mark.parametrize("compressed", [True, False])
 def test_client_register_optionally_avoids_building_flow(
     patch_post, compressed, monkeypatch
 ):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -407,57 +407,6 @@ def test_client_register_docker_image_name(patch_post, compressed, monkeypatch, 
 
 
 @pytest.mark.parametrize("compressed", [True, False])
-def test_client_register_docker_image_name_catches_value_error(
-    patch_post, compressed, monkeypatch, tmpdir
-):
-    if compressed:
-        response = {
-            "data": {
-                "project": [{"id": "proj-id"}],
-                "create_flow_from_compressed_string": {"id": "long-id"},
-            }
-        }
-    else:
-        response = {
-            "data": {"project": [{"id": "proj-id"}], "create_flow": {"id": "long-id"}}
-        }
-    post = patch_post(response)
-
-    monkeypatch.setattr(
-        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
-    )
-    monkeypatch.setattr("prefect.environments.storage.Docker._build_image", MagicMock())
-
-    with set_temporary_config(
-        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
-    ):
-        client = Client()
-    flow = prefect.Flow(
-        name="test",
-        storage=prefect.environments.storage.Docker(image_name="test_image"),
-    )
-    flow.result = flow.storage.result
-
-    flow_id = client.register(
-        flow, project_name="my-default-project", compressed=compressed, build=False
-    )
-
-    ## extract POST info
-    if compressed:
-        serialized_flow = decompress(
-            json.loads(post.call_args[1]["json"]["variables"])["input"][
-                "serialized_flow"
-            ]
-        )
-    else:
-        serialized_flow = json.loads(post.call_args[1]["json"]["variables"])["input"][
-            "serialized_flow"
-        ]
-    assert serialized_flow["storage"] is not None
-    assert serialized_flow["environment"]["metadata"].get("image", None) is None
-
-
-@pytest.mark.parametrize("compressed", [True, False])
 def test_client_register_optionally_avoids_building_flow(
     patch_post, compressed, monkeypatch
 ):

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2581,28 +2581,6 @@ class TestFlowRegister:
         assert "foo" in f.environment.labels
         assert len(f.environment.labels) == 2
 
-    def test_flow_register_passes_image_to_env_metadata(
-        self, monkeypatch,
-    ):
-        monkeypatch.setattr("prefect.Client", MagicMock())
-        f = Flow(name="test")
-
-        assert f.storage is None
-        with set_temporary_config(
-            {
-                "flows.defaults.storage.default_class": "prefect.environments.storage.Docker"
-            }
-        ):
-            f.register(
-                "My-project",
-                registry_url="FOO",
-                image_name="BAR",
-                image_tag="BIG",
-                no_url=True,
-            )
-
-        assert f.environment.metadata == {"image": "FOO/BAR:BIG"}
-
     def test_flow_register_passes_kwargs_to_storage(self, monkeypatch):
         monkeypatch.setattr("prefect.Client", MagicMock())
 


### PR DESCRIPTION
If a registry or name are not provided to Docker storage then the value of `storage.name` will raise an error if the storage has not been built yet (we add a random name/tag on build if not set). This moves the place where the `storage.name` is appended to the `environment.metadata` to _after_ the build.