### PR TITLE
Fix zombie maps

### DIFF
--- a/changes/issue2656.yaml
+++ b/changes/issue2656.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with Mapped tasks not always reloading child state results on reruns - [#2656](https://github.com/PrefectHQ/prefect/issues/2656)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -262,6 +262,9 @@ class CloudTaskRunner(TaskRunner):
         upstream_results = {}
 
         try:
+            if state.is_mapped():
+                # ensures mapped children are only loaded once
+                state = state.load_result(self.result)
             for edge, upstream_state in upstream_states.items():
                 upstream_states[edge] = upstream_state.load_result(
                     edge.upstream_task.result or self.flow_result

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -111,6 +111,8 @@ class State:
                 s.load_result(result) if s is not None else None
                 for s in self.map_states  # type: ignore
             ]
+            if self.map_states:
+                self.result = [getattr(s, "result", None) for s in self.map_states]
             return self
 
         result_reader = result or self._result

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -112,7 +112,9 @@ class State:
                 for s in self.map_states  # type: ignore
             ]
             if self.map_states:
-                self.result = [getattr(s, "result", None) for s in self.map_states]
+                self.result = [
+                    s.result if s is not None else None for s in self.map_states
+                ]
             return self
 
         result_reader = result or self._result

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -107,6 +107,10 @@ class State:
             - State: the current state with a fully hydrated Result attached
         """
         if self.is_mapped():
+            self.map_states = [
+                s.load_result(result) if s is not None else None
+                for s in self.map_states  # type: ignore
+            ]
             return self
 
         result_reader = result or self._result

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -68,6 +68,7 @@ def apply_map(func: Callable, *args: Any, flow: "Flow" = None, **kwargs: Any) ->
 
     with Flow("example") as flow:
         apply_map(inc_if_even, range(10))
+    ```
     """
     from prefect.tasks.core.constants import Constant
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -518,6 +518,11 @@ class TestResultInterface:
             assert not new_state._result.location
 
     def test_state_load_result_loads_map_states(self):
+        """
+        This test ensures that loading state results also loads mapped children results.
+        See https://github.com/PrefectHQ/prefect/pull/2952
+        """
+
         class MyResult(Result):
             def read(self, *args, **kwargs):
                 new = self.copy()

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -536,7 +536,7 @@ class TestResultInterface:
         assert [getattr(s, "result", None) for s in state.map_states] == [None] * 3
 
         new_state = state.load_result(MyResult(location=""))
-        assert new_state.result is None
+        assert new_state.result == [None, "foo", "bar"]
         assert not new_state._result.location
         assert [getattr(s, "result", None) for s in state.map_states] == [
             None,

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -517,6 +517,33 @@ class TestResultInterface:
             assert new_state.result is None
             assert not new_state._result.location
 
+    def test_state_load_result_loads_map_states(self):
+        class MyResult(Result):
+            def read(self, *args, **kwargs):
+                new = self.copy()
+                new.value = kwargs.get("location", args[0])
+                return new
+
+        state = Mapped(
+            map_states=[
+                None,
+                Success("1", result=MyResult(location="foo")),
+                Success("2", result=MyResult(location="bar")),
+            ]
+        )
+        assert state.message is None
+        assert state.result is None
+        assert [getattr(s, "result", None) for s in state.map_states] == [None] * 3
+
+        new_state = state.load_result(MyResult(location=""))
+        assert new_state.result is None
+        assert not new_state._result.location
+        assert [getattr(s, "result", None) for s in state.map_states] == [
+            None,
+            "foo",
+            "bar",
+        ]
+
     @pytest.mark.parametrize("cls", all_states)
     def test_state_load_result_doesnt_call_read_if_value_present(self, cls):
         """


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes a very specific situation, where if a Mapped pipeline doesn't complete due to zombie tasks, _and_ if there is a "reducer" task downstream of the mapped task, on the next run of that pipeline the reducer task will receive incomplete data.  Ultimately this was caused by the task runners not properly re-loading mapped children state results.


## Why is this PR important?
Closes https://github.com/PrefectHQ/prefect/issues/2656