### PR TITLE
Update API error retry delay to be a little more conservative

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -427,7 +427,7 @@ class Client:
                 )
                 if "API_ERROR" in str(response.json().get("errors")):
                     retry_count += 1
-                    time.sleep(0.1 * (2 ** (retry_count - 1)))
+                    time.sleep(0.25 * (2 ** (retry_count - 1)))
                 else:
                     success = True
 


### PR DESCRIPTION
**Thanks for contributing to Prefect!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note that your PR will not be reviewed unless all three boxes are checked.

## What does this PR change?
This PR makes the API error backoff a little more conservative.


## Why is this PR important?
Previously the retry happened so quickly it's not clear that it had any benefit.  This should extend the longest sleep to around 8 seconds which is a decent amount of time for things to change.