### PR TITLE
Update docs to use JSON literal

### DIFF
--- a/docs/orchestration/concepts/cloud_hooks.md
+++ b/docs/orchestration/concepts/cloud_hooks.md
@@ -110,11 +110,19 @@ To create a Cloud Hook using the [API](/orchestration/concepts/api.html), you ca
 
 ```graphql
 mutation {
-  create_cloud_hook(input: {type: EMAIL, name: "Example", version_group_id: "abc", states: ["Running"], config: {to: "test@test.com"}}) {
+  create_cloud_hook(
+    input: {
+      type: EMAIL,
+      name: "Example",
+      version_group_id: "abc",
+      states: ["Running"],
+      config: "{\"to\": \"test@test.com\"}"}
+      ) {
     id
   }
 }
 ```
+
 A full list of Cloud Hook queries and mutations can be found in the API schema (for example in the [Interactive API](/orchestration/ui/interactive-api.html) page of the UI.)
 
 <style>


### PR DESCRIPTION
Simple change to update a GQL command in the docs that is not valid GraphQL - the JSON payload must be passed as a literal JSON string or variable.