### PR TITLE
Fix how storage secrets are populated within k8s and dask k8s environments

### DIFF
--- a/changes/pr2780.yaml
+++ b/changes/pr2780.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with declared storage secrets in K8s job environment and Dask K8s environment - [#2780](https://github.com/PrefectHQ/prefect/pull/2780)"

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -12,6 +12,7 @@ import prefect
 from prefect.client import Secret
 from prefect.environments.execution import Environment
 from prefect.environments.storage import Docker
+from prefect.tasks.secrets import PrefectSecret
 
 
 class DaskKubernetesEnvironment(Environment):
@@ -310,7 +311,7 @@ class DaskKubernetesEnvironment(Environment):
                 ## populate global secrets
                 secrets = prefect.context.get("secrets", {})
                 for secret in flow.storage.secrets:
-                    secrets[secret.name] = secret.run()
+                    secrets[secret] = PrefectSecret(name=secret).run()
 
                 with prefect.context(secrets=secrets):
                     executor = DaskExecutor(address=cluster.scheduler_address)

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -12,7 +12,6 @@ import prefect
 from prefect.client import Secret
 from prefect.environments.execution import Environment
 from prefect.environments.storage import Docker
-from prefect.tasks.secrets import PrefectSecret
 
 
 class DaskKubernetesEnvironment(Environment):
@@ -311,7 +310,9 @@ class DaskKubernetesEnvironment(Environment):
                 ## populate global secrets
                 secrets = prefect.context.get("secrets", {})
                 for secret in flow.storage.secrets:
-                    secrets[secret] = PrefectSecret(name=secret).run()
+                    secrets[secret] = prefect.tasks.secrets.PrefectSecret(
+                        name=secret
+                    ).run()
 
                 with prefect.context(secrets=secrets):
                     executor = DaskExecutor(address=cluster.scheduler_address)

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -8,6 +8,7 @@ import yaml
 import prefect
 from prefect.environments.execution import Environment
 from prefect.environments.storage import Docker
+from prefect.tasks.secrets import PrefectSecret
 
 
 class KubernetesJobEnvironment(Environment):
@@ -175,7 +176,7 @@ class KubernetesJobEnvironment(Environment):
                 ## populate global secrets
                 secrets = prefect.context.get("secrets", {})
                 for secret in flow.storage.secrets:
-                    secrets[secret.name] = secret.run()
+                    secrets[secret] = PrefectSecret(name=secret).run()
 
                 with prefect.context(secrets=secrets):
                     runner_cls = get_default_flow_runner_class()

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -8,7 +8,6 @@ import yaml
 import prefect
 from prefect.environments.execution import Environment
 from prefect.environments.storage import Docker
-from prefect.tasks.secrets import PrefectSecret
 
 
 class KubernetesJobEnvironment(Environment):
@@ -176,7 +175,9 @@ class KubernetesJobEnvironment(Environment):
                 ## populate global secrets
                 secrets = prefect.context.get("secrets", {})
                 for secret in flow.storage.secrets:
-                    secrets[secret] = PrefectSecret(name=secret).run()
+                    secrets[secret] = prefect.tasks.secrets.PrefectSecret(
+                        name=secret
+                    ).run()
 
                 with prefect.context(secrets=secrets):
                     runner_cls = get_default_flow_runner_class()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR correctly uses the `PrefectSecret` interface for retrieving secrets declared on Storage when running with the k8s / dask k8s environments.


## Why is this PR important?
Bug fix.