### PR TITLE
Quiet "no valid cached states" logging

### DIFF
--- a/changes/issue2815.yaml
+++ b/changes/issue2815.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Quiet * no candidate Cached states were valid* debug logging - [#2815](https://github.com/PrefectHQ/prefect/issues/2815)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -215,24 +215,33 @@ class CloudTaskRunner(TaskRunner):
                 self.logger.debug(
                     "Task '{name}': {num} candidate cached states were found".format(
                         name=prefect.context.get("task_full_name", self.task.name),
-                        num=len(cached_states), ))
+                        num=len(cached_states),
+                    )
+                )
 
                 for candidate_state in cached_states:
                     assert isinstance(candidate_state, Cached)  # mypy assert
                     candidate_state.load_cached_results(inputs)
                     sanitized_inputs = {key: res.value for key, res in inputs.items()}
-                    if self.task.cache_validator(candidate_state, sanitized_inputs,
-                        prefect.context.get("parameters")):
+                    if self.task.cache_validator(
+                        candidate_state,
+                        sanitized_inputs,
+                        prefect.context.get("parameters"),
+                    ):
                         return candidate_state.load_result(self.result)
 
                 self.logger.debug(
                     "Task '{name}': can't use cache because no candidate Cached states "
                     "were valid".format(
-                        name=prefect.context.get("task_full_name", self.task.name)))
+                        name=prefect.context.get("task_full_name", self.task.name)
+                    )
+                )
             else:
                 self.logger.debug(
                     "Task '{name}': can't use cache because no Cached states were found".format(
-                        name=prefect.context.get("task_full_name", self.task.name)))
+                        name=prefect.context.get("task_full_name", self.task.name)
+                    )
+                )
 
         return state
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -211,35 +211,28 @@ class CloudTaskRunner(TaskRunner):
                 created_after=oldest_valid_cache,
             )
 
-            if not cached_states:
-                self.logger.debug(
-                    "Task '{name}': can't use cache because no Cached states were found".format(
-                        name=prefect.context.get("task_full_name", self.task.name)
-                    )
-                )
-            else:
+            if cached_states:
                 self.logger.debug(
                     "Task '{name}': {num} candidate cached states were found".format(
                         name=prefect.context.get("task_full_name", self.task.name),
-                        num=len(cached_states),
-                    )
-                )
+                        num=len(cached_states), ))
 
-            for candidate_state in cached_states:
-                assert isinstance(candidate_state, Cached)  # mypy assert
-                candidate_state.load_cached_results(inputs)
-                sanitized_inputs = {key: res.value for key, res in inputs.items()}
-                if self.task.cache_validator(
-                    candidate_state, sanitized_inputs, prefect.context.get("parameters")
-                ):
-                    return candidate_state.load_result(self.result)
+                for candidate_state in cached_states:
+                    assert isinstance(candidate_state, Cached)  # mypy assert
+                    candidate_state.load_cached_results(inputs)
+                    sanitized_inputs = {key: res.value for key, res in inputs.items()}
+                    if self.task.cache_validator(candidate_state, sanitized_inputs,
+                        prefect.context.get("parameters")):
+                        return candidate_state.load_result(self.result)
 
                 self.logger.debug(
                     "Task '{name}': can't use cache because no candidate Cached states "
                     "were valid".format(
-                        name=prefect.context.get("task_full_name", self.task.name)
-                    )
-                )
+                        name=prefect.context.get("task_full_name", self.task.name)))
+            else:
+                self.logger.debug(
+                    "Task '{name}': can't use cache because no Cached states were found".format(
+                        name=prefect.context.get("task_full_name", self.task.name)))
 
         return state
 


### PR DESCRIPTION
- [ ] adds new tests (n/a)
- [X] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (n/a)

## What does this PR change?

Eliminates redundant, repeated debug logging re: _can't use cache because no candidate Cached states were valid_

## Why is this PR important?

Redundant logging message make remainder of logging harder to use.

