### PR TITLE
Move parameters to standalone module

### DIFF
--- a/changes/pr2758.yaml
+++ b/changes/pr2758.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Move `Parameter` to a standalone module - [#2758](https://github.com/PrefectHQ/prefect/pull/2758)"
+
+deprecation:
+  - "Accessing `prefect.core.task.Parameter` is deprecated in favor of `prefect.core.parameter.Parameter` - [#2758](https://github.com/PrefectHQ/prefect/pull/2758)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -83,7 +83,12 @@ classes = ["Flow"]
 [pages.core.task]
 title = "Task"
 module = "prefect.core.task"
-classes = ["Task", "Parameter"]
+classes = ["Task"]
+
+[pages.core.parameters]
+title = "Parameter"
+module = "prefect.core.parameter"
+classes = ["Parameter"]
 
 [pages.engine.cache_validators]
 title = "Cache Validators"

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -21,7 +21,7 @@ import prefect.agent
 # DEPRECATED - this is to allow backwards-compatible access to Parameters
 # This awkward assignment avoids circular imports in core.task
 # https://github.com/PrefectHQ/prefect/pull/2758
-prefect.core.task.Parameter = Parameter # type: ignore
+prefect.core.task.Parameter = Parameter  # type: ignore
 
 # ---------------------------------------------
 # Versioneer

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -18,15 +18,6 @@ import prefect.serialization
 
 import prefect.agent
 
-# DEPRECATED - this is to allow backwards-compatible access to Parameters
-# This awkward assignment avoids circular imports in core.task
-# https://github.com/PrefectHQ/prefect/pull/2758
-prefect.core.task.Parameter = Parameter  # type: ignore
-
-# ---------------------------------------------
-# Versioneer
-# ---------------------------------------------
-
 from ._version import get_versions
 
 __version__ = get_versions()["version"]  # type: ignore

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -18,6 +18,15 @@ import prefect.serialization
 
 import prefect.agent
 
+# DEPRECATED - this is to allow backwards-compatible access to Parameters
+# This awkward assignment avoids circular imports in core.task
+# https://github.com/PrefectHQ/prefect/pull/2758
+prefect.core.task.Parameter = Parameter # type: ignore
+
+# ---------------------------------------------
+# Versioneer
+# ---------------------------------------------
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]  # type: ignore

--- a/src/prefect/core/__init__.py
+++ b/src/prefect/core/__init__.py
@@ -1,3 +1,4 @@
-from prefect.core.task import Task, Parameter
-from prefect.core.flow import Flow
+from prefect.core.task import Task
+from prefect.core.parameter import Parameter
 from prefect.core.edge import Edge
+from prefect.core.flow import Flow

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -31,7 +31,8 @@ from slugify import slugify
 import prefect
 import prefect.schedules
 from prefect.core.edge import Edge
-from prefect.core.task import Parameter, Task
+from prefect.core.task import Task
+from prefect.core.parameter import Parameter
 from prefect.engine.result import NoResult, Result
 from prefect.engine.results import ResultHandlerResult
 from prefect.engine.result_handlers import ResultHandler

--- a/src/prefect/core/parameter.py
+++ b/src/prefect/core/parameter.py
@@ -1,0 +1,110 @@
+from typing import TYPE_CHECKING, Any, Dict, Iterable
+
+import prefect
+import prefect.engine.signals
+import prefect.triggers
+from prefect.core.task import Task
+from prefect.engine.results import PrefectResult
+
+if TYPE_CHECKING:
+    from prefect.core.flow import Flow  # pylint: disable=W0611
+    from prefect.engine.result import Result  # pylint: disable=W0611
+
+
+class Parameter(Task):
+    """
+    A Parameter is a special task that defines a required flow input.
+
+    A parameter's "slug" is automatically -- and immutably -- set to the parameter name.
+    Flows enforce slug uniqueness across all tasks, so this ensures that the flow has
+    no other parameters by the same name.
+
+    Args:
+        - name (str): the Parameter name.
+        - required (bool, optional): If True, the Parameter is required and the default
+            value is ignored.
+        - default (any, optional): A default value for the parameter. If the default
+            is not None, the Parameter will not be required.
+        - tags ([str], optional): A list of tags for this parameter
+
+    """
+
+    def __init__(
+        self,
+        name: str,
+        default: Any = None,
+        required: bool = True,
+        tags: Iterable[str] = None,
+        result: "Result" = None,
+    ):
+        if default is not None:
+            required = False
+
+        self.required = required
+        self.default = default
+
+        if result is None:
+            result = PrefectResult()
+
+        super().__init__(
+            name=name, slug=name, tags=tags, result=result, checkpoint=True,
+        )
+
+    def __repr__(self) -> str:
+        return "<Parameter: {self.name}>".format(self=self)
+
+    def __call__(self, flow: "Flow" = None) -> "Parameter":  # type: ignore
+        """
+        Calling a Parameter adds it to a flow.
+
+        Args:
+            - flow (Flow, optional): The flow to set dependencies on, defaults to the current
+                flow in context if no flow is specified
+
+        Returns:
+            - Task: a new Task instance
+
+        """
+        result = super().bind(flow=flow)
+        assert isinstance(result, Parameter)  # mypy assert
+        return result
+
+    def copy(self, name: str, **task_args: Any) -> "Task":  # type: ignore
+        """
+        Creates a copy of the Parameter with a new name.
+
+        Args:
+            - name (str): the new Parameter name
+            - **task_args (dict, optional): a dictionary of task attribute keyword arguments,
+                these attributes will be set on the new copy
+
+        Raises:
+            - AttributeError: if any passed `task_args` are not attributes of the original
+
+        Returns:
+            - Parameter: a copy of the current Parameter, with a new name and any attributes
+                updated from `task_args`
+        """
+        return super().copy(name=name, slug=name, **task_args)
+
+    def run(self) -> Any:
+        params = prefect.context.get("parameters") or {}
+        if self.required and self.name not in params:
+            self.logger.debug(
+                'Parameter "{}" was required but not provided.'.format(self.name)
+            )
+            raise prefect.engine.signals.FAIL(
+                'Parameter "{}" was required but not provided.'.format(self.name)
+            )
+        return params.get(self.name, self.default)
+
+    # Serialization ------------------------------------------------------------
+
+    def serialize(self) -> Dict[str, Any]:
+        """
+        Creates a serialized representation of this parameter
+
+        Returns:
+            - dict representing this parameter
+        """
+        return prefect.serialization.task.ParameterSchema().dump(self)

--- a/src/prefect/core/parameter.py
+++ b/src/prefect/core/parameter.py
@@ -8,7 +8,6 @@ from prefect.engine.results import PrefectResult
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
-    from prefect.engine.result import Result  # pylint: disable=W0611
 
 
 class Parameter(Task):
@@ -35,7 +34,6 @@ class Parameter(Task):
         default: Any = None,
         required: bool = True,
         tags: Iterable[str] = None,
-        result: "Result" = None,
     ):
         if default is not None:
             required = False
@@ -43,11 +41,8 @@ class Parameter(Task):
         self.required = required
         self.default = default
 
-        if result is None:
-            result = PrefectResult()
-
         super().__init__(
-            name=name, slug=name, tags=tags, result=result, checkpoint=True,
+            name=name, slug=name, tags=tags, result=PrefectResult(), checkpoint=True,
         )
 
     def __repr__(self) -> str:

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -17,7 +17,7 @@ from typing import (
 
 import prefect
 import prefect.engine.cache_validators
-from prefect.engine.results import PrefectResult, ResultHandlerResult
+from prefect.engine.results import ResultHandlerResult
 import prefect.engine.signals
 import prefect.triggers
 from prefect.utilities import logging
@@ -1089,100 +1089,6 @@ class Task(metaclass=SignatureValidator):
         """
         return prefect.tasks.core.operators.LessThanOrEqual().bind(self, other)
 
-
-class Parameter(Task):
-    """
-    A Parameter is a special task that defines a required flow input.
-
-    A parameter's "slug" is automatically -- and immutably -- set to the parameter name.
-    Flows enforce slug uniqueness across all tasks, so this ensures that the flow has
-    no other parameters by the same name.
-
-    Args:
-        - name (str): the Parameter name.
-        - required (bool, optional): If True, the Parameter is required and the default
-            value is ignored.
-        - default (any, optional): A default value for the parameter. If the default
-            is not None, the Parameter will not be required.
-        - tags ([str], optional): A list of tags for this parameter
-
-    """
-
-    def __init__(
-        self,
-        name: str,
-        default: Any = None,
-        required: bool = True,
-        tags: Iterable[str] = None,
-    ):
-        if default is not None:
-            required = False
-
-        self.required = required
-        self.default = default
-
-        super().__init__(
-            name=name, slug=name, tags=tags, result=PrefectResult(), checkpoint=True,
-        )
-
-    def __repr__(self) -> str:
-        return "<Parameter: {self.name}>".format(self=self)
-
-    def __call__(self, flow: "Flow" = None) -> "Parameter":  # type: ignore
-        """
-        Calling a Parameter adds it to a flow.
-
-        Args:
-            - flow (Flow, optional): The flow to set dependencies on, defaults to the current
-                flow in context if no flow is specified
-
-        Returns:
-            - Task: a new Task instance
-
-        """
-        result = super().bind(flow=flow)
-        assert isinstance(result, Parameter)  # mypy assert
-        return result
-
-    def copy(self, name: str, **task_args: Any) -> "Task":  # type: ignore
-        """
-        Creates a copy of the Parameter with a new name.
-
-        Args:
-            - name (str): the new Parameter name
-            - **task_args (dict, optional): a dictionary of task attribute keyword arguments,
-                these attributes will be set on the new copy
-
-        Raises:
-            - AttributeError: if any passed `task_args` are not attributes of the original
-
-        Returns:
-            - Parameter: a copy of the current Parameter, with a new name and any attributes
-                updated from `task_args`
-        """
-        return super().copy(name=name, slug=name, **task_args)
-
-    def run(self) -> Any:
-        params = prefect.context.get("parameters") or {}
-        if self.required and self.name not in params:
-            self.logger.debug(
-                'Parameter "{}" was required but not provided.'.format(self.name)
-            )
-            raise prefect.engine.signals.FAIL(
-                'Parameter "{}" was required but not provided.'.format(self.name)
-            )
-        return params.get(self.name, self.default)
-
-    # Serialization ------------------------------------------------------------
-
-    def serialize(self) -> Dict[str, Any]:
-        """
-        Creates a serialized representation of this parameter
-
-        Returns:
-            - dict representing this parameter
-        """
-        return prefect.serialization.task.ParameterSchema().dump(self)
 
 
 # All keyword-only arguments to Task.__call__, used for dynamically generating

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -1097,3 +1097,13 @@ EXTRA_CALL_PARAMETERS = [
     for p in inspect.Signature.from_callable(Task.__call__).parameters.values()
     if p.kind == inspect.Parameter.KEYWORD_ONLY
 ]
+
+# DEPRECATED - this is to allow backwards-compatible access to Parameters
+# https://github.com/PrefectHQ/prefect/pull/2758
+from .parameter import Parameter as _Parameter
+
+
+class Parameter(_Parameter):
+    def __new__(cls, *args, **kwargs):  # type: ignore
+        warnings.warn("`Parameter` has moved, please import as `prefect.Parameter`")
+        return super().__new__(cls)

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -1090,7 +1090,6 @@ class Task(metaclass=SignatureValidator):
         return prefect.tasks.core.operators.LessThanOrEqual().bind(self, other)
 
 
-
 # All keyword-only arguments to Task.__call__, used for dynamically generating
 # Signature objects for Task objects
 EXTRA_CALL_PARAMETERS = [

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -18,7 +18,7 @@ from prefect.utilities.serialization import (
 
 def get_parameters(obj: prefect.Flow, context: dict) -> Set:
     if isinstance(obj, prefect.Flow):
-        return {p for p in obj.tasks if isinstance(p, prefect.core.task.Parameter)}
+        return {p for p in obj.tasks if isinstance(p, prefect.core.parameter.Parameter)}
     else:
         return utils.get_value(obj, "parameters")
 

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -118,7 +118,7 @@ class TaskSchema(TaskMethodsMixin, ObjectSchema):
 
 class ParameterSchema(TaskMethodsMixin, ObjectSchema):
     class Meta:
-        object_class = lambda: prefect.core.task.Parameter  # type: ignore
+        object_class = lambda: prefect.core.parameter.Parameter  # type: ignore
         exclude_fields = ["type", "outputs", "slug"]
 
     type = fields.Function(lambda task: to_qualified_name(type(task)), lambda x: x)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -17,7 +17,8 @@ import toml
 import prefect
 from prefect.core.edge import Edge
 from prefect.core.flow import Flow
-from prefect.core.task import Parameter, Task
+from prefect.core.task import Task
+from prefect.core.parameter import Parameter
 from prefect.engine.cache_validators import all_inputs, partial_inputs_only
 from prefect.engine.executors import LocalExecutor
 from prefect.engine.result import Result

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -1,5 +1,6 @@
 import pytest
 
+import prefect
 from prefect.core.flow import Flow
 from prefect.core.task import Task
 from prefect.core.parameter import Parameter
@@ -90,3 +91,10 @@ def test_copy_requires_name():
     x = Parameter("x")
     with pytest.raises(TypeError, match="required positional argument"):
         x.copy()
+
+def test_backwards_compatible_access():
+    """
+    Deprecated test that asserts that backwards compatible access works after 0.12
+    Can be removed once the backwards compatibility is no longer maintained.
+    """
+    assert prefect.core.task.Parameter is prefect.core.parameter.Parameter

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -93,9 +93,14 @@ def test_copy_requires_name():
         x.copy()
 
 
-def test_backwards_compatible_access():
+def test_deprecated_parameter_in_task_module():
     """
     Deprecated test that asserts that backwards compatible access works after 0.12
     Can be removed once the backwards compatibility is no longer maintained.
     """
-    assert prefect.core.task.Parameter is prefect.core.parameter.Parameter
+    from prefect.core.task import Parameter as OldParameter
+
+    with pytest.warns(UserWarning, match="please import as"):
+        p = OldParameter("hello")
+
+    assert isinstance(p, Parameter)

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -92,6 +92,7 @@ def test_copy_requires_name():
     with pytest.raises(TypeError, match="required positional argument"):
         x.copy()
 
+
 def test_backwards_compatible_access():
     """
     Deprecated test that asserts that backwards compatible access works after 0.12

--- a/tests/flows/test_parameter.py
+++ b/tests/flows/test_parameter.py
@@ -1,7 +1,8 @@
 import pytest
 
 from prefect.core.flow import Flow
-from prefect.core.task import Parameter, Task
+from prefect.core.task import Task
+from prefect.core.parameter import Parameter
 from prefect.tasks.core.function import FunctionTask
 
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
As I work with Parameters to increase their "first-class-ness", including extensions of #2755, I'm becoming acutely aware of the awkwardness of accessing them from `core/task.py`. This PR moves them to a more appropriate home, `core/parameter.py`. It makes no other changes to behavior or code.

I believe this is not a user-facing change as we have always encouraged accessing them at the top-level (in fact, our own code only referenced `task.Parameter` three times), but I've added a backwards-compatible access nonetheless.

So this remains the recommended access:
```python
from prefect import Parameter
```

But these are also possible:
```python
# new location
from prefect.core.parameter import Parameter
# deprecated location
from prefect.core.task import Parameter
```

(I did *not* move `prefect.serialization.task.ParameterSchema` because serializers are more sensitive, but am also looking at cleaning that up in other PRs)


## Why is this PR important?
Code organization

