### PR TITLE
Add support for db argument at run time in the SQLiteQuery and SQLiteScript

### DIFF
--- a/changes/pr2782.yaml
+++ b/changes/pr2782.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add support for db argument at run time in the SQLiteQuery and SQLiteScript - [#2782](https://github.com/PrefectHQ/prefect/pull/2782)"
+
+contributor:
+  - "[Paweł Cieśliński](https://github.com/pcieslinski)"

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -12,7 +12,7 @@ class SQLiteQuery(Task):
     the result (if any) from the query.
 
     Args:
-        - db (str): the location of the database (.db) file
+        - db (str, optional): the location of the database (.db) file
         - query (str, optional): the optional _default_ query to execute at runtime;
             can also be provided as a keyword to `run`, which takes precendence over this default.
             Note that a query should consist of a _single SQL statement_.
@@ -20,23 +20,26 @@ class SQLiteQuery(Task):
             standard Task initalization
     """
 
-    def __init__(self, db: str, query: str = None, **kwargs: Any):
+    def __init__(self, db: str = None, query: str = None, **kwargs: Any):
         self.db = db
         self.query = query
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("query")
-    def run(self, query: str = None):
+    @defaults_from_attrs("db", "query")
+    def run(self, db: str = None, query: str = None):
         """
         Args:
+            - db (str, optional): the location of the database (.db) file;
+                if not provided, `self.db` will be used instead.
             - query (str, optional): the optional query to execute at runtime;
                 if not provided, `self.query` will be used instead. Note that a query should consist of a _single SQL statement_.
 
         Returns:
             - [Any]: the results of the query
         """
+        db = cast(str, db)
         query = cast(str, query)
-        with closing(sql.connect(self.db)) as conn:
+        with closing(sql.connect(db)) as conn:
             with closing(conn.cursor()) as cursor:
                 cursor.execute(query)
                 out = cursor.fetchall()

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -52,26 +52,28 @@ class SQLiteScript(Task):
     Task for executing a SQL script against a sqlite3 database.
 
     Args:
-        - db (str): the location of the database (.db) file
+        - db (str, optional): the location of the database (.db) file
         - script (str, optional): the optional _default_ script string to render at runtime;
             can also be provided as a keyword to `run`, which takes precendence over this default.
         - **kwargs (optional): additional keyword arguments to pass to the
             standard Task initialization
     """
 
-    def __init__(self, db: str, script: str = None, **kwargs: Any):
+    def __init__(self, db: str = None, script: str = None, **kwargs: Any):
         self.db = db
         self.script = script
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("script")
-    def run(self, script: str = None):
+    @defaults_from_attrs("db", "script")
+    def run(self, db: str = None, script: str = None):
         """
         Args:
+            - db (str, optional): the location of the database (.db) file;
+                if not provided, `self.db` will be used instead.
             - script (str, optional): the optional script to execute at runtime;
                 if not provided, `self.script` will be used instead.
         """
-        with closing(sql.connect(self.db)) as conn:
+        with closing(sql.connect(db)) as conn:
             with closing(conn.cursor()) as cursor:
                 cursor.executescript(script)
                 conn.commit()

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -7,7 +7,7 @@ import pytest
 
 from prefect import Flow
 from prefect.tasks.database import SQLiteQuery, SQLiteScript
-from prefect.utilities.debug import raise_on_exception
+
 
 sql_script = """
 CREATE TABLE TEST (NUMBER INTEGER, DATA TEXT);

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -30,9 +30,8 @@ def database():
 
 
 class TestSQLiteQuery:
-    def test_sqlite_query_task_requires_db(self):
-        with pytest.raises(TypeError):
-            task = SQLiteQuery()
+    def test_initialization(self):
+        task = SQLiteQuery()
 
     def test_sqlite_query_task_initializes_and_runs_basic_query(self, database):
         with Flow(name="test") as f:
@@ -65,9 +64,8 @@ class TestSQLiteQuery:
 
 
 class TestSQLiteScript:
-    def test_sqlite_script_task_requires_db(self):
-        with pytest.raises(TypeError):
-            task = SQLiteScript()
+    def test_initialization(self):
+        task = SQLiteScript()
 
     def test_sqlite_script_task_initializes_and_runs_basic_script(self, database):
         with Flow(name="test") as f:
@@ -109,9 +107,12 @@ def test_parametrization_of_tasks(database):
         script = Parameter("script")
 
         script = SQLiteScript(db=database)(script=script)
-        task = SQLiteQuery()(db=db, query="SELECT * FROM TEST WHERE NUMBER = 14",
-                             upstream_tasks=[script])
+        task = SQLiteQuery()(
+            db=db, query="SELECT * FROM TEST WHERE NUMBER = 14", upstream_tasks=[script]
+        )
 
-    out = f.run(db=database, script="INSERT INTO TEST (NUMBER, DATA) VALUES (14, 'fourth')")
+    out = f.run(
+        db=database, script="INSERT INTO TEST (NUMBER, DATA) VALUES (14, 'fourth')"
+    )
     assert out.is_successful()
     assert out.result[task].result == [(14, "fourth")]


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Support for using the `db` argument at run time in `SQLiteQuery` and `SQLiteScript` has been added. It is directly related to this issue: https://github.com/PrefectHQ/prefect/issues/2405

## Why is this PR important?
Due to the fact that we can provide `db` arugment for the`run` method, we can also start parameterizing this argument in `Flow` using `Parameter`.
