### PR TITLE
make sure `environment` and serialized flow in client.register() match

### DIFF
--- a/changes/pr2838.yaml
+++ b/changes/pr2838.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Make sure image from Docker storage is always used with KubernetesJobEnvironment - [#2838](https://github.com/PrefectHQ/prefect/pull/2838)"

--- a/changes/pr2838.yaml
+++ b/changes/pr2838.yaml
@@ -1,2 +1,5 @@
 fix:
   - "Make sure image from Docker storage is always used with KubernetesJobEnvironment - [#2838](https://github.com/PrefectHQ/prefect/pull/2838)"
+
+contributor:
+ - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -662,7 +662,7 @@ class Client:
         # Set Docker storage image in environment metadata if provided
         if isinstance(flow.storage, prefect.environments.storage.Docker):
             flow.environment.metadata["image"] = flow.storage.name
-            serialized_flow = flow.serialize(build=False)  # type: Any
+            serialized_flow = flow.serialize(build=False)
 
         # If no image ever set, default metadata to all_extras image on current version
         if not flow.environment.metadata.get("image"):
@@ -670,7 +670,7 @@ class Client:
             flow.environment.metadata[
                 "image"
             ] = f"prefecthq/prefect:all_extras-{version}"
-            serialized_flow = flow.serialize(build=False)  # type: Any
+            serialized_flow = flow.serialize(build=False)
 
         # verify that the serialized flow can be deserialized
         try:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -657,9 +657,12 @@ class Client:
                     )
                 )
 
+        serialized_flow = flow.serialize(build=build)  # type: Any
+
         # Set Docker storage image in environment metadata if provided
         if isinstance(flow.storage, prefect.environments.storage.Docker):
             flow.environment.metadata["image"] = flow.storage.name
+            serialized_flow = flow.serialize(build=False)  # type: Any
 
         # If no image ever set, default metadata to all_extras image on current version
         if not flow.environment.metadata.get("image"):
@@ -667,8 +670,7 @@ class Client:
             flow.environment.metadata[
                 "image"
             ] = f"prefecthq/prefect:all_extras-{version}"
-
-        serialized_flow = flow.serialize(build=build)  # type: Any
+            serialized_flow = flow.serialize(build=False)  # type: Any
 
         # verify that the serialized flow can be deserialized
         try:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -657,8 +657,6 @@ class Client:
                     )
                 )
 
-        serialized_flow = flow.serialize(build=build)  # type: Any
-
         # Set Docker storage image in environment metadata if provided
         if isinstance(flow.storage, prefect.environments.storage.Docker):
             flow.environment.metadata["image"] = flow.storage.name
@@ -669,6 +667,8 @@ class Client:
             flow.environment.metadata[
                 "image"
             ] = f"prefecthq/prefect:all_extras-{version}"
+
+        serialized_flow = flow.serialize(build=build)  # type: Any
 
         # verify that the serialized flow can be deserialized
         try:


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

In `client.register()`, the client checks if the flow is using `Docker` storage and, if so, gets the image from that storage and puts it on `flow.environment.metadata["image"]`. This PR proposes ~doing that *before* capturing the serialized flow with `flow.serialize()`.~ updating `serialized_flow` after doing that.

## Why is this PR important?

This will help users avoid a mistake that I just made, which took a bit of time to debug.

I've been using `KubernetesAgent` and `KubernetesJobEnvironment`, and experimenting with different types of storage. From a previous attempt that was using `S3` storage, I had an image set in the environment's `metadata` left over in my `KubernetesJobEnvironmnet` code:

```python
env = KubernetesJobEnvironment(
    job_spec_file="prefect-flow-run.yaml",
    metadata={
       "image": "prefecthq/prefect:0.12.0-python3.7"
   }
)

flow.storage = Docker(
    base_image="prefecthq/prefect:0.12.0-python3.7",
    image_name="prefect-testing",
    image_tag="1.1",
    registry_url="localhost:32000"
)
```

When I registered this flow and ran it, the flow runs failed with an error like this

> Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prefect/environments/execution/base.py", line 131, in run_flow
    flow = storage.get_flow(storage.flows[flow_data.name])
  File "/usr/local/lib/python3.8/site-packages/prefect/environments/storage/docker.py", line 244, in get_flow
    with open(flow_location, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/opt/prefect/flows/my-flow.prefect'

After some time spent debugging, I realized that jobs created by `KubernetesAgent` were using the image `prefecthq/prefect:0.12.0-python3.7` (from the `environment`), not the new image built from my storage.

I believe that the changes in this PR will eliminate this error without breaking any expected behavior. The effect of this PR is that `{"metadata": {"image` set in the `environment` is ignored if you use `Docker` storage.

#### Environment info

I observed this behavior with `prefect` 0.12.0, running an agent that used image `prefecthq/prefect:0.12.0-python3.7`.

Thanks for your time and consideration.