### PR TITLE
prevent assignment of duplicate labels to agents

### DIFF
--- a/changes/pr3042.yaml
+++ b/changes/pr3042.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Prevent duplicated agent labels - [#3029](https://github.com/PrefectHQ/prefect/pull/3042)'
+
+contributor:
+  - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -85,14 +85,16 @@ class LocalAgent(Agent):
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)
-        self.labels.extend(
-            [
-                "azure-flow-storage",
-                "gcs-flow-storage",
-                "s3-flow-storage",
-                "github-flow-storage",
-            ]
-        )
+
+        all_storage_labels = [
+            "azure-flow-storage",
+            "gcs-flow-storage",
+            "s3-flow-storage",
+            "github-flow-storage",
+        ]
+        for label in all_storage_labels:
+            if label not in self.labels:
+                self.labels.append(label)
 
         self.logger.debug(f"Import paths: {self.import_paths}")
         self.logger.debug(f"Show flow logs: {self.show_flow_logs}")

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -246,10 +246,12 @@ def start(
             k, v = env_var.split("=")
             env_vars[k] = v
 
+        labels = list(set(label))
+
         if agent_option == "local":
             from_qualified_name(retrieved_agent)(
                 name=name,
-                labels=list(label),
+                labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
                 agent_address=agent_address,
@@ -260,7 +262,7 @@ def start(
         elif agent_option == "docker":
             from_qualified_name(retrieved_agent)(
                 name=name,
-                labels=list(label),
+                labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
                 agent_address=agent_address,
@@ -274,7 +276,7 @@ def start(
         elif agent_option == "fargate":
             from_qualified_name(retrieved_agent)(
                 name=name,
-                labels=list(label),
+                labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
                 agent_address=agent_address,
@@ -284,7 +286,7 @@ def start(
             from_qualified_name(retrieved_agent)(
                 namespace=namespace,
                 name=name,
-                labels=list(label),
+                labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
                 agent_address=agent_address,
@@ -292,7 +294,7 @@ def start(
         else:
             from_qualified_name(retrieved_agent)(
                 name=name,
-                labels=list(label),
+                labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
                 agent_address=agent_address,
@@ -476,6 +478,7 @@ def install(
         k, v = env_var.split("=")
         env_vars[k] = v
 
+    labels = list(set(label))
     if name == "kubernetes":
         deployment = from_qualified_name(retrieved_agent).generate_deployment_yaml(
             token=token,
@@ -491,7 +494,7 @@ def install(
             cpu_limit=cpu_limit,
             image_pull_policy=image_pull_policy,
             service_account_name=service_account_name,
-            labels=list(label),
+            labels=labels,
             env_vars=env_vars,
             backend=backend,
         )
@@ -499,7 +502,7 @@ def install(
     elif name == "local":
         conf = from_qualified_name(retrieved_agent).generate_supervisor_conf(
             token=token,
-            labels=list(label),
+            labels=labels,
             import_paths=list(import_path),
             show_flow_logs=show_flow_logs,
         )

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -25,6 +25,19 @@ def test_local_agent_init(runner_token):
     assert agent.name == "agent"
 
 
+def test_local_agent_deduplicates_labels(runner_token):
+    agent = LocalAgent(labels=["azure-flow-storage"])
+    assert agent
+    assert set(agent.labels) == {
+        socket.gethostname(),
+        "azure-flow-storage",
+        "s3-flow-storage",
+        "gcs-flow-storage",
+        "github-flow-storage",
+    }
+    assert len(agent.labels) == len(set(agent.labels))
+
+
 def test_local_agent_config_options(runner_token):
     with set_temporary_config(
         {"cloud.agent.auth_token": "TEST_TOKEN", "logging.log_to_cloud": True}


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR attempts to prevent the situation where an agent has duplicate labels.

## Why is this PR important?

While testing #3000 , I noticed something surprising...it's possible for duplicates to exist in an agent's set of labels:

For example:

```shell
prefect agent start \
    -t ${PREFECT_RUNNER_TOKEN} \
    --label 'i-am-duplicated' \
    --label 'i-am-duplicated' \
    --label 'i-am-duplicated'
```

![image](https://user-images.githubusercontent.com/7608904/88618381-a1e71280-d05e-11ea-961d-3b0ba48606f5.png)

![image](https://user-images.githubusercontent.com/7608904/88618408-b6c3a600-d05e-11ea-86e4-b05986caad09.png)

I'm not sure if this would cause any problems today, but I could see it causing these types of problems:

* breaking code that allows wildcards for matching flows to agents, but throws an error if more than one label is matched
* breaking code that queries for agents by label and cannot handle duplicates
* slightly hurting the experience in the Prefect Cloud UI if duplicate labels are enough to push other labels into the collapsed `+n` box like in the screenshot above

So, I'm not aware of anything that is not working well *today* because of this, but I think this change might be a minor way to prevent some weird cases in the future.

Thanks for your time and consideration.
