### PR TITLE
Remove references to "whitelist" and "blacklist" wherever possible

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,11 +5,11 @@
 # run arbitrary code
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the deny list. They should be base names, not
 # paths.
 ignore=CVS
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the deny list. The
 # regex matches against base names, not paths.
 ignore-patterns=
 

--- a/server/src/prefect_server/utilities/names.py
+++ b/server/src/prefect_server/utilities/names.py
@@ -4,7 +4,7 @@
 
 import coolname
 
-BLACKLIST = {
+DENYLIST = {
     "sexy",
     "demonic",
     "kickass",
@@ -35,8 +35,8 @@ def generate_slug(n_words: int) -> str:
     """
     words = coolname.generate(n_words)
 
-    # regenerate words if they include blacklisted words
-    while BLACKLIST.intersection(words):
+    # regenerate words if they include deny listed words
+    while DENYLIST.intersection(words):
         words = coolname.generate(n_words)
 
     return "-".join(words)

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -358,7 +358,7 @@ class StatefulFunctionReference(fields.Field):
     Note that `nonlocals` MUST be JSON-compatible, with the exception of datetimes.
 
     Args:
-        - valid_functions (List[Callable]): a whitelist of valid functions
+        - valid_functions (List[Callable]): an allow list of valid functions
         - reject_invalid (bool): if True, functions not in `valid_functions` will be rejected. If False,
             any value will be allowed, but only functions in `valid_functions` will be deserialized.
         - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
^ as the title states, it removes references to "whitelist" and "blacklist" wherever possible. There are two notable places where this wasn't possible (as far as I can tell): the `method_whitelist` kwarg for **urllib3** and the **VSCode** > `extension-pkg-whitelist`, for `pylint`.


## Why is this PR important?
Language is important. 

