### PR TITLE
Raise error on downstream mapped tasks with trigger other than all_successful

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -515,10 +515,15 @@ class Flow:
         # flow, so we need to perform this check here and not earlier.
         if validate and key and key in {e.key for e in self.edges_to(downstream_task)}:
             raise ValueError(
-                'Argument "{a}" for task {t} has already been assigned in '
+                "Argument '{a}' for task {t} has already been assigned in "
                 "this flow. If you are trying to call the task again with "
                 "new arguments, call Task.copy() before adding the result "
                 "to this flow.".format(a=key, t=downstream_task)
+            )
+
+        if mapped and downstream_task.trigger is not prefect.triggers.all_successful:
+            raise ValueError(
+                f"Mapped task {downstream_task} requires an `all_successful` trigger."
             )
 
         edge = Edge(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -422,13 +422,24 @@ def test_add_edge_raise_error_for_downstream_parameter():
         f.add_edge(upstream_task=t, downstream_task=p)
 
 
-def test_add_edge_raise_error_for():
+def test_add_edge_raise_error_for_incorrect_mapped_task_trigger():
     f = Flow(name="test")
-    t = Task()
-    p = Parameter("p")
 
-    with pytest.raises(ValueError, match="can not have upstream dependencies"):
-        f.add_edge(upstream_task=t, downstream_task=p)
+    class Vals(Task):
+        def run(self):
+            return [1, 2, 3]
+
+    class Output(Task):
+        def run(self, vals):
+            return vals
+
+    with pytest.raises(
+        ValueError,
+        match="Mapped task <Task: Output> requires an `all_successful` trigger.",
+    ):
+        vals = Vals()
+        output = Output(trigger=prefect.triggers.any_failed)
+        output.set_upstream(vals, key="vals", flow=f, mapped=True)
 
 
 def test_add_edge_raise_error_for_duplicate_key_if_validate():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -422,6 +422,15 @@ def test_add_edge_raise_error_for_downstream_parameter():
         f.add_edge(upstream_task=t, downstream_task=p)
 
 
+def test_add_edge_raise_error_for():
+    f = Flow(name="test")
+    t = Task()
+    p = Parameter("p")
+
+    with pytest.raises(ValueError, match="can not have upstream dependencies"):
+        f.add_edge(upstream_task=t, downstream_task=p)
+
+
 def test_add_edge_raise_error_for_duplicate_key_if_validate():
     f = Flow(name="test")
     t = Task()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Raise a `ValueError` when a mapped task's trigger is anything other than `all_successful`. Attempting to map over errors/exceptions can lead to unintentional behavior.


## Why is this PR important?
Situations like this:
```python
@task
def values():
    return [1, 2, 3]

@task
def calculate(x):
    if x == 2:
        raise ValueError()
    return x

@task(trigger=any_failed)
def sumit(x):
    print(sum(x))

with Flow("test") as f:
    vals = values()
    x = calculate.map(vals)
    sumit.map(x)
```

Will lead to unintentional runtime errors. We want to catch these potential errors earlier:

```
Traceback (most recent call last):
  File "/Users/josh/Desktop/code/prefect/src/prefect/engine/runner.py", line 48, in inner
    new_state = method(self, state, *args, **kwargs)
  File "/Users/josh/Desktop/code/prefect/src/prefect/engine/task_runner.py", line 806, in get_task_run_state
    self.task.run, timeout=self.task.timeout, **raw_inputs
  File "/Users/josh/Desktop/code/prefect/src/prefect/utilities/executors.py", line 186, in timeout_handler
    return fn(*args, **kwargs)
  File "maptrigger.py", line 16, in sumit
    print(sum(x))
TypeError: 'ValueError' object is not iterable
```