### PR TITLE
Recommend `tini` when running local agent in docker

### DIFF
--- a/docs/orchestration/agents/local.md
+++ b/docs/orchestration/agents/local.md
@@ -8,6 +8,11 @@ The local agent is designed to operate in any environment in which Prefect is in
 
 The local agent has no outside dependencies and only requires that Prefect is installed!
 
+If running the local agent inside a Docker container, we recommend you also use
+an init process like [`tini`](https://github.com/krallin/tini). Running without
+an init process may result in lingering zombie processes accumulating in your
+container.
+
 ### Usage
 
 #### Start from Flow


### PR DESCRIPTION
Adds a note to the docs recommending using an init process like `tini`
when running the local agent inside a docker container.

Fixes #2418.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)