### PR TITLE
fix access to core_version in get_flow_run_command()

### DIFF
--- a/changes/pr3177.yaml
+++ b/changes/pr3177.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "fix access to core_version in get_flow_run_command() - [#3177](https://github.com/PrefectHQ/prefect/pull/3177)"
+
+contributor:
+  - "[James Lamb](https://github.com/jameslamb)"

--- a/changes/pr3177.yaml
+++ b/changes/pr3177.yaml
@@ -1,5 +1,5 @@
 fix:
-  - "fix access to core_version in get_flow_run_command() - [#3177](https://github.com/PrefectHQ/prefect/pull/3177)"
+  - "Fix access to `core_version` in Agent's `get_flow_run_command()` - [#3177](https://github.com/PrefectHQ/prefect/pull/3177)"
 
 contributor:
   - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -52,7 +52,7 @@ def get_flow_run_command(flow_run: GraphQLResult) -> str:
     Returns:
         - str: a prefect CLI command to execute a flow run
     """
-    core_version = flow_run.flow.core_version or "0.0.0"
+    core_version = getattr(flow_run.flow, "core_version", None) or "0.0.0"
 
     if LooseVersion(core_version) < LooseVersion("0.13.0"):
         return "prefect execute cloud-flow"

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -86,3 +86,21 @@ def test_get_flow_run_command(core_version, command):
     )
 
     assert get_flow_run_command(flow_run) == command
+
+
+def test_get_flow_run_command_works_if_core_version_not_on_response():
+    legacy_command = "prefect execute cloud-flow"
+    flow_run = GraphQLResult(
+        {
+            "flow": GraphQLResult(
+                {
+                    "storage": Local().serialize(),
+                    "environment": LocalEnvironment().serialize(),
+                    "id": "id",
+                }
+            ),
+            "id": "id",
+        }
+    )
+
+    assert get_flow_run_command(flow_run) == legacy_command


### PR DESCRIPTION
## Summary

In #3113 , agents were changed to choose a different flow run command based on the current version of Prefect Core managing the flow. That PR added a default for `core_version` for the cases where `{"core_version": null}` exists on the response. However, if `core_version` is not present on the response at all, you get this hard-to-understand error:

```text
item = 'core_version'

    def __getattr__(self, item):
        try:
            try:
                value = self.__getitem__(item, _ignore_default=True)
            except KeyError:
                value = object.__getattribute__(self, item)
        except AttributeError as err:
            if item == '__getstate__':
                raise BoxKeyError(item) from None
            if item == '_box_config':
                raise BoxError('_box_config key must exist') from None
            if self._box_config['conversion_box']:
                safe_key = self._safe_attr(item)
                if safe_key in self._box_config['__safe_keys']:
                    return self.__getitem__(self._box_config['__safe_keys'][safe_key])
            if self._box_config['default_box']:
                return self.__get_default(item)
>           raise BoxKeyError(str(err)) from None
E           box.exceptions.BoxKeyError: "'GraphQLResult' object has no attribute 'core_version'"
```

This PR fixes that.

Thanks for your time and consideration!

## Changes

Changes to `utilities.agent.get_flow_run_command()` to use `getattr()` when looking for `core_version` in a `flow_run`.


## Importance

I discovered this PR while running the unit tests for a custom `KubernetesAgent` that I've written with some my-company-specific logic. I was mocking the `flow_run` contents and hadn't included `core_version`. Others doing that might face this issue, and this PR will mitigate it.

I'm not that familiar with GraphQL, so I don't know if you're guaranteed to get `{"core_version": null}` in the response if you ask for that field. If you aren't, then other people running versions of core that don't return this field would also face this issue without this fix.

## Checklist

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)