### PR TITLE
Add S3List task

### DIFF
--- a/changes/pr3282.yaml
+++ b/changes/pr3282.yaml
@@ -1,0 +1,4 @@
+task:
+    - "Add new `S3List` task for listing keys in an S3 bucket - [#3282](https://github.com/PrefectHQ/prefect/pull/3282)."
+contributor:
+    - "[Max Del Giudice](https://github.com/madelgi)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -246,7 +246,7 @@ classes = ["WriteAirtableRow", "ReadAirtableRow"]
 [pages.tasks.aws]
 title = "AWS Tasks"
 module = "prefect.tasks.aws"
-classes = ["S3Download", "S3Upload", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate", "AWSSecretsManager"]
+classes = ["S3Download", "S3Upload", "S3List", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate", "AWSSecretsManager"]
 
 [pages.tasks.azure]
 title = "Azure Tasks"

--- a/src/prefect/tasks/aws/__init__.py
+++ b/src/prefect/tasks/aws/__init__.py
@@ -4,7 +4,7 @@ This module contains a collection of tasks for interacting with AWS resources.
 All AWS related tasks can be authenticated using the `AWS_CREDENTIALS` Prefect Secret that should be a dictionary with two keys: `"ACCESS_KEY"` and `"SECRET_ACCESS_KEY"`.  See [Third Party Authentication](../../../orchestration/recipes/third_party_auth.html) for more information.
 """
 try:
-    from prefect.tasks.aws.s3 import S3Download, S3Upload
+    from prefect.tasks.aws.s3 import S3Download, S3Upload, S3List
     from prefect.tasks.aws.lambda_function import (
         LambdaCreate,
         LambdaDelete,

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -146,7 +146,7 @@ class S3List(Task):
     @defaults_from_attrs("bucket")
     def run(
         self,
-        key: str,
+        prefix: str,
         delimiter: str = "",
         page_size: int = None,
         max_items: int = None,
@@ -157,7 +157,7 @@ class S3List(Task):
         Task run method.
 
         Args:
-            - key (str): the name of the Key within this bucket to retrieve
+            - prefix (str): the name of the prefix within this bucket to retrieve objects from
             - delimiter (str): indicates the key hierarchy
             - page_size (int): controls the number of items returned per page of each result
             - max_items (int): limits the maximum number of total items returned during pagination
@@ -169,7 +169,7 @@ class S3List(Task):
             - bucket (str, optional): the name of the S3 Bucket to list the files of
 
         Returns:
-            - str: the contents of this Key / Bucket, as a string
+            - list[str]: A list of keys that match the given prefix.
         """
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
@@ -179,7 +179,7 @@ class S3List(Task):
         config = {"PageSize": page_size, "MaxItems": max_items}
         paginator = s3_client.get_paginator("list_objects_v2")
         results = paginator.paginate(
-            Bucket=bucket, Prefix=key, Delimiter=delimiter, PaginationConfig=config
+            Bucket=bucket, Prefix=prefix, Delimiter=delimiter, PaginationConfig=config
         )
 
         files = []

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import prefect
-from prefect.tasks.aws import S3Download, S3Upload
+from prefect.tasks.aws import S3Download, S3Upload, S3List
 from prefect.utilities.configuration import set_temporary_config
 
 
@@ -49,3 +49,18 @@ class TestS3Upload:
             ):
                 task.run(data="")
         assert type(client.upload_fileobj.call_args[1]["Key"]) == str
+
+
+class TestS3List:
+    def test_initialization(self):
+        task = S3List()
+
+    def test_initialization_passes_to_task_constructor(self):
+        task = S3List(name="test", tags=["AWS"])
+        assert task.name == "test"
+        assert task.tags == {"AWS"}
+
+    def test_raises_if_bucket_not_eventually_provided(self):
+        task = S3List()
+        with pytest.raises(ValueError, match="bucket"):
+            task.run(key="fake/path")

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -63,4 +63,4 @@ class TestS3List:
     def test_raises_if_bucket_not_eventually_provided(self):
         task = S3List()
         with pytest.raises(ValueError, match="bucket"):
-            task.run(key="fake/path")
+            task.run(prefix="fake/path")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR adds a new task to the S3 task library, allowing for the listing of keys for a given prefix in some S3 bucket.


## Changes
<!-- What does this PR change? -->

Adds an `S3List` class to the `prefect/tasks/aws/s3.py` file, along with a corresponding test.

## Importance
<!-- Why is this PR important? -->

This is a pretty simple addition, but I often find myself reaching for this functionality when using S3. It seemed relevant enough to add to the core task library.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)