### PR TITLE
move some job_spec details for KubernetesJobEnvironment to build time

### DIFF
--- a/changes/pr2950.yaml
+++ b/changes/pr2950.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Separate build-time and run-time job spec details in KubernetsJobEnvironment - [#2950](https://github.com/PrefectHQ/prefect/pull/2950)"
+
+contributor:
+ - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -40,9 +40,9 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
     `$ /bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"`
 
     Args:
-        - job_spec_file (str, optional): Path to a job spec YAML file.
-            When this class is initialized, the contents of `job_spec_file` are read in
-            and stored in `self._job_spec`.
+        - job_spec_file (str, optional): Path to a job spec YAML file. This path is only
+            used when the environment is built, so should refer to a file on the machine
+            used to build the flow.
         - unique_job_name (bool, optional): whether to use a unique name for each job created
             with this environment. Defaults to `False`
         - executor (Executor, optional): the executor to run the flow with. If not provided, the

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import uuid
 import warnings
@@ -39,7 +40,9 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
     `$ /bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"`
 
     Args:
-        - job_spec_file (str, optional): Path to a job spec YAML file
+        - job_spec_file (str, optional): Path to a job spec YAML file.
+            When this class is initialized, the contents of `job_spec_file` are read in
+            and stored in `self._job_spec`.
         - unique_job_name (bool, optional): whether to use a unique name for each job created
             with this environment. Defaults to `False`
         - executor (Executor, optional): the executor to run the flow with. If not provided, the
@@ -82,6 +85,7 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
 
         # Load specs from file if path given, store on object
         self._job_spec = self._load_spec_from_file()
+        self._job_spec = self._populate_build_time_job_spec_details(self._job_spec)
 
         self._identifier_label = ""
 
@@ -135,9 +139,7 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
 
         batch_client = client.BatchV1Api()
 
-        job = self._populate_job_spec_yaml(
-            yaml_obj=self._job_spec, docker_name=docker_name,
-        )
+        job = self._populate_run_time_job_spec_details(docker_name=docker_name,)
 
         # Create Job
         try:
@@ -152,13 +154,113 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
     # Custom YAML Spec Manipulation
     ###############################
 
-    def _populate_job_spec_yaml(self, yaml_obj: dict, docker_name: str,) -> dict:
+    @staticmethod
+    def _ensure_required_job_spec_sections(yaml_obj: dict) -> dict:
         """
-        Populate the custom execution job yaml object used in this environment with the proper
-        values.
+        Ensure that the required sections exist in the given job YAML.
+
+        Makes sure the following sections exist:
+
+        * `metadata`
+        * `metadata.labels`
+        * `spec`
+        * `spec.template`
+        * `spec.template.metadata`
+        * `spec.template.metadata.labels`
+        * `spec.template.spec`
+        * `spec.template.spec.containers`
+        * and on the first container in `spec.template.spec.containers`:
+            - `command`
+            - `args`
 
         Args:
             - yaml_obj (dict): A dictionary representing the parsed yaml
+
+        Returns:
+            - dict: a dictionary with the yaml values replaced
+        """
+        if not yaml_obj.get("metadata"):
+            yaml_obj["metadata"] = {}
+
+        if not yaml_obj["metadata"].get("labels"):
+            yaml_obj["metadata"]["labels"] = {}
+
+        if not yaml_obj.get("spec"):
+            yaml_obj["spec"] = {}
+
+        if not yaml_obj["spec"].get("template"):
+            yaml_obj["spec"]["template"] = {}
+
+        if not yaml_obj["spec"]["template"].get("spec"):
+            yaml_obj["spec"]["template"]["spec"] = {}
+
+        if not yaml_obj["spec"]["template"]["spec"].get("containers"):
+            yaml_obj["spec"]["template"]["spec"]["containers"] = {}
+
+        if not yaml_obj["spec"]["template"].get("metadata"):
+            yaml_obj["spec"]["template"]["metadata"] = {}
+
+        if not yaml_obj["spec"]["template"]["metadata"].get("labels"):
+            yaml_obj["spec"]["template"]["metadata"]["labels"] = {}
+
+        if not yaml_obj["spec"]["template"]["spec"].get("containers"):
+            yaml_obj["spec"]["template"]["spec"]["containers"] = [{}]
+
+        if not yaml_obj["spec"]["template"]["spec"]["containers"][0].get("command"):
+            yaml_obj["spec"]["template"]["spec"]["containers"][0]["command"] = []
+
+        if not yaml_obj["spec"]["template"]["spec"]["containers"][0].get("args"):
+            yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
+
+        return yaml_obj
+
+    def _populate_build_time_job_spec_details(self, yaml_obj: dict) -> dict:
+        """
+        Populate some details of the custom execution job YAML used in this environment.
+
+        This method fills in details that are known at the build time (when assigning
+        `flow.environment`). Other details which can only be filled in at runtime are
+        handled by `_populate_job_spec_yaml()`.
+
+        Changes the first container in `spec.template.spec.containers`.
+
+        * `/bin/sh -c` as the `command`
+        * prefect-specific `args` that run the floow
+
+        Args:
+            - yaml_obj (dict): A dictionary representing the parsed yaml
+
+        Returns:
+            - dict: a dictionary with the yaml values replaced
+        """
+        yaml_obj = self._ensure_required_job_spec_sections(yaml_obj)
+
+        # set command on first container
+        yaml_obj["spec"]["template"]["spec"]["containers"][0]["command"] = [
+            "/bin/sh",
+            "-c",
+        ]
+
+        # set args on first container
+        yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
+            'python -c "import prefect; prefect.environments.execution.load_and_run_flow()"'
+        ]
+
+        return yaml_obj
+
+    def _populate_run_time_job_spec_details(self, docker_name: str) -> dict:
+        """
+        Fill in the custom execution job yaml object stored in `self._job_spec`
+        with relevant details.
+
+        * `metadata.name`: adds a random name if `self.unique_job_name` is True
+        * `metadata.labels`: appends prefect-specific labels
+        * `spec.template.metadata.labels`: appends prefect-specific labels
+        * `spec.template.spec.containers` (first container):
+            - `env`: appends prefect-specific environment variables
+            - `image`: writes in image from flow's storage or evironment metadata
+
+        Args:
             - docker_name (str): the full path to the docker image
 
         Returns:
@@ -166,23 +268,13 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
         """
         flow_run_id = prefect.context.get("flow_run_id", "unknown")
 
-        # Create metadata label fields if they do not exist
-        if not yaml_obj.get("metadata"):
-            yaml_obj["metadata"] = {}
+        yaml_obj = copy.deepcopy(self._job_spec)
+        yaml_obj = self._ensure_required_job_spec_sections(yaml_obj)
 
         if self.unique_job_name:
             yaml_obj["metadata"][
                 "name"
             ] = f"{yaml_obj['metadata']['name']}-{str(uuid.uuid4())[:8]}"
-
-        if not yaml_obj["metadata"].get("labels"):
-            yaml_obj["metadata"]["labels"] = {}
-
-        if not yaml_obj["spec"]["template"].get("metadata"):
-            yaml_obj["spec"]["template"]["metadata"] = {}
-
-        if not yaml_obj["spec"]["template"]["metadata"].get("labels"):
-            yaml_obj["spec"]["template"]["metadata"]["labels"] = {}
 
         # Populate metadata label fields
         k8s_labels = {
@@ -228,27 +320,7 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
             container["env"].extend(env_values)
 
         # set image on first container
-        if not yaml_obj["spec"]["template"]["spec"]["containers"][0].get("image"):
-            yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"] = ""
-
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"] = docker_name
-
-        # set command on first container
-        if not yaml_obj["spec"]["template"]["spec"]["containers"][0].get("command"):
-            yaml_obj["spec"]["template"]["spec"]["containers"][0]["command"] = []
-
-        yaml_obj["spec"]["template"]["spec"]["containers"][0]["command"] = [
-            "/bin/sh",
-            "-c",
-        ]
-
-        # set args on first container
-        if not yaml_obj["spec"]["template"]["spec"]["containers"][0].get("args"):
-            yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = []
-
-        yaml_obj["spec"]["template"]["spec"]["containers"][0]["args"] = [
-            "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"
-        ]
 
         return yaml_obj
 

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import pytest
+
 import prefect
 from prefect import environments
 from prefect.serialization.environment import (
@@ -13,6 +15,11 @@ from prefect.serialization.environment import (
     RemoteEnvironmentSchema,
     RemoteDaskEnvironmentSchema,
 )
+
+
+@pytest.fixture
+def k8s_job_spec_content() -> str:
+    return "apiVersion: batch/v1\nkind: Job\n"
 
 
 def test_serialize_base_environment():
@@ -166,11 +173,11 @@ def test_serialize_fargate_task_environment_with_labels():
     assert new.labels == set(["a", "b", "c"])
 
 
-def test_serialize_k8s_job_environment():
+def test_serialize_k8s_job_environment(k8s_job_spec_content):
     with tempfile.TemporaryDirectory() as directory:
 
         with open(os.path.join(directory, "job.yaml"), "w+") as file:
-            file.write("job")
+            file.write(k8s_job_spec_content)
 
         env = environments.KubernetesJobEnvironment(
             job_spec_file=os.path.join(directory, "job.yaml")
@@ -188,10 +195,10 @@ def test_serialize_k8s_job_environment():
     assert new.job_spec_file is None
 
 
-def test_serialize_k8s_job_env_with_job_spec():
+def test_serialize_k8s_job_env_with_job_spec(k8s_job_spec_content):
     with tempfile.TemporaryDirectory() as directory:
         with open(os.path.join(directory, "job.yaml"), "w+") as f:
-            f.write("job")
+            f.write(k8s_job_spec_content)
 
         env = environments.KubernetesJobEnvironment(
             job_spec_file=os.path.join(directory, "job.yaml")
@@ -204,11 +211,11 @@ def test_serialize_k8s_job_env_with_job_spec():
         assert isinstance(deserialized, environments.KubernetesJobEnvironment)
 
 
-def test_serialize_k8s_job_environment_with_labels():
+def test_serialize_k8s_job_environment_with_labels(k8s_job_spec_content):
     with tempfile.TemporaryDirectory() as directory:
 
         with open(os.path.join(directory, "job.yaml"), "w+") as file:
-            file.write("job")
+            file.write(k8s_job_spec_content)
 
         env = environments.KubernetesJobEnvironment(
             job_spec_file=os.path.join(directory, "job.yaml"), labels=["a", "b", "c"]


### PR DESCRIPTION

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR is my attempt to implement this suggestion: https://github.com/PrefectHQ/prefect/issues/2829#issuecomment-652544616.

It splits `KubernetesJobEnvironment._populate_job_spec_yaml()` into two methods:

* `._populate_build_time_job_spec_details()`: fill in bits of the job spec that can be known at build time when  `KubernetesJobEnvironment` is initialized
* `_populate_run_time_job_spec_detailis()`: fill in details of the job spec that can only be determined at run time of a flow (like the `flow_run_id` and prefect-specific  environment variables)

## Why is this PR important?

Right now, all prefect customization of the user-provided job spec happens at run time. This means that it isn't possible to change the `args`  and `command` for the container that runs `prefect.environments.execution.load_and_run_flow()`.

This PR makes it clear which changes to the template happen at build time and which happen at run time. The "build time" changes get stored in the pickled flow, in `environment._job_spec` and all the run-time changes except setting `image:`are append-only (i.e. they don't override what the user provided in `job_spec_file`).

This change would allow users to do something like this:

```python
environment = KubernetesJobEnvironment(
     job_spec_file="job_spec.yaml"
)
environment._job_spec["spec"]["template"]["spec"]["containers"][0]["command"] = [
    "/bin/bash",
    "-c"
]
environment._job_spec["spec"]["template"]["spec"]["containers"][0]["args"] = [
    "pip install some-library; python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'"
]
```

In this case I'm `pip install`-ing a library, but this approach would allow users to run *any* code before running the flow.

I believe that this PR doesn't break anyone's existing code and improves users' ability to customize the flow run job. I also think it makes it more obvious which changes to the template provided in `job_spec_file` can be done at build time and which need to be done at run time.

Thanks for the time and consideration!

