### PR TITLE
Fix context passing for Cloud

### DIFF
--- a/changes/pr2783.yaml
+++ b/changes/pr2783.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - server
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fix context handling for Cloud when working with in-process retries - [#2783](https://github.com/PrefectHQ/prefect/pull/2783)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -305,7 +305,6 @@ class CloudTaskRunner(TaskRunner):
         Returns:
             - `State` object representing the final post-run state of the Task
         """
-        context = context or {}
         end_state = super().run(
             state=state,
             upstream_states=upstream_states,
@@ -321,18 +320,11 @@ class CloudTaskRunner(TaskRunner):
             )
             time.sleep(naptime)
 
-            # currently required as context has reset to its original state
-            task_run_info = self.client.get_task_run_info(
-                flow_run_id=context.get("flow_run_id", ""),
-                task_id=context.get("task_id", ""),
-                map_index=context.get("map_index"),
-            )
-            context.update(task_run_version=task_run_info.version)  # type: ignore
-
             end_state = super().run(
                 state=end_state,
                 upstream_states=upstream_states,
                 context=context,
                 is_mapped_parent=is_mapped_parent,
             )
+
         return end_state

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -305,7 +305,7 @@ class CloudTaskRunner(TaskRunner):
         Returns:
             - `State` object representing the final post-run state of the Task
         """
-        with prefect.context(context):
+        with prefect.context(context or {}):
             end_state = super().run(
                 state=state,
                 upstream_states=upstream_states,

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -691,4 +691,5 @@ def run_task(
             state=state,
             upstream_states=upstream_states,
             is_mapped_parent=is_mapped_parent,
+            context=context
         )

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -691,5 +691,5 @@ def run_task(
             state=state,
             upstream_states=upstream_states,
             is_mapped_parent=is_mapped_parent,
-            context=context
+            context=context,
         )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This pr fixes a minor bug that resulted from #2707. `CloudTaskRunner.run()` begins by instantiating a default context as `context = context or {}`, and the passed context has a default of None. Since no `context` was being passed to this method, [this call](https://github.com/PrefectHQ/prefect/blob/d52cc24981a43ea12b7c6d10c6280aa24aa3efc0/src/prefect/engine/cloud/task_runner.py#L325) would fail when attempting an in-process retry since context was empty. 



## Why is this PR important?


