### PR TITLE
Add support for HTML content in the EmailTask

### DIFF
--- a/changes/pr2811.yaml
+++ b/changes/pr2811.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Add support for HTML content in the EmailTask - [#2811](https://github.com/PrefectHQ/prefect/pull/2811)"
+
+contributor:
+  - "[Paweł Cieśliński](https://github.com/pcieslinski)"

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -15,7 +15,8 @@ class EmailTask(Task):
     Task for sending email from an authenticated email service over SMTP. For this task to function properly,
     you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect Secrets set.  It is recommended
     you use a [Google App Password](https://support.google.com/accounts/answer/185833) if you use Gmail.
-    The default SMTP server is set to the Gmail SMTP server on port 465 (SMTP-over-SSL)
+    The default SMTP server is set to the Gmail SMTP server on port 465 (SMTP-over-SSL). Sending messages
+    containing HTML code is support - the default MIME type is set to the text/html.
 
     Args:
         - subject (str, optional): the subject of the email; can also be provided at runtime
@@ -38,7 +39,7 @@ class EmailTask(Task):
         smtp_server: str = "smtp.gmail.com",
         smtp_port: int = 465,
         smtp_type: str = "SSL",
-        **kwargs: Any
+        **kwargs: Any,
     ):
         self.subject = subject
         self.msg = msg
@@ -96,7 +97,7 @@ class EmailTask(Task):
         email_to = cast(str, email_to)
 
         contents = MIMEMultipart("alternative")
-        contents.attach(MIMEText(cast(str, msg), "plain"))
+        contents.attach(MIMEText(cast(str, msg), "html"))
 
         contents["Subject"] = Header(subject, "UTF-8")
         contents["From"] = email_from

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -16,7 +16,7 @@ class EmailTask(Task):
     you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect Secrets set.  It is recommended
     you use a [Google App Password](https://support.google.com/accounts/answer/185833) if you use Gmail.
     The default SMTP server is set to the Gmail SMTP server on port 465 (SMTP-over-SSL). Sending messages
-    containing HTML code is support - the default MIME type is set to the text/html.
+    containing HTML code is supported - the default MIME type is set to the text/html.
 
     Args:
         - subject (str, optional): the subject of the email; can also be provided at runtime

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -1,3 +1,4 @@
+import ssl
 import smtplib
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
@@ -102,12 +103,13 @@ class EmailTask(Task):
         contents["To"] = email_to
 
         message = contents.as_string()
+        context = ssl.create_default_context()
 
         if smtp_type == "SSL":
-            server = smtplib.SMTP_SSL(smtp_server, smtp_port)
+            server = smtplib.SMTP_SSL(smtp_server, smtp_port, context=context)
         elif smtp_type == "STARTTLS":
             server = smtplib.SMTP(smtp_server, smtp_port)
-            server.starttls()
+            server.starttls(context=context)
 
         server.login(username, password)
         try:

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -110,6 +110,8 @@ class EmailTask(Task):
         elif smtp_type == "STARTTLS":
             server = smtplib.SMTP(smtp_server, smtp_port)
             server.starttls(context=context)
+        else:
+            raise ValueError(f"{smtp_type} is an unsupported value for smtp_type.")
 
         server.login(username, password)
         try:

--- a/tests/tasks/notifications/test_email_task.py
+++ b/tests/tasks/notifications/test_email_task.py
@@ -27,6 +27,14 @@ class TestInitialization:
                 res = t.run()
         assert smtp.SMTP_SSL.return_value.login.call_args[0] == ("foo", "bar")
 
+    def test_run_raises_error_when_called_with_unsupported_smtp_type(self):
+        t = EmailTask(msg="", smtp_type="TEST")
+        with pytest.raises(
+            ValueError, match="TEST is an unsupported value for smtp_type."
+        ):
+            with context({"secrets": dict(EMAIL_USERNAME="foo", EMAIL_PASSWORD="bar")}):
+                res = t.run()
+
     def test_kwarg_for_email_from_get_passed_to_task_init(self, monkeypatch):
         smtp = MagicMock()
         monkeypatch.setattr("prefect.tasks.notifications.email_task.smtplib", smtp)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
MIME type `text/html` has been set as the default option for `EmailTask`. This was done in accordance with what was mentioned in the issue: https://github.com/PrefectHQ/prefect/issues/2487

Minor changes:
* start using `ssl.create_default_context`, which provides much better default options for sending emails - https://docs.python.org/3/library/ssl.html#ssl.create_default_context 
* adding **error handling** when specifying unsupported `smtp_type`

## Why is this PR important?

We are increasing the possibilities offered by EmailTask. From now on it will be able to start sending emails with correctly rendered HTML code.

```
email = EmailTask(
     subject='Hello from Prefect',
     msg='<h1>Hello!</h1>',
     email_to='you@gmail.com',
     email_from='prefect@gmail.com'
 )
```