### PR TITLE
Healthcheck raise Warning instead of Exception when result types are not present

### DIFF
--- a/changes/pr3146.yaml
+++ b/changes/pr3146.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Raise Warning instead of Exception during storage healthcheck when Result type is not provided - [#3146](https://github.com/PrefectHQ/prefect/pull/3146)"

--- a/src/prefect/environments/storage/_healthcheck.py
+++ b/src/prefect/environments/storage/_healthcheck.py
@@ -69,7 +69,7 @@ def result_check(flows: list):
                     if e.key is not None
                 ]
             ):
-                raise ValueError(
+                warnings.warn(
                     f"Task {task} has retry settings but some upstream dependencies do not "
                     f"have result types. See https://docs.prefect.io/core/concepts/results.html "
                     f"for more details."
@@ -79,7 +79,7 @@ def result_check(flows: list):
         cached_tasks = [t for t in flow.tasks if t.cache_for is not None]
         for task in cached_tasks:
             if task.result is None:
-                raise ValueError(
+                warnings.warn(
                     f"Task {task} has cache settings but does not have a result type. "
                     f"See https://docs.prefect.io/core/concepts/results.html for more "
                     f"details."
@@ -91,7 +91,7 @@ def result_check(flows: list):
                     if e.key is not None
                 ]
             ):
-                raise ValueError(
+                warnings.warn(
                     f"Task {task} has cache settings but some upstream dependencies do not have "
                     f"result types. See https://docs.prefect.io/core/concepts/results.html for "
                     f"more details."

--- a/tests/environments/storage/test_docker_healthcheck.py
+++ b/tests/environments/storage/test_docker_healthcheck.py
@@ -147,8 +147,8 @@ class TestResultCheck:
         with Flow("upstream-test") as f:
             result = down(x=up)
 
-        with pytest.raises(
-            ValueError, match="upstream dependencies do not have result types."
+        with pytest.warns(
+            UserWarning, match="upstream dependencies do not have result types."
         ):
             healthchecks.result_check([f])
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Updates the healthcheck script to raise a warning instead of an exception when upstream tasks do not have a result type set and things like retries/caching are used.


## Why is this PR important?
There is potential for things like retries to happen in the same process if their delay is short enough and in that case the result wouldn't be necessary.

