### PR TITLE
Fix url of the guide

### DIFF
--- a/docs/core/task_library/great_expectations.md
+++ b/docs/core/task_library/great_expectations.md
@@ -7,7 +7,7 @@ title: Great Expectations
 A collection of tasks for interacting with Great Expectations deployments and APIs.
 
 Note that all tasks currently require being executed in an environment where the great expectations configuration directory can be found; 
-learn more about how to initialize a great expectation deployment [on their Getting Started docs](https://docs.greatexpectations.io/en/latest/tutorials/getting_started.html).
+learn more about how to initialize a great expectation deployment [on their Getting Started docs](https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started.html).
 
 ## RunGreatExpectationsCheckpoint <Badge text="task"/>
 


### PR DESCRIPTION
Fix url to point to new location of getting started guide

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Reflect reorganization of the GreatExpectation's tutorials being placed under a main /guides virtual folder



## Changes
<!-- What does this PR change? -->
Fix the broken url to the getting started guide for GreatExpectations



## Importance
<!-- Why is this PR important? -->
The current url destination shows the error page of read the docs instead of the documentation



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)