### PR TITLE
Add flag for API error retries

### DIFF
--- a/changes/pr3012.yaml
+++ b/changes/pr3012.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - 'Add retry_on_api_error flag to client methods - [#3012](https://github.com/PrefectHQ/prefect/pull/3012)'

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -130,6 +130,8 @@ class Client:
             - headers (dict, optional): Headers to pass with the request
             - params (dict): GET parameters
             - token (str): an auth token. If not supplied, the `client.access_token` is used.
+            - retry_on_api_error (bool): whether the operation should be retried if the API returns
+                an API_ERROR code
 
         Returns:
             - dict: Dictionary representation of the request made
@@ -168,6 +170,8 @@ class Client:
             - headers(dict): headers to pass with the request
             - params (dict): POST parameters
             - token (str): an auth token. If not supplied, the `client.access_token` is used.
+            - retry_on_api_error (bool): whether the operation should be retried if the API returns
+                an API_ERROR code
 
         Returns:
             - dict: Dictionary representation of the request made
@@ -208,6 +212,8 @@ class Client:
             - variables (dict): Variables to be filled into a query with the key being
                 equivalent to the variables that are accepted by the query
             - token (str): an auth token. If not supplied, the `client.access_token` is used.
+            - retry_on_api_error (bool): whether the operation should be retried if the API returns
+                an API_ERROR code
 
         Returns:
             - dict: Data returned from the GraphQL query
@@ -292,6 +298,8 @@ class Client:
                 server is used if not specified
             - headers (dict, optional): Headers to pass with the request
             - token (str): an auth token. If not supplied, the `client.access_token` is used.
+            - retry_on_api_error (bool): whether the operation should be retried if the API returns
+                an API_ERROR code
 
         Returns:
             - requests.models.Response: The response returned from the request
@@ -703,7 +711,7 @@ class Client:
                     version_group_id=version_group_id,
                 )
             ),
-            retry_on_api_error=False
+            retry_on_api_error=False,
         )  # type: Any
 
         flow_id = (

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -117,6 +117,7 @@ class Client:
         headers: dict = None,
         params: Dict[str, JSONLike] = None,
         token: str = None,
+        retry_on_api_error: bool = True,
     ) -> dict:
         """
         Convenience function for calling the Prefect API with token auth and GET request
@@ -140,6 +141,7 @@ class Client:
             server=server,
             headers=headers,
             token=token,
+            retry_on_api_error=retry_on_api_error,
         )
         if response.text:
             return response.json()
@@ -153,6 +155,7 @@ class Client:
         headers: dict = None,
         params: Dict[str, JSONLike] = None,
         token: str = None,
+        retry_on_api_error: bool = True,
     ) -> dict:
         """
         Convenience function for calling the Prefect API with token auth and POST request
@@ -176,6 +179,7 @@ class Client:
             server=server,
             headers=headers,
             token=token,
+            retry_on_api_error=retry_on_api_error,
         )
         if response.text:
             return response.json()
@@ -189,6 +193,7 @@ class Client:
         headers: Dict[str, str] = None,
         variables: Dict[str, JSONLike] = None,
         token: str = None,
+        retry_on_api_error: bool = True,
     ) -> GraphQLResult:
         """
         Convenience function for running queries against the Prefect GraphQL API
@@ -216,6 +221,7 @@ class Client:
             headers=headers,
             params=dict(query=parse_graphql(query), variables=json.dumps(variables)),
             token=token,
+            retry_on_api_error=retry_on_api_error,
         )
 
         if raise_on_error and "errors" in result:
@@ -273,6 +279,7 @@ class Client:
         server: str = None,
         headers: dict = None,
         token: str = None,
+        retry_on_api_error: bool = True,
     ) -> "requests.models.Response":
         """
         Runs any specified request (GET, POST, DELETE) against the server
@@ -342,7 +349,7 @@ class Client:
                 raise ClientError("Malformed response received from API.")
 
         # check if there was an API_ERROR code in the response
-        if "API_ERROR" in str(json_resp.get("errors")):
+        if "API_ERROR" in str(json_resp.get("errors")) and retry_on_api_error:
             success, retry_count = False, 0
             # retry up to six times
             while success is False and retry_count < 6:
@@ -696,6 +703,7 @@ class Client:
                     version_group_id=version_group_id,
                 )
             ),
+            retry_on_api_error=False
         )  # type: Any
 
         flow_id = (

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -48,7 +48,7 @@ endpoint = "${server.host}:${server.port}"
     graphql_url = "http://localhost:4200/graphql"
 
     [server.telemetry]
-    enabled = false
+    enabled = true
 
 [cloud]
 api = "${${backend}.endpoint}"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -48,7 +48,7 @@ endpoint = "${server.host}:${server.port}"
     graphql_url = "http://localhost:4200/graphql"
 
     [server.telemetry]
-    enabled = true
+    enabled = false
 
 [cloud]
 api = "${${backend}.endpoint}"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR adds a `retry_on_api_error` flag to the client. Wasn't 100% sure of a clean way to test this, but happy to add tests if it's appropriate.

## Why is this PR important?

This allows us to opt out of retrying nonatomic mutations, as discussed in #3004. 
