### PR TITLE
Revert "Color pytest ouptut logs"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --color=yes


### PR DESCRIPTION
I'm not too familiar with `pytest.ini` but the presence of this file causes a lot of my tests to fail because they are no longer independent of my local environment cc @jcrist @cicdw 