### PR TITLE
Add option to log the output from stderr in the case of non-zero exit codes in ShellTask

### DIFF
--- a/changes/pr2961.yaml
+++ b/changes/pr2961.yaml
@@ -1,0 +1,2 @@
+task:
+  - "Add `log_stderr` option to `ShellTask` and `DbtShellTask` for logging the full output from stderr - [#2961](https://github.com/PrefectHQ/prefect/pull/2961)"

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -34,6 +34,9 @@ class DbtShellTask(ShellTask):
         - shell (string, optional): shell to run the command with; defaults to "bash"
         - return_all (bool, optional): boolean specifying whether this task should return all
             lines of stdout as a list, or just the last line as a string; defaults to `False`
+        - log_stderr (bool, optional): boolean specifying whether this task
+            should log the output from stderr in the case of a non-zero exit code;
+            defaults to `False`
         - **kwargs: additional keyword arguments to pass to the Task constructor
 
     Example:
@@ -71,6 +74,7 @@ class DbtShellTask(ShellTask):
         helper_script: str = None,
         shell: str = "bash",
         return_all: bool = False,
+        log_stderr: bool = False,
         **kwargs: Any
     ):
         self.command = command
@@ -81,7 +85,11 @@ class DbtShellTask(ShellTask):
         self.set_profiles_envar = set_profiles_envar
         self.dbt_kwargs = dbt_kwargs
         super().__init__(
-            **kwargs, shell=shell, return_all=return_all, helper_script=helper_script
+            **kwargs,
+            shell=shell,
+            return_all=return_all,
+            log_stderr=log_stderr,
+            helper_script=helper_script
         )
 
     @defaults_from_attrs("command", "env", "dbt_kwargs")

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -112,12 +112,10 @@ class ShellTask(prefect.Task):
             sub_process.wait()
             if sub_process.returncode:
                 msg = "Command failed with exit code {0}: {1}".format(
-                    sub_process.returncode, line
+                    sub_process.returncode,
+                    "\n".join(lines) if self.log_stderr else line,
                 )
                 self.logger.error(msg)
-
-                if self.log_stderr:
-                    self.logger.error(lines)
 
                 raise prefect.engine.signals.FAIL(msg) from None  # type: ignore
         if self.return_all:

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -110,6 +110,8 @@ class ShellTask(prefect.Task):
                     sub_process.returncode, line
                 )
                 self.logger.error(msg)
+                if self.return_all:
+                    self.logger.error(lines)
                 raise prefect.engine.signals.FAIL(msg) from None  # type: ignore
         if self.return_all:
             return lines

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -111,11 +111,11 @@ class ShellTask(prefect.Task):
                     self.logger.debug(line)
             sub_process.wait()
             if sub_process.returncode:
-                msg = "Command failed with exit code {0}: {1}".format(
-                    sub_process.returncode,
-                    "\n".join(lines) if self.log_stderr else line,
-                )
+                msg = "Command failed with exit code {}".format(sub_process.returncode,)
                 self.logger.error(msg)
+
+                if self.log_stderr:
+                    self.logger.error("\n".join(lines))
 
                 raise prefect.engine.signals.FAIL(msg) from None  # type: ignore
         if self.return_all:

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -96,7 +96,7 @@ def test_shell_task_env_can_be_set_at_init():
     assert out.result[task].result == "test"
 
 
-def test_shell_logs_error_on_non_zero_exit(caplog):
+def test_shell_logs_non_zero_exit(caplog):
     with Flow(name="test") as f:
         task = ShellTask()(command="ls surely_a_dir_that_doesnt_exist")
     out = f.run()
@@ -105,8 +105,7 @@ def test_shell_logs_error_on_non_zero_exit(caplog):
     error_log = [c for c in caplog.records if c.levelname == "ERROR"]
     assert len(error_log) == 1
     assert error_log[0].name == "prefect.ShellTask"
-    assert "surely_a_dir_that_doesnt_exist" in error_log[0].message
-    assert "No such file or directory" in error_log[0].message
+    assert "Command failed" in error_log[0].message
 
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
@@ -118,11 +117,11 @@ def test_shell_logs_stderr_on_non_zero_exit(caplog):
     assert out.is_failed()
 
     error_log = [c for c in caplog.records if c.levelname == "ERROR"]
-    assert len(error_log) == 1
+    assert len(error_log) == 2
     assert error_log[0].name == "prefect.ShellTask"
-    assert "surely_a_dir_that_doesnt_exist" in error_log[0].message
-    assert "No such file or directory" in error_log[0].message
     assert "Command failed" in error_log[0].message
+    assert "No such file or directory" in error_log[1].message
+    assert "surely_a_dir_that_doesnt_exist" in error_log[1].message
 
 
 def test_shell_initializes_and_runs_multiline_cmd():

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -109,6 +109,20 @@ def test_shell_logs_error_on_non_zero_exit(caplog):
     assert "No such file or directory" in error_log[0].message
 
 
+def test_shell_logs_stderr_on_non_zero_exit(caplog):
+    with Flow(name="test") as f:
+        task = ShellTask(log_stderr=True)(command="ls surely_a_dir_that_doesnt_exist")
+    out = f.run()
+    assert out.is_failed()
+
+    error_log = [c for c in caplog.records if c.levelname == "ERROR"]
+    assert len(error_log) == 2
+    assert error_log[0].name == "prefect.ShellTask"
+    assert "surely_a_dir_that_doesnt_exist" in error_log[0].message
+    assert "No such file or directory" in error_log[0].message
+    assert "Command failed" in error_log[0].message
+
+
 def test_shell_initializes_and_runs_multiline_cmd():
     cmd = """
     TEST=$(cat <<-END

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -111,7 +111,9 @@ def test_shell_logs_error_on_non_zero_exit(caplog):
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     with Flow(name="test") as f:
-        task = ShellTask(log_stderr=True, return_all=True)(command="ls surely_a_dir_that_doesnt_exist")
+        task = ShellTask(log_stderr=True, return_all=True)(
+            command="ls surely_a_dir_that_doesnt_exist"
+        )
     out = f.run()
     assert out.is_failed()
 

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -111,12 +111,12 @@ def test_shell_logs_error_on_non_zero_exit(caplog):
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     with Flow(name="test") as f:
-        task = ShellTask(log_stderr=True)(command="ls surely_a_dir_that_doesnt_exist")
+        task = ShellTask(log_stderr=True, return_all=True)(command="ls surely_a_dir_that_doesnt_exist")
     out = f.run()
     assert out.is_failed()
 
     error_log = [c for c in caplog.records if c.levelname == "ERROR"]
-    assert len(error_log) == 2
+    assert len(error_log) == 1
     assert error_log[0].name == "prefect.ShellTask"
     assert "surely_a_dir_that_doesnt_exist" in error_log[0].message
     assert "No such file or directory" in error_log[0].message


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds a `log_stderr` boolean kwarg to ShellTask and DbtShellTask for logging the full output in the case of a non-zero exit code.


## Why is this PR important?
User encountered a case where an error in their DbtShellTask didn't output the full traceback

