### PR TITLE
Server versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,22 @@ jobs:
           name: Upload Coverage
           command: bash <(curl -s https://codecov.io/bash) -cF python -s "/tmp/workspace/coverage/"
 
+  promote_image:
+    description: Promotes images by retagging them
+    parameters:
+      IMAGE_NAME:
+        type: string
+      VERSION:
+        type: string
+    steps:
+      - run:
+          name: Promote
+          command: |
+            IMAGE_NAME=<<parameters.IMAGE_NAME>> && VERSION=<<parameters.VERSION>>
+            docker pull prefecthq/${IMAGE_NAME}:latest
+            docker tag prefecthq/${IMAGE_NAME}:latest prefecthq/${IMAGE_NAME}:${VERSION}
+            docker push prefecthq/${IMAGE_NAME}:${VERSION}
+
   build_docker_image:
     docker:
       - image: docker
@@ -404,6 +420,23 @@ jobs:
                   docker push prefecthq/prefect:all_extras
 
 
+  promote_server_artifacts:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - setup_remote_docker:
+          version: 18.09.3
+      - promote_image:
+          IMAGE_NAME: apollo
+          VERSION: core-${CIRCLE_TAG}
+      - promote_image:
+          IMAGE_NAME: server
+          VERSION: core-${CIRCLE_TAG}
+      - promote_image:
+          IMAGE_NAME: ui
+          VERSION: core-${CIRCLE_TAG}
+
   release_to_pypi:
     docker:
       - image: python:3.7
@@ -506,6 +539,12 @@ workflows:
           python_version: '3.8'
           extras: 'all_extras'
           tag_latest: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+      - promote_server_artifacts:
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,23 @@ references:
     attach_workspace:
       at: *workspace_root
 
+commands:
+  promote_image:
+    description: Promotes images by retagging them
+    parameters:
+      IMAGE_NAME:
+        type: string
+      VERSION:
+        type: string
+    steps:
+      - run:
+          name: Promote
+          command: |
+            IMAGE_NAME=<<parameters.IMAGE_NAME>> && VERSION=<<parameters.VERSION>>
+            docker pull prefecthq/${IMAGE_NAME}:latest
+            docker tag prefecthq/${IMAGE_NAME}:latest prefecthq/${IMAGE_NAME}:${VERSION}
+            docker push prefecthq/${IMAGE_NAME}:${VERSION}
+
 jobs:
   # ----------------------------------
   # Check formatting
@@ -241,23 +258,6 @@ jobs:
           name: Upload Coverage
           command: bash <(curl -s https://codecov.io/bash) -cF python -s "/tmp/workspace/coverage/"
 
-  promote_image:
-    docker:
-      - image: docker
-    description: Promotes images by retagging them
-    parameters:
-      IMAGE_NAME:
-        type: string
-      VERSION:
-        type: string
-    steps:
-      - run:
-          name: Promote
-          command: |
-            IMAGE_NAME=<<parameters.IMAGE_NAME>> && VERSION=<<parameters.VERSION>>
-            docker pull prefecthq/${IMAGE_NAME}:latest
-            docker tag prefecthq/${IMAGE_NAME}:latest prefecthq/${IMAGE_NAME}:${VERSION}
-            docker push prefecthq/${IMAGE_NAME}:${VERSION}
 
   build_docker_image:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,8 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash) -cF python -s "/tmp/workspace/coverage/"
 
   promote_image:
+    docker:
+      - image: docker
     description: Promotes images by retagging them
     parameters:
       IMAGE_NAME:

--- a/changes/pr3204.yaml
+++ b/changes/pr3204.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Use better coupled versioning scheme for Core / Server / UI images - [#3204](https://github.com/PrefectHQ/prefect/pull/3204)"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -219,9 +219,11 @@ def start(
     \b
     Options:
         --version, -v       TEXT    The server image versions to use (for example, '0.1.0' or
-                                    'master'). Defaults to `latest`.
+                                    'master'). Defaults to `core-a.b.c` where `a.b.c.` is the version
+                                    of Prefect Core currently running.
         --ui-version, -uv   TEXT    The UI image version to use (for example, '0.1.0' or
-                                    'master'). Defaults to `latest`.
+                                    'master'). Defaults to `core-a.b.c` where `a.b.c.` is the version
+                                    of Prefect Core currently running.
         --skip-pull                 Flag to skip pulling new images (if available)
         --no-upgrade, -n            Flag to avoid running a database upgrade when the database
                                     spins up
@@ -306,10 +308,15 @@ def start(
     ):
         env = make_env()
 
+    base_version = prefect.__version__.split("+")
+    if len(base_version) > 1:
+        default_tag = "master"
+    else:
+        default_tag = f"core-{base_version[0]}"
     if "PREFECT_SERVER_TAG" not in env:
-        env.update(PREFECT_SERVER_TAG=version or "latest")
+        env.update(PREFECT_SERVER_TAG=version or default_tag)
     if "PREFECT_UI_TAG" not in env:
-        env.update(PREFECT_UI_TAG=ui_version or "latest")
+        env.update(PREFECT_UI_TAG=ui_version or default_tag)
     if "PREFECT_SERVER_DB_CMD" not in env:
         cmd = (
             "prefect-server database upgrade -y"

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -95,9 +95,10 @@ def test_server_start(monkeypatch, macos_platform):
 @pytest.mark.parametrize(
     "version",
     [
-        ("0.10.3", "latest"),
-        ("0.10.3+114.g35bc7ba4", "latest"),
-        ("0.10.2+999.gr34343.dirty", "latest"),
+        ("0.10.3", "core-0.10.3"),
+        ("0.13.3", "core-0.13.3"),
+        ("0.10.3+114.g35bc7ba4", "master"),
+        ("0.10.2+999.gr34343.dirty", "master"),
     ],
 )
 def test_server_start_image_versions(monkeypatch, version, macos_platform):
@@ -120,7 +121,7 @@ def test_server_start_image_versions(monkeypatch, version, macos_platform):
     assert popen.call_args[0][0] == ["docker-compose", "up"]
     assert popen.call_args[1].get("cwd")
     assert popen.call_args[1].get("env")
-    assert popen.call_args[1]["env"].get("PREFECT_SERVER_TAG") == "latest"
+    assert popen.call_args[1]["env"].get("PREFECT_SERVER_TAG") == version[1]
 
 
 def test_server_start_options_and_flags(monkeypatch, macos_platform):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR introduces our new versioning scheme for Core / Server and the UI.  In particular:
- both the [server repo](https://github.com/PrefectHQ/server) and the [ui repo](https://github.com/PrefectHQ/ui) cut releases based on calendar versioning; each time this occurs, a new `latest` tag is pushed to the respective docker hub repositories (along with the true image tag)
- whenever Core cuts a new version / release, it will pull whatever is the `latest` release of both Server and the UI and retag those images with `core-X.X.X` corresponding to the current Core version being released

This ensures compatibility with all images and prevents the use of `latest` which has some associated risks.

## Changes
`prefect server start` will now use smart defaults for server image versions / tags based on the version of Core being run.  This can still be overwritten.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)