### PR TITLE
Allow for task targets to be callables

### DIFF
--- a/changes/pr2769.yaml
+++ b/changes/pr2769.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "All option to specify task targets as callables - [#2769](https://github.com/PrefectHQ/prefect/pull/2769)"

--- a/changes/pr2769.yaml
+++ b/changes/pr2769.yaml
@@ -1,2 +1,2 @@
 enhancement:
-  - "All option to specify task targets as callables - [#2769](https://github.com/PrefectHQ/prefect/pull/2769)"
+  - "Add option to specify task targets as callables - [#2769](https://github.com/PrefectHQ/prefect/pull/2769)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -142,7 +142,7 @@ class Task(metaclass=SignatureValidator):
             serves as a unique identifier for this Task's cache, and can be shared
             across both Tasks _and_ Flows; if not provided, the Task's _name_ will
             be used if running locally, or the Task's database ID if running in
-            Cloud 
+            Cloud
         - checkpoint (bool, optional): if this Task is successful, whether to
             store its result using the `result_handler` available during the run;
             Also note that checkpointing will only occur locally if
@@ -152,10 +152,14 @@ class Task(metaclass=SignatureValidator):
             provided, will default to the one attached to the Flow
         - result (Result, optional): the result instance used to retrieve and
             store task results during execution
-        - target (str, optional): location to check for task Result. If a result
+        - target (Union[str, Callable], optional): location to check for task Result. If a result
             exists at that location then the task run will enter a cached state.
             `target` strings can be templated formatting strings which will be
-            formatted at runtime with values from `prefect.context`
+            formatted at runtime with values from `prefect.context`. If a callable function
+            is provided, it should have signature `callable(**kwargs) -> str` and at write
+            time all formatting kwargs will be passed and a fully formatted location is
+            expected as the return value.  Can be used for string formatting logic that
+            `.format(**kwargs)` doesn't support
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
             that will be called whenever the task changes state, providing an
             opportunity to inspect or modify the new state. The handler
@@ -164,8 +168,8 @@ class Task(metaclass=SignatureValidator):
                 `state_handler(task: Task, old_state: State, new_state: State) -> Optional[State]`
             If multiple functions are passed, then the `new_state` argument will be the
             result of the previous handler.
-        - on_failure (Callable, optional): A function with signature 
-            `fn(task: Task, state: State) -> None` that will be called anytime this 
+        - on_failure (Callable, optional): A function with signature
+            `fn(task: Task, state: State) -> None` that will be called anytime this
             Task enters a failure state
         - log_stdout (bool, optional): Toggle whether or not to send stdout messages to
             the Prefect logger. Defaults to `False`.

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -93,7 +93,10 @@ class TaskRunner(Runner):
         else:
             self.result = Result().copy() if result is None else result.copy()
             if self.task.target:
-                self.result.location = self.task.target
+                if not isinstance(self.task.target, str):
+                    self.result.location = self.task.target(**prefect.context)
+                else:
+                    self.result.location = self.task.target
         self.default_result = default_result or Result()
         super().__init__(state_handlers=state_handlers)
 
@@ -670,6 +673,9 @@ class TaskRunner(Runner):
         target = self.task.target
 
         if result and target:
+            if not isinstance(target, str):
+                target = target(**prefect.context)
+
             if result.exists(target, **prefect.context):
                 new_res = result.read(target.format(**prefect.context))
                 cached_state = Cached(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -86,7 +86,7 @@ class TaskRunner(Runner):
         if task.result:
             self.result = task.result
         else:
-            self.result = Result().copy() if result is None else result.copy()
+            self.result = Result().copy() if flow_result is None else flow_result.copy()
 
         self.flow_result = flow_result
         super().__init__(state_handlers=state_handlers)

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1568,6 +1568,24 @@ class TestTargetExistsStep:
             assert state2.is_successful()
             assert state2.result[t].is_cached()
 
+    def test_target_with_callable_uses_run_context(self, tmp_dir):
+        with set_temporary_config({"flows.checkpointing": True}):
+
+            @prefect.task(target=lambda **kwargs: str(kwargs["task_run_count"]))
+            def my_task():
+                return "data"
+
+            with prefect.Flow("test", result=LocalResult(dir=tmp_dir)) as flow:
+                t = my_task()
+
+            state = flow.run()
+            assert state.is_successful()
+            assert state.result[t].is_successful()
+
+            state2 = flow.run()
+            assert state2.is_successful()
+            assert state2.result[t].is_cached()
+
 
 class TestCheckScheduledStep:
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR allows for task targets to be both strings and callables. This is similar to how result locations can also be both. e.g.:
```python
@task(target=lambda **kwargs: "{task_name}-88")
def get_data():
    """test"""
    return "data"

@task
def print_data(data):
    print(data)


with Flow("using-targets", result=LocalResult(), ) as flow:
    data = get_data()
    print_data(data)

flow.run()
```

```
# First run
[2020-06-11 21:50:17] DEBUG - prefect.LocalResult | Starting to upload result to get_data-88...
[2020-06-11 21:50:17] DEBUG - prefect.LocalResult | Finished uploading result to /Users/josh/.prefect/results/get_data-88...

...

# Second run
[2020-06-11 21:50:19] DEBUG - prefect.LocalResult | Starting to read result from get_data-88...
[2020-06-11 21:50:19] DEBUG - prefect.LocalResult | Finished reading result from get_data-88...
[2020-06-11 21:50:19] DEBUG - prefect.TaskRunner | Task 'get_data': Handling state change from Pending to Cached
[2020-06-11 21:50:19] DEBUG - prefect.TaskRunner | Task 'get_data': can't set state to Running because it isn't Pending; ending run.
```

## Why is this PR important?
More functionality!

