### PR TITLE
Use fullname and tag when Docker Storage determines if build was successful

### DIFF
--- a/changes/pr3029.yaml
+++ b/changes/pr3029.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Use fullname and tag when Docker Storage determines if build was successful - [#3029](https://github.com/PrefectHQ/prefect/pull/3029)'
+
+contributor:
+  - "[Thomas Frederik Hoeck](https://github.com/thomasfrederikhoeck)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -375,7 +375,7 @@ class Docker(Storage):
             )
             self._parse_generator_output(output)
 
-            if len(client.images(name=full_name)) == 0:
+            if len(client.images(name="{}:{}".format(full_name, self.image_tag))) == 0:
                 raise ValueError(
                     "Your docker image failed to build!  Your flow might have "
                     "failed one of its deployment health checks - please ensure "


### PR DESCRIPTION
Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

The success of building the the Docker Storage is determined if an image with the name exists running the build. This PR changes it to requiring to match on both name and tag to ensure uniqueness. See issue #3015 for more details.

## Why is this PR important?

This ensures that the build report that it failed when it is the case.

