### PR TITLE
Added poke handler to notify agent process of available flow runs

### DIFF
--- a/changes/pr2914.yaml
+++ b/changes/pr2914.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Added poke handler to notify agent process of available flow runs. - [#2914](https://github.com/PrefectHQ/prefect/pull/2914)"
+
+contributor:
+  - "[Sandeep Aggarwal](https://github.com/asandeep)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -41,8 +41,8 @@ def exit_handler(agent: "Agent") -> Generator:
 
     def _exit_handler(*args: Any, **kwargs: Any) -> None:
         agent.logger.info("Keyboard Interrupt received: Agent is shutting down.")
-        AGENT_WAKE_EVENT.set()
         exit_event.set()
+        AGENT_WAKE_EVENT.set()
 
     original = signal.getsignal(signal.SIGINT)
     try:
@@ -191,7 +191,7 @@ class Agent:
         new flow runs to deploy
 
         Args:
-            - _loop_intervals (dict, optional): Default loop_intervals override for unit tests.
+            - _loop_intervals (dict, optional): Exposed for testing only.
         """
         if config.backend == "cloud":
             self._verify_token(self.client.get_auth_token())

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -185,7 +185,7 @@ class Agent:
 
         return agent_id
 
-    def start(self, _loop_intervals=None) -> None:
+    def start(self, _loop_intervals: dict = None) -> None:
         """
         The main entrypoint to the agent. This function loops and constantly polls for
         new flow runs to deploy

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -76,7 +76,7 @@ class Client:
             will be used as authorization.
     """
 
-    def __init__(self, api_server: str = None, api_token: str = None):
+    def __init__(self, api_server: str = None, api_token: str = None, agent_server: str = None):
         self._access_token = None
         self._refresh_token = None
         self._access_token_expires_at = pendulum.now()
@@ -91,6 +91,8 @@ class Client:
         self._api_token = api_token or prefect.context.config.cloud.get(
             "auth_token", None
         )
+
+        self.agent_server = agent_server
 
         # if no api token was passed, attempt to load state from local storage
         if not self._api_token and prefect.config.backend == "cloud":
@@ -875,6 +877,16 @@ class Client:
         if run_name is not None:
             inputs.update(flow_run_name=run_name)  # type: ignore
         res = self.graphql(create_mutation, variables=dict(input=inputs))
+
+        import requests
+
+        url = urljoin(self.agent_server, "/poke")
+        self.logger.debug("Poking agent process for new flow runs: %s", url)
+        try:
+            requests.get(url, timeout=0.25)
+        except requests.exceptions.RequestException as rex:
+            self.logger.info("Error poking agent process: %s", str(rex))
+
         return res.data.create_flow_run.id  # type: ignore
 
     def get_flow_run_info(self, flow_run_id: str) -> FlowRunInfoResult:

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -542,3 +542,58 @@ def test_agent_health_check(runner_token, cloud_api):
 
     agent.cleanup()
     assert not agent._api_server_thread.is_alive()
+
+def test_agent_poke_api(monkeypatch, runner_token, cloud_api):
+    import threading
+    requests = pytest.importorskip("requests")
+
+    def _poke_agent(agent_address):
+        # May take a sec for the api server to startup
+        for attempt in range(5):
+            try:
+                resp = requests.get(f"{agent_address}/api/health")
+                break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            assert False, "Failed to connect to health check"
+
+        assert resp.status_code == 200
+        # Agent API is now available. Poke agent to start processing.
+        requests.get(f"{agent_address}/api/poke")
+
+    agent_process = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_process", agent_process)
+
+    agent_connect = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.agent.agent.Agent.agent_connect", agent_connect)
+
+    heartbeat = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Agent.heartbeat", heartbeat)
+
+
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+
+    agent_address = f"http://127.0.0.1:{port}"
+
+    # Poke agent in separate thread as main thread is blocked by main agent
+    # process waiting for loop interval to complete.
+    poke_agent_thread = threading.Thread(target=_poke_agent, args=(agent_address,))
+    poke_agent_thread.start()
+
+    agent_start_time = time.time()
+    agent = Agent(agent_address=agent_address, max_polls=1)
+    # Override loop interval to 5 seconds.
+    agent.start(_loop_intervals={0:5.0})
+    agent_stop_time = time.time()
+
+    agent.cleanup()
+
+    assert agent_stop_time - agent_start_time < 5.0
+
+    assert not agent._api_server_thread.is_alive()
+    assert heartbeat.call_count == 1
+    assert agent_process.call_count == 1
+    assert agent_connect.call_count == 1

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -543,8 +543,10 @@ def test_agent_health_check(runner_token, cloud_api):
     agent.cleanup()
     assert not agent._api_server_thread.is_alive()
 
+
 def test_agent_poke_api(monkeypatch, runner_token, cloud_api):
     import threading
+
     requests = pytest.importorskip("requests")
 
     def _poke_agent(agent_address):
@@ -571,7 +573,6 @@ def test_agent_poke_api(monkeypatch, runner_token, cloud_api):
     heartbeat = MagicMock()
     monkeypatch.setattr("prefect.agent.agent.Agent.heartbeat", heartbeat)
 
-
     with socket.socket() as sock:
         sock.bind(("", 0))
         port = sock.getsockname()[1]
@@ -586,7 +587,7 @@ def test_agent_poke_api(monkeypatch, runner_token, cloud_api):
     agent_start_time = time.time()
     agent = Agent(agent_address=agent_address, max_polls=1)
     # Override loop interval to 5 seconds.
-    agent.start(_loop_intervals={0:5.0})
+    agent.start(_loop_intervals={0: 5.0})
     agent_stop_time = time.time()
 
     agent.cleanup()


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This is following the conversion in [2908](https://github.com/PrefectHQ/prefect/discussions/2908), to reduce the latency in executing the flow runs by agent process due to loop intervals.

The PR implements a poke handler to wake up agent process and start processing the flow runs.

## Why is this PR important?
The current loop interval adds a sort of limitation when prefect needs to be invoked in realtime scenarios. The poke handler implemented in this PR provides a way for users to trigger the flow execution without waiting for loop interval to complete.

