### PR TITLE
Avoid `distributed.Variable` pickle usage

### DIFF
--- a/changes/pr3009.yaml
+++ b/changes/pr3009.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug in `DaskExecutor` when running with external cluster where dask clients could potentially be leaked - [#3009](https://github.com/PrefectHQ/prefect/pull/3009)"


### PR DESCRIPTION
In certain configurations (systems where a distributed scheduler may be addressable via multiple IPs, and somehow multiple get used due), unpickling a `distributed.Variable` can do the wrong thing and create a new `Client` each time, potentially exhausting file descriptors.

This fixes that by avoiding pickling the `Variable` - instead we recreate it on usage. This is no more expensive than before, but in *the bad case* is much less expensive.

This bad behavior was introduced in version 0.12.3, and affects users using external dask clusters (i.e. an explicit `address` is passed to `DaskExecutor`), and not every user may run into it (I was able to reproduce on a dockerized system but not locally, the actual buggy code has to do with differences in address resolution for the scheduler - I view this as a bug in distributed itself, will fix).

Reported via slack, see https://app.slack.com/client/TL09B008Y/threads/thread/CL09KU1K7-1594902433.238300

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)