### PR TITLE
Optimizing constants out of graph still add downstream

### DIFF
--- a/changes/pr3230.yaml
+++ b/changes/pr3230.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix edge case with `add_edge` method - [#3230](https://github.com/PrefectHQ/prefect/pull/3230)"
+
+contributor:
+  - "[shaunc](https://github.com/shaunc)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -602,6 +602,7 @@ class Flow:
             self.constants[edge.downstream_task].update(
                 {edge.key: edge.upstream_task.value}
             )
+            self.add_task(edge.downstream_task)
             return edge
 
         # add the edge

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -447,6 +447,11 @@ def test_add_edge_returns_edge():
     assert added_edge in f.edges
     assert edge in f.edges
 
+def test_add_edge_from_contant():
+    f = Flow(name="test")
+    c1 = constants.Constant(1)
+    t1 = Task()
+    edge = f.add_edge(upstream_task=c1, downstream_task=t1, key="foo")
 
 def test_chain():
     f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -449,9 +449,12 @@ def test_add_edge_returns_edge():
 
 def test_add_edge_from_contant():
     f = Flow(name="test")
-    c1 = constants.Constant(1)
+    value = 1
+    c1 = constants.Constant(value)
     t1 = Task()
-    edge = f.add_edge(upstream_task=c1, downstream_task=t1, key="foo")
+    f.add_edge(upstream_task=c1, downstream_task=t1, key="foo")
+    assert t1 in f.get_tasks()
+    assert f.constants[t1]['foo'] == value
 
 def test_chain():
     f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -455,7 +455,7 @@ def test_add_edge_from_contant():
     t1 = Task()
     f.add_edge(upstream_task=c1, downstream_task=t1, key="foo")
     assert t1 in f.get_tasks()
-    assert f.constants[t1]['foo'] == value
+    assert f.constants[t1]["foo"] == value
 
 def test_chain():
     f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -19,6 +19,7 @@ from prefect import task
 from prefect.core.edge import Edge
 from prefect.core.flow import Flow
 from prefect.core.task import Task
+from prefect.tasks.core import constants
 from prefect.core.parameter import Parameter
 from prefect.engine.cache_validators import all_inputs, partial_inputs_only
 from prefect.engine.executors import LocalExecutor

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -448,6 +448,7 @@ def test_add_edge_returns_edge():
     assert added_edge in f.edges
     assert edge in f.edges
 
+
 def test_add_edge_from_contant():
     f = Flow(name="test")
     value = 1
@@ -456,6 +457,7 @@ def test_add_edge_from_contant():
     f.add_edge(upstream_task=c1, downstream_task=t1, key="foo")
     assert t1 in f.get_tasks()
     assert f.constants[t1]["foo"] == value
+
 
 def test_chain():
     f = Flow(name="test")


### PR DESCRIPTION
Although an edge can be omitted from the graph if source task is a constant, the target task should still be included in the graph. As it is a single edge graph from constant to task will contain no tasks if "add_edge()" is used to build it, but it should contain at least the target task.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->




## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)