### PR TITLE
Remove imagePullSecrets from prefect k8s job if not set

### DIFF
--- a/changes/issue3142.yaml
+++ b/changes/issue3142.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix empty string `imagePullSecrets` issue on AKS by removing if not set - [#3142](https://github.com/PrefectHQ/prefect/issues/3142)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -197,9 +197,11 @@ class KubernetesAgent(Agent):
             env.append(dict(name=key, value=value))
 
         # Use image pull secrets if provided
-        job["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"] = os.getenv(
-            "IMAGE_PULL_SECRETS", ""
-        )
+        image_pull_secrets = os.getenv("IMAGE_PULL_SECRETS")
+        if image_pull_secrets:
+            job["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"] = image_pull_secrets
+        else:
+            del job["spec"]["template"]["spec"]["imagePullSecrets"]
 
         # Set resource requirements if provided
         resources = job["spec"]["template"]["spec"]["containers"][0]["resources"]

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -199,7 +199,9 @@ class KubernetesAgent(Agent):
         # Use image pull secrets if provided
         image_pull_secrets = os.getenv("IMAGE_PULL_SECRETS")
         if image_pull_secrets:
-            job["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"] = image_pull_secrets
+            job["spec"]["template"]["spec"]["imagePullSecrets"][0][
+                "name"
+            ] = image_pull_secrets
         else:
             del job["spec"]["template"]["spec"]["imagePullSecrets"]
 

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -351,7 +351,7 @@ def test_k8s_agent_replace_yaml_no_pull_secrets(monkeypatch, cloud_api):
     agent = KubernetesAgent()
     job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
 
-    assert not job["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+    assert not job["spec"]["template"]["spec"].get("imagePullSecrets", None)
 
 
 def test_k8s_agent_includes_agent_labels_in_job(monkeypatch, cloud_api):


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #3142 

We can safely remove the `imagePullSecrets` field from the prefect job if not set. Previously it was set to `""` which could cause issues if container authentication is set at a higher level.


## Why is this PR important?
Ensure deployments operate properly on AKS

