### PR TITLE
Add config validation utility to Fargate Agent

### DIFF
--- a/changes/pr2768.yaml
+++ b/changes/pr2768.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add `validate_configuration` utility to Fargate Agent for verifying it can manage tasks properly - [#2768](https://github.com/PrefectHQ/prefect/pull/2768)"

--- a/docs/orchestration/agents/fargate.md
+++ b/docs/orchestration/agents/fargate.md
@@ -117,6 +117,10 @@ The Fargate Agent allows for a set of AWS configuration options to be set or pro
 
 While the above configuration options allow for the initialization of the boto3 client, you may also need to specify the arguments that allow for the registering and running of Fargate task definitions. The Fargate Agent makes no assumptions on how your particular AWS configuration is set up and instead has a `kwargs` argument which will accept any arguments for boto3's `register_task_definition` and `run_task` functions.
 
+::: tip Validating Configuration
+The Fargate Agent has a utility function [`validate_configuration`](/api/latest/agent/fargate.html#fargateagent) which can be used to test the configuration options set on the agent to ensure is it able to register the task definition and run the task.
+:::
+
 Accepted kwargs for [`register_task_definition`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition):
 
 ```
@@ -142,7 +146,7 @@ mountPoints                list
 logConfiguration           dict
 ```
 
-Environment was added to support adding flow level environment variables via the `use_external_kwargs` described later on in the documentation.  
+Environment was added to support adding flow level environment variables via the `use_external_kwargs` described later on in the documentation.
 You should continue to use the `env_vars` kwarg to pass agent level environment variables to your tasks.
 
 This adds support for Native AWS Secrets Manager and/or Parameter Store in your flows.

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -742,7 +742,7 @@ class FargateAgent(Agent):
             networkMode="awsvpc",
             **flow_task_definition_kwargs,
         )
-        self.logger.info("Task definition registration successful.")
+        self.logger.info("Task definition registration successful")
 
         # Run task
         flow_task_run_kwargs = copy.deepcopy(self.task_run_kwargs)
@@ -756,7 +756,7 @@ class FargateAgent(Agent):
             overrides={"containerOverrides": []},
             **flow_task_run_kwargs,
         )
-        self.logger.info(f"Task run {task['tasks'][0].get('taskArn')} successful.")
+        self.logger.info(f"Task run {task['tasks'][0].get('taskArn')} successful")
 
 
 if __name__ == "__main__":

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -684,7 +684,7 @@ class FargateAgent(Agent):
 
         return task["tasks"][0].get("taskArn")
 
-    def test_agent_configuration(self) -> None:
+    def validate_agent_configuration(self) -> None:
         """
         Utility function for testing Agent's configuration. This function is helpful in
         determining if the provided configuration for the Agent is able to register a

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -735,7 +735,7 @@ class FargateAgent(Agent):
         if self.launch_type:
             flow_task_definition_kwargs["requiresCompatibilities"] = [self.launch_type]
 
-        self.logger.info("Testing test task definition registration...")
+        self.logger.info("Testing task definition registration...")
         self.boto3_client.register_task_definition(
             family=task_name,
             containerDefinitions=container_definitions,
@@ -750,7 +750,7 @@ class FargateAgent(Agent):
         if self.launch_type:
             flow_task_run_kwargs["launchType"] = self.launch_type
 
-        self.logger.info("Testing test task run...")
+        self.logger.info("Testing task run...")
         task = self.boto3_client.run_task(
             taskDefinition=task_name,
             overrides={"containerOverrides": []},

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -684,7 +684,7 @@ class FargateAgent(Agent):
 
         return task["tasks"][0].get("taskArn")
 
-    def validate_agent_configuration(self) -> None:
+    def validate_configuration(self) -> None:
         """
         Utility function for testing Agent's configuration. This function is helpful in
         determining if the provided configuration for the Agent is able to register a

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -2000,7 +2000,7 @@ def test_agent_configuration_utility(monkeypatch, runner_token):
         region_name="region",
         **kwarg_dict
     )
-    agent.validate_agent_configuration()
+    agent.validate_configuration()
 
     assert boto3_client.register_task_definition.called
     assert boto3_client.run_task.called


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a function to the fargate agent for validating the configuration that it was provided. For example something like this could happen:

```python
agent = FargateAgent(
    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
    region_name="us-east-1",
    cpu="1024",
    memory="8192",
    executionRoleArn="my_arn...",
    containerDefinitions=[
        {
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-region": "us-east-1",
                    "awslogs-group": "my_group",
                    "awslogs-stream-prefix": "prefect",
                },
            },
        }
    ],
    networkConfiguration={
        "awsvpcConfiguration": {
            "assignPublicIp": "ENABLED",
            "subnets": ["subnet-0773697d1a87dd105"],
            "securityGroups": [],
        }
    },
)

agent.validate_configuration()
```

And this `validate_configuration` function will test to see if the agent has the proper setup to register a task definition and run the task.

```bash
[2020-06-11 20:01:12,321] INFO - agent | Testing task definition registration...
[2020-06-11 20:01:12,499] INFO - agent | Task definition registration successful.
[2020-06-11 20:01:12,499] INFO - agent | Testing task run...
[2020-06-11 20:01:13,409] INFO - agent | Task run ...my_task_run... successful.
```


## Why is this PR important?
It is not uncommon for questions around the fargate agent to be based around configuration and usually these are only discovered after getting it up and running. This can hopefully alleviate some issues before attempting to run a flow by validating ahead of time.

I'm also now thinking that maybe every agent should have its own `validate_configuration` to verify that it is configured properly.

