### PR TITLE
Fix state message when using targets

### DIFF
--- a/changes/pr3216.yaml
+++ b/changes/pr3216.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix state message when using targets - [#3216](https://github.com/PrefectHQ/prefect/pull/3216)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -666,7 +666,8 @@ class TaskRunner(Runner):
                 target = target(**formatting_kwargs)
 
             if result.exists(target, **formatting_kwargs):
-                new_res = result.read(target.format(**formatting_kwargs))
+                known_location = target.format(**formatting_kwargs)
+                new_res = result.read(known_location)
                 cached_state = Cached(
                     result=new_res,
                     hashed_inputs={
@@ -674,7 +675,7 @@ class TaskRunner(Runner):
                     },
                     cached_result_expiration=None,
                     cached_parameters=formatting_kwargs.get("parameters"),
-                    message=f"Result found at task target {target}",
+                    message=f"Result found at task target {known_location}",
                 )
                 return cached_state
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
It appeared that when using task targets, in the event that a target was found we would log the templated target string instead of the resolved location.  This PR fixes that.

**NOTE:** It seems that our tests still somehow are not independent from user configuration.  Some of my tests were failing because of my user configuration file - not sure if it's my IDE setup or something else.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)