### PR TITLE
Improve output format in prefect describe cli

### DIFF
--- a/changes/pr2934.yaml
+++ b/changes/pr2934.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Improve output formatting of `prefect describe` CLI - [#2934](https://github.com/PrefectHQ/prefect/pull/2934)"


### PR DESCRIPTION
Previously the default format for `prefect describe` was to print the
python object. This is similar to json, but not actually json. There's
not a good reason to not use json, so we default to json formatting, and
also add yaml as an option. We also pretty-print the json to make it
easier to read.

Fixes #2926.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)