### PR TITLE
added task AWSSecretsManager and tests

### DIFF
--- a/changes/issue2069.yaml
+++ b/changes/issue2069.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Implement AWSSecretsManager task - [#2069](https://github.com/PrefectHQ/prefect/issues/2069)"
+
+contributor:
+  - "[Robin Beer](https://github.com/Zaubeerer)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -206,7 +206,7 @@ classes = ["WriteAirtableRow", "ReadAirtableRow"]
 [pages.tasks.aws]
 title = "AWS Tasks"
 module = "prefect.tasks.aws"
-classes = ["S3Download", "S3Upload", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate"]
+classes = ["S3Download", "S3Upload", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate", "AWSSecretsManager"]
 
 [pages.tasks.azure]
 title = "Azure Tasks"

--- a/src/prefect/tasks/aws/__init__.py
+++ b/src/prefect/tasks/aws/__init__.py
@@ -12,6 +12,7 @@ try:
         LambdaList,
     )
     from prefect.tasks.aws.step_function import StepActivate
+    from prefect.tasks.aws.secrets_manager import AWSSecretsManager
 except ImportError:
     raise ImportError(
         'Using `prefect.tasks.aws` requires Prefect to be installed with the "aws" extra.'

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -22,12 +22,12 @@ class AWSSecretsManager(SecretBase):
             Task constructor
     """
 
-    def __init__(self, name: str, **kwargs):
-        kwargs["name"] = name
+    def __init__(self, secret: str = None, **kwargs):
+        self.secret = secret
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("name")
-    def run(self, name: str = None, credentials: str = None) -> dict:
+    @defaults_from_attrs("secret")
+    def run(self, secret: str = None, credentials: str = None) -> dict:
         """
         Task run method.
 
@@ -43,11 +43,13 @@ class AWSSecretsManager(SecretBase):
             - dict: the contents of this secret, as a dictionary
         """
 
-        if name is None:
+        if secret is None:
             raise ValueError("A secret name must be provided.")
 
         secrets_client = get_boto_client("secretsmanager", credentials=credentials)
 
-        secret = secrets_client.get_secret_value(SecretId=name)
+        secret_string = secrets_client.get_secret_value(SecretId=secret)
 
-        return json.loads(secret["SecretString"])
+        secret_dict = json.loads(secret["SecretString"])
+
+        return secret_dict

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -1,7 +1,5 @@
 import json
 
-import boto3
-
 from prefect.tasks.secrets.base import SecretBase
 from prefect.utilities.aws import get_boto_client
 from prefect.utilities.tasks import defaults_from_attrs

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -43,6 +43,9 @@ class AWSSecretsManager(SecretBase):
             - dict: the contents of this secret, as a dictionary
         """
 
+        if name is None:
+            raise ValueError("A secret name must be provided.")
+
         secrets_client = get_boto_client("secretsmanager", credentials=credentials)
 
         secret = secrets_client.get_secret_value(SecretId=name)

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -48,8 +48,8 @@ class AWSSecretsManager(SecretBase):
 
         secrets_client = get_boto_client("secretsmanager", credentials=credentials)
 
-        secret_string = secrets_client.get_secret_value(SecretId=secret)
+        secret_string = secrets_client.get_secret_value(SecretId=secret)["SecretString"]
 
-        secret_dict = json.loads(secret["SecretString"])
+        secret_dict = json.loads(secret_string)
 
         return secret_dict

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -1,0 +1,52 @@
+import json
+
+import boto3
+
+from prefect.tasks.secrets.base import SecretBase
+from prefect.utilities.aws import get_boto_client
+from prefect.utilities.tasks import defaults_from_attrs
+
+
+class AWSSecretsManager(SecretBase):
+    """
+    Task for retrieving secrets from an AWS Secrets Manager and returning it as a dictionary.
+    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+
+    For authentication, there are two options: you can set the `AWS_CREDENTIALS` Prefect Secret
+    containing your AWS access keys which will be passed directly to the `boto3` client, or you
+    can [configure your flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    for `boto3`.
+
+    Args:
+        - secret_name (str, optional): the name of the secret to retrieve
+        - **kwargs (dict, optional): additional keyword arguments to pass to the
+            Task constructor
+    """
+
+    def __init__(self, secret_name: str, **kwargs):
+        kwargs["name"] = secret_name
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs("name")
+    def run(self, name: str = None, credentials: str = None) -> dict:
+        """
+        Task run method.
+
+        Args:
+            - secret_name (str): the name of the secret to retrieve
+            - credentials (dict, optional): your AWS credentials passed from an upstream
+                Secret task; this Secret must be a JSON string
+                with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
+                passed directly to `boto3`.  If not provided here or in context, `boto3`
+                will fall back on standard AWS rules for authentication.
+
+        Returns:
+            - dict: the contents of this secret, as a dictionary
+        """
+
+        secrets_client = get_boto_client("secretsmanager", credentials=credentials)
+
+        secret = secrets_client.get_secret_value(SecretId=name)
+
+        return json.loads(secret["SecretString"])

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -17,7 +17,7 @@ class AWSSecretsManager(SecretBase):
     for `boto3`.
 
     Args:
-        - name (str, optional): the name of the secret to retrieve
+        - secret (str, optional): the name of the secret to retrieve
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -32,7 +32,7 @@ class AWSSecretsManager(SecretBase):
         Task run method.
 
         Args:
-            - name (str): the name of the secret to retrieve
+            - secret (str): the name of the secret to retrieve
             - credentials (dict, optional): your AWS credentials passed from an upstream
                 Secret task; this Secret must be a JSON string
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -19,13 +19,13 @@ class AWSSecretsManager(SecretBase):
     for `boto3`.
 
     Args:
-        - secret_name (str, optional): the name of the secret to retrieve
+        - name (str, optional): the name of the secret to retrieve
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, secret_name: str, **kwargs):
-        kwargs["name"] = secret_name
+    def __init__(self, name: str, **kwargs):
+        kwargs["name"] = name
         super().__init__(**kwargs)
 
     @defaults_from_attrs("name")
@@ -34,7 +34,7 @@ class AWSSecretsManager(SecretBase):
         Task run method.
 
         Args:
-            - secret_name (str): the name of the secret to retrieve
+            - name (str): the name of the secret to retrieve
             - credentials (dict, optional): your AWS credentials passed from an upstream
                 Secret task; this Secret must be a JSON string
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -3,21 +3,21 @@ from unittest.mock import MagicMock
 import pytest
 
 import prefect
-from prefect.tasks.aws import AWSSecretsManagerTask
+from prefect.tasks.aws import AWSSecretsManager
 from prefect.utilities.configuration import set_temporary_config
 
 
 class TestAWSSecretsManager:
     def test_initialization(self):
-        task = AWSSecretsManagerTask("test")
+        task = AWSSecretsManager("test")
 
     def test_initialization_passes_to_task_constructor(self):
-        task = AWSSecretsManagerTask(secret_name="test", tags=["AWS"])
+        task = AWSSecretsManager(secret_name="test", tags=["AWS"])
         assert task.name == "test"
         assert task.tags == {"AWS"}
 
     def test_raises_if_secret_not_eventually_provided(self):
-        task = AWSSecretsManagerTask(secret_name="test", tags=["AWS"])
+        task = AWSSecretsManager(secret_name="test", tags=["AWS"])
 
         # TODO: I did not understand what this test tests (copied from S3Download)
         with pytest.raises(ValueError, match="secret_name"):

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import prefect
+from prefect.tasks.aws import AWSSecretsManagerTask
+from prefect.utilities.configuration import set_temporary_config
+
+
+class TestAWSSecretsManager:
+    def test_initialization(self):
+        task = AWSSecretsManagerTask("test")
+
+    def test_initialization_passes_to_task_constructor(self):
+        task = AWSSecretsManagerTask(secret_name="test", tags=["AWS"])
+        assert task.name == "test"
+        assert task.tags == {"AWS"}
+
+    def test_raises_if_secret_not_eventually_provided(self):
+        task = AWSSecretsManagerTask(secret_name="test", tags=["AWS"])
+
+        # TODO: I did not understand what this test tests (copied from S3Download)
+        with pytest.raises(ValueError, match="secret_name"):
+            task.run(name="")

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -12,13 +12,13 @@ class TestAWSSecretsManager:
         task = AWSSecretsManager("test")
 
     def test_initialization_passes_to_task_constructor(self):
-        task = AWSSecretsManager(secret_name="test", tags=["AWS"])
+        task = AWSSecretsManager(name="test", tags=["AWS"])
         assert task.name == "test"
         assert task.tags == {"AWS"}
 
     def test_raises_if_secret_not_eventually_provided(self):
-        task = AWSSecretsManager(secret_name="test", tags=["AWS"])
+        task = AWSSecretsManager(name="test", tags=["AWS"])
 
         # TODO: I did not understand what this test tests (copied from S3Download)
-        with pytest.raises(ValueError, match="secret_name"):
+        with pytest.raises(ValueError, match="name"):
             task.run(name="")

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -17,8 +17,7 @@ class TestAWSSecretsManager:
         assert task.tags == {"AWS"}
 
     def test_raises_if_secret_not_eventually_provided(self):
-        task = AWSSecretsManager(tags=["AWS"])
+        task = AWSSecretsManager()
 
-        # TODO: I did not understand what this test tests (copied from S3Download)
-        with pytest.raises(ValueError, match="name"):
-            task.run(name="")
+        with pytest.raises(ValueError, match="secret"):
+            task.run()

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -17,7 +17,7 @@ class TestAWSSecretsManager:
         assert task.tags == {"AWS"}
 
     def test_raises_if_secret_not_eventually_provided(self):
-        task = AWSSecretsManager(name="test", tags=["AWS"])
+        task = AWSSecretsManager(tags=["AWS"])
 
         # TODO: I did not understand what this test tests (copied from S3Download)
         with pytest.raises(ValueError, match="name"):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, 
- [x] including `docs/outline.toml` for API reference docs (not sure whether appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Adds a task that enables secrets to be retrieved from AWS secrets manager.

## Why is this PR important?

This feature has been demanded by several users (see [issue 2069](https://github.com/PrefectHQ/prefect/issues/2069)).

closes #2069 