### PR TITLE
[docs] fix doc on Docker.create_dockerfile_object()

### DIFF
--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -388,9 +388,7 @@ class Docker(Storage):
         directory as well.
 
         Args:
-            - directory (str, optional): A directory where the Dockerfile will be
-                created, if no directory is specified is will be created in the
-                current working directory
+            - directory (str): A directory where the Dockerfile will be created
 
         Returns:
             - str: the absolute file path to the Dockerfile


### PR DESCRIPTION

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

The documentation for `prefect.environments.storage.docker.Docker.create_dockerfile_object()` says that `directory` is optional, but it's currently required. This PR fixes the the documentation to match the code.

## Why is this PR important?

This resolves a minor inconsistency in the documentation that might lead users to make a mistake the first time they use `create_dockerfile_object()`.

Thanks for your time and consideration.