### PR TITLE
[docs] clarify language on non-docker storage for KubernetesAgent

### DIFF
--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -141,7 +141,9 @@ flow.storage = S3(bucket="my-flows")
 flow.environment = RemoteEnvironment(metadata={"image": "repo/name:tag"})
 ```
 
-This example flow can now be run using an agent that orchestrates containerized environments. When the flow is run the image set in the environment's metadata will be used and inside that container the flow will be retrieved from the storage object (which is S3 in this example). Due to the cloud storage options have sensible defaults for labels make sure the agent's labels match the desired labels for the flows' storage objects.
+This example flow can now be run using an agent that orchestrates containerized environments. When the flow is run the image set in the environment's metadata will be used and inside that container the flow will be retrieved from the storage object (which is S3 in this example).
+
+Make sure that the agent's labels match the desired labels for the flow storage objects. For example, if you are using `prefect.environments.storage.s3` to store flows, the agent should get label `s3-flow-storage`. See the `"Sensible Defaults"` tips in the previous sections for more details.
 
 ```bash
 # starting a kubernetes agent that will pull flows stored in S3


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Congrats on release 0.12.0! I'm very excited about non-docker storage options for `KubernetesAgent` agents (#2666). I was reading through the documentation introduced in that PR, and found one sentence that was confusing. This looks like it was two separate sentences that were spliced together:

> Due to the cloud storage options have sensible defaults for labels make sure the agent's labels match the desired labels for the flows' storage objects.

This PR proposes clarifying that language.

## Why is this PR important?

This PR might improve users' understanding of how to use non-docker storage with `KubernetesAgent`.

Thanks for your time and consideration.
