### PR TITLE
Run tasks at most once with Dask multiprocessing

### DIFF
--- a/changes/pr3127.yaml
+++ b/changes/pr3127.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug with `LocalDaskExecutor('processes')` that allowed tasks to be run multiple times in certain cases - [#3127](https://github.com/PrefectHQ/prefect/pull/3127)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 7.0
 cloudpickle >=0.6.0
 croniter >= 0.3.24, <1.0
-dask >= 2.8.0
+dask >= 2.15.0
 distributed >= 2.8.0
 docker >=3.4.1
 marshmallow >= 3.0.0b19


### PR DESCRIPTION
Previously we added a dask scheduler plugin to cache tasks submitted
multiple times through the `LocalDaskExecutor`. This fixed several
issues with the `LocalDaskExecutor` running tasks twice, but fails in
certain cases when running with `scheduler="processes"`. Dask's
multiprocessing scheduler runs a task-fusion optimization pass, which
doesn't play well with our scheduler plugin. Task fusion results in
tasks embedded inside other tasks, which prevents the plugin from
finding and removing tasks submitted twice.

Unfortunately the multiprocessing scheduler doesn't expose the option to
disable the call to `fuse` in a way that can be disabled locally, so for
now we disable task fusion globally when using the multiprocessing
scheduler. Since user code will run in external processes in this case,
the global config shouldn't affect user code.

Fixes #3124.

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)