### PR TITLE
Send regular heartbeats while waiting to retry /dequeue

### DIFF
--- a/changes/pr2977.yaml
+++ b/changes/pr2977.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Send regular heartbeats while waiting to retry / dequeue - [#2977](https://github.com/PrefectHQ/prefect/pull/2977)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -324,13 +324,20 @@ class CloudTaskRunner(TaskRunner):
                 naptime = max(
                     (end_state.start_time - pendulum.now("utc")).total_seconds(), 0
                 )
-                time.sleep(naptime)
+                for _ in range(naptime // 30):
+                    # send heartbeat every 30 seconds to let API know task run is still alive
+                    self.client.update_task_run_heartbeat(
+                        task_run_id=prefect.context.get("task_run_id")
+                    )
+                    naptime -= 30
+                    time.sleep(30)
 
-                # send heartbeat on each iteration to let API know task run is still alive
+                if naptime > 0:
+                    time.sleep(naptime)  # ensures we don't start too early
+
                 self.client.update_task_run_heartbeat(
                     task_run_id=prefect.context.get("task_run_id")
                 )
-
                 # mapped children will retrieve their latest info inside
                 # initialize_run(), but we can load up-to-date versions
                 # for all other task runs here

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -324,7 +324,7 @@ class CloudTaskRunner(TaskRunner):
                 naptime = max(
                     (end_state.start_time - pendulum.now("utc")).total_seconds(), 0
                 )
-                for _ in range(naptime // 30):
+                for _ in range(int(naptime) // 30):
                     # send heartbeat every 30 seconds to let API know task run is still alive
                     self.client.update_task_run_heartbeat(
                         task_run_id=prefect.context.get("task_run_id")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR sends regular heartbeats (every 30 seconds) to the backend API while waiting to Retry / Dequeue a task run.


## Why is this PR important?
This allows Cloud to know that a process is out in the world waiting to rerun this task run, so that we can prevent flooding agents with unnecessary / redundant work.