### PR TITLE
Consider Queued states to be scheduled for proper queue handling

### DIFF
--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -248,7 +248,7 @@ class State:
         Returns:
             - bool: `True` if the state is skipped, `False` otherwise
         """
-        return isinstance(self, Scheduled)
+        return isinstance(self, (Scheduled, Queued))
 
     def is_submitted(self) -> bool:
         """

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -199,7 +199,6 @@ def test_only_scheduled_states_have_task_run_count_in_context(cls):
         assert state.context["task_run_count"] == 910
     else:
         assert not isinstance(state, Scheduled)
-        assert not state.is_scheduled()
 
 
 def test_retry_stores_loop_count():
@@ -423,7 +422,9 @@ class TestStateHierarchy:
         dict(state=Mapped(), assert_true={"is_finished", "is_mapped", "is_successful"}),
         dict(state=Paused(), assert_true={"is_pending", "is_scheduled"}),
         dict(state=Pending(), assert_true={"is_pending"}),
-        dict(state=Queued(), assert_true={"is_meta_state", "is_queued"}),
+        dict(
+            state=Queued(), assert_true={"is_meta_state", "is_queued", "is_scheduled"}
+        ),
         dict(state=Resume(), assert_true={"is_pending", "is_scheduled"}),
         dict(
             state=Retrying(), assert_true={"is_pending", "is_scheduled", "is_retrying"}


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR considers `Queued` states as `Scheduled` in the sense that `is_scheduled()` will now return `True` for queued states.  Agents only place task runs into `Submitted` states when pulled off the queue if https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/agent.py#L542 returns True, which was not previously the case for `Queued` states (ie., task runs that were queued due to concurrency restrictions).


## Why is this PR important?
Closes #2884 (@josh to confirm....)

