### PR TITLE
respect executor from environment

### DIFF
--- a/changes/pr2849.yaml
+++ b/changes/pr2849.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Change Environment.run_flow() to prefer executor from flow's environment - [#2849](https://github.com/PrefectHQ/prefect/pull/2849)"

--- a/changes/pr2849.yaml
+++ b/changes/pr2849.yaml
@@ -1,2 +1,5 @@
 fix:
   - "Change Environment.run_flow() to prefer executor from flow's environment - [#2849](https://github.com/PrefectHQ/prefect/pull/2849)"
+
+contributor:
+ - "[James Lamb](https://github.com/jameslamb)"

--- a/docs/orchestration/execution/fargate_task_environment.md
+++ b/docs/orchestration/execution/fargate_task_environment.md
@@ -95,7 +95,7 @@ The container dictionary above will be changed during setup:
 [
     "/bin/sh",
     "-c",
-    "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'",
+    "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
 ]
 ```
 

--- a/docs/orchestration/execution/k8s_job_environment.md
+++ b/docs/orchestration/execution/k8s_job_environment.md
@@ -57,7 +57,7 @@ In the above YAML block, `flow-container` will be changed during execution:
 - `command` and `args` will take the form of:
 
 ```bash
-/bin/sh -c "python -c 'import prefect; prefect.Flow.load(prefect.context.flow_file_path).environment.run_flow()'"
+/bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
 ```
 
 - `env` will have some extra variables automatically appended to it for Cloud-based Flow runs:

--- a/src/prefect/environments/execution/__init__.py
+++ b/src/prefect/environments/execution/__init__.py
@@ -4,7 +4,7 @@ Execution environments encapsulate the logic for where your Flow should execute 
 Currently, we recommend all users deploy their Flow using the `LocalEnvironment` configured with the
 appropriate choice of executor.
 """
-from prefect.environments.execution.base import Environment
+from prefect.environments.execution.base import Environment, load_and_run_flow
 from prefect.environments.execution.dask import DaskKubernetesEnvironment
 from prefect.environments.execution.dask import DaskCloudProviderEnvironment
 from prefect.environments.execution.fargate import FargateTaskEnvironment

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -130,7 +130,9 @@ class Environment:
             with prefect.context(secrets=secrets):
                 flow = storage.get_flow(storage.flows[flow_data.name])
                 runner_cls = get_default_flow_runner_class()
-                if getattr(self, "executor", None) is not None:
+                if getattr(flow.environment, "executor", None) is not None:
+                    executor = flow.environment.executor
+                elif getattr(self, "executor", None) is not None:
                     executor = self.executor  # type: ignore
                 else:
                     executor_cls = get_default_executor_class()

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -8,7 +8,7 @@ that environment. e.g. the `DaskKubernetesEnvironment` is an environment which
 runs a flow on Kubernetes using the `dask-kubernetes` library.
 """
 
-from typing import Any, Callable, Iterable, TYPE_CHECKING
+from typing import Callable, Iterable, TYPE_CHECKING
 
 import prefect
 from prefect.client import Client
@@ -65,13 +65,12 @@ class Environment:
             - flow (Flow): the Flow object
         """
 
-    def execute(self, flow: "Flow", **kwargs: Any) -> None:
+    def execute(self, flow: "Flow") -> None:
         """
-        Executes the flow for this environment from the storage parameter
+        Executes the flow for this environment.
 
         Args:
             - flow (Flow): the Flow object
-            - **kwargs (Any): additional keyword arguments to pass to the runner
         """
 
     def serialize(self) -> dict:
@@ -84,70 +83,86 @@ class Environment:
         schema = prefect.serialization.environment.EnvironmentSchema()
         return schema.dump(self)
 
-    def run_flow(self) -> None:
-        """
-        Run the flow using the default executor
 
-        Raises:
-            - ValueError: if no `flow_run_id` is found in context
+class _RunMixin:
+    """This mixin will go away when all environments share the same run
+    implementation.
+
+    For now this is just to share code between a few of the environments"""
+
+    def run(self, flow: "Flow") -> None:
         """
-        # Call on_start callback if specified
+        Run the flow using this environment.
+
+        Args:
+            - flow (Flow): the flow object
+        """
+        assert isinstance(self, Environment)  # mypy
         if self.on_start:
             self.on_start()
 
         try:
-            from prefect.engine import (
-                get_default_flow_runner_class,
-                get_default_executor_class,
-            )
+            from prefect.engine import get_default_flow_runner_class
 
-            flow_run_id = prefect.context.get("flow_run_id")
-
-            if not flow_run_id:
-                raise ValueError("No flow run ID found in context.")
-
-            query = {
-                "query": {
-                    with_args("flow_run", {"where": {"id": {"_eq": flow_run_id}}}): {
-                        "flow": {"name": True, "storage": True,},
-                    }
-                }
-            }
-
-            client = Client()
-            result = client.graphql(query)
-            flow_run = result.data.flow_run[0]
-
-            flow_data = flow_run.flow
-            storage_schema = prefect.serialization.storage.StorageSchema()
-            storage = storage_schema.load(flow_data.storage)
-
-            ## populate global secrets
-            secrets = prefect.context.get("secrets", {})
-            for secret in storage.secrets:
-                secrets[secret] = prefect.tasks.secrets.PrefectSecret(name=secret).run()
-
-            with prefect.context(secrets=secrets):
-                flow = storage.get_flow(storage.flows[flow_data.name])
-                runner_cls = get_default_flow_runner_class()
-                if getattr(flow.environment, "executor", None) is not None:
-                    executor = flow.environment.executor
-                elif getattr(self, "executor", None) is not None:
-                    executor = self.executor  # type: ignore
-                else:
-                    executor_cls = get_default_executor_class()
-                    # Deprecated, to be removed
-                    if hasattr(self, "executor_kwargs"):
-                        executor = executor_cls(**self.executor_kwargs)  # type: ignore
-                    else:
-                        executor = executor_cls
-                runner_cls(flow=flow).run(executor=executor)
+            runner_cls = get_default_flow_runner_class()
+            runner_cls(flow=flow).run(executor=self.executor)  # type: ignore
         except Exception as exc:
             self.logger.exception(
                 "Unexpected error raised during flow run: {}".format(exc)
             )
             raise exc
         finally:
-            # Call on_exit callback if specified
             if self.on_exit:
                 self.on_exit()
+
+
+def load_and_run_flow() -> None:
+    """
+    Loads a flow (and the corresponding environment), then runs the flow with
+    the environment.
+
+    This is useful for environments whose `execute` method schedules a job that
+    later needs to run the flow.
+
+    Raises:
+        - ValueError: if no `flow_run_id` is found in context
+    """
+    logger = logging.get_logger("Environment")
+    try:
+        from prefect.engine import (
+            get_default_flow_runner_class,
+            get_default_executor_class,
+        )
+
+        flow_run_id = prefect.context.get("flow_run_id")
+
+        if not flow_run_id:
+            raise ValueError("No flow run ID found in context.")
+
+        query = {
+            "query": {
+                with_args("flow_run", {"where": {"id": {"_eq": flow_run_id}}}): {
+                    "flow": {"name": True, "storage": True,},
+                }
+            }
+        }
+
+        client = Client()
+        result = client.graphql(query)
+        flow_run = result.data.flow_run[0]
+
+        flow_data = flow_run.flow
+        storage_schema = prefect.serialization.storage.StorageSchema()
+        storage = storage_schema.load(flow_data.storage)
+
+        ## populate global secrets
+        secrets = prefect.context.get("secrets", {})
+        for secret in storage.secrets:
+            secrets[secret] = prefect.tasks.secrets.PrefectSecret(name=secret).run()
+
+        with prefect.context(secrets=secrets):
+            flow = storage.get_flow(storage.flows[flow_data.name])
+            flow.environment.run(flow)
+    except Exception as exc:
+        logger.exception("Unexpected error raised during flow run: {}".format(exc))
+        raise exc

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -17,7 +17,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              'python -c "import prefect; prefect.environments.DaskKubernetesEnvironment().run_flow()"',
+              'python -c "import prefect; prefect.environments.execution.load_and_run_flow()"',
             ]
           env:
             - name: PREFECT__CLOUD__GRAPHQL

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import Any, Callable, List, TYPE_CHECKING
+from typing import Callable, List, TYPE_CHECKING
 
 import prefect
 from prefect import config

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -4,14 +4,14 @@ from typing import Any, Callable, List, TYPE_CHECKING
 
 import prefect
 from prefect import config
-from prefect.environments.execution import Environment
+from prefect.environments.execution.base import Environment, _RunMixin
 from prefect.utilities.storage import get_flow_image
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
 
 
-class FargateTaskEnvironment(Environment):
+class FargateTaskEnvironment(Environment, _RunMixin):
     """
     FargateTaskEnvironment is an environment which deploys your flow as a Fargate task.
     This environment requires AWS credentials and extra boto3 kwargs which
@@ -35,7 +35,7 @@ class FargateTaskEnvironment(Environment):
 
     Additionally, the following command will be applied to the first container:
 
-    `$ /bin/sh -c "python -c 'import prefect; prefect.environments.FargateTaskEnvironment().run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"`
 
     All `kwargs` are accepted that one would normally pass to boto3 for `register_task_definition`
     and `run_task`. For information on the kwargs supported visit the following links:
@@ -262,20 +262,17 @@ class FargateTaskEnvironment(Environment):
             self.task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; prefect.environments.FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
             ]
 
             boto3_c.register_task_definition(**self.task_definition_kwargs)
 
-    def execute(  # type: ignore
-        self, flow: "Flow", **kwargs: Any
-    ) -> None:
+    def execute(self, flow: "Flow") -> None:  # type: ignore
         """
         Run the Fargate task that was defined for this flow.
 
         Args:
             - flow (Flow): the Flow object
-            - **kwargs (Any): additional keyword arguments to pass to the runner
         """
         from boto3 import client as boto3_client
 

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -6,14 +6,14 @@ from typing import Any, Callable, List, TYPE_CHECKING
 import yaml
 
 import prefect
-from prefect.environments.execution import Environment
+from prefect.environments.execution.base import Environment, _RunMixin
 from prefect.utilities.storage import get_flow_image
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
 
 
-class KubernetesJobEnvironment(Environment):
+class KubernetesJobEnvironment(Environment, _RunMixin):
     """
     KubernetesJobEnvironment is an environment which deploys your flow as a Kubernetes
     job. This environment allows (and requires) a custom job YAML spec to be provided.
@@ -36,7 +36,7 @@ class KubernetesJobEnvironment(Environment):
     - `PREFECT__LOGGING__EXTRA_LOGGERS`
 
     Additionally, the following command will be applied to the first container:
-    `$ /bin/sh -c "python -c 'import prefect; prefect.environments.KubernetesJobEnvironment().run_flow()'"`
+    `$ /bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"`
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file
@@ -244,7 +244,7 @@ class KubernetesJobEnvironment(Environment):
             yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
 
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "python -c 'import prefect; prefect.environments.KubernetesJobEnvironment().run_flow()'"
+            "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"
         ]
 
         return yaml_obj

--- a/tests/environments/execution/test_base_environment.py
+++ b/tests/environments/execution/test_base_environment.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -5,7 +6,8 @@ import pytest
 import prefect
 from prefect import Flow
 from prefect.environments import Environment
-from prefect.environments.storage import Docker, Local
+from prefect.environments.execution import load_and_run_flow
+from prefect.environments.storage import Docker, Local, Storage
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
@@ -65,19 +67,25 @@ def test_serialize_environment():
     assert env["type"] == "Environment"
 
 
-def test_run_flow(monkeypatch, tmpdir):
-    environment = Environment()
+def test_load_and_run_flow(monkeypatch, tmpdir):
+    myflow = Flow("test-flow")
 
-    flow_runner = MagicMock()
-    flow_runner_class = MagicMock(return_value=flow_runner)
+    # This is gross. Since the flow is pickled/unpickled, there's no easy way
+    # to access the same object to set a flag. Resort to setting an environment
+    # variable as a global flag that won't get copied eagerly through
+    # cloudpickle.
+    monkeypatch.setenv("TEST_RUN_CALLED", "FALSE")
 
-    monkeypatch.setattr(
-        "prefect.engine.get_default_flow_runner_class",
-        MagicMock(return_value=flow_runner_class),
-    )
+    class MyEnvironment(Environment):
+        def run(self, flow):
+            assert flow is myflow
+            os.environ["TEST_RUN_CALLED"] = "TRUE"
 
-    d = Local(str(tmpdir))
-    d.add_flow(Flow("name"))
+    myflow.environment = MyEnvironment()
+
+    storage = Local(str(tmpdir))
+    myflow.storage = storage
+    storage.add_flow(myflow)
 
     gql_return = MagicMock(
         return_value=MagicMock(
@@ -86,7 +94,7 @@ def test_run_flow(monkeypatch, tmpdir):
                     GraphQLResult(
                         {
                             "flow": GraphQLResult(
-                                {"name": "name", "storage": d.serialize()}
+                                {"name": myflow.name, "storage": storage.serialize()}
                             )
                         }
                     )
@@ -101,18 +109,11 @@ def test_run_flow(monkeypatch, tmpdir):
     with set_temporary_config({"cloud.auth_token": "test"}), prefect.context(
         {"flow_run_id": "id"}
     ):
-        environment.run_flow()
-
-    assert flow_runner_class.call_args[1]["flow"].name == "name"
-    assert flow_runner.run.call_args[1]["executor"] is not None
+        load_and_run_flow()
+    assert os.environ["TEST_RUN_CALLED"] == "TRUE"
 
 
-def test_run_flow_no_flow_run_id_in_context(monkeypatch, tmpdir):
-    environment = Environment()
-
-    d = Local(str(tmpdir))
-    d.add_flow(Flow("name"))
-
+def test_load_and_run_flow_no_flow_run_id_in_context(monkeypatch, tmpdir):
     with set_temporary_config({"cloud.auth_token": "test"}):
         with pytest.raises(ValueError):
-            environment.run_flow()
+            load_and_run_flow()

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -7,9 +7,8 @@ import prefect
 from prefect import Flow
 from prefect.engine.executors import LocalDaskExecutor
 from prefect.environments import FargateTaskEnvironment
-from prefect.environments.storage import Docker, Local
+from prefect.environments.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
-from prefect.utilities.graphql import GraphQLResult
 
 from botocore.exceptions import ClientError
 
@@ -273,7 +272,7 @@ def test_setup_definition_register(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; prefect.environments.FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
             ],
             "environment": [
                 {
@@ -341,7 +340,7 @@ def test_setup_definition_register_no_defintions(monkeypatch):
             "command": [
                 "/bin/sh",
                 "-c",
-                "python -c 'import prefect; prefect.environments.FargateTaskEnvironment().run_flow()'",
+                "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
             ],
         }
     ]
@@ -427,224 +426,28 @@ def test_execute_run_task_agent_token(monkeypatch):
         assert boto3_client.run_task.call_args[1]["cluster"] == "test"
 
 
-def test_run_flow(monkeypatch, tmpdir):
-    environment = FargateTaskEnvironment()
+def test_environment_run():
+    class MyExecutor(LocalDaskExecutor):
+        submit_called = False
 
-    flow_runner = MagicMock()
-    flow_runner_class = MagicMock(return_value=flow_runner)
+        def submit(self, *args, **kwargs):
+            self.submit_called = True
+            return super().submit(*args, **kwargs)
 
-    monkeypatch.setattr(
-        "prefect.engine.get_default_flow_runner_class",
-        MagicMock(return_value=flow_runner_class),
-    )
+    global_dict = {}
 
-    d = Local(str(tmpdir))
-    d.add_flow(prefect.Flow("name"))
+    @prefect.task
+    def add_to_dict():
+        global_dict["run"] = True
 
-    gql_return = MagicMock(
-        return_value=MagicMock(
-            data=MagicMock(
-                flow_run=[
-                    GraphQLResult(
-                        {
-                            "flow": GraphQLResult(
-                                {"name": "name", "storage": d.serialize(),}
-                            )
-                        }
-                    )
-                ],
-            )
-        )
-    )
-    client = MagicMock()
-    client.return_value.graphql = gql_return
-    monkeypatch.setattr("prefect.environments.execution.base.Client", client)
+    executor = MyExecutor()
+    environment = FargateTaskEnvironment(executor=executor)
+    flow = prefect.Flow("test", tasks=[add_to_dict], environment=environment)
 
-    with set_temporary_config({"cloud.auth_token": "test"}), prefect.context(
-        {"flow_run_id": "id"}
-    ):
-        environment.run_flow()
+    environment.run(flow=flow)
 
-    assert flow_runner_class.call_args[1]["flow"].name == "name"
-    assert flow_runner.run.call_args[1]["executor"] is environment.executor
-
-
-def test_run_flow_calls_callbacks(monkeypatch, tmpdir):
-    start_func = MagicMock()
-    exit_func = MagicMock()
-
-    environment = FargateTaskEnvironment(on_start=start_func, on_exit=exit_func)
-
-    flow_runner = MagicMock()
-    monkeypatch.setattr(
-        "prefect.engine.get_default_flow_runner_class",
-        MagicMock(return_value=flow_runner),
-    )
-
-    d = Local(str(tmpdir))
-    d.add_flow(prefect.Flow("name"))
-
-    gql_return = MagicMock(
-        return_value=MagicMock(
-            data=MagicMock(
-                flow_run=[
-                    GraphQLResult(
-                        {
-                            "flow": GraphQLResult(
-                                {"name": "name", "storage": d.serialize(),}
-                            )
-                        }
-                    )
-                ],
-            )
-        )
-    )
-    client = MagicMock()
-    client.return_value.graphql = gql_return
-    monkeypatch.setattr("prefect.environments.execution.base.Client", client)
-
-    with set_temporary_config({"cloud.auth_token": "test"}), prefect.context(
-        {"flow_run_id": "id"}
-    ):
-        environment.run_flow()
-
-    assert flow_runner.call_args[1]["flow"].name == "name"
-
-    assert start_func.called
-    assert exit_func.called
-
-
-def test_entire_environment_process_together(monkeypatch, tmpdir):
-    boto3_client = MagicMock()
-    boto3_client.describe_task_definition.side_effect = ClientError({}, None)
-    boto3_client.register_task_definition.return_value = {}
-    boto3_client.run_task.return_value = {}
-    monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
-
-    flow_runner = MagicMock()
-    monkeypatch.setattr(
-        "prefect.engine.get_default_flow_runner_class",
-        MagicMock(return_value=flow_runner),
-    )
-
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
-    monkeypatch.setenv("AWS_SESSION_TOKEN", "session")
-    monkeypatch.setenv("REGION_NAME", "region")
-
-    with prefect.context({"flow_run_id": "id"}), set_temporary_config(
-        {"cloud.auth_token": "test", "logging.extra_loggers": "['test_logger']",}
-    ):
-        storage = Docker(registry_url="test", image_name="image", image_tag="tag")
-        flow = Flow("name", storage=storage)
-        environment = FargateTaskEnvironment(
-            containerDefinitions=[
-                {
-                    "name": "flow-container",
-                    "image": "image",
-                    "command": [],
-                    "environment": [],
-                    "essential": True,
-                }
-            ],
-            cluster="test",
-            family="test",
-            taskDefinition="test",
-        )
-
-        assert environment.aws_access_key_id == "id"
-        assert environment.aws_secret_access_key == "secret"
-        assert environment.aws_session_token == "session"
-        assert environment.region_name == "region"
-
-        environment.setup(flow=flow)
-
-        assert boto3_client.describe_task_definition.called
-        assert boto3_client.register_task_definition.called
-        assert boto3_client.register_task_definition.call_args[1]["family"] == "test"
-        assert boto3_client.register_task_definition.call_args[1][
-            "containerDefinitions"
-        ] == [
-            {
-                "name": "flow-container",
-                "image": "test/image:tag",
-                "command": [
-                    "/bin/sh",
-                    "-c",
-                    "python -c 'import prefect; prefect.environments.FargateTaskEnvironment().run_flow()'",
-                ],
-                "environment": [
-                    {
-                        "name": "PREFECT__CLOUD__GRAPHQL",
-                        "value": prefect.config.cloud.graphql,
-                    },
-                    {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
-                    {
-                        "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
-                        "value": "prefect.engine.cloud.CloudFlowRunner",
-                    },
-                    {
-                        "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
-                        "value": "prefect.engine.cloud.CloudTaskRunner",
-                    },
-                    {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                    {
-                        "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
-                        "value": "['test_logger']",
-                    },
-                ],
-                "essential": True,
-            }
-        ]
-
-        environment.execute(flow=flow)
-
-        assert boto3_client.run_task.called
-        assert boto3_client.run_task.call_args[1]["taskDefinition"] == "test"
-        assert boto3_client.run_task.call_args[1]["overrides"] == {
-            "containerOverrides": [
-                {
-                    "name": "flow-container",
-                    "environment": [
-                        {
-                            "name": "PREFECT__CLOUD__AUTH_TOKEN",
-                            "value": prefect.config.cloud.get("auth_token"),
-                        },
-                        {"name": "PREFECT__CONTEXT__FLOW_RUN_ID", "value": "id"},
-                        {"name": "PREFECT__CONTEXT__IMAGE", "value": "test/image:tag"},
-                    ],
-                }
-            ]
-        }
-        assert boto3_client.run_task.call_args[1]["launchType"] == "FARGATE"
-        assert boto3_client.run_task.call_args[1]["cluster"] == "test"
-
-        d = Local(str(tmpdir))
-        d.add_flow(prefect.Flow("name"))
-
-        gql_return = MagicMock(
-            return_value=MagicMock(
-                data=MagicMock(
-                    flow_run=[
-                        GraphQLResult(
-                            {
-                                "flow": GraphQLResult(
-                                    {"name": "name", "storage": d.serialize(),}
-                                )
-                            }
-                        )
-                    ],
-                )
-            )
-        )
-        client = MagicMock()
-        client.return_value.graphql = gql_return
-        monkeypatch.setattr("prefect.environments.execution.base.Client", client)
-
-        with set_temporary_config({"cloud.auth_token": "test"}):
-            environment.run_flow()
-
-        assert flow_runner.call_args[1]["flow"].name == "name"
+    assert global_dict.get("run") is True
+    assert executor.submit_called
 
 
 def test_roundtrip_cloudpickle():


### PR DESCRIPTION
*created from [this conversation in Prefect Community Slack](https://prefect-community.slack.com/archives/CL09KU1K7/p1592925843192100)*

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR proposes changing the behavior of `Environment.run_flow()`. Today, if you call this method on an instance of `Environment` or any child class of it, `run_flow()` will use the executor in `self.executor` if that attribute has been set.

https://github.com/PrefectHQ/prefect/blob/191f429cdb1c48cde1b2636e2fa04e24f94dfb79/src/prefect/environments/execution/base.py#L133-L135

That strategy means that despite the changes from #2805 , it is not currently possible to use `KubernetesJobEnvironment` and `DaskExecutor` together. That is because flows that use `KubernetesJobEnvironment` end up being run with `KubernetesJobEnvironment().run_flow()`

https://github.com/PrefectHQ/prefect/blob/191f429cdb1c48cde1b2636e2fa04e24f94dfb79/src/prefect/environments/execution/k8s/job.py#L247

`KubernetesJobEnvironment`'s constructor sets `self.executor` to the default executor from `prefect`'s config if one isn't passed.

https://github.com/PrefectHQ/prefect/blob/191f429cdb1c48cde1b2636e2fa04e24f94dfb79/src/prefect/environments/execution/k8s/job.py#L71-L74

Since `KubernetesJobEnvironment` inherits `run_flow()` from `Environment`, that means that the environment's `self.executor` will always be set and equal to the value from the config.

So if you use something like I tried today:

```python
KubernetesJobEnvironment(
    executor=DaskExecutor(
        cluster_class="prefect.engine.executors.DaskExecutor"
    ),
    job_spec_file="prefect-flow-run.yaml",
)
```

Then you'll never get that `DaskExecutor`. Flows will run with the default, which is often `LocalExecutor`.

This PR proposes changing that behavior, so that if the `environment` in the flow has an `executor`, `Environment.run_flow()` uses that.

## Why is this PR important?

Without this PR, the `executor` you pass to `KubernetesJobEnvironment` or `FargateTaskEnvironment` is ignored when flows are run.

If I'm right, that means that without this PR, the only way to use one of these environments with a non-default executor like `DaskExecutor` is to maybe set the default executor in a [user config](https://docs.prefect.io/core/concepts/configuration.html#user-configuration) (I have not tried this).

I think this is extra important because the use of a different executor is silent...in my case, the job environment happened to be sized appropriately to run my flow, so even though I wanted `DaskExecutor`, when I got `LocalExecutor` the flow happily ran and completed. If my job environment had been poorly sized for the work my flow does, I would have probably hit an out of memory error and it wouldn't have been immediately obvious that this PR's root cause was to blame.

## Questions for Reviewers

* I've tested this manually in my local setup, but I think it should get Prefect unit tests so the bug isn't re-introduced. Could you point me to relevant tests in the repo that I could use as a reference to write unit tests for this change?
* Would it be better to remove the "if no executor given, set `self.executor` to the default" logic in `FargateTaskEnvironment` and `KubernetesJobEnvironment`? I'm not sure what the implications of that would be, but it seems like it would be a cleaner separation of responsibilities.

Thanks for your time and consideration!
