### PR TITLE
Allow copying of directories into Docker image

### DIFF
--- a/changes/pr3296.yaml
+++ b/changes/pr3296.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Quiet Hasura logs with `prefect server start` - [#3296](https://github.com/PrefectHQ/prefect/pull/3296)"

--- a/changes/pr3296.yaml
+++ b/changes/pr3296.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Quiet Hasura logs with `prefect server start` - [#3296](https://github.com/PrefectHQ/prefect/pull/3296)"

--- a/changes/pr3299.yaml
+++ b/changes/pr3299.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Allow copying of directories into Docker image - [#3299](https://github.com/PrefectHQ/prefect/pull/3299)"

--- a/changes/pr3299.yaml
+++ b/changes/pr3299.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow copying of directories into Docker image - [#3299](https://github.com/PrefectHQ/prefect/pull/3299)"

--- a/changes/pr3299.yaml
+++ b/changes/pr3299.yaml
@@ -1,0 +1,4 @@
+enhancement:
+  - "Allow copying of directories into Docker image - [#3299](https://github.com/PrefectHQ/prefect/pull/3299)"
+contributor:
+  - "[David Severin Ryberg](https://github.com/sevberg)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -475,7 +475,10 @@ class Docker(Storage):
                         )
                     )
                 else:
-                    shutil.copy2(src, full_fname)
+                    if os.path.isdir(src):
+                        shutil.copytree(src, full_fname, symlinks=False, ignore=None)
+                    else:
+                        shutil.copy2(src, full_fname)
                 copy_files += "COPY {fname} {dest}\n".format(
                     fname=full_fname.replace("\\", "/") if self.dockerfile else fname,
                     dest=dest,

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -476,9 +476,17 @@ class Docker(Storage):
                     )
                 else:
                     if os.path.isdir(src):
-                        shutil.copytree(src, full_fname, symlinks=False, ignore=None)
+                        shutil.copytree(
+                            src=src, 
+                            dst=full_fname, 
+                            symlinks=False, 
+                            ignore=None
+                        )
                     else:
-                        shutil.copy2(src, full_fname)
+                        shutil.copy2(
+                            src=src, 
+                            dst=full_fname
+                        )
                 copy_files += "COPY {fname} {dest}\n".format(
                     fname=full_fname.replace("\\", "/") if self.dockerfile else fname,
                     dest=dest,

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -74,7 +74,7 @@ class Docker(Storage):
             populated with a UUID after build
         - env_vars (dict, optional): a dictionary of environment variables to
             use when building
-        - files (dict, optional): a dictionary of files or directories to copy into 
+        - files (dict, optional): a dictionary of files or directories to copy into
             the image when building. Takes the format of `{'src': 'dest'}`
         - prefect_version (str, optional): an optional branch, tag, or commit
             specifying the version of prefect you want installed into the container;
@@ -477,16 +477,10 @@ class Docker(Storage):
                 else:
                     if os.path.isdir(src):
                         shutil.copytree(
-                            src=src, 
-                            dst=full_fname, 
-                            symlinks=False, 
-                            ignore=None
+                            src=src, dst=full_fname, symlinks=False, ignore=None
                         )
                     else:
-                        shutil.copy2(
-                            src=src, 
-                            dst=full_fname
-                        )
+                        shutil.copy2(src=src, dst=full_fname)
                 copy_files += "COPY {fname} {dest}\n".format(
                     fname=full_fname.replace("\\", "/") if self.dockerfile else fname,
                     dest=dest,

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -74,8 +74,8 @@ class Docker(Storage):
             populated with a UUID after build
         - env_vars (dict, optional): a dictionary of environment variables to
             use when building
-        - files (dict, optional): a dictionary of files to copy into the image
-            when building. Takes the format of `{'src': 'dest'}`
+        - files (dict, optional): a dictionary of files or directories to copy into 
+            the image when building. Takes the format of `{'src': 'dest'}`
         - prefect_version (str, optional): an optional branch, tag, or commit
             specifying the version of prefect you want installed into the container;
             defaults to the version you are currently using or `"master"` if your


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This will allow user to copy whole directories into the built docker image with only a single COPY command




## Changes
Docker's COPY command can accept a directory path just as easily as it can accept a file path, but shutil.copy2 (the function Prefect currently used to prepare the file to be copied) fails if given a path to a directory. Therefore a check has been added which first checks if the user specified path is a file and, if it is, shutil.copy2 is still used. On the other hand, if a directory path is provided then shutil.copytree is used.




## Importance
Aligns the capabilities of Docker's COPY command with Prefect's image build workflow




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
    - No suitable test to update
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)