### PR TITLE
[docs] standardize example project name

### DIFF
--- a/docs/orchestration/agents/local.md
+++ b/docs/orchestration/agents/local.md
@@ -26,7 +26,7 @@ def welcome_logger():
 flow = Flow("Welcome Flow", tasks=[welcome_logger])
 
 # Register Flow with the Prefect API
-flow.register("My Project")
+flow.register(project_name="Hello, World!")
 
 # Spawn a local agent and run in process
 flow.run_agent()
@@ -51,7 +51,7 @@ def welcome():
 flow = Flow("Welcome Flow", tasks=[welcome_logger])
 
 # Register Flow with the Prefect API
-flow.register("My Project")
+flow.register(project_name="Hello, World!")
 ```
 
 This flow is registered with the Prefect API with the actual flow code stored in your local `~/.prefect/flows` directory. We can now start a local agent from the CLI and tell it to look for scheduled runs for the _Welcome Flow_.

--- a/docs/orchestration/concepts/cli.md
+++ b/docs/orchestration/concepts/cli.md
@@ -318,8 +318,8 @@ For more information regarding Prefect Agents refer to the [agent documentation]
 Running `prefect create project PROJECT_NAME` will create a project in Prefect Cloud with the given name. You can also specify a project description with `--description`.
 
 ```
-$ prefect create project "MY PROJECT" -d "description here"
-MY PROJECT created
+$ prefect create project "Hello, World!" -d "description here"
+Hello World! created
 ```
 
 ### execute

--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -13,10 +13,10 @@ flow.register()
 ```
 
 :::warning Projects <Badge text="Cloud"/>
-Prefect Cloud allows users to organize flows into projects.
+Prefect Cloud allows users to organize flows into projects. In this case we are using the `Hello, World!` Project created in [the "creating a project" tutorial](projects.html#creating-a-project).
 
 ```python
-flow.register(project_name="<project name>")
+flow.register(project_name="Hello, World!")
 ```
 
 :::

--- a/docs/orchestration/concepts/projects.md
+++ b/docs/orchestration/concepts/projects.md
@@ -15,7 +15,7 @@ Projects can be created from the project filter on the [dashboard](/orchestratio
 To create a new project with the Prefect CLI:
 
 ```
-$ prefect create project "My Project"
+$ prefect create project "Hello, World!"
 ```
 
 ### Core Client
@@ -26,7 +26,7 @@ To create a new project with the Core client:
 from prefect import Client
 
 client = Client()
-client.create_project(project_name="My Project")
+client.create_project(project_name="Hello, World!")
 ```
 
 ### GraphQL <Badge text="GQL"/>
@@ -35,7 +35,7 @@ To create a new project with GraphQL, issue the following mutation:
 
 ```graphql
 mutation {
-  create_project(input: { name: "My Project" }) {
+  create_project(input: { name: "Hello, World!" }) {
     project {
       id
       name

--- a/docs/orchestration/tutorial/docker.md
+++ b/docs/orchestration/tutorial/docker.md
@@ -28,7 +28,7 @@ flow.register()
 ```
 
 :::warning Projects <Badge text="Cloud"/>
-Prefect Cloud allows users to organize flows into projects. In this case we are using the default `Hello, World!` Project.
+Prefect Cloud allows users to organize flows into projects. In this case we are using the `Hello, World!` Project created in [the "creating a project" tutorial](../concepts/projects.html#creating-a-project).
 
 ```python
 flow.register(project_name="Hello, World!")

--- a/docs/orchestration/tutorial/first.md
+++ b/docs/orchestration/tutorial/first.md
@@ -29,7 +29,7 @@ flow.register()
 ```
 
 :::warning Projects <Badge text="Cloud"/>
-Prefect Cloud allows users to organize flows into projects. In this case we are using the default `Hello, World!` Project.
+Prefect Cloud allows users to organize flows into projects. In this case we are using the `Hello, World!` Project created in [the "creating a project" tutorial](../concepts/projects.html#creating-a-project).
 
 ```python
 flow.register(project_name="Hello, World!")

--- a/docs/orchestration/tutorial/multiple.md
+++ b/docs/orchestration/tutorial/multiple.md
@@ -21,7 +21,7 @@ flow.register()
 ```
 
 :::warning Projects <Badge text="Cloud"/>
-Prefect Cloud allows users to organize flows into projects. In this case we are using the default `Hello, World!` Project.
+Prefect Cloud allows users to organize flows into projects. In this case we are using the `Hello, World!` Project created in [the "creating a project" tutorial](projects.html#creating-a-project).
 
 ```python
 flow.register(project_name="Hello, World!")

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -19,12 +19,12 @@ def create():
 
     \b
     Examples:
-        $ prefect create project "My Project"
-        My Project created
+        $ prefect create project "Hello, World!"
+        Hello, World! created
 
     \b
-        $ prefect create project My-Project --description "My description"
-        My-Project created
+        $ prefect create project "Hello, World!" --description "My description"
+        Hello, World! created
     """
 
 

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -60,7 +60,7 @@ class FlowRunTask(Task):
             ```python
             from prefect.tasks.prefect.flow_run import FlowRunTask
 
-            kickoff_task = FlowRunTask(project_name="My Project", flow_name="My Cloud Flow")
+            kickoff_task = FlowRunTask(project_name="Hello, World!", flow_name="My Cloud Flow")
             ```
 
         """


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## Overview

This is a follow-up to #2776 . Working through the [First Flow docs](https://docs.prefect.io/orchestration/tutorial/first.html#register-flow-with-the-prefect-api), I came across this language:

> Prefect Cloud allows users to organize flows into projects. In this case we are using the default Hello, World! Project.
> `flow.register(project_name="Hello, World!")>

The use of the word "default" made me think that I could call that code as-is and that it would attach my flow to a project `Hello, World` that is created automatically when you create a Prefect Cloud account.

But that is not what happened:

> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jlamb/miniconda3/lib/python3.7/site-packages/prefect/core/flow.py", line 1442, in register
    no_url=no_url,
  File "/home/jlamb/miniconda3/lib/python3.7/site-packages/prefect/client/client.py", line 615, in register
    project_name, project_name
ValueError: Project Hello, World! not found. Run `client.create_project("Hello, World!")` to create it.

## What does this PR change?

This PR proposes two changes:

1. Linking to the `Create a Project` documentation (https://docs.prefect.io/orchestration/concepts/projects.html#creating-a-project) from the Flows note about projects for Prefect Cloud (https://docs.prefect.io/orchestration/tutorial/first.html#register-flow-with-the-prefect-api).
2. Standardize the example project name throughout the documentation. Right now half of the docs use `Hello, World!` and half use `My Project!`. That means that depending on the route through the docs that you took to get to https://docs.prefect.io/orchestration/tutorial/first.html#register-flow-with-the-prefect-api, you might not be able to just copy and paste that `flow.register()` call and have it work.

## Why is this PR important?

In my opinion, had the docs reflected the changes in this PR when I first started learning how to register a flow with Prefect Cloud, I would have had a smoother experience and would have moved on to more advanced topics sooner. I think that this PR improves the copy-pasteability of the documentation and reduces the searching that new users have to do to get the examples on the [First Flow page](https://docs.prefect.io/orchestration/tutorial/first.html#register-flow-with-the-prefect-api) working.

Thanks for your time and consideration!

