### PR TITLE
Fix bug with retrieving cached states when cache_key is None

### DIFF
--- a/changes/pr3168.yaml
+++ b/changes/pr3168.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - 'Fix querying for cached states with no `cache_key` - [#3168](https://github.com/PrefectHQ/prefect/pull/3168)'

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1161,7 +1161,7 @@ class Client:
             },
             "order_by": {"state_timestamp": EnumValue("desc")},
             "limit": 100,
-        }
+        }  # type: Dict[str, Any]
 
         # if a cache key was provided, match it against all tasks
         if cache_key is not None:

--- a/src/prefect/environments/storage/webhook.py
+++ b/src/prefect/environments/storage/webhook.py
@@ -210,12 +210,12 @@ class Webhook(Storage):
 
         if build_request_http_method not in self._method_to_function.keys():
             msg = "HTTP method '{}' not recognized".format(build_request_http_method)
-            self.logger.fatal(msg)
+            self.logger.critical(msg)
             raise RuntimeError(msg)
 
         if get_flow_request_http_method not in self._method_to_function.keys():
             msg = "HTTP method '{}' not recognized".format(get_flow_request_http_method)
-            self.logger.fatal(msg)
+            self.logger.critical(msg)
             raise RuntimeError(msg)
 
         self.stored_as_script = stored_as_script
@@ -357,14 +357,14 @@ class Webhook(Storage):
                 # so that serialization and deserialization of flows doesnot fail
                 if not self.flow_script_path:
                     msg = "flow_script_path must be provided if stored_as_script=True"
-                    self.logger.fatal(msg)
+                    self.logger.critical(msg)
                     raise RuntimeError(msg)
 
                 if not os.path.isfile(self.flow_script_path):
                     msg = "file '{}' passed to flow_script_path does not exist".format(
                         self.flow_script_path
                     )
-                    self.logger.fatal(msg)
+                    self.logger.critical(msg)
                     raise RuntimeError(msg)
 
                 with open(self.flow_script_path, "r") as f:


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR fixes a bug when querying for cached states that match a given task id and cache key. The old logic was this:
```python
		"where": {
                "state": {"_eq": "Cached"},	                
                "_or": [	
                    {	
                        "_and": [	
                            {"cache_key": {"_eq": cache_key}},	### NOTE THIS LINE
                            {"cache_key": {"_is_null": False}},	
                        ]	
                    },	
                    {"task_id": {"_eq": task_id}},	
                ],	
                "state_timestamp": {"_gte": created_after.isoformat()},
```


When Hasura receives an equality of `null`, it [ignores it](https://hasura.io/docs/1.0/graphql/manual/queries/query-filters.html#evaluation-of-null-values-in-comparision-expressions). This means that if `cache_key=None`, the annotated line above is ignored, and the where clause essentially reduces to:

```
where:
    or:
        cache_key is not null
        task_id = <task id>
```

Thus, when `cache_key=None`, the query matches ALL non-null cache keys AND all cached states of the current task id. This is not the correct logic.

This PR updates the query to have one of two where clauses. If the cache key is provided, then the where clause matches all tasks with the same cache key. If no cache key is provided, then the where clause matches all cached states of the provided task id.

In addition, due to the possibility of enormous numbers of results, this PR adds a limit of 100 to the query.