### PR TITLE
Update changelog generation to handle .yml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Released on August 6, 2020.
 - Gracefully recover from version lock errors - [#2731](https://github.com/PrefectHQ/prefect/issues/2731
 - Add `--ui-version` server start CLI option to run a specific UI image - [#3087](https://github.com/PrefectHQ/prefect/pull/3087)
 - Agent querying of flow runs now passes active tenant ID - [#3087](https://github.com/PrefectHQ/prefect/pull/3087)
+- Ignore calls to flow.register when parsing a flow using file based storage - [#3051](https://github.com/PrefectHQ/prefect/issues/3051)
 
 ### Task Library
 
@@ -50,6 +51,7 @@ Released on August 6, 2020.
 
 - [James Lamb](https://github.com/jameslamb)
 - [Pravin Dahal](https://github.com/pravindahal)
+- [Panagiotis Simakis](https://github.com/sp1thas)
 
 ## 0.12.6 <Badge text="beta" type="success" />
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Released on August 6, 2020.
 
 ### Enhancements
 
-- Only supply versions when setting `SUBMITTED` and `RUNNING` states - [#2730](https://github.com/PrefectHQ/prefect/issues/2730
-- Gracefully recover from version lock errors - [#2731](https://github.com/PrefectHQ/prefect/issues/2731
+- Only supply versions when setting `SUBMITTED` and `RUNNING` states - [#2730](https://github.com/PrefectHQ/prefect/issues/2730)
+- Gracefully recover from version lock errors - [#2731](https://github.com/PrefectHQ/prefect/issues/2731)
 - Add `--ui-version` server start CLI option to run a specific UI image - [#3087](https://github.com/PrefectHQ/prefect/pull/3087)
 - Agent querying of flow runs now passes active tenant ID - [#3087](https://github.com/PrefectHQ/prefect/pull/3087)
 - Ignore calls to flow.register when parsing a flow using file based storage - [#3051](https://github.com/PrefectHQ/prefect/issues/3051)

--- a/changes/issue3051.yml
+++ b/changes/issue3051.yml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Ignore calls to flow.register when parsing a flow using file based storage` - [#3051](https://github.com/PrefectHQ/prefect/issues/3051)"
-
-contributor:
-  - "[Panagiotis Simakis](https://github.com/sp1thas)"

--- a/update_changelog.py
+++ b/update_changelog.py
@@ -33,6 +33,7 @@ CHANGES_DIR = os.path.join(REPO_DIR, "changes")
 
 def get_change_files():
     change_files = sorted(glob.glob(os.path.join(CHANGES_DIR, "*.yaml")))
+    change_files.extend(sorted(glob.glob(os.path.join(CHANGES_DIR, "*.yml"))))
     change_files = [p for p in change_files if not p.endswith("EXAMPLE.yaml")]
     return change_files
 


### PR DESCRIPTION
This change update was left off of the `0.13.0` changelog due to it being a `.yml` instead of a `.yaml` so I updated the changelog script to accept both of these formats. I also manually updated the release notes and changelog to account for the missing entry.