### PR TITLE
UPDATED runner create-token command in CLI help

### DIFF
--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -193,7 +193,7 @@ def create_token(name, scope):
     \b
     Options:
         --name, -n      TEXT    A name to give the generated token
-        --scope, -r     TEXT    A scope for the token
+        --scope, -s     TEXT    A scope for the token
     """
     check_override_auth_token()
 


### PR DESCRIPTION
The -r (scope) option does not exist in version 0.12.2

-s must be used to specify the scope of the token (role is not used anymore)

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

The -r (scope) option does not exist in version 0.12.2

-s must be used to specify the scope of the token (role is not used anymore)

## Why is this PR important?

CLI help is currently wrong and command does not work:
```
$ prefect auth create-token -n my-runner-token -r RUNNER
Usage: prefect auth create-token [OPTIONS]
Try 'prefect auth create-token -h' for help.

Error: no such option: -r
```

Current documentation is as follow:
```
$ prefect auth create-token -h
Usage: prefect auth create-token [OPTIONS]

  Create a Prefect Cloud API token.

  For more info on API tokens visit
  https://docs.prefect.io/orchestration/concepts/api.html

  Options:
      --name, -n      TEXT    A name to give the generated token
      --scope, -r     TEXT    A scope for the token // <-- WRONG LINE. -r should be -s

Options:
  -h, --help  Show this message and exit.
```