### PR TITLE
Update apollo service in docker compose to wait for graphql service

### DIFF
--- a/changes/pr3150.yaml
+++ b/changes/pr3150.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Apollo service error output while waiting for GraphQL service with `prefect server start` - [#3150](https://github.com/PrefectHQ/prefect/pull/3150)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -64,12 +64,14 @@ services:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
       - "${APOLLO_HOST_PORT:-4200}:4200"
-    command: "npm run serve"
+    command: bash -c "./post-start.sh && npm run serve"
     environment:
       HASURA_API_URL: ${HASURA_API_URL:-http://hasura:3000/v1alpha1/graphql}
       PREFECT_API_URL: ${PREFECT_API_URL:-http://graphql:4201/graphql/}
       PREFECT_API_HEALTH_URL: ${PREFECT_API_HEALTH_URL:-http://graphql:4201/health}
       PREFECT_SERVER__TELEMETRY__ENABLED: ${PREFECT_SERVER__TELEMETRY__ENABLED:-true}
+      GRAPHQL_SERVICE_HOST: http://graphql
+      GRAPHQL_SERVICE_PORT: ${GRAPHQL_HOST_PORT:-4201}
     networks:
       - prefect-server
     restart: "always"


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR makes use of server's `post-start.sh` to have the apollo service properly wait for the graphql service to be running and healthy.

This PR depends on https://github.com/PrefectHQ/server/pull/41

## Why is this PR important?

In its current form we will commonly see an error when running `prefect server start` that looks like:
```
apollo_1    |
apollo_1    | > @ serve /apollo
apollo_1    | > node dist/index.js
apollo_1    |
apollo_1    | Building schema...
apollo_1    | { FetchError: request to http://graphql:4201/graphql/ failed, reason: connect ECONNREFUSED 172.31.0.4:4201
apollo_1    |     at ClientRequest.<anonymous> (/apollo/node_modules/node-fetch/lib/index.js:1455:11)
apollo_1    |     at ClientRequest.emit (events.js:182:13)
apollo_1    |     at Socket.socketErrorListener (_http_client.js:392:9)
apollo_1    |     at Socket.emit (events.js:182:13)
apollo_1    |     at emitErrorNT (internal/streams/destroy.js:82:8)
apollo_1    |     at emitErrorAndCloseNT (internal/streams/destroy.js:50:3)
apollo_1    |     at process._tickCallback (internal/process/next_tick.js:63:19)
apollo_1    |   message:
apollo_1    |    'request to http://graphql:4201/graphql/ failed, reason: connect ECONNREFUSED 172.31.0.4:4201',
apollo_1    |   type: 'system',
apollo_1    |   errno: 'ECONNREFUSED',
apollo_1    |   code: 'ECONNREFUSED' }
apollo_1    | Trying again in 3 seconds...
```

This is due to docker-compose telling apollo it can start because the graphql container is up however the graphql service has not finished standing itself up—thus leading to this error. This error output can be confusing to new users.