### PR TITLE
Update graphql responses with underlying api response statuses

### DIFF
--- a/changes/pr2839.yaml
+++ b/changes/pr2839.yaml
@@ -1,0 +1,25 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - server
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+    - "Forward state change status back to core - [#2839](https://github.com/PrefectHQ/prefect/pull/2839)"
+  
+  contributor:
+    - "[Alex Cano](https://github.com/alexisprince1994)"
+  

--- a/server/src/prefect_server/graphql/states.py
+++ b/server/src/prefect_server/graphql/states.py
@@ -28,15 +28,12 @@ async def resolve_set_flow_run_states(
     async def set_state(state_input: dict) -> str:
         state = state_schema.load(state_input["state"])
 
-        await api.states.set_flow_run_state(
+        payload = await api.states.set_flow_run_state(
             flow_run_id=state_input["flow_run_id"], state=state,
         )
+        payload.update(id=state_input["flow_run_id"], message=None)
 
-        return {
-            "id": state_input["flow_run_id"],
-            "status": "SUCCESS",
-            "message": None,
-        }
+        return payload
 
     result = await asyncio.gather(
         *[set_state(state_input) for state_input in input["states"]],
@@ -57,15 +54,12 @@ async def resolve_set_task_run_states(
 
         state = state_schema.load(state_input["state"])
 
-        await api.states.set_task_run_state(
+        payload = await api.states.set_task_run_state(
             task_run_id=state_input["task_run_id"], state=state,
         )
 
-        return {
-            "id": state_input["task_run_id"],
-            "status": "SUCCESS",
-            "message": None,
-        }
+        payload.update(id=state_input["task_run_id"], message=None)
+        return payload
 
     result = await asyncio.gather(
         *[set_state(state_input) for state_input in input["states"]],


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR changes the `set_flow_run_states` and `set_task_run_states` mutations to return the status from the underlying function call.


## Why is this PR important?
This PR is important for implementing `Queued` statuses for both flows and tasks, as it forwards the signals back to core.

