### PR TITLE
allow customization of the yaml template

### DIFF
--- a/changes/pr3046.yaml
+++ b/changes/pr3046.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow for setting path to a custom job YAML spec on the Kubernetes Agent - [#3046](https://github.com/PrefectHQ/prefect/pull/3046)"
+
+contributor:
+  - "[emcake](https://github.com/emcake)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -157,7 +157,9 @@ class KubernetesAgent(Agent):
         Returns:
             - dict: a dictionary representation of a k8s job for flow execution
         """
-        yaml_path = os.getenv("YAML_TEMPLATE", path.join(path.dirname(__file__), "job_spec.yaml"))
+        yaml_path = os.getenv(
+            "YAML_TEMPLATE", path.join(path.dirname(__file__), "job_spec.yaml")
+        )
         with open(yaml_path, "r") as job_file:
             job = yaml.safe_load(job_file)
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -147,6 +147,8 @@ class KubernetesAgent(Agent):
                 container registry, such as Amazon ECR.
         - `SERVICE_ACCOUNT_NAME`: name of a service account to run the job as.
                 By default, none is specified.
+        - `YAML_TEMPLATE`: a path to where the YAML template should be loaded from. defaults
+                to the embedded `job_spec.yaml`.
 
         Args:
             - flow_run (GraphQLResult): A flow run object
@@ -155,7 +157,8 @@ class KubernetesAgent(Agent):
         Returns:
             - dict: a dictionary representation of a k8s job for flow execution
         """
-        with open(path.join(path.dirname(__file__), "job_spec.yaml"), "r") as job_file:
+        yaml_path = os.getenv("YAML_TEMPLATE", path.join(path.dirname(__file__), "job_spec.yaml"))
+        with open(yaml_path, "r") as job_file:
             job = yaml.safe_load(job_file)
 
         identifier = str(uuid.uuid4())[:8]


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] add a changelog entry in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

Add an extra configurable `YAML_TEMPLATE` argument to the `KubernetesAgent` to allow overwriting of the template job spec.

## Why is this PR important?

Due to environmental setup of our k8s cluster I found myself needing to alter the podspec run in ways not exposed by current environment variables, and it didn't seem sensible to add new environment variables for every change I'd want to make to the template. This approach allows me to build a custom container with a specialized yaml spec.
