### PR TITLE
Determine checkpointing from context.config

### DIFF
--- a/changes/pr3085.yaml
+++ b/changes/pr3085.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Determine if checkpointing is enabled from config set in the flow-runner process - [#3085](https://github.com/PrefectHQ/prefect/pull/3085)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -159,7 +159,12 @@ class TaskRunner(Runner):
             task_name=self.task.name,
             task_tags=self.task.tags,
         )
-        context.setdefault("checkpointing", config.flows.checkpointing)
+        # Use the config stored in context if possible (should always be present)
+        try:
+            checkpointing = context["config"]["flows"]["checkpointing"]
+        except KeyError:
+            checkpointing = config.flows.checkpointing
+        context.setdefault("checkpointing", checkpointing)
 
         map_index = context.get("map_index", None)
         if isinstance(map_index, int) and context.get("task_full_name"):

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -435,6 +435,13 @@ class TestInitializeRun:
         with prefect.context() as ctx:
             assert "checkpointing" not in ctx
             with set_temporary_config({"flows.checkpointing": "FOO"}):
+                # Pull from context.config if present
+                prefect.config.flows.checkpointing = False
+                result = TaskRunner(Task()).initialize_run(state=None, context=ctx)
+                assert result.context.checkpointing == "FOO"
+                # Otherwise fallback to local config
+                prefect.config.flows.checkpointing = "FOO"
+                del prefect.context.config.flows.checkpointing
                 result = TaskRunner(Task()).initialize_run(state=None, context=ctx)
                 assert result.context.checkpointing == "FOO"
 


### PR DESCRIPTION
Previously the global checkpointing config was determined by looking at
`prefect.config.flows.checkpointing`, which required configuring this
value on all dask workers for things to work properly.  We now use
`prefect.context.config.flows.checkpointing`, which will match the value
configured for the flow runner alone, better matching user expectations.

Fixes #3071.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)