### PR TITLE
Update task runner to send heartbeat on each iteration of a retry loop

### DIFF
--- a/changes/pr2893.yaml
+++ b/changes/pr2893.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Send heartbeats on each iteration of the Cloud task runner's retry loop - [#2893](https://github.com/PrefectHQ/prefect/pull/2893)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -323,6 +323,11 @@ class CloudTaskRunner(TaskRunner):
                 )
                 time.sleep(naptime)
 
+                # send heartbeat on each iteration to let API know task run is still alive
+                self.client.update_task_run_heartbeat(
+                    task_run_id=prefect.context.get("task_run_id")
+                )
+
                 # mapped children will retrieve their latest info inside
                 # initialize_run(), but we can load up-to-date versions
                 # for all other task runs here

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -952,6 +952,7 @@ def test_cloud_task_runner_handles_retries_with_queued_states_from_cloud(client)
 
 def test_cloud_task_runner_sends_heartbeat_on_queued_retries(client):
     calls = []
+    tr_ids = []
 
     def queued_mock(*args, **kwargs):
         calls.append(kwargs)
@@ -961,13 +962,10 @@ def test_cloud_task_runner_sends_heartbeat_on_queued_retries(client):
         else:
             return kwargs.get("state")
 
-    client.set_task_run_state = queued_mock
-
-    tr_ids = []
-
     def mock_heartbeat(**kwargs):
         tr_ids.append(kwargs.get("task_run_id"))
 
+    client.set_task_run_state = queued_mock
     client.update_task_run_heartbeat = mock_heartbeat
 
     @prefect.task(

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -950,6 +950,49 @@ def test_cloud_task_runner_handles_retries_with_queued_states_from_cloud(client)
     assert calls[2]["state"].cached_inputs["x"].value == 42
 
 
+def test_cloud_task_runner_sends_heartbeat_on_queued_retries(client):
+    calls = []
+
+    def queued_mock(*args, **kwargs):
+        calls.append(kwargs)
+        # first retry attempt will get queued
+        if len(calls) == 4:
+            return Queued()  # immediate start time
+        else:
+            return kwargs.get("state")
+
+    client.set_task_run_state = queued_mock
+
+    tr_ids = []
+
+    def mock_heartbeat(**kwargs):
+        tr_ids.append(kwargs.get("task_run_id"))
+
+    client.update_task_run_heartbeat = mock_heartbeat
+
+    @prefect.task(
+        max_retries=2,
+        retry_delay=datetime.timedelta(seconds=0),
+        result=PrefectResult(),
+    )
+    def tagged_task(x):
+        if prefect.context.get("task_run_count", 1) == 1:
+            raise ValueError("gimme a sec")
+        return x
+
+    upstream_result = PrefectResult(value=42, location="42")
+    CloudTaskRunner(task=tagged_task).run(
+        context={"task_run_version": 1, "task_run_id": "id"},
+        state=None,
+        upstream_states={
+            Edge(Task(), tagged_task, key="x"): Success(result=upstream_result)
+        },
+    )
+
+    assert len(calls) == 6
+    assert tr_ids == ["id", "id"]
+
+
 class TestLoadResults:
     def test_load_results_from_upstream_reads_results(self):
         result = PrefectResult(location="1")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updates `cloud/task_runner.py` to send a heartbeat on each iteration of the retry loop.


## Why is this PR important?
This is a step towards making a backend API aware of when a task run is still out there retrying or queued and that it should not be readded to the work queue.

