### PR TITLE
Fix Fargate agent providing empty parameters if not set

### DIFF
--- a/changes/issue2878.yaml
+++ b/changes/issue2878.yaml
@@ -1,0 +1,2 @@
+fix:
+  "Fix Fargate agent providing empty parameters if not set - [#2878](https://github.com/PrefectHQ/prefect/issues/2878)"

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -641,18 +641,26 @@ class FargateAgent(Agent):
         container_definitions[0]["environment"].extend(  # type: ignore
             container_definitions_environment
         )
-        container_definitions[0]["secrets"] = container_definitions_kwargs.get(
-            "secrets", []
-        )
-        container_definitions[0]["mountPoints"] = container_definitions_kwargs.get(
-            "mountPoints", []
-        )
-        container_definitions[0]["logConfiguration"] = container_definitions_kwargs.get(
-            "logConfiguration", {}
-        )
-        container_definitions[0][
-            "repositoryCredentials"
-        ] = container_definitions_kwargs.get("repositoryCredentials", {})
+
+        # Set container definition values if provided
+        if container_definitions_kwargs.get("secrets"):
+            container_definitions[0]["secrets"] = container_definitions_kwargs.get(
+                "secrets", []
+            )
+
+        if container_definitions_kwargs.get("mountPoints"):
+            container_definitions[0]["mountPoints"] = container_definitions_kwargs.get(
+                "mountPoints", []
+            )
+        if container_definitions_kwargs.get("logConfiguration"):
+            container_definitions[0][
+                "logConfiguration"
+            ] = container_definitions_kwargs.get("logConfiguration", {})
+
+        if container_definitions_kwargs.get("repositoryCredentials"):
+            container_definitions[0][
+                "repositoryCredentials"
+            ] = container_definitions_kwargs.get("repositoryCredentials", {})
 
         # Register task definition
         self.logger.debug(

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -610,9 +610,6 @@ class FargateAgent(Agent):
                         "value": "prefect.engine.cloud.CloudTaskRunner",
                     },
                 ],
-                "secrets": [],
-                "mountPoints": [],
-                "logConfiguration": {},
                 "essential": True,
             }
         ]
@@ -747,9 +744,6 @@ class FargateAgent(Agent):
                 "image": "busybox",
                 "command": ["/bin/sh", "-c", "echo 'I am alive!'"],
                 "environment": [],
-                "secrets": [],
-                "mountPoints": [],
-                "logConfiguration": {},
                 "essential": True,
             }
         ]
@@ -765,15 +759,27 @@ class FargateAgent(Agent):
         container_definitions[0]["environment"].extend(  # type: ignore
             container_definitions_environment
         )
-        container_definitions[0]["secrets"] = flow_container_definitions_kwargs.get(
-            "secrets", []
-        )
-        container_definitions[0]["mountPoints"] = flow_container_definitions_kwargs.get(
-            "mountPoints", []
-        )
-        container_definitions[0][
-            "logConfiguration"
-        ] = flow_container_definitions_kwargs.get("logConfiguration", {})
+
+        # Assign user-provided container definition options
+        if flow_container_definitions_kwargs.get("secrets"):
+            container_definitions[0]["secrets"] = flow_container_definitions_kwargs.get(
+                "secrets", []
+            )
+
+        if flow_container_definitions_kwargs.get("mountPoints"):
+            container_definitions[0][
+                "mountPoints"
+            ] = flow_container_definitions_kwargs.get("mountPoints", [])
+
+        if flow_container_definitions_kwargs.get("logConfiguration"):
+            container_definitions[0][
+                "logConfiguration"
+            ] = flow_container_definitions_kwargs.get("logConfiguration", {})
+
+        if flow_container_definitions_kwargs.get("repositoryCredentials"):
+            container_definitions[0][
+                "repositoryCredentials"
+            ] = flow_container_definitions_kwargs.get("repositoryCredentials", {})
 
         # Register task definition
         flow_task_definition_kwargs = copy.deepcopy(self.task_definition_kwargs)

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -1168,7 +1168,6 @@ def test_deploy_flows_includes_agent_labels_in_environment(
             "secrets": [],
             "mountPoints": [],
             "logConfiguration": {},
-            "repositoryCredentials": {},
         }
     ]
     assert boto3_client.register_task_definition.call_args[1][

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -1165,9 +1165,6 @@ def test_deploy_flows_includes_agent_labels_in_environment(
                 },
             ],
             "essential": True,
-            "secrets": [],
-            "mountPoints": [],
-            "logConfiguration": {},
         }
     ]
     assert boto3_client.register_task_definition.call_args[1][
@@ -1176,70 +1173,6 @@ def test_deploy_flows_includes_agent_labels_in_environment(
     assert boto3_client.register_task_definition.call_args[1]["networkMode"] == "awsvpc"
     assert boto3_client.register_task_definition.call_args[1]["cpu"] == "1"
     assert boto3_client.register_task_definition.call_args[1]["memory"] == "2"
-
-
-def test_deploy_flow_register_task_definition_no_repo_credentials(
-    monkeypatch, runner_token, cloud_api
-):
-    boto3_client = MagicMock()
-
-    boto3_client.describe_task_definition.side_effect = ClientError({}, None)
-    boto3_client.run_task.return_value = {"tasks": [{"taskArn": "test"}]}
-    boto3_client.register_task_definition.return_value = {}
-
-    monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
-
-    with set_temporary_config({"logging.log_to_cloud": True}):
-        agent = FargateAgent()
-
-    agent.deploy_flow(
-        flow_run=GraphQLResult(
-            {
-                "flow": GraphQLResult(
-                    {
-                        "storage": Docker(
-                            registry_url="test", image_name="name", image_tag="tag"
-                        ).serialize(),
-                        "environment": LocalEnvironment().serialize(),
-                        "id": "id",
-                    }
-                ),
-                "id": "id",
-            }
-        )
-    )
-
-    assert boto3_client.describe_task_definition.called
-    assert boto3_client.register_task_definition.called
-    assert boto3_client.register_task_definition.call_args[1][
-        "containerDefinitions"
-    ] == [
-        {
-            "name": "flow",
-            "image": "test/name:tag",
-            "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
-            "environment": [
-                {"name": "PREFECT__CLOUD__API", "value": "https://api.prefect.io"},
-                {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
-                {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
-                {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                {"name": "PREFECT__LOGGING__LEVEL", "value": "DEBUG"},
-                {
-                    "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
-                    "value": "prefect.engine.cloud.CloudFlowRunner",
-                },
-                {
-                    "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
-                    "value": "prefect.engine.cloud.CloudTaskRunner",
-                },
-            ],
-            "essential": True,
-            "secrets": [],
-            "mountPoints": [],
-            "logConfiguration": {},
-            "repositoryCredentials": {},
-        }
-    ]
 
 
 def test_deploy_flows_require_docker_storage(monkeypatch, runner_token):
@@ -1330,10 +1263,6 @@ def test_deploy_flows_enable_task_revisions_no_tags(
                     },
                 ],
                 "essential": True,
-                "secrets": [],
-                "mountPoints": [],
-                "logConfiguration": {},
-                "repositoryCredentials": {},
             }
         ],
         family="name",
@@ -1711,10 +1640,6 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
                     },
                 ],
                 "essential": True,
-                "secrets": [],
-                "mountPoints": [],
-                "logConfiguration": {},
-                "repositoryCredentials": {},
             }
         ],
         cpu="256",


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2878 


## Why is this PR important?
boto3 has some kwargs for `containerDefinitions` that don't have to be provided however if an empty value is set for them at all (`[]` or `{}`) then it requires them to be populated.

