### PR TITLE
Fix agent CLI api flag not being respected on start

### DIFF
--- a/changes/pr3186.yaml
+++ b/changes/pr3186.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `--api` CLI option not being respected by agent Client  - [#3186](https://github.com/PrefectHQ/prefect/pull/3186)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -149,7 +149,7 @@ class Agent:
 
         self.logger.debug(f"Prefect backend: {config.backend}")
 
-        self.client = Client(api_token=token)
+        self.client = Client(api_server=config.cloud.api, api_token=token)
 
     def _verify_token(self, token: str) -> None:
         """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Fix the `--api` option for the agent CLI commands not being respected



## Changes
Passes the set API endpoint to the agent's client



## Importance
Fix broken CLI option



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)