### PR TITLE
Use relative paths in generated Dockerfile

### DIFF
--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -435,7 +435,9 @@ class Docker(Storage):
             for src, dest in self.files.items():
                 fname = os.path.basename(src)
                 full_fname = os.path.join(directory, fname)
-                relative_fname = os.path.relpath(full_fname, os.getcwd()).replace('\\', '/')
+                relative_fname = os.path.relpath(full_fname, os.getcwd()).replace(
+                    "\\", "/"
+                )
                 if os.path.exists(full_fname) and filecmp.cmp(src, full_fname) is False:
                     raise ValueError(
                         "File {fname} already exists in {directory}".format(
@@ -454,7 +456,9 @@ class Docker(Storage):
             for flow_name, flow_location in self.flows.items():
                 clean_name = slugify(flow_name)
                 flow_path = os.path.join(directory, "{}.flow".format(clean_name))
-                flow_path_relative = os.path.relpath(flow_path, os.getcwd()).replace('\\', '/')
+                flow_path_relative = os.path.relpath(flow_path, os.getcwd()).replace(
+                    "\\", "/"
+                )
                 with open(flow_path, "wb") as f:
                     cloudpickle.dump(self._flows[flow_name], f)
                 copy_flows += "COPY {source} {dest}\n".format(
@@ -481,7 +485,9 @@ class Docker(Storage):
             healthcheck = healthscript.read()
 
         healthcheck_loc = os.path.join(directory, "healthcheck.py")
-        healthcheck_loc_relative = os.path.relpath(healthcheck_loc, os.getcwd()).replace('\\', '/')
+        healthcheck_loc_relative = os.path.relpath(
+            healthcheck_loc, os.getcwd()
+        ).replace("\\", "/")
         with open(healthcheck_loc, "w") as health_file:
             health_file.write(healthcheck)
 

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -463,7 +463,9 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
             ), output
             assert (
                 "COPY {} /opt/prefect/healthcheck.py".format(
-                    os.path.join(directory, "healthcheck.py")
+                    os.path.relpath(os.path.join(directory, "healthcheck.py")).replace(
+                        "\\", "/"
+                    )
                 )
                 in output
             )

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -447,12 +447,15 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
 
             assert (
                 "COPY {} /opt/prefect/flows/foo.prefect".format(
-                    os.path.join(directory, "foo.flow")
+                    os.path.relpath(os.path.join(directory, "foo.flow"), os.getcwd()).replace('\\', '/')
                 )
                 in output
             ), output
             assert (
-                "COPY {} ./test2".format(os.path.join(directory, "test")) in output
+                "COPY {} ./test2".format(
+                    os.path.relpath(os.path.join(directory, "test"), os.getcwd()).replace('\\', '/')
+                )
+                in output
             ), output
             assert (
                 "COPY {} /opt/prefect/healthcheck.py".format(

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -447,13 +447,17 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
 
             assert (
                 "COPY {} /opt/prefect/flows/foo.prefect".format(
-                    os.path.relpath(os.path.join(directory, "foo.flow"), os.getcwd()).replace('\\', '/')
+                    os.path.relpath(
+                        os.path.join(directory, "foo.flow"), os.getcwd()
+                    ).replace("\\", "/")
                 )
                 in output
             ), output
             assert (
                 "COPY {} ./test2".format(
-                    os.path.relpath(os.path.join(directory, "test"), os.getcwd()).replace('\\', '/')
+                    os.path.relpath(
+                        os.path.join(directory, "test"), os.getcwd()
+                    ).replace("\\", "/")
                 )
                 in output
             ), output


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

Before the fix, in the temporary Dockerfile that is created when using Docker storage for a flow, full paths to files are inserted. This causes docker build to fail as reported here: https://github.com/PrefectHQ/prefect/issues/3023

