### PR TITLE
Added option to mount volumes with KubernetesAgent

### DIFF
--- a/changes/pr3210.yaml
+++ b/changes/pr3210.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Added option to mount volumes with KubernetesAgent  - [#1234](https://github.com/PrefectHQ/prefect/pull/3210)"
+
+contributor:
+  - "[Thomas Frederik Hoeck](https://github.com/thomasfrederikhoeck)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from os import path
-from typing import Iterable
+from typing import Iterable, List
 
 import yaml
 
@@ -57,6 +57,12 @@ class KubernetesAgent(Agent):
             (default).
         - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
             and all deployed flow runs
+        - volume_mounts (list, optional): A list of volumeMounts to mount when a job is
+            run. The volumeMounts in the list should be specified as dicts
+            i.e `[{"name": "my-vol", "mountPath": "/mnt/my-mount"}]`
+        - volumes (list, optional): A list of volumes to make available to be mounted when a
+            job is run. The volumes in the list should be specified as nested dicts.
+            i.e `[{"name": "my-vol", "csi": {"driver": "secrets-store.csi.k8s.io"}}]`
     """
 
     def __init__(
@@ -68,6 +74,8 @@ class KubernetesAgent(Agent):
         max_polls: int = None,
         agent_address: str = None,
         no_cloud_logs: bool = False,
+        volume_mounts: List[dict] = None,
+        volumes: List[dict] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -79,6 +87,8 @@ class KubernetesAgent(Agent):
         )
 
         self.namespace = namespace
+        self.volume_mounts = volume_mounts
+        self.volumes = volumes
 
         from kubernetes import client, config
 
@@ -216,6 +226,16 @@ class KubernetesAgent(Agent):
             resources["requests"]["cpu"] = os.getenv("JOB_CPU_REQUEST")
         if os.getenv("JOB_CPU_LIMIT"):
             resources["limits"]["cpu"] = os.getenv("JOB_CPU_LIMIT")
+        if self.volume_mounts:
+            job["spec"]["template"]["spec"]["containers"][0][
+                "volumeMounts"
+            ] = self.volume_mounts
+        else:
+            del job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+        if self.volumes:
+            job["spec"]["template"]["spec"]["volumes"] = self.volumes
+        else:
+            del job["spec"]["template"]["spec"]["volumes"]
         if os.getenv("IMAGE_PULL_POLICY"):
             job["spec"]["template"]["spec"]["containers"][0][
                 "imagePullPolicy"

--- a/src/prefect/agent/kubernetes/job_spec.yaml
+++ b/src/prefect/agent/kubernetes/job_spec.yaml
@@ -42,6 +42,10 @@ spec:
               cpu: "100m"
             limits:
               cpu: "100m"
+          volumeMounts:
+            - name: ""
       restartPolicy: Never
       imagePullSecrets:
       - name: ""
+      volumes:
+        - name: ""


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR adds the option to give let KubernetesAgent mount volumes in the k8 jobs.



## Changes
Adds the two options `volume_mounts `and `volumes` to `KubernetesAgent  `



## Importance
Allows for mount volume which has many use-cases. One is #3184 but this PR allows for much broader use.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)