### PR TITLE
Update pypi stats badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </a>
 
 <a href="https://pypi.org/project/prefect/">
-    <img src="https://static.pepy.tech/badge/prefect">
+    <img src="https://static.pepy.tech/badge/prefect/month">
 </a>
 
 <a href="https://hub.docker.com/r/prefecthq/prefect">

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </a>
 
 <a href="https://pypi.org/project/prefect/">
-    <img src="https://img.shields.io/pypi/dm/prefect.svg?color=%2327B1FF&label=installs&logoColor=%234D606E">
+    <img src="https://static.pepy.tech/badge/prefect">
 </a>
 
 <a href="https://hub.docker.com/r/prefecthq/prefect">


### PR DESCRIPTION
It appears as if the API which powered the badge prior is now down (https://github.com/crflynn/pypistats.org/issues/29). If we want we could switch to this badge for the meantime