### PR TITLE
Expand FunctionTask AttributeError Message

### DIFF
--- a/changes/pr3248.yaml
+++ b/changes/pr3248.yaml
@@ -1,0 +1,6 @@
+enhancement:
+    - "Expand FunctionTask AttributeError Message - [#3248](https://github.com/PrefectHQ/prefect/pull/3248)"
+  
+contributor:
+    - "[Rowan Molony](https://github.com/rdmolony)"
+  

--- a/pr.py
+++ b/pr.py
@@ -1,9 +1,0 @@
-import pandas as pd
-from prefect import task, Flow
-
-task_func = task(lambda: pd.DataFrame())
-undecorated_func = lambda x: x.rename("blah")
-
-with Flow(name="Broken Flow") as flow:
-    task_arg = task_func()
-    undecorated_func(task_arg)

--- a/pr.py
+++ b/pr.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from prefect import task, Flow
+
+task_func = task(lambda: pd.DataFrame())
+undecorated_func = lambda x: x.rename("blah")
+
+with Flow(name="Broken Flow") as flow:
+    task_arg = task_func()
+    undecorated_func(task_arg)

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -65,4 +65,8 @@ class FunctionTask(prefect.Task):
     def __getattr__(self, k):
         if k == "__wrapped__":
             return self.run
-        raise AttributeError(f"'FunctionTask' object has no attribute {k}")
+        raise AttributeError(
+            f"'FunctionTask' object has no attribute {k}."
+            f" Did you call {self.name} within a function that should have been"
+            " decorated with @prefect.task?"
+        )

--- a/src/prefect/tasks/core/function.py
+++ b/src/prefect/tasks/core/function.py
@@ -67,6 +67,6 @@ class FunctionTask(prefect.Task):
             return self.run
         raise AttributeError(
             f"'FunctionTask' object has no attribute {k}."
-            f" Did you call {self.name} within a function that should have been"
-            " decorated with @prefect.task?"
+            " Did you call this object within a function that should have been"
+            "decorated with @prefect.task?"
         )

--- a/tests/tasks/core/test_core.py
+++ b/tests/tasks/core/test_core.py
@@ -77,8 +77,11 @@ class TestFunctionTask:
             pass
 
         t = FunctionTask(fn=my_fn)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError) as exc:
             t.unknown_attribute
+            
+        assert "unknown_attribute" in str(exc.value)
+        assert "@prefect.task" in str(exc.value)
 
 
 class TestCollections:

--- a/tests/tasks/core/test_core.py
+++ b/tests/tasks/core/test_core.py
@@ -70,12 +70,12 @@ class TestFunctionTask:
         t = FunctionTask(fn=my_fn)
         assert t.__wrapped__ == my_fn
         assert not hasattr(FunctionTask, "__wrapped__")
-    
+
     def test_function_task_raises_attribute_error(self):
         def my_fn():
             """An example function"""
             pass
-        
+
         t = FunctionTask(fn=my_fn)
         with pytest.raises(AttributeError):
             t.unknown_attribute

--- a/tests/tasks/core/test_core.py
+++ b/tests/tasks/core/test_core.py
@@ -70,6 +70,15 @@ class TestFunctionTask:
         t = FunctionTask(fn=my_fn)
         assert t.__wrapped__ == my_fn
         assert not hasattr(FunctionTask, "__wrapped__")
+    
+    def test_function_task_raises_attribute_error(self):
+        def my_fn():
+            """An example function"""
+            pass
+        
+        t = FunctionTask(fn=my_fn)
+        with pytest.raises(AttributeError):
+            t.unknown_attribute
 
 
 class TestCollections:

--- a/tests/tasks/core/test_core.py
+++ b/tests/tasks/core/test_core.py
@@ -79,7 +79,7 @@ class TestFunctionTask:
         t = FunctionTask(fn=my_fn)
         with pytest.raises(AttributeError) as exc:
             t.unknown_attribute
-            
+
         assert "unknown_attribute" in str(exc.value)
         assert "@prefect.task" in str(exc.value)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Expand `FunctionTask` AttributeError Message to prompt user to check if they have called a `FunctionTask` within a function that should have been decorated with `prefect.task`


## Changes
<!-- What does this PR change? -->
- Expands `FunctionTask` AttributeError Message
- Adds a test for `FunctionTask` being called with an unknown attribute



## Importance
<!-- Why is this PR important? -->
Currently when a complete eejit such as myself forgets to decorate a function called in a `prefect.Flow` with `prefect.task` and passes another `prefect.task` to this function as an argument in this flow; the error message could nudge future me towards a quicker fix.  

In my case this forgetfulness resulted in a `pandas.DataFrame` function argument being interpreted as a `prefect.task` due to this missing decorator with the resulting error message:

Example:
```python
import pandas as pd
from prefect import task, Flow

task_func = task(lambda: pd.DataFrame())
undecorated_func = lambda x: x.rename("blah")

with Flow(name="Broken Flow") as flow:
    task_arg = task_func()
    undecorated_func(task_arg)
```
__Old Behaviour__:  `flow.run()` returns:
```python-traceback
AttributeError: 'FunctionTask' object has no attribute 'rename'
```
__New Behaviour__:  `flow.run()` returns:
```python-traceback
AttributeError: 'FunctionTask' object has no attribute 'rename'.  Did you call this object within a function that should have been decorated with @prefect.task?"
```


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)