### PR TITLE
Add support for `host_config` and arbitrary keyword arguments in Docker tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released on August 11, 2020.
 ### Task Library
 
 - Return `LoadJob` object in `BigQueryLoad` tasks - [#3086](https://github.com/PrefectHQ/prefect/issues/3086)
+- Add support for [`host_config`](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config) and arbitrary keyword arguments in `Docker` tasks.
 
 ### Fixes
 
@@ -28,6 +29,7 @@ Released on August 11, 2020.
 - [Franklin Winokur](https://github.com/fwinokur)
 - [Fraznist](https://github.com/Fraznist)
 - [Jackson Maxfield Brown](https://github.com/JacksonMaxfield)
+- [Nelson Cornet](https://github.com/sk4la)
 
 ## 0.13.1 <Badge text="beta" type="success" />
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Released on August 11, 2020.
 ### Task Library
 
 - Return `LoadJob` object in `BigQueryLoad` tasks - [#3086](https://github.com/PrefectHQ/prefect/issues/3086)
-- Add support for [`host_config`](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config) and arbitrary keyword arguments in `Docker` tasks.
 
 ### Fixes
 
@@ -29,7 +28,6 @@ Released on August 11, 2020.
 - [Franklin Winokur](https://github.com/fwinokur)
 - [Fraznist](https://github.com/Fraznist)
 - [Jackson Maxfield Brown](https://github.com/JacksonMaxfield)
-- [Nelson Cornet](https://github.com/sk4la)
 
 ## 0.13.1 <Badge text="beta" type="success" />
 

--- a/changes/pr3173.yaml
+++ b/changes/pr3173.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Add support for [`host_config`](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config) and arbitrary keyword arguments in `Docker` tasks - [#3173](https://github.com/PrefectHQ/prefect/pull/3173)"
+
+contributor:
+  - "[Nelson Cornet](https://github.com/sk4la)"

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Optional
+from typing import Any, Union
 
 from prefect import Task
 from prefect.engine.signals import FAIL
@@ -15,17 +15,20 @@ class CreateContainer(Task):
         - container_name (str, optional): A name for the container
         - command (Union[list, str], optional): A single command or a list of commands to run
         - detach (bool, optional): Run container in the background
-        - entrypoint (Union[str, list]): The entrypoint for the container
-        - environment (Union[dict, list]): Environment variables to set inside the container,
+        - entrypoint (Union[str, list], optional): The entrypoint for the container
+        - environment (Union[dict, list], optional): Environment variables to set inside the container,
             as a dictionary or a list of strings in the format ["SOMEVARIABLE=xxx"]
-        - volumes (Union[dict, list]): Volumes to mount inside the container, as a dictionary
-            or a list of strings in the format ["/path/host:/path/guest:ro"]. See
-            https://docker-py.readthedocs.io/en/stable/containers.html for more details
+        - volumes (Union[str, list], optional): List of paths inside the container to use as volumes
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra kwargs to pass through to `create_container`
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - host_config (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `create_host_config`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `create_container`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -37,10 +40,11 @@ class CreateContainer(Task):
         detach: bool = False,
         entrypoint: Union[list, str] = None,
         environment: Union[list, dict] = None,
-        volumes: Union[list, dict] = None,
+        volumes: Union[str, list] = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        extra_docker_kwargs: Optional[dict] = None,
-        **kwargs: Any
+        host_config: dict = None,
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.image_name = image_name
         self.container_name = container_name
@@ -50,7 +54,9 @@ class CreateContainer(Task):
         self.environment = environment
         self.volumes = volumes
         self.docker_server_url = docker_server_url
+        self.host_config = host_config
         self.extra_docker_kwargs = extra_docker_kwargs
+
         super().__init__(**kwargs)
 
     @defaults_from_attrs(
@@ -62,6 +68,7 @@ class CreateContainer(Task):
         "environment",
         "volumes",
         "docker_server_url",
+        "host_config",
         "extra_docker_kwargs",
     )
     def run(
@@ -72,9 +79,10 @@ class CreateContainer(Task):
         detach: bool = False,
         entrypoint: Union[list, str] = None,
         environment: Union[list, dict] = None,
-        volumes: Union[list, dict] = None,
+        volumes: Union[str, list] = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        extra_docker_kwargs: Optional[dict] = None,
+        host_config: dict = None,
+        extra_docker_kwargs: dict = None,
     ) -> str:
         """
         Task run method.
@@ -87,13 +95,16 @@ class CreateContainer(Task):
             - entrypoint (Union[str, list]): The entrypoint for the container
             - environment (Union[dict, list]): Environment variables to set inside the container,
                 as a dictionary or a list of strings in the format ["SOMEVARIABLE=xxx"]
-            - volumes (Union[dict, list]): Volumes to mount inside the container, as a dictionary
-                or a list of strings in the format ["/path/host:/path/guest:ro"]. See
-                https://docker-py.readthedocs.io/en/stable/containers.html for more details
+            - volumes (Union[str, list], optional): List of paths inside the container to use as volumes
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra kwargs to pass through to `create_container`
+            - host_config (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `create_host_config`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `create_container`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - str: A string representing the container id
@@ -109,10 +120,12 @@ class CreateContainer(Task):
         import docker
 
         client = docker.APIClient(base_url=docker_server_url, version="auto")
+
+        if host_config is not None:
+            host_config = client.create_host_config(**host_config)
+
         self.logger.debug(
-            "Starting to create container {} with command {}".format(
-                image_name, command
-            )
+            f"Creating container from image {image_name} with command: {command}"
         )
         container = client.create_container(
             image=image_name,
@@ -122,13 +135,17 @@ class CreateContainer(Task):
             entrypoint=entrypoint,
             environment=environment,
             volumes=volumes,
-            **(self.extra_docker_kwargs or dict())
-        )
-        self.logger.debug(
-            "Completed created container {} with command {}".format(image_name, command)
+            host_config=host_config,
+            **(extra_docker_kwargs or dict()),
         )
 
-        return container.get("Id")
+        container_id = container.get("Id")
+
+        self.logger.debug(
+            f"Created container {container_id} from image {image_name} with command: {command}"
+        )
+
+        return container_id
 
 
 class GetContainerLogs(Task):
@@ -141,7 +158,10 @@ class GetContainerLogs(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `logs`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -149,18 +169,21 @@ class GetContainerLogs(Task):
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url")
+    @defaults_from_attrs("container_id", "docker_server_url", "extra_docker_kwargs")
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> str:
         """
         Task run method.
@@ -170,6 +193,9 @@ class GetContainerLogs(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `logs`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - str: A string representation of the logs from the container
@@ -184,19 +210,16 @@ class GetContainerLogs(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting fetching container logs from container with id {}".format(
-                container_id
-            )
-        )
+        self.logger.debug(f"Gathering logs from container {container_id}")
 
         client = docker.APIClient(base_url=docker_server_url, version="auto")
-        api_result = client.logs(container=container_id).decode()
-        self.logger.debug(
-            "Completed fetching all container logs from container with id {}".format(
-                container_id
-            )
-        )
+
+        api_result = client.logs(
+            container=container_id, **(extra_docker_kwargs or dict())
+        ).decode()
+
+        self.logger.debug(f"Gathered logs from container {container_id}")
+
         return api_result
 
 
@@ -213,7 +236,10 @@ class ListContainers(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `containers`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -222,20 +248,25 @@ class ListContainers(Task):
         all_containers: bool = False,
         filters: dict = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.all_containers = all_containers
         self.filters = filters
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("all_containers", "filters", "docker_server_url")
+    @defaults_from_attrs(
+        "all_containers", "filters", "docker_server_url", "extra_docker_kwargs"
+    )
     def run(
         self,
         all_containers: bool = False,
         filters: dict = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> list:
         """
         Task run method.
@@ -248,6 +279,9 @@ class ListContainers(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `container`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - list: A list of dicts, one per container
@@ -256,10 +290,12 @@ class ListContainers(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug("Starting to list containers")
+        self.logger.debug("Listing all containers")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
-        api_result = client.containers(all=all_containers, filters=filters)
-        self.logger.debug("Completed listing containers")
+        api_result = client.containers(
+            all=all_containers, filters=filters, **(extra_docker_kwargs or dict())
+        )
+        self.logger.debug("Listed all containers")
         return api_result
 
 
@@ -273,7 +309,10 @@ class StartContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `start`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -281,18 +320,21 @@ class StartContainer(Task):
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url")
+    @defaults_from_attrs("container_id", "docker_server_url", "extra_docker_kwargs")
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -302,6 +344,9 @@ class StartContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `start`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -313,13 +358,11 @@ class StartContainer(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug("Starting container with id {}".format(container_id))
+        self.logger.debug(f"Starting container {container_id}")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        client.start(container=container_id)
-        self.logger.debug(
-            "Completed starting container with id {}".format(container_id)
-        )
+        client.start(container=container_id, **(extra_docker_kwargs or dict()))
+        self.logger.debug(f"Started container {container_id}")
 
 
 class StopContainer(Task):
@@ -332,7 +375,10 @@ class StopContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `stop`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -340,18 +386,21 @@ class StopContainer(Task):
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url")
+    @defaults_from_attrs("container_id", "docker_server_url", "extra_docker_kwargs")
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -361,6 +410,9 @@ class StopContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `stop`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -372,13 +424,11 @@ class StopContainer(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug("Starting to stop container with id {}".format(container_id))
+        self.logger.debug(f"Stopping container {container_id}")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        client.stop(container=container_id)
-        self.logger.debug(
-            "Completed stopping container with id {}".format(container_id)
-        )
+        client.stop(container=container_id, **(extra_docker_kwargs or dict()))
+        self.logger.debug(f"Stopped container {container_id}")
 
 
 class RemoveContainer(Task):
@@ -391,7 +441,10 @@ class RemoveContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `remove_container`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -399,18 +452,21 @@ class RemoveContainer(Task):
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url")
+    @defaults_from_attrs("container_id", "docker_server_url", "extra_docker_kwargs")
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -420,6 +476,9 @@ class RemoveContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `remove_container`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -431,15 +490,13 @@ class RemoveContainer(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting to remove container with id {}".format(container_id)
-        )
+        self.logger.debug(f"Removing container {container_id}")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        client.remove_container(container=container_id)
-        self.logger.debug(
-            "Completed removing container with id {}".format(container_id)
+        client.remove_container(
+            container=container_id, **(extra_docker_kwargs or dict())
         )
+        self.logger.debug(f"Removed container {container_id}")
 
 
 class WaitOnContainer(Task):
@@ -454,7 +511,10 @@ class WaitOnContainer(Task):
             can be provided
         - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal
             for a nonzero exit code; defaults to `True`
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `wait`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -463,20 +523,25 @@ class WaitOnContainer(Task):
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
         raise_on_exit_code: bool = True,
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.container_id = container_id
         self.docker_server_url = docker_server_url
         self.raise_on_exit_code = raise_on_exit_code
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("container_id", "docker_server_url", "raise_on_exit_code")
+    @defaults_from_attrs(
+        "container_id", "docker_server_url", "raise_on_exit_code", "extra_docker_kwargs"
+    )
     def run(
         self,
         container_id: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
         raise_on_exit_code: bool = True,
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -488,6 +553,9 @@ class WaitOnContainer(Task):
                 can be provided
             - raise_on_exit_code (bool, optional): whether to raise a `FAIL`
                 signal for a nonzero exit code; defaults to `True`
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `wait`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - dict: a dictionary with `StatusCode` and `Error` keys
@@ -504,12 +572,10 @@ class WaitOnContainer(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting to wait on container with id {}".format(container_id)
-        )
+        self.logger.debug(f"Waiting on container {container_id}")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        result = client.wait(container=container_id)
+        result = client.wait(container=container_id, **(extra_docker_kwargs or dict()))
         if raise_on_exit_code and (
             (result.get("Error") is not None) or result.get("StatusCode")
         ):
@@ -525,7 +591,6 @@ class WaitOnContainer(Task):
                     msg=result.get("Error"),
                 )
             )
-        self.logger.debug(
-            "Completed waiting on container with id {}".format(container_id)
-        )
+        self.logger.debug(f"Container {container_id} has finished")
+
         return result

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -26,7 +26,7 @@ class CreateContainer(Task):
             (cf. method `create_host_config`). See https://docker-py.readthedocs.io/en/stable/api.html
             for more details
         - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker
-            call (cf. method `create_container`). Seelol
+            call (cf. method `create_container`). See
             https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor

--- a/src/prefect/tasks/docker/containers.py
+++ b/src/prefect/tasks/docker/containers.py
@@ -25,9 +25,9 @@ class CreateContainer(Task):
         - host_config (dict, optional): Extra keyword arguments to pass through to the Docker call
             (cf. method `create_host_config`). See https://docker-py.readthedocs.io/en/stable/api.html
             for more details
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `create_container`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker
+            call (cf. method `create_container`). Seelol
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -100,11 +100,11 @@ class CreateContainer(Task):
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
             - host_config (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `create_host_config`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `create_container`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+                (cf. method `create_host_config`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Dockercall (cf. method `create_container`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - str: A string representing the container id
@@ -158,9 +158,9 @@ class GetContainerLogs(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `logs`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker
+            call (cf. method `logs`). See https://docker-py.readthedocs.io/en/stable/api.html for more
+            details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -193,9 +193,9 @@ class GetContainerLogs(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `logs`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `logs`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - str: A string representation of the logs from the container
@@ -236,9 +236,9 @@ class ListContainers(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `containers`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker
+            call (cf. method `containers`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -279,9 +279,9 @@ class ListContainers(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `container`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `container`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - list: A list of dicts, one per container
@@ -309,9 +309,9 @@ class StartContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `start`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `start`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -344,9 +344,9 @@ class StartContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `start`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `start`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -375,9 +375,9 @@ class StopContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `stop`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `stop`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -410,9 +410,9 @@ class StopContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `stop`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `stop`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -441,9 +441,9 @@ class RemoveContainer(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `remove_container`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `remove_container`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -476,9 +476,9 @@ class RemoveContainer(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `remove_container`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `remove_container`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Raises:
             - ValueError: if `container_id` is `None`
@@ -511,9 +511,9 @@ class WaitOnContainer(Task):
             can be provided
         - raise_on_exit_code (bool, optional): whether to raise a `FAIL` signal
             for a nonzero exit code; defaults to `True`
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `wait`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `wait`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -553,9 +553,9 @@ class WaitOnContainer(Task):
                 can be provided
             - raise_on_exit_code (bool, optional): whether to raise a `FAIL`
                 signal for a nonzero exit code; defaults to `True`
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `wait`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `wait`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - dict: a dictionary with `StatusCode` and `Error` keys

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -19,7 +19,10 @@ class ListImages(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `images`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -29,17 +32,23 @@ class ListImages(Task):
         all_layers: bool = False,
         filters: dict = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.repository_name = repository_name
         self.all_layers = all_layers
         self.filters = filters
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
     @defaults_from_attrs(
-        "repository_name", "all_layers", "filters", "docker_server_url"
+        "repository_name",
+        "all_layers",
+        "filters",
+        "docker_server_url",
+        "extra_docker_kwargs",
     )
     def run(
         self,
@@ -47,6 +56,7 @@ class ListImages(Task):
         all_layers: bool = False,
         filters: dict = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> list:
         """
         Task run method.
@@ -60,6 +70,9 @@ class ListImages(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `images`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - list: A list of dictionaries containing information about the images found
@@ -68,16 +81,15 @@ class ListImages(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting docker pull for repository {}...".format(repository_name)
-        )
+        self.logger.debug(f"Listing images from {repository_name}")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
         api_result = client.images(
-            name=repository_name, all=all_layers, filters=filters
+            name=repository_name,
+            all=all_layers,
+            filters=filters,
+            **(extra_docker_kwargs or dict()),
         )
-        self.logger.debug(
-            "Completed docker pull for repository {}...".format(repository_name)
-        )
+        self.logger.debug(f"Listed images from {repository_name}")
 
         return api_result
 
@@ -94,7 +106,10 @@ class PullImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `pull`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -103,20 +118,25 @@ class PullImage(Task):
         repository: str = None,
         tag: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.repository = repository
         self.tag = tag
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("repository", "tag", "docker_server_url")
+    @defaults_from_attrs(
+        "repository", "tag", "docker_server_url", "extra_docker_kwargs"
+    )
     def run(
         self,
         repository: str = None,
         tag: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> str:
         """
         Task run method.
@@ -128,6 +148,9 @@ class PullImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `pull`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - str: The output from Docker for pulling the image
@@ -143,18 +166,12 @@ class PullImage(Task):
         import docker
 
         client = docker.APIClient(base_url=docker_server_url, version="auto")
-        self.logger.debug(
-            "Starting docker pull for repository {repo} with tag {tag}...".format(
-                repo=repository, tag=tag
-            )
+        self.logger.debug(f"Pulling image {repository}:{tag}")
+        api_result = client.pull(
+            repository=repository, tag=tag, **(extra_docker_kwargs or dict())
         )
-        api_result = client.pull(repository=repository, tag=tag)
 
-        self.logger.debug(
-            "Completed docker pull for repository {repo} with tag {tag}...".format(
-                repo=repository, tag=tag
-            )
-        )
+        self.logger.debug(f"Pulled image {repository}:{tag}")
         return api_result
 
 
@@ -170,7 +187,10 @@ class PushImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `push`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -179,20 +199,25 @@ class PushImage(Task):
         repository: str = None,
         tag: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.repository = repository
         self.tag = tag
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("repository", "tag", "docker_server_url")
+    @defaults_from_attrs(
+        "repository", "tag", "docker_server_url", "extra_docker_kwargs"
+    )
     def run(
         self,
         repository: str = None,
         tag: str = None,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> str:
         """
         Task run method.
@@ -204,6 +229,9 @@ class PushImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `push`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - str: The output from Docker for pushing the image
@@ -218,18 +246,12 @@ class PushImage(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting docker image push for repo {repo} and tag {tag}".format(
-                repo=repository, tag=tag
-            )
-        )
+        self.logger.debug(f"Pushing image {repository}:{tag} to the registry")
         client = docker.APIClient(base_url=docker_server_url, version="auto")
-        api_result = client.push(repository=repository, tag=tag)
-        self.logger.debug(
-            "Completed docker image push for repo {repo} and tag {tag}".format(
-                repo=repository, tag=tag
-            )
+        api_result = client.push(
+            repository=repository, tag=tag, **(extra_docker_kwargs or dict())
         )
+        self.logger.debug(f"Pushed image {repository}:{tag} to the registry")
         return api_result
 
 
@@ -244,7 +266,10 @@ class RemoveImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `remove_image`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -253,20 +278,23 @@ class RemoveImage(Task):
         image: str = None,
         force: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.image = image
         self.force = force
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("image", "force", "docker_server_url")
+    @defaults_from_attrs("image", "force", "docker_server_url", "extra_docker_kwargs")
     def run(
         self,
         image: str = None,
         force: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -277,6 +305,9 @@ class RemoveImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `remove_image`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Raises:
             - ValueError: if `image` is `None`
@@ -288,11 +319,12 @@ class RemoveImage(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug("Starting to remove Docker images: {}".format(image))
+        self.logger.debug(f"Removing image {image}")
+
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
-        client.remove_image(image=image, force=force)
-        self.logger.debug("Completed removing Docker images... {}".format(image))
+        client.remove_image(image=image, force=force, **(extra_docker_kwargs or dict()))
+        self.logger.debug(f"Removed image {image}")
 
 
 class TagImage(Task):
@@ -308,7 +340,10 @@ class TagImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `tag`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -319,17 +354,26 @@ class TagImage(Task):
         tag: str = None,
         force: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.image = image
         self.repository = repository
         self.tag = tag
         self.force = force
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("image", "repository", "tag", "force", "docker_server_url")
+    @defaults_from_attrs(
+        "image",
+        "repository",
+        "tag",
+        "force",
+        "docker_server_url",
+        "extra_docker_kwargs",
+    )
     def run(
         self,
         image: str = None,
@@ -337,6 +381,7 @@ class TagImage(Task):
         tag: str = None,
         force: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> bool:
         """
         Task run method.
@@ -349,6 +394,9 @@ class TagImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `tag`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - bool: Whether or not the tagging was successful
@@ -363,21 +411,18 @@ class TagImage(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting to tagging Docker image {image} with tag {tag} in repo {repo}".format(
-                image=image, tag=tag, repo=repository
-            )
-        )
+        self.logger.debug(f"Tagging image {repository}/{image}:{tag}")
+
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
         api_result = client.tag(
-            image=image, repository=repository, tag=tag, force=force
+            image=image,
+            repository=repository,
+            tag=tag,
+            force=force,
+            **(extra_docker_kwargs or dict()),
         )
-        self.logger.debug(
-            "Completed tagging Docker image {image} with tag {tag} in repo {repo}".format(
-                image=image, tag=tag, repo=repository
-            )
-        )
+        self.logger.debug(f"Tagged image {repository}/{image}:{tag}")
         return api_result
 
 
@@ -396,7 +441,10 @@ class BuildImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+            (cf. method `build`). See https://docker-py.readthedocs.io/en/stable/api.html
+            for more details
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
 
@@ -408,7 +456,8 @@ class BuildImage(Task):
         rm: bool = True,
         forcerm: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
-        **kwargs: Any
+        extra_docker_kwargs: dict = None,
+        **kwargs: Any,
     ):
         self.path = path
         self.tag = tag
@@ -416,10 +465,19 @@ class BuildImage(Task):
         self.rm = rm
         self.forcerm = forcerm
         self.docker_server_url = docker_server_url
+        self.extra_docker_kwargs = extra_docker_kwargs
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("path", "tag", "nocache", "rm", "forcerm", "docker_server_url")
+    @defaults_from_attrs(
+        "path",
+        "tag",
+        "nocache",
+        "rm",
+        "forcerm",
+        "docker_server_url",
+        "extra_docker_kwargs",
+    )
     def run(
         self,
         path: str = None,
@@ -428,6 +486,7 @@ class BuildImage(Task):
         rm: bool = True,
         forcerm: bool = False,
         docker_server_url: str = "unix:///var/run/docker.sock",
+        extra_docker_kwargs: dict = None,
     ) -> None:
         """
         Task run method.
@@ -442,6 +501,9 @@ class BuildImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
+                (cf. method `build`). See https://docker-py.readthedocs.io/en/stable/api.html
+                for more details
 
         Returns:
             - List[dict]: a cleaned dictionary of the output of `client.build`
@@ -458,24 +520,22 @@ class BuildImage(Task):
         # the 'import prefect' time low
         import docker
 
-        self.logger.debug(
-            "Starting docker build with path {path} and tag {tag}".format(
-                path=path, tag=tag
-            )
-        )
+        self.logger.debug(f"Building image from {path} with tag {tag}")
+
         client = docker.APIClient(base_url=docker_server_url, version="auto")
 
         payload = [
             line
             for line in client.build(
-                path=path, tag=tag, nocache=nocache, rm=rm, forcerm=forcerm
+                path=path,
+                tag=tag,
+                nocache=nocache,
+                rm=rm,
+                forcerm=forcerm,
+                **(extra_docker_kwargs or dict()),
             )
         ]
-        self.logger.debug(
-            "Completed docker build with path {path} and tag {tag}".format(
-                path=path, tag=tag
-            )
-        )
+        self.logger.debug(f"Built image from {path} with tag {tag}")
         output = [
             json.loads(line.decode("utf-8"))
             for resp in payload

--- a/src/prefect/tasks/docker/images.py
+++ b/src/prefect/tasks/docker/images.py
@@ -19,9 +19,9 @@ class ListImages(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `images`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `images`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -70,9 +70,9 @@ class ListImages(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `images`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `images`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - list: A list of dictionaries containing information about the images found
@@ -106,9 +106,9 @@ class PullImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `pull`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `pull`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -148,9 +148,9 @@ class PullImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `pull`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `pull`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - str: The output from Docker for pulling the image
@@ -187,9 +187,9 @@ class PushImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `push`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `push`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -229,9 +229,9 @@ class PushImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `push`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `push`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - str: The output from Docker for pushing the image
@@ -266,9 +266,9 @@ class RemoveImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `remove_image`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `remove_image`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -305,9 +305,9 @@ class RemoveImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `remove_image`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `remove_image`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Raises:
             - ValueError: if `image` is `None`
@@ -340,9 +340,9 @@ class TagImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `tag`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `tag`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -394,9 +394,9 @@ class TagImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `tag`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `tag`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - bool: Whether or not the tagging was successful
@@ -441,9 +441,9 @@ class BuildImage(Task):
         - docker_server_url (str, optional): URL for the Docker server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
             can be provided
-        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-            (cf. method `build`). See https://docker-py.readthedocs.io/en/stable/api.html
-            for more details
+        - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+            Docker call (cf. method `build`). See
+            https://docker-py.readthedocs.io/en/stable/api.html for more details
         - **kwargs (dict, optional): Additional keyword arguments to pass to the Task
             constructor
     """
@@ -501,9 +501,9 @@ class BuildImage(Task):
             - docker_server_url (str, optional): URL for the Docker server. Defaults to
                 `unix:///var/run/docker.sock` however other hosts such as `tcp://0.0.0.0:2375`
                 can be provided
-            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the Docker call
-                (cf. method `build`). See https://docker-py.readthedocs.io/en/stable/api.html
-                for more details
+            - extra_docker_kwargs (dict, optional): Extra keyword arguments to pass through to the
+                Docker call (cf. method `build`). See
+                https://docker-py.readthedocs.io/en/stable/api.html for more details
 
         Returns:
             - List[dict]: a cleaned dictionary of the output of `client.build`

--- a/tests/tasks/docker/test_containers.py
+++ b/tests/tasks/docker/test_containers.py
@@ -27,8 +27,12 @@ class DockerLoggingTestingUtilityMixin:
             initial = caplog.records[0]
             final = caplog.records[1]
 
-            assert "Starting" in initial.msg
-            assert "Completed" in final.msg
+            assert any(
+                container in initial.msg for container in ["container", "Container"]
+            )
+            assert any(
+                container in final.msg for container in ["container", "Container"]
+            )
 
     @staticmethod
     def assert_logs_once_on_docker_api_failure(task, caplog):
@@ -37,8 +41,13 @@ class DockerLoggingTestingUtilityMixin:
             with pytest.raises(docker.errors.DockerException):
                 task.run()
                 assert len(caplog.records) == 1
-                assert "Starting" in caplog.text
-                assert "Completed" not in caplog.text
+                assert any(
+                    container in caplog.text for container in ["container", "Container"]
+                )
+                assert any(
+                    container not in caplog.text
+                    for container in ["container", "Container"]
+                )
 
     @staticmethod
     def assert_doesnt_log_on_param_failure(task, caplog):

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -25,8 +25,8 @@ class DockerLoggingTestingUtilityMixin:
             initial = caplog.records[0]
             final = caplog.records[1]
 
-            assert "Starting" in initial.msg
-            assert "Completed" in final.msg
+            assert any(image in initial.msg for image in ["image", "Image"])
+            assert any(image in initial.msg for image in ["image", "Image"])
 
     @staticmethod
     def assert_logs_once_on_docker_api_failure(task, caplog):
@@ -35,8 +35,8 @@ class DockerLoggingTestingUtilityMixin:
             with pytest.raises(docker.errors.DockerException):
                 task.run()
                 assert len(caplog.records) == 1
-                assert "Starting" in caplog.text
-                assert "Completed" not in caplog.text
+                assert any(image in caplog.text for image in ["image", "Image"])
+                assert any(image not in caplog.text for image in ["image", "Image"])
 
     @staticmethod
     def assert_doesnt_log_on_param_failure(task, caplog):


### PR DESCRIPTION
## What does this PR change?

A couple of small edits in the `prefect.tasks.docker` package. Basically, I just:

* Added the `extra_docker_kwargs` parameter to every Docker-related `Task` class in order to pass in arbitrary keyword arguments to Docker API calls (as in the current `prefect.tasks.docker.containers.CreateContainer` task). This allows for use of the newer possibilities of the [Docker API client](https://docker-py.readthedocs.io/en/stable/api.html#low-level-api) without having to adapt the corresponding `Task` class.
* Rewrote some of the log messages to make them more accurate and homogeneous towards the rest of the project.
* Fixed an issue in the way the current `extra_docker_kwargs` parameter is handled in `prefect.tasks.docker.containers.CreateContainer`. The current class uses the instance variable (cf. `self.extra_docker_kwargs`) instead of the variable that is passed to the `run` method, therefore it's not possible to override the `extra_docker_kwargs` passed to the original `Task` constructor.
* Removed the implicit `typing.Optional` type hint (found them nowhere in the task library).
* Fixed and issue in the `prefect.tasks.docker.containers.CreateContainer` task class that encouraged passing a `Dict` as the `volumes` parameter even though the [documentation](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_container) says otherwise (my bad, that was my PR).
* Added the `host_config` parameter to the `prefect.tasks.docker.containers.CreateContainer` task class in order to pass in arbitrary keyword arguments to Docker API client's `create_host_configuration` method. Before that, you had to call `create_host_configuration` yourself by connecting to the Docker daemon, which was not always possible (and horribly tedious).

I did not update the tests since these are passthrough parameters.

## Why is this PR important?

I'm using Prefect at my workplace and needed to add some more support for [Docker Volumes](https://docs.docker.com/storage/volumes/). Since this capability might be useful to the community, I thought I'd share!