### PR TITLE
ignore Jupyter notebooks in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,15 @@ __pycache__/
 .import-time.txt
 
 # C extensions
+*.a
+*.dll
+*.dylib
+*.o
 *.so
+
+# executables for Windows
+*.exe
+*.msi
 
 # vim noise
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ docs/_build/
 target/
 
 # Jupyter Notebook
+*.ipynb
 .ipynb_checkpoints
 
 # pyenv


### PR DESCRIPTION
- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## What does this PR change?

This PR adds the following things to `.gitignore`:

* Jupyter notebooks (`.ipynb`)
* objects from compiling C/C++ code (`.a`, `.dll`,  `.dylib`, `.o`)
* Windows executables (`.exe`, `.msi`)

## Why is this PR important?

While working on #3000 , I was developing in a Jupyter notebook. I found that `.ipynb` notebooks are not currently ignored in this repo. I think that they should be, since this repo currently does not have any notebooks in it.

The C/C++ stuff and Windows executables are other things I noticed missing and that I expect should not be checked into this project.

Thanks for your time and consideration.