### PR TITLE
Set default env metadata image

### DIFF
--- a/changes/pr2828.yaml
+++ b/changes/pr2828.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Flows registered without an image set will default to `all_extras` - [#2828](https://github.com/PrefectHQ/prefect/pull/2828)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -648,8 +648,16 @@ class Client:
 
         serialized_flow = flow.serialize(build=build)  # type: Any
 
+        # Set Docker storage image in environment metadata if provided
         if isinstance(flow.storage, prefect.environments.storage.Docker):
             flow.environment.metadata["image"] = flow.storage.name
+
+        # If no image ever set, default metadata to all_extras image on current version
+        if not flow.environment.metadata.get("image"):
+            version = prefect.__version__.split("+")[0]
+            flow.environment.metadata[
+                "image"
+            ] = f"prefecthq/prefect:all_extras-{version}"
 
         # verify that the serialized flow can be deserialized
         try:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -407,6 +407,54 @@ def test_client_register_docker_image_name(patch_post, compressed, monkeypatch, 
 
 
 @pytest.mark.parametrize("compressed", [True, False])
+def test_client_register_default_all_extras_image(
+    patch_post, compressed, monkeypatch, tmpdir
+):
+    if compressed:
+        response = {
+            "data": {
+                "project": [{"id": "proj-id"}],
+                "create_flow_from_compressed_string": {"id": "long-id"},
+            }
+        }
+    else:
+        response = {
+            "data": {"project": [{"id": "proj-id"}], "create_flow": {"id": "long-id"}}
+        }
+    post = patch_post(response)
+
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+    monkeypatch.setattr("prefect.environments.storage.Docker._build_image", MagicMock())
+
+    with set_temporary_config(
+        {"cloud.api": "http://my-cloud.foo", "cloud.auth_token": "secret_token"}
+    ):
+        client = Client()
+    flow = prefect.Flow(name="test", storage=prefect.environments.storage.Local(tmpdir))
+    flow.result = flow.storage.result
+
+    flow_id = client.register(
+        flow, project_name="my-default-project", compressed=compressed, build=True
+    )
+
+    ## extract POST info
+    if compressed:
+        serialized_flow = decompress(
+            json.loads(post.call_args[1]["json"]["variables"])["input"][
+                "serialized_flow"
+            ]
+        )
+    else:
+        serialized_flow = json.loads(post.call_args[1]["json"]["variables"])["input"][
+            "serialized_flow"
+        ]
+    assert serialized_flow["storage"] is not None
+    assert "all_extras" in serialized_flow["environment"]["metadata"]["image"]
+
+
+@pytest.mark.parametrize("compressed", [True, False])
 def test_client_register_optionally_avoids_building_flow(
     patch_post, compressed, monkeypatch
 ):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This field should be populated by default in order to ensure flows are deployable without extra configuration


## Why is this PR important?
Could remove some potential hidden frictions for new users

