### PR TITLE
Change https://localhost to http in welcome message

### DIFF
--- a/changes/pr3271.yaml
+++ b/changes/pr3271.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Change https://localhost to http://localhost in the welcome message - [#3271](https://github.com/PrefectHQ/prefect/pull/3271) "

--- a/changes/pr3271.yaml
+++ b/changes/pr3271.yaml
@@ -1,2 +1,5 @@
 fix:
   - "Change https://localhost to http://localhost in the welcome message - [#3271](https://github.com/PrefectHQ/prefect/pull/3271) "
+
+contributor:
+  - "[Shunwen](https://github.com/shunwen)"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -372,7 +372,7 @@ def start(
 
 def ascii_welcome(ui_port="8080"):
     ui_url = click.style(
-        f"https://localhost:{ui_port}", fg="white", bg="blue", bold=True
+        f"http://localhost:{ui_port}", fg="white", bg="blue", bold=True
     )
     docs_url = click.style("https://docs.prefect.io", fg="white", bg="blue", bold=True)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Change `https://localhost` to `http://localhost` in the welcome message because HTTPS doesn't work on port 8080, see #3270.



## Changes
Change https://localhost to http://localhost in the local server welcome message




## Importance
1. It could not connect to localhost by copy-paste the URL in the welcome message in the browser.
2. Prefect Docs says `http://localhost:8080` instead of `https`



## Checklist
I think none of the checklist items is necessary for this change. Let me know if I missed anything.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)