### PR TITLE
Quiet the hasura logs by setting log level to warn

### DIFF
--- a/changes/pr3296.yaml
+++ b/changes/pr3296.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Quiet Hasura logs with `prefect server start` - [#3296](https://github.com/PrefectHQ/prefect/pull/3296)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_SERVER_PORT: "3000"
       HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE: 100
+      HASURA_GRAPHQL_LOG_LEVEL: "warn"
     networks:
       - prefect-server
     restart: "always"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
A user called out that the verbose logs are noisy - even in Cloud, we haven't found these logs to be particularly informative.


## Changes
<!-- What does this PR change? -->
Sets Hasura log level to "warn"



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)