### PR TITLE
Add flake8 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
 
       - run:
           name: Install python packages for static analysis
-          command: pip install black mypy mypy_extensions autoflake profimp
+          command: pip install black mypy mypy_extensions flake8 profimp
 
       - run:
           name: Quick installation of Prefect
@@ -89,13 +89,8 @@ jobs:
           command: mypy src/
 
       - run:
-          name: Check for potentially unused imports
-          command: |
-            if [[ $(autoflake --remove-all-unused-imports -r --exclude __init__.py src | tee .unused-imports.txt | wc -c ) -ne 0 ]]; then
-              echo "Potentially unused imports found"
-              cat .unused-imports.txt
-              exit 2
-            fi
+          name: Run flake8
+          command: flake8 src/
 
       - run:
           name: Ensure 'import prefect' is under 1 second

--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,4 @@ ignore =
 
 # black is set to 88, but isn't a strict limit so we add some wiggle room for
 # flake8 testing.
-max-line-length = 100
+max-line-length = 105

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-min_python_version = 3.6.0
 exclude =
     __init__.py,
     versioneer.py,

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,26 @@
+[flake8]
+min_python_version = 3.6.0
+exclude =
+    __init__.py,
+    versioneer.py,
+    _version.py
+ignore =
+    # Import formatting
+    E4,
+    # Space before :
+    E203,
+    # Comparing types instead of isinstance
+    E721,
+    # Assign a lambda
+    E731,
+    # Ambiguous variable names
+    E741,
+    # Allow breaks before/after binary operators
+    W503,
+    W504,
+    # Redefinition of unused import
+    F811
+
+# black is set to 88, but isn't a strict limit so we add some wiggle room for
+# flake8 testing.
+max-line-length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: local
   hooks:
     - id: black
@@ -6,3 +7,11 @@
       language: python
       language_version: python3
       types: [python]
+    - id: flake8
+      name: flake8
+      entry: flake8
+      language: python
+      language_version: python3
+      types: [python]
+      # only in src for now
+      files: ^src/prefect/

--- a/src/prefect/_siginfo.py
+++ b/src/prefect/_siginfo.py
@@ -39,7 +39,7 @@ def sig_handler(*args, **kwargs):
                 screen.timeout(30)
             if screen.getch() != -1:
                 break
-    except:
+    except Exception:
         pass
     finally:
         curses.endwin()

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -64,11 +64,11 @@ class Agent:
     Base class for Agents. Information on using the Prefect agents can be found at
     https://docs.prefect.io/orchestration/agents/overview.html
 
-    This Agent class is a standard point for executing Flows in Prefect Cloud. It is meant
-    to have subclasses which inherit functionality from this class. The only piece that
-    the subclasses should implement is the `deploy_flows` function, which specifies how to run a Flow on the given platform. It is built in this
-    way to keep Prefect Cloud logic standard but allows for platform specific
-    customizability.
+    This Agent class is a standard point for executing Flows in Prefect Cloud. It is meant to
+    have subclasses which inherit functionality from this class. The only piece that the
+    subclasses should implement is the `deploy_flows` function, which specifies how to run a
+    Flow on the given platform. It is built in this way to keep Prefect Cloud logic standard
+    but allows for platform specific customizability.
 
     In order for this to operate `PREFECT__CLOUD__AGENT__AUTH_TOKEN` must be set as an
     environment variable or in your user configuration file.
@@ -76,15 +76,17 @@ class Agent:
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
             the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will be set
-            on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
-            defaults to infinite
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
         - agent_address (str, optional): Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent and all deployed flow runs
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
     """
 
     def __init__(
@@ -329,7 +331,7 @@ class Agent:
                     ]
                 )
         except Exception as exc:
-            ## if the state update failed, we don't want to follow up with another state update
+            # if the state update failed, we don't want to follow up with another state update
             if "State update failed" in str(exc):
                 self.logger.debug("Updating Flow Run state failed: {}".format(str(exc)))
                 return
@@ -360,7 +362,8 @@ class Agent:
         attempting to deploy the flow run if the flow run id is still in the Cloud run queue.
 
         Args:
-            - fut (Future): a callback requirement, the future which has completed or been cancelled.
+            - fut (Future): a callback requirement, the future which has completed or been
+                cancelled.
             - flow_run_id (str): the id of the flow run that the future represents.
         """
         self.submitting_flow_runs.remove(flow_run_id)
@@ -371,7 +374,8 @@ class Agent:
         Full process for finding flow runs, updating states, and deploying.
 
         Args:
-            - executor (ThreadPoolExecutor): the interface to submit flow deployments in background threads
+            - executor (ThreadPoolExecutor): the interface to submit flow deployments in
+                background threads
 
         Returns:
             - bool: whether or not flow runs were found
@@ -409,7 +413,8 @@ class Agent:
             - list: A list of GraphQLResult flow run objects
         """
         self.logger.debug("Querying for flow runs")
-        # keep a copy of what was curringly running before the query (future callbacks may be updating this set)
+        # keep a copy of what was curringly running before the query (future callbacks may be
+        # updating this set)
         currently_submitting_flow_runs = self.submitting_flow_runs.copy()
 
         # Get scheduled flow runs from queue
@@ -423,7 +428,7 @@ class Agent:
         result = self.client.graphql(
             mutation,
             variables={
-                "input": {"before": now.isoformat(), "labels": list(self.labels),}
+                "input": {"before": now.isoformat(), "labels": list(self.labels)}
             },
         )
 
@@ -462,7 +467,8 @@ class Agent:
                             "_or": [
                                 # who are EITHER scheduled...
                                 {"state": {"_eq": "Scheduled"}},
-                                # OR running with task runs scheduled to start more than 3 seconds ago
+                                # OR running with task runs scheduled to start more than 3
+                                # seconds ago
                                 {
                                     "state": {"_eq": "Running"},
                                     "task_runs": {

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -34,27 +34,30 @@ class DockerAgent(Agent):
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
             the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will be set
-            on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
-            defaults to infinite
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
         - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent and all deployed flow runs
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
         - base_url (str, optional): URL for a Docker daemon server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as
             `tcp://0.0.0.0:2375` can be provided
         - no_pull (bool, optional): Flag on whether or not to pull flow images.
             Defaults to `False` if not provided here or in context.
-        - show_flow_logs (bool, optional): a boolean specifying whether the agent should re-route Flow run logs
-            to stdout; defaults to `False`
-        - volumes (List[str], optional): a list of Docker volume mounts to be attached to any and all created containers.
+        - show_flow_logs (bool, optional): a boolean specifying whether the agent should
+            re-route Flow run logs to stdout; defaults to `False`
+        - volumes (List[str], optional): a list of Docker volume mounts to be attached to any
+            and all created containers.
         - network (str, optional): Add containers to an existing docker network
-        - docker_interface (bool, optional): Toggle whether or not a `docker0` interface is present on this machine.
-            Defaults to `True`. **Note**: This is mostly relevant for some Docker-in-Docker setups that users may be
-            running their agent with.
+        - docker_interface (bool, optional): Toggle whether or not a `docker0` interface is
+            present on this machine.  Defaults to `True`. **Note**: This is mostly relevant for
+            some Docker-in-Docker setups that users may be running their agent with.
     """
 
     def __init__(
@@ -245,7 +248,8 @@ class DockerAgent(Agent):
                     )
             else:
                 if not external:
-                    # no internal container path given, assume the host path is the same as the internal path
+                    # no internal container path given, assume the host path is the same as the
+                    # internal path
                     external = internal
                 host_spec[external] = {
                     "bind": internal,
@@ -266,9 +270,8 @@ class DockerAgent(Agent):
 
             if len(fields) > 3:
                 raise ValueError(
-                    "Docker volume format is invalid: {} (should be 'external:internal[:mode]')".format(
-                        volume_spec
-                    )
+                    f"Docker volume format is invalid: {volume_spec} "
+                    f"(should be 'external:internal[:mode]')"
                 )
 
             if len(fields) == 1:
@@ -294,7 +297,8 @@ class DockerAgent(Agent):
                     )
             else:
                 if not external:
-                    # no internal container path given, assume the host path is the same as the internal path
+                    # no internal container path given, assume the host path is the same as the
+                    # internal path
                     external = internal
                 host_spec[external] = {
                     "bind": internal,

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -36,7 +36,14 @@ class FargateAgent(Agent):
 
     boto3 kwargs being provided to the Fargate Agent:
     ```
-    prefect agent start fargate networkConfiguration="{'awsvpcConfiguration': {'assignPublicIp': 'ENABLED', 'subnets': ['my_subnet_id'], 'securityGroups': []}}"
+    prefect agent start fargate \\
+        networkConfiguration="{\\
+            'awsvpcConfiguration': {\\
+                'assignPublicIp': 'ENABLED',\\
+                'subnets': ['my_subnet_id'],\\
+                'securityGroups': []\\
+            }\\
+        }"
     ```
 
     botocore configuration options can be provided to the Fargate Agent:
@@ -47,15 +54,17 @@ class FargateAgent(Agent):
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
             the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will be set
-            on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
-            defaults to infinite
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
         - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent and all deployed flow runs
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
         - launch_type (str, optional): either FARGATE or EC2, defaults to FARGATE
         - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
             client. Defaults to the value set in the environment variable
@@ -69,18 +78,21 @@ class FargateAgent(Agent):
         - region_name (str, optional): AWS region name for connecting the boto3 client.
             Defaults to the value set in the environment variable `REGION_NAME` or `None`
         - botocore_config (dict, optional): botocore configuration options to be passed to the
-            boto3 client. https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
-        - enable_task_revisions (bool, optional): Enable registration of task definitions using revisions.
-            When enabled, task definitions will use flow name as opposed to flow id and each new version will be a
-            task definition revision. Each revision will be registered with a tag called 'PrefectFlowId'
-            and 'PrefectFlowVersion' to enable proper lookup for existing revisions.  Flow name is reformatted
-            to support task definition naming rules by converting all non-alphanumeric characters to '_'.
+            boto3 client.
+            https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+        - enable_task_revisions (bool, optional): Enable registration of task definitions using
+            revisions.  When enabled, task definitions will use flow name as opposed to flow id
+            and each new version will be a task definition revision. Each revision will be
+            registered with a tag called 'PrefectFlowId' and 'PrefectFlowVersion' to enable
+            proper lookup for existing revisions.  Flow name is reformatted to support task
+            definition naming rules by converting all non-alphanumeric characters to '_'.
             Defaults to False.
-        - use_external_kwargs (bool, optional): When enabled, the agent will check for the existence of an
-            external json file containing kwargs to pass into the run_flow process.
-            Defaults to False.
+        - use_external_kwargs (bool, optional): When enabled, the agent will check for the
+            existence of an external json file containing kwargs to pass into the run_flow
+            process.  Defaults to False.
         - external_kwargs_s3_bucket (str, optional): S3 bucket containing external kwargs.
-        - external_kwargs_s3_key (str, optional): S3 key prefix for the location of <slugified_flow_name>/<flow_id[:8]>.json.
+        - external_kwargs_s3_key (str, optional): S3 key prefix for the location of
+            <slugified_flow_name>/<flow_id[:8]>.json.
         - **kwargs (dict, optional): additional keyword arguments to pass to boto3 for
             `register_task_definition` and `run_task`
     """
@@ -134,7 +146,8 @@ class FargateAgent(Agent):
         self.external_kwargs_s3_key = external_kwargs_s3_key
         self.launch_type = launch_type
 
-        # Parse accepted kwargs for task definition, run, and container definitions key of task definition
+        # Parse accepted kwargs for task definition, run, and container definitions key of task
+        # definition
         (
             self.task_definition_kwargs,
             self.task_run_kwargs,
@@ -289,7 +302,8 @@ class FargateAgent(Agent):
             - check_envars (bool): Whether to check envars for kwargs
 
         Returns:
-            tuple: a tuple of three dictionaries (task_definition_kwargs, task_run_kwargs, container_definitions_kwargs)
+            tuple: a tuple of three dictionaries (task_definition_kwargs, task_run_kwargs,
+              container_definitions_kwargs)
         """
         definition_kwarg_list = [
             "taskRoleArn",
@@ -482,7 +496,8 @@ class FargateAgent(Agent):
 
         Args:
             - flow_run (GraphQLResult): A GraphQLResult representing a flow run object
-            - task_definition_dict(dict): Dictionary containing task definition name to update if needed.
+            - task_definition_dict(dict): Dictionary containing task definition name to update
+                if needed.
 
         Returns:
             - bool: whether or not a preexisting task definition is found for this flow
@@ -550,7 +565,8 @@ class FargateAgent(Agent):
         Args:
             - image (str): The full name of an image to use for this task definition
             - flow_task_definition_kwargs (dict): kwargs to use for registration
-            - container_definitions_kwargs (dict): container definitions kwargs to use for registration
+            - container_definitions_kwargs (dict): container definitions kwargs to use for
+                registration
             - task_definition_name (str): task definition name to use
         """
         self.logger.debug("Using image {} for task definition".format(image))
@@ -591,12 +607,17 @@ class FargateAgent(Agent):
         ]
 
         for key, value in self.env_vars.items():
-            container_definitions[0]["environment"].append(dict(name=key, value=value))  # type: ignore
+            container_definitions[0]["environment"].append(  # type: ignore
+                dict(name=key, value=value)
+            )
 
         # apply container definitions to "containerDefinitions" key of task definition
-        # do not allow override of static envars from Prefect base task definition, which may include self.env_vars
+        # do not allow override of static envars from Prefect base task definition, which may
+        # include self.env_vars
 
-        base_envar_keys = [x["name"] for x in container_definitions[0]["environment"]]  # type: ignore
+        base_envar_keys = [
+            x["name"] for x in container_definitions[0]["environment"]  # type: ignore
+        ]
         self.logger.debug(
             "Removing static Prefect envars from container_definitions_kwargs if exists"
         )
@@ -714,7 +735,9 @@ class FargateAgent(Agent):
             }
         ]
 
-        base_envar_keys = [x["name"] for x in container_definitions[0]["environment"]]  # type: ignore
+        base_envar_keys = [
+            x["name"] for x in container_definitions[0]["environment"]  # type: ignore
+        ]
         container_definitions_environment = [
             x
             for x in flow_container_definitions_kwargs.get("environment", [])

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -36,15 +36,17 @@ class KubernetesAgent(Agent):
             to the environment variable `NAMESPACE` or `default`.
         - name (str, optional): An optional name to give this agent. Can also be set through
             the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will be set
-            on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
-            defaults to infinite
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
         - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent and all deployed flow runs
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
     """
 
     def __init__(

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -32,22 +32,25 @@ class LocalAgent(Agent):
     Args:
         - name (str, optional): An optional name to give this agent. Can also be set through
             the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will be set
-            on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud for flow runs;
-            defaults to infinite
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
         - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent and all deployed flow runs
-        - import_paths (List[str], optional): system paths which will be provided to each Flow's runtime environment;
-            useful for Flows which import from locally hosted scripts or packages
-        - show_flow_logs (bool, optional): a boolean specifying whether the agent should re-route Flow run logs
-            to stdout; defaults to `False`
-        - hostname_label (boolean, optional): a boolean specifying whether this agent should auto-label itself
-            with the hostname of the machine it is running on.  Useful for flows which are stored on the local
-            filesystem.
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
+        - import_paths (List[str], optional): system paths which will be provided to each
+            Flow's runtime environment; useful for Flows which import from locally hosted
+            scripts or packages
+        - show_flow_logs (bool, optional): a boolean specifying whether the agent should
+            re-route Flow run logs to stdout; defaults to `False`
+        - hostname_label (boolean, optional): a boolean specifying whether this agent should
+            auto-label itself with the hostname of the machine it is running on.  Useful for
+            flows which are stored on the local filesystem.
     """
 
     def __init__(
@@ -204,10 +207,11 @@ class LocalAgent(Agent):
             - token (str, optional): A `RUNNER` token to give the agent
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
-            - import_paths (List[str], optional): system paths which will be provided to each Flow's runtime environment;
-                useful for Flows which import from locally hosted scripts or packages
-            - show_flow_logs (bool, optional): a boolean specifying whether the agent should re-route Flow run logs
-                to stdout; defaults to `False`
+            - import_paths (List[str], optional): system paths which will be provided to each
+                Flow's runtime environment; useful for Flows which import from locally hosted
+                scripts or packages
+            - show_flow_logs (bool, optional): a boolean specifying whether the agent should
+                re-route Flow run logs to stdout; defaults to `False`
 
         Returns:
             - str: A string representation of the generated configuration file

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -160,8 +160,8 @@ def start(
 
     \b
     Arguments:
-        agent-option    TEXT    The name of an agent to start (e.g. `docker`, `kubernetes`, `local`, `fargate`)
-                                Defaults to `local`
+        agent-option    TEXT    The name of an agent to start (e.g. `docker`, `kubernetes`,
+                                `local`, `fargate`). Defaults to `local`
 
     \b
     Options:
@@ -172,11 +172,13 @@ def start(
                                 Defaults to INFO level logging
         --label, -l     TEXT    Labels the agent will use to query for flow runs
                                 Multiple values supported e.g. `-l label1 -l label2`
+
         --env, -e       TEXT    Environment variables to set on each submitted flow run.
-                                Note that equal signs in environment variable values are not currently supported from the CLI.
-                                Multiple values supported e.g. `-e AUTH=token -e PKG_SETTING=true`
-        --max-polls     INT     Maximum number of times the agent should poll the Prefect API for flow runs. Will run forever
-                                if not specified.
+                                Note that equal signs in environment variable values are not
+                                currently supported from the CLI.  Multiple values supported
+                                e.g. `-e AUTH=token -e PKG_SETTING=true`
+        --max-polls     INT     Maximum number of times the agent should poll the Prefect API
+                                for flow runs. Will run forever if not specified.
         --no-cloud-logs         Turn off logging to the Prefect API for all flow runs
                                 Defaults to `False`
         --agent-address TEXT    The address to server internal api at. Currently this is
@@ -185,22 +187,27 @@ def start(
 
     \b
     Local Agent Options:
-        --import-path, -p   TEXT    Import paths which will be provided to each Flow's runtime environment.
-                                    Used for Flows which might import from scripts or local packages.
-                                    Multiple values supported e.g. `-p /root/my_scripts -p /utilities`
-        --show-flow-logs, -f        Display logging output from flows run by the agent (available for Local and Docker agents only)
+        --import-path, -p   TEXT    Import paths which will be provided to each Flow's runtime
+                                    environment.  Used for Flows which might import from
+                                    scripts or local packages.  Multiple values supported e.g.
+                                    `-p /root/my_scripts -p /utilities`
+        --show-flow-logs, -f        Display logging output from flows run by the agent (available
+                                    for Local and Docker agents only)
 
     \b
     Docker Agent Options:
         --base-url, -b      TEXT    A Docker daemon host URL for a DockerAgent
         --no-pull                   Pull images for a DockerAgent
                                     Defaults to pulling if not provided
-        --volume            TEXT    Host paths for Docker bind mount volumes attached to each Flow runtime container.
-                                    Multiple values supported e.g. `--volume /some/path --volume /some/other/path`
+
+        --volume            TEXT    Host paths for Docker bind mount volumes attached to each
+                                    Flow runtime container.  Multiple values supported e.g.
+                                    `--volume /some/path --volume /some/other/path`
         --network           TEXT    Add containers to an existing docker network
+
         --no-docker-interface       Disable the check of a Docker interface on this machine.
-                                    **Note**: This is mostly relevant for some Docker-in-Docker setups that users may be
-                                    running their agent with.
+                                    **Note**: This is mostly relevant for some Docker-in-Docker
+                                    setups that users may be running their agent with.
 
     \b
     Kubernetes Agent Options:
@@ -414,16 +421,19 @@ def install(
 
     \b
     Arguments:
-        name                        TEXT    The name of an agent to install (e.g. `kubernetes`, `local`)
+        name                        TEXT    The name of an agent to install (e.g.
+                                            `kubernetes`, `local`)
 
     \b
     Options:
         --token, -t                 TEXT    A Prefect Cloud API token
         --label, -l                 TEXT    Labels the agent will use to query for flow runs
                                             Multiple values supported e.g. `-l label1 -l label2`
-        --env, -e                   TEXT    Environment variables to set on each submitted flow run.
-                                            Note that equal signs in environment variable values are not currently supported from the CLI.
-                                            Multiple values supported e.g. `-e AUTH=token -e PKG_SETTING=true`
+        --env, -e                   TEXT    Environment variables to set on each submitted flow
+                                            run. Note that equal signs in environment variable
+                                            values are not currently supported from the CLI.
+                                            Multiple values supported e.g. `-e AUTH=token -e
+                                            PKG_SETTING=true`
 
     \b
     Kubernetes Agent Options:
@@ -445,7 +455,8 @@ def install(
     \b
     Local Agent Options:
         --import-path, -p           TEXT    Absolute import paths to provide to the local agent.
-                                            Multiple values supported e.g. `-p /root/my_scripts -p /utilities`
+                                            Multiple values supported e.g. `-p /root/my_scripts
+                                            -p /utilities`
         --show-flow-logs, -f                Display logging output from flows run by the agent
     """
 

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -42,7 +42,8 @@ def auth():
         $ prefect auth list-tenants
         NAME                        SLUG                        ID
         Test Person                 test-person                 816sghf2-4d51-4338-a333-1771gns7614d
-        test@prefect.io's Account   test-prefect-io-s-account   1971hs9f-e8ha-4a33-8c33-64512gds86g1  *
+        test@prefect.io's Account   test-prefect-io-s-account   \
+1971hs9f-e8ha-4a33-8c33-64512gds86g1  *
 
     \b
         $ prefect auth switch-tenants --slug test-person

--- a/src/prefect/cli/describe.py
+++ b/src/prefect/cli/describe.py
@@ -70,7 +70,7 @@ def flows(name, version, project, output):
                                 Defaults to Python dictionary format.
     """
 
-    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
+    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version}}}
     query_results = {
         "name": True,
         "version": True,
@@ -133,7 +133,7 @@ def tasks(name, version, project, output):
                                 Defaults to Python dictionary format.
     """
 
-    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
+    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version}}}
 
     if project:
         where_clause["_and"]["project"] = {"name": {"_eq": project}}

--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -60,7 +60,7 @@ def cloud_flow():
         storage_schema = prefect.serialization.storage.StorageSchema()
         storage = storage_schema.load(flow_data.storage)
 
-        ## populate global secrets
+        # populate global secrets
         secrets = prefect.context.get("secrets", {})
         for secret in storage.secrets:
             secrets[secret] = PrefectSecret(name=secret).run()

--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -39,8 +39,10 @@ def get():
     \b
         $ prefect get tasks --flow-name Test-Flow
         NAME          FLOW NAME   FLOW VERSION   AGE          MAPPED   TYPE
-        first_task    Test-Flow   1              5 days ago   False    prefect.tasks.core.function.FunctionTask
-        second_task   Test-Flow   1              5 days ago   True     prefect.tasks.core.function.FunctionTask
+        first_task    Test-Flow   1              5 days ago   False    \
+prefect.tasks.core.function.FunctionTask
+        second_task   Test-Flow   1              5 days ago   True     \
+prefect.tasks.core.function.FunctionTask
     """
 
 
@@ -71,7 +73,7 @@ def flows(name, version, project, limit, all_versions):
     if all_versions:
         distinct_on = None
 
-    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
+    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version}}}
 
     query_results = {
         "name": True,
@@ -219,7 +221,7 @@ def flow_runs(limit, flow, project, started):
 
         where = {
             "_and": {
-                "flow": {"_and": {"name": {"_eq": flow},}},
+                "flow": {"_and": {"name": {"_eq": flow}}},
                 "start_time": {"_is_null": False},
             }
         }
@@ -229,7 +231,7 @@ def flow_runs(limit, flow, project, started):
     else:
         order = {"created": EnumValue("desc")}
 
-        where = {"flow": {"_and": {"name": {"_eq": flow},}}}
+        where = {"flow": {"_and": {"name": {"_eq": flow}}}}
 
         if config.backend == "cloud":
             where["flow"]["_and"]["project"] = {"name": {"_eq": project}}
@@ -318,7 +320,7 @@ def tasks(name, flow_name, flow_version, project, limit):
     where_clause = {
         "_and": {
             "name": {"_eq": name},
-            "flow": {"name": {"_eq": flow_name}, "version": {"_eq": flow_version},},
+            "flow": {"name": {"_eq": flow_name}, "version": {"_eq": flow_version}},
         }
     }
 

--- a/src/prefect/cli/heartbeat.py
+++ b/src/prefect/cli/heartbeat.py
@@ -43,8 +43,8 @@ def task_run(id, num):
 
     \b
     Options:
-        --id, -i                TEXT        The id of a task run to send heartbeats for         [required]
-        --num, -n               TEXT        The number of times to send a heartbeat             [required]
+        --id, -i                TEXT        The id of a task run to send heartbeats for [required]
+        --num, -n               TEXT        The number of times to send a heartbeat [required]
 
     \b
     If num is not provided, the heartbeat will be sent indefinitely.
@@ -81,8 +81,8 @@ def flow_run(id, num):
 
     \b
     Options:
-        --id, -i                TEXT        The id of a flow run to send heartbeats for         [required]
-        --num, -n               TEXT        The number of times to send a heartbeat             [required]
+        --id, -i                TEXT        The id of a flow run to send heartbeats for [required]
+        --num, -n               TEXT        The number of times to send a heartbeat [required]
 
     \b
     If num is not provided, the heartbeat will be sent indefinitely.

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -89,13 +89,15 @@ def cloud(
 
     \b
     Options:
-        --name, -n                  TEXT        The name of a flow to run                                       [required]
-        --project, -p               TEXT        The name of a project that contains the flow                    [required]
+        --name, -n                  TEXT        The name of a flow to run [required]
+        --project, -p               TEXT        The name of a project that contains
+                                                the flow [required]
         --version, -v               INTEGER     A flow version to run
         --parameters-file, -pf      FILE PATH   A filepath of a JSON file containing parameters
         --parameters-string, -ps    TEXT        A string of JSON parameters
         --run-name, -rn             TEXT        A name to assign for this run
-        --watch, -w                             Watch current state of the flow run, stream output to stdout
+        --watch, -w                             Watch current state of the flow run, stream
+                                                output to stdout
         --logs, -l                              Get logs of the flow run, stream output to stdout
         --no-url                                Only output the flow run id instead of a link
 
@@ -108,7 +110,7 @@ def cloud(
     File contains:  {"a": 1, "b": 2}
     String:         '{"a": 3}'
     Parameters passed to the flow run: {"a": 3, "b": 2}
-    
+
     Returns:
         - flow_run_id (str): the flow run ID if the flow run completes
         - None: if flow or flow run canot be found
@@ -166,12 +168,13 @@ def server(
 
     \b
     Options:
-        --name, -n                  TEXT        The name of a flow to run                                       [required]
+        --name, -n                  TEXT        The name of a flow to run [required]
         --version, -v               INTEGER     A flow version to run
         --parameters-file, -pf      FILE PATH   A filepath of a JSON file containing parameters
         --parameters-string, -ps    TEXT        A string of JSON parameters
         --run-name, -rn             TEXT        A name to assign for this run
-        --watch, -w                             Watch current state of the flow run, stream output to stdout
+        --watch, -w                             Watch current state of the flow run, stream output
+                                                to stdout
         --logs, -l                              Get logs of the flow run, stream output to stdout
         --no-url                                Only output the flow run id instead of a link
 
@@ -184,7 +187,7 @@ def server(
     File contains:  {"a": 1, "b": 2}
     String:         '{"a": 3}'
     Parameters passed to the flow run: {"a": 3, "b": 2}
-    
+
     Returns:
         - flow_run_id (str): the flow run ID if the flow run completes
         - None: if flow or flow run canot be found
@@ -218,7 +221,7 @@ def _run_flow(
         )
         return
 
-    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version},}}
+    where_clause = {"_and": {"name": {"_eq": name}, "version": {"_eq": version}}}
 
     if project:
         where_clause["_and"]["project"] = {"name": {"_eq": project}}

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -323,7 +323,7 @@ def start(
         proc = subprocess.Popen(cmd, cwd=compose_dir_path, env=env)
         while True:
             time.sleep(0.5)
-    except Exception:
+    except BaseException:
         click.secho(
             "Exception caught; killing services (press ctrl-C to force)",
             fg="white",

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -214,10 +214,11 @@ def start(
 
     \b
     Options:
-        --version, -v       TEXT    The server image versions to use (for example, '0.10.0' or 'master')
-                                    Defaults to the current installed Prefect version.
+        --version, -v       TEXT    The server image versions to use (for example, '0.10.0' or
+                                    'master'). Defaults to the current installed Prefect version.
         --skip-pull                 Flag to skip pulling new images (if available)
-        --no-upgrade, -n            Flag to avoid running a database upgrade when the database spins up
+        --no-upgrade, -n            Flag to avoid running a database upgrade when the database
+                                    spins up
         --no-ui, -u                 Flag to avoid starting the UI
 
     \b
@@ -236,7 +237,8 @@ def start(
 
     \b
         --use-volume                Enable the use of a volume for the Postgres service
-        --volume-path       TEXT    A path to use for the Postgres volume, defaults to '~/.prefect/pg_data'
+        --volume-path       TEXT    A path to use for the Postgres volume, defaults to
+                                    '~/.prefect/pg_data'
     """
 
     docker_dir = Path(__file__).parents[0]
@@ -324,7 +326,7 @@ def start(
         proc = subprocess.Popen(cmd, cwd=compose_dir_path, env=env)
         while True:
             time.sleep(0.5)
-    except:
+    except Exception:
         click.secho(
             "Exception caught; killing services (press ctrl-C to force)",
             fg="white",

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -59,10 +59,7 @@ def make_env(fname=None):
 
     if fname is not None:
         list_of_pairs = [
-            "{k}={repr(v)}".format(k=k, v=v)
-            if "\n" in v
-            else "{k}={v}".format(k=k, v=v)
-            for k, v in ENV.items()
+            f"{k}={v!r}" if "\n" in v else f"{k}={v}" for k, v in ENV.items()
         ]
         with open(fname, "w") as f:
             f.write("\n".join(list_of_pairs))

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -335,7 +335,8 @@ class Client:
         except json.JSONDecodeError:
             if prefect.config.backend == "cloud" and "Authorization" not in headers:
                 raise ClientError(
-                    "Malformed response received from Cloud - please ensure that you have an API token properly configured."
+                    "Malformed response received from Cloud - please ensure that you "
+                    "have an API token properly configured."
                 )
             else:
                 raise ClientError(f"Malformed response received from API.")
@@ -584,16 +585,16 @@ class Client:
             - project_name (str, optional): the project that should contain this flow.
             - build (bool, optional): if `True`, the flow's environment is built
                 prior to serialization; defaults to `True`
-            - set_schedule_active (bool, optional): if `False`, will set the
-                schedule to inactive in the database to prevent auto-scheduling runs (if the Flow has a schedule).
-                Defaults to `True`. This can be changed later.
-            - version_group_id (str, optional): the UUID version group ID to use for versioning this Flow
-                in Cloud; if not provided, the version group ID associated with this Flow's project and name
-                will be used.
-            - compressed (bool, optional): if `True`, the serialized flow will be; defaults to `True`
-                compressed
-            - no_url (bool, optional): if `True`, the stdout from this function will not contain the
-                URL link to the newly-registered flow in the Cloud UI
+            - set_schedule_active (bool, optional): if `False`, will set the schedule to
+                inactive in the database to prevent auto-scheduling runs (if the Flow has a
+                schedule).  Defaults to `True`. This can be changed later.
+            - version_group_id (str, optional): the UUID version group ID to use for versioning
+                this Flow in Cloud; if not provided, the version group ID associated with this
+                Flow's project and name will be used.
+            - compressed (bool, optional): if `True`, the serialized flow will be; defaults to
+                `True` compressed
+            - no_url (bool, optional): if `True`, the stdout from this function will not
+                contain the URL link to the newly-registered flow in the Cloud UI
 
         Returns:
             - str: the ID of the newly-registered flow
@@ -615,8 +616,8 @@ class Client:
                 )
         if any(e.key for e in flow.edges) and flow.result is None:
             warnings.warn(
-                "No result handler was specified on your Flow. Cloud features such as input caching and resuming task runs from failure may not work properly.",
-                UserWarning,
+                "No result handler was specified on your Flow. Cloud features such as "
+                "input caching and resuming task runs from failure may not work properly."
             )
         if compressed:
             create_mutation = {
@@ -637,7 +638,8 @@ class Client:
             if project_name is None:
                 raise TypeError(
                     "'project_name' is a required field when registering a flow with Cloud. "
-                    "If you are attempting to register a Flow with a local Prefect server you may need to run `prefect backend server` first."
+                    "If you are attempting to register a Flow with a local Prefect server "
+                    "you may need to run `prefect backend server` first."
                 )
 
             query_project = {
@@ -688,7 +690,7 @@ class Client:
             create_mutation,
             variables=dict(
                 input=dict(
-                    project_id=project[0].id if project else None,
+                    project_id=(project[0].id if project else None),
                     serialized_flow=serialized_flow,
                     set_schedule_active=set_schedule_active,
                     version_group_id=version_group_id,
@@ -721,7 +723,8 @@ class Client:
                 defaults to `True`. Only used internally for queries made from RUNNERs
 
         Returns:
-            - str: the URL corresponding to the appropriate base URL, tenant slug, subdirectory and ID
+            - str: the URL corresponding to the appropriate base URL, tenant slug, subdirectory
+                and ID
 
         Example:
 
@@ -749,7 +752,7 @@ class Client:
         if tenant_slug:
             full_url = "/".join([base_url.rstrip("/"), tenant_slug, subdirectory, id])
         elif prefect.config.backend == "server":
-            full_url = "/".join([prefect.config.server.ui.endpoint, subdirectory, id,])
+            full_url = "/".join([prefect.config.server.ui.endpoint, subdirectory, id])
 
         return full_url
 
@@ -820,22 +823,26 @@ class Client:
         version_group_id: str = None,
     ) -> str:
         """
-        Create a new flow run for the given flow id.  If `start_time` is not provided, the flow run will be scheduled to start immediately.
-        If both `flow_id` and `version_group_id` are provided, only the `flow_id` will be used.
+        Create a new flow run for the given flow id.  If `start_time` is not provided, the flow
+        run will be scheduled to start immediately.  If both `flow_id` and `version_group_id`
+        are provided, only the `flow_id` will be used.
 
         Args:
             - flow_id (str, optional): the id of the Flow you wish to schedule
             - context (dict, optional): the run context
             - parameters (dict, optional): a dictionary of parameter values to pass to the flow run
-            - scheduled_start_time (datetime, optional): the time to schedule the execution for; if not provided, defaults to now
-            - idempotency_key (str, optional): an idempotency key; if provided, this run will be cached for 24
-                hours. Any subsequent attempts to create a run with the same idempotency key
-                will return the ID of the originally created run (no new run will be created after the first).
-                An error will be raised if parameters or context are provided and don't match the original.
-                Each subsequent request will reset the TTL for 24 hours.
+            - scheduled_start_time (datetime, optional): the time to schedule the execution
+                for; if not provided, defaults to now
+            - idempotency_key (str, optional): an idempotency key; if provided, this run will
+                be cached for 24 hours. Any subsequent attempts to create a run with the same
+                idempotency key will return the ID of the originally created run (no new run
+                will be created after the first).  An error will be raised if parameters or
+                context are provided and don't match the original.  Each subsequent request
+                will reset the TTL for 24 hours.
             - run_name (str, optional): The name assigned to this flow run
-            - version_group_id (str, optional): if provided, the unique unarchived flow within this version group will be scheduled
-                to run.  This input can be used as a stable API for running flows which are regularly updated.
+            - version_group_id (str, optional): if provided, the unique unarchived flow within
+                this version group will be scheduled to run.  This input can be used as a
+                stable API for running flows which are regularly updated.
 
         Returns:
             - str: the ID of the newly-created flow run
@@ -851,9 +858,10 @@ class Client:
         if not flow_id and not version_group_id:
             raise ValueError("One of flow_id or version_group_id must be provided")
 
-        inputs = (
-            dict(flow_id=flow_id) if flow_id else dict(version_group_id=version_group_id)  # type: ignore
-        )
+        if flow_id:
+            inputs = dict(flow_id=flow_id)
+        else:
+            inputs = dict(version_group_id=version_group_id)  # type: ignore
         if parameters is not None:
             inputs.update(parameters=parameters)  # type: ignore
         if context is not None:
@@ -1036,8 +1044,10 @@ class Client:
 
         Args:
             - task_id (str): the task id for this task run
-            - cache_key (Optional[str]): the cache key for this Task's cache; if `None`, the task id alone will be used
-            - created_after (datetime.datetime): the earliest date the state should have been created at
+            - cache_key (Optional[str]): the cache key for this Task's cache; if `None`, the
+                task id alone will be used
+            - created_after (datetime.datetime): the earliest date the state should have been
+                created at
 
         Returns:
             - List[State]: a list of Cached states created after the given date
@@ -1145,8 +1155,8 @@ class Client:
             - task_run_id (str): the id of the task run to set state for
             - version (int): the current version of the task run state
             - state (State): the new state for this task run
-            - cache_for (timedelta, optional): how long to store the result of this task for, using the
-                serializer set in config; if not provided, no caching occurs
+            - cache_for (timedelta, optional): how long to store the result of this task for,
+                using the serializer set in config; if not provided, no caching occurs
 
         Raises:
             - ClientError: if the GraphQL mutation is bad for any reason

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -339,7 +339,7 @@ class Client:
                     "have an API token properly configured."
                 )
             else:
-                raise ClientError(f"Malformed response received from API.")
+                raise ClientError("Malformed response received from API.")
 
         # check if there was an API_ERROR code in the response
         if "API_ERROR" in str(json_resp.get("errors")):

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -1,6 +1,8 @@
 """
 ::: warning Secret Tasks are preferred
-While this Secrets API is fully supported, using a [Prefect Secret Task](../tasks/secrets) is typically preferred for better reuse of Secret values and visibility into the secrets used within Tasks / Flows.
+While this Secrets API is fully supported, using a [Prefect Secret Task](../tasks/secrets) is
+typically preferred for better reuse of Secret values and visibility into the secrets used
+within Tasks / Flows.
 :::
 
 A Secret is a serializable object used to represent a secret key & value.
@@ -9,7 +11,8 @@ The value of the `Secret` is not set upon initialization and instead is set
 either in `prefect.context` or on the server, with behavior dependent on the value
 of the `use_local_secrets` flag in your Prefect configuration file.
 
-To set a Secret in Prefect Cloud, you can use `prefect.Client.set_secret`, or set it directly via GraphQL:
+To set a Secret in Prefect Cloud, you can use `prefect.Client.set_secret`, or set it directly
+via GraphQL:
 
 ```graphql
 mutation {
@@ -19,7 +22,8 @@ mutation {
 }
 ```
 
-To set a _local_ Secret, either place the value in your user configuration file (located at `~/.prefect/config.toml`):
+To set a _local_ Secret, either place the value in your user configuration file (located at
+`~/.prefect/config.toml`):
 
 ```
 [context.secrets]
@@ -42,11 +46,16 @@ export PREFECT__CONTEXT__SECRETS__MY_KEY="MY_VALUE"
 ```
 
 ::: tip Default secrets
-Special default secret names can be used to authenticate to third-party systems in a installation-wide way. Read more about this in our [Secrets concept documentation](/core/concepts/secrets.md#default-secrets).
+Special default secret names can be used to authenticate to third-party systems in a
+installation-wide way. Read more about this in our [Secrets concept
+documentation](/core/concepts/secrets.md#default-secrets).
 :::
 
 ::: tip
-When settings secrets via `.toml` config files, you can use the [TOML Keys](https://github.com/toml-lang/toml#keys) docs for data structure specifications. Running `prefect` commands with invalid `.toml` config files will lead to tracebacks that contain references to: `..../toml/decoder.py`.
+When settings secrets via `.toml` config files, you can use the [TOML
+Keys](https://github.com/toml-lang/toml#keys) docs for data structure specifications. Running
+`prefect` commands with invalid `.toml` config files will lead to tracebacks that contain
+references to: `..../toml/decoder.py`.
 :::
 
 """
@@ -112,10 +121,11 @@ class Secret:
             - Any: the value of the secret; if not found, raises an error
 
         Raises:
-            - ValueError: if `.get()` is called within a Flow building context, or if `use_local_secrets=True`
-                and your Secret doesn't exist
+            - ValueError: if `.get()` is called within a Flow building context, or if
+                `use_local_secrets=True` and your Secret doesn't exist
             - KeyError: if `use_local_secrets=False` and the Client fails to retrieve your secret
-            - ClientError: if the client experiences an unexpected error communicating with the backend
+            - ClientError: if the client experiences an unexpected error communicating with the
+                backend
         """
         if isinstance(prefect.context.get("flow"), prefect.core.flow.Flow):
             raise ValueError(
@@ -139,7 +149,9 @@ class Secret:
                 except ClientError as exc:
                     if "No value found for the requested key" in str(exc):
                         raise KeyError(
-                            f"The secret {self.name} was not found.  Please ensure that it was set correctly in your tenant: https://docs.prefect.io/orchestration/concepts/secrets.html"
+                            f"The secret {self.name} was not found.  Please ensure that it "
+                            f"was set correctly in your tenant: https://docs.prefect.io/"
+                            f"orchestration/concepts/secrets.html"
                         )
                     else:
                         raise exc

--- a/src/prefect/contrib/tasks/mysql/mysql.py
+++ b/src/prefect/contrib/tasks/mysql/mysql.py
@@ -8,13 +8,14 @@ from typing import Any
 
 class MySQLExecute(Task):
     """
-    Task for executing a query against a MySQL database. 
+    Task for executing a query against a MySQL database.
     Args:
         - db_name (str): name of MySQL database
         - user (str): user name used to authenticate
         - password (str): password used to authenticate
         - host (str): database host address
-        - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not provided
+        - port (int, optional): port used to connect to MySQL database, defaults to 3307
+            if not provided
         - query (str, optional): query to execute against database
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset you want to use (defaults to utf8mb4)
@@ -93,15 +94,18 @@ class MySQLExecute(Task):
 class MySQLFetch(Task):
     """
     Task for fetching results of query from MySQL database.
-    
+
     Args:
         - db_name (str): name of MySQL database
         - user (str): user name used to authenticate
         - password (str): password used to authenticate
         - host (str): database host address
-        - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not provided
-        - fetch (str, optional): one of "one" "many" or "all", used to determine how many results to fetch from executed query
-        - fetch_count (int, optional): if fetch = 'many', determines the number of results to fetch, defaults to 10
+        - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not
+            provided
+        - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+            results to fetch from executed query
+        - fetch_count (int, optional): if fetch = 'many', determines the number of results to
+            fetch, defaults to 10
         - query (str, optional): query to execute against database
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset of the query, defaults to "utf8mb4"
@@ -148,8 +152,10 @@ class MySQLFetch(Task):
         Task run method. Executes a query against MySQL database and fetches results.
 
         Args:
-            - fetch (str, optional): one of "one" "many" or "all", used to determine how many results to fetch from executed query
-            - fetch_count (int, optional): if fetch = 'many', determines the number of results to fetch, defaults to 10
+            - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+                results to fetch from executed query
+            - fetch_count (int, optional): if fetch = 'many', determines the number of results
+                to fetch, defaults to 10
             - query (str, optional): query to execute against database
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - charset (str, optional): charset of the query, defaults to "utf8mb4"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -80,8 +80,9 @@ def cache(method: Callable) -> Callable:
 
 class Flow:
     """
-    The Flow class is used as the representation of a collection of dependent Tasks.
-    Flows track Task dependencies, parameters and provide the main API for constructing and managing workflows.
+    The Flow class is used as the representation of a collection of dependent Tasks.  Flows
+    track Task dependencies, parameters and provide the main API for constructing and managing
+    workflows.
 
     Initializing Flow example:
     ```python
@@ -118,7 +119,8 @@ class Flow:
         - edges ([Edge], optional): A list of edges between tasks
         - reference_tasks ([Task], optional): A list of tasks that determine the final
             state of a flow
-        - result (Result, optional, RESERVED FOR FUTURE USE): the result instance used to retrieve and store task results during execution
+        - result (Result, optional, RESERVED FOR FUTURE USE): the result instance used to
+            retrieve and store task results during execution
         - result_handler (ResultHandler, optional, DEPRECATED): the handler to use for
             retrieving and storing state results during execution
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
@@ -129,8 +131,8 @@ class Flow:
                 `state_handler(flow: Flow, old_state: State, new_state: State) -> Optional[State]`
             If multiple functions are passed, then the `new_state` argument will be the
             result of the previous handler.
-        - on_failure (Callable, optional): A function with signature `fn(flow: Flow, state: State) -> None`
-            which will be called anytime this Flow enters a failure state
+        - on_failure (Callable, optional): A function with signature `fn(flow: Flow, state:
+            State) -> None` which will be called anytime this Flow enters a failure state
         - validate (bool, optional): Whether or not to check the validity of
             the flow (e.g., presence of cycles and illegal keys) after adding the edges passed
             in the `edges` argument. Defaults to the value of `eager_edge_validation` in
@@ -345,8 +347,9 @@ class Flow:
                 f"{unused_task_tracker.difference(self.tasks)}. This can occur "
                 "when `Task` classes, including `Parameters`, are instantiated "
                 "inside a `with flow:` block but not added to the flow either "
-                "explicitly or as the input to another task. For more information, "
-                "see https://docs.prefect.io/core/advanced_tutorials/task-guide.html#adding-tasks-to-flows."
+                "explicitly or as the input to another task. For more information, see "
+                "https://docs.prefect.io/core/advanced_tutorials/"
+                "task-guide.html#adding-tasks-to-flows."
             )
 
     def __enter__(self) -> "Flow":
@@ -354,7 +357,7 @@ class Flow:
         return self._ctx.__enter__()
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
-        result = self._ctx.__exit__(exc_type, exc_value, traceback)
+        self._ctx.__exit__(exc_type, exc_value, traceback)
         # delete _ctx because it's an active generator, which prevents pickling
         del self._ctx
 
@@ -392,23 +395,24 @@ class Flow:
 
     def reference_tasks(self) -> Set[Task]:
         """
-        A flow's "reference tasks" are used to determine its state when it runs. If all the reference
-        tasks are successful, then the flow run is considered successful. However, if
+        A flow's "reference tasks" are used to determine its state when it runs. If all the
+        reference tasks are successful, then the flow run is considered successful. However, if
         any of the reference tasks fail, the flow is considered to fail. (Note that skips are
-        counted as successes; see [the state documentation](../engine/state.html) for a full description
-        of what is considered failure, success, etc.)
+        counted as successes; see [the state documentation](../engine/state.html) for a full
+        description of what is considered failure, success, etc.)
 
         By default, a flow's reference tasks are its terminal tasks. This means the state of a
         flow is determined by those tasks that have no downstream dependencies.
 
-        In some situations, users may want to customize this behavior; for example, if a
-        flow's terminal tasks are "clean up" tasks for the rest of the flow that only run
-        if certain (more relevant) tasks fail, we might not want them determining the overall
-        state of the flow run. The `flow.set_reference_tasks()` method can be used to set such custom `reference_tasks`.
+        In some situations, users may want to customize this behavior; for example, if a flow's
+        terminal tasks are "clean up" tasks for the rest of the flow that only run if certain
+        (more relevant) tasks fail, we might not want them determining the overall state of the
+        flow run. The `flow.set_reference_tasks()` method can be used to set such custom
+        `reference_tasks`.
 
-        Please note that even if `reference_tasks` are provided that are not terminal tasks, the flow
-        will not be considered "finished" until all terminal tasks have completed. Only then
-        will state be determined, using the reference tasks.
+        Please note that even if `reference_tasks` are provided that are not terminal tasks,
+        the flow will not be considered "finished" until all terminal tasks have completed.
+        Only then will state be determined, using the reference tasks.
 
         Returns:
             - set of Task objects which are the reference tasks in the flow
@@ -441,9 +445,10 @@ class Flow:
         Given a Task, generates the corresponding slug for this Flow.  Slugs are the unique IDs
         the Prefect API uses to track state updates for each task within a Flow.
 
-        The logic for slug generation within a Flow is essentially "name-tags-#count".
-        Having slugs be properties of (Task, Flow) instead of just Task alone allows Prefect
-        to ensure that every time you run the same build script for a Flow, the Task slugs remain constant.
+        The logic for slug generation within a Flow is essentially "name-tags-#count".  Having
+        slugs be properties of (Task, Flow) instead of just Task alone allows Prefect to ensure
+        that every time you run the same build script for a Flow, the Task slugs remain
+        constant.
 
         Args:
             - task (Task): the task to generate a slug for
@@ -512,12 +517,14 @@ class Flow:
         Args:
             - upstream_task (Task): The task that the edge should start from
             - downstream_task (Task): The task that the edge should end with
-            - key (str, optional): The key to be set for the new edge; the result of the upstream task
-            will be passed to the downstream task's `run()` method under this keyword argument
-            - mapped (bool, optional): Whether this edge represents a call to `Task.map()`; defaults to `False`
-            - validate (bool, optional): Whether or not to check the validity of
-                the flow (e.g., presence of cycles and illegal keys). Defaults to the value
-                of `eager_edge_validation` in your prefect configuration file.
+            - key (str, optional): The key to be set for the new edge; the result of the
+                upstream task will be passed to the downstream task's `run()` method under this
+                keyword argument
+            - mapped (bool, optional): Whether this edge represents a call to `Task.map()`;
+                defaults to `False`
+            - validate (bool, optional): Whether or not to check the validity of the flow
+                (e.g., presence of cycles and illegal keys). Defaults to the value of
+                `eager_edge_validation` in your prefect configuration file.
 
         Returns:
             - prefect.core.edge.Edge: The `Edge` object that was successfully added to the flow
@@ -577,8 +584,8 @@ class Flow:
         Args:
             - *tasks (list): A list of tasks to chain together
             - validate (bool, optional): Whether or not to check the validity of
-                the flow (e.g., presence of cycles).  Defaults to the value of `eager_edge_validation`
-                in your prefect configuration file.
+                the flow (e.g., presence of cycles).  Defaults to the value of
+                `eager_edge_validation` in your prefect configuration file.
 
         Returns:
             - A list of Edge objects added to the flow
@@ -824,10 +831,10 @@ class Flow:
         Args:
             - task (object): a Task that will become part of the Flow. If the task is not a
                 Task subclass, Prefect will attempt to convert it to one.
-            - upstream_tasks ([object], optional): Tasks that will run before the task runs. If any task
-                is not a Task subclass, Prefect will attempt to convert it to one.
-            - downstream_tasks ([object], optional): Tasks that will run after the task runs. If any task
-                is not a Task subclass, Prefect will attempt to convert it to one.
+            - upstream_tasks ([object], optional): Tasks that will run before the task runs. If
+                any task is not a Task subclass, Prefect will attempt to convert it to one.
+            - downstream_tasks ([object], optional): Tasks that will run after the task runs.
+                If any task is not a Task subclass, Prefect will attempt to convert it to one.
             - keyword_tasks ({key: object}, optional): The results of these tasks
                 will be provided to the task under the specified keyword
                 arguments. If any task is not a Task subclass, Prefect will attempt to
@@ -836,8 +843,8 @@ class Flow:
                 and non-keyed) should be mapped over; defaults to `False`. If `True`, any
                 tasks wrapped in the `prefect.utilities.tasks.unmapped` container will
                 _not_ be mapped over.
-            - validate (bool, optional): Whether or not to check the validity of
-                the flow (e.g., presence of cycles).  Defaults to the value of `eager_edge_validation`
+            - validate (bool, optional): Whether or not to check the validity of the flow
+                (e.g., presence of cycles).  Defaults to the value of `eager_edge_validation`
                 in your Prefect configuration file.
 
         Returns:
@@ -898,7 +905,7 @@ class Flow:
 
         base_parameters = parameters or dict()
 
-        ## determine time of first run
+        # determine time of first run
         try:
             if run_on_schedule and self.schedule is not None:
                 next_run_event = self.schedule.next(1, return_events=True)[0]
@@ -910,7 +917,7 @@ class Flow:
         except IndexError:
             raise ValueError("Flow has no more scheduled runs.") from None
 
-        ## setup initial states
+        # setup initial states
         flow_state = prefect.engine.state.Scheduled(start_time=next_run_time, result={})
         flow_state = kwargs.pop("state", flow_state)
         if not isinstance(flow_state.result, dict):
@@ -923,7 +930,7 @@ class Flow:
             "context", {}
         ).copy()  # copy to avoid modification
 
-        ## run this flow indefinitely, so long as its schedule has future dates
+        # run this flow indefinitely, so long as its schedule has future dates
         while True:
 
             flow_run_context.update(scheduled_start_time=next_run_time)
@@ -940,7 +947,7 @@ class Flow:
 
             error = False
 
-            ## begin a single flow run
+            # begin a single flow run
             while not flow_state.is_finished():
                 runner = runner_cls(flow=self)
                 flow_state = runner.run(
@@ -983,7 +990,7 @@ class Flow:
                     default=pendulum.now("utc"),
                 )
 
-                ## wait until first task is ready for retry
+                # wait until first task is ready for retry
                 now = pendulum.now("utc")
                 naptime = max((earliest_start - now).total_seconds(), 0)
                 if naptime > 0:
@@ -994,7 +1001,7 @@ class Flow:
                     )
                 time.sleep(naptime)
 
-            ## create next scheduled run
+            # create next scheduled run
             if not error:
                 # update context cache
                 for t, s in flow_state.result.items():
@@ -1045,21 +1052,22 @@ class Flow:
         **kwargs: Any,
     ) -> "prefect.engine.state.State":
         """
-        Run the flow on its schedule using an instance of a FlowRunner.  If the Flow has no schedule,
-        a single stateful run will occur (including retries).
+        Run the flow on its schedule using an instance of a FlowRunner.  If the Flow has no
+        schedule, a single stateful run will occur (including retries).
 
-        Note that this command will block and run this Flow on its schedule indefinitely (if it has one);
-        all task states will be stored in memory, and task retries will not occur until every Task in the Flow has had a chance
-        to run.
+        Note that this command will block and run this Flow on its schedule indefinitely (if it
+        has one); all task states will be stored in memory, and task retries will not occur
+        until every Task in the Flow has had a chance to run.
 
         Args:
             - parameters (Dict[str, Any], optional): values to pass into the runner
-            - run_on_schedule (bool, optional): whether to run this flow on its schedule, or run a single execution;
-                if not provided, will default to the value set in your user config
+            - run_on_schedule (bool, optional): whether to run this flow on its schedule, or
+                run a single execution; if not provided, will default to the value set in your
+                user config
             - runner_cls (type): an optional FlowRunner class (will use the default if not provided)
-            - **kwargs: additional keyword arguments; if any provided keywords
-                match known parameter names, they will be used as such. Otherwise they will be passed to the
-                `FlowRunner.run()` method
+            - **kwargs: additional keyword arguments; if any provided keywords match known
+                parameter names, they will be used as such. Otherwise they will be passed to
+                the `FlowRunner.run()` method
 
         Raises:
             - ValueError: if this Flow has a Schedule with no more scheduled runs
@@ -1070,7 +1078,8 @@ class Flow:
         """
         if prefect.context.get("loading_flow", False):
             raise RuntimeError(
-                "Attempting to call `flow.run` during execution of flow file will lead to unexpected results."
+                "Attempting to call `flow.run` during execution of flow file will lead to "
+                "unexpected results."
             )
 
         # protect against old behavior
@@ -1162,8 +1171,9 @@ class Flow:
 
         Args:
             - flow_state (State, optional): flow state object used to optionally color the nodes
-            - filename (str, optional): a filename specifying a location to save this visualization to; if provided,
-                the visualization will not be rendered automatically
+            - filename (str, optional): a filename specifying a location to save this
+                visualization to; if provided, the visualization will not be rendered
+                automatically
             - format (str, optional): a format specifying the output file type; defaults to 'pdf'.
               Refer to http://www.graphviz.org/doc/info/output.html for valid formats
 
@@ -1248,7 +1258,7 @@ class Flow:
                         e.key,
                         style=style,
                     )
-            ## this edge represents a "reduce" step from a mapped task -> normal task
+            # this edge represents a "reduce" step from a mapped task -> normal task
             elif flow_state and flow_state.result[e.upstream_task].is_mapped():
                 assert isinstance(flow_state.result, dict)  # mypy assert
                 up_state = flow_state.result[e.upstream_task]
@@ -1285,9 +1295,12 @@ class Flow:
                     try:
                         graph.render(tmp.name, view=True)
                     except graphviz.backend.ExecutableNotFound:
-                        msg = "It appears you do not have Graphviz installed, or it is not on your PATH.\n"
-                        msg += "Please install Graphviz from http://www.graphviz.org/download/\n"
-                        msg += "And note: just installing the `graphviz` python package is not sufficient!"
+                        msg = (
+                            "It appears you do not have Graphviz installed, or it is not on your "
+                            "PATH. Please install Graphviz from http://www.graphviz.org/download/. "
+                            "And note: just installing the `graphviz` python package is not "
+                            "sufficient!"
+                        )
                         raise graphviz.backend.ExecutableNotFound(msg)
                     finally:
                         os.unlink(tmp.name)
@@ -1330,8 +1343,9 @@ class Flow:
                 self.storage.add_flow(self)
             else:
                 warnings.warn(
-                    "A flow with the same name is already contained in storage; if you changed your Flow since"
-                    " the last build, you might experience unexpected issues and should re-create your storage object."
+                    "A flow with the same name is already contained in storage; if you "
+                    "changed your Flow since the last build, you might experience "
+                    "unexpected issues and should re-create your storage object."
                 )
             storage = self.storage.build()  # type: Optional[Storage]
         else:
@@ -1348,8 +1362,8 @@ class Flow:
         Get flow and Prefect diagnostic information
 
         Args:
-            - include_secret_names (bool, optional): toggle output of Secret names, defaults to False.
-                Note: Secret values are never returned, only their names.
+            - include_secret_names (bool, optional): toggle output of Secret names, defaults to
+                False.  Note: Secret values are never returned, only their names.
         """
         return diagnostics.diagnostic_info(self, include_secret_names)
 
@@ -1407,10 +1421,10 @@ class Flow:
         Args:
             - token (str, optional): A Prefect Cloud API token with a RUNNER scope;
                 will default to the token found in `config.cloud.agent.auth_token`
-            - show_flow_logs (bool, optional): a boolean specifying whether the agent should re-route Flow run logs
-                to stdout; defaults to `False`
-            - log_to_cloud (bool, optional): a boolean specifying whether Flow run logs should be sent to Prefect Cloud;
-                defaults to `True`
+            - show_flow_logs (bool, optional): a boolean specifying whether the agent should
+                re-route Flow run logs to stdout; defaults to `False`
+            - log_to_cloud (bool, optional): a boolean specifying whether Flow run logs should
+                be sent to Prefect Cloud; defaults to `True`
         """
         temp_config = {
             "cloud.agent.auth_token": token or prefect.config.cloud.agent.auth_token,
@@ -1434,32 +1448,35 @@ class Flow:
         **kwargs: Any,
     ) -> str:
         """
-        Register the flow with Prefect Cloud; if no storage is present on the Flow, the default value from your config
-        will be used and initialized with `**kwargs`.
+        Register the flow with Prefect Cloud; if no storage is present on the Flow, the default
+        value from your config will be used and initialized with `**kwargs`.
 
         Args:
             - project_name (str, optional): the project that should contain this flow.
             - build (bool, optional): if `True`, the flow's environment is built
                 prior to serialization; defaults to `True`
-            - labels (List[str], optional): a list of labels to add to this Flow's environment; useful for
-                associating Flows with individual Agents; see http://docs.prefect.io/orchestration/agents/overview.html#flow-affinity-labels
-            - set_schedule_active (bool, optional): if `False`, will set the
-                schedule to inactive in the database to prevent auto-scheduling runs (if the Flow has a schedule).
-                Defaults to `True`. This can be changed later.
-            - version_group_id (str, optional): the UUID version group ID to use for versioning this Flow
-                in Cloud; if not provided, the version group ID associated with this Flow's project and name
-                will be used.
-            - no_url (bool, optional): if `True`, the stdout from this function will not contain the
-                URL link to the newly-registered flow in the Cloud UI
-            - **kwargs (Any): if instantiating a Storage object from default settings, these keyword arguments
-                will be passed to the initialization method of the default Storage class
+            - labels (List[str], optional): a list of labels to add to this Flow's environment;
+                useful for associating Flows with individual Agents; see
+                http://docs.prefect.io/orchestration/agents/overview.html#flow-affinity-labels
+            - set_schedule_active (bool, optional): if `False`, will set the schedule to
+                inactive in the database to prevent auto-scheduling runs (if the Flow has a
+                schedule).  Defaults to `True`. This can be changed later.
+            - version_group_id (str, optional): the UUID version group ID to use for versioning
+                this Flow in Cloud; if not provided, the version group ID associated with this
+                Flow's project and name will be used.
+            - no_url (bool, optional): if `True`, the stdout from this function will not
+                contain the URL link to the newly-registered flow in the Cloud UI
+            - **kwargs (Any): if instantiating a Storage object from default settings, these
+                keyword arguments will be passed to the initialization method of the default
+                Storage class
 
         Returns:
             - str: the ID of the flow that was registered
         """
         if prefect.context.get("loading_flow", False):
             raise RuntimeError(
-                "Attempting to call `flow.register` during execution of flow file will lead to unexpected results."
+                "Attempting to call `flow.register` during execution of flow file will lead "
+                "to unexpected results."
             )
 
         if self.storage is None:

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -24,11 +24,11 @@ from prefect.utilities.notifications import callback_factory
 from prefect.utilities.tasks import unmapped
 
 if TYPE_CHECKING:
-    from prefect.core.flow import Flow  # pylint: disable=W0611
-    from prefect.engine.result import Result  # pylint: disable=W0611
-    from prefect.engine.result_handlers import ResultHandler  # pylint: disable=W0611
-    from prefect.engine.state import State  # pylint: disable=W0611
-    from prefect.core import Edge  # pylint: disable=W0611
+    from prefect.core.flow import Flow
+    from prefect.engine.result import Result
+    from prefect.engine.result_handlers import ResultHandler
+    from prefect.engine.state import State
+    from prefect.core import Edge
 
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
 
@@ -115,9 +115,9 @@ class Task(metaclass=SignatureValidator):
 
     Args:
         - name (str, optional): The name of this task
-        - slug (str, optional): The slug for this task. Slugs provide a stable ID for tasks so that
-            the Prefect API can identify task run states. If a slug is not provided, one will be generated
-            automatically once the task is added to a Flow.
+        - slug (str, optional): The slug for this task. Slugs provide a stable ID for tasks so
+            that the Prefect API can identify task run states. If a slug is not provided, one
+            will be generated automatically once the task is added to a Flow.
         - tags ([str], optional): A list of tags for this task
         - max_retries (int, optional): The maximum amount of times this task can be retried
         - retry_delay (timedelta, optional): The amount of time to wait until task is retried
@@ -190,7 +190,7 @@ class Task(metaclass=SignatureValidator):
         max_retries: int = None,
         retry_delay: timedelta = None,
         timeout: int = None,
-        trigger: Callable[[Dict["Edge", "State"]], bool] = None,
+        trigger: "Callable[[Dict[Edge, State]], bool]" = None,
         skip_on_upstream_skip: bool = True,
         cache_for: timedelta = None,
         cache_validator: Callable = None,
@@ -235,7 +235,8 @@ class Task(metaclass=SignatureValidator):
         # specify not max retries because the default is false
         if retry_delay is not None and not max_retries:
             raise ValueError(
-                "A `max_retries` argument greater than 0 must be provided if specifying a retry delay."
+                "A `max_retries` argument greater than 0 must be provided if specifying "
+                "a retry delay."
             )
         if timeout is not None and not isinstance(timeout, int):
             raise TypeError(
@@ -253,7 +254,8 @@ class Task(metaclass=SignatureValidator):
             and cache_validator is not prefect.engine.cache_validators.never_use
         ):
             warnings.warn(
-                "cache_validator provided without specifying cache expiration (cache_for); this Task will not be cached."
+                "cache_validator provided without specifying cache expiration "
+                "(cache_for); this Task will not be cached."
             )
 
         self.cache_for = cache_for
@@ -325,23 +327,24 @@ class Task(metaclass=SignatureValidator):
         *Note:* The implemented `run` method cannot have `*args` in its signature. In addition,
         the following keywords are reserved: `upstream_tasks`, `task_args` and `mapped`.
 
-        If a task has arguments in its `run()` method, these can be bound either by using the functional
-        API and _calling_ the task instance, or by using `self.bind` directly.
+        If a task has arguments in its `run()` method, these can be bound either by using the
+        functional API and _calling_ the task instance, or by using `self.bind` directly.
 
         In addition to running arbitrary functions, tasks can interact with Prefect in a few ways:
         <ul><li> Return an optional result. When this function runs successfully,
             the task is considered successful and the result (if any) can be
             made available to downstream tasks. </li>
         <li> Raise an error. Errors are interpreted as failure. </li>
-        <li> Raise a [signal](../engine/signals.html). Signals can include `FAIL`, `SUCCESS`, `RETRY`, `SKIP`, etc.
-            and indicate that the task should be put in the indicated state.
+        <li> Raise a [signal](../engine/signals.html). Signals can include `FAIL`, `SUCCESS`,
+            `RETRY`, `SKIP`, etc. and indicate that the task should be put in the indicated state.
                 <ul>
                 <li> `FAIL` will lead to retries if appropriate </li>
                 <li> `SUCCESS` will cause the task to be marked successful </li>
                 <li> `RETRY` will cause the task to be marked for retry, even if `max_retries`
                     has been exceeded </li>
                 <li> `SKIP` will skip the task and possibly propogate the skip state through the
-                    flow, depending on whether downstream tasks have `skip_on_upstream_skip=True`. </li></ul>
+                    flow, depending on whether downstream tasks have `skip_on_upstream_skip=True`.
+                </li></ul>
         </li></ul>
         """
 
@@ -352,8 +355,8 @@ class Task(metaclass=SignatureValidator):
         Creates and returns a copy of the current Task.
 
         Args:
-            - **task_args (dict, optional): a dictionary of task attribute keyword arguments, these attributes
-                will be set on the new copy
+            - **task_args (dict, optional): a dictionary of task attribute keyword arguments,
+                these attributes will be set on the new copy
 
         Raises:
             - AttributeError: if any passed `task_args` are not attributes of the original
@@ -452,8 +455,8 @@ class Task(metaclass=SignatureValidator):
                 with the specified keyword arguments; defaults to `False`.
                 If `True`, any arguments contained within a `prefect.utilities.tasks.unmapped`
                 container will _not_ be mapped over.
-            - task_args (dict, optional): a dictionary of task attribute keyword arguments, these attributes
-                will be set on the new copy
+            - task_args (dict, optional): a dictionary of task attribute keyword arguments,
+                these attributes will be set on the new copy
             - upstream_tasks ([Task], optional): a list of upstream dependencies
                 for the new task.  This kwarg can be used to functionally specify
                 dependencies without binding their result to `run()`
@@ -540,8 +543,8 @@ class Task(metaclass=SignatureValidator):
         **kwargs: Any
     ) -> "Task":
         """
-        Map the Task elementwise across one or more Tasks. Arguments that should _not_ be mapped over
-        should be placed in the `prefect.utilities.tasks.unmapped` container.
+        Map the Task elementwise across one or more Tasks. Arguments that should _not_ be
+        mapped over should be placed in the `prefect.utilities.tasks.unmapped` container.
 
         For example:
             ```
@@ -551,14 +554,16 @@ class Task(metaclass=SignatureValidator):
 
 
         Args:
-            - *args: arguments to map over, which will elementwise be bound to the Task's `run` method
+            - *args: arguments to map over, which will elementwise be bound to the Task's `run`
+                method
             - upstream_tasks ([Task], optional): a list of upstream dependencies
                 to map over
             - flow (Flow, optional): The flow to set dependencies on, defaults to the current
                 flow in context if no flow is specified
             - task_args (dict, optional): a dictionary of task attribute keyword arguments,
                 these attributes will be set on the new copy
-            - **kwargs: keyword arguments to map over, which will elementwise be bound to the Task's `run` method
+            - **kwargs: keyword arguments to map over, which will elementwise be bound to the
+                Task's `run` method
 
         Raises:
             - AttributeError: if any passed `task_args` are not attributes of the original
@@ -597,8 +602,8 @@ class Task(metaclass=SignatureValidator):
             - downstream_tasks ([object], optional): A list of downtream tasks for this task
             - keyword_tasks ({str, object}}, optional): The results of these tasks will be provided
             to this task under the specified keyword arguments.
-            - mapped (bool, optional): Whether the results of the _upstream_ tasks should be mapped over
-                with the specified keyword arguments
+            - mapped (bool, optional): Whether the results of the _upstream_ tasks should be
+                mapped over with the specified keyword arguments
             - validate (bool, optional): Whether or not to check the validity of the flow. If not
                 provided, defaults to the value of `eager_edge_validation` in your Prefect
                 configuration file.
@@ -635,8 +640,9 @@ class Task(metaclass=SignatureValidator):
                 as a upstream dependency of this task.
             - flow (Flow, optional): The flow to set dependencies on, defaults to the current
                 flow in context if no flow is specified
-            - key (str, optional): The key to be set for the new edge; the result of the upstream task
-                will be passed to this task's `run()` method under this keyword argument.
+            - key (str, optional): The key to be set for the new edge; the result of the
+                upstream task will be passed to this task's `run()` method under this keyword
+                argument.
             - mapped (bool, optional): Whether this dependency is mapped; defaults to `False`
 
         Raises:

--- a/src/prefect/engine/cache_validators.py
+++ b/src/prefect/engine/cache_validators.py
@@ -137,7 +137,8 @@ def partial_parameters_only(validate_on: Iterable[str] = None,) -> Callable:
             to validate against
 
     Returns:
-        - Callable: the actual validation function specifying whether or not the cache should be used
+        - Callable: the actual validation function specifying whether or not the cache should
+            be used
 
     Example:
     ```python
@@ -177,7 +178,8 @@ def partial_parameters_only(validate_on: Iterable[str] = None,) -> Callable:
         The actual cache validation function that will be used.
 
         Args:
-            - state (State): a `Success` state from the last successful Task run that contains the cache
+            - state (State): a `Success` state from the last successful Task run that contains
+                the cache
             - inputs (dict): a `dict` of inputs that were available on the last
                 successful run of the cached Task
             - parameters (dict): a `dict` of parameters that were available on the
@@ -214,7 +216,8 @@ def partial_inputs_only(validate_on: Iterable[str] = None,) -> Callable:
             to validate against
 
     Returns:
-        - Callable: the actual validation function specifying whether or not the cache should be used
+        - Callable: the actual validation function specifying whether or not the cache should
+            be used
 
     Example:
     ```python
@@ -256,7 +259,8 @@ def partial_inputs_only(validate_on: Iterable[str] = None,) -> Callable:
         The actual cache validation function that will be used.
 
         Args:
-            - state (State): a `Success` state from the last successful Task run that contains the cache
+            - state (State): a `Success` state from the last successful Task run that contains
+                the cache
             - inputs (dict): a `dict` of inputs that were available on the last
                 successful run of the cached Task
             - parameters (dict): a `dict` of parameters that were available on the

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -81,7 +81,7 @@ class CloudFlowRunner(FlowRunner):
             if not flow_run.flow.settings.get("heartbeat_enabled", True):
                 return False
             return True
-        except Exception as exc:
+        except Exception:
             self.logger.exception(
                 "Heartbeat failed for Flow '{}'".format(self.flow.name)
             )
@@ -160,13 +160,14 @@ class CloudFlowRunner(FlowRunner):
                 values, with keys being strings representing Parameter names and values being
                 their corresponding values
             - task_runner_state_handlers (Iterable[Callable], optional): A list of state change
-                handlers that will be provided to the task_runner, and called whenever a task changes
-                state.
+                handlers that will be provided to the task_runner, and called whenever a task
+                changes state.
             - executor (Executor, optional): executor to use when performing
                 computation; defaults to the executor specified in your prefect configuration
             - context (Dict[str, Any], optional): prefect.Context to use for execution
                 to use for each Task run
-            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be provided to each task
+            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be
+                provided to each task
 
         Returns:
             - State: `State` representing the final post-run state of the `Flow`.
@@ -241,7 +242,8 @@ class CloudFlowRunner(FlowRunner):
             - task_states (Dict[Task, State]): a dictionary of any initial task states
             - context (Dict[str, Any], optional): prefect.Context to use for execution
                 to use for each Task run
-            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be provided to each task
+            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be
+                provided to each task
             - parameters(dict): the parameter values for the run
 
         Returns:
@@ -282,7 +284,8 @@ class CloudFlowRunner(FlowRunner):
             except KeyError:
                 msg = (
                     f"Task slug {task_run.task_slug} not found in the current Flow; "
-                    "this is usually caused by changing the Flow without reregistering it with the Prefect API."
+                    f"this is usually caused by changing the Flow without reregistering "
+                    f"it with the Prefect API."
                 )
                 raise KeyError(msg)
             task_states.setdefault(task, task_run.state)

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -13,7 +13,6 @@ from prefect.engine.state import (
     Cached,
     ClientFailed,
     Failed,
-    Mapped,
     Queued,
     Retrying,
     State,
@@ -34,12 +33,12 @@ class CloudTaskRunner(TaskRunner):
     Args:
         - task (Task): the Task to be run / executed
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
-            that will be called whenever the task changes state, providing an
-            opportunity to inspect or modify the new state. The handler
-            will be passed the task runner instance, the old (prior) state, and the new
-            (current) state, with the following signature: `state_handler(TaskRunner, old_state, new_state) -> State`;
-            If multiple functions are passed, then the `new_state` argument will be the
-            result of the previous handler.
+            that will be called whenever the task changes state, providing an opportunity to
+            inspect or modify the new state. The handler will be passed the task runner
+            instance, the old (prior) state, and the new (current) state, with the following
+            signature: `state_handler(TaskRunner, old_state, new_state) -> State`; If multiple
+            functions are passed, then the `new_state` argument will be the result of the
+            previous handler.
         - flow_result: the result instance configured for the flow (if any)
     """
 
@@ -73,7 +72,7 @@ class CloudTaskRunner(TaskRunner):
             if not flow_run.flow.settings.get("heartbeat_enabled", True):
                 return False
             return True
-        except Exception as exc:
+        except Exception:
             self.logger.exception(
                 "Heartbeat failed for Task '{}'".format(self.task.name)
             )
@@ -249,7 +248,8 @@ class CloudTaskRunner(TaskRunner):
         self, state: State, upstream_states: Dict[Edge, State]
     ) -> Tuple[State, Dict[Edge, State]]:
         """
-        Given the task's current state and upstream states, populates all relevant result objects for this task run.
+        Given the task's current state and upstream states, populates all relevant result
+        objects for this task run.
 
         Args:
             - state (State): the task's current state.
@@ -291,8 +291,8 @@ class CloudTaskRunner(TaskRunner):
         """
         The main endpoint for TaskRunners.  Calling this method will conditionally execute
         `self.task.run` with any provided inputs, assuming the upstream dependencies are in a
-        state which allow this Task to run.  Additionally, this method will wait and perform Task retries
-        which are scheduled for <= 1 minute in the future.
+        state which allow this Task to run.  Additionally, this method will wait and perform
+        Task retries which are scheduled for <= 1 minute in the future.
 
         Args:
             - state (State, optional): initial `State` to begin task run from;
@@ -301,8 +301,8 @@ class CloudTaskRunner(TaskRunner):
                 representing the states of any tasks upstream of this one. The keys of the
                 dictionary should correspond to the edges leading to the task.
             - context (dict, optional): prefect Context to use for execution
-            - is_mapped_parent (bool): a boolean indicating whether this task run is the run of a parent
-                mapped task
+            - is_mapped_parent (bool): a boolean indicating whether this task run is the run of
+                a parent mapped task
 
         Returns:
             - `State` object representing the final post-run state of the Task

--- a/src/prefect/engine/executors/base.py
+++ b/src/prefect/engine/executors/base.py
@@ -33,7 +33,8 @@ class Executor:
         Args:
             - fn (Callable): function that is being submitted for execution
             - *args (Any): arguments to be passed to `fn`
-            - extra_context (dict, optional): an optional dictionary with extra information about the submitted task
+            - extra_context (dict, optional): an optional dictionary with extra information
+                about the submitted task
             - **kwargs (Any): keyword arguments to be passed to `fn`
 
         Returns:

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -260,7 +260,8 @@ class DaskExecutor(Executor):
         Args:
             - fn (Callable): function that is being submitted for execution
             - *args (Any): arguments to be passed to `fn`
-            - extra_context (dict, optional): an optional dictionary with extra information about the submitted task
+            - extra_context (dict, optional): an optional dictionary with extra information
+                about the submitted task
             - **kwargs (Any): keyword arguments to be passed to `fn`
 
         Returns:

--- a/src/prefect/engine/executors/local.py
+++ b/src/prefect/engine/executors/local.py
@@ -18,7 +18,8 @@ class LocalExecutor(Executor):
         Args:
             - fn (Callable): function that is being submitted for execution
             - *args (Any): arguments to be passed to `fn`
-            - extra_context (dict, optional): an optional dictionary with extra information about the submitted task
+            - extra_context (dict, optional): an optional dictionary with extra information
+                about the submitted task
             - **kwargs (Any): keyword arguments to be passed to `fn`
 
         Returns:

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -59,7 +59,7 @@ class FlowRunner(Runner):
             opportunity to inspect or modify the new state. The handler
             will be passed the flow runner instance, the old (prior) state, and the new
             (current) state, with the following signature:
-                `state_handler(fr: FlowRunner, old_state: State, new_state: State) -> Optional[State]`
+            `state_handler(fr: FlowRunner, old_state: State, new_state: State) -> Optional[State]`
             If multiple functions are passed, then the `new_state` argument will be the
             result of the previous handler.
 
@@ -137,7 +137,8 @@ class FlowRunner(Runner):
             - task_states (Dict[Task, State]): a dictionary of any initial task states
             - context (Dict[str, Any], optional): prefect.Context to use for execution
                 to use for each Task run
-            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be provided to each task
+            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be
+                provided to each task
             - parameters(dict): the parameter values for the run
 
         Returns:
@@ -208,13 +209,14 @@ class FlowRunner(Runner):
                 values, with keys being strings representing Parameter names and values being
                 their corresponding values
             - task_runner_state_handlers (Iterable[Callable], optional): A list of state change
-                handlers that will be provided to the task_runner, and called whenever a task changes
-                state.
+                handlers that will be provided to the task_runner, and called whenever a task
+                changes state.
             - executor (Executor, optional): executor to use when performing
                 computation; defaults to the executor specified in your prefect configuration
             - context (Dict[str, Any], optional): prefect.Context to use for execution
                 to use for each Task run
-            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be provided to each task
+            - task_contexts (Dict[Task, Dict[str, Any]], optional): contexts that will be
+                provided to each task
 
         Returns:
             - State: `State` representing the final post-run state of the `Flow`.
@@ -369,14 +371,15 @@ class FlowRunner(Runner):
                 `Pending`
             - task_states (dict): dictionary of task states to begin
                 computation with, with keys being Tasks and values their corresponding state
-            - task_contexts (Dict[Task, Dict[str, Any]]): contexts that will be provided to each task
+            - task_contexts (Dict[Task, Dict[str, Any]]): contexts that will be provided to
+                each task
             - return_tasks ([Task], optional): list of Tasks to include in the
                 final returned Flow state. Defaults to `None`
-            - task_runner_state_handlers (Iterable[Callable]): A list of state change
-                handlers that will be provided to the task_runner, and called whenever a task changes
+            - task_runner_state_handlers (Iterable[Callable]): A list of state change handlers
+                that will be provided to the task_runner, and called whenever a task changes
                 state.
-            - executor (Executor): executor to use when performing
-                computation; defaults to the executor provided in your prefect configuration
+            - executor (Executor): executor to use when performing computation; defaults to the
+                executor provided in your prefect configuration
 
         Returns:
             - State: `State` representing the final post-run state of the `Flow`.
@@ -418,10 +421,10 @@ class FlowRunner(Runner):
                 ):
                     task_states[task] = task_state = Success(result=task.value)
 
-                # if the state is finished, don't run the task, just use the provided state
-                # if the state is cached / mapped, we still want to run the task runner pipeline steps
-                # to either ensure the cache is still valid / or to recreate the mapped pipeline for
-                # possible retries
+                # if the state is finished, don't run the task, just use the provided state if
+                # the state is cached / mapped, we still want to run the task runner pipeline
+                # steps to either ensure the cache is still valid / or to recreate the mapped
+                # pipeline for possible retries
                 if (
                     isinstance(task_state, State)
                     and task_state.is_finished()
@@ -432,9 +435,9 @@ class FlowRunner(Runner):
 
                 upstream_states = {}  # type: Dict[Edge, State]
 
-                # this dictionary is used exclusively for "reduce" tasks
-                # in particular we store the states / futures corresponding to
-                # the upstream children, and if running on Dask, let Dask resolve them at the appropriate time
+                # this dictionary is used exclusively for "reduce" tasks in particular we store
+                # the states / futures corresponding to the upstream children, and if running
+                # on Dask, let Dask resolve them at the appropriate time
                 upstream_mapped_states = {}  # type: Dict[Edge, list]
 
                 # -- process each edge to the task
@@ -465,14 +468,14 @@ class FlowRunner(Runner):
                 # handle mapped tasks
                 if any([edge.mapped for edge in upstream_states.keys()]):
 
-                    ## wait on upstream states to determine the width of the pipeline
-                    ## this is the key to depth-first execution
+                    # wait on upstream states to determine the width of the pipeline
+                    # this is the key to depth-first execution
                     upstream_states = executor.wait(
                         {e: state for e, state in upstream_states.items()}
                     )
-                    ## we submit the task to the task runner to determine if
-                    ## we can proceed with mapping - if the new task state is not a Mapped
-                    ## state then we don't proceed
+                    # we submit the task to the task runner to determine if
+                    # we can proceed with mapping - if the new task state is not a Mapped
+                    # state then we don't proceed
                     task_states[task] = executor.wait(
                         executor.submit(
                             run_task,
@@ -491,8 +494,8 @@ class FlowRunner(Runner):
                         )
                     )
 
-                    ## either way, we should now have enough resolved states to restructure
-                    ## the upstream states into a list of upstream state dictionaries to iterate over
+                    # either way, we should now have enough resolved states to restructure
+                    # the upstream states into a list of upstream state dictionaries to iterate over
                     list_of_upstream_states = prepare_upstream_states_for_mapping(
                         task_states[task], upstream_states, mapped_children
                     )
@@ -500,9 +503,9 @@ class FlowRunner(Runner):
                     submitted_states = []
 
                     for idx, states in enumerate(list_of_upstream_states):
-                        ## if we are on a future rerun of a partially complete flow run,
-                        ## there might be mapped children in a retrying state; this check
-                        ## looks into the current task state's map_states for such info
+                        # if we are on a future rerun of a partially complete flow run,
+                        # there might be mapped children in a retrying state; this check
+                        # looks into the current task state's map_states for such info
                         if (
                             isinstance(task_state, Mapped)
                             and len(task_state.map_states) >= idx + 1
@@ -515,7 +518,7 @@ class FlowRunner(Runner):
                         else:
                             current_state = task_state
 
-                        ## this is where each child is submitted for actual work
+                        # this is where each child is submitted for actual work
                         submitted_states.append(
                             executor.submit(
                                 run_task,
@@ -610,7 +613,8 @@ class FlowRunner(Runner):
 
         Args:
             - state (State): the current state of the Flow
-            - key_states (Set[State]): the states which will determine the success / failure of the flow run
+            - key_states (Set[State]): the states which will determine the success / failure of
+                the flow run
             - return_states (Dict[Task, State]): states to return as results
             - terminal_states (Set[State]): the states of the terminal tasks for this flow
 

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -160,9 +160,10 @@ class Result(ResultInterface):
 
     def validate(self) -> bool:
         """
-        Run any validator functions associated with this result and return whether the result is valid or not.
-        All individual validator functions must return True for this method to return True.
-        Emits a warning log if run_validators isn't true, and proceeds to run validation functions anyway.
+        Run any validator functions associated with this result and return whether the result
+        is valid or not.  All individual validator functions must return True for this method
+        to return True.  Emits a warning log if run_validators isn't true, and proceeds to run
+        validation functions anyway.
 
 
         Returns:
@@ -170,9 +171,10 @@ class Result(ResultInterface):
         """
         if not self.run_validators:
             self.logger.warning(
-                "A Result's validate method has been called, but its run_validators attribute is False. "
-                "Prefect will not honor the validators without run_validators=True, so please change it "
-                "if you expect validation to occur automatically for this Result in your pipeline."
+                "A Result's validate method has been called, but its run_validators "
+                "attribute is False. Prefect will not honor the validators without "
+                "run_validators=True, so please change it if you expect validation "
+                "to occur automatically for this Result in your pipeline."
             )
 
         if self.validators:
@@ -199,7 +201,8 @@ class Result(ResultInterface):
 
     def format(self, **kwargs: Any) -> "Result":
         """
-        Takes a set of string format key-value pairs and renders the result.location to a final location string
+        Takes a set of string format key-value pairs and renders the result.location to a final
+        location string
 
         Args:
             - **kwargs (Any): string format arguments for result.location
@@ -233,7 +236,9 @@ class Result(ResultInterface):
             - bool: whether or not the target result exists.
         """
         raise NotImplementedError(
-            "Not implemented on the base Result class - if you are seeing this error you might be trying to use features that require choosing a Result subclass; see https://docs.prefect.io/core/concepts/results.html"
+            "Not implemented on the base Result class - if you are seeing this error you "
+            "might be trying to use features that require choosing a Result subclass; "
+            "see https://docs.prefect.io/core/concepts/results.html"
         )
 
     def read(self, location: str) -> "Result":
@@ -247,7 +252,9 @@ class Result(ResultInterface):
             - Any: The value saved to the result.
         """
         raise NotImplementedError(
-            "Not implemented on the base Result class - if you are seeing this error you might be trying to use features that require choosing a Result subclass; see https://docs.prefect.io/core/concepts/results.html"
+            "Not implemented on the base Result class - if you are seeing this error you "
+            "might be trying to use features that require choosing a Result subclass; "
+            "see https://docs.prefect.io/core/concepts/results.html"
         )
 
     def write(self, value: Any, **kwargs: Any) -> "Result":
@@ -264,14 +271,17 @@ class Result(ResultInterface):
             - Result: a new result object with the appropriately formatted location destination
         """
         raise NotImplementedError(
-            "Not implemented on the base Result class - if you are seeing this error you might be trying to use features that require choosing a Result subclass; see https://docs.prefect.io/core/concepts/results.html"
+            "Not implemented on the base Result class - if you are seeing this error you "
+            "might be trying to use features that require choosing a Result subclass; "
+            "see https://docs.prefect.io/core/concepts/results.html"
         )
 
 
 class SafeResult(ResultInterface):
     """
-    A _safe_ representation of the result of a Prefect task; this class contains information about
-    the serialized value of a task's result, and a result handler specifying how to deserialize this value
+    A _safe_ representation of the result of a Prefect task; this class contains information
+    about the serialized value of a task's result, and a result handler specifying how to
+    deserialize this value
 
     Args:
         - value (Any): the safe representation of a value

--- a/src/prefect/engine/result_handlers/azure_result_handler.py
+++ b/src/prefect/engine/result_handlers/azure_result_handler.py
@@ -18,17 +18,16 @@ class AzureResultHandler(ResultHandler):
     """
     Result Handler for writing to and reading from an Azure Blob storage.
 
-    Note that your flow's runtime environment must be able to authenticate with
-    Azure; there are currently two supported options: provide a connection string
-    either at initialization or at runtime through an environment variable, or
-    set your Azure credentials as a Prefect Secret.  Using an environment variable is the recommended
-    approach.
+    Note that your flow's runtime environment must be able to authenticate with Azure; there
+    are currently two supported options: provide a connection string either at initialization
+    or at runtime through an environment variable, or set your Azure credentials as a Prefect
+    Secret.  Using an environment variable is the recommended approach.
 
     Args:
         - container (str): the name of the container to write to / read from
         - connection_string (str, optional): an Azure connection string for communicating with
-            Blob storage. If not provided the value set in the environment as `AZURE_STORAGE_CONNECTION_STRING`
-            will be used
+            Blob storage. If not provided the value set in the environment as
+            `AZURE_STORAGE_CONNECTION_STRING` will be used
         - azure_credentials_secret (str, optional): the name of a Prefect Secret
             which stores your Azure credentials; this Secret must be a JSON payload
             with two keys: `ACCOUNT_NAME` and either `ACCOUNT_KEY` or `SAS_TOKEN`
@@ -103,10 +102,10 @@ class AzureResultHandler(ResultHandler):
         uri = "{date}/{uuid}.prefect_result".format(date=date, uuid=uuid.uuid4())
         self.logger.debug("Starting to upload result to {}...".format(uri))
 
-        ## prepare data
+        # prepare data
         binary_data = base64.b64encode(cloudpickle.dumps(result)).decode()
 
-        ## upload
+        # upload
         self.service.create_blob_from_text(
             container_name=self.container, blob_name=uri, text=binary_data
         )

--- a/src/prefect/engine/result_handlers/gcs_result_handler.py
+++ b/src/prefect/engine/result_handlers/gcs_result_handler.py
@@ -16,9 +16,10 @@ class GCSResultHandler(ResultHandler):
     """
     Result Handler for writing to and reading from a Google Cloud Bucket.
 
-    To authenticate with Google Cloud, you need to ensure that your flow's
-    runtime environment has the proper credentials available
-    (see https://cloud.google.com/docs/authentication/production for all the authentication options).
+    To authenticate with Google Cloud, you need to ensure that your flow's runtime environment
+    has the proper credentials available (see
+    https://cloud.google.com/docs/authentication/production for all the authentication
+    options).
 
     You can also optionally provide the name of a Prefect Secret containing your
     service account key.

--- a/src/prefect/engine/result_handlers/local_result_handler.py
+++ b/src/prefect/engine/result_handlers/local_result_handler.py
@@ -1,7 +1,9 @@
 """
-Result Handlers provide the hooks that Prefect uses to store task results in production; a `ResultHandler` can be provided to a `Flow` at creation.
+Result Handlers provide the hooks that Prefect uses to store task results in production; a
+`ResultHandler` can be provided to a `Flow` at creation.
 
-Anytime a task needs its output or inputs stored, a result handler is used to determine where this data should be stored (and how it can be retrieved).
+Anytime a task needs its output or inputs stored, a result handler is used to determine where
+this data should be stored (and how it can be retrieved).
 """
 import os
 from typing import Any

--- a/src/prefect/engine/result_handlers/result_handler.py
+++ b/src/prefect/engine/result_handlers/result_handler.py
@@ -1,9 +1,11 @@
 """
 Note: Result Handlers have been deprecated in 0.11.0.
 
-Result Handlers provide the hooks that Prefect uses to store task results in production for Prefect < 0.11.0; a `ResultHandler` can be provided to a `Flow` at creation.
+Result Handlers provide the hooks that Prefect uses to store task results in production for
+Prefect < 0.11.0; a `ResultHandler` can be provided to a `Flow` at creation.
 
-Anytime a task needs its output or inputs stored, a result handler is used to determine where this data should be stored (and how it can be retrieved).
+Anytime a task needs its output or inputs stored, a result handler is used to determine where
+this data should be stored (and how it can be retrieved).
 """
 from typing import Any
 

--- a/src/prefect/engine/result_handlers/s3_result_handler.py
+++ b/src/prefect/engine/result_handlers/s3_result_handler.py
@@ -19,9 +19,10 @@ class S3ResultHandler(ResultHandler):
     """
     Result Handler for writing to and reading from an AWS S3 Bucket.
 
-    For authentication, there are two options: you can set a Prefect Secret containing
-    your AWS access keys which will be passed directly to the `boto3` client, or you can
-    [configure your flow's runtime environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    For authentication, there are two options: you can set a Prefect Secret containing your AWS
+    access keys which will be passed directly to the `boto3` client, or you can [configure your
+    flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
     for `boto3`.
 
     Args:
@@ -31,7 +32,8 @@ class S3ResultHandler(ResultHandler):
             with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
             passed directly to `boto3`.  If not provided, `boto3`
             will fall back on standard AWS rules for authentication.
-        - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
+        - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client
+            session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
             is initialized (changing the "service_name" is not permitted).
     """
 
@@ -62,7 +64,8 @@ class S3ResultHandler(ResultHandler):
         if self.aws_credentials_secret:
             if aws_access_key is not None or aws_secret_access_key is not None:
                 self.logger.warning(
-                    '"aws_access_key" or "aws_secret_access_key" were set in "boto3_kwargs", ignoring those for what is populated in "aws_credentials_secret"'
+                    "'aws_access_key' or 'aws_secret_access_key' were set in 'boto3_kwargs', "
+                    "ignoring those for what is populated in 'aws_credentials_secret'"
                 )
 
             aws_credentials = Secret(self.aws_credentials_secret).get()
@@ -72,8 +75,8 @@ class S3ResultHandler(ResultHandler):
             aws_access_key = aws_credentials["ACCESS_KEY"]
             aws_secret_access_key = aws_credentials["SECRET_ACCESS_KEY"]
 
-        # use a new boto session when initializing in case we are in a new thread
-        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
+        # use a new boto session when initializing in case we are in a new thread see
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
         session = boto3.session.Session()
         s3_client = session.client(
             "s3",
@@ -87,7 +90,9 @@ class S3ResultHandler(ResultHandler):
     def client(self) -> "boto3.client":
         """
         Initializes a client if we believe we are in a new thread.
-        We consider ourselves in a new thread if we haven't stored a client yet in the current context.
+
+        We consider ourselves in a new thread if we haven't stored a client yet in the current
+        context.
         """
         if not prefect.context.get("boto3client") or not getattr(self, "_client", None):
             self.initialize_client()
@@ -123,11 +128,11 @@ class S3ResultHandler(ResultHandler):
         uri = "{date}/{uuid}.prefect_result".format(date=date, uuid=uuid.uuid4())
         self.logger.debug("Starting to upload result to {}...".format(uri))
 
-        ## prepare data
+        # prepare data
         binary_data = base64.b64encode(cloudpickle.dumps(result))
         stream = io.BytesIO(binary_data)
 
-        ## upload
+        # upload
         self.client.upload_fileobj(stream, Bucket=self.bucket, Key=uri)
         self.logger.debug("Finished uploading result to {}.".format(uri))
         return uri
@@ -146,7 +151,7 @@ class S3ResultHandler(ResultHandler):
             self.logger.debug("Starting to download result from {}...".format(uri))
             stream = io.BytesIO()
 
-            ## download
+            # download
             self.client.download_fileobj(Bucket=self.bucket, Key=uri, Fileobj=stream)
             stream.seek(0)
 

--- a/src/prefect/engine/result_handlers/secret_result_handler.py
+++ b/src/prefect/engine/result_handlers/secret_result_handler.py
@@ -6,8 +6,8 @@ from prefect.engine.result_handlers import ResultHandler
 
 class SecretResultHandler(ResultHandler):
     """
-    Hook for storing and retrieving sensitive task results from a Secret store. Only intended to be used
-    for Secret tasks.
+    Hook for storing and retrieving sensitive task results from a Secret store. Only intended
+    to be used for Secret tasks.
 
     Args:
         - secret_task (Task): the Secret Task that this result handler will be used for

--- a/src/prefect/engine/results/azure_result.py
+++ b/src/prefect/engine/results/azure_result.py
@@ -21,8 +21,8 @@ class AzureResult(Result):
     Args:
         - container (str): the name of the container to write to / read from
         - connection_string (str, optional): an Azure connection string for communicating with
-            Blob storage. If not provided the value set in the environment as `AZURE_STORAGE_CONNECTION_STRING`
-            will be used
+            Blob storage. If not provided the value set in the environment as
+            `AZURE_STORAGE_CONNECTION_STRING` will be used
         - connection_string_secret (str, optional): the name of a Prefect Secret
             which stores your Azure connection tring
         - **kwargs (Any, optional): any additional `Result` initialization options
@@ -93,7 +93,7 @@ class AzureResult(Result):
 
         self.logger.debug("Starting to upload result to {}...".format(new.location))
 
-        ## prepare data
+        # prepare data
         binary_data = new.serializer.serialize(new.value)
 
         # initialize client and upload

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -10,15 +10,19 @@ class GCSResult(Result):
     """
     Result that is written to and read from a Google Cloud Bucket.
 
-    To authenticate with Google Cloud, you need to ensure that your flow's
-    runtime environment has the proper credentials available
-    (see https://cloud.google.com/docs/authentication/production for all the authentication options).
+    To authenticate with Google Cloud, you need to ensure that your flow's runtime environment
+    has the proper credentials available (see
+    https://cloud.google.com/docs/authentication/production for all the authentication
+    options).
 
-    You can also optionally provide your service account key to `prefect.context.secrets.GCP_CREDENTIALS` for
-    automatic authentication - see [Third Party Authentication](../../../orchestration/recipes/third_party_auth.html) for more information.
+    You can also optionally provide your service account key to
+    `prefect.context.secrets.GCP_CREDENTIALS` for automatic authentication - see [Third Party
+    Authentication](../../../orchestration/recipes/third_party_auth.html) for more information.
 
-    To read more about service account keys see https://cloud.google.com/iam/docs/creating-managing-service-account-keys.
-    To read more about the JSON representation of service account keys see https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys.
+    To read more about service account keys see
+    https://cloud.google.com/iam/docs/creating-managing-service-account-keys.  To read more
+    about the JSON representation of service account keys see
+    https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys.
 
     Args:
         - bucket (str): the name of the bucket to write to / read from

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -36,7 +36,8 @@ class LocalResult(Result):
                     [full_prefect_path, os.path.abspath(dir)]
                 )
         except ValueError:
-            # ValueError is raised if comparing two paths in Windows from different drives, e.g., E:/ and C:/
+            # ValueError is raised if comparing two paths in Windows from different drives,
+            # e.g., E:/ and C:/
             pass
         if dir is None or common_path == full_prefect_path:
             directory = os.path.join(config.home_dir, "results")

--- a/src/prefect/engine/results/result_handler_result.py
+++ b/src/prefect/engine/results/result_handler_result.py
@@ -31,6 +31,15 @@ CONVERSIONS = [
     (LocalResultHandler, dict(dir="dir"), LocalResult),
     (S3ResultHandler, dict(bucket="bucket", boto3_kwargs="boto3_kwargs"), S3Result),
     (SecretResultHandler, dict(secret_task="secret_task"), SecretResult),
+    (
+        AzureResultHandler,
+        dict(
+            container="container",
+            connection_string="connection_string",
+            connection_string_secret="connection_string_secret",
+        ),
+        AzureResult,
+    ),
 ]  # type: List[Tuple[Type[ResultHandler], Dict[Any, Any], Type[Result]]]
 
 
@@ -52,8 +61,8 @@ class ResultHandlerResult(Result):
 
     def read(self, location: str) -> Result:
         """
-        Exposes the read method of the underlying custom result handler fitting the Result interface.
-        Returns a new Result with the value read from the custom result handler.
+        Exposes the read method of the underlying custom result handler fitting the Result
+        interface.  Returns a new Result with the value read from the custom result handler.
 
         Args:
             - location (str): the location to read from
@@ -67,7 +76,8 @@ class ResultHandlerResult(Result):
 
     def write(self, value: Any, **kwargs: Any) -> Result:
         """
-        Exposes the write method of the underlying custom result handler fitting the Result interface.
+        Exposes the write method of the underlying custom result handler fitting the Result
+        interface.
 
         Args:
             - value (Any): the value to write and attach to the result

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -12,16 +12,19 @@ class S3Result(Result):
     """
     Result that is written to and retrieved from an AWS S3 Bucket.
 
-    For authentication, there are two options: you can provide your AWS credentials
-    to `prefect.context.secrets.AWS_CREDENTIALS` for automatic authentication
-    or you can [configure your flow's runtime environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    For authentication, there are two options: you can provide your AWS credentials to
+    `prefect.context.secrets.AWS_CREDENTIALS` for automatic authentication or you can
+    [configure your flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
     for `boto3`.
 
-    See [Third Party Authentication](../../../orchestration/recipes/third_party_auth.html) for more information.
+    See [Third Party Authentication](../../../orchestration/recipes/third_party_auth.html) for
+    more information.
 
     Args:
         - bucket (str): the name of the bucket to write to / read from
-        - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
+        - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client
+            session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
             is initialized (changing the "service_name" is not permitted).
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
@@ -43,8 +46,8 @@ class S3Result(Result):
         """
         from prefect.utilities.aws import get_boto_client
 
-        # use a new boto session when initializing in case we are in a new thread
-        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
+        # use a new boto session when initializing in case we are in a new thread see
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
         s3_client = get_boto_client(
             "s3", credentials=None, use_session=True, **self.boto3_kwargs
         )
@@ -54,7 +57,9 @@ class S3Result(Result):
     def client(self) -> "boto3.client":
         """
         Initializes a client if we believe we are in a new thread.
-        We consider ourselves in a new thread if we haven't stored a client yet in the current context.
+
+        We consider ourselves in a new thread if we haven't stored a client yet in the current
+        context.
         """
         if not prefect.context.get("boto3client") or not getattr(self, "_client", None):
             self.initialize_client()
@@ -96,7 +101,7 @@ class S3Result(Result):
 
         stream = io.BytesIO(binary_data)
 
-        ## upload
+        # upload
         from botocore.exceptions import ClientError
 
         try:
@@ -110,7 +115,8 @@ class S3Result(Result):
 
     def read(self, location: str) -> Result:
         """
-        Reads a result from S3, reads it and returns a new `Result` object with the corresponding value.
+        Reads a result from S3, reads it and returns a new `Result` object with the
+        corresponding value.
 
         Args:
             - location (str): the S3 URI to read from
@@ -125,7 +131,7 @@ class S3Result(Result):
             self.logger.debug("Starting to download result from {}...".format(location))
             stream = io.BytesIO()
 
-            ## download - uses `self` in case the client is already instantiated
+            # download - uses `self` in case the client is already instantiated
             self.client.download_fileobj(
                 Bucket=self.bucket, Key=location, Fileobj=stream
             )

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -1,6 +1,7 @@
 """
-These Exceptions, when raised, are used to signal state changes when tasks or flows are running. Signals
-are used in TaskRunners and FlowRunners as a way of communicating the changes in states.
+These Exceptions, when raised, are used to signal state changes when tasks or flows are
+running. Signals are used in TaskRunners and FlowRunners as a way of communicating the changes
+in states.
 """
 
 from prefect.engine import state

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -2,7 +2,8 @@
 State is the main currency in the Prefect platform. It is used to represent the current
 status of a flow or task.
 
-This module contains all Prefect state classes, all ultimately inheriting from the base State class as follows:
+This module contains all Prefect state classes, all ultimately inheriting from the base State
+class as follows:
 
 ![diagram of state inheritances](/state_inheritance_diagram.svg){.viz-padded}
 
@@ -94,9 +95,10 @@ class State:
 
     def load_result(self, result: Result = None) -> "State":
         """
-        Given another Result instance, uses the current Result's `location` to create a fully hydrated `Result`
-        using the logic of the provided result.  This method is mainly intended to be used
-        by `TaskRunner` methods to hydrate deserialized Cloud results into fully functional `Result` instances.
+        Given another Result instance, uses the current Result's `location` to create a fully
+        hydrated `Result` using the logic of the provided result.  This method is mainly
+        intended to be used by `TaskRunner` methods to hydrate deserialized Cloud results into
+        fully functional `Result` instances.
 
         Args:
             - result (Result): the result instance to hydrate with `self.location`
@@ -118,12 +120,14 @@ class State:
         self, results: Mapping[str, Optional[Result]] = None
     ) -> "State":
         """
-        Given another Result instance, uses the current Result's `location` to create a fully hydrated `Result`
-        using the logic of the provided result.  This method is mainly intended to be used
-        by `TaskRunner` methods to hydrate deserialized Cloud results into fully functional `Result` instances.
+        Given another Result instance, uses the current Result's `location` to create a fully
+        hydrated `Result` using the logic of the provided result.  This method is mainly
+        intended to be used by `TaskRunner` methods to hydrate deserialized Cloud results into
+        fully functional `Result` instances.
 
         Args:
-            - results (Dict[str, Result]): a dictionary of result instances to hydrate `self.cached_inputs` with
+            - results (Dict[str, Result]): a dictionary of result instances to hydrate
+                `self.cached_inputs` with
 
         Returns:
             - State: the current state with a fully hydrated Result attached
@@ -661,8 +665,8 @@ class Finished(State):
 
 class Looped(Finished):
     """
-    Finished state indicating one successful run of a looped task - if a Task is in this state, it will
-    run the next iteration of the loop immediately after.
+    Finished state indicating one successful run of a looped task - if a Task is in this state,
+    it will run the next iteration of the loop immediately after.
 
     Args:
         - message (str or Exception, optional): Defaults to `None`. A message about the

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -6,7 +6,6 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Set,
@@ -28,7 +27,6 @@ from prefect.engine.state import (
     Failed,
     Looped,
     Mapped,
-    Paused,
     Pending,
     Resume,
     Retrying,
@@ -36,7 +34,6 @@ from prefect.engine.state import (
     Scheduled,
     Skipped,
     State,
-    Submitted,
     Success,
     TimedOut,
     TriggerFailed,
@@ -63,13 +60,13 @@ class TaskRunner(Runner):
 
     Args:
         - task (Task): the Task to be run / executed
-        - state_handlers (Iterable[Callable], optional): A list of state change handlers
-            that will be called whenever the task changes state, providing an
-            opportunity to inspect or modify the new state. The handler
-            will be passed the task runner instance, the old (prior) state, and the new
-            (current) state, with the following signature: `state_handler(TaskRunner, old_state, new_state) -> Optional[State]`;
-            If multiple functions are passed, then the `new_state` argument will be the
-            result of the previous handler.
+        - state_handlers (Iterable[Callable], optional): A list of state change handlers that
+            will be called whenever the task changes state, providing an opportunity to inspect
+            or modify the new state. The handler will be passed the task runner instance, the
+            old (prior) state, and the new (current) state, with the following signature:
+            `state_handler(TaskRunner, old_state, new_state) -> Optional[State]`; If multiple
+            functions are passed, then the `new_state` argument will be the result of the
+            previous handler.
         - flow_result: the result instance configured for the flow (if any)
     """
 
@@ -128,7 +125,8 @@ class TaskRunner(Runner):
         state. Otherwise, we assume the run count is 1. The run count is stored in context as
         task_run_count.
 
-        Also, if the task is being resumed through a `Resume` state, updates context to have `resume=True`.
+        Also, if the task is being resumed through a `Resume` state, updates context to have
+        `resume=True`.
 
         Args:
             - state (Optional[State]): the initial state of the run
@@ -211,8 +209,8 @@ class TaskRunner(Runner):
                 representing the states of any tasks upstream of this one. The keys of the
                 dictionary should correspond to the edges leading to the task.
             - context (dict, optional): prefect Context to use for execution
-            - is_mapped_parent (bool): a boolean indicating whether this task run is the run of a parent
-                mapped task
+            - is_mapped_parent (bool): a boolean indicating whether this task run is the run of
+                a parent mapped task
 
         Returns:
             - `State` object representing the final post-run state of the Task
@@ -431,7 +429,7 @@ class TaskRunner(Runner):
         if state.is_mapped():
             raise ENDRUN(state)
 
-        ## we can't map if there are no success states with iterables upstream
+        # we can't map if there are no success states with iterables upstream
         if upstream_states and not any(
             [
                 edge.mapped and state.is_successful()
@@ -530,18 +528,16 @@ class TaskRunner(Runner):
         # are generated (note that if the children tasks)
         elif state.is_mapped():
             self.logger.debug(
-                "Task '{name}': task is mapped, but run will proceed so children are generated.".format(
-                    name=prefect.context.get("task_full_name", self.task.name)
-                )
+                "Task '%s': task is mapped, but run will proceed so children are generated.",
+                prefect.context.get("task_full_name", self.task.name),
             )
             return state
 
         # this task is already running
         elif state.is_running():
             self.logger.debug(
-                "Task '{name}': task is already running.".format(
-                    name=prefect.context.get("task_full_name", self.task.name)
-                )
+                "Task '%s': task is already running.",
+                prefect.context.get("task_full_name", self.task.name),
             )
             raise ENDRUN(state)
 
@@ -643,7 +639,8 @@ class TaskRunner(Runner):
         self, state: State, upstream_states: Dict[Edge, State]
     ) -> Tuple[State, Dict[Edge, State]]:
         """
-        Given the task's current state and upstream states, populates all relevant result objects for this task run.
+        Given the task's current state and upstream states, populates all relevant result
+        objects for this task run.
 
         Args:
             - state (State): the task's current state.
@@ -813,7 +810,9 @@ class TaskRunner(Runner):
             )
             timeout_handler = prefect.utilities.executors.timeout_handler
             if getattr(self.task, "log_stdout", False):
-                with redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger)):  # type: ignore
+                with redirect_stdout(
+                    prefect.utilities.logging.RedirectToLog(self.logger)  # type: ignore
+                ):
                     value = timeout_handler(
                         self.task.run, timeout=self.task.timeout, **raw_inputs
                     )
@@ -846,7 +845,8 @@ class TaskRunner(Runner):
             )
             return new_state
 
-        ## checkpoint tasks if a result is present, except for when the user has opted out by disabling checkpointing
+        # checkpoint tasks if a result is present, except for when the user has opted out by
+        # disabling checkpointing
         if (
             prefect.context.get("checkpointing") is True
             and self.task.checkpoint is not False
@@ -930,7 +930,8 @@ class TaskRunner(Runner):
                     value=prefect.context.get("task_loop_result")
                 )
 
-                ## checkpoint tasks if a result is present, except for when the user has opted out by disabling checkpointing
+                # checkpoint tasks if a result is present, except for when the user has opted
+                # out by disabling checkpointing
                 if (
                     prefect.context.get("checkpointing") is True
                     and self.task.checkpoint is not False
@@ -974,7 +975,8 @@ class TaskRunner(Runner):
         context: Dict[str, Any] = None,
     ) -> State:
         """
-        Checks to see if the task is in a `Looped` state and if so, rerun the pipeline with an incremeneted `loop_count`.
+        Checks to see if the task is in a `Looped` state and if so, rerun the pipeline with an
+        incremeneted `loop_count`.
 
         Args:
             - state (State, optional): initial `State` to begin task run from;

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -30,10 +30,12 @@ class Environment:
     The `setup` and `execute` functions of an environment require a Prefect Flow object.
 
     Args:
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
     """
 
@@ -129,11 +131,6 @@ def load_and_run_flow() -> None:
     """
     logger = logging.get_logger("Environment")
     try:
-        from prefect.engine import (
-            get_default_flow_runner_class,
-            get_default_executor_class,
-        )
-
         flow_run_id = prefect.context.get("flow_run_id")
 
         if not flow_run_id:
@@ -142,7 +139,7 @@ def load_and_run_flow() -> None:
         query = {
             "query": {
                 with_args("flow_run", {"where": {"id": {"_eq": flow_run_id}}}): {
-                    "flow": {"name": True, "storage": True,},
+                    "flow": {"name": True, "storage": True},
                 }
             }
         }
@@ -155,7 +152,7 @@ def load_and_run_flow() -> None:
         storage_schema = prefect.serialization.storage.StorageSchema()
         storage = storage_schema.load(flow_data.storage)
 
-        ## populate global secrets
+        # populate global secrets
         secrets = prefect.context.get("secrets", {})
         for secret in storage.secrets:
             secrets[secret] = prefect.tasks.secrets.PrefectSecret(name=secret).run()

--- a/src/prefect/environments/execution/dask/cloud_provider.py
+++ b/src/prefect/environments/execution/dask/cloud_provider.py
@@ -54,23 +54,28 @@ class DaskCloudProviderEnvironment(RemoteDaskEnvironment):
             are using.
         - adaptive_max_workers (int, optional): Maximum number of workers for adaptive
             mode.
-        - security (Type[Security], optional): a Dask Security object from `distributed.security.Security`.
-            Use this to connect to a Dask cluster that is enabled with TLS encryption.
-            For more on using TLS with Dask see https://distributed.dask.org/en/latest/tls.html
+        - security (Type[Security], optional): a Dask Security object from
+            `distributed.security.Security`.  Use this to connect to a Dask cluster that is
+            enabled with TLS encryption.  For more on using TLS with Dask see
+            https://distributed.dask.org/en/latest/tls.html
         - executor_kwargs (dict, optional): a dictionary of kwargs to be passed to
             the executor; defaults to an empty dictionary
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_execute (Callable[[Dict[str, Any], Dict[str, Any]], None], optional): a function callback which will
-            be called before the flow begins to run. The callback function can examine the Flow run
-            parameters and modify  kwargs to be passed to the Dask Cloud Provider class's constructor prior
-            to launching the Dask cluster for the Flow run. This allows for dynamically sizing the cluster based
-            on the Flow run parameters, e.g. settings n_workers. The callback function's signature should be:
-                `def on_execute(parameters: Dict[str, Any], provider_kwargs: Dict[str, Any]) -> None:`
-            The callback function may modify provider_kwargs (e.g. `provider_kwargs["n_workers"] = 3`) and any
-            relevant changes will be used when creating the Dask cluster via a Dask Cloud Provider class.
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_execute (Callable[[Dict[str, Any], Dict[str, Any]], None], optional): a function
+            callback which will be called before the flow begins to run. The callback function
+            can examine the Flow run parameters and modify  kwargs to be passed to the Dask
+            Cloud Provider class's constructor prior to launching the Dask cluster for the Flow
+            run.  This allows for dynamically sizing the cluster based on the Flow run
+            parameters, e.g.  settings n_workers. The callback function's signature should be:
+            `on_execute(parameters: Dict[str, Any], provider_kwargs: Dict[str, Any]) -> None`
+            The callback function may modify provider_kwargs
+            (e.g.  `provider_kwargs["n_workers"] = 3`) and any relevant changes will be used when
+            creating the Dask cluster via a Dask Cloud Provider class.
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
         - **kwargs (dict, optional): additional keyword arguments to pass to boto3 for
             `register_task_definition` and `run_task`
@@ -96,8 +101,9 @@ class DaskCloudProviderEnvironment(RemoteDaskEnvironment):
         self._on_execute = on_execute
         self._provider_kwargs = kwargs
         if "skip_cleanup" not in self._provider_kwargs:
-            # Prefer this default (if not provided) to avoid deregistering task definitions
-            # See this issue in Dask Cloud Provider: https://github.com/dask/dask-cloudprovider/issues/94
+            # Prefer this default (if not provided) to avoid deregistering task definitions See
+            # this issue in Dask Cloud Provider:
+            # https://github.com/dask/dask-cloudprovider/issues/94
             self._provider_kwargs["skip_cleanup"] = True
         self._security = security
         if self._security:

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -19,18 +19,22 @@ if TYPE_CHECKING:
 class DaskKubernetesEnvironment(Environment):
     """
     DaskKubernetesEnvironment is an environment which deploys your flow on Kubernetes by
-    spinning up a temporary Dask Cluster (using [dask-kubernetes](https://kubernetes.dask.org/en/latest/))
-    and running the Prefect `DaskExecutor` on this cluster.
+    spinning up a temporary Dask Cluster (using
+    [dask-kubernetes](https://kubernetes.dask.org/en/latest/)) and running the Prefect
+    `DaskExecutor` on this cluster.
 
-    When running your flows that are registered with a private container registry, you
-    should either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment`
+    When running your flows that are registered with a private container registry, you should
+    either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment`
     or directly set the `imagePullSecrets` on your custom worker/scheduler specs.
 
-    It is possible to provide a custom scheduler and worker spec YAML files through the `scheduler_spec_file` and
-    `worker_spec_file` arguments. These specs (if provided) will be used in place of the defaults. Your spec files
-    should be modeled after the job.yaml and worker_pod.yaml found [here](https://github.com/PrefectHQ/prefect/tree/master/src/prefect/environments/execution/dask).
-    The main aspects to be aware of are the `command` and `args` on the container. The following environment variables, required for cloud,
-    do not need to be included––they are automatically added and populated during execution:
+    It is possible to provide a custom scheduler and worker spec YAML files through the
+    `scheduler_spec_file` and `worker_spec_file` arguments. These specs (if provided) will be
+    used in place of the defaults. Your spec files should be modeled after the job.yaml and
+    worker_pod.yaml found
+    [here](https://github.com/PrefectHQ/prefect/tree/master/src/prefect/environments/execution/dask).
+    The main aspects to be aware of are the `command` and `args` on the container. The
+    following environment variables, required for cloud, do not need to be included––they are
+    automatically added and populated during execution:
 
     - `PREFECT__CLOUD__GRAPHQL`
     - `PREFECT__CLOUD__AUTH_TOKEN`
@@ -47,25 +51,30 @@ class DaskKubernetesEnvironment(Environment):
     Args:
         - min_workers (int, optional): the minimum allowed number of Dask worker pods; defaults to 1
         - max_workers (int, optional): the maximum allowed number of Dask worker pods; defaults to 1
-        - work_stealing (bool, optional): toggle Dask Distributed scheduler work stealing; defaults to False
-            Only used when a custom scheduler spec is not provided. Enabling this may cause ClientErrors
-            to appear when multiple Dask workers try to run the same Prefect Task.
+        - work_stealing (bool, optional): toggle Dask Distributed scheduler work stealing;
+            defaults to False Only used when a custom scheduler spec is not provided. Enabling
+            this may cause ClientErrors to appear when multiple Dask workers try to run the
+            same Prefect Task.
         - scheduler_logs (bool, optional): log all Dask scheduler logs, defaults to False
-        - private_registry (bool, optional, DEPRECATED): a boolean specifying whether your Flow's Docker container will be in a private
-            Docker registry; if so, requires a Prefect Secret containing your docker credentials to be set.
-            Defaults to `False`.
-        - docker_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing your Docker credentials; defaults to
-            `"DOCKER_REGISTRY_CREDENTIALS"`.  This Secret should be a dictionary containing the following keys: `"docker-server"`,
+        - private_registry (bool, optional, DEPRECATED): a boolean specifying whether your
+            Flow's Docker container will be in a private Docker registry; if so, requires a
+            Prefect Secret containing your docker credentials to be set.  Defaults to `False`.
+        - docker_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing
+            your Docker credentials; defaults to `"DOCKER_REGISTRY_CREDENTIALS"`.  This Secret
+            should be a dictionary containing the following keys: `"docker-server"`,
             `"docker-username"`, `"docker-password"`, and `"docker-email"`.
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
         - scheduler_spec_file (str, optional): Path to a scheduler spec YAML file
         - worker_spec_file (str, optional): Path to a worker spec YAML file
-        - image_pull_secret (str, optional): optional name of an `imagePullSecret` to use for the scheduler and worker
-            pods. For more information go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+        - image_pull_secret (str, optional): optional name of an `imagePullSecret` to use for
+            the scheduler and worker pods. For more information go
+            [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     """
 
     def __init__(
@@ -93,7 +102,8 @@ class DaskKubernetesEnvironment(Environment):
             self.docker_secret = docker_secret or "DOCKER_REGISTRY_CREDENTIALS"
 
             warnings.warn(
-                "The `private_registry` and `docker_secret` options are deprecated. Please set `imagePullSecrets` on custom work and scheduler YAML manifests.",
+                "The `private_registry` and `docker_secret` options are deprecated. "
+                "Please set `imagePullSecrets` on custom work and scheduler YAML manifests.",
                 stacklevel=2,
             )
         else:
@@ -421,7 +431,8 @@ class DaskKubernetesEnvironment(Environment):
 
     def _populate_scheduler_spec_yaml(self, yaml_obj: dict, docker_name: str) -> dict:
         """
-        Populate the custom execution job yaml object used in this environment with the proper values
+        Populate the custom execution job yaml object used in this environment with the proper
+        values.
 
         Args:
             - yaml_obj (dict): A dictionary representing the parsed yaml

--- a/src/prefect/environments/execution/dask/remote.py
+++ b/src/prefect/environments/execution/dask/remote.py
@@ -37,14 +37,17 @@ class RemoteDaskEnvironment(RemoteEnvironment):
     Args:
         - address (str): an address of the scheduler of a Dask cluster in URL form,
             e.g. `tcp://172.33.17.28:8786`
-        - security (Security, optional): a Dask Security object from `distributed.security.Security`.
-            Use this to connect to a Dask cluster that is enabled with TLS encryption.
+        - security (Security, optional): a Dask Security object from
+          `distributed.security.Security`.  Use this to connect to a Dask cluster that is
+          enabled with TLS encryption.
         - executor_kwargs (dict, optional): a dictionary of kwargs to be passed to
             the executor; defaults to an empty dictionary
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
     """
 

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -44,7 +44,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
 
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task
 
-    Note: You must provide `family` and `taskDefinition` with the same string so they match on run of the task.
+    Note: You must provide `family` and `taskDefinition` with the same string so they match on
+    run of the task.
 
     The secrets and kwargs that are provided at initialization time of this environment
     are not serialized and will only ever exist on this object.
@@ -68,10 +69,12 @@ class FargateTaskEnvironment(Environment, _RunMixin):
         - executor (Executor, optional): the executor to run the flow with. If not provided, the
             default executor will be used.
         - executor_kwargs (dict, optional): DEPRECATED
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
         - **kwargs (dict, optional): additional keyword arguments to pass to boto3 for
             `register_task_definition` and `run_task`

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -40,15 +40,17 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
 
     Args:
         - job_spec_file (str, optional): Path to a job spec YAML file
-        - unique_job_name (bool, optional): whether to use a unique name for each job created with this environment. Defaults
-            to `False`
+        - unique_job_name (bool, optional): whether to use a unique name for each job created
+            with this environment. Defaults to `False`
         - executor (Executor, optional): the executor to run the flow with. If not provided, the
             default executor will be used.
         - executor_kwargs (dict, optional): DEPRECATED
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
         - metadata (dict, optional): extra metadata to be set and serialized on this environment
     """
 
@@ -152,7 +154,8 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
 
     def _populate_job_spec_yaml(self, yaml_obj: dict, docker_name: str,) -> dict:
         """
-        Populate the custom execution job yaml object used in this environment with the proper values
+        Populate the custom execution job yaml object used in this environment with the proper
+        values.
 
         Args:
             - yaml_obj (dict): A dictionary representing the parsed yaml

--- a/src/prefect/environments/execution/local.py
+++ b/src/prefect/environments/execution/local.py
@@ -14,11 +14,14 @@ class LocalEnvironment(Environment, _RunMixin):
     Args:
         - executor (Executor, optional): the executor to run the flow with. If not provided, the
             default executor will be used.
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
-        - metadata (dict, optional): extra metadata to be set and serialized on this environment
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
+        - metadata (dict, optional): extra metadata to be set and serialized on this
+            environment
     """
 
     def __init__(

--- a/src/prefect/environments/execution/remote.py
+++ b/src/prefect/environments/execution/remote.py
@@ -31,11 +31,14 @@ class RemoteEnvironment(Environment):
             to `prefect.config.engine.executor.default_class`
         - executor_kwargs (dict, optional): a dictionary of kwargs to be passed to
             the executor; defaults to an empty dictionary
-        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect
-            Agents when polling for work
-        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
-        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
-        - metadata (dict, optional): extra metadata to be set and serialized on this environment
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the
+            flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow
+            finishes its run
+        - metadata (dict, optional): extra metadata to be set and serialized on this
+            environment
     """
 
     def __init__(

--- a/src/prefect/environments/storage/_healthcheck.py
+++ b/src/prefect/environments/storage/_healthcheck.py
@@ -19,7 +19,11 @@ def system_check(python_version: str):
         sys.version_info.minor < python_version[1]
         or sys.version_info.minor > python_version[1]
     ):
-        msg = "Your Docker container is using python version {sys_ver}, but your Flow was serialized using {user_ver}; this could lead to unexpected errors in deployment.".format(
+        msg = (
+            "Your Docker container is using python version {sys_ver}, but your Flow was "
+            "serialized using {user_ver}; this could lead to unexpected errors in "
+            "deployment."
+        ).format(
             sys_ver=(sys.version_info.major, sys.version_info.minor),
             user_ver=python_version,
         )
@@ -47,7 +51,7 @@ def result_check(flows: list):
         if flow.result is not None:
             continue
 
-        ## test for tasks which might retry without upstream result handlers
+        # test for tasks which might retry without upstream result handlers
         retry_tasks = [t for t in flow.tasks if t.max_retries > 0]
         upstream_edges = flow.all_upstream_edges()
         for task in retry_tasks:
@@ -59,19 +63,19 @@ def result_check(flows: list):
                 ]
             ):
                 raise ValueError(
-                    "Task {} has retry settings but some upstream dependencies do not have result types. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
-                        task
-                    )
+                    f"Task {task} has retry settings but some upstream dependencies do not "
+                    f"have result types. See https://docs.prefect.io/core/concepts/results.html "
+                    f"for more details."
                 )
 
-        ## test for tasks which request caching with no result handler or no upstream result handlers
+        # test for tasks which request caching with no result handler or no upstream result handlers
         cached_tasks = [t for t in flow.tasks if t.cache_for is not None]
         for task in cached_tasks:
             if task.result is None:
                 raise ValueError(
-                    "Task {} has cache settings but does not have a result type. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
-                        task
-                    )
+                    f"Task {task} has cache settings but does not have a result type. "
+                    f"See https://docs.prefect.io/core/concepts/results.html for more "
+                    f"details."
                 )
             if any(
                 [
@@ -81,9 +85,9 @@ def result_check(flows: list):
                 ]
             ):
                 raise ValueError(
-                    "Task {} has cache settings but some upstream dependencies do not have result types. See https://docs.prefect.io/core/concepts/results.html for more details.".format(
-                        task
-                    )
+                    f"Task {task} has cache settings but some upstream dependencies do not have "
+                    f"result types. See https://docs.prefect.io/core/concepts/results.html for "
+                    f"more details."
                 )
     print("Result check: OK")
 

--- a/src/prefect/environments/storage/azure.py
+++ b/src/prefect/environments/storage/azure.py
@@ -27,8 +27,8 @@ class Azure(Storage):
     Args:
         - container (str): the name of the Azure Blob Container to store the Flow
         - connection_string (str, optional): an Azure connection string for communicating with
-            Blob storage. If not provided the value set in the environment as `AZURE_STORAGE_CONNECTION_STRING`
-            will be used
+            Blob storage. If not provided the value set in the environment as
+            `AZURE_STORAGE_CONNECTION_STRING` will be used
         - blob_name (str, optional): a unique key to use for uploading this Flow to Azure. This
             is only useful when storing a single Flow using this storage object.
         - **kwargs (Any, optional): any additional `Storage` initialization options
@@ -74,7 +74,7 @@ class Azure(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if not flow_location in self.flows.values():
+        if flow_location not in self.flows.values():
             raise ValueError("Flow is not contained in this Storage")
 
         client = self._azure_block_blob_service.get_blob_client(

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -19,12 +19,13 @@ class Storage(metaclass=ABCMeta):
     Args:
         - result (Result, optional): a default result to use for
             all flows which utilize this storage class
-        - secrets (List[str], optional): a list of Prefect Secrets which will be used to populate `prefect.context`
-            for each flow run.  Used primarily for providing authentication credentials.
+        - secrets (List[str], optional): a list of Prefect Secrets which will be used to
+            populate `prefect.context` for each flow run.  Used primarily for providing
+            authentication credentials.
         - labels (List[str], optional): a list of labels to associate with this `Storage`.
-        - add_default_labels (bool): If `True`, adds the storage specific default label (if applicable)
-            to the storage labels. Defaults to the value specified in the configuration at
-            `flows.defaults.storage.add_default_labels`.
+        - add_default_labels (bool): If `True`, adds the storage specific default label (if
+            applicable) to the storage labels. Defaults to the value specified in the
+            configuration at `flows.defaults.storage.add_default_labels`.
     """
 
     def __init__(

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -67,10 +67,12 @@ class Docker(Storage):
             are included.
         - base_url (str, optional): a URL of a Docker daemon to use when for
             Docker related functionality.  Defaults to DOCKER_HOST env var if not set
-        - tls_config (Union[bool, docker.tls.TLSConfig], optional): a TLS configuration to pass to the Docker
-            client. [Documentation](https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig)
-        - build_kwargs (dict, optional): Additional keyword arguments to pass to Docker's build step.
-            [Documentation](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.build.BuildApiMixin.build)
+        - tls_config (Union[bool, docker.tls.TLSConfig], optional): a TLS configuration to pass
+            to the Docker client.
+            [Documentation](https://docker-py.readthedocs.io/en/stable/tls.html#docker.tls.TLSConfig)
+        - build_kwargs (dict, optional): Additional keyword arguments to pass to Docker's build
+            step. [Documentation](https://docker-py.readthedocs.io/en/stable/
+            api.html#docker.api.build.BuildApiMixin.build)
         - **kwargs (Any, optional): any additional `Storage` initialization options
 
     Raises:
@@ -94,7 +96,7 @@ class Docker(Storage):
         base_url: str = None,
         tls_config: Union[bool, "docker.tls.TLSConfig"] = False,
         build_kwargs: dict = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         self.registry_url = registry_url
         if sys.platform == "win32":
@@ -132,7 +134,7 @@ class Docker(Storage):
             python_version = "{}.{}".format(
                 sys.version_info.major, sys.version_info.minor
             )
-            if re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", self.prefect_version) != None:
+            if re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", self.prefect_version) is not None:
                 self.base_image = "prefecthq/prefect:{}-python{}".format(
                     self.prefect_version, python_version
                 )
@@ -150,12 +152,12 @@ class Docker(Storage):
             self.base_image = base_image  # type: ignore
 
         self.dockerfile = dockerfile
-        # we should always try to install prefect, unless it is already installed. We can't determine this until
-        # image build time.
+        # we should always try to install prefect, unless it is already installed. We can't
+        # determine this until image build time.
         self.extra_commands.append(
-            "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@{}#egg=prefect[kubernetes]".format(
-                self.prefect_version
-            )
+            f"pip show prefect || "
+            f"pip install git+https://github.com/PrefectHQ/prefect.git"
+            f"@{self.prefect_version}#egg=prefect[kubernetes]"
         )
 
         not_absolute = [
@@ -163,9 +165,10 @@ class Docker(Storage):
         ]
         if not_absolute:
             raise ValueError(
-                "Provided paths {} are not absolute file paths, please provide absolute paths only.".format(
-                    ", ".join(not_absolute)
-                )
+                (
+                    "Provided paths {} are not absolute file paths, please provide "
+                    "absolute paths only."
+                ).format(", ".join(not_absolute))
             )
         super().__init__(**kwargs)
 
@@ -190,8 +193,9 @@ class Docker(Storage):
             client = self._get_client()
             container = client.create_container(image, command="tail -f /dev/null")
             client.start(container=container.get("Id"))
-            python_script = "import cloudpickle; f = open('{}', 'rb'); flow = cloudpickle.load(f); f.close(); flow.run()".format(
-                flow_location
+            python_script = (
+                f"import cloudpickle; f = open('{flow_location}', 'rb'); "
+                f"flow = cloudpickle.load(f); f.close(); flow.run()"
             )
             try:
                 ee = client.exec_create(

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -14,10 +14,11 @@ if TYPE_CHECKING:
 
 class GCS(Storage):
     """
-    GoogleCloudStorage storage class.  This class represents the Storage interface for Flows stored as
-    bytes in an GCS bucket.  To authenticate with Google Cloud, you need to ensure that your Prefect
-    Agent has the proper credentials available (see https://cloud.google.com/docs/authentication/production
-    for all the authentication options).
+    GoogleCloudStorage storage class.  This class represents the Storage interface for Flows
+    stored as bytes in an GCS bucket.  To authenticate with Google Cloud, you need to ensure
+    that your Prefect Agent has the proper credentials available (see
+    https://cloud.google.com/docs/authentication/production for all the authentication
+    options).
 
     This storage class optionally takes a `key` which will be the name of the Flow object
     when stored in GCS. If this key is not provided the Flow upload name will take the form
@@ -66,7 +67,7 @@ class GCS(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if not flow_location in self.flows.values():
+        if flow_location not in self.flows.values():
             raise ValueError("Flow is not contained in this Storage")
 
         bucket = self._gcs_client.get_bucket(self.bucket)

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -71,7 +71,7 @@ class Local(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if not flow_location in self.flows.values():
+        if flow_location not in self.flows.values():
             raise ValueError("Flow is not contained in this Storage")
 
         return prefect.core.flow.Flow.load(flow_location)

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -65,7 +65,7 @@ class S3(Storage):
             - ValueError: if the Flow is not contained in this storage
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
-        if not flow_location in self.flows.values():
+        if flow_location not in self.flows.values():
             raise ValueError("Flow is not contained in this Storage")
 
         stream = io.BytesIO()
@@ -83,7 +83,7 @@ class S3(Storage):
             self.logger.error("Error downloading Flow from S3: {}".format(err))
             raise err
 
-        ## prepare data and return
+        # prepare data and return
         stream.seek(0)
         output = stream.read()
 

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -48,9 +48,9 @@ class Clock:
     Args:
         - start_date (datetime, optional): an optional start date for the clock
         - end_date (datetime, optional): an optional end date for the clock
-        - parameter_defaults (dict, optional): an optional dictionary of default Parameter values;
-            if provided, these values will be passed as the Parameter values for all Flow Runs which are
-            run on this clock's events
+        - parameter_defaults (dict, optional): an optional dictionary of default Parameter
+            values; if provided, these values will be passed as the Parameter values for all
+            Flow Runs which are run on this clock's events
 
     """
 
@@ -106,9 +106,9 @@ class IntervalClock(Clock):
         - start_date (datetime, optional): first date of clock. If None, will be set to
             "2019-01-01 00:00:00 UTC"
         - end_date (datetime, optional): an optional end date for the clock
-        - parameter_defaults (dict, optional): an optional dictionary of default Parameter values;
-            if provided, these values will be passed as the Parameter values for all Flow Runs which are
-            run on this clock's events
+        - parameter_defaults (dict, optional): an optional dictionary of default Parameter
+            values; if provided, these values will be passed as the Parameter values for all
+            Flow Runs which are run on this clock's events
 
     Raises:
         - TypeError: if start_date is not a datetime
@@ -206,9 +206,9 @@ class CronClock(Clock):
         - cron (str): a valid cron string
         - start_date (datetime, optional): an optional start date for the clock
         - end_date (datetime, optional): an optional end date for the clock
-        - parameter_defaults (dict, optional): an optional dictionary of default Parameter values;
-            if provided, these values will be passed as the Parameter values for all Flow Runs which are
-            run on this clock's events
+        - parameter_defaults (dict, optional): an optional dictionary of default Parameter
+            values; if provided, these values will be passed as the Parameter values for all
+            Flow Runs which are run on this clock's events
 
     Raises:
         - ValueError: if the cron string is invalid
@@ -299,9 +299,9 @@ class DatesClock(Clock):
 
     Args:
         - dates (List[datetime]): a list of `datetimes` on which the clock should fire
-        - parameter_defaults (dict, optional): an optional dictionary of default Parameter values;
-            if provided, these values will be passed as the Parameter values for all Flow Runs which are
-            run on this clock's events
+        - parameter_defaults (dict, optional): an optional dictionary of default Parameter
+            values; if provided, these values will be passed as the Parameter values for all
+            Flow Runs which are run on this clock's events
     """
 
     def __init__(self, dates: List[datetime], parameter_defaults: dict = None):

--- a/src/prefect/schedules/schedules.py
+++ b/src/prefect/schedules/schedules.py
@@ -12,11 +12,12 @@ import prefect.schedules.filters
 
 class Schedule:
     """
-    Schedules are used to generate dates for flow runs. Scheduling logic works as follows: First off, 
-    candidate events are emitted by one or more `clocks`. Secondly, if filters were specified, 
-    they are applied in this order: all `filters` must return True, at least one `or_filter` must 
-    return True, then all `not_filters` must return False. Thridly, events that pass the filters 
-    are adjusted based on the `adjustments` functions. Finally, the resulting `datetime` is emitted.
+    Schedules are used to generate dates for flow runs. Scheduling logic works as follows:
+    First off, candidate events are emitted by one or more `clocks`. Secondly, if filters were
+    specified, they are applied in this order: all `filters` must return True, at least one
+    `or_filter` must return True, then all `not_filters` must return False. Thridly, events
+    that pass the filters are adjusted based on the `adjustments` functions. Finally, the
+    resulting `datetime` is emitted.
 
     Example:
 
@@ -33,7 +34,10 @@ class Schedule:
         filters=[filters.is_weekday],
 
         # only include 9am and 5pm
-        or_filters=[filters.between_times(time(9), time(9)), filters.between_times(time(17), time(17))]
+        or_filters=[
+            filters.between_times(time(9), time(9)),
+            filters.between_times(time(17), time(17))
+        ]
     )
 
     schedule.next(4) # returns the next 4 occurences of 9am and 5pm on weekdays
@@ -92,8 +96,9 @@ class Schedule:
             - n (int): the number of dates to return
             - after (datetime): an optional starting point. All returned dates will be after this
                 time.
-            - return_events (bool, optional): an optional boolean specifying whether to return a full
-                Clock Event or just the start_time of the associated event; defaults to `False`
+            - return_events (bool, optional): an optional boolean specifying whether to return
+                a full Clock Event or just the start_time of the associated event; defaults to
+                `False`
 
         Returns:
             - List[datetime]: a list of datetimes
@@ -132,7 +137,8 @@ class Schedule:
         # this next line yields items only if they differ from the previous item, which means
         # this generator only yields unique events (since the input is sorted)
         #
-        # code from `unique_justseen()` at https://docs.python.org/3/library/itertools.html#itertools-recipes
+        # code from `unique_justseen()` at
+        # https://docs.python.org/3/library/itertools.html#itertools-recipes
         unique_events = map(
             next, map(operator.itemgetter(1), itertools.groupby(sorted_events))
         )  # type: Iterable[prefect.schedules.clocks.ClockEvent]

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -9,7 +9,6 @@ from prefect.serialization.schedule import ScheduleSchema
 from prefect.serialization.storage import StorageSchema
 from prefect.serialization.task import ParameterSchema, TaskSchema
 from prefect.utilities.serialization import (
-    JSONCompatible,
     Nested,
     ObjectSchema,
     to_qualified_name,

--- a/src/prefect/serialization/result_handlers.py
+++ b/src/prefect/serialization/result_handlers.py
@@ -9,10 +9,8 @@ from prefect.engine.result_handlers import (
     LocalResultHandler,
     ResultHandler,
     S3ResultHandler,
-    SecretResultHandler,
 )
 from prefect.utilities.serialization import (
-    JSONCompatible,
     ObjectSchema,
     OneOfSchema,
     to_qualified_name,

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -10,7 +10,6 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     OneOfSchema,
     StatefulFunctionReference,
-    to_qualified_name,
 )
 
 FILTERS = [

--- a/src/prefect/serialization/schedule_compat.py
+++ b/src/prefect/serialization/schedule_compat.py
@@ -10,8 +10,6 @@ import prefect
 from prefect.utilities.serialization import (
     DateTimeTZ,
     ObjectSchema,
-    OneOfSchema,
-    to_qualified_name,
 )
 
 

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from marshmallow import fields, post_load
 
@@ -9,11 +9,7 @@ from prefect.utilities.serialization import (
     Nested,
     ObjectSchema,
     OneOfSchema,
-    to_qualified_name,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 def get_safe(obj: state.State, context: dict) -> Any:

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -4,13 +4,9 @@ from marshmallow import fields, post_load
 
 import prefect
 from prefect.utilities.serialization import (
-    UUID,
-    FunctionReference,
     JSONCompatible,
     ObjectSchema,
-    OneOfSchema,
     StatefulFunctionReference,
-    from_qualified_name,
     to_qualified_name,
 )
 

--- a/src/prefect/tasks/aws/lambda_function.py
+++ b/src/prefect/tasks/aws/lambda_function.py
@@ -79,7 +79,7 @@ class LambdaCreate(Task):
         self.role = role
         self.handler = handler
 
-        ## if zip file is provided, pass this to boto3 create, otherwise pass s3 object
+        # if zip file is provided, pass this to boto3 create, otherwise pass s3 object
         if zip_file:
             self.code = {"ZipFile": open(zip_file, "rb").read()}
         else:
@@ -124,7 +124,7 @@ class LambdaCreate(Task):
 
         lambda_client = get_boto_client("lambda", credentials=credentials)
 
-        ## create lambda function
+        # create lambda function
         response = lambda_client.create_function(
             FunctionName=self.function_name,
             Runtime=self.runtime,
@@ -181,7 +181,7 @@ class LambdaDelete(Task):
 
         lambda_client = get_boto_client("lambda", credentials=credentials)
 
-        ## delete function, depending on if qualifier provided
+        # delete function, depending on if qualifier provided
         if len(self.qualifier) > 0:
             response = lambda_client.delete_function(
                 FunctionName=self.function_name, Qualifier=self.qualifier
@@ -228,7 +228,7 @@ class LambdaInvoke(Task):
         self.invocation_type = invocation_type
         self.log_type = log_type
 
-        ## encode input dictionary as base64 json
+        # encode input dictionary as base64 json
         self.client_context = self._encode_lambda_context(**(client_context or {}))
 
         self.payload = payload
@@ -276,7 +276,7 @@ class LambdaInvoke(Task):
 
         lambda_client = get_boto_client("lambda", credentials=credentials)
 
-        ## invoke lambda function
+        # invoke lambda function
         response = lambda_client.invoke(
             FunctionName=function_name,
             InvocationType=self.invocation_type,
@@ -337,7 +337,7 @@ class LambdaList(Task):
 
         lambda_client = get_boto_client("lambda", credentials=credentials)
 
-        ## list functions, optionally passing in marker if not None
+        # list functions, optionally passing in marker if not None
         if self.marker:
             response = lambda_client.list_functions(
                 MasterRegion=self.master_region,

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -11,9 +11,10 @@ class S3Download(Task):
     Task for downloading data from an S3 bucket and returning it as a string.
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
-    For authentication, there are two options: you can set the `AWS_CREDENTIALS` Prefect Secret containing
-    your AWS access keys which will be passed directly to the `boto3` client, or you can
-    [configure your flow's runtime environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    For authentication, there are two options: you can set the `AWS_CREDENTIALS` Prefect Secret
+    containing your AWS access keys which will be passed directly to the `boto3` client, or you
+    can [configure your flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
     for `boto3`.
 
     Args:
@@ -52,10 +53,10 @@ class S3Download(Task):
 
         stream = io.BytesIO()
 
-        ## download
+        # download
         s3_client.download_fileobj(Bucket=bucket, Key=key, Fileobj=stream)
 
-        ## prepare data and return
+        # prepare data and return
         stream.seek(0)
         output = stream.read()
         return output.decode()
@@ -66,9 +67,10 @@ class S3Upload(Task):
     Task for uploading string data (e.g., a JSON string) to an S3 bucket.
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
-    For authentication, there are two options: you can set a Prefect Secret containing
-    your AWS access keys which will be passed directly to the `boto3` client, or you can
-    [configure your flow's runtime environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    For authentication, there are two options: you can set a Prefect Secret containing your AWS
+    access keys which will be passed directly to the `boto3` client, or you can [configure your
+    flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
     for `boto3`.
 
     Args:
@@ -107,16 +109,16 @@ class S3Upload(Task):
 
         s3_client = get_boto_client("s3", credentials=credentials)
 
-        ## prepare data
+        # prepare data
         try:
             stream = io.BytesIO(data)
         except TypeError:
             stream = io.BytesIO(data.encode())
 
-        ## create key if not provided
+        # create key if not provided
         if key is None:
             key = str(uuid.uuid4())
 
-        ## upload
+        # upload
         s3_client.upload_fileobj(stream, Bucket=bucket, Key=key)
         return key

--- a/src/prefect/tasks/azure/blobstorage.py
+++ b/src/prefect/tasks/azure/blobstorage.py
@@ -118,7 +118,7 @@ class BlobStorageUpload(Task):
 
         blob_service = azure.storage.blob.BlockBlobService(conn_str=azure_credentials)
 
-        ## create key if not provided
+        # create key if not provided
         if blob_name is None:
             blob_name = str(uuid.uuid4())
 

--- a/src/prefect/tasks/azure/cosmosdb.py
+++ b/src/prefect/tasks/azure/cosmosdb.py
@@ -9,20 +9,20 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class CosmosDBCreateItem(Task):
     """
-    Task for creating an item in a Azure Cosmos database. 
+    Task for creating an item in a Azure Cosmos database.
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
     Args:
         - url (str, optional): The url to the database.
         - database_or_container_link (str, optional): link to the database or container.
         - item (dict, optional): the item to create
-        - azure_credentials_secret (str, optional): the name of the Prefect Secret
-            that stores your Azure credentials; this Secret must be JSON string with the key
-            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-            where the `masterKey` value is the default authorization key to use to
-            create the client, and `resourceTokens` value is the alternative
+        - azure_credentials_secret (str, optional): the name of the Prefect Secret that stores
+            your Azure credentials; this Secret must be JSON string with the key
+            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+            `resourceTokens`, where the `masterKey` value is the default authorization key to
+            use to create the client, and `resourceTokens` value is the alternative
             authorization key.
-        - options (dict, optional): options to be passed to the 
+        - options (dict, optional): options to be passed to the
             `azure.cosmos.cosmos_client.CosmosClient.CreateItem` method.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -67,12 +67,12 @@ class CosmosDBCreateItem(Task):
             - database_or_container_link (str, optional): link to the database or container.
             - item (dict, optional): the item to create
             - azure_credentials_secret (str, optional): the name of the Prefect Secret
-                that stores your Azure credentials; this Secret must be JSON string with the key
-                `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-                where the `masterKey` value is the default authorization key to use to
-                create the client, and `resourceTokens` value is the alternative
+                that stores your Azure credentials; this Secret must be JSON string with the
+                key `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+                `resourceTokens`, where the `masterKey` value is the default authorization key
+                to use to create the client, and `resourceTokens` value is the alternative
                 authorization key.
-            - options (dict, optional): options to be passed to the 
+            - options (dict, optional): options to be passed to the
                 `azure.cosmos.cosmos_client.CosmosClient.CreateItem` method.
 
         Returns:
@@ -104,21 +104,21 @@ class CosmosDBCreateItem(Task):
 
 class CosmosDBReadItems(Task):
     """
-    Task for reading items from a Azure Cosmos database.  
+    Task for reading items from a Azure Cosmos database.
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
     Args:
         - url (str, optional): The url to the database.
-        - document_or_container_link (str, optional): link to a document or container. 
-            If a document link is provided, the document in question is returned, otherwise 
+        - document_or_container_link (str, optional): link to a document or container.
+            If a document link is provided, the document in question is returned, otherwise
             all docuements are returned.
         - azure_credentials_secret (str, optional): the name of the Prefect Secret
             that stores your Azure credentials; this Secret must be JSON string with the key
-            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-            where the `masterKey` value is the default authorization key to use to
-            create the client, and `resourceTokens` value is the alternative
+            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+            `resourceTokens`, where the `masterKey` value is the default authorization key to
+            use to create the client, and `resourceTokens` value is the alternative
             authorization key.
-        - options (dict, optional): options to be passed to the 
+        - options (dict, optional): options to be passed to the
             `azure.cosmos.cosmos_client.CosmosClient.ReadItem` or `ReadItems` method.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -154,20 +154,20 @@ class CosmosDBReadItems(Task):
 
         Args:
             - url (str, optional): The url to the database.
-            - document_or_container_link (str, optional): link to a document or container. 
-                If a document link is provided, the document in question is returned, otherwise 
+            - document_or_container_link (str, optional): link to a document or container.
+                If a document link is provided, the document in question is returned, otherwise
                 all docuements are returned.
             - azure_credentials_secret (str, optional): the name of the Prefect Secret
-                that stores your Azure credentials; this Secret must be JSON string with the key
-                `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-                where the `masterKey` value is the default authorization key to use to
-                create the client, and `resourceTokens` value is the alternative
+                that stores your Azure credentials; this Secret must be JSON string with the
+                key `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+                `resourceTokens`, where the `masterKey` value is the default authorization key
+                to use to create the client, and `resourceTokens` value is the alternative
                 authorization key.
-            - options (dict, optional): options to be passed to the 
+            - options (dict, optional): options to be passed to the
                 `azure.cosmos.cosmos_client.CosmosClient.ReadItem` or `ReadItems` method.
 
         Returns:
-            - (dict or list)): a single document or all documents. 
+            - (dict or list)): a single document or all documents.
         """
 
         if url is None:
@@ -210,7 +210,7 @@ class CosmosDBReadItems(Task):
 
 class CosmosDBQueryItems(Task):
     """
-    Task for creating an item in a Azure Cosmos database. 
+    Task for creating an item in a Azure Cosmos database.
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
     Args:
@@ -219,11 +219,11 @@ class CosmosDBQueryItems(Task):
         - query (dict, optional): the query to run
         - azure_credentials_secret (str, optional): the name of the Prefect Secret
             that stores your Azure credentials; this Secret must be JSON string with the key
-            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-            where the `masterKey` value is the default authorization key to use to
-            create the client, and `resourceTokens` value is the alternative
+            `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+            `resourceTokens`, where the `masterKey` value is the default authorization key to
+            use to create the client, and `resourceTokens` value is the alternative
             authorization key.
-        - options (dict, optional): options to be passed to the 
+        - options (dict, optional): options to be passed to the
             `azure.cosmos.cosmos_client.CosmosClient.QueryItems` method.
         - partition_key (str, None): Partition key for the query.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
@@ -273,17 +273,17 @@ class CosmosDBQueryItems(Task):
             - database_or_container_link (str, optional): link to the database or container.
             - query (dict, optional): the query to run
             - azure_credentials_secret (str, optional): the name of the Prefect Secret
-                that stores your Azure credentials; this Secret must be JSON string with the key
-                `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or `resourceTokens`, 
-                where the `masterKey` value is the default authorization key to use to
-                create the client, and `resourceTokens` value is the alternative
+                that stores your Azure credentials; this Secret must be JSON string with the
+                key `AZ_COSMOS_AUTH`. The value should be dictionary containing `masterKey` or
+                `resourceTokens`, where the `masterKey` value is the default authorization key
+                to use to create the client, and `resourceTokens` value is the alternative
                 authorization key.
-            - options (dict, optional): options to be passed to the 
+            - options (dict, optional): options to be passed to the
                 `azure.cosmos.cosmos_client.CosmosClient.QueryItems` method.
             - partition_key (str, None): Partition key for the query.
 
         Returns:
-            - (list): a list containing the query results, one item per row.  
+            - (list): a list containing the query results, one item per row.
         """
 
         if url is None:

--- a/src/prefect/tasks/azureml/dataset.py
+++ b/src/prefect/tasks/azureml/dataset.py
@@ -11,25 +11,44 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class DatasetCreateFromDelimitedFiles(Task):
     """
-    Task for creating a TabularDataset from delimited files for use in a Azure Machine Learning service Workspace. The files should exist in a Datastore.
-    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+    Task for creating a TabularDataset from delimited files for use in a Azure Machine Learning
+    service Workspace. The files should exist in a Datastore.  Note that all initialization
+    arguments can optionally be provided or overwritten at runtime.
 
     Args:
         - dataset_name (str, optional): The name of the Dataset in the Workspace
-        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
-        - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
+        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the
+            files.
+        - path (Union[str, List[str]], optional): The path to the delimited files in the
+            Datastore.
         - dataset_description (str, optional): Description of the Dataset.
         - dataset_tags (str, optional): Tags to associate with the Dataset.
-        - include_path (bool, optional): Boolean to keep path information as column in the dataset.
+        - include_path (bool, optional): Boolean to keep path information as column in the
+            dataset.
         - infer_column_types (bool, optional): Boolean to infer column data types.
-        - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set column data type, where key is column name and value is a `azureml.data.DataType`.
+        - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set
+            column data type, where key is column name and value is a `azureml.data.DataType`.
         - fine_grain_timestamp (str, optional): The name of column as fine grain timestamp.
         - coarse_grain_timestamp (str, optional): The name of column coarse grain timestamp.
         - separator (str, optional): The separator used to split columns.
-        - header (azureml.data.dataset_type_definitions.PromoteHeadersBehavior, optional): Controls how column headers are promoted when reading from files. Defaults to assume that all files have the same header.
-        - partition_format (str, optional): Specify the partition format of path. Defaults to None. The partition information of each path will be extracted into columns based on the specified format. Format part `{column_name}` creates string column, and `{column_name:yyyy/MM/dd/HH/mm/ss}` creates datetime column, where `yyyy`, `MM`, `dd`, `HH`, `mm` and `ss` are used to extrat year, month, day, hour, minute and second for the datetime type. The format should start from the position of first partition key until the end of file path. For example, given the path `../Germany/2019/01/01/data.csv` where the partition is by country and time, `partition_format="/{Country}/{PartitionDate:yyyy/MM/dd}/data.csv"` creates string column `Country` with value `Germany` and datetime column `PartitionDate` with value `2019-01-01`.
-        - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+        - header (azureml.data.dataset_type_definitions.PromoteHeadersBehavior, optional):
+            Controls how column headers are promoted when reading from files. Defaults to
+            assume that all files have the same header.
+        - partition_format (str, optional): Specify the partition format of path. Defaults to
+            None. The partition information of each path will be extracted into columns based
+            on the specified format. Format part `{column_name}` creates string column, and
+            `{column_name:yyyy/MM/dd/HH/mm/ss}` creates datetime column, where `yyyy`, `MM`,
+            `dd`, `HH`, `mm` and `ss` are used to extrat year, month, day, hour, minute and
+            second for the datetime type. The format should start from the position of first
+            partition key until the end of file path. For example, given the path
+            `../Germany/2019/01/01/data.csv` where the partition is by country and time,
+            `partition_format="/{Country}/{PartitionDate:yyyy/MM/dd}/data.csv"` creates string
+            column `Country` with value `Germany` and datetime column `PartitionDate` with
+            value `2019-01-01`.
+        - create_new_version (bool, optional): Boolean to register the dataset as a new version
+            under the specified name.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor
     """
 
     def __init__(
@@ -105,19 +124,27 @@ class DatasetCreateFromDelimitedFiles(Task):
 
         Args:
             - dataset_name (str, optional): The name of the Dataset in the Workspace
-            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
-            - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
+            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds
+                the files.
+            - path (Union[str, List[str]], optional): The path to the delimited files in the
+                Datastore.
             - dataset_description (str, optional): Description of the Dataset.
             - dataset_tags (str, optional): Tags to associate with the Dataset.
-            - include_path (bool, optional): Boolean to keep path information as column in the dataset.
+            - include_path (bool, optional): Boolean to keep path information as column in the
+                dataset.
             - infer_column_types (bool, optional): Boolean to infer column data types.
-            - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set column data type, where key is column name and value is a `azureml.data.DataType`.
+            - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to
+                set column data type, where key is column name and value is a
+                `azureml.data.DataType`.
             - fine_grain_timestamp (str, optional): The name of column as fine grain timestamp.
             - coarse_grain_timestamp (str, optional): The name of column coarse grain timestamp.
             - separator (str, optional): The separator used to split columns.
-            - header (azureml.data.dataset_type_definitions.PromoteHeadersBehavior, optional): Controls how column headers are promoted when reading from files. Defaults to assume that all files have the same header.
+            - header (azureml.data.dataset_type_definitions.PromoteHeadersBehavior, optional):
+                Controls how column headers are promoted when reading from files. Defaults to
+                assume that all files have the same header.
             - partition_format (str, optional): Specify the partition format of path.
-            - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
+            - create_new_version (bool, optional): Boolean to register the dataset as a new
+                version under the specified name.
 
         Returns:
             - azureml.data.TabularDataset: the created TabularDataset
@@ -164,21 +191,35 @@ class DatasetCreateFromDelimitedFiles(Task):
 
 class DatasetCreateFromParquetFiles(Task):
     """
-    Task for creating a TabularDataset from Parquet files for use in a Azure Machine Learning service Workspace. The files should exist in a Datastore.
-    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+    Task for creating a TabularDataset from Parquet files for use in a Azure Machine Learning
+    service Workspace. The files should exist in a Datastore.  Note that all initialization
+    arguments can optionally be provided or overwritten at runtime.
 
     Args:
         - dataset_name (str, optional): The name of the Dataset in the Workspace
-        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
+        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the
+            files.
         - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
         - dataset_description (str, optional): Description of the Dataset.
         - dataset_tags (str, optional): Tags to associate with the Dataset.
         - include_path (bool, optional): Boolean to keep path information as column in the dataset.
-        - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set column data type, where key is column name and value is a `azureml.data.DataType`.
+        - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set
+            column data type, where key is column name and value is a `azureml.data.DataType`.
         - fine_grain_timestamp (str, optional): The name of column as fine grain timestamp.
         - coarse_grain_timestamp (str, optional): The name of column coarse grain timestamp.
-        - partition_format (str, optional): Specify the partition format of path. Defaults to None. The partition information of each path will be extracted into columns based on the specified format. Format part `{column_name}` creates string column, and `{column_name:yyyy/MM/dd/HH/mm/ss}` creates datetime column, where `yyyy`, `MM`, `dd`, `HH`, `mm` and `ss` are used to extrat year, month, day, hour, minute and second for the datetime type. The format should start from the position of first partition key until the end of file path. For example, given the path `../Germany/2019/01/01/data.csv` where the partition is by country and time, `partition_format="/{Country}/{PartitionDate:yyyy/MM/dd}/data.csv"` creates string column `Country` with value `Germany` and datetime column `PartitionDate` with value `2019-01-01`.
-        - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
+        - partition_format (str, optional): Specify the partition format of path. Defaults to
+            None. The partition information of each path will be extracted into columns based
+            on the specified format. Format part `{column_name}` creates string column, and
+            `{column_name:yyyy/MM/dd/HH/mm/ss}` creates datetime column, where `yyyy`, `MM`,
+            `dd`, `HH`, `mm` and `ss` are used to extrat year, month, day, hour, minute and
+            second for the datetime type. The format should start from the position of first
+            partition key until the end of file path. For example, given the path
+            `../Germany/2019/01/01/data.csv` where the partition is by country and time,
+            `partition_format="/{Country}/{PartitionDate:yyyy/MM/dd}/data.csv"` creates string
+            column `Country` with value `Germany` and datetime column `PartitionDate` with
+            value `2019-01-01`.
+        - create_new_version (bool, optional): Boolean to register the dataset as a new version
+            under the specified name.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -244,16 +285,22 @@ class DatasetCreateFromParquetFiles(Task):
 
         Args:
             - dataset_name (str, optional): The name of the Dataset in the Workspace
-            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
-            - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
+            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds
+                the files.
+            - path (Union[str, List[str]], optional): The path to the delimited files in the
+                Datastore.
             - dataset_description (str, optional): Description of the Dataset.
             - dataset_tags (str, optional): Tags to associate with the Dataset.
-            - include_path (bool, optional): Boolean to keep path information as column in the dataset.
-            - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to set column data type, where key is column name and value is a `azureml.data.DataType`.
+            - include_path (bool, optional): Boolean to keep path information as column in the
+                dataset.
+            - set_column_types (Dict[str, azureml.data.DataType], optional): A dictionary to
+                set column data type, where key is column name and value is a
+                `azureml.data.DataType`.
             - fine_grain_timestamp (str, optional): The name of column as fine grain timestamp.
             - coarse_grain_timestamp (str, optional): The name of column coarse grain timestamp.
             - partition_format (str, optional): Specify the partition format of path.
-            - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
+            - create_new_version (bool, optional): Boolean to register the dataset as a new
+                version under the specified name.
 
         Returns:
             - azureml.data.TabularDataset: the created TabularDataset.
@@ -296,16 +343,19 @@ class DatasetCreateFromParquetFiles(Task):
 
 class DatasetCreateFromFiles(Task):
     """
-    Task for creating a FileDataset from files for use in a Azure Machine Learning service Workspace. The files should exist in a Datastore.
-    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+    Task for creating a FileDataset from files for use in a Azure Machine Learning service
+    Workspace. The files should exist in a Datastore.  Note that all initialization arguments
+    can optionally be provided or overwritten at runtime.
 
     Args:
         - dataset_name (str, optional): The name of the Dataset in the Workspace
-        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
+        - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the
+            files.
         - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
         - dataset_description (str, optional): Description of the Dataset.
         - dataset_tags (str, optional): Tags to associate with the Dataset.
-        - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
+        - create_new_version (bool, optional): Boolean to register the dataset as a new version
+            under the specified name.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -351,11 +401,14 @@ class DatasetCreateFromFiles(Task):
 
         Args:
             - dataset_name (str, optional): The name of the Dataset in the Workspace
-            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds the files.
-            - path (Union[str, List[str]], optional): The path to the delimited files in the Datastore.
+            - datastore (azureml.core.datastore.Datastore, optional): The Datastore which holds
+                the files.
+            - path (Union[str, List[str]], optional): The path to the delimited files in the
+                Datastore.
             - dataset_description (str, optional): Description of the Dataset.
             - dataset_tags (str, optional): Tags to associate with the Dataset.
-            - create_new_version (bool, optional): Boolean to register the dataset as a new version under the specified name.
+            - create_new_version (bool, optional): Boolean to register the dataset as a new
+                version under the specified name.
 
         Returns:
             - azureml.data.FileDataset: the created FileDataset

--- a/src/prefect/tasks/azureml/datastore.py
+++ b/src/prefect/tasks/azureml/datastore.py
@@ -16,17 +16,27 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class DatastoreRegisterBlobContainer(Task):
     """
-    Task for registering Azure Blob Storage container as a Datastore in a Azure ML service Workspace. 
+    Task for registering Azure Blob Storage container as a Datastore in a Azure ML service
+    Workspace.
 
     Args:
-        - workspace (azureml.core.workspace.Workspace): The Workspace to which the Datastore is to be registered.
+        - workspace (azureml.core.workspace.Workspace): The Workspace to which the Datastore is
+            to be registered.
         - container_name (str, optional): The name of the container.
-        - datastore_name (str, optional): The name of the datastore. If not defined, the container name will be used.
-        - create_container_if_not_exists (bool, optional): Create a container, if one does not exist with the given name. 
-        - overwrite_existing_datastore (bool, optional): Overwrite an existing datastore. If the datastore does not exist, it will be created.
-        - azure_credentials_secret (str, optinonal): The name of the Prefect Secret that stores your Azure credentials; this Secret must be a JSON string with two keys: `ACCOUNT_NAME` and either `ACCOUNT_KEY` or `SAS_TOKEN` (if both are defined then`ACCOUNT_KEY` is used). 
-        - set_as_default (bool optional): Set the created Datastore as the default datastore for the Workspace.
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+        - datastore_name (str, optional): The name of the datastore. If not defined, the
+            container name will be used.
+        - create_container_if_not_exists (bool, optional): Create a container, if one does not
+            exist with the given name.
+        - overwrite_existing_datastore (bool, optional): Overwrite an existing datastore. If
+            the datastore does not exist, it will be created.
+        - azure_credentials_secret (str, optinonal): The name of the Prefect Secret that stores
+            your Azure credentials; this Secret must be a JSON string with two keys:
+            `ACCOUNT_NAME` and either `ACCOUNT_KEY` or `SAS_TOKEN` (if both are defined
+            then`ACCOUNT_KEY` is used).
+        - set_as_default (bool optional): Set the created Datastore as the default datastore
+            for the Workspace.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor
     """
 
     def __init__(
@@ -69,18 +79,25 @@ class DatastoreRegisterBlobContainer(Task):
     ) -> AzureBlobDatastore:
         """
         Task run method.
-        
+
         Args:
             - container_name (str, optional): The name of the container.
-            - datastore_name (str, optional): The name of the datastore. If not defined, the container name will be used.
-            - create_container_if_not_exists (bool, optional): Create a container, if one does not exist with the given name. 
-            - overwrite_existing_datastore (bool, optional): Overwrite an existing datastore. If the datastore does not exist, it will be created.
-            - azure_credentials_secret (str, optinonal): The name of the Prefect Secret that stores your Azure credentials; this Secret must be a JSON string with two keys: `ACCOUNT_NAME` and either `ACCOUNT_KEY` or `SAS_TOKEN` (if both are defined then`ACCOUNT_KEY` is used)
-            - set_as_default (bool optional): Set the created Datastore as the default datastore for the Workspace.
+            - datastore_name (str, optional): The name of the datastore. If not defined, the
+                container name will be used.
+            - create_container_if_not_exists (bool, optional): Create a container, if one does
+                not exist with the given name.
+            - overwrite_existing_datastore (bool, optional): Overwrite an existing datastore.
+                If the datastore does not exist, it will be created.
+            - azure_credentials_secret (str, optinonal): The name of the Prefect Secret that
+                stores your Azure credentials; this Secret must be a JSON string with two keys:
+                `ACCOUNT_NAME` and either `ACCOUNT_KEY` or `SAS_TOKEN` (if both are defined
+                then`ACCOUNT_KEY` is used)
+            - set_as_default (bool optional): Set the created Datastore as the default
+                datastore for the Workspace.
 
         Return:
             - (azureml.data.azure_storage_datastore.AzureBlobDatastore): The registered Datastore.
-        
+
         """
         if container_name is None:
             raise ValueError("A container name must be provided.")
@@ -116,9 +133,10 @@ class DatastoreList(Task):
     Task for listing the Datastores in a Workspace.
 
     Args:
-        - workspace (azureml.core.workspace.Workspace): The Workspace which Datastores are to be listed. 
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
-    """
+        - workspace (azureml.core.workspace.Workspace): The Workspace which Datastores are to
+            be listed.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor """
 
     def __init__(self, workspace: Workspace, **kwargs) -> None:
         self.workspace = workspace
@@ -130,7 +148,8 @@ class DatastoreList(Task):
         Task run method.
 
         Returns:
-            -  (Dict[str, Datastore]): a dictionary with the datastore names as keys and Datastore objects as items. 
+            -  Dict[str, Datastore]: a dictionary with the datastore names as keys and
+                 Datastore objects as items.
         """
 
         return self.workspace.datastores
@@ -141,9 +160,11 @@ class DatastoreGet(Task):
     Task for getting a Datastore registered to a given Workspace.
 
     Args:
-        - workspace (azureml.core.workspace.Workspace): The Workspace which Datastore is retrieved. 
-        - datastore_name (str, optional): The name of the Datastore. If `None`, then the default Datastore of the Workspace is returned. 
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+        - workspace (azureml.core.workspace.Workspace): The Workspace which Datastore is retrieved.
+        - datastore_name (str, optional): The name of the Datastore. If `None`, then the
+            default Datastore of the Workspace is returned.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor
     """
 
     def __init__(
@@ -157,13 +178,14 @@ class DatastoreGet(Task):
     @defaults_from_attrs("datastore_name")
     def run(self, datastore_name: str = None) -> azureml.core.datastore.Datastore:
         """
-        Task run method. 
+        Task run method.
 
         Args:
-            - datastore_name (str, optional): The name of the Datastore. If `None`, then the default Datastore of the Workspace is returned. 
-    
+            - datastore_name (str, optional): The name of the Datastore. If `None`, then the
+                default Datastore of the Workspace is returned.
+
         Returns:
-            - (azureml.core.datastore.Datastore): The Datastore. 
+            - (azureml.core.datastore.Datastore): The Datastore.
 
         """
         if datastore_name is None:
@@ -178,10 +200,16 @@ class DatastoreUpload(Task):
     Task for uploading local files to a Datastore.
 
     Args:
-        - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore, optional): The datastore to upload the files to. 
-        - relative_root (str, optional): The root from which is used to determine the path of the files in the blob. For example, if we upload /path/to/file.txt, and we define base path to be /path, when file.txt is uploaded to the blob storage, it will have the path of /to/file.txt.
-        - path (Union[str, List[str]], optional): The path to a single file, single directory, or a list of path to files to eb uploaded. 
-        - target_path (str, optional): The location in the blob container to upload to. If None, then upload to root.
+        - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore,
+            optional): The datastore to upload the files to.
+        - relative_root (str, optional): The root from which is used to determine the path of
+            the files in the blob. For example, if we upload /path/to/file.txt, and we define
+            base path to be /path, when file.txt is uploaded to the blob storage, it will have
+            the path of /to/file.txt.
+        - path (Union[str, List[str]], optional): The path to a single file, single directory,
+            or a list of path to files to eb uploaded.
+        - target_path (str, optional): The location in the blob container to upload to. If
+            None, then upload to root.
         - overwrite (bool, optional): Overwrite existing file(s).
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
 
@@ -217,16 +245,23 @@ class DatastoreUpload(Task):
     ) -> DataReference:
         """
         Task run method.
-        
+
         Args:
-            - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore, optional): The datastore to upload the files to. 
-            - relative_root (str, optional): The root from which is used to determine the path of the files in the blob. For example, if we upload `/path/to/file.txt`, and we define base path to be `/path`, when `file.txt` is uploaded to the blob storage, it will have the path of `/to/file.txt`.
-            - path (Union[str, List[str]], optional): The path to a single file, single directory, or a list of path to files to eb uploaded. 
-            - target_path (str, optional): The location in the blob container to upload to. If None, then upload to root.
+            - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore,
+                optional): The datastore to upload the files to.
+            - relative_root (str, optional): The root from which is used to determine the path
+                of the files in the blob. For example, if we upload `/path/to/file.txt`, and we
+                define base path to be `/path`, when `file.txt` is uploaded to the blob
+                storage, it will have the path of `/to/file.txt`.
+            - path (Union[str, List[str]], optional): The path to a single file, single
+                directory, or a list of path to files to eb uploaded.
+            - target_path (str, optional): The location in the blob container to upload to. If
+                None, then upload to root.
             - overwrite (bool, optional): Overwrite existing file(s).
 
         Returns:
-            - (azureml.data.data_reference.DataReference): The DataReference instance for the target path uploaded
+            - (azureml.data.data_reference.DataReference): The DataReference instance for the
+              target path uploaded
         """
 
         if datastore is None:

--- a/src/prefect/tasks/azureml/datastore.py
+++ b/src/prefect/tasks/azureml/datastore.py
@@ -200,8 +200,8 @@ class DatastoreUpload(Task):
     Task for uploading local files to a Datastore.
 
     Args:
-        - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore,
-            optional): The datastore to upload the files to.
+        - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore, optional):
+            The datastore to upload the files to.
         - relative_root (str, optional): The root from which is used to determine the path of
             the files in the blob. For example, if we upload /path/to/file.txt, and we define
             base path to be /path, when file.txt is uploaded to the blob storage, it will have
@@ -247,8 +247,8 @@ class DatastoreUpload(Task):
         Task run method.
 
         Args:
-            - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore,
-                optional): The datastore to upload the files to.
+            - datastore (azureml.data.azure_storage_datastore.AbstractAzureStorageDatastore, optional):
+                The datastore to upload the files to.
             - relative_root (str, optional): The root from which is used to determine the path
                 of the files in the blob. For example, if we upload `/path/to/file.txt`, and we
                 define base path to be `/path`, when `file.txt` is uploaded to the blob

--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -86,9 +86,10 @@ def switch(condition: Task, cases: Dict[Any, Task], mapped: bool = False) -> Non
 
     Raises:
         - PrefectWarning: if any of the tasks in "cases" have upstream dependencies,
-            then this task will warn that those upstream tasks may run whether or not the switch condition matches their branch. The most common cause of this
-            is passing a list of tasks as one of the cases, which adds the `List` task
-            to the switch condition but leaves the tasks themselves upstream.
+            then this task will warn that those upstream tasks may run whether or not the
+            switch condition matches their branch. The most common cause of this is passing a
+            list of tasks as one of the cases, which adds the `List` task to the switch
+            condition but leaves the tasks themselves upstream.
     """
 
     with prefect.tags("switch"):

--- a/src/prefect/tasks/control_flow/filter.py
+++ b/src/prefect/tasks/control_flow/filter.py
@@ -8,8 +8,8 @@ from prefect.triggers import all_finished
 class FilterTask(Task):
     """
     Task for filtering lists of results.  The default filter removes `NoResult`s, `None`s and
-    Exceptions, intended to be used for filtering out mapped results.  Note that this task has a default trigger of
-    `all_finished` and `skip_on_upstream_skip=False`.
+    Exceptions, intended to be used for filtering out mapped results.  Note that this task has
+    a default trigger of `all_finished` and `skip_on_upstream_skip=False`.
 
     Args:
         - filter_func (Callable, optional): a function to use for filtering

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -32,7 +32,8 @@ class SQLiteQuery(Task):
             - db (str, optional): the location of the database (.db) file;
                 if not provided, `self.db` will be used instead.
             - query (str, optional): the optional query to execute at runtime;
-                if not provided, `self.query` will be used instead. Note that a query should consist of a _single SQL statement_.
+                if not provided, `self.query` will be used instead. Note that a
+                query should consist of a _single SQL statement_.
 
         Returns:
             - [Any]: the results of the query

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -13,24 +13,27 @@ class DbtShellTask(ShellTask):
     Args:
         - command (string, optional): dbt command to be executed; can also be
             provided post-initialization by calling this task instance
-        - dbt_kwargs (dict, optional): keyword arguments used to populate the profiles.yml file (e.g.
-         `{'type': 'snowflake', 'threads': 4, 'account': '...'}`); can also be provided at runtime
+        - dbt_kwargs (dict, optional): keyword arguments used to populate the profiles.yml file
+            (e.g.  `{'type': 'snowflake', 'threads': 4, 'account': '...'}`); can also be
+            provided at runtime
         - env (dict, optional): dictionary of environment variables to use for
             the subprocess; can also be provided at runtime
         - environment (string, optional): The default target your dbt project will use
-        - overwrite_profiles (boolean, optional): flag to indicate whether existing profiles.yml file
-            should be overwritten; defaults to `False`
-        - profile_name (string, optional): Profile name used for populating the profile name of profiles.yml
-        - profiles_dir (string, optional): path to directory where the profile.yml file will be contained
-        - set_profiles_envar (boolean, optional): flag to indicate whether DBT_PROFILES_DIR should be set to the
-            provided profiles_dir; defaults to `True`
+        - overwrite_profiles (boolean, optional): flag to indicate whether existing
+            profiles.yml file should be overwritten; defaults to `False`
+        - profile_name (string, optional): Profile name used for populating the profile name of
+            profiles.yml
+        - profiles_dir (string, optional): path to directory where the profile.yml file will be
+            contained
+        - set_profiles_envar (boolean, optional): flag to indicate whether DBT_PROFILES_DIR
+            should be set to the provided profiles_dir; defaults to `True`
         - helper_script (str, optional): a string representing a shell script, which
             will be executed prior to the `command` in the same process. Can be used to
             change directories, define helper functions, etc. when re-using this Task
             for different commands in a Flow
         - shell (string, optional): shell to run the command with; defaults to "bash"
-        - return_all (bool, optional): boolean specifying whether this task should return all lines of stdout
-            as a list, or just the last line as a string; defaults to `False`
+        - return_all (bool, optional): boolean specifying whether this task should return all
+            lines of stdout as a list, or just the last line as a string; defaults to `False`
         - **kwargs: additional keyword arguments to pass to the Task constructor
 
     Example:
@@ -86,8 +89,9 @@ class DbtShellTask(ShellTask):
         self, command: str = None, env: dict = None, dbt_kwargs: dict = None
     ) -> str:
         """
-        If no profiles.yml file is found or if overwrite_profiles flag is set to True, this will first generate
-        a profiles.yml file in the profiles_dir directory. Then run the dbt cli shell command.
+        If no profiles.yml file is found or if overwrite_profiles flag is set to True, this
+        will first generate a profiles.yml file in the profiles_dir directory. Then run the dbt
+        cli shell command.
 
         Args:
             - command (string): shell command to be executed; can also be
@@ -99,9 +103,10 @@ class DbtShellTask(ShellTask):
              - dbt_kwargs(dict, optional): keyword arguments used to populate the profiles.yml file
 
         Returns:
-            - stdout (string): if `return_all` is `False` (the default), only the last line of stdout
-                is returned, otherwise all lines are returned, which is useful for passing
-                result of shell command to other downstream tasks. If there is no output, `None` is returned.
+            - stdout (string): if `return_all` is `False` (the default), only the last line of
+                stdout is returned, otherwise all lines are returned, which is useful for
+                passing result of shell command to other downstream tasks. If there is no
+                output, `None` is returned.
 
         Raises:
             - prefect.engine.signals.FAIL: if command has an exit code other

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -193,7 +193,8 @@ class ListContainers(Task):
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
     Args:
-        - all_containers (bool, optional): Show all containers. Only running containers are shown by default
+        - all_containers (bool, optional): Show all containers. Only running
+            containers are shown by default
         - filters (dict, optional): Filter the results. See
             https://docker-py.readthedocs.io/en/stable/containers.html for more details
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
@@ -227,7 +228,8 @@ class ListContainers(Task):
         Task run method.
 
         Args:
-            - all_containers (bool, optional): Show all containers. Only running containers are shown by default
+            - all_containers (bool, optional): Show all containers. Only
+                running containers are shown by default
             - filters (dict, optional): Filter the results. See
                 https://docker-py.readthedocs.io/en/stable/containers.html for more details
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
@@ -437,8 +439,8 @@ class WaitOnContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
-            defaults to `True`
+        - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal
+            for a nonzero exit code; defaults to `True`
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task
             constructor
     """
@@ -471,15 +473,16 @@ class WaitOnContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal for a nonzero exit code;
-                defaults to `True`
+            - raise_on_exit_code (bool, optional): whether to raise a `FAIL`
+                signal for a nonzero exit code; defaults to `True`
 
         Returns:
             - dict: a dictionary with `StatusCode` and `Error` keys
 
         Raises:
             - ValueError: if `container_id` is `None`
-            - FAIL: if `raise_on_exit_code` is `True` and the container exits with a nonzero exit code
+            - FAIL: if `raise_on_exit_code` is `True` and the container exits
+                with a nonzero exit code
         """
         if not container_id:
             raise ValueError("A container id must be provided.")

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -291,7 +291,7 @@ class RemoveImage(Task):
         self.logger.debug("Starting to remove Docker images: {}".format(image))
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        feed = client.remove_image(image=image, force=force)
+        client.remove_image(image=image, force=force)
         self.logger.debug("Completed removing Docker images... {}".format(image))
 
 

--- a/src/prefect/tasks/dropbox/dropbox.py
+++ b/src/prefect/tasks/dropbox/dropbox.py
@@ -14,8 +14,8 @@ class DropboxDownload(Task):
 
     Args:
         - path (str, optional): the path to the file to download. May be provided at runtime.
-        - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing a
-            Dropbox access token
+        - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret
+            containing a Dropbox access token
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -32,13 +32,14 @@ class DropboxDownload(Task):
         access_token_secret: str = None,
     ) -> bytes:
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
             - path (str, optional): the path to the file to download
             - access_token (str): a Dropbox access token, provided with a Prefect secret.
-            - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret containing a
-                Dropbox access token
+            - access_token_secret (str, optional, DEPRECATED): the name of the Prefect Secret
+                containing a Dropbox access token
 
         Raises:
             - ValueError: if the `path` is `None`
@@ -46,7 +47,7 @@ class DropboxDownload(Task):
         Returns:
             - bytes: the file contents, as bytes
         """
-        ## check for any argument inconsistencies
+        # check for any argument inconsistencies
         if path is None:
             raise ValueError("No path provided.")
 

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -17,24 +17,25 @@ class BigQueryTask(Task):
 
     Args:
         - query (str, optional): a string of the query to execute
-        - query_params (list[tuple], optional): a list of 3-tuples specifying
-            BigQuery query parameters; currently only scalar query parameters are supported. See
-            [the Google documentation](https://cloud.google.com/bigquery/docs/parameterized-queries#bigquery-query-params-python)
+        - query_params (list[tuple], optional): a list of 3-tuples specifying BigQuery query
+            parameters; currently only scalar query parameters are supported.  See [the Google
+            documentation](https://cloud.google.com/bigquery/docs/parameterized-queries#bigquery-query-params-python)
             for more details on how both the query and the query parameters should be formatted
-        - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-            will default to the one inferred from your credentials
+        - project (str, optional): the project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials
         - location (str, optional): location of the dataset that will be queried; defaults to "US"
-        - dry_run_max_bytes (int, optional): if provided, the maximum number of bytes the query is allowed
-            to process; this will be determined by executing a dry run and raising a `ValueError` if the
-            maximum is exceeded
+        - dry_run_max_bytes (int, optional): if provided, the maximum number of bytes the query
+            is allowed to process; this will be determined by executing a dry run and raising a
+            `ValueError` if the maximum is exceeded
         - dataset_dest (str, optional): the optional name of a destination dataset to write the
-            query results to, if you don't want them returned; if provided, `table_dest` must also be
-            provided
+            query results to, if you don't want them returned; if provided, `table_dest` must
+            also be provided
         - table_dest (str, optional): the optional name of a destination table to write the
-            query results to, if you don't want them returned; if provided, `dataset_dest` must also be
-            provided
-        - job_config (dict, optional): an optional dictionary of job configuration parameters; note that
-            the parameters provided here must be pickleable (e.g., dataset references will be rejected)
+            query results to, if you don't want them returned; if provided, `dataset_dest` must
+            also be provided
+        - job_config (dict, optional): an optional dictionary of job configuration parameters;
+            note that the parameters provided here must be pickleable (e.g., dataset references
+            will be rejected)
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -83,31 +84,37 @@ class BigQueryTask(Task):
         job_config: dict = None,
     ):
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
             - query (str, optional): a string of the query to execute
-            - query_params (list[tuple], optional): a list of 3-tuples specifying
-                BigQuery query parameters; currently only scalar query parameters are supported. See
-                [the Google documentation](https://cloud.google.com/bigquery/docs/parameterized-queries#bigquery-query-params-python)
-                for more details on how both the query and the query parameters should be formatted
-            - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-                will default to the one inferred from your credentials
-            - location (str, optional): location of the dataset that will be queried; defaults to "US"
-            - dry_run_max_bytes (int, optional): if provided, the maximum number of bytes the query is allowed
-                to process; this will be determined by executing a dry run and raising a `ValueError` if the
-                maximum is exceeded
+            - query_params (list[tuple], optional): a list of 3-tuples specifying BigQuery
+                query parameters; currently only scalar query parameters are supported. See
+                [the Google
+                documentation](https://cloud.google.com/bigquery/docs/parameterized-queries#bigquery-query-params-python)
+                for more details on how both the query and the query parameters should be
+                formatted
+            - project (str, optional): the project to initialize the BigQuery Client with; if
+                not provided, will default to the one inferred from your credentials
+            - location (str, optional): location of the dataset that will be queried; defaults
+                to "US"
+            - dry_run_max_bytes (int, optional): if provided, the maximum number of bytes the
+                query is allowed to process; this will be determined by executing a dry run and
+                raising a `ValueError` if the maximum is exceeded
             - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+                You should provide these at runtime with an upstream Secret task.  If not
+                provided, Prefect will first check `context` for `GCP_CREDENTIALS` and lastly
+                will use default Google client logic.
             - dataset_dest (str, optional): the optional name of a destination dataset to write the
-                query results to, if you don't want them returned; if provided, `table_dest` must also be
-                provided
+                query results to, if you don't want them returned; if provided, `table_dest`
+                must also be provided
             - table_dest (str, optional): the optional name of a destination table to write the
-                query results to, if you don't want them returned; if provided, `dataset_dest` must also be
-                provided
-            - job_config (dict, optional): an optional dictionary of job configuration parameters; note that
-                the parameters provided here must be pickleable (e.g., dataset references will be rejected)
+                query results to, if you don't want them returned; if provided, `dataset_dest`
+                must also be provided
+            - job_config (dict, optional): an optional dictionary of job configuration
+                parameters; note that the parameters provided here must be pickleable (e.g.,
+                dataset references will be rejected)
 
         Raises:
             - ValueError: if the `query` is `None`
@@ -117,18 +124,19 @@ class BigQueryTask(Task):
         Returns:
             - list: a fully populated list of Query results, with one item per row
         """
-        ## check for any argument inconsistencies
+        # check for any argument inconsistencies
         if query is None:
             raise ValueError("No query provided.")
         if sum([dataset_dest is None, table_dest is None]) == 1:
             raise ValueError(
-                "Both `dataset_dest` and `table_dest` must be provided if writing to a destination table."
+                "Both `dataset_dest` and `table_dest` must be provided if writing to a "
+                "destination table."
             )
 
-        ## create client
+        # create client
         client = get_bigquery_client(project=project, credentials=credentials)
 
-        ## setup jobconfig
+        # setup jobconfig
         job_config = bigquery.QueryJobConfig(**job_config)
         if query_params is not None:
             hydrated_params = [
@@ -136,7 +144,7 @@ class BigQueryTask(Task):
             ]
             job_config.query_parameters = hydrated_params
 
-        ## perform dry_run if requested
+        # perform dry_run if requested
         if dry_run_max_bytes is not None:
             old_info = dict(
                 dry_run=job_config.dry_run, use_query_cache=job_config.use_query_cache
@@ -146,15 +154,15 @@ class BigQueryTask(Task):
             self.logger.debug("Performing a dry run...")
             query_job = client.query(query, location=location, job_config=job_config)
             if query_job.total_bytes_processed > dry_run_max_bytes:
-                raise ValueError(
-                    "Query will process {0} bytes which is above the set maximum of {1} for this task.".format(
-                        query_job.total_bytes_processed, dry_run_max_bytes
-                    )
-                )
+                msg = (
+                    "Query will process {0} bytes which is above the set maximum of {1} "
+                    "for this task."
+                ).format(query_job.total_bytes_processed, dry_run_max_bytes)
+                raise ValueError(msg)
             job_config.dry_run = old_info["dry_run"]
             job_config.use_query_cache = old_info["use_query_cache"]
 
-        ## if writing to a destination table
+        # if writing to a destination table
         if dataset_dest is not None:
             table_ref = client.dataset(dataset_dest).table(table_dest)
             job_config.destination = table_ref
@@ -165,17 +173,19 @@ class BigQueryTask(Task):
 
 class BigQueryStreamingInsert(Task):
     """
-    Task for insert records in a Google BigQuery table via [the streaming API](https://cloud.google.com/bigquery/streaming-data-into-bigquery).
-    Note that all of these settings can optionally be provided or overwritten at runtime.
+    Task for insert records in a Google BigQuery table via [the streaming
+    API](https://cloud.google.com/bigquery/streaming-data-into-bigquery).  Note that all of
+    these settings can optionally be provided or overwritten at runtime.
 
     Args:
         - dataset_id (str, optional): the id of a destination dataset to write the
             records to
         - table (str, optional): the name of a destination table to write the
             records to
-        - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-            will default to the one inferred from your credentials
-        - location (str, optional): location of the dataset that will be written to; defaults to "US"
+        - project (str, optional): the project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials
+        - location (str, optional): location of the dataset that will be written to; defaults
+            to "US"
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -205,24 +215,27 @@ class BigQueryStreamingInsert(Task):
         **kwargs,
     ):
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
-            - records (list[dict]): the list of records to insert as rows into
-                the BigQuery table; each item in the list should be a dictionary whose keys correspond
-                to columns in the table
-            - dataset_id (str, optional): the id of a destination dataset to write the
-                records to; if not provided here, will default to the one provided at initialization
+            - records (list[dict]): the list of records to insert as rows into the BigQuery
+                table; each item in the list should be a dictionary whose keys correspond to
+                columns in the table
+            - dataset_id (str, optional): the id of a destination dataset to write the records
+                to; if not provided here, will default to the one provided at initialization
             - table (str, optional): the name of a destination table to write the
                 records to; if not provided here, will default to the one provided at initialization
-            - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-                will default to the one inferred from your credentials
-            - location (str, optional): location of the dataset that will be written to; defaults to "US"
-            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
-            - **kwargs (optional): additional kwargs to pass to the
-                `insert_rows_json` method; see the documentation here:
+            - project (str, optional): the project to initialize the BigQuery Client with; if
+                not provided, will default to the one inferred from your credentials
+            - location (str, optional): location of the dataset that will be written to;
+                defaults to "US"
+            - credentials (dict, optional): a JSON document containing Google Cloud
+                credentials.  You should provide these at runtime with an upstream Secret task.
+                If not provided, Prefect will first check `context` for `GCP_CREDENTIALS` and
+                lastly will use default Google client logic.
+            - **kwargs (optional): additional kwargs to pass to the `insert_rows_json` method;
+                see the documentation here:
                 https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.client.Client.html
 
         Raises:
@@ -232,17 +245,17 @@ class BigQueryStreamingInsert(Task):
         Returns:
             - the response from `insert_rows_json`
         """
-        ## check for any argument inconsistencies
+        # check for any argument inconsistencies
         if dataset_id is None or table is None:
             raise ValueError("Both dataset_id and table must be provided.")
 
-        ## create client
+        # create client
         client = get_bigquery_client(project=project, credentials=credentials)
 
-        ## get table reference
+        # get table reference
         table_ref = client.dataset(dataset_id).table(table)
 
-        ## stream data in
+        # stream data in
         response = client.insert_rows_json(table=table_ref, json_rows=records, **kwargs)
 
         errors = []
@@ -260,8 +273,9 @@ class BigQueryStreamingInsert(Task):
 
 class BigQueryLoadGoogleCloudStorage(Task):
     """
-    Task for insert records in a Google BigQuery table via a [load job](https://cloud.google.com/bigquery/docs/loading-data).
-    Note that all of these settings can optionally be provided or overwritten at runtime.
+    Task for insert records in a Google BigQuery table via a [load
+    job](https://cloud.google.com/bigquery/docs/loading-data).  Note that all of these settings
+    can optionally be provided or overwritten at runtime.
 
     Args:
         - uri (str, optional): GCS path to load data from
@@ -269,8 +283,8 @@ class BigQueryLoadGoogleCloudStorage(Task):
             records to
         - table (str, optional): the name of a destination table to write the
             records to
-        - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-            will default to the one inferred from your credentials
+        - project (str, optional): the project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials
         - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
         - location (str, optional): location of the dataset that will be queried; defaults to "US"
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
@@ -307,7 +321,8 @@ class BigQueryLoadGoogleCloudStorage(Task):
         **kwargs,
     ):
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
             - uri (str, optional): GCS path to load data from
@@ -315,13 +330,16 @@ class BigQueryLoadGoogleCloudStorage(Task):
                 records to; if not provided here, will default to the one provided at initialization
             - table (str, optional): the name of a destination table to write the
                 records to; if not provided here, will default to the one provided at initialization
-            - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-                will default to the one inferred from your credentials
-            - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
-            - location (str, optional): location of the dataset that will be written to; defaults to "US"
-            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+            - project (str, optional): the project to initialize the BigQuery Client with; if
+                not provided, will default to the one inferred from your credentials
+            - schema (List[bigquery.SchemaField], optional): the schema to use when creating
+                the table
+            - location (str, optional): location of the dataset that will be written to;
+                defaults to "US"
+            - credentials (dict, optional): a JSON document containing Google Cloud
+                credentials.  You should provide these at runtime with an upstream Secret task.
+                If not provided, Prefect will first check `context` for `GCP_CREDENTIALS` and
+                lastly will use default Google client logic.
             - **kwargs (optional): additional kwargs to pass to the `bigquery.LoadJobConfig`;
                 see the documentation here:
                 https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.client.Client.html
@@ -333,43 +351,47 @@ class BigQueryLoadGoogleCloudStorage(Task):
         Returns:
             - the response from `load_table_from_uri`
         """
-        ## check for any argument inconsistencies
+        # check for any argument inconsistencies
         if dataset_id is None or table is None:
             raise ValueError("Both dataset_id and table must be provided.")
 
-        ## create client
+        # create client
         client = get_bigquery_client(project=project, credentials=credentials)
 
-        ## get table reference
+        # get table reference
         table_ref = client.dataset(dataset_id).table(table)
 
-        ## load data
+        # load data
         autodetect = kwargs.pop("autodetect", True)
         job_config = bigquery.LoadJobConfig(autodetect=autodetect, **kwargs)
         if schema:
             job_config.schema = schema
         load_job = client.load_table_from_uri(uri, table_ref, job_config=job_config)
-        result = load_job.result()  # block until job is finished
+        load_job.result()  # block until job is finished
 
 
 class BigQueryLoadFile(Task):
     """
-    Task for insert records in a Google BigQuery table via a [load job](https://cloud.google.com/bigquery/docs/loading-data).
-    Note that all of these settings can optionally be provided or overwritten at runtime.
+    Task for insert records in a Google BigQuery table via a [load
+    job](https://cloud.google.com/bigquery/docs/loading-data).  Note that all of these settings
+    can optionally be provided or overwritten at runtime.
 
     Args:
-        - file (Union[str, path-like object], optional): A string or path-like object of the file to be loaded
-        - rewind (bool, optional): if True, seek to the beginning of the file handle before reading the file
-        - size (int, optional):  the number of bytes to read from the file handle. If size is None or large,
-            resumable upload will be used. Otherwise, multipart upload will be used.
-        - dataset_id (str, optional): the id of a destination dataset to write the
-            records to
-        - table (str, optional): the name of a destination table to write the
-            records to
-        - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-            will default to the one inferred from your credentials
-        - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
-        - location (str, optional): location of the dataset that will be queried; defaults to "US"
+        - file (Union[str, path-like object], optional): A string or path-like object of the
+            file to be loaded
+        - rewind (bool, optional): if True, seek to the beginning of the file handle before
+            reading the file
+        - size (int, optional):  the number of bytes to read from the file handle. If size is
+            None or large, resumable upload will be used. Otherwise, multipart upload will be
+            used.
+        - dataset_id (str, optional): the id of a destination dataset to write the records to
+        - table (str, optional): the name of a destination table to write the records to
+        - project (str, optional): the project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials
+        - schema (List[bigquery.SchemaField], optional): the schema to use when creating the
+            table
+        - location (str, optional): location of the dataset that will be queried; defaults to
+            "US"
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -422,23 +444,29 @@ class BigQueryLoadFile(Task):
         **kwargs,
     ):
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task. Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
-            - file (Union[str, path-liike object], optional): A string or path-like object of the file to be loaded
-            - rewind (bool, optional): if True, seek to the beginning of the file handle before reading the file
-            - size (int, optional):  the number of bytes to read from the file handle. If size is None or large,
-                resumable upload will be used. Otherwise, multipart upload will be used.
-            - dataset_id (str, optional): the id of a destination dataset to write the
-                records to; if not provided here, will default to the one provided at initialization
-            - table (str, optional): the name of a destination table to write the
-                records to; if not provided here, will default to the one provided at initialization
-            - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-                will default to the one inferred from your credentials
-            - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
-            - location (str, optional): location of the dataset that will be written to; defaults to "US"
-            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.
+            - file (Union[str, path-liike object], optional): A string or path-like object of
+                the file to be loaded
+            - rewind (bool, optional): if True, seek to the beginning of the file handle before
+                reading the file
+            - size (int, optional):  the number of bytes to read from the file handle. If size
+                is None or large, resumable upload will be used. Otherwise, multipart upload
+                will be used.
+            - dataset_id (str, optional): the id of a destination dataset to write the records
+                to; if not provided here, will default to the one provided at initialization
+            - table (str, optional): the name of a destination table to write the records to;
+                if not provided here, will default to the one provided at initialization
+            - project (str, optional): the project to initialize the BigQuery Client with; if
+                not provided, will default to the one inferred from your credentials
+            - schema (List[bigquery.SchemaField], optional): the schema to use when creating
+                the table
+            - location (str, optional): location of the dataset that will be written to;
+                defaults to "US"
+            - credentials (dict, optional): a JSON document containing Google Cloud
+                credentials.  You should provide these at runtime with an upstream Secret task.
             - **kwargs (optional): additional kwargs to pass to the `bigquery.LoadJobConfig`;
                 see the documentation here:
                 https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.client.Client.html
@@ -451,7 +479,7 @@ class BigQueryLoadFile(Task):
         Returns:
             - the response from `load_table_from_file`
         """
-        ## check for any argument inconsistencies
+        # check for any argument inconsistencies
         if dataset_id is None or table is None:
             raise ValueError("Both dataset_id and table must be provided.")
         try:
@@ -461,19 +489,19 @@ class BigQueryLoadFile(Task):
         if not path.is_file():
             raise ValueError(f"File {path.as_posix()} does not exist.")
 
-        ## create client
+        # create client
         client = get_bigquery_client(project=project, credentials=credentials,)
 
-        ## get table reference
+        # get table reference
         table_ref = client.dataset(dataset_id).table(table)
 
-        ## configure job
+        # configure job
         autodetect = kwargs.pop("autodetect", True)
         job_config = bigquery.LoadJobConfig(autodetect=autodetect, **kwargs)
         if schema:
             job_config.schema = schema
 
-        ## load data
+        # load data
         try:
             with open(file, "rb") as file_obj:
                 load_job = client.load_table_from_file(
@@ -487,7 +515,7 @@ class BigQueryLoadFile(Task):
         except IOError:
             raise IOError(f"Can't open and read from {path.as_posix()}.")
 
-        result = load_job.result()  # block until job is finished
+        load_job.result()  # block until job is finished
 
 
 class CreateBigQueryTable(Task):
@@ -496,14 +524,15 @@ class CreateBigQueryTable(Task):
     can optionally be provided at runtime.
 
     Args:
-        - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-            will default to the one inferred from your credentials
+        - project (str, optional): the project to initialize the BigQuery Client with; if not
+            provided, will default to the one inferred from your credentials
         - dataset (str, optional): the name of a dataset in that the table will be created
         - table (str, optional): the name of a table to create
         - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
         - clustering_fields (List[str], optional): a list of fields to cluster the table by
-        - time_partitioning (bigquery.TimePartitioning, optional): a `bigquery.TimePartitioning` object specifying
-            a partitioninig of the newly created table
+        - time_partitioning (bigquery.TimePartitioning, optional): a
+            `bigquery.TimePartitioning` object specifying a partitioninig of the newly created
+            table
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -535,17 +564,20 @@ class CreateBigQueryTable(Task):
         schema: List[bigquery.SchemaField] = None,
     ):
         """
-        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after initialization.
+        Run method for this Task.  Invoked by _calling_ this Task within a Flow context, after
+        initialization.
 
         Args:
-            - project (str, optional): the project to initialize the BigQuery Client with; if not provided,
-                will default to the one inferred from your credentials
-            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+            - project (str, optional): the project to initialize the BigQuery Client with; if
+                not provided, will default to the one inferred from your credentials
+            - credentials (dict, optional): a JSON document containing Google Cloud
+                credentials.  You should provide these at runtime with an upstream Secret task.
+                If not provided, Prefect will first check `context` for `GCP_CREDENTIALS` and
+                lastly will use default Google client logic.
             - dataset (str, optional): the name of a dataset in that the table will be created
             - table (str, optional): the name of a table to create
-            - schema (List[bigquery.SchemaField], optional): the schema to use when creating the table
+            - schema (List[bigquery.SchemaField], optional): the schema to use when creating
+                the table
 
         Returns:
             - None

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -56,7 +56,7 @@ class GCSBaseTask(Task):
         if blob is None:
             blob = "prefect-" + context.get("task_run_id", "no-id-" + str(uuid.uuid4()))
 
-        ## pull encryption_key if requested
+        # pull encryption_key if requested
         if encryption_key_secret is not None:
             warnings.warn(
                 "The `encryption_key_secret` argument is deprecated. Use a `Secret` task "
@@ -81,9 +81,10 @@ class GCSDownload(GCSBaseTask):
             storing an optional `encryption_key` to be used when downloading the Blob
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
 
-    Note that the design of this task allows you to initialize a _template_ with default settings.  Each inidividual
-    occurence of the task in a Flow can overwrite any of these default settings for custom use (for example, if you want to pull different
-    credentials for a given Task, or specify the Blob name at runtime).
+    Note that the design of this task allows you to initialize a _template_ with default
+    settings.  Each inidividual occurence of the task in a Flow can overwrite any of these
+    default settings for custom use (for example, if you want to pull different credentials for
+    a given Task, or specify the Blob name at runtime).
     """
 
     def __init__(
@@ -122,11 +123,12 @@ class GCSDownload(GCSBaseTask):
         Args:
             - bucket (str, optional): the bucket name to upload to
             - blob (str, optional): blob name to download from
-            - project (str, optional): Google Cloud project to work within.
-                If not provided here or at initialization, will be inferred from your Google Cloud credentials
-            - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+            - project (str, optional): Google Cloud project to work within. If not provided
+                here or at initialization, will be inferred from your Google Cloud credentials
+            - credentials (dict, optional): a JSON document containing Google Cloud
+                credentials.  You should provide these at runtime with an upstream Secret task.
+                If not provided, Prefect will first check `context` for `GCP_CREDENTIALS` and
+                lastly will use default Google client logic.
             - encryption_key (str, optional): an encryption key
             - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
                 storing an optional `encryption_key` to be used when uploading the Blob
@@ -140,15 +142,15 @@ class GCSDownload(GCSBaseTask):
             - ValueError: if `blob` name hasn't been provided
 
         """
-        ## create client
+        # create client
         client = get_storage_client(project=project, credentials=credentials)
 
-        ## retrieve bucket
+        # retrieve bucket
         bucket = self._retrieve_bucket(
             client=client, bucket=bucket, create_bucket=False
         )
 
-        ## identify blob name
+        # identify blob name
         gcs_blob = self._get_blob(
             bucket,
             blob,
@@ -170,8 +172,8 @@ class GCSUpload(GCSBaseTask):
             beginning with `prefect-` and containing the Task Run ID will be used
         - project (str, optional): default Google Cloud project to work within.
             If not provided, will be inferred from your Google Cloud credentials
-        - create_bucket (bool, optional): boolean specifying whether to create the bucket if it does not exist,
-            otherwise an Exception is raised. Defaults to `False`.
+        - create_bucket (bool, optional): boolean specifying whether to create the bucket if it
+            does not exist, otherwise an Exception is raised. Defaults to `False`.
         - encryption_key_secret (str, optional, DEPRECATED): the name of the Prefect Secret
             storing an optional `encryption_key` to be used when uploading the Blob
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
@@ -229,8 +231,9 @@ class GCSUpload(GCSBaseTask):
             - project (str, optional): Google Cloud project to work within. Can be inferred
                 from credentials if not provided.
             - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+                You should provide these at runtime with an upstream Secret task.  If not
+                provided, Prefect will first check `context` for `GCP_CREDENTIALS` and lastly
+                will use default Google client logic.
             - encryption_key (str, optional): an encryption key
             - create_bucket (bool, optional): boolean specifying whether to create the bucket
                 if it does not exist, otherwise an Exception is raised. Defaults to `False`.
@@ -238,20 +241,21 @@ class GCSUpload(GCSBaseTask):
                 storing an optional `encryption_key` to be used when uploading the Blob.
 
         Raises:
-            - google.cloud.exception.NotFound: if `create_bucket=False` and the bucket name is not found
+            - google.cloud.exception.NotFound: if `create_bucket=False` and the bucket name is
+                not found
 
         Returns:
             - str: the blob name that now stores the provided data
         """
-        ## create client
+        # create client
         client = get_storage_client(project=project, credentials=credentials)
 
-        ## retrieve bucket
+        # retrieve bucket
         bucket = self._retrieve_bucket(
             client=client, bucket=bucket, create_bucket=create_bucket
         )
 
-        ## identify blob name
+        # identify blob name
         gcs_blob = self._get_blob(
             bucket,
             blob,
@@ -280,9 +284,10 @@ class GCSCopy(GCSBaseTask):
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
 
-    Note that the design of this task allows you to initialize a _template_ with default settings.  Each inidividual
-    occurence of the task in a Flow can overwrite any of these default settings for custom use (for example, if you want to pull different
-    credentials for a given Task, or specify the Blob name at runtime).
+    Note that the design of this task allows you to initialize a _template_ with default
+    settings.  Each inidividual occurence of the task in a Flow can overwrite any of these
+    default settings for custom use (for example, if you want to pull different credentials for
+    a given Task, or specify the Blob name at runtime).
     """
 
     def __init__(
@@ -328,8 +333,9 @@ class GCSCopy(GCSBaseTask):
             - project (str, optional): default Google Cloud project to work within.
                 If not provided, will be inferred from your Google Cloud credentials
             - credentials (dict, optional): a JSON document containing Google Cloud credentials.
-                You should provide these at runtime with an upstream Secret task.  If not provided, Prefect will
-                first check `context` for `GCP_CREDENTIALS` and lastly will use default Google client logic.
+                You should provide these at runtime with an upstream Secret task.  If not
+                provided, Prefect will first check `context` for `GCP_CREDENTIALS` and lastly
+                will use default Google client logic.
 
         Returns:
             - str: the name of the destination blob
@@ -344,7 +350,7 @@ class GCSCopy(GCSBaseTask):
         elif (source_bucket, source_blob) == (dest_bucket, dest_blob):
             raise ValueError("Source and destination are identical.")
 
-        ## create client
+        # create client
         client = get_storage_client(project=project, credentials=credentials)
 
         # get source bucket and blob

--- a/src/prefect/tasks/github/issues.py
+++ b/src/prefect/tasks/github/issues.py
@@ -10,13 +10,16 @@ class OpenGitHubIssue(Task):
     Task for opening / creating new GitHub issues using the v3 version of the GitHub REST API.
 
     Args:
-        - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-            form `organization/repo_name`; can also be provided to the `run` method
-        - title (str, optional): the title of the issue to create; can also be provided to the `run` method
+        - repo (str, optional): the name of the repository to open the issue in; must be
+            provided in the form `organization/repo_name`; can also be provided to the `run`
+            method
+        - title (str, optional): the title of the issue to create; can also be provided to the
+            `run` method
         - body (str, optional): the contents of the issue; can also be provided to the `run` method
-        - labels (List[str], optional): a list of labels to apply to the newly opened issues; can also
-            be provided to the `run` method
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method
+        - labels (List[str], optional): a list of labels to apply to the newly opened issues;
+            can also be provided to the `run` method
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method
     """
 
     def __init__(
@@ -43,16 +46,19 @@ class OpenGitHubIssue(Task):
         token: str = None,
     ) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
-            - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-                form `organization/repo_name`; defaults to the one provided at initialization
-            - title (str, optional): the title of the issue to create; defaults to the one provided at initialization
-            - body (str, optional): the contents of the issue; defaults to the one provided at initialization
-            - labels (List[str], optional): a list of labels to apply to the newly opened issues; defaults to
-            the ones provided at initialization
+            - repo (str, optional): the name of the repository to open the issue in; must be
+                provided in the form `organization/repo_name`; defaults to the one provided at
+                initialization
+            - title (str, optional): the title of the issue to create; defaults to the one
+                provided at initialization
+            - body (str, optional): the contents of the issue; defaults to the one provided at
+                initialization
+            - labels (List[str], optional): a list of labels to apply to the newly opened
+                issues; defaults to the ones provided at initialization
             - token (str): a GitHub API token
 
         Raises:
@@ -76,6 +82,6 @@ class OpenGitHubIssue(Task):
         }
         issue = {"title": title, "body": body, "labels": labels}
 
-        ## send the request
+        # send the request
         resp = requests.post(url, data=json.dumps(issue), headers=headers)
         resp.raise_for_status()

--- a/src/prefect/tasks/github/prs.py
+++ b/src/prefect/tasks/github/prs.py
@@ -7,18 +7,21 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class CreateGitHubPR(Task):
     """
-    Task for opening / creating new GitHub Pull Requests using the v3 version of the GitHub REST API.
+    Task for opening/creating new GitHub Pull Requests using the v3 version of the GitHub REST API.
 
     Args:
-        - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-            form `organization/repo_name`; can also be provided to the `run` method
-        - title (str, optional): the title of the issue to create; can also be provided to the `run` method
+        - repo (str, optional): the name of the repository to open the issue in; must be
+            provided in the form `organization/repo_name`; can also be provided to the `run`
+            method
+        - title (str, optional): the title of the issue to create; can also be provided to the
+            `run` method
         - body (str, optional): the contents of the issue; can also be provided to the `run` method
         - head (str, optional): the name of the branch where your changes are implemented; can also
             be provided to the `run` method
         - base (str, optional): the name of the branch you want the changes pulled into; can also
             be provided to the `run` method
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method
     """
 
     def __init__(
@@ -48,14 +51,17 @@ class CreateGitHubPR(Task):
         token: str = None,
     ) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
-            - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-                form `organization/repo_name`; defaults to the one provided at initialization
-            - title (str, optional): the title of the issue to create; defaults to the one provided at initialization
-            - body (str, optional): the contents of the issue; defaults to the one provided at initialization
+            - repo (str, optional): the name of the repository to open the issue in; must be
+                provided in the form `organization/repo_name`; defaults to the one provided at
+                initialization
+            - title (str, optional): the title of the issue to create; defaults to the one
+                provided at initialization
+            - body (str, optional): the contents of the issue; defaults to the one provided at
+                initialization
             - head (str, optional): the name of the branch where your changes are implemented;
                 defaults to the one provided at initialization
             - base (str, optional): the name of the branch you want the changes pulled into;
@@ -83,6 +89,6 @@ class CreateGitHubPR(Task):
         }
         pr = {"title": title, "body": body, "head": head, "base": base}
 
-        ## send the request
+        # send the request
         resp = requests.post(url, data=json.dumps(pr), headers=headers)
         resp.raise_for_status()

--- a/src/prefect/tasks/github/repos.py
+++ b/src/prefect/tasks/github/repos.py
@@ -9,11 +9,15 @@ class GetRepoInfo(Task):
     Task for retrieving GitHub repository information using the v3 version of the GitHub REST API.
 
     Args:
-        - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-            form `organization/repo_name` or `user/repo_name`; can also be provided to the `run` method
-        - info_keys (List[str], optional): a list of repo attributes to pull (e.g., `["stargazers_count", "subscribers_count"]`).
-            A full list of available keys can be found in the official [GitHub documentation](https://developer.github.com/v3/repos/)
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method
+        - repo (str, optional): the name of the repository to open the issue in; must be
+            provided in the form `organization/repo_name` or `user/repo_name`; can also be
+            provided to the `run` method
+        - info_keys (List[str], optional): a list of repo attributes to pull (e.g.,
+            `["stargazers_count", "subscribers_count"]`).  A full list of available keys can be
+            found in the official [GitHub
+            documentation](https://developer.github.com/v3/repos/)
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method
     """
 
     def __init__(self, repo: str = None, info_keys: List[str] = None, **kwargs: Any):
@@ -27,14 +31,17 @@ class GetRepoInfo(Task):
         self, repo: str = None, info_keys: List[str] = None, token: str = None
     ) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
-            - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-                form `organization/repo_name`; defaults to the one provided at initialization
-            - info_keys (List[str], optional): a list of repo attributes to pull (e.g., `["stargazers_count", "subscribers_count"]`).
-                A full list of available keys can be found in the official [GitHub documentation](https://developer.github.com/v3/repos/)
+            - repo (str, optional): the name of the repository to open the issue in; must be
+                provided in the form `organization/repo_name`; defaults to the one provided at
+                initialization
+            - info_keys (List[str], optional): a list of repo attributes to pull (e.g.,
+                `["stargazers_count", "subscribers_count"]`).  A full list of available keys
+                can be found in the official [GitHub
+                documentation](https://developer.github.com/v3/repos/)
             - token (str): a GitHub access token
 
         Raises:
@@ -57,7 +64,7 @@ class GetRepoInfo(Task):
             "Accept": "application/vnd.github.v3+json",
         }
 
-        ## send the request
+        # send the request
         resp = requests.get(url, headers=headers)
         resp.raise_for_status()
         data = resp.json()
@@ -70,12 +77,15 @@ class CreateBranch(Task):
     Task for creating new branches using the v3 version of the GitHub REST API.
 
     Args:
-        - repo (str, optional): the name of the repository to create the branch in; must be provided in the
-            form `organization/repo_name` or `user/repo_name`; can also be provided to the `run` method
-        - base (str, optional): the name of the branch you want to branch off; can also
-            be provided to the `run` method.  Defaults to "master".
-        - branch_name (str, optional): the name of the new branch; can also be provided to the `run` method
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method
+        - repo (str, optional): the name of the repository to create the branch in; must be
+            provided in the form `organization/repo_name` or `user/repo_name`; can also be
+            provided to the `run` method
+        - base (str, optional): the name of the branch you want to branch off; can also be
+            provided to the `run` method.  Defaults to "master".
+        - branch_name (str, optional): the name of the new branch; can also be provided to the
+            `run` method
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method
     """
 
     def __init__(
@@ -100,20 +110,22 @@ class CreateBranch(Task):
         token: str = None,
     ) -> dict:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
-            - repo (str, optional): the name of the repository to open the issue in; must be provided in the
-                form `organization/repo_name`; defaults to the one provided at initialization
-            - base (str, optional): the name of the branch you want to branch off; if not provided here,
+            - repo (str, optional): the name of the repository to open the issue in; must be
+                provided in the form `organization/repo_name`; defaults to the one provided at
+                initialization
+            - base (str, optional): the name of the branch you want to branch off; if not
+                provided here, defaults to the one set at initialization
+            - branch_name (str, optional): the name of the new branch; if not provided here,
                 defaults to the one set at initialization
-            - branch_name (str, optional): the name of the new branch; if not provided here, defaults to
-                the one set at initialization
             - token (str): a GitHub access token
 
         Raises:
-            - ValueError: if a `repo` or `branch_name` was never provided, or if the base branch wasn't found
+            - ValueError: if a `repo` or `branch_name` was never provided, or if the base
+                branch wasn't found
             - HTTPError: if the GET request returns a non-200 status code
 
         Returns:
@@ -135,7 +147,7 @@ class CreateBranch(Task):
             "Accept": "application/vnd.github.v3+json",
         }
 
-        ## gather branch information
+        # gather branch information
         resp = requests.get(url + "/heads", headers=headers)
         resp.raise_for_status()
         branch_data = resp.json()
@@ -149,7 +161,7 @@ class CreateBranch(Task):
         if commit_sha is None:
             raise ValueError("Base branch {} not found.".format(base))
 
-        ## create new branch
+        # create new branch
         new_branch = {"ref": "refs/heads/{}".format(branch_name), "sha": commit_sha}
         resp = requests.post(url, headers=headers, json=new_branch)
         resp.raise_for_status()

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -1,9 +1,12 @@
 """
-Great Expectations checkpoints are combinations of data source, expectation suite, and validation operators configuration that can be used to run Great Expectations actions. 
-Checkpoints are the preferred deployment of validation configuration; you can read more about setting up checkpoints 
-[at the Great Expectation docs](https://docs.greatexpectations.io/en/latest/tutorials/getting_started/set_up_your_first_checkpoint.html#set-up-your-first-checkpoint).
+Great Expectations checkpoints are combinations of data source, expectation suite, and
+validation operators configuration that can be used to run Great Expectations actions.
+Checkpoints are the preferred deployment of validation configuration; you can read more about
+setting up checkpoints [at the Great Expectation
+docs](https://docs.greatexpectations.io/en/latest/tutorials/getting_started/set_up_your_first_checkpoint.html#set-up-your-first-checkpoint).
 
-You can use these task library tasks to interact with your Great Expectations checkpoint from a Prefect flow.
+You can use these task library tasks to interact with your Great Expectations checkpoint from a
+Prefect flow.
 """
 import prefect
 from prefect import Task
@@ -16,14 +19,19 @@ import great_expectations as ge
 
 class RunGreatExpectationsCheckpoint(Task):
     """
-    Task for running a Great Expectations checkpoint. For this task to run properly, it must be run above your great_expectations directory 
-    or configured with the `context_root_dir` for your great_expectations directory on the local file system of the worker process.
+    Task for running a Great Expectations checkpoint. For this task to run properly, it must be
+    run above your great_expectations directory or configured with the `context_root_dir` for
+    your great_expectations directory on the local file system of the worker process.
 
     Args:
-        - checkpoint_name (str): the name of the checkpoint; should match the filename of the checkpoint without .py
-        - context_root_dir (str): the absolute or relative path to the directory holding your `great_expectations.yml`
-        - runtime_environment (dict): a dictionary of great expectation config key-value pairs to overwrite your config in `great_expectations.yml`
-        - run_name (str): the name of this Great Expectation validation run; defaults to the task slug
+        - checkpoint_name (str): the name of the checkpoint; should match the filename of the
+            checkpoint without .py
+        - context_root_dir (str): the absolute or relative path to the directory holding your
+            `great_expectations.yml`
+        - runtime_environment (dict): a dictionary of great expectation config key-value pairs
+            to overwrite your config in `great_expectations.yml`
+        - run_name (str): the name of this Great Expectation validation run; defaults to the
+            task slug
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
@@ -57,16 +65,23 @@ class RunGreatExpectationsCheckpoint(Task):
         Task run method.
 
         Args:
-            - checkpoint_name (str): the name of the checkpoint; should match the filename of the checkpoint without .py
-            - context_root_dir (str): the absolute or relative path to the directory holding your `great_expectations.yml`
-            - runtime_environment (dict): a dictionary of great expectation config key-value pairs to overwrite your config in `great_expectations.yml`
-            - run_name (str): the name of this  Great Expectation validation run; defaults to the task slug
-            - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+            - checkpoint_name (str): the name of the checkpoint; should match the filename of
+                the checkpoint without .py
+            - context_root_dir (str): the absolute or relative path to the directory holding
+                your `great_expectations.yml`
+            - runtime_environment (dict): a dictionary of great expectation config key-value
+                pairs to overwrite your config in `great_expectations.yml`
+            - run_name (str): the name of this  Great Expectation validation run; defaults to
+                the task slug
+            - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+                constructor
 
         Raises:
             - 'signals.VALIDATIONFAIL' if the validation was not a success
         Returns:
-            - result ('great_expectations.validation_operators.types.validation_operator_result.ValidationOperatorResult'): The Great Expectations metadata returned from the validation
+            - result
+                ('great_expectations.validation_operators.types.validation_operator_result.ValidationOperatorResult'):
+                The Great Expectations metadata returned from the validation
 
         """
 

--- a/src/prefect/tasks/gsheets/gsheets.py
+++ b/src/prefect/tasks/gsheets/gsheets.py
@@ -97,7 +97,7 @@ class ReadGsheetRow(Task):
             - worksheet_name (str): The worksheet to target
 
         Returns:
-            - a list of values from the row 
+            - a list of values from the row
         """
         client = gspread.service_account(filename=credentials_filename)
         google_sheet = client.open_by_key(sheet_key)

--- a/src/prefect/tasks/jira/jira_service_desk.py
+++ b/src/prefect/tasks/jira/jira_service_desk.py
@@ -13,28 +13,41 @@ except ImportError:
 class JiraServiceDeskTask(Task):
     """
     Task for creating a Jira Service Desk customer request. For this task to function properly,
-    you need a Jira account and API token.  The API token can be created at: https://id.atlassian.com/manage/api-tokens 
-    The Jira account username ('JIRAUSER'), API token ('JIRATOKEN') can be set as part of a 'JIRASECRETS' object in Prefect Secrets. 
-    
-    An example 'JIRASECRETS' object looks like this:
-    ```
-    JIRASECRETS = { JIRATOKEN = "XXXXXXXXX", JIRAUSER = "xxxxx@yyy.com", JIRASERVER = "https://???.atlassian.net" }
+    you need a Jira account and API token.  The API token can be created at:
+    https://id.atlassian.com/manage/api-tokens The Jira account username ('JIRAUSER'), API
+    token ('JIRATOKEN') can be set as part of a 'JIRASECRETS' object in Prefect Secrets.
+
+    An example 'JIRASECRETS' secret configuration looks like:
+
+    ```toml
+    [secrets]
+    JIRASECRETS.JIRATOKEN = "XXXXXXXXX"
+    JIRASECRETS.JIRAUSER = "xxxxx@yyy.com"
+    JIRASECRETS.JIRASERVER = "https://???.atlassian.net"
     ```
 
-    The server URL can be set as part of the 'JIRASECRETS' object ('JIRASERVER') or passed to the task as the "server_URL" argument.
+    The server URL can be set as part of the 'JIRASECRETS' object ('JIRASERVER') or passed to
+    the task as the "server_URL" argument.
 
-    The service desk id and issue type will show in the URL when you raise a customer request in the UI.  For example, in the below URL the service desk id is "3" and the issue_type is 10010:
+    The service desk id and issue type will show in the URL when you raise a customer request
+    in the UI.  For example, in the below URL the service desk id is "3" and the issue_type is
+    10010:
+
     ```
     https://test.atlassian.net/servicedesk/customer/portal/3/group/3/create/10010
     ````
-    
+
     Args:
-        - server_url (str): the URL of your atlassian account e.g. "https://test.atlassian.net".  Can also be set as a Prefect Secret. 
-        - service_desk_id (str):  the id for your jira service desk. Can also be set at run time. 
-        - issue_type (int, optional): the type of issue you want to create.  Can also be set at run time. 
-        - summary (str, optional): summary or title for your issue. Can also be set at run time. 
-        - description (str, optional): description or additional information for the issue. Can also be set at run time. 
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method. 
+        - server_url (str): the URL of your atlassian account e.g.
+            "https://test.atlassian.net".  Can also be set as a Prefect Secret.
+        - service_desk_id (str):  the id for your jira service desk. Can also be set at run time.
+        - issue_type (int, optional): the type of issue you want to create.  Can also be set at
+            run time.
+        - summary (str, optional): summary or title for your issue. Can also be set at run time.
+        - description (str, optional): description or additional information for the issue. Can
+            also be set at run time.
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method.
     """
 
     def __init__(
@@ -67,21 +80,28 @@ class JiraServiceDeskTask(Task):
         description: str = None,
     ) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
-            - username(str): the jira username, provided with a Prefect secret (defaults to JIRAUSER in JIRASECRETS)
-            - access_token (str): a Jira access token, provided with a Prefect secret (defaults to JIRATOKEN in JIRASECRETS)
-            - server_url (str): the URL of your atlassian account e.g. "https://test.atlassian.net".  Can also be set as a Prefect Secret. Defaults to the one provided at initialization
-            - service_desk_id(str):  the key for your jira project; defaults to the one provided at initialization
-            - issue_type (str, optional): the type of issue you want to create; 
-            - summary (str, optional): summary or title for your issue; defaults to the one provided at initialization
-            - description (str, optional): description or additional information for the issue; defaults to the one provided at initialization
-        
+            - username(str): the jira username, provided with a Prefect secret (defaults to
+                JIRAUSER in JIRASECRETS)
+            - access_token (str): a Jira access token, provided with a Prefect secret (defaults
+                to JIRATOKEN in JIRASECRETS)
+            - server_url (str): the URL of your atlassian account e.g.
+                "https://test.atlassian.net".  Can also be set as a Prefect Secret. Defaults to
+                the one provided at initialization
+            - service_desk_id(str):  the key for your jira project; defaults to the one
+                provided at initialization
+            - issue_type (str, optional): the type of issue you want to create;
+            - summary (str, optional): summary or title for your issue; defaults to the one
+                provided at initialization
+            - description (str, optional): description or additional information for the issue;
+                defaults to the one provided at initialization
+
         Raises:
             - ValueError: if a `service_desk_id`, `request_type`, or `summary` are not provided
-        
+
         Returns:
             - None
         """

--- a/src/prefect/tasks/jira/jira_task.py
+++ b/src/prefect/tasks/jira/jira_task.py
@@ -12,25 +12,37 @@ except ImportError:
 
 class JiraTask(Task):
     """
-    Task for creating a jira issue. For this task to function properly,
-    you need a Jira account and API token.  The API token can be created at: https://id.atlassian.com/manage/api-tokens 
-    The Jira account username ('JIRAUSER'), API token ('JIRATOKEN') can be set as part of a 'JIRASECRETS' object in Prefect Secrets. 
-    
-    An example 'JIRASECRETS' object looks like this:
-    ```
-    JIRASECRETS = { JIRATOKEN = "XXXXXXXXX", JIRAUSER = "xxxxx@yyy.com", JIRASERVER = "https://???.atlassian.net" }
+    Task for creating a jira issue. For this task to function properly, you need a Jira account
+    and API token.  The API token can be created at: https://id.atlassian.com/manage/api-tokens
+    The Jira account username ('JIRAUSER'), API token ('JIRATOKEN') can be set as part of a
+    'JIRASECRETS' object in Prefect Secrets.
+
+    An example 'JIRASECRETS' secret configuration looks like:
+
+    ```toml
+    [secrets]
+    JIRASECRETS.JIRATOKEN = "XXXXXXXXX"
+    JIRASECRETS.JIRAUSER = "xxxxx@yyy.com"
+    JIRASECRETS.JIRASERVER = "https://???.atlassian.net"
     ```
 
-    The server URL can be set as part of the 'JIRASECRETS' object ('JIRASERVER') or passed to the task as the "server_URL" argument.
-    
+    The server URL can be set as part of the 'JIRASECRETS' object ('JIRASERVER') or passed to
+    the task as the "server_URL" argument.
+
     Args:
-        - server_url (str): the URL of your atlassian account e.g. "https://test.atlassian.net".  Can also be set as a Prefect Secret. 
-        - project_name(str):  the key for your jira project. Can also be set at run time. 
-        - assignee (str, optional): the atlassian accountId of the person you want to assign the ticket to.  Defaults to "automatic" if this is not set. Can also be set at run time. 
-        - issue_type (str, optional): the type of issue you want to create.  Can also be set at run time. Defaults to 'Task'. 
-        - summary (str, optional): summary or title for your issue. Can also be set at run time. 
-        - description (str, optional): description or additional information for the issue. Can also be set at run time. 
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method. 
+        - server_url (str): the URL of your atlassian account e.g.
+            "https://test.atlassian.net".  Can also be set as a Prefect Secret.
+        - project_name(str):  the key for your jira project. Can also be set at run time.
+        - assignee (str, optional): the atlassian accountId of the person you want to assign
+            the ticket to.  Defaults to "automatic" if this is not set. Can also be set at run
+            time.
+        - issue_type (str, optional): the type of issue you want to create.  Can also be set at
+            run time. Defaults to 'Task'.
+        - summary (str, optional): summary or title for your issue. Can also be set at run time.
+        - description (str, optional): description or additional information for the issue. Can
+            also be set at run time.
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method.
     """
 
     def __init__(
@@ -66,19 +78,29 @@ class JiraTask(Task):
         description: str = None,
     ) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
-        
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
+
         Args:
-            - username(str): the jira username, provided with a Prefect secret (defaults to JIRAUSER in JIRASECRETS)
-            - access_token (str): a Jira access token, provided with a Prefect secret (defaults to JIRATOKEN in JIRASECRETS)
-            - server_url (str): the URL of your atlassian account e.g. "https://test.atlassian.net".  Can also be set as a Prefect Secret. Defaults to the one provided at initialization
-            - project_name(str):  the key for your jira project; defaults to the one provided at initialization
-            - assignee (str, optional): the atlassian accountId of the person you want to assign the ticket to; defaults to "automatic" if this is not set; defaults to the one provided at initialization
-            - issue_type (str, optional): the type of issue you want to create; defaults to 'Task'
-            - summary (str, optional): summary or title for your issue; defaults to the one provided at initialization
-            - description (str, optional): description or additional information for the issue; defaults to the one provided at initialization
-        
+            - username(str): the jira username, provided with a Prefect secret (defaults to
+                JIRAUSER in JIRASECRETS)
+            - access_token (str): a Jira access token, provided with a Prefect secret (defaults
+                to JIRATOKEN in JIRASECRETS)
+            - server_url (str): the URL of your atlassian account e.g.
+                "https://test.atlassian.net".  Can also be set as a Prefect Secret. Defaults to
+                the one provided at initialization
+            - project_name(str):  the key for your jira project; defaults to the one provided
+                at initialization
+            - assignee (str, optional): the atlassian accountId of the person you want to
+                assign the ticket to; defaults to "automatic" if this is not set; defaults to
+                the one provided at initialization
+            - issue_type (str, optional): the type of issue you want to create; defaults to
+                'Task'
+            - summary (str, optional): summary or title for your issue; defaults to the one
+                provided at initialization
+            - description (str, optional): description or additional information for the issue;
+                defaults to the one provided at initialization
+
         Raises:
             - ValueError: if a `project_name` or 'summary' are not provided
 

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -12,10 +12,11 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class EmailTask(Task):
     """
-    Task for sending email from an authenticated email service over SMTP. For this task to function properly,
-    you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect Secrets set.  It is recommended
-    you use a [Google App Password](https://support.google.com/accounts/answer/185833) if you use Gmail.
-    The default SMTP server is set to the Gmail SMTP server on port 465 (SMTP-over-SSL). Sending messages
+    Task for sending email from an authenticated email service over SMTP. For this task to
+    function properly, you must have the `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` Prefect
+    Secrets set.  It is recommended you use a [Google App
+    Password](https://support.google.com/accounts/answer/185833) if you use Gmail.  The default
+    SMTP server is set to the Gmail SMTP server on port 465 (SMTP-over-SSL). Sending messages
     containing HTML code is supported - the default MIME type is set to the text/html.
 
     Args:
@@ -23,11 +24,13 @@ class EmailTask(Task):
         - msg (str, optional): the contents of the email; can also be provided at runtime
         - email_to (str, optional): the destination email address to send the message to; can also
             be provided at runtime
-        - email_from (str, optional): the email address to send from; defaults to notifications@prefect.io
+        - email_from (str, optional): the email address to send from; defaults to
+            notifications@prefect.io
         - smtp_server (str, optional): the hostname of the SMTP server; defaults to smtp.gmail.com
         - smtp_port (int, optional): the port number of the SMTP server; defaults to 465
         - smtp_type (str, optional): either SSL or STARTTLS; defaults to SSL
-        - **kwargs (Any, optional): additional keyword arguments to pass to the base Task initialization
+        - **kwargs (Any, optional): additional keyword arguments to pass to the base Task
+            initialization
     """
 
     def __init__(

--- a/src/prefect/tasks/notifications/pushbullet_task.py
+++ b/src/prefect/tasks/notifications/pushbullet_task.py
@@ -11,12 +11,16 @@ except ImportError:
 
 class PushbulletTask(Task):
     """
-    Task for sending a notification to a mobile phone (or other device) using pushbullet. For this task to function properly,
-    you must have the `"PUSHBULLET_TOKEN"` Prefect Secret set. You can set up a pushbullet account and/or get a token here: https://www.pushbullet.com/#settings/account
+    Task for sending a notification to a mobile phone (or other device) using pushbullet. For
+    this task to function properly, you must have the `"PUSHBULLET_TOKEN"` Prefect Secret set.
+    You can set up a pushbullet account and/or get a token here:
+    https://www.pushbullet.com/#settings/account
 
     Args:
-        - msg(str, optional):  The message you want to send to your phone; can also be provided at runtime.
-        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task init method
+        - msg(str, optional):  The message you want to send to your phone; can also be provided
+            at runtime.
+        - **kwargs (Any, optional): additional keyword arguments to pass to the standard Task
+            init method
     """
 
     def __init__(self, msg: str = None, **kwargs: Any):
@@ -26,19 +30,14 @@ class PushbulletTask(Task):
     @defaults_from_attrs("msg")
     def run(self, msg: str = None, access_token: str = None) -> None:
         """
-        Run method for this Task. Invoked by calling this Task after initialization within a Flow context,
-        or by using `Task.bind`.
+        Run method for this Task. Invoked by calling this Task after initialization within a
+        Flow context, or by using `Task.bind`.
 
         Args:
             - msg (str): The message you want sent to your phone; defaults to the one provided
                 at initialization
-            - access_token (str): a Pushbullet access token, provided with a Prefect secret. Defaults to the "PUSHBULLET_TOKEN" secret
-
-        Raises:
-            - None
-
-        Returns:
-            - None
+            - access_token (str): a Pushbullet access token, provided with a Prefect secret.
+                Defaults to the "PUSHBULLET_TOKEN" secret
         """
         if access_token is None:
             access_token = Secret("PUSHBULLET_TOKEN").get()
@@ -48,5 +47,5 @@ class PushbulletTask(Task):
         if msg is None:
             raise ValueError("A message must be provided")
 
-        ## send the request
+        # send the request
         pb.push_note("Flow Notification", msg)

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -7,15 +7,18 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class SlackTask(Task):
     """
-    Task for sending a message via Slack.  For this task to function properly,
-    you must have a Prefect Secret set which stores your Slack webhook URL.  For installing the Prefect App,
-    please see these [installation instructions](https://docs.prefect.io/core/advanced_tutorials/slack-notifications.html#installation-instructions).
+    Task for sending a message via Slack.  For this task to function properly, you must have a
+    Prefect Secret set which stores your Slack webhook URL.  For installing the Prefect App,
+    please see these [installation
+    instructions](https://docs.prefect.io/core/advanced_tutorials/slack-notifications.html#installation-instructions).
 
     Args:
-        - message (str, optional): the message to send as either a dictionary or a plain string; can also be provided at runtime
-        - webhook_secret (str, optional): the name of the Prefect Secret which stores your slack webhook URL;
-            defaults to `"SLACK_WEBHOOK_URL"`
-        - **kwargs (Any, optional): additional keyword arguments to pass to the base Task initialization
+        - message (str, optional): the message to send as either a dictionary or a plain
+            string; can also be provided at runtime
+        - webhook_secret (str, optional): the name of the Prefect Secret which stores your
+            slack webhook URL; defaults to `"SLACK_WEBHOOK_URL"`
+        - **kwargs (Any, optional): additional keyword arguments to pass to the base Task
+            initialization
     """
 
     def __init__(
@@ -34,8 +37,9 @@ class SlackTask(Task):
         Run method which sends a Slack message.
 
         Args:
-            - message (Union[str,dict], optional): the message to send as either a dictionary or a plain string; 
-            if not provided here, will use the value provided at initialization
+            - message (Union[str,dict], optional): the message to send as either a dictionary
+                or a plain string; if not provided here, will use the value provided at
+                initialization
 
         Returns:
             - None

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -13,9 +13,11 @@ class PostgresExecute(Task):
         - user (str): user name used to authenticate
         - password (str): password used to authenticate
         - host (str): database host address
-        - port (int, optional): port used to connect to Postgres database, defaults to 5432 if not provided
+        - port (int, optional): port used to connect to Postgres database, defaults to 5432 if
+            not provided
         - query (str, optional): query to execute against database
-        - data (tuple, optional): values to use in query, must be specified using placeholder is query string
+        - data (tuple, optional): values to use in query, must be specified using placeholder
+            is query string
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -64,8 +66,8 @@ class PostgresExecute(Task):
         if not query:
             raise ValueError("A query string must be provided")
 
-        ## connect to database, open cursor
-        ## allow psycopg2 to pass through any exceptions raised
+        # connect to database, open cursor
+        # allow psycopg2 to pass through any exceptions raised
         conn = pg.connect(
             dbname=self.db_name,
             user=self.user,
@@ -74,8 +76,8 @@ class PostgresExecute(Task):
             port=self.port,
         )
 
-        ## try to execute query
-        ## context manager automatically rolls back failed transactions
+        # try to execute query
+        # context manager automatically rolls back failed transactions
         try:
             with conn:
                 with conn.cursor() as cursor:
@@ -88,7 +90,7 @@ class PostgresExecute(Task):
             conn.close()
             return executed
 
-        ## pass through error, and ensure connection is closed
+        # pass through error, and ensure connection is closed
         except (Exception, pg.DatabaseError) as error:
             conn.close()
             raise error
@@ -103,11 +105,15 @@ class PostgresFetch(Task):
         - user (str): user name used to authenticate
         - password (str): password used to authenticate
         - host (str): database host address
-        - port (int, optional): port used to connect to Postgres database, defaults to 5432 if not provided
-        - fetch (str, optional): one of "one" "many" or "all", used to determine how many results to fetch from executed query
-        - fetch_count (int, optional): if fetch = 'many', determines the number of results to fetch, defaults to 10
+        - port (int, optional): port used to connect to Postgres database, defaults to 5432 if
+            not provided
+        - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+            results to fetch from executed query
+        - fetch_count (int, optional): if fetch = 'many', determines the number of results to
+            fetch, defaults to 10
         - query (str, optional): query to execute against database
-        - data (tuple, optional): values to use in query, must be specified using placeholder is query string
+        - data (tuple, optional): values to use in query, must be specified using placeholder
+            is query string
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -152,10 +158,13 @@ class PostgresFetch(Task):
         Task run method. Executes a query against Postgres database and fetches results.
 
         Args:
-            - fetch (str, optional): one of "one" "many" or "all", used to determine how many results to fetch from executed query
-            - fetch_count (int, optional): if fetch = 'many', determines the number of results to fetch, defaults to 10
+            - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+                results to fetch from executed query
+            - fetch_count (int, optional): if fetch = 'many', determines the number of results
+                to fetch, defaults to 10
             - query (str, optional): query to execute against database
-            - data (tuple, optional): values to use in query, must be specified using placeholder is query string
+            - data (tuple, optional): values to use in query, must be specified using
+                placeholder is query string
             - commit (bool, optional): set to True to commit transaction, defaults to false
 
         Returns:
@@ -173,8 +182,8 @@ class PostgresFetch(Task):
                 "The 'fetch' parameter must be one of the following - ('one', 'many', 'all')"
             )
 
-        ## connect to database, open cursor
-        ## allow psycopg2 to pass through any exceptions raised
+        # connect to database, open cursor
+        # allow psycopg2 to pass through any exceptions raised
         conn = pg.connect(
             dbname=self.db_name,
             user=self.user,
@@ -183,14 +192,14 @@ class PostgresFetch(Task):
             port=self.port,
         )
 
-        ## try to execute query
-        ## context manager automatically rolls back failed transactions
+        # try to execute query
+        # context manager automatically rolls back failed transactions
         try:
             with conn:
                 with conn.cursor() as cursor:
                     cursor.execute(query=query, vars=data)
 
-                    ## fetch results
+                    # fetch results
                     if fetch == "all":
                         records = cursor.fetchall()
                     elif fetch == "many":
@@ -204,7 +213,7 @@ class PostgresFetch(Task):
             conn.close()
             return records
 
-        ## pass through error, and ensure connection is closed
+        # pass through error, and ensure connection is closed
         except (Exception, pg.DatabaseError) as error:
             conn.close()
             raise error

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -9,16 +9,17 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 class FlowRunTask(Task):
     """
-    Task used to kick off a flow run using Prefect Core's server or Prefect Cloud.
-    If multiple versions of the flow are found, this task will kick off the most recent unarchived version.
+    Task used to kick off a flow run using Prefect Core's server or Prefect Cloud.  If multiple
+    versions of the flow are found, this task will kick off the most recent unarchived version.
 
     Args:
-        - flow_name (str, optional): the name of the flow to schedule; this value may also be provided at run time
-        - project_name (str, optional): if running with Cloud as a backend, this is the project in which the flow is
-            located; this value may also be provided at runtime. If running with Prefect Core's server as the backend,
-            this should not be provided.
-        - parameters (dict, optional): the parameters to pass to the flow run being scheduled; this value may also
-            be provided at run time
+        - flow_name (str, optional): the name of the flow to schedule; this value may also be
+            provided at run time
+        - project_name (str, optional): if running with Cloud as a backend, this is the project
+            in which the flow is located; this value may also be provided at runtime. If
+            running with Prefect Core's server as the backend, this should not be provided.
+        - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
+            this value may also be provided at run time
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
@@ -42,20 +43,21 @@ class FlowRunTask(Task):
         Run method for the task; responsible for scheduling the specified flow run.
 
         Args:
-            - flow_name (str, optional): the name of the flow to schedule; if not provided, this method will
-                use the flow name provided at initialization
-            - project_name (str, optional): the Cloud project in which the flow is located; if not provided, this method
-                will use the project provided at initialization. If running with Prefect Core's server as the backend,
-                this should not be provided.
-            - parameters (dict, optional): the parameters to pass to the flow run being scheduled; if not provided,
-                this method will use the parameters provided at initialization
+            - flow_name (str, optional): the name of the flow to schedule; if not provided,
+                this method will use the flow name provided at initialization
+            - project_name (str, optional): the Cloud project in which the flow is located; if
+                not provided, this method will use the project provided at initialization. If
+                running with Prefect Core's server as the backend, this should not be provided.
+            - parameters (dict, optional): the parameters to pass to the flow run being
+                scheduled; if not provided, this method will use the parameters provided at
+                initialization
 
         Returns:
             - str: the ID of the newly-scheduled flow run
 
         Raises:
-            - ValueError: if flow was not provided, cannot be found, or if a project name was not provided while using
-                Cloud as a backend
+            - ValueError: if flow was not provided, cannot be found, or if a project name was
+                not provided while using Cloud as a backend
 
         Example:
             ```python

--- a/src/prefect/tasks/redis/redis_tasks.py
+++ b/src/prefect/tasks/redis/redis_tasks.py
@@ -15,17 +15,21 @@ class RedisSet(Task):
         - db (int, optional): redis database index, defaults to 0
         - password_secret (str, optional): the name of the Prefect Secret
             that stores your Redis credentials
-        - redis_key (str, optional): Redis key to be set, can be provided at initialization or runtime
-        - redis_val (Redis native type, optional): Redis val to be set, can be provided at initialization or runtime,
-            Redis native types include strings, dictionaries, lists, sets, and sorted sets
-        - redis_connection_params (dict, optional): key-value pairs passed to the redis.Redis connection
-            initializer
-        - ex (int, optional): if provided, sets an expire flag, in seconds, on 'redis_key' set
-        - px (int, optional): if provided, sets an expire flag, in milliseconds, on 'redis_key' set
-        - nx (int, optional): if set to True, set the value at 'redis_key' to 'redis_val' only
-            if it does not exist, defaults to False
-        - xx (int, optional): if set to True, set the value at 'redis_key' to 'redis_val' only
-            if it already exists, defaults to False
+        - redis_key (str, optional): Redis key to be set, can be provided at
+            initialization or runtime
+        - redis_val (Redis native type, optional): Redis val to be set, can be
+            provided at initialization or runtime, Redis native types include
+            strings, dictionaries, lists, sets, and sorted sets
+        - redis_connection_params (dict, optional): key-value pairs passed to
+            the redis.Redis connection initializer
+        - ex (int, optional): if provided, sets an expire flag, in seconds, on
+            'redis_key' set
+        - px (int, optional): if provided, sets an expire flag, in
+            milliseconds, on 'redis_key' set
+        - nx (int, optional): if set to True, set the value at 'redis_key' to
+            'redis_val' only if it does not exist, defaults to False
+        - xx (int, optional): if set to True, set the value at 'redis_key' to
+            'redis_val' only if it already exists, defaults to False
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -73,15 +77,19 @@ class RedisSet(Task):
         Task run method. Sets Redis key-value pair.
 
         Args:
-            - redis_key (str, optional): Redis key to be set, can be provided at initialization or runtime
-            - redis_val (Redis native type, optional): Redis val to be set, can be provided at initialization or runtime,
-                Redis native types include strings, dictionaries, lists, sets, and sorted sets
-            - ex (int, optional): if provided, sets an expire flag, in seconds, on 'redis_key' set
-            - px (int, optional): if provided, sets an expire flag, in milliseconds, on 'redis_key' set
-            - nx (int, optional): if set to True, set the value at 'redis_key' to 'redis_val' only
-                if it does not exist, defaults to False
-            - xx (int, optional): if set to True, set the value at 'redis_key' to 'redis_val' only
-                if it already exists, defaults to False
+            - redis_key (str, optional): Redis key to be set, can be provided
+                at initialization or runtime
+            - redis_val (Redis native type, optional): Redis val to be set, can
+                be provided at initialization or runtime, Redis native types
+                include strings, dictionaries, lists, sets, and sorted sets
+            - ex (int, optional): if provided, sets an expire flag, in seconds,
+                on 'redis_key' set
+            - px (int, optional): if provided, sets an expire flag, in
+                milliseconds, on 'redis_key' set
+            - nx (int, optional): if set to True, set the value at 'redis_key'
+                to 'redis_val' only if it does not exist, defaults to False
+            - xx (int, optional): if set to True, set the value at 'redis_key'
+                to 'redis_val' only if it already exists, defaults to False
 
         Returns:
             - bool: status of set operation
@@ -92,7 +100,7 @@ class RedisSet(Task):
         if None in (redis_key, redis_val):
             raise ValueError("redis_key and redis_val must be provided")
 
-        ## connect to redis
+        # connect to redis
         password = Secret(self.password_secret).get()
         connection = redis.Redis(
             host=self.host,
@@ -119,9 +127,10 @@ class RedisGet(Task):
         - db (int, optional): redis database index, defaults to 0
         - password_secret (str, optional): the name of the Prefect Secret
             that stores your Redis password
-        - redis_connection_params (dict, optional): key-value pairs passed to the redis.Redis connection
-            initializer
-        - redis_key (str, optional): Redis key to get value, can be provided at initialization or runtime
+        - redis_connection_params (dict, optional): key-value pairs passed to
+            the redis.Redis connection initializer
+        - redis_key (str, optional): Redis key to get value, can be provided at
+            initialization or runtime
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -151,7 +160,8 @@ class RedisGet(Task):
         Task run method.
 
         Args:
-            - redis_key (str, optional): Redis key to get value, can be provided at initialization or runtime
+            - redis_key (str, optional): Redis key to get value, can be
+                provided at initialization or runtime
 
         Returns:
             - value: value associated with redis_key
@@ -162,7 +172,7 @@ class RedisGet(Task):
         if not redis_key:
             raise ValueError("redis_key must be provided")
 
-        ## connect to redis
+        # connect to redis
         password = Secret(self.password_secret).get()
         connection = redis.Redis(
             host=self.host,
@@ -187,10 +197,10 @@ class RedisExecute(Task):
         - db (int, optional): redis database index, defaults to 0
         - password_secret (str, optional): the name of the Prefect Secret
             that stores your Redis credentials
-        - redis_connection_params (dict, optional): key-value pairs passed to the redis.Redis connection
-            initializer
-        - redis_cmd (str, optional): Redis command to execute, must be provided at initialization or
-            runtime
+        - redis_connection_params (dict, optional): key-value pairs passed to
+            the redis.Redis connection initializer
+        - redis_cmd (str, optional): Redis command to execute, must be provided
+            at initialization or runtime
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -220,8 +230,8 @@ class RedisExecute(Task):
         Task run method. Executes a command against a Redis connection.
 
         Args:
-            - redis_cmd (str, optional): Redis command to execute, must be provided at initialization or
-                runtime
+            - redis_cmd (str, optional): Redis command to execute, must be
+                provided at initialization or runtime
 
         Returns:
             - result: result of executed Redis command
@@ -229,7 +239,7 @@ class RedisExecute(Task):
         if not redis_cmd:
             raise ValueError("A redis command must be specified")
 
-        ## connect to redis
+        # connect to redis
         password = Secret(self.password_secret).get()
         connection = redis.Redis(
             host=self.host,

--- a/src/prefect/tasks/secrets/base.py
+++ b/src/prefect/tasks/secrets/base.py
@@ -11,9 +11,9 @@ class SecretBase(Task):
     Base Secrets Task.  This task does not perform any action but rather serves as the base
     task class which should be inherited from when writing new Secret Tasks.
 
-    Users should subclass this Task and override its `run` method for plugging into other Secret stores,
-    as it is handled differently during execution to ensure the underlying secret value is not accidentally
-    persisted in a non-safe location.
+    Users should subclass this Task and override its `run` method for plugging into other
+    Secret stores, as it is handled differently during execution to ensure the underlying
+    secret value is not accidentally persisted in a non-safe location.
 
     Args:
         - **kwargs (Any, optional): additional keyword arguments to pass to the Task constructor
@@ -50,10 +50,11 @@ class PrefectSecret(SecretBase):
     @defaults_from_attrs("name")
     def run(self, name: str = None):
         """
-        The run method for Secret Tasks.  This method actually retrieves and returns the underlying secret value
-        using the `Secret.get()` method.  Note that this method first checks context for the secret value, and if not
-        found either raises an error or queries Prefect Cloud, depending on whether `config.cloud.use_local_secrets`
-        is `True` or `False`.
+        The run method for Secret Tasks.  This method actually retrieves and returns the
+        underlying secret value using the `Secret.get()` method.  Note that this method first
+        checks context for the secret value, and if not found either raises an error or queries
+        Prefect Cloud, depending on whether `config.cloud.use_local_secrets` is `True` or
+        `False`.
 
         Args:
             - name (str, optional): the name of the underlying Secret to retrieve. Defaults

--- a/src/prefect/tasks/secrets/env_var.py
+++ b/src/prefect/tasks/secrets/env_var.py
@@ -34,8 +34,8 @@ class EnvVarSecret(PrefectSecret):
         Returns the value of an environment variable after applying an optional `cast` function.
 
         Args:
-            - name (str, optional): the name of the underlying environment variable to retrieve. Defaults
-                to the name provided at initialization.
+            - name (str, optional): the name of the underlying environment variable to
+                retrieve. Defaults to the name provided at initialization.
 
         Returns:
             - Any: the (optionally type-cast) value of the environment variable

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -21,8 +21,9 @@ class ShellTask(prefect.Task):
             change directories, define helper functions, etc. when re-using this Task
             for different commands in a Flow
         - shell (string, optional): shell to run the command with; defaults to "bash"
-        - return_all (bool, optional): boolean specifying whether this task should return all lines of stdout
-            as a list, or just the last line as a string; defaults to `False`
+        - return_all (bool, optional): boolean specifying whether this task
+            should return all lines of stdout as a list, or just the last line
+            as a string; defaults to `False`
         - **kwargs: additional keyword arguments to pass to the Task constructor
 
     Example:
@@ -70,9 +71,11 @@ class ShellTask(prefect.Task):
                 the subprocess
 
         Returns:
-            - stdout (string): if `return_all` is `False` (the default), only the last line of stdout
-                is returned, otherwise all lines are returned, which is useful for passing
-                result of shell command to other downstream tasks. If there is no output, `None` is returned.
+            - stdout (string): if `return_all` is `False` (the default), only
+                the last line of stdout is returned, otherwise all lines are
+                returned, which is useful for passing result of shell command
+                to other downstream tasks. If there is no output, `None` is
+                returned.
 
         Raises:
             - prefect.engine.signals.FAIL: if command has an exit code other

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -18,7 +18,8 @@ class SnowflakeQuery(Task):
         - role (str, optional): name of the default role to use
         - warehouse (str, optional): name of the default warehouse to use
         - query (str, optional): query to execute against database
-        - data (tuple, optional): values to use in query, must be specified using placeholder is query string
+        - data (tuple, optional): values to use in query, must be specified using placeholder
+            is query string
         - autocommit (bool, optional): set to True to autocommit, defaults to None, which
             takes snowflake AUTOCOMMIT parameter
         - **kwargs (dict, optional): additional keyword arguments to pass to the
@@ -92,10 +93,10 @@ class SnowflakeQuery(Task):
             if value is not None
         }
 
-        ## connect to database, open cursor
+        # connect to database, open cursor
         conn = sf.connect(**connect_params)
-        ## try to execute query
-        ## context manager automatically rolls back failed transactions
+        # try to execute query
+        # context manager automatically rolls back failed transactions
         try:
             with conn:
                 with conn.cursor() as cursor:
@@ -104,7 +105,7 @@ class SnowflakeQuery(Task):
             conn.close()
             return executed
 
-        ## pass through error, and ensure connection is closed
+        # pass through error, and ensure connection is closed
         except Exception as error:
             conn.close()
             raise error

--- a/src/prefect/tasks/spacy/spacy_tasks.py
+++ b/src/prefect/tasks/spacy/spacy_tasks.py
@@ -38,7 +38,7 @@ class SpacyNLP(Task):
         self.disable = disable or []
         self.component_cfg = component_cfg or {}
 
-        ## load spacy model
+        # load spacy model
         if nlp:
             self.nlp = nlp
         else:
@@ -212,7 +212,7 @@ class SpacyComponent(Task):
         if nlp is None:
             raise ValueError("A spaCy pipeline must be provided")
 
-        ## iterate through pipeline to find object
+        # iterate through pipeline to find object
         for name, component in nlp.pipeline:
             if name == component_name:
                 return component

--- a/src/prefect/tasks/templates/jinja2.py
+++ b/src/prefect/tasks/templates/jinja2.py
@@ -8,7 +8,8 @@ try:
     from jinja2 import Template
 except ImportError:
     raise ImportError(
-        'Using `prefect.tasks.templates.jinja2` requires Prefect to be installed with the "templates" extra.'
+        "Using `prefect.tasks.templates.jinja2` requires Prefect to be installed "
+        "with the 'templates' extra."
     )
 
 

--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -49,8 +49,8 @@ from prefect.engine import signals
 from prefect.engine.state import Mapped
 
 if TYPE_CHECKING:
-    from prefect.engine import state  # pylint: disable=W0611
-    from prefect import core  # pylint: disable=W0611
+    from prefect.engine import state  # noqa
+    from prefect import core  # noqa
 
 
 def _get_all_states_as_set(upstream_states: Dict["core.Edge", "state.State"]) -> set:
@@ -175,19 +175,22 @@ def some_failed(
     at_least: Union[int, float] = None, at_most: Union[int, float] = None
 ) -> Callable[[Dict["core.Edge", "state.State"]], bool]:
     """
-    Runs if some amount of upstream tasks failed. This amount can be specified as an upper bound (`at_most`) or
-    a lower bound (`at_least`), and can be provided as an absolute number or a percentage of upstream tasks.
+    Runs if some amount of upstream tasks failed. This amount can be specified
+    as an upper bound (`at_most`) or a lower bound (`at_least`), and can be
+    provided as an absolute number or a percentage of upstream tasks.
 
-    Note that `SKIPPED` tasks are considered successes and `TRIGGER_FAILED` tasks are considered failures.
+    Note that `SKIPPED` tasks are considered successes and `TRIGGER_FAILED`
+    tasks are considered failures.
 
     Args:
-        - at_least (Union[int, float], optional): the minimum number of upstream failures that must occur for
-            this task to run.  If the provided number is less than 0, it will be interpreted as a percentage, otherwise as an
-            absolute number.
-        - at_most (Union[int, float], optional): the maximum number of upstream failures to allow for
-            this task to run.  If the provided number is less than 0, it will be interpreted as a percentage, otherwise as an
-            absolute number.
-    """
+        - at_least (Union[int, float], optional): the minimum number of
+            upstream failures that must occur for this task to run.  If the
+            provided number is less than 0, it will be interpreted as a
+            percentage, otherwise as an absolute number.
+        - at_most (Union[int, float], optional): the maximum number of upstream
+           failures to allow for this task to run.  If the provided number is
+           less than 0, it will be interpreted as a percentage, otherwise as an
+           absolute number.  """
 
     def _some_failed(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
         """
@@ -229,18 +232,23 @@ def some_successful(
     at_least: Union[int, float] = None, at_most: Union[int, float] = None
 ) -> Callable[[Dict["core.Edge", "state.State"]], bool]:
     """
-    Runs if some amount of upstream tasks succeed. This amount can be specified as an upper bound (`at_most`) or
-    a lower bound (`at_least`), and can be provided as an absolute number or a percentage of upstream tasks.
 
-    Note that `SKIPPED` tasks are considered successes and `TRIGGER_FAILED` tasks are considered failures.
+    Runs if some amount of upstream tasks succeed. This amount can be specified
+    as an upper bound (`at_most`) or a lower bound (`at_least`), and can be
+    provided as an absolute number or a percentage of upstream tasks.
+
+    Note that `SKIPPED` tasks are considered successes and `TRIGGER_FAILED`
+    tasks are considered failures.
 
     Args:
-        - at_least (Union[int, float], optional): the minimum number of upstream successes that must occur for
-            this task to run.  If the provided number is less than 0, it will be interpreted as a percentage, otherwise as an
-            absolute number.
-        - at_most (Union[int, float], optional): the maximum number of upstream successes to allow for
-            this task to run.  If the provided number is less than 0, it will be interpreted as a percentage, otherwise as an
-            absolute number.
+        - at_least (Union[int, float], optional): the minimum number of
+            upstream successes that must occur for this task to run.  If the
+            provided number is less than 0, it will be interpreted as a
+            percentage, otherwise as an absolute number.
+        - at_most (Union[int, float], optional): the maximum number of upstream
+            successes to allow for this task to run.  If the provided number is
+            less than 0, it will be interpreted as a percentage, otherwise as
+            an absolute number.
     """
 
     def _some_successful(upstream_states: Dict["core.Edge", "state.State"]) -> bool:

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -32,7 +32,8 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
             prefect.environments.storage.Docker,
         ):
             raise ValueError(
-                f"Storage for flow run {flow_run.id} is not of type Docker and environment has no `image` attribute in the metadata field."
+                f"Storage for flow run {flow_run.id} is not of type Docker and "
+                f"environment has no `image` attribute in the metadata field."
             )
 
         return storage.name

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -15,10 +15,11 @@ def get_boto_client(
 
     Args:
         - resource (str): the name of the resource to retrieve a client for
-        - credentials (dict, optional): a dictionary of AWS credentials used to initialize the Client; if
-            not provided, will attempt to load the Client using ambient environment settings
-        - use_session (bool, optional): a boolean specifying whether to load this client using a session or not;
-            defaults to `False`
+        - credentials (dict, optional): a dictionary of AWS credentials used to
+            initialize the Client; if not provided, will attempt to load the
+            Client using ambient environment settings
+        - use_session (bool, optional): a boolean specifying whether to load
+            this client using a session or not; defaults to `False`
         - **kwargs (Any, optional): additional keyword arguments to pass to boto3
 
     Returns:
@@ -39,7 +40,7 @@ def get_boto_client(
         aws_session_token = ctx_credentials.get("SESSION_TOKEN")
 
     if use_session:
-        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
+        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing  # noqa
         session = boto3.session.Session()
         return session.client(
             resource,

--- a/src/prefect/utilities/configuration.py
+++ b/src/prefect/utilities/configuration.py
@@ -1,6 +1,7 @@
 """
-Utilities for interacting with [Prefect configuration](https://docs.prefect.io/core/concepts/configuration.html).  These are only intended
-to be used for testing.
+Utilities for interacting with [Prefect
+configuration](https://docs.prefect.io/core/concepts/configuration.html).  These are only
+intended to be used for testing.
 """
 from contextlib import contextmanager
 from typing import Iterator
@@ -15,8 +16,8 @@ def set_temporary_config(temp_config: dict) -> Iterator:
     Temporarily sets configuration values for the duration of the context manager.
 
     Args:
-        - temp_config (dict): a dictionary containing (possibly nested) configuration keys and values.
-            Nested configuration keys should be supplied as `.`-delimited strings.
+        - temp_config (dict): a dictionary containing (possibly nested) configuration keys and
+            values. Nested configuration keys should be supplied as `.`-delimited strings.
 
     Example:
         ```python

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -27,9 +27,13 @@ Prefect provides various key / value pairs in context that are always available 
 | `tomorrow` | tomorrow's date formatted as `YYYY-MM-DD`|
 | `tomorrow_nodash` | tomorrow's date formatted as `YYYYMMDD`|
 | `logger` | the logger for the current task |
-| `config` | the complete [Prefect configuration](https://docs.prefect.io/core/concepts/configuration.html) object that is being used during this run |
+| `config` | the complete [Prefect configuration]\
+(https://docs.prefect.io/core/concepts/configuration.html) object that is being used \
+during this run |
 | `flow_name` | the name of the current flow |
-| `scheduled_start_time` | a datetime object representing the scheduled start time for the flow run; falls back to `now` for unscheduled runs |
+| `scheduled_start_time` | \
+a datetime object representing the scheduled start time for the flow run; \
+falls back to `now` for unscheduled runs |
 | `parameters` | a dictionary of parameter values for the current flow run |
 | `map_index` | the map index of the current task (if mapped, otherwise `None`) |
 | `task_name` | the name of the current task |
@@ -52,7 +56,9 @@ In addition, Prefect Cloud supplies some additional context variables:
 | `task_run_id` | the id of the current task run |
 | `task_run_version` | the state version of the current task run |
 
-Users can also provide values to context at runtime. For more information, see the [Context concept doc](https://docs.prefect.io/core/concepts/execution.html#context).
+Users can also provide values to context at runtime. For more information, see
+the [Context concept
+doc](https://docs.prefect.io/core/concepts/execution.html#context).
 """
 
 import contextlib
@@ -88,12 +94,8 @@ class Context(DotDict, threading.local):
         as an attribute of the prefect module.
         """
         raise TypeError(
-            "\n".join(
-                [
-                    "Pickling context objects is explicitly not supported.",
-                    "You should always access context as an attribute of the `prefect` module, as in `prefect.context`",
-                ]
-            )
+            "Pickling context objects is explicitly not supported. You should always "
+            "access context as an attribute of the `prefect` module, as in `prefect.context`"
         )
 
     def __repr__(self) -> str:

--- a/src/prefect/utilities/debug.py
+++ b/src/prefect/utilities/debug.py
@@ -18,8 +18,9 @@ def is_serializable(obj: Any, raise_on_error: bool = False) -> bool:
 
     Args:
         - obj (Any): the object to check
-        - raise_on_error(bool, optional): if `True`, raises the `CalledProcessError` for inspection;
-            the `output` attribute of this exception can contain useful information about why the object is not registrable
+        - raise_on_error(bool, optional): if `True`, raises the `CalledProcessError` for
+          inspection; the `output` attribute of this exception can contain useful information
+          about why the object is not registrable
 
     Returns:
         - bool: `True` if registrable, `False` otherwise

--- a/src/prefect/utilities/gcp.py
+++ b/src/prefect/utilities/gcp.py
@@ -12,10 +12,11 @@ def get_google_client(submodule, credentials: dict = None, project: str = None):
 
     Args:
         - submodule: a Python submodule with a Client attribute
-        - credentials (dict, optional): a dictionary of Google credentials used to initialize the Client; if
-            not provided, will attempt to load the Client using ambient environment settings
-        - project (str, optional): the Google project to point the Client to; if not provided, Client defaults
-            will be used
+        - credentials (dict, optional): a dictionary of Google credentials used to initialize
+            the Client; if not provided, will attempt to load the Client using ambient
+            environment settings
+        - project (str, optional): the Google project to point the Client to; if not provided,
+            Client defaults will be used
 
     Returns:
         - Client: an initialized and authenticated Google Client
@@ -38,10 +39,11 @@ def get_storage_client(credentials: dict = None, project: str = None):
     Utility function for instantiating a Google Storage Client from a given set of credentials.
 
     Args:
-        - credentials (dict, optional): a dictionary of Google credentials used to initialize the Client; if
-            not provided, will attempt to load the Client using ambient environment settings
-        - project (str, optional): the Google project to point the Client to; if not provided, Client defaults
-            will be used
+        - credentials (dict, optional): a dictionary of Google credentials used to initialize
+            the Client; if not provided, will attempt to load the Client using ambient
+            environment settings
+        - project (str, optional): the Google project to point the Client to; if not provided,
+            Client defaults will be used
 
     Returns:
         - Client: an initialized and authenticated Google Client
@@ -56,10 +58,11 @@ def get_bigquery_client(credentials: dict = None, project: str = None):
     Utility function for instantiating a Google BigQuery Client from a given set of credentials.
 
     Args:
-        - credentials (dict, optional): a dictionary of Google credentials used to initialize the Client; if
-            not provided, will attempt to load the Client using ambient environment settings
-        - project (str, optional): the Google project to point the Client to; if not provided, Client defaults
-            will be used
+        - credentials (dict, optional): a dictionary of Google credentials used to initialize
+            the Client; if not provided, will attempt to load the Client using ambient
+            environment settings
+        - project (str, optional): the Google project to point the Client to; if not provided,
+            Client defaults will be used
 
     Returns:
         - Client: an initialized and authenticated Google Client

--- a/src/prefect/utilities/git.py
+++ b/src/prefect/utilities/git.py
@@ -13,8 +13,9 @@ def get_github_client(credentials: dict = None, **kwargs: Any) -> "Github":
     Utility function for loading github client objects from a given set of credentials.
 
     Args:
-        - credentials (dict, optional): a dictionary of AWS credentials used to initialize the Client; if
-            not provided, will attempt to load the Client using ambient environment settings
+        - credentials (dict, optional): a dictionary of AWS credentials used to
+            initialize the Client; if not provided, will attempt to load the
+            Client using ambient environment settings
         - **kwargs (Any, optional): additional keyword arguments to pass to the github Client
 
     Returns:

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -1,6 +1,6 @@
 """
-Utility functions for interacting with and configuring logging.  The main entrypoint for retrieving loggers for
-customization is the `get_logger` utility.
+Utility functions for interacting with and configuring logging.  The main entrypoint for
+retrieving loggers for customization is the `get_logger` utility.
 
 Note that Prefect Tasks come equipped with their own loggers.  These can be accessed via:
     - `self.logger` if implementing a Task class
@@ -82,7 +82,7 @@ class CloudHandler(logging.StreamHandler):
                 try:
                     assert self.client is not None
                     self.client.write_run_logs([self._make_error_log(message)])
-                except Exception as exc:
+                except Exception:
                     self.logger.critical("Unable to write logs to Prefect Cloud")
 
     def _monitor(self) -> None:
@@ -129,7 +129,7 @@ class CloudHandler(logging.StreamHandler):
             assert isinstance(self.client, Client)  # mypy assert
 
             record_dict = record.__dict__.copy()
-            ## remove potentially non-json serializable formatting args
+            # remove potentially non-json serializable formatting args
             record_dict.pop("args", None)
 
             log = dict()
@@ -168,7 +168,8 @@ class CloudHandler(logging.StreamHandler):
 
 def _log_record_context_injector(*args: Any, **kwargs: Any) -> logging.LogRecord:
     """
-    A custom logger LogRecord Factory that injects selected context parameters into newly created logs.
+    A custom logger LogRecord Factory that injects selected context parameters into newly
+    created logs.
 
     Args:
         - *args: arguments to pass to the original LogRecord Factory

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -1,7 +1,8 @@
 """
 Tools and utilities for notifications and callbacks.
 
-For an in-depth guide to setting up your system for using Slack notifications, [please see our tutorial](/core/advanced_tutorials/slack-notifications.html).
+For an in-depth guide to setting up your system for using Slack notifications, [please see our
+tutorial](/core/advanced_tutorials/slack-notifications.html).
 """
 import smtplib
 from email.header import Header
@@ -16,7 +17,7 @@ import prefect
 if TYPE_CHECKING:
     import prefect.engine.state
     import prefect.client
-    from prefect import Flow, Task  # pylint: disable=W0611
+    from prefect import Flow, Task  # noqa
 
 TrackedObjectType = Union["Flow", "Task"]
 
@@ -33,14 +34,15 @@ def callback_factory(
 
     Args:
         - fn (Callable): a function with signature `fn(obj, state: State) -> None`
-            that will be called anytime the associated state-check passes; in general,
-            it is expected that this function will have side effects (e.g., sends an email).  The first
-            argument to this function is the `Task` or `Flow` it is attached to.
+            that will be called anytime the associated state-check passes; in general, it is
+            expected that this function will have side effects (e.g., sends an email).  The
+            first argument to this function is the `Task` or `Flow` it is attached to.
         - check (Callable): a function with signature `check(state: State) -> bool`
             that is used for determining when the callback function should be called
 
     Returns:
-        - state_handler (Callable): a state handler function that can be attached to both Tasks and Flows
+        - state_handler (Callable): a state handler function that can be attached to both Tasks
+            and Flows
 
     Example:
         ```python
@@ -82,19 +84,19 @@ def email_message_formatter(
 
     html = """
     <html>
-        <head></head>
-        <body>
-            <table align="left" border="0" cellpadding="2px" cellspacing="2px">
-                <tr>
-                    <td style="border-left: 2px solid {color};">
-                        <img src="https://emoji.slack-edge.com/TAN3D79AL/prefect/2497370f58500a5a.png">
-                    </td>
-                    <td style="border-left: 2px solid {color}; padding-left: 6px;">
-                        {text}
-                    </td>
-                </tr>
-            </table>
-        </body>
+      <head></head>
+      <body>
+        <table align="left" border="0" cellpadding="2px" cellspacing="2px">
+          <tr>
+            <td style="border-left: 2px solid {color};">
+              <img src="https://emoji.slack-edge.com/TAN3D79AL/prefect/2497370f58500a5a.png">
+            </td>
+            <td style="border-left: 2px solid {color}; padding-left: 6px;">
+              {text}
+            </td>
+          </tr>
+        </table>
+      </body>
     </html>
     """
     color = state.color
@@ -174,21 +176,25 @@ def gmail_notifier(
     only_states: list = None,
 ) -> "prefect.engine.state.State":
     """
-    Email state change handler - configured to work solely with Gmail; works as a standalone state handler, or can be called from within a custom
-    state handler.  This function is curried meaning that it can be called multiple times to partially bind any keyword arguments (see example below).
+    Email state change handler - configured to work solely with Gmail; works as a standalone
+    state handler, or can be called from within a custom state handler.  This function is
+    curried meaning that it can be called multiple times to partially bind any keyword
+    arguments (see example below).
 
-    The username and password Gmail credentials will be taken from your `"EMAIL_USERNAME"` and `"EMAIL_PASSWORD"` secrets, respectively; note the username
-    will also serve as the destination email address for the notification.
+    The username and password Gmail credentials will be taken from your `"EMAIL_USERNAME"` and
+    `"EMAIL_PASSWORD"` secrets, respectively; note the username will also serve as the
+    destination email address for the notification.
 
     Args:
-        - tracked_obj (Task or Flow): Task or Flow object the handler is
-            registered with
+        - tracked_obj (Task or Flow): Task or Flow object the handler is registered with
         - old_state (State): previous state of tracked object
         - new_state (State): new state of tracked object
-        - ignore_states ([State], optional): list of `State` classes to ignore,
-            e.g., `[Running, Scheduled]`. If `new_state` is an instance of one of the passed states, no notification will occur.
-        - only_states ([State], optional): similar to `ignore_states`, but
-            instead _only_ notifies you if the Task / Flow is in a state from the provided list of `State` classes
+        - ignore_states ([State], optional): list of `State` classes to ignore, e.g.,
+            `[Running, Scheduled]`. If `new_state` is an instance of one of the passed states,
+            no notification will occur.
+        - only_states ([State], optional): similar to `ignore_states`, but instead _only_
+            notifies you if the Task / Flow is in a state from the provided list of `State`
+            classes
 
     Returns:
         - State: the `new_state` object that was provided
@@ -225,7 +231,7 @@ def gmail_notifier(
     server.login(username, password)
     try:
         server.sendmail("notifications@prefect.io", username, body)
-    except:
+    except Exception:
         raise ValueError("Email notification for {} failed".format(tracked_obj))
     finally:
         server.quit()
@@ -243,21 +249,24 @@ def slack_notifier(
     webhook_secret: str = None,
 ) -> "prefect.engine.state.State":
     """
-    Slack state change handler; requires having the Prefect slack app installed.
-    Works as a standalone state handler, or can be called from within a custom
-    state handler.  This function is curried meaning that it can be called multiple times to partially bind any keyword arguments (see example below).
+    Slack state change handler; requires having the Prefect slack app installed.  Works as a
+    standalone state handler, or can be called from within a custom state handler.  This
+    function is curried meaning that it can be called multiple times to partially bind any
+    keyword arguments (see example below).
 
     Args:
         - tracked_obj (Task or Flow): Task or Flow object the handler is
             registered with
         - old_state (State): previous state of tracked object
         - new_state (State): new state of tracked object
-        - ignore_states ([State], optional): list of `State` classes to ignore,
-            e.g., `[Running, Scheduled]`. If `new_state` is an instance of one of the passed states, no notification will occur.
-        - only_states ([State], optional): similar to `ignore_states`, but
-            instead _only_ notifies you if the Task / Flow is in a state from the provided list of `State` classes
-        - webhook_secret (str, optional): the name of the Prefect Secret that stores your slack webhook URL;
-            defaults to `"SLACK_WEBHOOK_URL"`
+        - ignore_states ([State], optional): list of `State` classes to ignore, e.g.,
+            `[Running, Scheduled]`. If `new_state` is an instance of one of the passed states,
+            no notification will occur.
+        - only_states ([State], optional): similar to `ignore_states`, but instead _only_
+            notifies you if the Task / Flow is in a state from the provided list of `State`
+            classes
+        - webhook_secret (str, optional): the name of the Prefect Secret that stores your slack
+            webhook URL; defaults to `"SLACK_WEBHOOK_URL"`
 
     Returns:
         - State: the `new_state` object that was provided

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -150,7 +150,8 @@ class ObjectSchema(Schema):
             - data (dict): the deserialized data
 
         Returns:
-            - Any: an instantiated object, if `create_object` is found in context; otherwise, the data dict
+            - Any: an instantiated object, if `create_object` is found in context; otherwise,
+                the data dict
         """
         if self.context.get("create_object", True):
             object_class = self.opts.object_class
@@ -199,8 +200,9 @@ class Nested(fields.Nested):
 
     Args:
         - nested (type): the nested schema class
-        - value_selection_fn (Callable): a function that is called whenever the object is serialized,
-            to retrieve the object (if not available as a simple attribute of the parent schema)
+        - value_selection_fn (Callable): a function that is called whenever the object is
+            serialized, to retrieve the object (if not available as a simple attribute of the
+            parent schema)
         - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
     """
 
@@ -302,8 +304,9 @@ class FunctionReference(fields.Field):
     Args:
         - valid_functions (List[Callable]): a list of functions that will be serialized as string
             references
-        - reject_invalid (bool): if True, functions not in `valid_functions` will be rejected. If False,
-            any value will be allowed, but only functions in `valid_functions` will be deserialized.
+        - reject_invalid (bool): if True, functions not in `valid_functions` will be rejected.
+            If False, any value will be allowed, but only functions in `valid_functions` will
+            be deserialized.
         - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
 
     """
@@ -359,8 +362,9 @@ class StatefulFunctionReference(fields.Field):
 
     Args:
         - valid_functions (List[Callable]): an allow list of valid functions
-        - reject_invalid (bool): if True, functions not in `valid_functions` will be rejected. If False,
-            any value will be allowed, but only functions in `valid_functions` will be deserialized.
+        - reject_invalid (bool): if True, functions not in `valid_functions` will be rejected.
+            If False, any value will be allowed, but only functions in `valid_functions` will
+            be deserialized.
         - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
 
     """
@@ -378,7 +382,7 @@ class StatefulFunctionReference(fields.Field):
 
         try:
             qual_name = to_qualified_name(value)
-        except:
+        except Exception:
             raise ValidationError(
                 f"Invalid function reference, function required, got {value}"
             )

--- a/src/prefect/utilities/storage.py
+++ b/src/prefect/utilities/storage.py
@@ -81,4 +81,4 @@ def extract_flow_from_file(
             elif not flow_name:
                 return exec_vals[var]
 
-    raise ValueError(f"No flow found in file.")
+    raise ValueError("No flow found in file.")

--- a/src/prefect/utilities/storage.py
+++ b/src/prefect/utilities/storage.py
@@ -29,7 +29,8 @@ def get_flow_image(flow: "Flow") -> str:
         storage = flow.storage
         if not isinstance(storage, prefect.environments.storage.Docker,):
             raise ValueError(
-                f"Storage for flow run {flow.name} is not of type Docker and environment has no `image` attribute in the metadata field."
+                f"Storage for flow run {flow.name} is not of type Docker and "
+                f"environment has no `image` attribute in the metadata field."
             )
 
         return storage.name

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import prefect.tasks.core.constants
     import prefect.tasks.core.collections
     import prefect.tasks.core.function
-    from prefect.core.flow import Flow  # pylint: disable=W0611
+    from prefect.core.flow import Flow
 
 
 @contextmanager
@@ -45,7 +45,7 @@ def tags(*tags: str) -> Iterator[None]:
         yield
 
 
-def as_task(x: Any, flow: Optional["Flow"] = None) -> "prefect.Task":
+def as_task(x: Any, flow: "Optional[Flow]" = None) -> "prefect.Task":
     """
     Wraps a function, collection, or constant with the appropriate Task type. If a constant
     or collection of constants is passed, a `Constant` task is returned.
@@ -237,11 +237,12 @@ class unmapped:
 def defaults_from_attrs(*attr_args: str) -> Callable:
     """
     Helper decorator for dealing with Task classes with attributes that serve
-    as defaults for `Task.run`.  Specifically, this decorator allows the author of a Task
-    to identify certain keyword arguments to the run method which will fall back to `self.ATTR_NAME`
-    if not explicitly provided to `self.run`.  This pattern allows users to create a Task "template",
-    whose default settings can be created at initialization but overrided in individual instances when the
-    Task is called.
+    as defaults for `Task.run`.  Specifically, this decorator allows the author
+    of a Task to identify certain keyword arguments to the run method which
+    will fall back to `self.ATTR_NAME` if not explicitly provided to
+    `self.run`.  This pattern allows users to create a Task "template", whose
+    default settings can be created at initialization but overrided in
+    individual instances when the Task is called.
 
     Args:
         - *attr_args (str): a splatted list of strings specifying which


### PR DESCRIPTION
[`flake8`](https://flake8.pycqa.org/en/latest/) is a popular linter used by many python projects. We use it for all repos in the dask org (other usage examples include pandas, scikit-learn, jupyterhub, jupyter, ipython, ...) - the tool is common in the ecosystem. Besides linting formatting, the tool provides several good static analysis checks - I find it more helpful in this regard than `mypy`. Both unneeded and missing imports are found (more accurate than `autoflake8`, the current tool prefect uses), as well as unnecessary variables, dead code, poor idioms (e.g. `not foo in bar` instead of `foo not in bar`, `foo == None` instead of `foo is None`), etc...

I use flake8 as part of my editor setup, and currently the prefect codebase generates a bunch of warnings, which makes the tool less useful. The goal of this PR was to:

- Pick a (hopefully) non-controversial config that should be lightweight to follow. Black solves most of the formatting issues for us, the main one missing is max line lengths in docstrings. I've set the max line length to 105 for flake8, which is 17 more than black's currently configured limit.
- Fix all the warnings so we pass cleanly (I've only applied this to `src/prefect` for now). The diff is large, but it's mostly reformatting docstrings.
- Add flake8 to ci
- Add flake8 to our pre-commit hooks

In my experience with the above tooling, formatting issues rarely show up in PR discussions, so I'm not terribly worried about the additional checks slowing down progress in this repo. I'm mainly interested in getting the added benefits of the additional checks that `flake8` provides (better extra/missing import detection than autoflake, extraneous variable detection, etc...).

Apologies for the large diff, I don't really expect anyone to be able to review this PR in full :/

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)