### PR TITLE
Color pytest ouptut logs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --color=yes


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Color pytest ouptut logs to make it easier to identify test failures.


## Changes
<!-- What does this PR change? -->

Add `pytest.ini` to configure pytest to enable the `--color` option by default.


Before:

<img width="1010" alt="Screen Shot 2020-08-23 at 19 29 35" src="https://user-images.githubusercontent.com/17039389/90976327-0bcbdc80-e577-11ea-9c25-c363c88211c4.png">


After:

<img width="1080" alt="Screen Shot 2020-08-23 at 19 32 34" src="https://user-images.githubusercontent.com/17039389/90976379-7b41cc00-e577-11ea-8a6b-6f6efb7b3e5a.png">



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)