### PR TITLE
Make kubernetes extra logger in DaskKubernetesEnvironment optional

### DIFF
--- a/changes/issue2988.yaml
+++ b/changes/issue2988.yaml
@@ -1,2 +1,5 @@
 enhancement:
   - "Make use of `kubernetes` extra logger in the `DaskKubernetesEnvironment` optional - [#2988](https://github.com/PrefectHQ/prefect/issues/2988)"
+
+breaking:
+  - "DaskKubernetesEnvironment no longer logs Kubernetes errors by default - [#2988](https://github.com/PrefectHQ/prefect/issues/2988)"

--- a/changes/issue2988.yaml
+++ b/changes/issue2988.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Make use of `kubernetes` extra logger in the `DaskKubernetesEnvironment` optional - [#2988](https://github.com/PrefectHQ/prefect/issues/2988)"

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -328,7 +328,7 @@ class DaskKubernetesEnvironment(Environment):
             "distributed.deploy.adaptive",
         ]
 
-        if self.log_k8s_erros:
+        if self.log_k8s_errors:
             cluster_loggers.append("kubernetes")
 
         config_extra_loggers = prefect.config.logging.extra_loggers

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -119,7 +119,7 @@ class DaskKubernetesEnvironment(Environment):
         self._scheduler_spec, self._worker_spec = self._load_specs_from_file()
 
         self._identifier_label = ""
-        self.log_k8s_erros = log_k8s_errors
+        self.log_k8s_errors = log_k8s_errors
 
         super().__init__(
             labels=labels, on_start=on_start, on_exit=on_exit, metadata=metadata

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -75,6 +75,8 @@ class DaskKubernetesEnvironment(Environment):
         - image_pull_secret (str, optional): optional name of an `imagePullSecret` to use for
             the scheduler and worker pods. For more information go
             [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+        - log_k8s_errors (bool, optional): optional toggle to also log Kubernetes errors that may occur
+            using the Prefect logger. Defaults to `False`.
     """
 
     def __init__(
@@ -92,6 +94,7 @@ class DaskKubernetesEnvironment(Environment):
         scheduler_spec_file: str = None,
         worker_spec_file: str = None,
         image_pull_secret: str = None,
+        log_k8s_errors: bool = False,
     ) -> None:
         self.min_workers = min_workers
         self.max_workers = max_workers
@@ -116,6 +119,7 @@ class DaskKubernetesEnvironment(Environment):
         self._scheduler_spec, self._worker_spec = self._load_specs_from_file()
 
         self._identifier_label = ""
+        self.log_k8s_erros = log_k8s_errors
 
         super().__init__(
             labels=labels, on_start=on_start, on_exit=on_exit, metadata=metadata
@@ -322,8 +326,11 @@ class DaskKubernetesEnvironment(Environment):
         cluster_loggers = [
             "dask_kubernetes.core",
             "distributed.deploy.adaptive",
-            "kubernetes",
         ]
+
+        if self.log_k8s_erros:
+            cluster_loggers.append("kubernetes")
+
         config_extra_loggers = prefect.config.logging.extra_loggers
 
         extra_loggers = [*config_extra_loggers, *cluster_loggers]

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -232,7 +232,9 @@ def test_environment_run(monkeypatch):
 
 
 def test_populate_job_yaml():
-    environment = DaskKubernetesEnvironment(work_stealing=True, scheduler_logs=True)
+    environment = DaskKubernetesEnvironment(
+        work_stealing=True, scheduler_logs=True, log_k8s_errors=True
+    )
 
     file_path = os.path.dirname(prefect.environments.execution.dask.k8s.__file__)
 
@@ -314,7 +316,7 @@ def test_populate_worker_pod_yaml():
     assert env[2]["value"] == "id_test"
     assert (
         env[10]["value"]
-        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive', 'kubernetes']"
+        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
     assert yaml_obj["spec"]["containers"][0]["image"] == "my_image"
@@ -415,7 +417,7 @@ def test_populate_custom_worker_spec_yaml(log_flag):
     assert env[7]["value"] == str(log_flag).lower()
     assert (
         env[8]["value"]
-        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive', 'kubernetes']"
+        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
     assert yaml_obj["spec"]["containers"][0]["image"] == "my_image"
@@ -462,7 +464,7 @@ def test_populate_custom_scheduler_spec_yaml(log_flag):
     assert env[9]["value"] == str(log_flag).lower()
     assert (
         env[10]["value"]
-        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive', 'kubernetes']"
+        == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
     assert (


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
Closes #2988 
Adds a new kwarg to the DaskKubernetesEnvironment `log_k8s_errors` which can be used to toggle the use of the `kubernetes` extra logger.


## Why is this PR important?
Could lead to logging unintended information so we should make this opt-in

