### PR TITLE
Issue 3086 bq load file return load job

### DIFF
--- a/changes/issue3086.yml
+++ b/changes/issue3086.yml
@@ -1,4 +1,4 @@
-enhancement:
+task:
   - "Return `LoadJob` object in `BigQueryLoad` tasks - [#3086](https://github.com/PrefectHQ/prefect/issues/3086)"
 
 contributor:

--- a/changes/issue3086.yml
+++ b/changes/issue3086.yml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Return `LoadJob` object in `BigQueryLoad` tasks - [#3086](https://github.com/PrefectHQ/prefect/issues/3086)"
+
+contributor:
+  - "[Franklin Winokur](https://github.com/fwinokur)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -306,9 +306,10 @@ classes = [
         "GCSUpload",
         "GCSCopy",
         "BigQueryTask",
-        "BigQueryLoadGoogleCloudStorage",
         "BigQueryStreamingInsert",
-        "CreateBigQueryTable"
+        "CreateBigQueryTable",
+        "BigQueryLoadGoogleCloudStorage",
+        "BigQueryLoadFile"
         ]
 
 [pages.tasks.great_expectations]

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -362,7 +362,7 @@ class BigQueryLoadGoogleCloudStorage(Task):
             - ValueError: if the load job results in an error
 
         Returns:
-            - the response from `load_table_from_uri`
+            - google.cloud.bigquery.job.LoadJob: the response from `load_table_from_uri`
         """
         # check for any argument inconsistencies
         if dataset_id is None or table is None:
@@ -381,6 +381,8 @@ class BigQueryLoadGoogleCloudStorage(Task):
             job_config.schema = schema
         load_job = client.load_table_from_uri(uri, table_ref, job_config=job_config)
         load_job.result()  # block until job is finished
+
+        return load_job
 
 
 class BigQueryLoadFile(Task):
@@ -490,7 +492,7 @@ class BigQueryLoadFile(Task):
             - ValueError: if the load job results in an error
 
         Returns:
-            - the response from `load_table_from_file`
+            - google.cloud.bigquery.job.LoadJob: the response from `load_table_from_file`
         """
         # check for any argument inconsistencies
         if dataset_id is None or table is None:
@@ -529,6 +531,8 @@ class BigQueryLoadFile(Task):
             raise IOError(f"Can't open and read from {path.as_posix()}.")
 
         load_job.result()  # block until job is finished
+
+        return load_job
 
 
 class CreateBigQueryTable(Task):

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -399,6 +399,8 @@ class BigQueryLoadFile(Task):
         - size (int, optional):  the number of bytes to read from the file handle. If size is
             None or large, resumable upload will be used. Otherwise, multipart upload will be
             used.
+        - num_retries (int, optional): the number of max retries for loading the bigquery table from
+            file. Defaults to `6`
         - dataset_id (str, optional): the id of a destination dataset to write the records to
         - table (str, optional): the name of a destination table to write the records to
         - project (str, optional): the project to initialize the BigQuery Client with; if not
@@ -470,6 +472,8 @@ class BigQueryLoadFile(Task):
             - size (int, optional):  the number of bytes to read from the file handle. If size
                 is None or large, resumable upload will be used. Otherwise, multipart upload
                 will be used.
+            - num_retries (int, optional): the number of max retries for loading the bigquery table from
+                file. Defaults to `6`
             - dataset_id (str, optional): the id of a destination dataset to write the records
                 to; if not provided here, will default to the one provided at initialization
             - table (str, optional): the name of a destination table to write the records to;


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [X] adds new tests (if appropriate)
- [X] add a changelog entry in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Return `google.cloud.bigquery.job.LoadJob` object in `BigQueryLoadGoogleCloudStorage` and `BigQueryLoadFile` tasks.  It also adds BigQueryLoadFile to the API reference as it was missing.


## Why is this PR important?
This is actually what the docstring suggested, but it wasn't implemented.  The LoadJob object allows you to inspect important information pertaining to the load including output_rows (number of rows written to BigQuery table) and errors which are useful for debugging.

Closes #3086 