### PR TITLE
Remove stale env vars on dask k8s and update work stealing default

### DIFF
--- a/changes/pr2973.yaml
+++ b/changes/pr2973.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Turn work stealing ON by default on Dask K8s environment - [#2973](https://github.com/PrefectHQ/prefect/pull/2973)"

--- a/src/prefect/environments/execution/dask/job.yaml
+++ b/src/prefect/environments/execution/dask/job.yaml
@@ -45,9 +45,7 @@ spec:
             - name: PREFECT__DEBUG
               value: "true"
             - name: DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING
-              value: "False"
-            - name: DASK_DISTRIBUTED__SCHEDULER__BLOCKED_HANDLERS
-              value: "['feed', 'run_function']"
+              value: "True"
             - name: PREFECT__LOGGING__EXTRA_LOGGERS
               value: PREFECT__LOGGING__EXTRA_LOGGERS
           resources:

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -81,7 +81,7 @@ class DaskKubernetesEnvironment(Environment):
         self,
         min_workers: int = 1,
         max_workers: int = 2,
-        work_stealing: bool = False,
+        work_stealing: bool = True,
         scheduler_logs: bool = False,
         private_registry: bool = False,
         docker_secret: str = None,
@@ -381,7 +381,7 @@ class DaskKubernetesEnvironment(Environment):
         env[3]["value"] = prefect.context.get("namespace", "default")
         env[4]["value"] = docker_name
         env[12]["value"] = str(self.work_stealing)
-        env[14]["value"] = self._extra_loggers()
+        env[13]["value"] = self._extra_loggers()
 
         # set image
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"] = docker_name
@@ -407,7 +407,7 @@ class DaskKubernetesEnvironment(Environment):
         env[0]["value"] = prefect.config.cloud.graphql
         env[1]["value"] = prefect.config.cloud.auth_token
         env[2]["value"] = prefect.context.get("flow_run_id", "")
-        env[11]["value"] = self._extra_loggers()
+        env[10]["value"] = self._extra_loggers()
 
         pod_spec = yaml_obj["spec"]
         if self.private_registry:

--- a/src/prefect/environments/execution/dask/worker_pod.yaml
+++ b/src/prefect/environments/execution/dask/worker_pod.yaml
@@ -30,8 +30,6 @@ spec:
         value: "DEBUG"
       - name: PREFECT__DEBUG
         value: "true"
-      - name: DASK_DISTRIBUTED__SCHEDULER__BLOCKED_HANDLERS
-        value: "['feed', 'run_function']"
       - name: PREFECT__LOGGING__EXTRA_LOGGERS
         value: PREFECT__LOGGING__EXTRA_LOGGERS
     resources:

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -22,7 +22,7 @@ def test_create_dask_environment():
     assert environment
     assert environment.min_workers == 1
     assert environment.max_workers == 2
-    assert environment.work_stealing is False
+    assert environment.work_stealing is True
     assert environment.scheduler_logs is False
     assert environment.private_registry is False
     assert environment.docker_secret is None
@@ -38,7 +38,7 @@ def test_create_dask_environment_args():
     environment = DaskKubernetesEnvironment(
         min_workers=5,
         max_workers=6,
-        work_stealing=True,
+        work_stealing=False,
         scheduler_logs=True,
         private_registry=True,
         docker_secret="docker",
@@ -48,7 +48,7 @@ def test_create_dask_environment_args():
     assert environment
     assert environment.min_workers == 5
     assert environment.max_workers == 6
-    assert environment.work_stealing is True
+    assert environment.work_stealing is False
     assert environment.scheduler_logs is True
     assert environment.private_registry is True
     assert environment.docker_secret == "docker"
@@ -273,7 +273,7 @@ def test_populate_job_yaml():
     assert env[4]["value"] == "test1/test2:test3"
     assert env[12]["value"] == "True"
     assert (
-        env[14]["value"]
+        env[13]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive', 'kubernetes', 'distributed.scheduler']"
     )
 
@@ -313,7 +313,7 @@ def test_populate_worker_pod_yaml():
     assert env[1]["value"] == "auth_test"
     assert env[2]["value"] == "id_test"
     assert (
-        env[11]["value"]
+        env[10]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive', 'kubernetes']"
     )
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR:
- removes blocked handlers from the dask k8s environment spec (stale code essentially)
- changes the default value of work stealing to `True`

## Why is this PR important?
Turning work stealing off hampers the dask scheduler's ability to distribute work, and was originally turned off to avoid bad UX with version locking.  Might help #2958 