### PR TITLE
Add option to limit Docker Agent to only pull images from some registries.

### DIFF
--- a/changes/pr3026.yaml
+++ b/changes/pr3026.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - 'Add `reg_allow_list` option for Docker Agent - [#3026](https://github.com/PrefectHQ/prefect/pull/3026#issuecomment-663078217)'
+
+contributor:
+  - "[Thomas Frederik Hoeck](https://github.com/thomasfrederikhoeck)"


### PR DESCRIPTION
Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds an option for Docker Agent to only pull from registries specified in the `reg_allow_list`


## Why is this PR important?
To ensure that if someone where to get access to your Prefect Account they would not be able to run their own images.

