### PR TITLE
Issue 3027 remove storage objects check get flows

### DIFF
--- a/changes/issue3027.yaml
+++ b/changes/issue3027.yaml
@@ -1,0 +1,5 @@
+
+fix:
+  - "Move initial check in `get_flows()` to be checked when a flow_location generated from `add_flow()` is provided. - [#3027](https://github.com/PrefectHQ/prefect/issues/3027)"
+
+

--- a/changes/issue3027.yaml
+++ b/changes/issue3027.yaml
@@ -1,6 +1,6 @@
 
 fix:
-  - "Move initial check in `get_flows()` to be checked when a flow_location generated from `add_flow()` is provided. - [#3027](https://github.com/PrefectHQ/prefect/issues/3027)"
+  - "Fix check of flow existence in storage object `get_flow` to only occur when provided - [#3027](https://github.com/PrefectHQ/prefect/issues/3027)"
 
 contributor:
-    - "[berosen](https://github.com/berosen)"
+  - "[berosen](https://github.com/berosen)"

--- a/changes/issue3027.yaml
+++ b/changes/issue3027.yaml
@@ -2,4 +2,5 @@
 fix:
   - "Move initial check in `get_flows()` to be checked when a flow_location generated from `add_flow()` is provided. - [#3027](https://github.com/PrefectHQ/prefect/issues/3027)"
 
-
+contributor:
+    - "[berosen](https://github.com/berosen)"

--- a/src/prefect/environments/storage/azure.py
+++ b/src/prefect/environments/storage/azure.py
@@ -64,13 +64,13 @@ class Azure(Storage):
     def default_labels(self) -> List[str]:
         return ["azure-flow-storage"]
 
-    def get_flow(self, flow_location: str) -> "Flow":
+    def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path where a Flow has been serialized to
+            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+                a file path where a Flow has been serialized to. Will use `blob_name` if not provided.
 
         Returns:
             - Flow: the requested flow

--- a/src/prefect/environments/storage/azure.py
+++ b/src/prefect/environments/storage/azure.py
@@ -78,8 +78,13 @@ class Azure(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if flow_location not in self.flows.values():
-            raise ValueError("Flow is not contained in this Storage")
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.blob_name:
+            flow_location = self.blob_name
+        else:
+            raise ValueError("No flow location provided")
 
         client = self._azure_block_blob_service.get_blob_client(
             container=self.container, blob=flow_location

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -259,7 +259,18 @@ class Docker(Storage):
 
         Returns:
             - Flow: the requested flow
+
+        Raises:
+            - ValueError: if the flow is not contained in this storage
         """
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.path:
+            flow_location = self.path
+        else:
+            raise ValueError("No flow location provided")
+
         if self.stored_as_script:
             return extract_flow_from_file(file_path=flow_location)
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -249,13 +249,14 @@ class Docker(Storage):
         self._flows[flow.name] = flow  # needed prior to build
         return flow_path
 
-    def get_flow(self, flow_location: str) -> "prefect.core.flow.Flow":
+    def get_flow(self, flow_location: str = None) -> "prefect.core.flow.Flow":
         """
         Given a file path within this Docker container, returns the underlying Flow.
         Note that this method should only be run _within_ the container itself.
 
         Args:
-            - flow_location (str): the file path of a flow within this container
+            - flow_location (str, optional): the file path of a flow within this container. Will use
+                `path` if not provided.
 
         Returns:
             - Flow: the requested flow

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -61,13 +61,13 @@ class GCS(Storage):
     def default_labels(self) -> List[str]:
         return ["gcs-flow-storage"]
 
-    def get_flow(self, flow_location: str) -> "Flow":
+    def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path where a Flow has been serialized to
+            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+                a file path where a Flow has been serialized to. Will use `key` if not provided.
 
         Returns:
             - Flow: the requested flow

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -75,8 +75,13 @@ class GCS(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if flow_location not in self.flows.values():
-            raise ValueError("Flow is not contained in this Storage")
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.key:
+            flow_location = self.key
+        else:
+            raise ValueError("No flow location provided")
 
         bucket = self._gcs_client.get_bucket(self.bucket)
 

--- a/src/prefect/environments/storage/github.py
+++ b/src/prefect/environments/storage/github.py
@@ -59,8 +59,17 @@ class GitHub(Storage):
             - Flow: the requested Flow
 
         Raises:
-            - UnknownObjectException: if the Flow file is unable to be retrieved
+            - ValueError: if the flow is not contained in this storage
+            - UnknownObjectException: if the flow file is unable to be retrieved
         """
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.path:
+            flow_location = self.path
+        else:
+            raise ValueError("No flow location provided")
+
         from github import UnknownObjectException
 
         repo = self._github_client.get_repo(self.repo)

--- a/src/prefect/environments/storage/github.py
+++ b/src/prefect/environments/storage/github.py
@@ -46,14 +46,15 @@ class GitHub(Storage):
     def default_labels(self) -> List[str]:
         return ["github-flow-storage"]
 
-    def get_flow(self, flow_location: str) -> "Flow":
+    def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
         If the Flow is not found an error will be logged and `None` will be returned.
 
         Args:
             - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path on a repository where a Flow file has been committed
+                a file path on a repository where a Flow file has been committed. Will use `path` if not
+                provided.
 
         Returns:
             - Flow: the requested Flow

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -84,8 +84,13 @@ class Local(Storage):
         Raises:
             - ValueError: if the flow is not contained in this storage
         """
-        if flow_location not in self.flows.values():
-            raise ValueError("Flow is not contained in this Storage")
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.path:
+            flow_location = self.path
+        else:
+            raise ValueError("No flow location provided")
 
         if self.stored_as_script:
             return extract_flow_from_file(file_path=flow_location)

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -70,13 +70,13 @@ class Local(Storage):
         else:
             return []
 
-    def get_flow(self, flow_location: str) -> "Flow":
+    def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path where a Flow has been serialized to
+            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+                a file path where a Flow has been serialized to. Will use `path` if not provided.
 
         Returns:
             - Flow: the requested flow

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -59,8 +59,8 @@ class S3(Storage):
 
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
-        Given a flow_location within this Storage object or S3, returns the underlying Flow.
-        If the Flow cannot be found or properly downloaded an exception will be raised.
+        Given a flow_location within this Storage object or S3, returns the underlying Flow
+        (if possible).
 
         Args:
             - flow_location (str, optional): the location of a flow within this Storage; in this case
@@ -70,19 +70,16 @@ class S3(Storage):
             - Flow: the requested Flow
 
         Raises:
-            - ValueError: If the Flow location cannot be found, ie. obtained from `flow_location`
-              or `self.key`
+            - ValueError: if the flow is not contained in this storage
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
         if flow_location:
             if flow_location not in self.flows.values():
                 raise ValueError("Flow is not contained in this Storage")
-
         elif self.key:
             flow_location = self.key
-
         else:
-            raise ValueError("No Flow location provided")
+            raise ValueError("No flow location provided")
 
         stream = io.BytesIO()
 

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -59,11 +59,11 @@ class S3(Storage):
 
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
-        If the Flow is not found an error will be logged and `None` will be returned.
+        Given a flow_location within this Storage object or S3, returns the underlying Flow (if possible).
+        If the Flow cannot be found or properly downloaded an exception will be raised.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+            - flow_location (str, optional): the location of a flow within this Storage or ; in this case,
                 an S3 object key where a Flow has been serialized to.
 
         Returns:

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -63,8 +63,8 @@ class S3(Storage):
         If the Flow is not found an error will be logged and `None` will be returned.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                an S3 object key where a Flow has been serialized to
+            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+                an S3 object key where a Flow has been serialized to.
 
         Returns:
             - Flow: the requested Flow

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -70,8 +70,7 @@ class S3(Storage):
             - Flow: the requested Flow
 
         Raises:
-            - ValueError: if the Flow is not contained in this storage
-            - Exception: if the Flow location cannot be obtained from `flow_location` or `self.key`
+            - ValueError: If the Flow location cannot be found, ie. obtained from `flow_location` or `self.key`
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
         if flow_location:
@@ -82,7 +81,7 @@ class S3(Storage):
             flow_location = self.key
 
         else:
-            raise Exception("No Flow location provided")
+            raise ValueError("No Flow location provided")
 
         stream = io.BytesIO()
 

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -71,7 +71,7 @@ class S3(Storage):
 
         Raises:
             - ValueError: if the Flow is not contained in this storage
-            - Exception: if the Flow location cannot be obtained from flow_location or self.key
+            - Exception: if the Flow location cannot be obtained from `flow_location` or `self.key`
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
         if flow_location:

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -64,7 +64,7 @@ class S3(Storage):
 
         Args:
             - flow_location (str, optional): the location of a flow within this Storage; in this case
-                an S3 object key where a Flow has been serialized to.
+                an S3 object key where a Flow has been serialized to. Will use `key` if not provided.
 
         Returns:
             - Flow: the requested Flow

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -63,7 +63,7 @@ class S3(Storage):
         If the Flow cannot be found or properly downloaded an exception will be raised.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage or ; in this case,
+            - flow_location (str, optional): the location of a flow within this Storage; in this case,
                 an S3 object key where a Flow has been serialized to.
 
         Returns:

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -57,24 +57,32 @@ class S3(Storage):
     def default_labels(self) -> List[str]:
         return ["s3-flow-storage"]
 
-    def get_flow(self, flow_location: str) -> "Flow":
+    def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
         If the Flow is not found an error will be logged and `None` will be returned.
 
         Args:
             - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path where a Flow has been serialized to
+                an S3 object key where a Flow has been serialized to
 
         Returns:
             - Flow: the requested Flow
 
         Raises:
             - ValueError: if the Flow is not contained in this storage
+            - Exception: if the Flow location cannot be obtained from flow_location or self.key
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
-        if flow_location not in self.flows.values():
-            raise ValueError("Flow is not contained in this Storage")
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+
+        elif self.key:
+            flow_location = self.key
+
+        else:
+            raise Exception("No Flow location provided")
 
         stream = io.BytesIO()
 

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -59,18 +59,19 @@ class S3(Storage):
 
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
-        Given a flow_location within this Storage object or S3, returns the underlying Flow (if possible).
+        Given a flow_location within this Storage object or S3, returns the underlying Flow.
         If the Flow cannot be found or properly downloaded an exception will be raised.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage; in this case,
+            - flow_location (str, optional): the location of a flow within this Storage; in this case
                 an S3 object key where a Flow has been serialized to.
 
         Returns:
             - Flow: the requested Flow
 
         Raises:
-            - ValueError: If the Flow location cannot be found, ie. obtained from `flow_location` or `self.key`
+            - ValueError: If the Flow location cannot be found, ie. obtained from `flow_location`
+              or `self.key`
             - botocore.ClientError: if there is an issue downloading the Flow from S3
         """
         if flow_location:

--- a/tests/environments/storage/test_azure_storage.py
+++ b/tests/environments/storage/test_azure_storage.py
@@ -173,6 +173,9 @@ def test_get_flow_azure(monkeypatch):
 
     storage = Azure(container="container")
 
+    with pytest.raises(ValueError):
+        storage.get_flow()
+
     assert f.name not in storage
     flow_location = storage.add_flow(f)
 

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -764,19 +764,22 @@ def test_docker_storage_name_registry_url_none():
 
 
 def test_docker_storage_get_flow_method():
-    storage = Docker(base_image="python:3.6")
     with tempfile.TemporaryDirectory() as directory:
+        storage = Docker(base_image="python:3.6", prefect_directory=directory)
 
         @prefect.task
         def add_to_dict():
             with open(os.path.join(directory, "output"), "w") as tmp:
                 tmp.write("success")
 
-        with open(os.path.join(directory, "flow_env.prefect"), "w+") as env:
+        os.makedirs(directory + "/flows", exist_ok=True)
+
+        with open(os.path.join(directory + "/flows", "test.prefect"), "w+") as env:
             flow = Flow("test", tasks=[add_to_dict])
-            flow_path = os.path.join(directory, "flow_env.prefect")
+            flow_path = os.path.join(directory + "/flows", "test.prefect")
             with open(flow_path, "wb") as f:
                 cloudpickle.dump(flow, f)
+            out = storage.add_flow(flow)
 
         f = storage.get_flow(flow_path)
         assert isinstance(f, Flow)

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -767,6 +767,9 @@ def test_docker_storage_get_flow_method():
     with tempfile.TemporaryDirectory() as directory:
         storage = Docker(base_image="python:3.6", prefect_directory=directory)
 
+        with pytest.raises(ValueError):
+            storage.get_flow()
+
         @prefect.task
         def add_to_dict():
             with open(os.path.join(directory, "output"), "w") as tmp:
@@ -803,3 +806,4 @@ def test_add_flow_with_weird_name_is_cleaned():
     assert "!" not in loc
     assert " " not in loc
     assert "~" not in loc
+

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -806,4 +806,3 @@ def test_add_flow_with_weird_name_is_cleaned():
     assert "!" not in loc
     assert " " not in loc
     assert "~" not in loc
-

--- a/tests/environments/storage/test_gcs_storage.py
+++ b/tests/environments/storage/test_gcs_storage.py
@@ -96,6 +96,10 @@ class TestGCSStorage:
         bucket_mock = MagicMock(get_blob=MagicMock(return_value=blob_mock))
         google_client.return_value.get_bucket = MagicMock(return_value=bucket_mock)
 
+        with pytest.raises(ValueError):
+            storage = GCS(bucket="test")
+            storage.get_flow()
+
         storage = GCS(bucket="awesome-bucket", key="a-place")
         storage.add_flow(f)
 

--- a/tests/environments/storage/test_github_storage.py
+++ b/tests/environments/storage/test_github_storage.py
@@ -78,6 +78,10 @@ def test_get_flow_github(monkeypatch):
         MagicMock(return_value=f),
     )
 
+    with pytest.raises(ValueError):
+        storage = GitHub(repo="test/repo")
+        storage.get_flow()
+
     storage = GitHub(repo="test/repo", path="flow")
 
     assert f.name not in storage

--- a/tests/environments/storage/test_local_storage.py
+++ b/tests/environments/storage/test_local_storage.py
@@ -98,6 +98,7 @@ def test_get_env_runner_raises():
 def test_get_flow_raises_if_flow_not_present():
     s = Local()
     with pytest.raises(ValueError):
+        s.get_flow()
         s.get_flow("test")
 
 

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -399,5 +399,5 @@ def test_get_flow_s3_no_location_set(monkeypatch):
 
     storage = S3(bucket="bucket")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         storage.get_flow()

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -234,6 +234,9 @@ def test_get_flow_s3(monkeypatch):
 
     storage = S3(bucket="bucket")
 
+    with pytest.raises(ValueError):
+        storage.get_flow()
+
     assert f.name not in storage
     flow_location = storage.add_flow(f)
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

These changes will allow a user to initialize an S3 Storage object with a bucket name and object key, then call `get_flow()` without any args to retrieve that object from S3. Previously, a call to `add_flow()` would need to have been made to add entries to `self.flows()` and `self._flows()`, or the dictionaries would have to be set by the user. If this was not done `get_flow()` would raise an exception. 

## Why is this PR important?

Simplifies process of downloading a Flow from S3 Storage. 


