### PR TITLE
Revert back to using relative paths in generated Dockerfile on Windows

### DIFF
--- a/changes/pr3044.yaml
+++ b/changes/pr3044.yaml
@@ -1,0 +1,6 @@
+
+fix:
+  - "Fix use of absolute path in Docker storage on Windows - [#3044](https://github.com/PrefectHQ/prefect/pull/3044)"
+
+contributor:
+  - "[Pravin Dahal](https://github.com/pravindahal)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -457,7 +457,8 @@ class Docker(Storage):
                 else:
                     shutil.copy2(src, full_fname)
                 copy_files += "COPY {fname} {dest}\n".format(
-                    fname=full_fname if self.dockerfile else fname, dest=dest
+                    fname=full_fname.replace("\\", "/") if self.dockerfile else fname,
+                    dest=dest,
                 )
 
         # Write all flows to file and load into the image
@@ -469,7 +470,7 @@ class Docker(Storage):
                 with open(flow_path, "wb") as f:
                     cloudpickle.dump(self._flows[flow_name], f)
                 copy_flows += "COPY {source} {dest}\n".format(
-                    source=flow_path
+                    source=flow_path.replace("\\", "/")
                     if self.dockerfile
                     else "{}.flow".format(clean_name),
                     dest=flow_location,
@@ -520,7 +521,7 @@ class Docker(Storage):
                 extra_commands=extra_commands,
                 pip_installs=pip_installs,
                 copy_flows=copy_flows,
-                healthcheck_loc=healthcheck_loc
+                healthcheck_loc=healthcheck_loc.replace("\\", "/")
                 if self.dockerfile
                 else "healthcheck.py",
                 copy_files=copy_files,

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -352,10 +352,6 @@ class Docker(Storage):
             dir="." if self.dockerfile else None
         ) as tempdir:
 
-            if sys.platform == "win32":
-                # problem with docker and relative paths only on windows
-                tempdir = os.path.abspath(tempdir)
-
             # Build the dockerfile
             if self.base_image and not self.local_image:
                 self.pull_image()
@@ -378,6 +374,11 @@ class Docker(Storage):
 
             # Use the docker client to build the image
             self.logger.info("Building the flow's Docker storage...")
+
+            if sys.platform == "win32":
+                # problem with docker and relative paths only on windows
+                dockerfile_path = os.path.abspath(dockerfile_path)
+
             output = client.build(
                 path="." if self.dockerfile else tempdir,
                 dockerfile=dockerfile_path,

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -447,16 +447,19 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
 
             assert (
                 "COPY {} /opt/prefect/flows/foo.prefect".format(
-                    os.path.join(directory, "foo.flow")
+                    os.path.join(directory, "foo.flow").replace("\\", "/")
                 )
                 in output
             ), output
             assert (
-                "COPY {} ./test2".format(os.path.join(directory, "test")) in output
+                "COPY {} ./test2".format(
+                    os.path.join(directory, "test").replace("\\", "/")
+                )
+                in output
             ), output
             assert (
                 "COPY {} /opt/prefect/healthcheck.py".format(
-                    os.path.join(directory, "healthcheck.py")
+                    os.path.join(directory, "healthcheck.py").replace("\\", "/")
                 )
                 in output
             )


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?
https://github.com/PrefectHQ/prefect/pull/2390 introduced a change so that on Windows, Dockerfile contained absolute paths which prevents docker build from working when using wsl backend or ssh (see https://github.com/PrefectHQ/prefect/issues/3023).

The fix here is to use relative paths in Dockerfile (i.e. revert to behavior before https://github.com/PrefectHQ/prefect/pull/2390) but pass absolute path of Dockerfile to `client.build`.

For previous attempt at addressing this problem, see the discussion here: https://github.com/PrefectHQ/prefect/pull/3035