### PR TITLE
Add compression argument to S3Upload and S3Download

### DIFF
--- a/changes/issue3259.yaml
+++ b/changes/issue3259.yaml
@@ -1,4 +1,4 @@
-enhacement:
+enhancement:
     - "Adds a compression argument to both S3Upload and S3Download, allowing for compression of data upon upload and decompression of data upon download - [#3259](https://github.com/PrefectHQ/prefect/issues/3259)"
 
 contributor:

--- a/changes/issue3259.yaml
+++ b/changes/issue3259.yaml
@@ -1,0 +1,5 @@
+enhacement:
+    - "Adds a compression argument to both S3Upload and S3Download, allowing for compression of data upon upload and decompression of data upon download - [#3259](https://github.com/PrefectHQ/prefect/issues/3259)"
+
+contributor:
+    - "[Max Del Giudice](https://github.com/madelgi)"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adds a `compression` argument to `S3Upload` and `S3Download`, initially referenced in [3259](https://github.com/PrefectHQ/prefect/issues/3259)



## Changes
- Adds an optional `compression` argument to `S3Upload`, compressing data upon upload. Currently supports only gzip.
- Adds an optional `compression` argument to `S3Download`, decompressing data upon download. Currently supports only gzip.




## Importance
Frequently, users will want to save on upload time / bucket space by compressing data, and this streamlines the process. Likewise, when downloading compressed data for immediate use, this allows the user to skip the intermediate step of decompression.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)