### PR TITLE
Fix edge case in Interval Clocks

### DIFF
--- a/changes/pr2906.yaml
+++ b/changes/pr2906.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with short-interval IntervalClocks that had a start_date far in the past - [#2906](https://github.com/PrefectHQ/prefect/pull/2906)"

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -176,6 +176,9 @@ class IntervalClock(Clock):
             days = interval.days
             seconds = interval.total_seconds() - (days * 24 * 60 * 60)
             next_date = start_date.add(days=days, seconds=seconds)
+            if next_date < after:
+                interval += self.interval
+                continue
             if self.end_date and next_date > self.end_date:
                 break
             yield ClockEvent(

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -187,6 +187,23 @@ class TestIntervalClockDaylightSavingsTime:
     survives.
     """
 
+    def test_interval_clock_always_has_the_right_offset(self):
+        """
+        Tests the situation where a long duration has passed since the start date that crosses a DST boundary;
+        for very short intervals this occasionally could result in "next" scheduled times that are in the past by one hour.
+        """
+        start_date = pendulum.from_timestamp(1582002945.964696).astimezone(
+            pendulum.timezone("US/Pacific")
+        )
+        current_date = pendulum.from_timestamp(1593643144.233938).astimezone(
+            pendulum.timezone("UTC")
+        )
+        c = clocks.IntervalClock(
+            timedelta(minutes=1, seconds=15), start_date=start_date
+        )
+        next_4 = islice(c.events(after=current_date), 4)
+        assert all([d > current_date for d in next_4])
+
     @pytest.mark.parametrize("serialize", [True, False])
     def test_interval_clock_hourly_daylight_savings_time_forward_with_UTC(
         self, serialize


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes an edge case involving interval clocks with short intervals and DST-observing start dates far in the past.


## Why is this PR important?
Scheduling should be robust!

**cc:** @zdhughes / @jlowin this fixes the issue we were poking at earlier today