### PR TITLE
Executor leaves no background work upon exiting `start` contextmanager

### DIFF
--- a/changes/pr2920.yaml
+++ b/changes/pr2920.yaml
@@ -1,0 +1,2 @@
+fix:
+  - When terminating early, executors ensure all pending work is cancelled/completed before returning, ensuring no lingering background processing - [#2920](https://github.com/PrefectHQ/prefect/pull/2920)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click >= 7.0, < 8.0
 cloudpickle >=0.6.0, <2.0
 croniter >= 0.3.24, <1.0
-dask[bag] >=0.19.3, <3.0
-distributed >= 1.26.1, < 3.0
+dask[bag] >= 2.8.0, <3.0
+distributed >= 2.8.0, < 3.0
 docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 3.6.2
 marshmallow-oneofschema >= 2.0.0b2, < 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 7.0, < 8.0
 cloudpickle >=0.6.0, <2.0
 croniter >= 0.3.24, <1.0
-dask[bag] >= 2.8.0, <3.0
+dask >= 2.8.0, <3.0
 distributed >= 2.8.0, < 3.0
 docker >=3.4.1, <5.0
 marshmallow >= 3.0.0b19, < 3.6.2

--- a/src/prefect/engine/executors/base.py
+++ b/src/prefect/engine/executors/base.py
@@ -1,6 +1,7 @@
-import uuid
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
+
+from prefect.utilities.logging import get_logger
 
 
 class Executor:
@@ -9,7 +10,7 @@ class Executor:
     """
 
     def __init__(self) -> None:
-        self.executor_id = type(self).__name__ + ": " + str(uuid.uuid4())
+        self.logger = get_logger(type(self).__name__)
 
     def __repr__(self) -> str:
         return "<Executor: {}>".format(type(self).__name__)

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -193,12 +193,15 @@ class DaskExecutor(Executor):
 
         if client_kwargs is None:
             client_kwargs = {}
+        else:
+            client_kwargs = client_kwargs.copy()
         if kwargs:
             warnings.warn(
                 "Forwarding executor kwargs to `Client` is now handled by the "
                 "`client_kwargs` parameter, please update accordingly"
             )
             client_kwargs.update(kwargs)
+        client_kwargs.setdefault("set_as_default", False)
 
         self.address = address
         self.cluster_class = cluster_class
@@ -458,7 +461,7 @@ class LocalDaskExecutor(Executor):
             if self.scheduler == "synchronous":
                 self._pool = None
             else:
-                num_workers = dask.config.get("num_workers", CPU_COUNT)
+                num_workers = dask.config.get("num_workers", None) or CPU_COUNT
                 if self.scheduler == "threads":
                     from multiprocessing.pool import ThreadPool
 

--- a/src/prefect/engine/executors/dask.py
+++ b/src/prefect/engine/executors/dask.py
@@ -210,6 +210,9 @@ class DaskExecutor(Executor):
         self.client_kwargs = client_kwargs
         # Runtime attributes
         self.client = None
+        # These are coupled - they're either both None, or both non-None.
+        # They're used in the case we can't forcibly kill all the dask workers,
+        # and need to wait for all the dask tasks to cleanup before exiting.
         self._futures = None  # type: Optional[weakref.WeakSet[Future]]
         self._should_run_var = None  # type: Optional[Variable]
 

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -77,10 +77,10 @@ class TestLocalDaskExecutor:
     def test_submit(self):
         e = LocalDaskExecutor()
         with e.start():
-            assert e.submit(lambda: 1).compute() == 1
-            assert e.submit(lambda x: x, 1).compute() == 1
-            assert e.submit(lambda x: x, x=1).compute() == 1
-            assert e.submit(lambda: prefect).compute() is prefect
+            assert e.submit(lambda: 1).compute(scheduler="sync") == 1
+            assert e.submit(lambda x: x, 1).compute(scheduler="sync") == 1
+            assert e.submit(lambda x: x, x=1).compute(scheduler="sync") == 1
+            assert e.submit(lambda: prefect).compute(scheduler="sync") is prefect
 
     def test_wait(self):
         e = LocalDaskExecutor()
@@ -274,7 +274,7 @@ class TestDaskExecutor:
             assert executor.address == client.scheduler.address
             assert executor.cluster_class is None
             assert executor.cluster_kwargs is None
-            assert executor.client_kwargs == {}
+            assert executor.client_kwargs == {"set_as_default": False}
 
             with executor.start():
                 res = executor.wait(executor.submit(lambda x: x + 1, 1))
@@ -358,7 +358,7 @@ class TestDaskExecutor:
 
         assert executor.cluster_class == TestCluster
         assert executor.cluster_kwargs == {}
-        assert executor.client_kwargs == {}
+        assert executor.client_kwargs == {"set_as_default": False}
 
     def test_deprecated_client_kwargs(self):
         with pytest.warns(UserWarning, match="client_kwargs"):

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -124,7 +124,7 @@ class TestLocalDaskExecutor:
         with e.start():
             post = cloudpickle.loads(cloudpickle.dumps(e))
             assert isinstance(post, LocalDaskExecutor)
-            assert post._callback is None
+            assert post._pool is None
 
 
 class TestLocalExecutor:
@@ -185,7 +185,7 @@ class TestDaskExecutor:
 
         def record_times():
             start_time = time.time()
-            time.sleep(random.random() * 0.25 + 0.1)
+            time.sleep(random.random() * 0.25 + 0.5)
             end_time = time.time()
             return start_time, end_time
 

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -1,7 +1,10 @@
 import logging
+import os
 import random
 import sys
+import threading
 import time
+import uuid
 
 import cloudpickle
 import dask
@@ -58,6 +61,18 @@ class TestLocalDaskExecutor:
             check_scheduler("threads")
             with e.start():
                 e.submit(check_scheduler, "synchronous")
+
+    def test_normalize_scheduler(self):
+        normalize = LocalDaskExecutor._normalize_scheduler
+        assert normalize("THREADS") == "threads"
+        for name in ["threading", "threads"]:
+            assert normalize(name) == "threads"
+        for name in ["multiprocessing", "processes"]:
+            assert normalize(name) == "processes"
+        for name in ["sync", "synchronous", "single-threaded"]:
+            assert normalize(name) == "synchronous"
+        with pytest.raises(ValueError):
+            normalize("unknown")
 
     def test_submit(self):
         e = LocalDaskExecutor()
@@ -125,6 +140,59 @@ class TestLocalDaskExecutor:
             post = cloudpickle.loads(cloudpickle.dumps(e))
             assert isinstance(post, LocalDaskExecutor)
             assert post._pool is None
+
+    @pytest.mark.parametrize("scheduler", ["threads", "processes", "synchronous"])
+    @pytest.mark.parametrize("num_workers", [None, 2])
+    def test_temporary_pool_created_of_proper_size_and_kind(
+        self, scheduler, num_workers
+    ):
+        from dask.system import CPU_COUNT
+        from multiprocessing.pool import Pool, ThreadPool
+
+        e = LocalDaskExecutor(scheduler, num_workers=num_workers)
+        with e.start():
+            if scheduler == "synchronous":
+                assert e._pool is None
+            else:
+                sol = num_workers or CPU_COUNT
+                kind = ThreadPool if scheduler == "threads" else Pool
+                assert isinstance(e._pool, kind)
+                assert e._pool._processes == sol
+        assert e._pool is None
+
+    @pytest.mark.parametrize("scheduler", ["threads", "processes", "synchronous"])
+    def test_interrupt_stops_running_tasks_quickly(self, scheduler):
+        # Windows implements `queue.get` using polling,
+        # which means we can set an exception to interrupt the call to `get`.
+        # Python 3 on other platforms requires sending SIGINT to the main thread.
+        if os.name == "nt":
+            from _thread import interrupt_main
+        else:
+            main_thread = threading.get_ident()
+
+            def interrupt_main():
+                import signal
+
+                signal.pthread_kill(main_thread, signal.SIGINT)
+
+        def long_task():
+            for i in range(50):
+                time.sleep(0.1)
+
+        e = LocalDaskExecutor(scheduler)
+        try:
+            interrupter = threading.Timer(0.5, interrupt_main)
+            interrupter.start()
+            start = time.time()
+            with e.start():
+                e.wait(e.submit(long_task))
+        except KeyboardInterrupt:
+            pass
+        except Exception:
+            assert False, "Failed to interrupt"
+        stop = time.time()
+        if stop - start > 4:
+            assert False, "Failed to interrupt"
 
 
 class TestLocalExecutor:
@@ -358,3 +426,61 @@ class TestDaskExecutor:
             post = cloudpickle.loads(cloudpickle.dumps(executor))
             assert isinstance(post, DaskExecutor)
             assert post.client is None
+            assert post._futures is None
+            assert post._should_run_var is None
+
+    @pytest.mark.parametrize("kind", ["external", "inproc"])
+    def test_exit_early_with_external_or_inproc_cluster_waits_for_pending_futures(
+        self, kind, monkeypatch
+    ):
+        key = "TESTING_%s" % uuid.uuid4().hex
+
+        monkeypatch.setenv(key, "initial")
+
+        def slow():
+            time.sleep(0.5)
+            os.environ[key] = "changed"
+
+        def pending(x):
+            # This function shouldn't ever start, since it's pending when the
+            # shutdown signal is received
+            os.environ[key] = "changed more"
+
+        if kind == "external":
+            with distributed.Client(processes=False, set_as_default=False) as client:
+                executor = DaskExecutor(address=client.scheduler.address)
+                with executor.start():
+                    fut = executor.submit(slow)
+                    fut2 = executor.submit(pending, fut)  # noqa
+                    time.sleep(0.2)
+                assert os.environ[key] == "changed"
+
+        elif kind == "inproc":
+            executor = DaskExecutor(cluster_kwargs={"processes": False})
+            with executor.start():
+                fut = executor.submit(slow)
+                fut2 = executor.submit(pending, fut)  # noqa
+                time.sleep(0.2)
+            assert os.environ[key] == "changed"
+
+        assert executor.client is None
+        assert executor._futures is None
+        assert executor._should_run_var is None
+
+    def test_temporary_cluster_forcefully_cancels_pending_tasks(self, tmpdir):
+        filname = tmpdir.join("signal")
+
+        def slow():
+            time.sleep(10)
+            with open(filname, "w") as f:
+                f.write("Got here")
+
+        executor = DaskExecutor()
+        with executor.start():
+            start = time.time()
+            fut = executor.submit(slow)  # noqa
+            time.sleep(0.1)
+        stop = time.time()
+        # Cluster shutdown before task could complete
+        assert stop - start < 5
+        assert not os.path.exists(filname)


### PR DESCRIPTION
Previously when the `executor.start()` contextmanager would exit early (say on an interrupt or error), there might be background work still happening, since the executor wouldn't wait for or cancel the remaining submitted tasks.

We now attempt to cancel all pending work running on the executor, and wait for tasks that haven't completed in cases where we can't efficiently/robustly cancel them. This ensures that when `executor.start()` exits, no tasks will continue to progress.

- For a `DaskExecutor` with a temporary cluster, we shutdown the cluster, so no lingering work can persist.
- For a `DaskExecutor` with an external cluster (specified with an `address`) or an `inproc` cluster (using local threads only), we stop all pending tasks and wait for all running tasks to finish.
- For a `LocalDaskExecutor`, we terminate the backing pool as quickly as possible, then wait for the pool to close.
  - For a process pool, this terminates the processes
  - For a thread pool, we attempt to interrupt the threads (CPython specific).
- A `LocalExecutor` runs everything in the main thread, so no background tasks can persist.

This is a precursor for the cancellation implementation (#2771).



Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

