### PR TITLE
Remove extra UUID labels from jobs created by the kubernetes agent

### DIFF
--- a/changes/pr3129.yaml
+++ b/changes/pr3129.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Clean up extra labels on jobs created by Kubernetes agent - [#3129](https://github.com/PrefectHQ/prefect/pull/3129)"

--- a/src/prefect/agent/kubernetes/job_spec.yaml
+++ b/src/prefect/agent/kubernetes/job_spec.yaml
@@ -1,16 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: prefect-job-UUID
-  labels:
-    app: prefect-job-UUID
-    identifier: UUID
+  name: prefect-job
+  labels: {}
 spec:
   template:
     metadata:
-      labels:
-        app: prefect-job-UUID
-        identifier: UUID
+      labels: {}
     spec:
       containers:
         - name: flow


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
A while ago we switched to using `prefect.io/` labels for jobs created by the kubernetes agent and these UUID labels are no longer needed.


## Why is this PR important?
Remove some unnecessary labels from the flow run job manifest

