### PR TITLE
Same Python exe for is_serializable subprocess

### DIFF
--- a/changes/issue1262.yaml
+++ b/changes/issue1262.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Ensure `is_serializable` always uses same executable for subprocess. - [#1262](https://github.com/PrefectHQ/prefect/issues/1262)"
+
+contributor:
+  - "[Chris Bowdon](https://github.com/cbowdon)"

--- a/src/prefect/utilities/debug.py
+++ b/src/prefect/utilities/debug.py
@@ -50,7 +50,9 @@ def is_serializable(obj: Any, raise_on_error: bool = False) -> bool:
             sf.write(template.format(binary_file))
         try:
             subprocess.check_output(
-                "python {}".format(script_file), shell=True, stderr=subprocess.STDOUT
+                "{} {}".format(sys.executable, script_file),
+                shell=True,
+                stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as exc:
             if raise_on_error:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate) **N/A**
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate) **N/A**

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This fixes an issue where if the user is running a Python that is not
the default Python on their $PATH then is_serializable fails because
it invokes a subprocess running a different Python (the system
default). This would occur if e.g. the user is running the executable
from a virtual env without first activating the virtual environment.

N.B. I haven't added a test specifically for this fix because the amount of test engineering you'd have to do around running multiple Pythons is almost certainly not worth the trouble.

## Why is this PR important?

It resolves an old and probably uncommon issue, #1262 , so "important" is a bit much. But you may find it helpful.
