### PR TITLE
Closes #2809. Fix flake8 error in server dev CLI code

### DIFF
--- a/server/src/prefect_server/cli/dev.py
+++ b/server/src/prefect_server/cli/dev.py
@@ -85,7 +85,7 @@ def build(version):
     """
     docker_dir = Path(prefect_server.__file__).parents[2] / "docker"
 
-    env = make_env()
+    env = make_dev_env()
 
     if "PREFECT_SERVER_TAG" not in env:
         env.update(PREFECT_SERVER_TAG=version)


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [n/a] adds new tests (if appropriate)
- [n/a] add a changelog entry in the `changes/` directory (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2809. A while ago I changed the name of this function for clarity (https://github.com/PrefectHQ/prefect/pull/2299#pullrequestreview-390186444) but missed updating it in this spot in the dev CLI commands.


## Why is this PR important?
build image CLI utility for server dev doesn't work without it, and it's a flake8 error too!

