### PR TITLE
Some cleanups to dbtshelltask

### DIFF
--- a/changes/pr2980.yaml
+++ b/changes/pr2980.yaml
@@ -1,0 +1,3 @@
+task:
+  - "Update return value and config for DbtShellTask - [#2980](https://github.com/PrefectHQ/prefect/pull/2980)"
+  

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ extras = {
         "azure-cosmos >= 3.1.1, <3.2",
     ],
     "dask_cloudprovider": ["dask_cloudprovider >= 0.2.0, < 1.0"],
+    "dbt": ["dbt >= 0.17.1"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -86,10 +86,12 @@ class DbtShellTask(ShellTask):
         self.dbt_kwargs = dbt_kwargs
         super().__init__(
             **kwargs,
+            command=command,
+            env=env,
+            helper_script=helper_script,
             shell=shell,
             return_all=return_all,
-            log_stderr=log_stderr,
-            helper_script=helper_script
+            log_stderr=log_stderr
         )
 
     @defaults_from_attrs("command", "env", "dbt_kwargs")

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -149,6 +149,4 @@ class DbtShellTask(ShellTask):
         if self.set_profiles_envar:
             os.environ["DBT_PROFILES_DIR"] = self.profiles_dir
 
-        super(DbtShellTask, self).run(
-            command=command, env=env,
-        )
+        return super(DbtShellTask, self).run(command=command, env=env,)

--- a/tests/tasks/dbt/__init__.py
+++ b/tests/tasks/dbt/__init__.py
@@ -1,5 +1,3 @@
-from shutil import which
 import pytest
 
-if not which("dbt"):
-    pytest.mark.skip("dbt not installed")
+pytest.importorskip("dbt")

--- a/tests/tasks/dbt/test_dbt.py
+++ b/tests/tasks/dbt/test_dbt.py
@@ -11,6 +11,60 @@ pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="DbtShellTask currently not supported on Windows"
 )
 
+def test_shell_result_from_stdout(tmpdir):
+    dbt_dir = tmpdir.mkdir("dbt")
+    with Flow(name="test") as f:
+        task = DbtShellTask(
+            profile_name="default",
+            environment="test",
+            dbt_kwargs={
+                "type": "snowflake",
+                "threads": 1,
+                "account": "JH72176.us-east-1",
+                "user": "jane@company.com",
+                "role": "analyst",
+                "database": "staging",
+                "warehouse": "data_science",
+                "schema": "analysis",
+                "private_key_path": "/src/private_key.p8",
+                "private_key_passphrase": "password123",
+            },
+            overwrite_profiles=True,
+                profiles_dir=str(dbt_dir),
+        )(command="dbt --version")
+    out = f.run()
+    # check that the result is non None/not empty
+    assert out._result.value[task].result
+    # default config should return a string
+    assert isinstance(out._result.value[task].result, str)
+
+def test_shell_result_from_stdout_with_full_return(tmpdir):
+    dbt_dir = tmpdir.mkdir("dbt")
+    with Flow(name="test") as f:
+        task = DbtShellTask(
+            return_all=True,
+            profile_name="default",
+            environment="test",
+            dbt_kwargs={
+                "type": "snowflake",
+                "threads": 1,
+                "account": "JH72176.us-east-1",
+                "user": "jane@company.com",
+                "role": "analyst",
+                "database": "staging",
+                "warehouse": "data_science",
+                "schema": "analysis",
+                "private_key_path": "/src/private_key.p8",
+                "private_key_passphrase": "password123",
+            },
+            overwrite_profiles=True,
+                profiles_dir=str(dbt_dir),
+        )(command="dbt --version")
+    out = f.run()
+    # check that the result is non None/not empty
+    assert out._result.value[task].result
+    # return all should return a list
+    assert isinstance(out._result.value[task].result, list)
 
 def test_shell_creates_profiles_yml_file(tmpdir):
     dbt_dir = tmpdir.mkdir("dbt")

--- a/tests/tasks/dbt/test_dbt.py
+++ b/tests/tasks/dbt/test_dbt.py
@@ -11,60 +11,65 @@ pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="DbtShellTask currently not supported on Windows"
 )
 
+
 def test_shell_result_from_stdout(tmpdir):
     dbt_dir = tmpdir.mkdir("dbt")
-    with Flow(name="test") as f:
-        task = DbtShellTask(
-            profile_name="default",
-            environment="test",
-            dbt_kwargs={
-                "type": "snowflake",
-                "threads": 1,
-                "account": "JH72176.us-east-1",
-                "user": "jane@company.com",
-                "role": "analyst",
-                "database": "staging",
-                "warehouse": "data_science",
-                "schema": "analysis",
-                "private_key_path": "/src/private_key.p8",
-                "private_key_passphrase": "password123",
-            },
-            overwrite_profiles=True,
-                profiles_dir=str(dbt_dir),
-        )(command="dbt --version")
-    out = f.run()
-    # check that the result is non None/not empty
-    assert out._result.value[task].result
+
+    task = DbtShellTask(
+        command="dbt --version",
+        profile_name="default",
+        environment="test",
+        dbt_kwargs={
+            "type": "snowflake",
+            "threads": 1,
+            "account": "JH72176.us-east-1",
+            "user": "jane@company.com",
+            "role": "analyst",
+            "database": "staging",
+            "warehouse": "data_science",
+            "schema": "analysis",
+            "private_key_path": "/src/private_key.p8",
+            "private_key_passphrase": "password123",
+        },
+        overwrite_profiles=True,
+        profiles_dir=str(dbt_dir),
+    )
+    out = task.run()
     # default config should return a string
-    assert isinstance(out._result.value[task].result, str)
+    assert isinstance(out, str)
+    # check that the result is not empty
+    assert len(out) > 0
+
 
 def test_shell_result_from_stdout_with_full_return(tmpdir):
     dbt_dir = tmpdir.mkdir("dbt")
-    with Flow(name="test") as f:
-        task = DbtShellTask(
-            return_all=True,
-            profile_name="default",
-            environment="test",
-            dbt_kwargs={
-                "type": "snowflake",
-                "threads": 1,
-                "account": "JH72176.us-east-1",
-                "user": "jane@company.com",
-                "role": "analyst",
-                "database": "staging",
-                "warehouse": "data_science",
-                "schema": "analysis",
-                "private_key_path": "/src/private_key.p8",
-                "private_key_passphrase": "password123",
-            },
-            overwrite_profiles=True,
-                profiles_dir=str(dbt_dir),
-        )(command="dbt --version")
-    out = f.run()
-    # check that the result is non None/not empty
-    assert out._result.value[task].result
-    # return all should return a list
-    assert isinstance(out._result.value[task].result, list)
+
+    task = DbtShellTask(
+        return_all=True,
+        command="dbt --version",
+        profile_name="default",
+        environment="test",
+        dbt_kwargs={
+            "type": "snowflake",
+            "threads": 1,
+            "account": "JH72176.us-east-1",
+            "user": "jane@company.com",
+            "role": "analyst",
+            "database": "staging",
+            "warehouse": "data_science",
+            "schema": "analysis",
+            "private_key_path": "/src/private_key.p8",
+            "private_key_passphrase": "password123",
+        },
+        overwrite_profiles=True,
+        profiles_dir=str(dbt_dir),
+    )
+    out = task.run()
+    # when set to `return_all=True`, should return a list
+    assert isinstance(out, list)
+    # check that the result is multiple lines
+    assert len(out) > 1
+
 
 def test_shell_creates_profiles_yml_file(tmpdir):
     dbt_dir = tmpdir.mkdir("dbt")


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [n/a] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
First off, adds `return` that I think just got missed in the original dbtshelltask. Otherwise the stdout from dbt being run in the shell is not retrieved as the return value of the task, against what is says in its docstrings and the intention of ShellTask itself and presumably its derivatives. This was brought up in this slack thread: https://prefect-community.slack.com/archives/CL09KU1K7/p1594912760250100

While writing tests I realized that the super method was also failing to forward `command` and `env` kwargs which made the `@default_from_attrs` functionality not work properly for those two, so I fixed that too.

And while running tests that actually called dbt I realized that it wasn't being added as an `extras` option in setup.py (and thus it wasn't really possible to meaningfully run the tests on CI) so I've added that as well.

## Why is this PR important?
So that people can use the stdout from the DbtShellTask for anything downstream.

