### PR TITLE
Added backend_info toggle for slack_notifier

### DIFF
--- a/changes/pr3136.yml
+++ b/changes/pr3136.yml
@@ -1,2 +1,5 @@
 fix:
-  - "Add toggle to bypass bug in slack_notifier that attempted to connect to backend even if the backend didn't exist. - [#3136](https://github.com/PrefectHQ/prefect/pull/3136)"
+  - "Add toggle to bypass bug in slack_notifier that attempted to connect to backend even if the backend didn't exist - [#3136](https://github.com/PrefectHQ/prefect/pull/3136)"
+
+contributor:
+  - "[Fraznist](https://github.com/Fraznist)"

--- a/changes/pr3136.yml
+++ b/changes/pr3136.yml
@@ -1,0 +1,2 @@
+fix:
+  - "Add toggle to bypass bug in slack_notifier that attempted to connect to backend even if the backend didn't exist. - [#3136](https://github.com/PrefectHQ/prefect/pull/3136)"

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -124,7 +124,7 @@ def email_message_formatter(
 def slack_message_formatter(
     tracked_obj: TrackedObjectType,
     state: "prefect.engine.state.State",
-    backend_info: bool=True,
+    backend_info: bool = True,
 ) -> dict:
     # see https://api.slack.com/docs/message-attachments
     fields = []

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -124,7 +124,7 @@ def email_message_formatter(
 def slack_message_formatter(
     tracked_obj: TrackedObjectType,
     state: "prefect.engine.state.State",
-    backend_info: bool,
+    backend_info: bool=True,
 ) -> dict:
     # see https://api.slack.com/docs/message-attachments
     fields = []

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -270,6 +270,8 @@ def slack_notifier(
             classes
         - webhook_secret (str, optional): the name of the Prefect Secret that stores your slack
             webhook URL; defaults to `"SLACK_WEBHOOK_URL"`
+        - backend_info (bool, optional): Whether to supply slack notification with urls
+            pointing to backend pages; defaults to True
 
     Returns:
         - State: the `new_state` object that was provided

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -122,7 +122,9 @@ def email_message_formatter(
 
 
 def slack_message_formatter(
-    tracked_obj: TrackedObjectType, state: "prefect.engine.state.State"
+    tracked_obj: TrackedObjectType,
+    state: "prefect.engine.state.State",
+    backend_info: bool,
 ) -> dict:
     # see https://api.slack.com/docs/message-attachments
     fields = []
@@ -148,7 +150,7 @@ def slack_message_formatter(
         "footer": "Prefect notification",
     }
 
-    if prefect.context.get("flow_run_id"):
+    if backend_info and prefect.context.get("flow_run_id"):
         url = None
 
         if isinstance(tracked_obj, prefect.Flow):
@@ -247,6 +249,7 @@ def slack_notifier(
     ignore_states: list = None,
     only_states: list = None,
     webhook_secret: str = None,
+    backend_info: bool = True,
 ) -> "prefect.engine.state.State":
     """
     Slack state change handler; requires having the Prefect slack app installed.  Works as a
@@ -302,7 +305,7 @@ def slack_notifier(
     # the 'import prefect' time low
     import requests
 
-    form_data = slack_message_formatter(tracked_obj, new_state)
+    form_data = slack_message_formatter(tracked_obj, new_state, backend_info)
     r = requests.post(webhook_url, json=form_data)
     if not r.ok:
         raise ValueError("Slack notification for {} failed".format(tracked_obj))


### PR DESCRIPTION
backend_info toggle (default=true) enables or disables supplementing
the notification with urls from prefect server/cloud. Message formatter
queries the graphql for a flow/task url only if backend_info=True.

Fixes #2930 and #3133 

**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?



## Why is this PR important?


