### PR TITLE
Add display_name_callable to task.map

### DIFF
--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -540,6 +540,7 @@ class Task(metaclass=SignatureValidator):
         upstream_tasks: Iterable[Any] = None,
         flow: "Flow" = None,
         task_args: dict = None,
+        display_name_callable: Callable = None,
         **kwargs: Any
     ) -> "Task":
         """
@@ -562,6 +563,8 @@ class Task(metaclass=SignatureValidator):
                 flow in context if no flow is specified
             - task_args (dict, optional): a dictionary of task attribute keyword arguments,
                 these attributes will be set on the new copy
+            - display_name_callable (Callable, optional): a function that can be used to format the
+                name of mapped tasks
             - **kwargs: keyword arguments to map over, which will elementwise be bound to the
                 Task's `run` method
 
@@ -579,6 +582,11 @@ class Task(metaclass=SignatureValidator):
                     )
                 )
         new = self.copy(**(task_args or {}))
+
+        # TODO: is setting attributes like this a weird access pattern?
+        if display_name_callable is not None:
+            setattr(new, "display_name_callable", display_name_callable)
+
         return new.bind(
             *args, mapped=True, upstream_tasks=upstream_tasks, flow=flow, **kwargs
         )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Addresses #2100 


## Why is this PR important?

-----

Opening this as a draft PR to get some thoughts on the implementation. This PR adds a `display_name_callable` to `task.map` (alternatively we could add this as a task attribute itself) and unlocks functionality like the following:

```python
# inputs as names
from prefect import task, Flow

@task
def pval(val):
    print(f"My value is {val} and that should be my key ^")

with Flow("mapitems") as flow:
    pval.map(["abc", "def", "ghi"], display_name_callable=lambda **kwargs: kwargs["val"])

flow.run()
```

```
[2020-07-15 19:29:13] INFO - prefect.FlowRunner | Beginning Flow run for 'mapitems'
[2020-07-15 19:29:13] INFO - prefect.FlowRunner | Starting flow run.
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval': Starting task run...
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval': finished task run for task with final state: 'Mapped'
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[abc]': Starting task run...
My value is abc and that should be my key ^
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[abc]': finished task run for task with final state: 'Success'
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[def]': Starting task run...
My value is def and that should be my key ^
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[def]': finished task run for task with final state: 'Success'
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[ghi]': Starting task run...
My value is ghi and that should be my key ^
[2020-07-15 19:29:13] INFO - prefect.TaskRunner | Task 'pval[ghi]': finished task run for task with final state: 'Success'
[2020-07-15 19:29:13] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
```

```python
# values from context
from prefect import task, Flow

@task
def pval(val):
    print(f"My value is {val}")

with Flow("mapitems") as flow:
    pval.map(
        ["abc", "def", "ghi"],
        display_name_callable=lambda **kwargs: f"{kwargs['map_index']}-{kwargs['flow_name']}",
    )

flow.run()
```

```
[2020-07-15 19:31:52] INFO - prefect.FlowRunner | Beginning Flow run for 'mapitems'
[2020-07-15 19:31:52] INFO - prefect.FlowRunner | Starting flow run.
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval': Starting task run...
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval': finished task run for task with final state: 'Mapped'
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[0-mapitems]': Starting task run...
My value is abc
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[0-mapitems]': finished task run for task with final state: 'Success'
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[1-mapitems]': Starting task run...
My value is def
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[1-mapitems]': finished task run for task with final state: 'Success'
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[2-mapitems]': Starting task run...
My value is ghi
[2020-07-15 19:31:52] INFO - prefect.TaskRunner | Task 'pval[2-mapitems]': finished task run for task with final state: 'Success'
[2020-07-15 19:31:52] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
```

There are a few `TODO`s in the code looking for feedback!