### PR TITLE
A few control-flow fixups

### DIFF
--- a/changes/pr3293.yaml
+++ b/changes/pr3293.yaml
@@ -1,0 +1,3 @@
+fix:
+  - "Allow using `apply_map` under a `case` or `resource_manager` block - [#3293](https://github.com/PrefectHQ/prefect/pull/3293)"
+  - "Fix bug with interaction between `case` blocks and `Constant` tasks which resulted in some tasks never skipping - [#3293](https://github.com/PrefectHQ/prefect/pull/3293)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -521,9 +521,9 @@ class Flow:
             self.tasks.add(task)
             self._cache.clear()
 
-            # Parameters must be root tasks
+            # Parameters and constants must be root tasks
             # All other new tasks should be added to the current case/resource (if any)
-            if not isinstance(task, Parameter):
+            if not isinstance(task, (Parameter, prefect.tasks.core.constants.Constant)):
                 case = prefect.context.get("case", None)
                 if case is not None:
                     case.add_task(task, self)

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -115,7 +115,9 @@ def apply_map(func: Callable, *args: Any, flow: "Flow" = None, **kwargs: Any) ->
     kwargs2 = {k: preprocess(v) for k, v in kwargs.items()}
 
     # Construct a temporary flow for the subgraph
-    with prefect.context(mapped=True):
+    # We set case=None & resource=None to ignore any external case/resource
+    # blocks while constructing the temporary flow.
+    with prefect.context(mapped=True, case=None, resource=None):
         with flow2:
             if no_flow_provided:
                 res = func(*args2, **kwargs2)

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -6,7 +6,6 @@ from prefect.engine.result import NoResult
 from prefect.engine.state import Skipped, Success
 from prefect.tasks.control_flow import FilterTask, ifelse, merge, switch, case
 from prefect.tasks.control_flow.conditional import CompareValue
-from prefect.tasks.core.constants import Constant
 
 
 class Condition(Task):
@@ -158,7 +157,7 @@ def test_merge_imperative_flow():
     c = merge(a, b, flow=flow)
 
     state = flow.run()
-    assert state.result[cond].result == True
+    assert state.result[cond].result is True
     assert state.result[a].result == 2
     assert state.result[b].is_skipped()
     assert state.result[c].result == 2
@@ -591,3 +590,15 @@ class TestCase:
         state = flow.run(x=1)
         assert state.result[y1].result == 2
         assert state.result[y2].is_skipped()
+
+    def test_case_with_constants(self):
+        with Flow("test") as flow:
+            cond = identity(True)
+            with case(cond, True):
+                res = inc.map(range(4))
+            with case(cond, False):
+                res2 = inc.map(range(4))
+
+        state = flow.run()
+        assert state.result[res].result == [1, 2, 3, 4]
+        assert state.result[res2].is_skipped()


### PR DESCRIPTION
A few assorted control-flow bug fixes:

- Support case blocks that create a new constant in them. These would
  work before, but due to how the `FlowRunner` special-cases `Constant`
  execution, they would never be skipped, leading to downstream tasks
  not being skipped. A different fix would be to remove this special-
  casing in the `FlowRunner`, as it can still lead to odd behavior in
  certain edge cases. For example:

  ```python
  from prefect import Flow, case, Parameter
  from prefect.utilities.tasks import as_task
  from prefect.tasks.control_flow import merge

  with Flow("this still fails") as flow:
      cond = Parameter("cond")
      flow.add_task(cond)
      with case(cond, True):
          val1 = as_task("if true")
      with case(cond, False):
          val2 = as_task("if false")
      branch = merge(val1, val2)

  state = flow.run(cond=False)
  val = state.result[branch].result
  print(f"This should be 'if false': {val!r}")
  ```

  ```
  $ python test.py
  [2020-09-10 19:35:46] INFO - prefect.FlowRunner | Beginning Flow run for 'this still fails'
  [2020-09-10 19:35:46] INFO - prefect.TaskRunner | Task 'cond': Starting task run...
  [2020-09-10 19:35:46] INFO - prefect.TaskRunner | Task 'cond': finished task run for task with final state: 'Success'
  [2020-09-10 19:35:46] INFO - prefect.TaskRunner | Task 'Merge': Starting task run...
  [2020-09-10 19:35:46] INFO - prefect.TaskRunner | Task 'Merge': finished task run for task with final state: 'Success'
  [2020-09-10 19:35:46] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
  This should be 'if false': 'if true'
  ```

- Support using `apply_map` under a `case` or `resource_manager`
  statement. Since `apply_map` creates a temporary flow before merging
  the results back into the main flow, the `case` and `resource`
  contexts need to be cleared while creating the temporary flow to avoid
  errors about "multiple flows" being used with the same case/resource
  block.

Fixes #3291.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)