### PR TITLE
Remove `dbt` extra

### DIFF
--- a/changes/pr3018.yaml
+++ b/changes/pr3018.yaml
@@ -1,0 +1,2 @@
+breaking:
+  - "Remove `dbt` extra from dependencies - [#3018](https://github.com/PrefectHQ/prefect/pull/3018)"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ extras = {
         "azure-cosmos >= 3.1.1, <3.2",
     ],
     "dask_cloudprovider": ["dask_cloudprovider >= 0.2.0, < 1.0"],
-    "dbt": ["dbt >= 0.17.1"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],


### PR DESCRIPTION
`dbt` pins all its dependencies, and doesn't generally play well with
others when used as a library. Their extreme dependency pinning was
causing complications with other dependencies (e.g. conflicts with
versions of `google-cloud-bigquery`). Since most users will have `dbt`
installed as a CLI, and prefect only uses it as a CLI, we remove the
package from our immediate dependencies.

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)