### PR TITLE
Cleanup `LocalDaskExecutor`

### DIFF
--- a/changes/pr2819.yaml
+++ b/changes/pr2819.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix the `LocalDaskExecutor` to only compute tasks once, not multiple times - [#2819](https://github.com/PrefectHQ/prefect/pull/2819)"
+
+enhancement:
+  - "Set task names in `LocalDaskExecutor` - [#2819](https://github.com/PrefectHQ/prefect/pull/2819)"

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from distributed import Future
 
 
+__any__ = ("DaskExecutor", "LocalDaskExecutor")
+
+
 # XXX: remove when deprecation of DaskExecutor kwargs is done
 _valid_client_kwargs = {
     "timeout",
@@ -214,7 +217,7 @@ class DaskExecutor(Executor):
 
         # set a key for the dask scheduler UI
         if task_name:
-            dask_kwargs.update(key=f"{task_name}-{str(uuid.uuid4())}")
+            dask_kwargs.update(key=f"{task_name}-{uuid.uuid4().hex}")
 
         # infer from context if dask resources are being utilized
         dask_resource_tags = [
@@ -276,31 +279,50 @@ class DaskExecutor(Executor):
 
 class LocalDaskExecutor(Executor):
     """
-    An executor that runs all functions locally using `dask` and a configurable dask scheduler.  Note that
-    this executor is known to occasionally run tasks twice when using multi-level mapping.
+    An executor that runs all functions locally using `dask` and a configurable
+    dask scheduler.
 
     Args:
-        - scheduler (str): The local dask scheduler to use; common options are "synchronous", "threads" and "processes".  Defaults to "threads".
+        - scheduler (str): The local dask scheduler to use; common options are
+            "threads", "processes", and "synchronous".  Defaults to "threads".
         - **kwargs (Any): Additional keyword arguments to pass to dask config
     """
 
     def __init__(self, scheduler: str = "threads", **kwargs: Any):
+        self._callback = None
         self.scheduler = scheduler
-        self.kwargs = kwargs
+        self.dask_config = kwargs
         super().__init__()
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_callback"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
 
     @contextmanager
     def start(self) -> Iterator:
-        """
-        Context manager for initializing execution.
-
-        Configures `dask` and yields the `dask.config` contextmanager.
-        """
+        """Context manager for initializing execution."""
         # import dask here to reduce prefect import times
-        import dask
+        from dask.callbacks import Callback
 
-        with dask.config.set(scheduler=self.scheduler, **self.kwargs) as cfg:
-            yield cfg
+        class PrefectCallback(Callback):
+            def __init__(self):  # type: ignore
+                self.cache = {}
+
+            def _start(self, dsk):  # type: ignore
+                overlap = set(dsk) & set(self.cache)
+                for key in overlap:
+                    dsk[key] = self.cache[key]
+
+            def _posttask(self, key, value, dsk, state, id):  # type: ignore
+                self.cache[key] = value
+
+        self._callback = PrefectCallback()  # type: ignore
+        yield
+        self._callback = None
 
     def submit(
         self, fn: Callable, *args: Any, extra_context: dict = None, **kwargs: Any
@@ -311,20 +333,27 @@ class LocalDaskExecutor(Executor):
         Args:
             - fn (Callable): function that is being submitted for execution
             - *args (Any): arguments to be passed to `fn`
-            - extra_context (dict, optional): an optional dictionary with extra information about the submitted task
+            - extra_context (dict, optional): an optional dictionary with extra
+                information about the submitted task
             - **kwargs (Any): keyword arguments to be passed to `fn`
 
         Returns:
-            - dask.delayed: a `dask.delayed` object that represents the computation of `fn(*args, **kwargs)`
+            - dask.delayed: a `dask.delayed` object that represents the
+                computation of `fn(*args, **kwargs)`
         """
         # import dask here to reduce prefect import times
         import dask
 
-        return dask.delayed(fn)(*args, **kwargs)
+        extra_kwargs = {}
+        task_name = (extra_context or {}).get("task_name", "")
+        if task_name:
+            extra_kwargs["dask_key_name"] = f"{task_name}-{uuid.uuid4().hex}"
+        return dask.delayed(fn, pure=False)(*args, **kwargs, **extra_kwargs)
 
     def wait(self, futures: Any) -> Any:
         """
-        Resolves a `dask.delayed` object to its values. Blocks until the computation is complete.
+        Resolves a (potentially nested) collection of `dask.delayed` object to
+        its values. Blocks until the computation is complete.
 
         Args:
             - futures (Any): iterable of `dask.delayed` objects to compute
@@ -335,5 +364,5 @@ class LocalDaskExecutor(Executor):
         # import dask here to reduce prefect import times
         import dask
 
-        with dask.config.set(scheduler=self.scheduler, **self.kwargs):
-            return dask.compute(futures)[0]
+        with self._callback, dask.config.set(**self.dask_config):  # type: ignore
+            return dask.compute(futures, scheduler=self.scheduler)[0]

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -320,9 +320,11 @@ class LocalDaskExecutor(Executor):
             def _posttask(self, key, value, dsk, state, id):  # type: ignore
                 self.cache[key] = value
 
-        self._callback = PrefectCallback()  # type: ignore
-        yield
-        self._callback = None
+        try:
+            self._callback = PrefectCallback()  # type: ignore
+            yield
+        finally:
+            self._callback = None
 
     def submit(
         self, fn: Callable, *args: Any, extra_context: dict = None, **kwargs: Any

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 import cloudpickle
+import dask
 import distributed
 import pytest
 
@@ -58,13 +59,17 @@ class TestLocalDaskExecutor:
         e = LocalDaskExecutor()
         assert e.scheduler == "threads"
 
-    def test_responds_to_kwargs(self):
-        e = LocalDaskExecutor(scheduler="threads")
-        assert e.scheduler == "threads"
+    def test_configurable_scheduler(self):
+        e = LocalDaskExecutor(scheduler="synchronous")
+        assert e.scheduler == "synchronous"
 
-    def test_start_yields_cfg(self):
-        with LocalDaskExecutor(scheduler="threads").start() as cfg:
-            assert cfg["scheduler"] == "threads"
+        def check_scheduler(val):
+            assert dask.config.get("scheduler") == val
+
+        with dask.config.set(scheduler="threads"):
+            check_scheduler("threads")
+            with e.start():
+                e.submit(check_scheduler, "synchronous")
 
     def test_submit(self):
         e = LocalDaskExecutor()
@@ -84,6 +89,36 @@ class TestLocalDaskExecutor:
             assert e.wait(e.submit(lambda x: x, x=1)) == 1
             assert e.wait(e.submit(lambda: prefect)) is prefect
 
+    def test_submit_sets_task_name(self):
+        e = LocalDaskExecutor()
+        with e.start():
+            f = e.submit(lambda x: x + 1, 1, extra_context={"task_name": "inc"})
+            (res,) = e.wait([f])
+            assert f.key.startswith("inc-")
+            assert res == 2
+
+    def test_only_compute_once(self):
+        e = LocalDaskExecutor()
+        count = 0
+
+        def inc(x):
+            nonlocal count
+            count += 1
+            return x + 1
+
+        with e.start():
+            f1 = e.submit(inc, 0)
+            f2 = e.submit(inc, f1)
+            f3 = e.submit(inc, f2)
+            assert e.wait([f1]) == [1]
+            assert count == 1
+            assert e.wait([f2]) == [2]
+            assert count == 2
+            assert e.wait([f3]) == [3]
+            assert count == 3
+            assert e.wait([f1, f2, f3]) == [1, 2, 3]
+            assert count == 3
+
     def test_is_pickleable(self):
         e = LocalDaskExecutor()
         post = cloudpickle.loads(cloudpickle.dumps(e))
@@ -94,6 +129,7 @@ class TestLocalDaskExecutor:
         with e.start():
             post = cloudpickle.loads(cloudpickle.dumps(e))
             assert isinstance(post, LocalDaskExecutor)
+            assert post._callback is None
 
 
 class TestLocalExecutor:


### PR DESCRIPTION
- Fixes `LocalDaskExecutor` to only compute once. Previously this would recompute tasks, sometimes many many times (the comment saying "twice" was being optimistic).
- Adds support for setting task names in the `LocalDaskExecutor`.

Also a few misc cleanups.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)