### PR TITLE
Add py.typed to allow type hints to pass into userland

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
     scripts=[],
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    package_data={"prefect": ["py.typed"]},
     include_package_data=True,
     entry_points={"console_scripts": ["prefect=prefect.cli:cli"]},
     python_requires=">=3.6",


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
It simply introduces a `py.typed` file and includes in the `setuptools` configuration. This follows from [PEP-0561](https://www.python.org/dev/peps/pep-0561/).


## Why is this PR important?
This lets type checkers (like `mypy`) use the type hints present in the library.

The current behavior with the package:
```bash
$ mypy -c 'import prefect; reveal_type(prefect.Flow("test"))'
<string>:1: error: Skipping analyzing 'prefect': found module but no type hints or library stubs
<string>:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
<string>:1: note: Revealed type is 'Any'
Found 1 error in 1 file (checked 1 source file)

```

After the change in this PR:
```bash
$ mypy -c 'import prefect; reveal_type(prefect.Flow("test"))'
<string>:1: note: Revealed type is 'prefect.core.flow.Flow'
```
