### PR TITLE
Changelog script improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,10 @@ jobs:
           command: flake8 src/
 
       - run:
+          name: Lint changelog entries
+          command: python update_changelog.py lint
+
+      - run:
           name: Ensure 'import prefect' is under 1 second
           command: |
             apt update && apt install jq bc -y

--- a/update_changelog.py
+++ b/update_changelog.py
@@ -2,7 +2,6 @@ import argparse
 import datetime
 import glob
 import os
-import sys
 
 import yaml
 
@@ -19,7 +18,7 @@ SECTIONS = [
 ]
 DEDUPLICATE_SECTIONS = ["contributor"]
 
-TEMPLATE = """
+TEMPLATE = """\
 ## {version} <Badge text="beta" type="success" />
 
 Released on {date}.
@@ -32,12 +31,16 @@ CHANGELOG_PATH = os.path.join(REPO_DIR, "CHANGELOG.md")
 CHANGES_DIR = os.path.join(REPO_DIR, "changes")
 
 
-def run(version, overwrite=False):
+def get_change_files():
     change_files = sorted(glob.glob(os.path.join(CHANGES_DIR, "*.yaml")))
     change_files = [p for p in change_files if not p.endswith("EXAMPLE.yaml")]
+    return change_files
+
+
+def generate_new_section(version):
     # Load changes
     changes = {s: [] for s, _ in SECTIONS}
-    for path in change_files:
+    for path in get_change_files():
         with open(path) as f:
             data = yaml.safe_load(f)
             for k, v in data.items():
@@ -57,12 +60,19 @@ def run(version, overwrite=False):
             values = sorted(set(values))
         if values:
             text = "\n".join("- %s" % v for v in values)
-            sections.append(f"{header}\n\n{text}")
+            sections.append(f"### {header}\n\n{text}")
 
     # Build new release section
     date = "{dt:%B} {dt.day}, {dt:%Y}".format(dt=datetime.date.today())
-    new = TEMPLATE.format(version=version, date=date, sections="\n\n".join(sections))
+    return TEMPLATE.format(version=version, date=date, sections="\n\n".join(sections))
 
+
+def preview():
+    print(generate_new_section("Upcoming Release"))
+
+
+def generate(version):
+    new = generate_new_section(version)
     # Insert new section in existing changelog
     with open(CHANGELOG_PATH) as f:
         existing = f.readlines()
@@ -70,35 +80,37 @@ def run(version, overwrite=False):
     head = existing[:SKIPLINES]
     tail = existing[SKIPLINES:]
 
-    def write(f):
+    with open(CHANGELOG_PATH, "w") as f:
         f.writelines(head)
+        f.write("\n")
         f.write(new)
         f.writelines(tail)
-
-    # Output results
-    if overwrite:
-        with open(CHANGELOG_PATH, "w") as f:
-            write(f)
-        # Remove change files that were added
-        for path in change_files:
-            os.remove(path)
-    else:
-        write(sys.stdout)
+    # Remove change files that were added
+    for path in get_change_files():
+        os.remove(path)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Update the Prefect changelog")
-    parser.add_argument(
+    subparser = parser.add_subparsers(metavar="command", dest="command")
+    subparser.required = True
+    preview_parser = subparser.add_parser(
+        "preview", help="Preview just the new section of of the changelog"
+    )
+    preview_parser.set_defaults(command="preview")
+    generate_parser = subparser.add_parser(
+        "generate",
+        help="Generate the changelog for a release, and cleanup the `changes` directory",
+    )
+    generate_parser.set_defaults(command="generate")
+    generate_parser.add_argument(
         "version", help="The version number to name this release section"
     )
-    parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        default=False,
-        help="If set, will overwrite the existing changelog and clear the `changes` directory",
-    )
     args = parser.parse_args()
-    run(args.version, args.overwrite)
+    if args.command == "generate":
+        generate(args.version)
+    elif args.command == "preview":
+        preview()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A few improvements to the changelog script

- Drop unused sections, instead of inserting `- None` lines.
- Add `lint` subcommand for validating changelog entries
- Add the linting to the CI run