### PR TITLE
Update FargateTaskEnvironment to throw if task definition is inconsistent with existing task definition

### DIFF
--- a/changes/pr3031.yaml
+++ b/changes/pr3031.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Update FargateTaskEnvironment to throw if task definition is inconsistent with existing task definition - [#3031](https://github.com/PrefectHQ/prefect/pull/3031)"
+
+contributor:
+  - "[Spencer Ellinor](https://github.com/zpencerq)"

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -10,6 +10,24 @@ from prefect.utilities.storage import get_flow_image
 if TYPE_CHECKING:
     from prefect.core.flow import Flow  # pylint: disable=W0611
 
+_DEFINITION_KWARG_LIST = [
+    "family",
+    "taskRoleArn",
+    "executionRoleArn",
+    "networkMode",
+    "containerDefinitions",
+    "volumes",
+    "placementConstraints",
+    "requiresCompatibilities",
+    "cpu",
+    "memory",
+    "tags",
+    "pidMode",
+    "ipcMode",
+    "proxyConfiguration",
+    "inferenceAccelerators",
+]
+
 
 class FargateTaskEnvironment(Environment, _RunMixin):
     """
@@ -135,23 +153,6 @@ class FargateTaskEnvironment(Environment, _RunMixin):
         Returns:
             tuple: a tuple of two dictionaries (task_definition_kwargs, task_run_kwargs)
         """
-        definition_kwarg_list = [
-            "family",
-            "taskRoleArn",
-            "executionRoleArn",
-            "networkMode",
-            "containerDefinitions",
-            "volumes",
-            "placementConstraints",
-            "requiresCompatibilities",
-            "cpu",
-            "memory",
-            "tags",
-            "pidMode",
-            "ipcMode",
-            "proxyConfiguration",
-            "inferenceAccelerators",
-        ]
 
         run_kwarg_list = [
             "cluster",
@@ -170,7 +171,7 @@ class FargateTaskEnvironment(Environment, _RunMixin):
 
         task_definition_kwargs = {}
         for key, item in user_kwargs.items():
-            if key in definition_kwarg_list:
+            if key in _DEFINITION_KWARG_LIST:
                 task_definition_kwargs.update({key: item})
 
         task_run_kwargs = {}
@@ -183,6 +184,115 @@ class FargateTaskEnvironment(Environment, _RunMixin):
     @property
     def dependencies(self) -> list:
         return ["boto3", "botocore"]
+
+    def _render_task_definition_kwargs(self, flow: "Flow") -> dict:
+        task_definition_kwargs = self.task_definition_kwargs.copy()
+
+        env_values = [
+            {"name": "PREFECT__CLOUD__GRAPHQL", "value": config.cloud.graphql},
+            {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
+            {
+                "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
+                "value": "prefect.engine.cloud.CloudFlowRunner",
+            },
+            {
+                "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
+                "value": "prefect.engine.cloud.CloudTaskRunner",
+            },
+            {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
+            {
+                "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                "value": str(config.logging.extra_loggers),
+            },
+        ]
+
+        # create containerDefinitions if they do not exist
+        if not task_definition_kwargs.get("containerDefinitions"):
+            task_definition_kwargs["containerDefinitions"] = []
+            task_definition_kwargs["containerDefinitions"].append({})
+
+        # set environment variables for all containers
+        for definition in task_definition_kwargs["containerDefinitions"]:
+            if not definition.get("environment"):
+                definition["environment"] = []
+            definition["environment"].extend(env_values)
+
+        # set name on first container
+        if not task_definition_kwargs["containerDefinitions"][0].get("name"):
+            task_definition_kwargs["containerDefinitions"][0]["name"] = ""
+
+        task_definition_kwargs.get("containerDefinitions")[0]["name"] = "flow-container"
+
+        # set image on first container
+        if not task_definition_kwargs["containerDefinitions"][0].get("image"):
+            task_definition_kwargs["containerDefinitions"][0]["image"] = ""
+
+        task_definition_kwargs.get("containerDefinitions")[0]["image"] = get_flow_image(
+            flow
+        )
+
+        # set command on first container
+        if not task_definition_kwargs["containerDefinitions"][0].get("command"):
+            task_definition_kwargs["containerDefinitions"][0]["command"] = []
+
+        task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
+            "/bin/sh",
+            "-c",
+            "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
+        ]
+
+        return task_definition_kwargs
+
+    def _validate_task_definition(
+        self, existing_task_definition: dict, task_definition_kwargs: dict
+    ) -> None:
+        containerDifferences = [
+            "containerDefinition.{idx}.{key} -> Given: {given}, Expected: {expected}".format(
+                idx=idx,
+                key=key,
+                given=value,
+                expected=existing_container_definition.get(key),
+            )
+            for idx, (
+                container_definition,
+                existing_container_definition,
+            ) in enumerate(
+                zip(
+                    task_definition_kwargs["containerDefinitions"],
+                    existing_task_definition["containerDefinitions"],
+                )
+            )
+            for key, value in container_definition.items()
+            if value != existing_container_definition.get(key)
+        ]
+
+        otherDifferences = [
+            "{key} -> Given: {given}, Expected: {expected}".format(
+                key=key,
+                given=task_definition_kwargs[key],
+                expected=existing_task_definition.get(key),
+            )
+            for key in _DEFINITION_KWARG_LIST
+            if key != "containerDefinitions"
+            and key in task_definition_kwargs
+            and existing_task_definition.get(key) != task_definition_kwargs[key]
+        ]
+
+        differences = containerDifferences + otherDifferences
+
+        if differences:
+            raise ValueError(
+                (
+                    "The given taskDefinition does not match the existing taskDefinition {}.\n"
+                    "Detail: \n\t{}\n\n"
+                    "If the given configuration is desired, deregister the existing\n"
+                    "taskDefinition and re-run the flow. Alternatively, you can\n"
+                    "change the family/taskDefinition name in the FargateTaskEnvironment\n"
+                    "for this flow."
+                ).format(
+                    self.task_definition_kwargs.get("family"), "\n\t".join(differences),
+                )
+            )
 
     def setup(self, flow: "Flow") -> None:  # type: ignore
         """
@@ -202,73 +312,17 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             region_name=self.region_name,
         )
 
-        definition_exists = True
+        task_definition_kwargs = self._render_task_definition_kwargs(flow)
         try:
-            boto3_c.describe_task_definition(
+            existing_task_definition = boto3_c.describe_task_definition(
                 taskDefinition=self.task_definition_kwargs.get("family")
+            )["taskDefinition"]
+
+            self._validate_task_definition(
+                existing_task_definition, task_definition_kwargs
             )
         except ClientError:
-            definition_exists = False
-
-        if not definition_exists:
-            env_values = [
-                {"name": "PREFECT__CLOUD__GRAPHQL", "value": config.cloud.graphql},
-                {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
-                {
-                    "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
-                    "value": "prefect.engine.cloud.CloudFlowRunner",
-                },
-                {
-                    "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
-                    "value": "prefect.engine.cloud.CloudTaskRunner",
-                },
-                {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                {
-                    "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
-                    "value": str(config.logging.extra_loggers),
-                },
-            ]
-
-            # create containerDefinitions if they do not exist
-            if not self.task_definition_kwargs.get("containerDefinitions"):
-                self.task_definition_kwargs["containerDefinitions"] = []
-                self.task_definition_kwargs["containerDefinitions"].append({})
-
-            # set environment variables for all containers
-            for definition in self.task_definition_kwargs["containerDefinitions"]:
-                if not definition.get("environment"):
-                    definition["environment"] = []
-                definition["environment"].extend(env_values)
-
-            # set name on first container
-            if not self.task_definition_kwargs["containerDefinitions"][0].get("name"):
-                self.task_definition_kwargs["containerDefinitions"][0]["name"] = ""
-
-            self.task_definition_kwargs.get("containerDefinitions")[0][
-                "name"
-            ] = "flow-container"
-
-            # set image on first container
-            if not self.task_definition_kwargs["containerDefinitions"][0].get("image"):
-                self.task_definition_kwargs["containerDefinitions"][0]["image"] = ""
-
-            self.task_definition_kwargs.get("containerDefinitions")[0][
-                "image"
-            ] = get_flow_image(flow)
-
-            # set command on first container
-            if not self.task_definition_kwargs["containerDefinitions"][0].get(
-                "command"
-            ):
-                self.task_definition_kwargs["containerDefinitions"][0]["command"] = []
-
-            self.task_definition_kwargs.get("containerDefinitions")[0]["command"] = [
-                "/bin/sh",
-                "-c",
-                "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
-            ]
-
-            boto3_c.register_task_definition(**self.task_definition_kwargs)
+            boto3_c.register_task_definition(**task_definition_kwargs)
 
     def execute(self, flow: "Flow") -> None:  # type: ignore
         """

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -1,10 +1,11 @@
 from unittest.mock import MagicMock
 
+
 import cloudpickle
 import pytest
 
 import prefect
-from prefect import Flow
+from prefect import Flow, config
 from prefect.engine.executors import LocalDaskExecutor
 from prefect.environments import FargateTaskEnvironment
 from prefect.environments.storage import Docker
@@ -227,10 +228,7 @@ def test_setup_definition_exists(monkeypatch):
         "containerDefinitions": [
             {
                 "environment": [
-                    {
-                        "name": "PREFECT__CLOUD__GRAPHQL",
-                        "value": "http://localhost:4200/graphql",
-                    },
+                    {"name": "PREFECT__CLOUD__GRAPHQL", "value": config.cloud.graphql},
                     {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
                     {
                         "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
@@ -241,7 +239,10 @@ def test_setup_definition_exists(monkeypatch):
                         "value": "prefect.engine.cloud.CloudTaskRunner",
                     },
                     {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                    {"name": "PREFECT__LOGGING__EXTRA_LOGGERS", "value": "[]"},
+                    {
+                        "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                        "value": str(config.logging.extra_loggers),
+                    },
                 ],
                 "name": "flow-container",
                 "image": "test/image:tag",
@@ -278,10 +279,7 @@ def test_setup_definition_changed(monkeypatch):
         "containerDefinitions": [
             {
                 "environment": [
-                    {
-                        "name": "PREFECT__CLOUD__GRAPHQL",
-                        "value": "http://localhost:4200/graphql",
-                    },
+                    {"name": "PREFECT__CLOUD__GRAPHQL", "value": config.cloud.graphql},
                     {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
                     {
                         "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
@@ -292,7 +290,10 @@ def test_setup_definition_changed(monkeypatch):
                         "value": "prefect.engine.cloud.CloudTaskRunner",
                     },
                     {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
-                    {"name": "PREFECT__LOGGING__EXTRA_LOGGERS", "value": "[]"},
+                    {
+                        "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                        "value": str(config.logging.extra_loggers),
+                    },
                 ],
                 "name": "flow-container",
                 "image": "test/image:tag",

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -229,7 +229,12 @@ def test_setup_definition_exists(monkeypatch):
 
     environment = FargateTaskEnvironment()
 
-    environment.setup(Docker(registry_url="test", image_name="image", image_tag="tag"))
+    environment.setup(
+        Flow(
+            "test",
+            storage=Docker(registry_url="test", image_name="image", image_tag="tag"),
+        )
+    )
 
     assert boto3_client.describe_task_definition.called
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR adds a validation step in the `FargateTaskEnvironment` setup to verify the given task definition. 

It attempts to give a very helpful `ValueError` to point out the exact inconsistency.

For instance, if you update the image and cpu in your `FargateTaskEnvironment` you'll be greeted with:
```
ValueError: The given taskDefinition does not match the existing taskDefinition {family}.
Detail:
    containerDefinition.0.image -> Given: test/image:newtag, Expected: test/image:tag
    cpu -> Given: 1024, Expected: 512

If the given configuration is desired, deregister the existing
taskDefinition and re-run the flow. Alternatively, you can
change the family/taskDefinition name in the FargateTaskEnvironment
for this flow.
```

## Why is this PR important?
Normal operation of `FargateTaskEnvironment` can lead to unexpectedly stale runtime behavior. Currently, the `setup` method will register the task definition that is used for the flow run itself. These task definitions are named by the `family` attribute and versioned in ECS. Since the environment of a flow is critical to ensuring consistency in the flow run, this change ensures that the existing task definition matches the configuration of the `FargateTaskEnvironment`.

### Scenario
0. You start with no task definitions registered in ECS.
1. You register a flow `my-flow` with a `FargateTaskEnvironment` specifying an image of `datadeps:1` and `family` of `fuzzy`. 
2. You run `my-flow`, which will create a task-definition `fuzzy:1`.
2. You update the `datadeps` image and simply update the `FargateTaskEnvironment` of the flow to use image `datadeps:2` and register `my-flow` again.
3. When this new version of `my-flow` runs, it will use the existing task definition which will use the outdated image `datadeps:1` almost certainly causing unexpected behavior.

An alternative approach could be to simply create a new task definition every time there's a change. However, since the revision numbers are out of the enduser's control, this would impact previous versions of flows; the previous flow versions run newer versions of the task definitions which could cause inconsistencies. 
Maybe there's some approach with tagging and version groups that could work? That's a bit out of my depth 😅 

As an aside, could this be too aggressive of a change? It could break existing deployments, perhaps introducing a warning is enough? Where does `prefect` draw the line in avoiding inconsistent flow execution?