### PR TITLE
Mirror flow run state within task

### DIFF
--- a/changes/pr2935.yaml
+++ b/changes/pr2935.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add new `wait` kwarg to Flow Run Task for reflecting the flow run state in the task - [#2935](https://github.com/PrefectHQ/prefect/pull/2935)"

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -4,8 +4,36 @@ running. Signals are used in TaskRunners and FlowRunners as a way of communicati
 in states.
 """
 
+from typing import Type
+
 from prefect.engine import state
 from prefect.utilities.exceptions import PrefectError
+
+
+def signal_from_state(state: state.State) -> Type["PrefectStateSignal"]:
+    """
+    Given a state instance, returns the corresponding Signal type.
+
+    Args:
+        - state (State): an instance of a Prefect State
+
+    Returns:
+        - PrefectStateSignal: the Prefect Signal corresponding to
+            the provided state
+
+    Raises:
+        - KeyError: if no signal matches the provided state
+    """
+    unprocessed = set(PrefectStateSignal.__subclasses__())
+    signals = dict()
+    while unprocessed:
+        sig = unprocessed.pop()
+        signals[sig._state_cls.__name__] = sig
+        unprocessed = unprocessed.union(sig.__subclasses__())
+    try:
+        return signals[type(state).__name__]
+    except KeyError:
+        raise KeyError(f"No signal matches the provided state: {state}") from None
 
 
 class ENDRUN(Exception):

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -22,7 +22,7 @@ def signal_from_state(state: state.State) -> Type["PrefectStateSignal"]:
             the provided state
 
     Raises:
-        - KeyError: if no signal matches the provided state
+        - ValueError: if no signal matches the provided state
     """
     unprocessed = set(PrefectStateSignal.__subclasses__())
     signals = dict()
@@ -33,7 +33,7 @@ def signal_from_state(state: state.State) -> Type["PrefectStateSignal"]:
     try:
         return signals[type(state).__name__]
     except KeyError:
-        raise KeyError(f"No signal matches the provided state: {state}") from None
+        raise ValueError(f"No signal matches the provided state: {state}") from None
 
 
 class ENDRUN(Exception):

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -2,7 +2,7 @@ import time
 from typing import Any
 from urllib.parse import urlparse
 
-from prefect import config, Task
+from prefect import config, context, Task
 from prefect.client import Client
 from prefect.engine.signals import PrefectStateSignal
 from prefect.utilities.graphql import EnumValue, with_args
@@ -22,7 +22,7 @@ class FlowRunTask(Task):
             running with Prefect Core's server as the backend, this should not be provided.
         - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
             this value may also be provided at run time
-        - mirror (bool, optional): whether to mirror the triggered flow run's state; if True, this
+        - wait (bool, optional): whether to wait the triggered flow run's state; if True, this
             task will wait until the flow run is complete, and then reflect the corresponding
             state as the state of this task.  Defaults to `False`.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
@@ -33,13 +33,13 @@ class FlowRunTask(Task):
         flow_name: str = None,
         project_name: str = None,
         parameters: dict = None,
-        mirror: bool = False,
+        wait: bool = False,
         **kwargs: Any,
     ):
         self.flow_name = flow_name
         self.project_name = project_name
         self.parameters = parameters
-        self.mirror = mirror
+        self.wait = wait
         super().__init__(**kwargs)
 
     @defaults_from_attrs("flow_name", "project_name", "parameters")
@@ -113,9 +113,16 @@ class FlowRunTask(Task):
 
         # grab the ID for the most recent version
         flow_id = flow[0].id
-        flow_run_id = client.create_flow_run(flow_id=flow_id, parameters=parameters)
 
-        if not mirror:
+        # providing an idempotency key ensures that retries for this task
+        # will not create additional flow runs
+        flow_run_id = client.create_flow_run(
+            flow_id=flow_id,
+            parameters=parameters,
+            idempotency_key=context.get("flow_run_id"),
+        )
+
+        if not self.wait:
             return flow_run_id
 
         signals = {

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -132,8 +132,8 @@ class FlowRunTask(Task):
         while True:
             time.sleep(10)
             flow_run_state = client.get_flow_run_info(flow_run_id).state
-            if state.is_finished():
-                exc = signals[type(state).__name__](
-                    f"{flow_run_id} finished in state {state}"
+            if flow_run_state.is_finished():
+                exc = signals[type(flow_run_state).__name__](
+                    f"{flow_run_id} finished in state {flow_run_state}"
                 )
                 raise exc

--- a/tests/engine/test_signals.py
+++ b/tests/engine/test_signals.py
@@ -14,6 +14,7 @@ from prefect.engine.signals import (
     TRIGGERFAIL,
     VALIDATIONFAIL,
     PrefectStateSignal,
+    signal_from_state,
 )
 from prefect.engine.state import (
     Failed,
@@ -118,3 +119,19 @@ def test_retry_signals_carry_default_retry_time_on_state():
     assert exc.value.state.start_time is not None
     now = pendulum.now("utc")
     assert now - exc.value.state.start_time < datetime.timedelta(seconds=0.1)
+
+
+@pytest.mark.parametrize(
+    "signal,state",
+    [
+        (FAIL, Failed),
+        (TRIGGERFAIL, TriggerFailed),
+        (VALIDATIONFAIL, ValidationFailed),
+        (SUCCESS, Success),
+        (PAUSE, Paused),
+        (RETRY, Retrying),
+        (SKIP, Skipped),
+    ],
+)
+def test_signal_from_state_returns_correct_signal(signal, state):
+    assert signal_from_state(state("Dummy message")) == signal


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a new `wait` kwarg to `FlowRunTask` which will wait until the triggered flow run completes, and reflect the corresponding state back in this task.  Note that an idempotency key is used so that retries, etc. work robustly without triggering new flow runs.


## Why is this PR important?
This task can now be used to create flow-to-flow dependencies