### PR TITLE
Add tip about enabling checkpointing and change the task definition

### DIFF
--- a/docs/core/concepts/results.md
+++ b/docs/core/concepts/results.md
@@ -98,7 +98,7 @@ from prefect import Flow, task
 from prefect.engine.results import LocalResult
 
 @task
-def my_task(result=LocalResult(dir='~/Desktop/HelloWorld/results'), target='result.bytes'):
+def my_task(result=LocalResult(dir='~/Desktop/HelloWorld/results')):
     return 3
 ```
 

--- a/docs/core/concepts/results.md
+++ b/docs/core/concepts/results.md
@@ -89,12 +89,16 @@ def my_task():
 
 If checkpointing is turned on, the Prefect pipeline will persist the return value of tasks using the `write` method of the task's configured `Result` subclass. Consider the following example task configured to store its return value as a `LocalResult` into the `~/Desktop/HelloWorld/results` directory.
 
+::: tip Enabling Checkpointing During Local Testing
+Checkpointing is only turned on by default when running on Prefect Cloud or Server. To enable checkpointing for local testing, set the `PREFECT__FLOWS__CHECKPOINTING` environment variable to `true`.
+:::
+
 ```python
 from prefect import Flow, task
 from prefect.engine.results import LocalResult
 
 @task
-def my_task(checkpointing=True, result=LocalResult(dir='~/Desktop/HelloWorld/results')):
+def my_task(result=LocalResult(dir='~/Desktop/HelloWorld/results'), target='result.bytes'):
     return 3
 ```
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

## What does this PR change?
After attempting to setup result storage on my local machine and failing, got some answers from @cicdw in Slack which I think should be added / updated on the `concepts/results.md` documentation.

Specific slack conversation reference: [here](https://prefect-community.slack.com/archives/CL09KU1K7/p1594417008008500)

Shortened:
> Hey Jackson - if you’re running this locally you additionally need to set the environment variable `PREFECT__FLOWS__CHECKPOINTING=true` to “turn on” the feature (it is enabled by default against a backend but toggleable for local runs for testing >purposes)

## Why is this PR important?
Better docs means people don't ask the same question as me later on :tada: 

