### PR TITLE
Improved helper methods

### DIFF
--- a/changes/pr3212.yaml
+++ b/changes/pr3212.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add more kwargs to State.children and State.parents for common access patterns - [#3212](https://github.com/PrefectHQ/prefect/pull/3212)"

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -174,7 +174,7 @@ class State:
         return children
 
     @classmethod
-    def parents(cls) -> "List[Type[State]]":
+    def parents(cls, include_self: bool = False) -> "List[Type[State]]":
         parents = []
         for state in cls.mro():
             if state in [object, cls]:
@@ -183,6 +183,8 @@ class State:
             # hide "private" state types
             if not state.__name__.startswith("_"):
                 parents.append(state)
+        if include_self:
+            parents += [cls]
         return parents
 
     def is_pending(self) -> bool:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -165,6 +165,18 @@ class State:
     def children(
         cls, include_self: bool = False, names_only: bool = False
     ) -> "List[Type[State]]":
+        """
+        Helper method for retrieving all possible child states of this state.
+
+        Args:
+            - include_self (bool, optional): whether to include the calling state in the return
+                values; defaults to `False`
+            - names_only (bool, optional): whether to only return the string names of the states;
+                defaults to `False`, in which case the actual classes are returned
+
+        Returns:
+            - list: a (possibly empty) list of states or state names
+        """
         children = []
         for state in cls.__subclasses__():
             # hide "private" state types
@@ -181,6 +193,18 @@ class State:
     def parents(
         cls, include_self: bool = False, names_only: bool = False
     ) -> "List[Type[State]]":
+        """
+        Helper method for retrieving all possible parent states of this state.
+
+        Args:
+            - include_self (bool, optional): whether to include the calling state in the return
+                values; defaults to `False`
+            - names_only (bool, optional): whether to only return the string names of the states;
+                defaults to `False`, in which case the actual classes are returned
+
+        Returns:
+            - list: a (possibly empty) list of states or state names
+        """
         parents = []
         for state in cls.mro():
             if state in [object, cls]:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -162,7 +162,9 @@ class State:
         return self
 
     @classmethod
-    def children(cls, include_self: bool = False) -> "List[Type[State]]":
+    def children(
+        cls, include_self: bool = False, names_only: bool = False
+    ) -> "List[Type[State]]":
         children = []
         for state in cls.__subclasses__():
             # hide "private" state types
@@ -171,10 +173,14 @@ class State:
             children.extend(state.children())
         if include_self:
             children += [cls]
+        if names_only:
+            return [s.__name__ for s in children]
         return children
 
     @classmethod
-    def parents(cls, include_self: bool = False) -> "List[Type[State]]":
+    def parents(
+        cls, include_self: bool = False, names_only: bool = False
+    ) -> "List[Type[State]]":
         parents = []
         for state in cls.mro():
             if state in [object, cls]:
@@ -185,6 +191,8 @@ class State:
                 parents.append(state)
         if include_self:
             parents += [cls]
+        if names_only:
+            return [s.__name__ for s in parents]
         return parents
 
     def is_pending(self) -> bool:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -174,7 +174,7 @@ class State:
         if include_self:
             children += [cls]
         if names_only:
-            return [s.__name__ for s in children]
+            return [s.__name__ for s in children]  # type: ignore
         return children
 
     @classmethod
@@ -192,7 +192,7 @@ class State:
         if include_self:
             parents += [cls]
         if names_only:
-            return [s.__name__ for s in parents]
+            return [s.__name__ for s in parents]  # type: ignore
         return parents
 
     def is_pending(self) -> bool:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -162,13 +162,15 @@ class State:
         return self
 
     @classmethod
-    def children(cls) -> "List[Type[State]]":
+    def children(cls, include_self: bool = False) -> "List[Type[State]]":
         children = []
         for state in cls.__subclasses__():
             # hide "private" state types
             if not state.__name__.startswith("_"):
                 children.append(state)
             children.extend(state.children())
+        if include_self:
+            children += [cls]
         return children
 
     @classmethod

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -473,17 +473,25 @@ def test_children_method_on_leaf_state_returns_empty():
     assert TriggerFailed.children() == []
 
 
-def test_children_method_on_success():
+@pytest.mark.parametrize("include_self", [True, False])
+def test_children_method_on_success(include_self):
     expected = {Cached, Mapped, Skipped}
-    assert set(Success.children()) == expected
+    if include_self:
+        expected.add(Success)
+    assert set(Success.children(include_self=include_self)) == expected
 
 
-def test_parent_method_on_base_state():
-    assert State.parents() == []
+@pytest.mark.parametrize("include_self", [True, False])
+def test_parent_method_on_base_state(include_self):
+    assert State.parents(include_self=include_self) == ([State] if include_self else [])
 
 
-def test_children_method_on_leaf_state_returns_hierarchy():
-    assert set(TriggerFailed.parents()) == {Finished, Failed, State}
+@pytest.mark.parametrize("include_self", [True, False])
+def test_children_method_on_leaf_state_returns_hierarchy(include_self):
+    expected = {Finished, Failed, State}
+    if include_self:
+        expected.add(TriggerFailed)
+    assert set(TriggerFailed.parents(include_self=include_self)) == expected
 
 
 def test_parents_method_on_success():

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -461,10 +461,12 @@ def test_state_is_methods(state_check):
                 assert not getattr(state, attr)()
 
 
-def test_children_method_on_base_state():
+@pytest.mark.parametrize("include_self", [True, False])
+def test_children_method_on_base_state(include_self):
     all_states_set = set(all_states)
-    all_states_set.remove(State)
-    assert all_states_set == set(State.children())
+    if not include_self:
+        all_states_set.remove(State)
+    assert all_states_set == set(State.children(include_self=include_self))
 
 
 def test_children_method_on_leaf_state_returns_empty():

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -473,6 +473,12 @@ def test_children_method_on_leaf_state_returns_empty():
     assert TriggerFailed.children() == []
 
 
+def test_children_method_names_only_returns_strings():
+    assert TriggerFailed.children(include_self=True, names_only=True) == [
+        "TriggerFailed"
+    ]
+
+
 @pytest.mark.parametrize("include_self", [True, False])
 def test_children_method_on_success(include_self):
     expected = {Cached, Mapped, Skipped}
@@ -484,6 +490,13 @@ def test_children_method_on_success(include_self):
 @pytest.mark.parametrize("include_self", [True, False])
 def test_parent_method_on_base_state(include_self):
     assert State.parents(include_self=include_self) == ([State] if include_self else [])
+
+
+@pytest.mark.parametrize("include_self", [True, False])
+def test_parent_method_on_base_state_names_only(include_self):
+    assert State.parents(include_self=include_self, names_only=True) == (
+        ["State"] if include_self else []
+    )
 
 
 @pytest.mark.parametrize("include_self", [True, False])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR adds two new kwargs to `State.children` and `State.parents`:
- `include_self`: a boolean specifying whether to include the class on which the method is called
- `names_only`: a boolean specifying whether to return a list of string names instead of the classes themselves

## Importance
Reduces duplication of this logic all over the place.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)