### PR TITLE
make identifier optional in KubernetesAgent.replace_job_spec_yaml() (fixes #3250)

### DIFF
--- a/changes/pr3251.yaml
+++ b/changes/pr3251.yaml
@@ -1,4 +1,4 @@
-feature:
+fix:
   - "Make identifier optional in KubernetesAgent.replace_job_spec_yaml() - [#3251](https://github.com/PrefectHQ/prefect/pull/3251)"
 
 contributor:

--- a/changes/pr3251.yaml
+++ b/changes/pr3251.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Make identifier optional in KubernetesAgent.replace_job_spec_yaml() - [#3251](https://github.com/PrefectHQ/prefect/pull/3251)"
+
+contributor:
+ - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -213,10 +213,7 @@ class KubernetesAgent(Agent):
 
         image = get_flow_image(flow_run=flow_run)
 
-        identifier = str(uuid.uuid4())[:8]
-        job_spec = self.replace_job_spec_yaml(
-            flow_run=flow_run, image=image, identifier=identifier
-        )
+        job_spec = self.replace_job_spec_yaml(flow_run=flow_run, image=image)
 
         self.logger.debug(
             "Creating namespaced job {}".format(job_spec["metadata"]["name"])
@@ -230,7 +227,7 @@ class KubernetesAgent(Agent):
         return "Job {}".format(job.metadata.name)
 
     def replace_job_spec_yaml(
-        self, flow_run: GraphQLResult, image: str, identifier: str
+        self, flow_run: GraphQLResult, image: str, identifier: str = None
     ) -> dict:
         """
         Populate a k8s job spec. This spec defines a k8s job that handles
@@ -259,11 +256,13 @@ class KubernetesAgent(Agent):
         Args:
             - flow_run (GraphQLResult): A flow run object
             - image (str): The full name of an image to use for the job
-            - identifier (str): A unique identifier to identify this job
+            - identifier (str): A unique identifier to identify this job. If none is given,
+                Prefect will create a random identifier each time a job is created.
 
         Returns:
             - dict: a dictionary representation of a k8s job for flow execution
         """
+        identifier = identifier or str(uuid.uuid4())[:8]
         yaml_path = os.getenv(
             "YAML_TEMPLATE", path.join(path.dirname(__file__), "job_spec.yaml")
         )

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -247,9 +247,7 @@ def test_k8s_agent_replace_yaml_uses_user_env_vars(monkeypatch, cloud_api):
         {"cloud.agent.auth_token": "token", "logging.log_to_cloud": True}
     ):
         agent = KubernetesAgent(env_vars=dict(AUTH_THING="foo", PKG_SETTING="bar"))
-        job = agent.replace_job_spec_yaml(
-            flow_run, image="test/name:tag", identifier="identifier"
-        )
+        job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
 
         assert job["metadata"]["labels"]["prefect.io/flow_run_id"] == "id"
         assert job["metadata"]["labels"]["prefect.io/flow_id"] == "new_id"
@@ -323,9 +321,7 @@ def test_k8s_agent_replace_yaml(monkeypatch, cloud_api):
         volume_mounts = [{"name": "my-vol", "mountPath": "/mnt/my-mount"}]
         volumes = [{"name": "my-vol", "hostPath": "/host/folder"}]
         agent = KubernetesAgent(volume_mounts=volume_mounts, volumes=volumes)
-        job = agent.replace_job_spec_yaml(
-            flow_run, image="test/name:tag", identifier="identifier"
-        )
+        job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
 
         assert job["metadata"]["labels"]["prefect.io/flow_run_id"] == "id"
         assert job["metadata"]["labels"]["prefect.io/flow_id"] == "new_id"
@@ -405,9 +401,7 @@ def test_k8s_agent_replace_yaml_responds_to_logging_config(
     )
 
     agent = KubernetesAgent(no_cloud_logs=flag)
-    job = agent.replace_job_spec_yaml(
-        flow_run, image="test/name:tag", identifier="identifier"
-    )
+    job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
     env = job["spec"]["template"]["spec"]["containers"][0]["env"]
     assert env[6]["value"] == str(not flag).lower()
 
@@ -439,9 +433,7 @@ def test_k8s_agent_replace_yaml_no_pull_secrets(monkeypatch, cloud_api):
     )
 
     agent = KubernetesAgent()
-    job = agent.replace_job_spec_yaml(
-        flow_run, image="test/name:tag", identifier="identifier"
-    )
+    job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
 
     assert not job["spec"]["template"]["spec"].get("imagePullSecrets", None)
 
@@ -467,7 +459,7 @@ def test_k8s_agent_removes_yaml_no_volume(monkeypatch, cloud_api):
     )
 
     agent = KubernetesAgent()
-    job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag", identifier="id")
+    job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
 
     assert not job["spec"]["template"]["spec"].get("volumes", None)
     assert not job["spec"]["template"]["spec"]["containers"][0].get(
@@ -502,9 +494,7 @@ def test_k8s_agent_includes_agent_labels_in_job(monkeypatch, cloud_api):
     )
 
     agent = KubernetesAgent(labels=["foo", "bar"])
-    job = agent.replace_job_spec_yaml(
-        flow_run, image="test/name:tag", identifier="identifier"
-    )
+    job = agent.replace_job_spec_yaml(flow_run, image="test/name:tag")
     env = job["spec"]["template"]["spec"]["containers"][0]["env"]
     assert env[5]["value"] == "['foo', 'bar']"
 


### PR DESCRIPTION
## Summary

See #3250 for a summary.

## Changes

Makes `identifier` optional in `KuebrnetesAgent.replace_job_spec_yaml()` to avoid breaking older code that is using that method directly.

## Importance

This PR fixes a small regression introduced in 0.13.5 which could break older code that directly calls `KubernetesAgent.replace_job_spec_yaml()`.

Instead of removing the `identifier` argument in this PR, I opted to give it a default value. If I just removed it, code written in v 0.13.5 which passes `identifier` would break in the next release.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)