### PR TITLE
Fix Fargate agent not parsing containerDefinitions if provided as string

### DIFF
--- a/changes/issue2875.yaml
+++ b/changes/issue2875.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Fargate agent not parsing string provided containerDefinitions - [#2875](https://github.com/PrefectHQ/prefect/issues/2875)"

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -376,9 +376,9 @@ class FargateAgent(Agent):
         except (ValueError, SyntaxError):
             pass
 
-        if len(container_defs) > 1:
+        if len(container_defs) != 1:
             raise ValueError(
-                "Multiple container definitions provided to Fargate agent."
+                "Fargate agent only accepts configuration for a single container definition."
             )
 
         for key, item in container_defs[0].items():

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -370,7 +370,13 @@ class FargateAgent(Agent):
                 self.logger.debug("{} = {}".format(key, item))
 
         container_definitions_kwargs = {}
-        for key, item in user_kwargs.get("containerDefinitions", [{}])[0].items():
+        container_defs = user_kwargs.get("containerDefinitions", [{}])
+        try:
+            container_defs = literal_eval(container_defs)
+        except (ValueError, SyntaxError):
+            pass
+
+        for key, item in container_defs[0].items():
             if key in container_definitions_kwarg_list:
                 try:
                     # Parse kwarg if needed

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -376,6 +376,11 @@ class FargateAgent(Agent):
         except (ValueError, SyntaxError):
             pass
 
+        if len(container_defs) > 1:
+            raise ValueError(
+                "Multiple container definitions provided to Fargate agent."
+            )
+
         for key, item in container_defs[0].items():
             if key in container_definitions_kwarg_list:
                 try:

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -225,6 +225,35 @@ def test_parse_container_definition_kwargs_provided_as_string(
     }
 
 
+def test_parse_container_definition_kwargs_errors_on_multiple(
+    monkeypatch, runner_token
+):
+    boto3_client = MagicMock()
+    monkeypatch.setattr("boto3.client", boto3_client)
+
+    agent = FargateAgent()
+
+    kwarg_dict = {
+        "containerDefinitions": [
+            {
+                "environment": "test",
+                "secrets": "test",
+                "mountPoints": "test",
+                "logConfiguration": "test",
+                "repositoryCredentials": "repo",
+            },
+            {"test": "here"},
+        ]
+    }
+
+    with pytest.raises(ValueError):
+        (
+            task_definition_kwargs,
+            task_run_kwargs,
+            container_definitions_kwargs,
+        ) = agent._parse_kwargs(kwarg_dict)
+
+
 def test_parse_container_definition_kwargs_errors(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -188,6 +188,43 @@ def test_parse_container_definition_kwargs(monkeypatch, runner_token):
     }
 
 
+def test_parse_container_definition_kwargs_provided_as_string(
+    monkeypatch, runner_token
+):
+    boto3_client = MagicMock()
+    monkeypatch.setattr("boto3.client", boto3_client)
+
+    agent = FargateAgent()
+
+    kwarg_dict = {
+        "containerDefinitions": str(
+            [
+                {
+                    "environment": "test",
+                    "secrets": "test",
+                    "mountPoints": "test",
+                    "logConfiguration": "test",
+                    "repositoryCredentials": "repo",
+                }
+            ]
+        )
+    }
+
+    (
+        task_definition_kwargs,
+        task_run_kwargs,
+        container_definitions_kwargs,
+    ) = agent._parse_kwargs(kwarg_dict)
+
+    assert container_definitions_kwargs == {
+        "environment": "test",
+        "secrets": "test",
+        "mountPoints": "test",
+        "logConfiguration": "test",
+        "repositoryCredentials": "repo",
+    }
+
+
 def test_parse_container_definition_kwargs_errors(monkeypatch, runner_token):
     boto3_client = MagicMock()
     monkeypatch.setattr("boto3.client", boto3_client)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2875 


## Why is this PR important?
The eval parses the contents of containerDefinitions but an extra eval needs to be added to parse the containerDefinitions prior if it is provided as a string through the CLI

