### PR TITLE
Support passing in explicit `default=None` to Parameter

### DIFF
--- a/changes/pr2995.yaml
+++ b/changes/pr2995.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - Simplify creation of optional parameters with default of `None` - [#2995](https://github.com/PrefectHQ/prefect/pull/2995)

--- a/src/prefect/core/parameter.py
+++ b/src/prefect/core/parameter.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
 
 
+# A sentinel value indicating no default was provided
+no_default = type(
+    "no_default",
+    (object,),
+    dict.fromkeys(["__repr__", "__reduce__"], lambda s: "no_default"),
+)()
+
+
 class Parameter(Task):
     """
     A Parameter is a special task that defines a required flow input.
@@ -20,10 +28,10 @@ class Parameter(Task):
 
     Args:
         - name (str): the Parameter name.
-        - required (bool, optional): If True, the Parameter is required and the default
-            value is ignored.
-        - default (any, optional): A default value for the parameter. If the default
-            is not None, the Parameter will not be required.
+        - default (any, optional): A default value for the parameter.
+        - required (bool, optional): If True, the Parameter is required and the
+            default value is ignored. Defaults to `False` if a `default` is
+            provided, otherwise `True`.
         - tags ([str], optional): A list of tags for this parameter
 
     """
@@ -31,13 +39,14 @@ class Parameter(Task):
     def __init__(
         self,
         name: str,
-        default: Any = None,
-        required: bool = True,
+        default: Any = no_default,
+        required: bool = None,
         tags: Iterable[str] = None,
     ):
-        if default is not None:
-            required = False
-
+        if required is None:
+            required = default is no_default
+        if default is no_default:
+            default = None
         self.required = required
         self.default = default
 

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -20,6 +20,13 @@ def test_create_parameter_with_default():
     assert x.run() == 2
 
 
+def test_create_parameter_with_default_none():
+    x = Parameter("x", default=None)
+    assert x.default is None
+    assert not x.required
+    assert x.run() is None
+
+
 def test_parameter_slug_is_its_name():
     x = Parameter("x")
     assert x.name == x.slug == "x"


### PR DESCRIPTION
This allows creating a parameter with a default of `None` without explicitly setting `required=False`. I find this more intuitive to use - any value can be passed to `default` to create an optional `Parameter`, `None` is no longer special-cased.


- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)