### PR TITLE
Determine flow run command based on flow version

### DIFF
--- a/changes/pr3113.yaml
+++ b/changes/pr3113.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Agents set flow run execution command based on flow's core version - [#3113](https://github.com/PrefectHQ/prefect/pull/3113)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -484,7 +484,7 @@ class Agent:
 
         self.logger.debug(msg)
 
-        # Query metadata fow flow runs found in queue
+        # Query metadata for flow runs found in queue
         query = {
             "query": {
                 with_args(
@@ -515,7 +515,7 @@ class Agent:
                     "state": True,
                     "serialized_state": True,
                     "parameters": True,
-                    "flow": {"id", "name", "environment", "storage", "version"},
+                    "flow": {"id", "name", "environment", "storage", "version", "core_version"},
                     with_args(
                         "task_runs",
                         {

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -515,7 +515,14 @@ class Agent:
                     "state": True,
                     "serialized_state": True,
                     "parameters": True,
-                    "flow": {"id", "name", "environment", "storage", "version", "core_version"},
+                    "flow": {
+                        "id",
+                        "name",
+                        "environment",
+                        "storage",
+                        "version",
+                        "core_version",
+                    },
                     with_args(
                         "task_runs",
                         {

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
 
 from prefect import config, context
 from prefect.agent import Agent
-from prefect.utilities.agent import get_flow_image
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.docker_util import get_docker_ip
 from prefect.utilities.graphql import GraphQLResult
 
@@ -384,7 +384,7 @@ class DockerAgent(Agent):
 
         container = self.docker_client.create_container(
             image,
-            command="prefect execute cloud-flow",
+            command=get_flow_run_command(flow_run),
             environment=env_vars,
             volumes=container_mount_paths,
             host_config=self.docker_client.create_host_config(**host_config),

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -489,7 +489,7 @@ class FargateAgent(Agent):
                 flow_task_definition_kwargs=flow_task_definition_kwargs,
                 container_definitions_kwargs=flow_container_definitions_kwargs,
                 task_definition_name=task_definition_dict["task_definition_name"],
-                flow_run_command=flow_run_command
+                flow_run_command=flow_run_command,
             )
 
         # run task

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -9,7 +9,7 @@ from slugify import slugify
 
 from prefect import config
 from prefect.agent import Agent
-from prefect.utilities.agent import get_flow_image
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.graphql import GraphQLResult
 
 
@@ -478,6 +478,7 @@ class FargateAgent(Agent):
             )  # type: ignore
 
         image = get_flow_image(flow_run=flow_run)
+        flow_run_command = get_flow_run_command(flow_run=flow_run)
 
         # check if task definition exists
         self.logger.debug("Checking for task definition")
@@ -488,6 +489,7 @@ class FargateAgent(Agent):
                 flow_task_definition_kwargs=flow_task_definition_kwargs,
                 container_definitions_kwargs=flow_container_definitions_kwargs,
                 task_definition_name=task_definition_dict["task_definition_name"],
+                flow_run_command=flow_run_command
             )
 
         # run task
@@ -568,6 +570,7 @@ class FargateAgent(Agent):
         flow_task_definition_kwargs: dict,
         container_definitions_kwargs: dict,
         task_definition_name: str,
+        flow_run_command: str,
     ) -> None:
         """
         Create a task definition for the flow that each flow run will use. This function
@@ -579,13 +582,14 @@ class FargateAgent(Agent):
             - container_definitions_kwargs (dict): container definitions kwargs to use for
                 registration
             - task_definition_name (str): task definition name to use
+            - flow_run_command (str): the flow run command to execute
         """
         self.logger.debug("Using image {} for task definition".format(image))
         container_definitions = [
             {
                 "name": "flow",
                 "image": image,
-                "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
+                "command": ["/bin/sh", "-c", flow_run_command],
                 "environment": [
                     {
                         "name": "PREFECT__CLOUD__API",

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -177,7 +177,9 @@ class KubernetesAgent(Agent):
         self.logger.debug("Using image {} for job".format(image))
 
         # Datermine flow run command
-        job["spec"]["template"]["spec"]["containers"][0]["args"] = [get_flow_run_command(flow_run)]
+        job["spec"]["template"]["spec"]["containers"][0]["args"] = [
+            get_flow_run_command(flow_run)
+        ]
 
         # Populate environment variables for flow run execution
         env = job["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -8,7 +8,7 @@ import yaml
 import prefect
 from prefect import config
 from prefect.agent import Agent
-from prefect.utilities.agent import get_flow_image
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.graphql import GraphQLResult
 
 AGENT_DIRECTORY = path.expanduser("~/.prefect/agent")
@@ -175,6 +175,9 @@ class KubernetesAgent(Agent):
         job["spec"]["template"]["spec"]["containers"][0]["image"] = image
 
         self.logger.debug("Using image {} for job".format(image))
+
+        # Datermine flow run command
+        job["spec"]["template"]["spec"]["containers"][0]["args"] = [get_flow_run_command(flow_run)]
 
         # Populate environment variables for flow run execution
         env = job["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/src/prefect/agent/kubernetes/job_spec.yaml
+++ b/src/prefect/agent/kubernetes/job_spec.yaml
@@ -17,7 +17,7 @@ spec:
           image: prefecthq/prefect:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
-          args: ["prefect execute cloud-flow"]
+          args: ["prefect execute flow-run"]
           env:
             - name: PREFECT__CLOUD__API
               value: PREFECT__CLOUD__API

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -154,7 +154,6 @@ class LocalAgent(Agent):
 
         stdout = sys.stdout if self.show_flow_logs else DEVNULL
 
-
         # note: we will allow these processes to be orphaned if the agent were to exit
         # before the flow runs have completed. The lifecycle of the agent should not
         # dictate the lifecycle of the flow run. However, if the user has elected to

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -8,6 +8,7 @@ from prefect import config
 from prefect.agent import Agent
 from prefect.environments.storage import GCS, S3, Azure, Local, GitHub, Webhook
 from prefect.serialization.storage import StorageSchema
+from prefect.utilities.agent import get_flow_run_command
 from prefect.utilities.graphql import GraphQLResult
 
 
@@ -153,13 +154,14 @@ class LocalAgent(Agent):
 
         stdout = sys.stdout if self.show_flow_logs else DEVNULL
 
+
         # note: we will allow these processes to be orphaned if the agent were to exit
         # before the flow runs have completed. The lifecycle of the agent should not
         # dictate the lifecycle of the flow run. However, if the user has elected to
         # show flow logs, these log entries will continue to stream to the users terminal
         # until these child processes exit, even if the agent has already exited.
         p = Popen(
-            ["prefect", "execute", "cloud-flow"],
+            get_flow_run_command(flow_run).split(" "),
             stdout=stdout,
             stderr=STDOUT,
             env=current_env,

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import prefect
 from prefect.utilities.graphql import GraphQLResult
 
@@ -37,3 +39,21 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
             )
 
         return storage.name
+
+def get_flow_run_command(flow_run: GraphQLResult) -> str:
+    """
+    Determine the flow run command to use based on a flow's version. This is due to a command
+    deprecation in `0.13.0` where `execute cloud-flow` was changes to `execute flow-run`
+
+    Args:
+        - flow_run (GraphQLResult): A GraphQLResult flow run object
+
+    Returns:
+        - str: a prefect CLI command to execute a flow run
+    """
+    core_version = flow_run.flow.core_version
+
+    if LooseVersion(core_version) < LooseVersion("0.13.0"):
+        return "prefect execute cloud-flow"
+
+    return "prefect execute flow-run"

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -52,7 +52,7 @@ def get_flow_run_command(flow_run: GraphQLResult) -> str:
     Returns:
         - str: a prefect CLI command to execute a flow run
     """
-    core_version = flow_run.flow.core_version
+    core_version = flow_run.flow.core_version or "0.0.0"
 
     if LooseVersion(core_version) < LooseVersion("0.13.0"):
         return "prefect execute cloud-flow"

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -40,6 +40,7 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
 
         return storage.name
 
+
 def get_flow_run_command(flow_run: GraphQLResult) -> str:
     """
     Determine the flow run command to use based on a flow's version. This is due to a command

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -241,7 +241,16 @@ def test_populate_env_vars_is_responsive_to_logging_config(
     assert env_vars["PREFECT__LOGGING__LOG_TO_CLOUD"] == str(not flag).lower()
 
 
-def test_docker_agent_deploy_flow(monkeypatch, cloud_api):
+@pytest.mark.parametrize(
+    "core_version,command",
+    [
+        ("0.10.0", "prefect execute cloud-flow"),
+        ("0.6.0+134", "prefect execute cloud-flow"),
+        ("0.13.0", "prefect execute flow-run"),
+        ("0.13.1+134", "prefect execute flow-run"),
+    ],
+)
+def test_docker_agent_deploy_flow(core_version, command, monkeypatch, cloud_api):
     api = MagicMock()
     api.ping.return_value = True
     api.create_container.return_value = {"Id": "container_id"}
@@ -262,6 +271,7 @@ def test_docker_agent_deploy_flow(monkeypatch, cloud_api):
                             registry_url="test", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": core_version,
                     }
                 ),
                 "id": "id",
@@ -275,7 +285,7 @@ def test_docker_agent_deploy_flow(monkeypatch, cloud_api):
     assert api.start.called
 
     assert api.create_host_config.call_args[1]["auto_remove"] is True
-    assert api.create_container.call_args[1]["command"] == "prefect execute cloud-flow"
+    assert api.create_container.call_args[1]["command"] == command
     assert api.create_container.call_args[1]["host_config"]["AutoRemove"] is True
     assert api.start.call_args[1]["container"] == "container_id"
 
@@ -301,6 +311,7 @@ def test_docker_agent_deploy_flow_uses_environment_metadata(monkeypatch, cloud_a
                         "environment": LocalEnvironment(
                             metadata={"image": "repo/name:tag"}
                         ).serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -314,7 +325,7 @@ def test_docker_agent_deploy_flow_uses_environment_metadata(monkeypatch, cloud_a
     assert api.start.called
 
     assert api.create_host_config.call_args[1]["auto_remove"] is True
-    assert api.create_container.call_args[1]["command"] == "prefect execute cloud-flow"
+    assert api.create_container.call_args[1]["command"] == "prefect execute flow-run"
     assert api.create_container.call_args[1]["host_config"]["AutoRemove"] is True
     assert api.start.call_args[1]["container"] == "container_id"
 
@@ -341,6 +352,7 @@ def test_docker_agent_deploy_flow_storage_raises(monkeypatch, cloud_api):
                             "storage": Local().serialize(),
                             "id": "foo",
                             "environment": LocalEnvironment().serialize(),
+                            "core_version": "0.13.0",
                         }
                     ),
                     "id": "id",
@@ -374,6 +386,7 @@ def test_docker_agent_deploy_flow_no_pull(monkeypatch, cloud_api):
                             registry_url="test", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -410,6 +423,7 @@ def test_docker_agent_deploy_flow_no_pull_using_environment_metadata(
                         "environment": LocalEnvironment(
                             metadata={"image": "name:tag"}
                         ).serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -444,6 +458,7 @@ def test_docker_agent_deploy_flow_reg_allow_list_allowed(monkeypatch, cloud_api)
                             registry_url="test1", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -479,6 +494,7 @@ def test_docker_agent_deploy_flow_reg_allow_list_not_allowed(monkeypatch, cloud_
                                 registry_url="test2", image_name="name", image_tag="tag"
                             ).serialize(),
                             "environment": LocalEnvironment().serialize(),
+                            "core_version": "0.13.0",
                         }
                     ),
                     "id": "id",
@@ -522,6 +538,7 @@ def test_docker_agent_deploy_flow_show_flow_logs(monkeypatch, cloud_api):
                             registry_url="test", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -578,6 +595,7 @@ def test_docker_agent_deploy_flow_no_registry_does_not_pull(monkeypatch, cloud_a
                             registry_url="", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1001,6 +1019,7 @@ def test_docker_agent_network(monkeypatch, cloud_api):
                             registry_url="test", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1040,6 +1059,7 @@ def test_docker_agent_deploy_with_interface_check_linux(
                             registry_url="", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1077,6 +1097,7 @@ def test_docker_agent_deploy_with_no_interface_check_linux(
                             registry_url="", image_name="name", image_tag="tag"
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -640,6 +640,7 @@ def test_deploy_flow_local_storage_raises(monkeypatch, cloud_api):
                             "storage": Local().serialize(),
                             "id": "id",
                             "environment": LocalEnvironment().serialize(),
+                            "core_version": "0.13.0",
                         }
                     ),
                     "id": "id",
@@ -670,6 +671,7 @@ def test_deploy_flow_docker_storage_raises(monkeypatch, cloud_api):
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -736,6 +738,7 @@ def test_deploy_flow_all_args(monkeypatch, cloud_api):
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -789,6 +792,7 @@ def test_deploy_flow_register_task_definition(monkeypatch, cloud_api):
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -826,6 +830,7 @@ def test_deploy_flow_register_task_definition_uses_environment_metadata(
                             metadata={"image": "repo/name:tag"}
                         ).serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -869,6 +874,7 @@ def test_deploy_flow_register_task_definition_uses_user_env_vars(
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -895,7 +901,18 @@ def test_deploy_flow_register_task_definition_uses_user_env_vars(
     assert container_defs[0]["environment"][-2] in user_vars
 
 
-def test_deploy_flow_register_task_definition_all_args(monkeypatch, cloud_api):
+@pytest.mark.parametrize(
+    "core_version,command",
+    [
+        ("0.10.0", "prefect execute cloud-flow"),
+        ("0.6.0+134", "prefect execute cloud-flow"),
+        ("0.13.0", "prefect execute flow-run"),
+        ("0.13.1+134", "prefect execute flow-run"),
+    ],
+)
+def test_deploy_flow_register_task_definition_all_args(
+    core_version, command, monkeypatch, cloud_api
+):
     boto3_client = MagicMock()
 
     boto3_client.describe_task_definition.side_effect = ClientError({}, None)
@@ -983,6 +1000,7 @@ def test_deploy_flow_register_task_definition_all_args(monkeypatch, cloud_api):
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": core_version,
                     }
                 ),
                 "id": "id",
@@ -1002,7 +1020,7 @@ def test_deploy_flow_register_task_definition_all_args(monkeypatch, cloud_api):
         {
             "name": "flow",
             "image": "test/name:tag",
-            "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
+            "command": ["/bin/sh", "-c", command],
             "environment": [
                 {"name": "PREFECT__CLOUD__API", "value": "https://api.prefect.io"},
                 {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
@@ -1117,6 +1135,7 @@ def test_deploy_flows_includes_agent_labels_in_environment(
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1136,7 +1155,7 @@ def test_deploy_flows_includes_agent_labels_in_environment(
         {
             "name": "flow",
             "image": "test/name:tag",
-            "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
+            "command": ["/bin/sh", "-c", "prefect execute flow-run"],
             "environment": [
                 {"name": "PREFECT__CLOUD__API", "value": "https://api.prefect.io"},
                 {
@@ -1188,6 +1207,7 @@ def test_deploy_flows_require_docker_storage(monkeypatch, cloud_api):
                             "id": "id",
                             "version": 2,
                             "name": "name",
+                            "core_version": "0.13.0",
                         }
                     ),
                     "id": "id",
@@ -1224,6 +1244,7 @@ def test_deploy_flows_enable_task_revisions_no_tags(monkeypatch, cloud_api):
                         "id": "id",
                         "version": 2,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1238,7 +1259,7 @@ def test_deploy_flows_enable_task_revisions_no_tags(monkeypatch, cloud_api):
             {
                 "name": "flow",
                 "image": "test/name:tag",
-                "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
+                "command": ["/bin/sh", "-c", "prefect execute flow-run"],
                 "environment": [
                     {"name": "PREFECT__CLOUD__API", "value": "https://api.prefect.io"},
                     {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
@@ -1296,6 +1317,7 @@ def test_deploy_flows_enable_task_revisions_tags_current(monkeypatch, cloud_api)
                         "id": "id",
                         "version": 5,
                         "name": "name #1",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1339,6 +1361,7 @@ def test_deploy_flows_enable_task_revisions_old_version_exists(monkeypatch, clou
                         "id": "id",
                         "version": 3,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1412,6 +1435,7 @@ def test_override_kwargs(monkeypatch, cloud_api):
                         "id": "id",
                         "version": 2,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1480,6 +1504,7 @@ def test_override_kwargs_exception(monkeypatch, cloud_api):
                         "id": "id",
                         "version": 2,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1528,6 +1553,7 @@ def test_deploy_flows_enable_task_revisions_tags_passed_in(monkeypatch, cloud_ap
                         "id": "id",
                         "version": 2,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1597,6 +1623,7 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
                         "id": "new_id",
                         "version": 6,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1610,7 +1637,7 @@ def test_deploy_flows_enable_task_revisions_with_external_kwargs(
             {
                 "name": "flow",
                 "image": "test/name:tag",
-                "command": ["/bin/sh", "-c", "prefect execute cloud-flow"],
+                "command": ["/bin/sh", "-c", "prefect execute flow-run"],
                 "environment": [
                     {"name": "PREFECT__CLOUD__API", "value": "https://api.prefect.io"},
                     {
@@ -1707,6 +1734,7 @@ def test_deploy_flows_disable_task_revisions_with_external_kwargs(
                         "id": "new_id",
                         "version": 6,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1781,6 +1809,7 @@ def test_deploy_flows_launch_type_ec2(monkeypatch, cloud_api):
                         "id": "new_id",
                         "version": 6,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -1855,6 +1884,7 @@ def test_deploy_flows_launch_type_none(monkeypatch, cloud_api):
                         "id": "new_id",
                         "version": 6,
                         "name": "name",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -40,7 +40,16 @@ def test_k8s_agent_config_options(monkeypatch, cloud_api):
         assert agent.batch_client
 
 
-def test_k8s_agent_deploy_flow(monkeypatch, cloud_api):
+@pytest.mark.parametrize(
+    "core_version,command",
+    [
+        ("0.10.0", "prefect execute cloud-flow"),
+        ("0.6.0+134", "prefect execute cloud-flow"),
+        ("0.13.0", "prefect execute flow-run"),
+        ("0.13.1+134", "prefect execute flow-run"),
+    ],
+)
+def test_k8s_agent_deploy_flow(core_version, command, monkeypatch, cloud_api):
     k8s_config = MagicMock()
     monkeypatch.setattr("kubernetes.config", k8s_config)
 
@@ -61,6 +70,7 @@ def test_k8s_agent_deploy_flow(monkeypatch, cloud_api):
                         ).serialize(),
                         "environment": LocalEnvironment().serialize(),
                         "id": "id",
+                        "core_version": core_version,
                     }
                 ),
                 "id": "id",
@@ -76,6 +86,9 @@ def test_k8s_agent_deploy_flow(monkeypatch, cloud_api):
         agent.batch_client.create_namespaced_job.call_args[1]["body"]["apiVersion"]
         == "batch/v1"
     )
+    assert agent.batch_client.create_namespaced_job.call_args[1]["body"]["spec"][
+        "template"
+    ]["spec"]["containers"][0]["args"] == [command]
 
 
 def test_k8s_agent_deploy_flow_uses_environment_metadata(monkeypatch, cloud_api):
@@ -99,6 +112,7 @@ def test_k8s_agent_deploy_flow_uses_environment_metadata(monkeypatch, cloud_api)
                             metadata={"image": "repo/name:tag"}
                         ).serialize(),
                         "id": "id",
+                        "core_version": "0.13.0",
                     }
                 ),
                 "id": "id",
@@ -135,6 +149,7 @@ def test_k8s_agent_deploy_flow_raises(monkeypatch, cloud_api):
                             "storage": Local().serialize(),
                             "id": "id",
                             "environment": LocalEnvironment().serialize(),
+                            "core_version": "0.13.0",
                         }
                     ),
                     "id": "id",
@@ -166,6 +181,7 @@ def test_k8s_agent_replace_yaml_uses_user_env_vars(monkeypatch, cloud_api):
                     ).serialize(),
                     "environment": LocalEnvironment().serialize(),
                     "id": "new_id",
+                    "core_version": "0.13.0",
                 }
             ),
             "id": "id",
@@ -231,6 +247,7 @@ def test_k8s_agent_replace_yaml(monkeypatch, cloud_api):
                     ).serialize(),
                     "environment": LocalEnvironment().serialize(),
                     "id": "new_id",
+                    "core_version": "0.13.0",
                 }
             ),
             "id": "id",
@@ -297,6 +314,7 @@ def test_k8s_agent_replace_yaml_responds_to_logging_config(
                     ).serialize(),
                     "environment": LocalEnvironment().serialize(),
                     "id": "new_id",
+                    "core_version": "0.13.0",
                 }
             ),
             "id": "id",
@@ -323,6 +341,7 @@ def test_k8s_agent_replace_yaml_no_pull_secrets(monkeypatch, cloud_api):
                     ).serialize(),
                     "environment": LocalEnvironment().serialize(),
                     "id": "id",
+                    "core_version": "0.13.0",
                 }
             ),
             "id": "id",
@@ -348,6 +367,7 @@ def test_k8s_agent_includes_agent_labels_in_job(monkeypatch, cloud_api):
                     ).serialize(),
                     "environment": LocalEnvironment().serialize(),
                     "id": "new_id",
+                    "core_version": "0.13.0",
                 }
             ),
             "id": "id",

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -223,7 +223,11 @@ def test_local_agent_deploy_processes_local_storage(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": Local(directory="test").serialize(), "id": "foo"}
+                    {
+                        "storage": Local(directory="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -244,7 +248,11 @@ def test_local_agent_deploy_processes_gcs_storage(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": GCS(bucket="test").serialize(), "id": "foo"}
+                    {
+                        "storage": GCS(bucket="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -265,7 +273,11 @@ def test_local_agent_deploy_processes_s3_storage(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": GCS(bucket="test").serialize(), "id": "foo"}
+                    {
+                        "storage": GCS(bucket="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -286,7 +298,11 @@ def test_local_agent_deploy_processes_azure_storage(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": GCS(bucket="test").serialize(), "id": "foo"}
+                    {
+                        "storage": GCS(bucket="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -312,7 +328,13 @@ def test_local_agent_deploy_processes_webhook_storage(monkeypatch, runner_token)
     agent.deploy_flow(
         flow_run=GraphQLResult(
             {
-                "flow": GraphQLResult({"storage": webhook.serialize(), "id": "foo"}),
+                "flow": GraphQLResult(
+                    {
+                        "storage": webhook.serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
+                ),
                 "id": "id",
             }
         )
@@ -334,7 +356,14 @@ def test_local_agent_deploy_storage_raises_not_supported_storage(
     with pytest.raises(ValueError):
         agent.deploy_flow(
             flow_run=GraphQLResult(
-                {"id": "id", "flow": {"storage": Docker().serialize(), "id": "foo"}},
+                {
+                    "id": "id",
+                    "flow": {
+                        "storage": Docker().serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    },
+                },
             )
         )
 
@@ -358,7 +387,9 @@ def test_local_agent_deploy_storage_fails_none(monkeypatch, cloud_api):
         agent.deploy_flow(
             flow_run=GraphQLResult(
                 {
-                    "flow": GraphQLResult({"storage": None, "id": "foo"}),
+                    "flow": GraphQLResult(
+                        {"storage": None, "id": "foo", "core_version": "0.13.0"}
+                    ),
                     "id": "id",
                     "version": 1,
                 }
@@ -380,7 +411,11 @@ def test_local_agent_deploy_import_paths(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": Local(directory="test").serialize(), "id": "foo"}
+                    {
+                        "storage": Local(directory="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -403,7 +438,11 @@ def test_local_agent_deploy_keep_existing_python_path(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": Local(directory="test").serialize(), "id": "foo"}
+                    {
+                        "storage": Local(directory="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -429,7 +468,11 @@ def test_local_agent_deploy_no_existing_python_path(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": Local(directory="test").serialize(), "id": "foo"}
+                    {
+                        "storage": Local(directory="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }
@@ -471,7 +514,7 @@ def test_local_agent_heartbeat(
     popen = MockPopen()
     # expect a process to be called with the following command (with specified behavior)
     popen.set_command(
-        "prefect execute cloud-flow",
+        "prefect execute flow-run",
         stdout=b"awesome output!",
         stderr=b"blerg, eRroR!",
         returncode=returncode,
@@ -484,7 +527,11 @@ def test_local_agent_heartbeat(
         flow_run=GraphQLResult(
             {
                 "flow": GraphQLResult(
-                    {"storage": Local(directory="test").serialize(), "id": "foo"}
+                    {
+                        "storage": Local(directory="test").serialize(),
+                        "id": "foo",
+                        "core_version": "0.13.0",
+                    }
                 ),
                 "id": "id",
             }


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Adds an agent utility for determining the flow run execution command based on the version of the flow. For core_version < `0.13.0` it will use `execute cloud-flow` and for versions >= `0.13.0` it will use `execute flow-run`.


## Why is this PR important?
Maintain backwards compatibility while also respecting the deprecation of commands

