### PR TITLE
Remove password from init method of postgres tasks

### DIFF
--- a/changes/issue1345.yaml
+++ b/changes/issue1345.yaml
@@ -1,0 +1,2 @@
+breaking:
+  - "Remove password from Postgres tasks' initialization methods for security - [#1345](https://github.com/PrefectHQ/prefect/issues/1345)"

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -11,7 +11,6 @@ class PostgresExecute(Task):
     Args:
         - db_name (str): name of Postgres database
         - user (str): user name used to authenticate
-        - password (str): password used to authenticate
         - host (str): database host address
         - port (int, optional): port used to connect to Postgres database, defaults to 5432 if
             not provided
@@ -27,7 +26,6 @@ class PostgresExecute(Task):
         self,
         db_name: str,
         user: str,
-        password: str,
         host: str,
         port: int = 5432,
         query: str = None,
@@ -37,7 +35,6 @@ class PostgresExecute(Task):
     ):
         self.db_name = db_name
         self.user = user
-        self.password = password
         self.host = host
         self.port = port
         self.query = query
@@ -46,7 +43,13 @@ class PostgresExecute(Task):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("query", "data", "commit")
-    def run(self, query: str = None, data: tuple = None, commit: bool = False):
+    def run(
+        self,
+        query: str = None,
+        data: tuple = None,
+        commit: bool = False,
+        password: str = None,
+    ):
         """
         Task run method. Executes a query against Postgres database.
 
@@ -55,6 +58,7 @@ class PostgresExecute(Task):
             - data (tuple, optional): values to use in query, must be specified using
                 placeholder is query string
             - commit (bool, optional): set to True to commit transaction, defaults to false
+            - password (str): password used to authenticate; should be provided from a `Secret` task
 
         Returns:
             - None
@@ -71,7 +75,7 @@ class PostgresExecute(Task):
         conn = pg.connect(
             dbname=self.db_name,
             user=self.user,
-            password=self.password,
+            password=password,
             host=self.host,
             port=self.port,
         )
@@ -103,7 +107,6 @@ class PostgresFetch(Task):
     Args:
         - db_name (str): name of Postgres database
         - user (str): user name used to authenticate
-        - password (str): password used to authenticate
         - host (str): database host address
         - port (int, optional): port used to connect to Postgres database, defaults to 5432 if
             not provided
@@ -123,7 +126,6 @@ class PostgresFetch(Task):
         self,
         db_name: str,
         user: str,
-        password: str,
         host: str,
         port: int = 5432,
         fetch: str = "one",
@@ -135,7 +137,6 @@ class PostgresFetch(Task):
     ):
         self.db_name = db_name
         self.user = user
-        self.password = password
         self.host = host
         self.port = port
         self.fetch = fetch
@@ -153,6 +154,7 @@ class PostgresFetch(Task):
         query: str = None,
         data: tuple = None,
         commit: bool = False,
+        password: str = None,
     ):
         """
         Task run method. Executes a query against Postgres database and fetches results.
@@ -166,6 +168,7 @@ class PostgresFetch(Task):
             - data (tuple, optional): values to use in query, must be specified using
                 placeholder is query string
             - commit (bool, optional): set to True to commit transaction, defaults to false
+            - password (str): password used to authenticate; should be provided from a `Secret` task
 
         Returns:
             - records (tuple or list of tuples): records from provided query
@@ -187,7 +190,7 @@ class PostgresFetch(Task):
         conn = pg.connect(
             dbname=self.db_name,
             user=self.user,
-            password=self.password,
+            password=password,
             host=self.host,
             port=self.port,
         )

--- a/tests/tasks/postgres/test_postgres.py
+++ b/tests/tasks/postgres/test_postgres.py
@@ -5,15 +5,11 @@ from prefect.tasks.postgres import PostgresExecute, PostgresFetch
 
 class TestPostgresExecute:
     def test_construction(self):
-        task = PostgresExecute(
-            db_name="test", user="test", host="test"
-        )
+        task = PostgresExecute(db_name="test", user="test", host="test")
         assert task.commit is False
 
     def test_query_string_must_be_provided(self):
-        task = PostgresExecute(
-            db_name="test", user="test", host="test"
-        )
+        task = PostgresExecute(db_name="test", user="test", host="test")
         with pytest.raises(ValueError, match="A query string must be provided"):
             task.run()
 

--- a/tests/tasks/postgres/test_postgres.py
+++ b/tests/tasks/postgres/test_postgres.py
@@ -6,13 +6,13 @@ from prefect.tasks.postgres import PostgresExecute, PostgresFetch
 class TestPostgresExecute:
     def test_construction(self):
         task = PostgresExecute(
-            db_name="test", user="test", password="test", host="test"
+            db_name="test", user="test", host="test"
         )
         assert task.commit is False
 
     def test_query_string_must_be_provided(self):
         task = PostgresExecute(
-            db_name="test", user="test", password="test", host="test"
+            db_name="test", user="test", host="test"
         )
         with pytest.raises(ValueError, match="A query string must be provided"):
             task.run()
@@ -20,16 +20,16 @@ class TestPostgresExecute:
 
 class TestPostgresFetch:
     def test_construction(self):
-        task = PostgresFetch(db_name="test", user="test", password="test", host="test")
+        task = PostgresFetch(db_name="test", user="test", host="test")
         assert task.fetch == "one"
 
     def test_query_string_must_be_provided(self):
-        task = PostgresFetch(db_name="test", user="test", password="test", host="test")
+        task = PostgresFetch(db_name="test", user="test", host="test")
         with pytest.raises(ValueError, match="A query string must be provided"):
             task.run()
 
     def test_bad_fetch_param_raises(self):
-        task = PostgresFetch(db_name="test", user="test", password="test", host="test")
+        task = PostgresFetch(db_name="test", user="test", host="test")
         with pytest.raises(
             ValueError,
             match=r"The 'fetch' parameter must be one of the following - \('one', 'many', 'all'\)",


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR removes `password` as a possible kwarg in the initialization of the postgres tasks in the task library in favor of providing the password at runtime via a Secret task type. 

## Why is this PR important?
Closes https://github.com/PrefectHQ/prefect/issues/1345

Prefect should encourage best practices, and having this initialization kwarg meant that passwords would be baked into where ever the Flow was stored.