### PR TITLE
Allow idempotency key in FlowRunTask when using server backend

### DIFF
--- a/changes/issue3006.yaml
+++ b/changes/issue3006.yaml
@@ -1,0 +1,3 @@
+task:
+  - "Allow idempotency keys in `FlowRunTask` when using server backend - [#3006](https://github.com/PrefectHQ/prefect/issues/3006)"
+  - "Require project name in `FlowRunTask` when using server backend - [#3006](https://github.com/PrefectHQ/prefect/issues/3006)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -1,8 +1,7 @@
 import time
 from typing import Any
-from urllib.parse import urlparse
 
-from prefect import config, context, Task
+from prefect import context, Task
 from prefect.client import Client
 from prefect.engine.signals import signal_from_state
 from prefect.utilities.graphql import EnumValue, with_args

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -122,6 +122,7 @@ class TestFlowRunTaskCoreServer:
         # verify that the task is initialized as expected
         task = FlowRunTask(
             name="My Flow Run Task",
+            project_name="Demo",
             checkpoint=False,
             flow_name="Test Flow",
             new_flow_context={"foo": "bar"},
@@ -135,7 +136,9 @@ class TestFlowRunTaskCoreServer:
 
     def test_flow_run_task(self, client, server_api):
         # verify that create_flow_run was called
-        task = FlowRunTask(flow_name="Test Flow", parameters={"test": "ing"},)
+        task = FlowRunTask(
+            flow_name="Test Flow", project_name="Demo", parameters={"test": "ing"},
+        )
         # verify that run returns the new flow run ID
         assert task.run() == "xyz890"
         # verify the GraphQL query was called with the correct arguments
@@ -158,7 +161,7 @@ class TestFlowRunTaskCoreServer:
 
     def test_flow_run_task_with_no_matching_flow(self, client, server_api):
         # verify a ValueError is raised if the client returns no flows
-        task = FlowRunTask(flow_name="Test Flow")
+        task = FlowRunTask(flow_name="Test Flow", project_name="Demo")
         client.graphql = MagicMock(return_value=MagicMock(data=MagicMock(flow=[])))
         with pytest.raises(ValueError, match="Flow 'Test Flow' not found."):
             task.run()
@@ -179,6 +182,6 @@ class TestFlowRunTaskCoreServer:
         client.create_flow_run.assert_called_once_with(
             flow_id="abc123",
             parameters={"test": "ing"},
-            idempotency_key=None,
+            idempotency_key="test-id",
             context=None,
         )


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #3006 


## Why is this PR important?
Recent server changes allow for idempotency key now when running a flow and also now requires the specification of a project name

