### PR TITLE
Ellipsis Support for GraphQL DSL

### DIFF
--- a/changes/pr3268.yaml
+++ b/changes/pr3268.yaml
@@ -1,0 +1,5 @@
+enhancement:
+    - "Ellipsis Support for GraphQL DSL - [#3268](https://github.com/PrefectHQ/prefect/pull/3268)"
+  
+contributor:
+    - "[Ashmeet Lamba](https://github.com/ashmeet13)"

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -117,14 +117,14 @@ def parse_graphql(document: Any) -> str:
     }
     ```
 
-    For convenience, if a dictionary key is True, it is ignored and the key alone is used as
-    a field name
+    For convenience, if a dictionary key is either True or Ellipsis(...), it is ignored and
+    the key alone is used as a field name.
 
     ```python
     {'query':{
         'books': {
             'id': True,
-            'name': True,
+            'name': ...,
             'author': {
                 'id',
                 'name',
@@ -177,7 +177,7 @@ def _parse_graphql_inner(document: Any, delimiter: str) -> str:
     elif isinstance(document, dict):
         result = []
         for key, value in document.items():
-            if value is True:
+            if value in (True, Ellipsis):
                 result.append(key)
             else:
                 result.append(

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -335,6 +335,26 @@ def test_use_true_to_indicate_field_name():
     )
 
 
+def test_use_ellipsis_to_indicate_field_name():
+    inner = OrderedDict()
+    inner["id"] = ...
+    inner["authors"] = {"id"}
+
+    verify(
+        query={"query": {"books": inner}},
+        expected="""
+            query {
+                books {
+                    id
+                    authors {
+                        id
+                    }
+                }
+            }
+        """,
+    )
+
+
 def test_box_query_parsing():
     verify(
         query=Box(query=Box(books={"id"})),


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Hi!
Was looking to make my first open source contribution and saw #1788 unpicked.
This PR implements the suggested aesthetic enhancement while writing GraqphQL in Python

Currently, if a dictionary key is True, it is ignored and the key alone is used as a field name.
Adding support for Ellipsis `...` to have the same behavior

#### Currently - 
```
python
    {'query':{
        'books': {
            'id': True,
            'name': True,
            'author': {
                'id',
                'name',
            }
        }
    }}
```
is equivalent to -
```
python
    {'query':{
        'books': [
            'id',
            'name',
            {'author': {
                'id',
                'name',
            }}
        ]
    }}
```




## Changes
This PR will enable the developer to write the following syntax in Python
```
python
    {'query':{
        'books': {
            'id': True,
            'name': ...,
            'author': {
                'id',
                'name',
            }
        }
    }}
```
and receive the same converted query as before -
```
python
    {'query':{
        'books': [
            'id',
            'name',
            {'author': {
                'id',
                'name',
            }}
        ]
    }}
```
[Permalink](https://github.com/ashmeet13/prefect/blob/3c640c664d156c4cba325b2523827ad95ba9beda/src/prefect/utilities/graphql.py#L180) for the modified logic
[Permalink](https://github.com/ashmeet13/prefect/blob/3c640c664d156c4cba325b2523827ad95ba9beda/tests/utilities/test_graphql.py#L338-L355) for the test added

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Closes #1788