### PR TITLE
Generate better dask task key names

### DIFF
--- a/changes/pr2831.yaml
+++ b/changes/pr2831.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Generate key names for mapped tasks that work better with Dask's dashboard - [#2831](https://github.com/PrefectHQ/prefect/pull/2831)"

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1551,6 +1551,10 @@ def test_constant_tasks_arent_submitted_when_mapped(caplog):
 
 
 def test_flow_runner_provides_consistent_extra_context():
+    """Check that the `extra_context` provided to an executor is consistent.
+
+    The `extra_context` is used by the dask executor to generate good key names
+    and add task resource requirements"""
     extra_contexts = []
 
     class MyExecutor(Executor):


### PR DESCRIPTION
Dask infers if different tasks do similar things with some custom
key-name splitting heuristics (it's *mostly* splitting by `-`, but not
entirely). The previous key names generated by mapped tasks didn't play
nice with this heuristic, resulting in the dask UI not grouping tasks
appropriately. This fixes that.

Fixes #2821

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)