### PR TITLE
bump cloudpickle version ceiling to 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >= 7.0, < 8.0
-cloudpickle >=0.6.0, <1.6
+cloudpickle >=0.6.0, <2.0
 croniter >= 0.3.24, <1.0
 dask[bag] >=0.19.3, <3.0
 distributed >= 1.26.1, < 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >= 7.0, < 8.0
-cloudpickle >=0.6.0, <1.5
+cloudpickle >=0.6.0, <1.6
 croniter >= 0.3.24, <1.0
 dask[bag] >=0.19.3, <3.0
 distributed >= 1.26.1, < 3.0


### PR DESCRIPTION

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR bumps the version ceiling for `cloudpickle` to 1.6, since version 1.5.0 was released yesterday. See #2910 for more background and discussion.

## Why is this PR important?

This PR makes it possible to install the version of `prefect` that is currently on `master` if you have the latest released version of `cloudpickle` installed, so that users don't hit the situation where their versions of `prefect` and `cloudpickle` are incompatible.

In my opinion this version ceiling should be removed completely, but I think for now at least bumping it to 1.6 would fix the immediate issue.

Thanks for your time and consideration!

