### PR TITLE
n_map_states

### DIFF
--- a/changes/issue3233.yaml
+++ b/changes/issue3233.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Begin storing the width of mapped pipelines on the parent Mapped state - [#3233](https://github.com/PrefectHQ/prefect/issues/3233)"

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -871,7 +871,7 @@ class Mapped(Success):
             message=message, result=result, context=context, cached_inputs=cached_inputs
         )
         self.map_states = map_states or []  # type: List[State]
-        self.n_map_states = n_map_states
+        self.n_map_states = n_map_states  # type: ignore
 
     @property
     def n_map_states(self) -> int:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -848,6 +848,8 @@ class Mapped(Success):
         - map_states (List): A list containing the states of any "children" of this task. When
             a task enters a Mapped state, it indicates that it has dynamically created copies
             of itself to map its operation over its inputs. Those copies are the children.
+        - n_map_states (int, optional): the number of tasks that were mapped; if not provided,
+            the value of `len(map_states)` is used
         - cached_inputs (dict, optional, DEPRECATED): A dictionary of input keys to fully hydrated
             `Result`s. Used / set if the Task requires retries.
         - context (dict, optional): A dictionary of execution context information; values
@@ -863,15 +865,21 @@ class Mapped(Success):
         map_states: List[State] = None,
         context: Dict[str, Any] = None,
         cached_inputs: Dict[str, Result] = None,
+        n_map_states: int = None,
     ):
         super().__init__(
             message=message, result=result, context=context, cached_inputs=cached_inputs
         )
         self.map_states = map_states or []  # type: List[State]
+        self.n_map_states = n_map_states
 
     @property
     def n_map_states(self) -> int:
-        return len(self.map_states)
+        return self._n_map_states or len(self.map_states)
+
+    @n_map_states.setter
+    def n_map_states(self, val: Optional[int]) -> None:
+        self._n_map_states = val
 
 
 class Cancelled(Finished):

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -444,6 +444,7 @@ class TaskRunner(Runner):
             new_state = Failed("At least one upstream state has an unmappable result.")
             raise ENDRUN(new_state)
         else:
+            # compute and set n_map_states
             n_map_states = min(
                 [
                     len(s.result)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -452,7 +452,7 @@ class TaskRunner(Runner):
                     if e.mapped and s.is_successful() and not s.is_mapped()
                 ]
                 + [
-                    s.n_map_states
+                    s.n_map_states  # type: ignore
                     for e, s in upstream_states.items()
                     if e.mapped and s.is_mapped()
                 ],

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -444,7 +444,22 @@ class TaskRunner(Runner):
             new_state = Failed("At least one upstream state has an unmappable result.")
             raise ENDRUN(new_state)
         else:
-            new_state = Mapped("Ready to proceed with mapping.")
+            n_map_states = min(
+                [
+                    len(s.result)
+                    for e, s in upstream_states.items()
+                    if e.mapped and s.is_successful() and not s.is_mapped()
+                ]
+                + [
+                    s.n_map_states
+                    for e, s in upstream_states.items()
+                    if e.mapped and s.is_mapped()
+                ],
+                default=0,
+            )
+            new_state = Mapped(
+                "Ready to proceed with mapping.", n_map_states=n_map_states
+            )
             raise ENDRUN(new_state)
 
     @call_state_handlers

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -723,3 +723,14 @@ def test_meta_states_dont_nest():
     new_state = StateSchema().load(state.serialize())
     assert new_state.is_meta_state()
     assert not new_state.state.is_meta_state()
+
+
+def test_n_map_states():
+    state = Mapped(map_states=[1, 2])
+    assert state.n_map_states == 2
+
+    state = Mapped(n_map_states=4)
+    assert state.n_map_states == 4
+
+    state = Mapped(map_states=[1, 2], n_map_states=4)
+    assert state.n_map_states == 4

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1834,6 +1834,26 @@ class TestCheckTaskReadyToMapStep:
             )
         assert exc.value.state.is_failed()
 
+    def test_run_mapped_sets_n_map_states(self):
+        upstreams = {
+            Edge(mapped=True, upstream_task=Task(), downstream_task=Task()): Success(
+                result=[1, 2, 3, 4, 5]
+            ),
+            Edge(mapped=True, upstream_task=Task(), downstream_task=Task()): Success(
+                result=[1, 2, 3, 4, 5]
+            ),
+            Edge(mapped=True, downstream_task=Task(), upstream_task=Task()): Success(
+                result=list(range(10))
+            ),
+        }
+
+        with pytest.raises(ENDRUN) as exc:
+            TaskRunner(task=Task()).check_task_ready_to_map(
+                state=Pending(), upstream_states=upstreams
+            )
+        assert exc.value.state.is_mapped()
+        assert exc.value.state.n_map_states == 5
+
 
 def test_task_runner_skips_upstream_check_for_parent_mapped_task():
     add = AddTask(trigger=prefect.triggers.all_failed)

--- a/tests/serialization/test_states.py
+++ b/tests/serialization/test_states.py
@@ -196,6 +196,17 @@ def test_serialize_mapped():
     assert serialized["__version__"] == prefect.__version__
 
 
+def test_serialize_mapped_uses_set_n_map_states():
+    serialized = StateSchema().dump(state.Mapped(message="message", n_map_states=20))
+    assert isinstance(serialized, dict)
+    assert serialized["type"] == "Mapped"
+    assert serialized["message"] == "message"
+    assert "_result" not in serialized
+    assert "map_states" not in serialized
+    assert serialized["n_map_states"] == 20
+    assert serialized["__version__"] == prefect.__version__
+
+
 @pytest.mark.parametrize("cls", [s for s in all_states if s is not state.Mapped])
 def test_deserialize_state(cls):
     s = cls(message="message")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR uses the already defined (but unused) `n_map_states` attribute on `Mapped` states to store the expected width of a mapped pipeline.  Will allow us to address point 1 in #3233 


## Changes
This PR refactors the already implemented but unused `n_map_states` attribute in a way that is backwards compatible with our serializer logic so will work off-the-shelf with no changes to Server / Cloud.




## Importance
For displaying more information about mapped pipelines in the UI.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)