### PR TITLE
[WIP] Capture warnings

### DIFF
--- a/changes/pr2929.yaml
+++ b/changes/pr2929.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add py.warnings as a default extra logger to capture Warnings as logs - [#2929](https://github.com/PrefectHQ/prefect/pull/2929)"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -99,7 +99,7 @@ datefmt = "%Y-%m-%d %H:%M:%S"
 log_to_cloud = false
 
 # Extra loggers for Prefect log configuration
-extra_loggers = "[]"
+extra_loggers = "['py.warnings']"
 
 [flows]
 # If true, edges are checked for cycles as soon as they are added to the flow. If false,

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -246,6 +246,8 @@ def configure_extra_loggers() -> None:
     """
     loggers = context.config.logging.get("extra_loggers", [])
     for l in loggers:
+        if l == "py.warnings":
+            logging.captureWarnings(True)
         _create_logger(l)
 
 

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -289,7 +289,10 @@ def test_setup_definition_register(monkeypatch):
                     "value": "prefect.engine.cloud.CloudTaskRunner",
                 },
                 {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                {"name": "PREFECT__LOGGING__EXTRA_LOGGERS", "value": "[]",},
+                {
+                    "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                    "value": "['py.warnings']",
+                },
             ],
             "essential": True,
         }
@@ -333,7 +336,10 @@ def test_setup_definition_register_no_defintions(monkeypatch):
                     "value": "prefect.engine.cloud.CloudTaskRunner",
                 },
                 {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                {"name": "PREFECT__LOGGING__EXTRA_LOGGERS", "value": "[]",},
+                {
+                    "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                    "value": "['py.warnings']",
+                },
             ],
             "name": "flow-container",
             "image": "test/image:tag",

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -241,7 +241,7 @@ def test_populate_job_yaml_no_defaults(job_spec_file, job):
     assert env[2]["value"] == "id_test"
     assert env[3]["value"] == "namespace_test"
     assert env[4]["value"] == "test1/test2:test3"
-    assert env[9]["value"] == "[]"
+    assert env[9]["value"] == "['py.warnings']"
 
     assert (
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"]


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds `py.warnings` as a default extra logger; if provided, `logging.captureWarnings(True)` is also called.  This will auto-convert warnings into WARNING level logs that Prefect ingests.

Note:
- this behavior can be turned off by removing `py.warnings` from `extra_loggers` config
- this applies a _global_ setting at Prefect import time; I'm guessing this is undesirable as a secret side effect so I wanted to open this PR for discussion on other ways of handling this


## Why is this PR important?
This has been informally requested before, and I think will expose useful info (e.g., Dask worker warnings) without being too noisy.