### PR TITLE
[docs] fix misspelled method name in KubernetesAgent docs

### DIFF
--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -33,7 +33,7 @@ class KubernetesAgent(Agent):
     ```
 
     For details on the available environment variables for customizing the job spec,
-    see `help(KubernetesAgent.replace_job-spec_yaml)`.
+    see `help(KubernetesAgent.replace_job_spec_yaml)`.
 
     Specifying a namespace for the agent will create flow run jobs in that namespace:
     ```


### PR DESCRIPTION
## Summary

Fixes a misspelled method name in the documentation for `KubernetesAgent`.

## Changes

Fixes a misspelled method name in the documentation for `KubernetesAgent`

## Importance

This PR eliminates a typo that would have led to a false negative grepping through the code or searching on the docs. Sorry, pretty sure this is a typo I introduced :grimacing: 

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)