### PR TITLE
UPDATED runner create-token command in docs

### DIFF
--- a/docs/orchestration/tutorial/configure.md
+++ b/docs/orchestration/tutorial/configure.md
@@ -49,7 +49,7 @@ If the `prefect` command is not found then Prefect may not be installed. Go [her
 Running deployed Flows requires an Agent being authenticated against Prefect Cloud. To do this, let's generate a `RUNNER`-scoped API token:
 
 ```bash
-prefect auth create-token -n my-runner-token -r RUNNER
+prefect auth create-token -n my-runner-token -s RUNNER
 ```
 
 Keep this runner token handy for future steps, or store it as an environment variable:


### PR DESCRIPTION
The -r (scope) option does not exist in version 0.12.2

-s must be used to specify the scope of the token (should be changed in the command line help as well)

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

The -r (scope) option does not exist in version 0.12.2

-s must be used to specify the scope of the token (should be changed in the command line help as well)

## Why is this PR important?

Documentation is currently wrong and command does not work:
```
$ prefect auth create-token -n my-runner-token -r RUNNER
Usage: prefect auth create-token [OPTIONS]
Try 'prefect auth create-token -h' for help.

Error: no such option: -r
```


