### PR TITLE
Update flows.md

### DIFF
--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -171,7 +171,7 @@ You can turn auto-scheduling on or off at any time: <Badge text="GQL"/>
 ```graphql
 mutation {
   set_schedule_active(input: {
-    flow_id: "<flow_id>"
+    schedule_id: "<schedule_id>"
   }) {
     success
   }
@@ -179,7 +179,7 @@ mutation {
 
 mutation {
   set_schedule_inactive(input: {
-    flow_id: "<flow_id>"
+    schedule_id: "<schedule_id>"
   }) {
     success
   }


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Switches the input for the set_schedule_active and set_schedule_inactive mutation examples in the docs to use schedule id instead of flow id.  

## Why is this PR important?

Flow id is only an input option in Cloud.  Schedule Id is an option in both cloud and server.  This switch makes the docs relevant to users of both cloud and server. 
