### PR TITLE
Make client robust to simple json

### DIFF
--- a/changes/issue3151.yaml
+++ b/changes/issue3151.yaml
@@ -2,4 +2,4 @@ enhancement:
   - "Make Client robust to simplejson - [#3151](https://github.com/PrefectHQ/prefect/issues/3151)"
 
 contributor:
-  - "[Contributor Name](https://github.com/zangell44)"
+  - "[Zach Angell](https://github.com/zangell44)"

--- a/changes/issue3151.yaml
+++ b/changes/issue3151.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Make Client robust to simplejson - [#3151](https://github.com/PrefectHQ/prefect/issues/3151)"
+
+contributor:
+  - "[Contributor Name](https://github.com/zangell44)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -9,6 +9,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 from urllib.parse import urljoin
 
+# if simplejson is installed, `requests` defaults to using it instead of json
+# this allows the client to gracefully handle either json or simplejson
+try:
+    from simplejson.errors import JSONDecodeError
+except ImportError:
+    from json.decoder import JSONDecodeError
+
 import pendulum
 import toml
 from slugify import slugify
@@ -397,7 +404,7 @@ class Client:
         # parse the response
         try:
             json_resp = response.json()
-        except json.JSONDecodeError:
+        except JSONDecodeError:
             if prefect.config.backend == "cloud" and "Authorization" not in headers:
                 raise ClientError(
                     "Malformed response received from Cloud - please ensure that you "


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?

This PR updates error handling in `Client._request` to handle situations in which the `requests` module defaults to using `simplejson` instead of json.

## Why is this PR important?

Without some dynamic error handling here, `Client._request` will raise `simplejson.errors.JSONDecoderError` instead of handling the exception and providing useful feedback to the user.
