### PR TITLE
add boto_kwargs to init method of aws_tasks

### DIFF
--- a/changes/pr3275.yaml
+++ b/changes/pr3275.yaml
@@ -1,0 +1,6 @@
+enhancement:
+    - "Add boto_kwargs to AWS tasks - [#3275](https://github.com/PrefectHQ/prefect/pull/3275)"
+  
+contributor:
+    - "[Robin Beer](https://github.com/Zaubeerer)"
+  

--- a/src/prefect/tasks/aws/lambda_function.py
+++ b/src/prefect/tasks/aws/lambda_function.py
@@ -46,6 +46,7 @@ class LambdaCreate(Task):
             subset of incoming requests with Amazon X-Ray
         - layers (List[str], optional): a list of function layers to add to
             the function's execution environment, specify each layer by its ARN
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -72,6 +73,7 @@ class LambdaCreate(Task):
         function_tags: dict = None,
         tracing_config: str = "PassThrough",
         layers: list = None,
+        boto_kwargs: dict = None,
         **kwargs
     ):
         self.function_name = function_name
@@ -105,9 +107,14 @@ class LambdaCreate(Task):
         self.tracing_config = tracing_config
         self.layers = layers
 
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None, boto_kwargs: dict = None):
+    def run(self, credentials: dict = None):
         """
         Task run method. Creates Lambda function.
 
@@ -117,17 +124,13 @@ class LambdaCreate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - json: response from AWS CreateFunction endpoint
         """
 
-        if boto_kwargs is None:
-            boto_kwargs = {}
-
         lambda_client = get_boto_client(
-            "lambda", credentials=credentials, **boto_kwargs
+            "lambda", credentials=credentials, **self.boto_kwargs
         )
 
         # create lambda function
@@ -161,16 +164,29 @@ class LambdaDelete(Task):
         - function_name (str): name of the Lambda function to delete
         - qualifier (str, optional): specify a version to delete, if not
             provided, the function will be deleted entirely
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, function_name: str, qualifier: str = "", **kwargs):
+    def __init__(
+        self,
+        function_name: str,
+        qualifier: str = "",
+        boto_kwargs: dict = None,
+        **kwargs
+    ):
         self.function_name = function_name
         self.qualifier = qualifier
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None, boto_kwargs: dict = None):
+    def run(self, credentials: dict = None):
         """
         Task run method. Deletes Lambda function.
 
@@ -180,17 +196,13 @@ class LambdaDelete(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict: response from AWS DeleteFunction endpoint
         """
 
-        if boto_kwargs is None:
-            boto_kwargs = {}
-
         lambda_client = get_boto_client(
-            "lambda", credentials=credentials, **boto_kwargs
+            "lambda", credentials=credentials, **self.boto_kwargs
         )
 
         # delete function, depending on if qualifier provided
@@ -222,6 +234,7 @@ class LambdaInvoke(Task):
             Lambda function as input
         - qualifier (str, optional): specify a version or alias to invoke a
             published version of the function, defaults to $LATEST
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -234,6 +247,7 @@ class LambdaInvoke(Task):
         client_context: dict = None,
         payload: str = json.dumps(None),
         qualifier: str = "$LATEST",
+        boto_kwargs: dict = None,
         **kwargs
     ):
         self.function_name = function_name
@@ -245,6 +259,12 @@ class LambdaInvoke(Task):
 
         self.payload = payload
         self.qualifier = qualifier
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
     def _encode_lambda_context(self, custom=None, env=None, client=None):
@@ -267,11 +287,7 @@ class LambdaInvoke(Task):
 
     @defaults_from_attrs("function_name", "payload")
     def run(
-        self,
-        function_name: str = None,
-        payload: str = None,
-        credentials: dict = None,
-        boto_kwargs: dict = None,
+        self, function_name: str = None, payload: str = None, credentials: dict = None,
     ):
         """
         Task run method. Invokes Lambda function.
@@ -285,16 +301,13 @@ class LambdaInvoke(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict : response from AWS Invoke endpoint
         """
-        if boto_kwargs is None:
-            boto_kwargs = {}
 
         lambda_client = get_boto_client(
-            "lambda", credentials=credentials, **boto_kwargs
+            "lambda", credentials=credentials, **self.boto_kwargs
         )
 
         # invoke lambda function
@@ -323,6 +336,7 @@ class LambdaList(Task):
             by a previous request to retreive the next page of results
         - max_items (int, optional): specify a value between 1 and 50 to limit
             the number of functions in the response
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -333,15 +347,22 @@ class LambdaList(Task):
         function_version: str = "ALL",
         marker: str = None,
         max_items: int = 50,
+        boto_kwargs: dict = None,
         **kwargs
     ):
         self.master_region = master_region
         self.function_version = function_version
         self.marker = marker
         self.max_items = max_items
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None, boto_kwargs: dict = None):
+    def run(self, credentials: dict = None):
         """
         Task fun method. Lists all Lambda functions.
 
@@ -351,16 +372,13 @@ class LambdaList(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict : a list of Lambda functions from AWS ListFunctions endpoint
         """
-        if boto_kwargs is None:
-            boto_kwargs = {}
 
         lambda_client = get_boto_client(
-            "lambda", credentials=credentials, **boto_kwargs
+            "lambda", credentials=credentials, **self.boto_kwargs
         )
 
         # list functions, optionally passing in marker if not None

--- a/src/prefect/tasks/aws/lambda_function.py
+++ b/src/prefect/tasks/aws/lambda_function.py
@@ -107,7 +107,7 @@ class LambdaCreate(Task):
 
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None):
+    def run(self, credentials: dict = None, boto_kwargs: dict = None):
         """
         Task run method. Creates Lambda function.
 
@@ -117,12 +117,19 @@ class LambdaCreate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - json: response from AWS CreateFunction endpoint
         """
 
-        lambda_client = get_boto_client("lambda", credentials=credentials)
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
+        lambda_client = get_boto_client(
+            "lambda", credentials=credentials, **boto_kwargs
+        )
 
         # create lambda function
         response = lambda_client.create_function(
@@ -164,7 +171,7 @@ class LambdaDelete(Task):
         self.qualifier = qualifier
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None):
+    def run(self, credentials: dict = None, boto_kwargs: dict = None):
         """
         Task run method. Deletes Lambda function.
 
@@ -174,12 +181,19 @@ class LambdaDelete(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - dict: response from AWS DeleteFunction endpoint
         """
 
-        lambda_client = get_boto_client("lambda", credentials=credentials)
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
+        lambda_client = get_boto_client(
+            "lambda", credentials=credentials, **boto_kwargs
+        )
 
         # delete function, depending on if qualifier provided
         if len(self.qualifier) > 0:
@@ -255,7 +269,11 @@ class LambdaInvoke(Task):
 
     @defaults_from_attrs("function_name", "payload")
     def run(
-        self, function_name: str = None, payload: str = None, credentials: dict = None
+        self,
+        function_name: str = None,
+        payload: str = None,
+        credentials: dict = None,
+        boto_kwargs: dict = None,
     ):
         """
         Task run method. Invokes Lambda function.
@@ -269,12 +287,18 @@ class LambdaInvoke(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - dict : response from AWS Invoke endpoint
         """
+        if boto_kwargs is None:
+            boto_kwargs = {}
 
-        lambda_client = get_boto_client("lambda", credentials=credentials)
+        lambda_client = get_boto_client(
+            "lambda", credentials=credentials, **boto_kwargs
+        )
 
         # invoke lambda function
         response = lambda_client.invoke(
@@ -320,7 +344,7 @@ class LambdaList(Task):
         self.max_items = max_items
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None):
+    def run(self, credentials: dict = None, boto_kwargs: dict = None):
         """
         Task fun method. Lists all Lambda functions.
 
@@ -330,12 +354,18 @@ class LambdaList(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - dict : a list of Lambda functions from AWS ListFunctions endpoint
         """
+        if boto_kwargs is None:
+            boto_kwargs = {}
 
-        lambda_client = get_boto_client("lambda", credentials=credentials)
+        lambda_client = get_boto_client(
+            "lambda", credentials=credentials, **boto_kwargs
+        )
 
         # list functions, optionally passing in marker if not None
         if self.marker:

--- a/src/prefect/tasks/aws/lambda_function.py
+++ b/src/prefect/tasks/aws/lambda_function.py
@@ -117,8 +117,7 @@ class LambdaCreate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - json: response from AWS CreateFunction endpoint
@@ -181,8 +180,7 @@ class LambdaDelete(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict: response from AWS DeleteFunction endpoint
@@ -287,8 +285,7 @@ class LambdaInvoke(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict : response from AWS Invoke endpoint
@@ -354,8 +351,7 @@ class LambdaList(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict : a list of Lambda functions from AWS ListFunctions endpoint

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -46,8 +46,7 @@ class S3Download(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to download from
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - str: the contents of this Key / Bucket, as a string
@@ -114,8 +113,7 @@ class S3Upload(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to upload to
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - str: the name of the Key the data payload was uploaded to

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -28,7 +28,13 @@ class S3Download(Task):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("bucket")
-    def run(self, key: str, credentials: str = None, bucket: str = None):
+    def run(
+        self,
+        key: str,
+        credentials: str = None,
+        bucket: str = None,
+        boto_kwargs: dict = None,
+    ):
         """
         Task run method.
 
@@ -40,6 +46,8 @@ class S3Download(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to download from
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - str: the contents of this Key / Bucket, as a string
@@ -47,7 +55,10 @@ class S3Download(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client("s3", credentials=credentials)
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
+        s3_client = get_boto_client("s3", credentials=credentials, **boto_kwargs)
 
         stream = io.BytesIO()
 
@@ -83,7 +94,12 @@ class S3Upload(Task):
 
     @defaults_from_attrs("bucket")
     def run(
-        self, data: str, key: str = None, credentials: dict = None, bucket: str = None
+        self,
+        data: str,
+        key: str = None,
+        credentials: dict = None,
+        bucket: str = None,
+        boto_kwargs: dict = None,
     ):
         """
         Task run method.
@@ -98,6 +114,8 @@ class S3Upload(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to upload to
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - str: the name of the Key the data payload was uploaded to
@@ -105,7 +123,10 @@ class S3Upload(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client("s3", credentials=credentials)
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
+        s3_client = get_boto_client("s3", credentials=credentials, **boto_kwargs)
 
         # prepare data
         try:

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -19,21 +19,24 @@ class S3Download(Task):
 
     Args:
         - bucket (str, optional): the name of the S3 Bucket to download from
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, bucket: str = None, **kwargs):
+    def __init__(self, bucket: str = None, boto_kwargs: dict = None, **kwargs):
         self.bucket = bucket
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
     @defaults_from_attrs("bucket")
     def run(
-        self,
-        key: str,
-        credentials: str = None,
-        bucket: str = None,
-        boto_kwargs: dict = None,
+        self, key: str, credentials: str = None, bucket: str = None,
     ):
         """
         Task run method.
@@ -46,7 +49,6 @@ class S3Download(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to download from
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - str: the contents of this Key / Bucket, as a string
@@ -54,10 +56,7 @@ class S3Download(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        if boto_kwargs is None:
-            boto_kwargs = {}
-
-        s3_client = get_boto_client("s3", credentials=credentials, **boto_kwargs)
+        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
 
         stream = io.BytesIO()
 
@@ -83,22 +82,24 @@ class S3Upload(Task):
 
     Args:
         - bucket (str, optional): the name of the S3 Bucket to upload to
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, bucket: str = None, **kwargs):
+    def __init__(self, bucket: str = None, boto_kwargs: dict = None, **kwargs):
         self.bucket = bucket
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
     @defaults_from_attrs("bucket")
     def run(
-        self,
-        data: str,
-        key: str = None,
-        credentials: dict = None,
-        bucket: str = None,
-        boto_kwargs: dict = None,
+        self, data: str, key: str = None, credentials: dict = None, bucket: str = None,
     ):
         """
         Task run method.
@@ -113,7 +114,6 @@ class S3Upload(Task):
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
             - bucket (str, optional): the name of the S3 Bucket to upload to
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - str: the name of the Key the data payload was uploaded to
@@ -121,10 +121,7 @@ class S3Upload(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        if boto_kwargs is None:
-            boto_kwargs = {}
-
-        s3_client = get_boto_client("s3", credentials=credentials, **boto_kwargs)
+        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
 
         # prepare data
         try:

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -38,6 +38,8 @@ class AWSSecretsManager(SecretBase):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - **kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor
 
         Returns:
             - dict: the contents of this secret, as a dictionary

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -27,7 +27,7 @@ class AWSSecretsManager(SecretBase):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("secret")
-    def run(self, secret: str = None, credentials: str = None) -> dict:
+    def run(self, secret: str = None, credentials: str = None, **kwargs) -> dict:
         """
         Task run method.
 
@@ -46,7 +46,7 @@ class AWSSecretsManager(SecretBase):
         if secret is None:
             raise ValueError("A secret name must be provided.")
 
-        secrets_client = get_boto_client("secretsmanager", credentials=credentials)
+        secrets_client = get_boto_client("secretsmanager", credentials=credentials, **kwargs)
 
         secret_string = secrets_client.get_secret_value(SecretId=secret)["SecretString"]
 

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -27,7 +27,9 @@ class AWSSecretsManager(SecretBase):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("secret")
-    def run(self, secret: str = None, credentials: str = None, **kwargs) -> dict:
+    def run(
+        self, secret: str = None, credentials: str = None, boto_kwargs: dict = None
+    ) -> dict:
         """
         Task run method.
 
@@ -38,8 +40,8 @@ class AWSSecretsManager(SecretBase):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - **kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - dict: the contents of this secret, as a dictionary
@@ -48,8 +50,11 @@ class AWSSecretsManager(SecretBase):
         if secret is None:
             raise ValueError("A secret name must be provided.")
 
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
         secrets_client = get_boto_client(
-            "secretsmanager", credentials=credentials, **kwargs
+            "secretsmanager", credentials=credentials, **boto_kwargs
         )
 
         secret_string = secrets_client.get_secret_value(SecretId=secret)["SecretString"]

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -46,7 +46,9 @@ class AWSSecretsManager(SecretBase):
         if secret is None:
             raise ValueError("A secret name must be provided.")
 
-        secrets_client = get_boto_client("secretsmanager", credentials=credentials, **kwargs)
+        secrets_client = get_boto_client(
+            "secretsmanager", credentials=credentials, **kwargs
+        )
 
         secret_string = secrets_client.get_secret_value(SecretId=secret)["SecretString"]
 

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -40,8 +40,7 @@ class AWSSecretsManager(SecretBase):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict: the contents of this secret, as a dictionary

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -39,8 +39,7 @@ class StepActivate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
-                Task constructor that are forwarded as kwargs to the boto client
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict: response from AWS StartExecution endpoint

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -29,7 +29,7 @@ class StepActivate(Task):
         self.execution_input = execution_input
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None):
+    def run(self, credentials: dict = None, boto_kwargs: dict = None):
         """
         Task run method. Activates AWS Step function.
 
@@ -39,12 +39,19 @@ class StepActivate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - boto_kwargs (dict, optional): additional keyword arguments to pass to the
+                Task constructor that are forwarded as kwargs to the boto client
 
         Returns:
             - dict: response from AWS StartExecution endpoint
         """
 
-        step_client = get_boto_client("stepfunctions", credentials=credentials)
+        if boto_kwargs is None:
+            boto_kwargs = {}
+
+        step_client = get_boto_client(
+            "stepfunctions", credentials=credentials, **boto_kwargs
+        )
 
         response = step_client.start_execution(
             stateMachineArn=self.state_machine_arn,

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -13,6 +13,7 @@ class StepActivate(Task):
             your AWS account, region, and state machine for 90 days
         - execution_input (str, optional): string that contains the JSON input data for
             the execution
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -22,14 +23,21 @@ class StepActivate(Task):
         state_machine_arn: str,
         execution_name: str,
         execution_input: str = "{}",
+        boto_kwargs: dict = None,
         **kwargs
     ):
         self.state_machine_arn = state_machine_arn
         self.execution_name = execution_name
         self.execution_input = execution_input
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None, boto_kwargs: dict = None):
+    def run(self, credentials: dict = None):
         """
         Task run method. Activates AWS Step function.
 
@@ -39,17 +47,13 @@ class StepActivate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
-            - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
 
         Returns:
             - dict: response from AWS StartExecution endpoint
         """
 
-        if boto_kwargs is None:
-            boto_kwargs = {}
-
         step_client = get_boto_client(
-            "stepfunctions", credentials=credentials, **boto_kwargs
+            "stepfunctions", credentials=credentials, **self.boto_kwargs
         )
 
         response = step_client.start_execution(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary & Changes
kwargs are added to the run method of the secrets manager task to enable the user to specify e.g. `region_name` in the boto client.

## Importance
It seems like there were previously no other functioning methods to specifying `AWS_DEFAULT_REGION`. This provides a general solution to such problems.

## Checklist

This PR:
I only added the kwargs as Args within the AWS secrets manager
- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)