### PR TITLE
UI runtime variable graphql_url => apollo_url

### DIFF
--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - "${UI_HOST_PORT:-8080}:8080"
     command: "/intercept.sh"
     environment:
-      PREFECT_SERVER__GRAPHQL_URL: ${GRAPHQL_URL:-http://localhost:4200/graphql}
+      PREFECT_SERVER__APOLLO_URL: ${APOLLO_URL:-http://localhost:4200/graphql}
     networks:
       - prefect-server
     restart: "always"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -397,10 +397,16 @@ def ascii_welcome(ui_port="8080"):
 
 @server.command(hidden=True)
 @click.option(
-    "--name", "-n", help="The name of a tenant to create", hidden=True,
+    "--name",
+    "-n",
+    help="The name of a tenant to create",
+    hidden=True,
 )
 @click.option(
-    "--slug", "-s", help="The slug of a tenant to create", hidden=True,
+    "--slug",
+    "-s",
+    help="The slug of a tenant to create",
+    hidden=True,
 )
 def create_tenant(name, slug):
     """

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -50,7 +50,7 @@ def make_env(fname=None):
         POSTGRES_DATA_PATH=config.server.database.volume_path,
     )
 
-    UI_ENV = dict(GRAPHQL_URL=config.server.ui.graphql_url)
+    UI_ENV = dict(APOLLO_URL=config.server.ui.apollo_url)
 
     HASURA_ENV = dict(HASURA_HOST_PORT=config.server.hasura.host_port)
 
@@ -397,16 +397,10 @@ def ascii_welcome(ui_port="8080"):
 
 @server.command(hidden=True)
 @click.option(
-    "--name",
-    "-n",
-    help="The name of a tenant to create",
-    hidden=True,
+    "--name", "-n", help="The name of a tenant to create", hidden=True,
 )
 @click.option(
-    "--slug",
-    "-s",
-    help="The slug of a tenant to create",
-    hidden=True,
+    "--slug", "-s", help="The slug of a tenant to create", hidden=True,
 )
 def create_tenant(name, slug):
     """

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -45,7 +45,7 @@ endpoint = "${server.host}:${server.port}"
     port = "8080"
     host_port = "8080"
     endpoint = "${server.ui.host}:${server.ui.port}"
-    graphql_url = "http://localhost:4200/graphql"
+    apollo_url = "http://localhost:4200/graphql"
 
     [server.telemetry]
     enabled = true


### PR DESCRIPTION

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Updates the variable passed by `docker-compose.yml` to the UI container from `graphql_url` => `apollo_url`.  



## Changes
<!-- What does this PR change? -->
Changes `docker-compose.yml`, the default `config.toml`, and `server.py` with the above.



## Importance
<!-- Why is this PR important? -->
This improves the clarity of which service the UI is connecting to; the UI does not connect to the GraphQL container but DOES connect to the Apollo container.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)


## Notes
This is a tandem PR with https://github.com/PrefectHQ/ui/pull/219, which will mean the UI will now respect the injected url.