### PR TITLE
Remove heartbeat from graphql

### DIFF
--- a/src/prefect/cli/describe.py
+++ b/src/prefect/cli/describe.py
@@ -240,7 +240,6 @@ def flow_runs(name, flow_name, output):
                 "start_time": True,
                 "end_time": True,
                 "duration": True,
-                "heartbeat": True,
                 "serialized_state": True,
             }
         }

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -261,7 +261,6 @@ def test_describe_flow_runs(monkeypatch, cloud_api):
             start_time
             end_time
             duration
-            heartbeat
             serialized_state
         }
     }
@@ -319,7 +318,6 @@ def test_describe_flow_runs_populated(monkeypatch, cloud_api):
             start_time
             end_time
             duration
-            heartbeat
             serialized_state
         }
     }


### PR DESCRIPTION
## What does this PR change?
Removes a query for run heartbeat to align with proposed changes in https://github.com/PrefectHQ/cloud/pull/2620 / https://github.com/PrefectHQ/cloud/pull/2621


