### PR TITLE
remove uses of dictionary as default

### DIFF
--- a/src/prefect/tasks/azureml/dataset.py
+++ b/src/prefect/tasks/azureml/dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 import azureml.core.dataset
 from azureml.core.datastore import Datastore
@@ -57,10 +57,10 @@ class DatasetCreateFromDelimitedFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         include_path: bool = False,
         infer_column_types: bool = True,
-        set_column_types: Dict[str, DataType] = None,
+        set_column_types: Optional[Dict[str, DataType]] = None,
         fine_grain_timestamp: str = None,
         coarse_grain_timestamp: str = None,
         separator: str = ",",
@@ -73,7 +73,7 @@ class DatasetCreateFromDelimitedFiles(Task):
         self.datastore = datastore
         self.path = path
         self.dataset_description = dataset_description
-        self.dataset_tags = dataset_tags
+        self.dataset_tags = dataset_tags or dict()
         self.include_path = include_path
         self.infer_column_types = infer_column_types
         self.set_column_types = set_column_types
@@ -108,10 +108,10 @@ class DatasetCreateFromDelimitedFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         include_path: bool = False,
         infer_column_types: bool = True,
-        set_column_types: Dict[str, DataType] = None,
+        set_column_types: Optional[Dict[str, DataType]] = None,
         fine_grain_timestamp: str = None,
         coarse_grain_timestamp: str = None,
         separator: str = ",",
@@ -161,6 +161,8 @@ class DatasetCreateFromDelimitedFiles(Task):
 
         if not isinstance(path, list):
             path = [path]
+
+        dataset_tags = dataset_tags or dict()
 
         dataset = azureml.core.dataset.Dataset.Tabular.from_delimited_files(
             path=[(datastore, path_item) for path_item in path],
@@ -230,9 +232,9 @@ class DatasetCreateFromParquetFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         include_path: bool = False,
-        set_column_types: Dict[str, DataType] = None,
+        set_column_types: Optional[Dict[str, DataType]] = None,
         fine_grain_timestamp: str = None,
         coarse_grain_timestamp: str = None,
         partition_format: str = None,
@@ -243,7 +245,7 @@ class DatasetCreateFromParquetFiles(Task):
         self.datastore = datastore
         self.path = path
         self.dataset_description = dataset_description
-        self.dataset_tags = dataset_tags
+        self.dataset_tags = dataset_tags or dict()
         self.include_path = include_path
         self.set_column_types = set_column_types
         self.fine_grain_timestamp = fine_grain_timestamp
@@ -272,9 +274,9 @@ class DatasetCreateFromParquetFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         include_path: bool = False,
-        set_column_types: Dict[str, DataType] = None,
+        set_column_types: Optional[Dict[str, DataType]] = None,
         fine_grain_timestamp: str = None,
         coarse_grain_timestamp: str = None,
         partition_format: str = None,
@@ -316,6 +318,8 @@ class DatasetCreateFromParquetFiles(Task):
 
         if not isinstance(path, list):
             path = [path]
+
+        dataset_tags = dataset_tags or dict()
 
         dataset = azureml.core.dataset.Dataset.Tabular.from_parquet_files(
             path=[(datastore, path_item) for path_item in path],
@@ -366,7 +370,7 @@ class DatasetCreateFromFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         create_new_version: bool = False,
         **kwargs
     ) -> None:
@@ -374,7 +378,7 @@ class DatasetCreateFromFiles(Task):
         self.datastore = datastore
         self.path = path
         self.dataset_description = dataset_description
-        self.dataset_tags = dataset_tags
+        self.dataset_tags = dataset_tags or dict()
         self.create_new_version = create_new_version
 
         super().__init__(**kwargs)
@@ -393,7 +397,7 @@ class DatasetCreateFromFiles(Task):
         datastore: Datastore = None,
         path: Union[str, List[str]] = None,
         dataset_description: str = "",
-        dataset_tags: Dict[str, str] = dict(),
+        dataset_tags: Optional[Dict[str, str]] = None,
         create_new_version: bool = False,
     ) -> azureml.data.FileDataset:
         """
@@ -424,6 +428,8 @@ class DatasetCreateFromFiles(Task):
 
         if not isinstance(path, list):
             path = [path]
+
+        dataset_tags = dataset_tags or dict()
 
         dataset = azureml.core.dataset.Dataset.File.from_files(
             path=[(datastore, path_item) for path_item in path]

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -16,6 +16,8 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 import great_expectations as ge
 
+from typing import Optional
+
 
 class RunGreatExpectationsCheckpoint(Task):
     """
@@ -39,13 +41,13 @@ class RunGreatExpectationsCheckpoint(Task):
         self,
         checkpoint_name: str = None,
         context_root_dir: str = None,
-        runtime_environment: dict = {},
+        runtime_environment: Optional[dict] = None,
         run_name: str = None,
         **kwargs
     ):
         self.checkpoint_name = checkpoint_name
         self.context_root_dir = context_root_dir
-        self.runtime_environment = runtime_environment
+        self.runtime_environment = runtime_environment or dict()
         self.run_name = run_name
 
         super().__init__(**kwargs)
@@ -57,7 +59,7 @@ class RunGreatExpectationsCheckpoint(Task):
         self,
         checkpoint_name: str = None,
         context_root_dir: str = None,
-        runtime_environment: dict = {},
+        runtime_environment: Optional[dict] = None,
         run_name: str = None,
         **kwargs
     ):
@@ -87,6 +89,8 @@ class RunGreatExpectationsCheckpoint(Task):
 
         if checkpoint_name is None:
             raise ValueError("You must provide the checkpoint name.")
+
+        runtime_environment = runtime_environment or dict()
 
         context = ge.DataContext(
             context_root_dir=context_root_dir, runtime_environment=runtime_environment

--- a/src/prefect/utilities/notifications/jira_notification.py
+++ b/src/prefect/utilities/notifications/jira_notification.py
@@ -2,7 +2,7 @@
 A state-handler that will create and assign a Jira ticket.
 """
 
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Union, cast, Optional
 from datetime import datetime
 from toolz import curry
 
@@ -40,7 +40,7 @@ def jira_notifier(
     ignore_states: list = None,
     only_states: list = None,
     server_URL: str = None,
-    options: dict = {},
+    options: Optional[dict] = None,
     assignee: str = "-1",
 ) -> "prefect.engine.state.State":
     """
@@ -111,6 +111,7 @@ def jira_notifier(
         ```
     """
 
+    options = options or dict()
     jira_credentials = cast(dict, prefect.client.Secret("JIRASECRETS").get())
     username = jira_credentials["JIRAUSER"]
     password = jira_credentials["JIRATOKEN"]


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

In the interest of contributing back, I ran `pylint src/prefect` tonight. It turned up a bunch of things, many of which are subjective style / formatting things.

This PR addresses one of the issues found which could actually lead to user-facing bugs:

> W0102: Dangerous default value {} as argument (dangerous-default-value)

This PR proposes changing those cases to avoid the use of a dangerous default that could lead to issues.

## Why is this PR important?

This PR removes a possible cause of future bugs. Dictionary defaults are dangerous because the default values are initialized one time when the module is loaded, and then all successive function calls access the same dictionary.

```python
import uuid

def print_stuff(x = dict()):
    x[str(uuid.uuid4())] = "hello"
    return x
```

![image](https://user-images.githubusercontent.com/7608904/88616121-e8397300-d058-11ea-82d5-75cd7ac273c2.png)


Thanks for your time and consideration.
