### PR TITLE
Fix issue w/ state handler signals

### DIFF
--- a/changes/issue3258.yaml
+++ b/changes/issue3258.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix handling of Prefect Signals when Task state handlers are called - [#3258](https://github.com/PrefectHQ/prefect/issues/3258)"

--- a/src/prefect/engine/runner.py
+++ b/src/prefect/engine/runner.py
@@ -52,7 +52,7 @@ def call_state_handlers(method: Callable[..., State]) -> Callable[..., State]:
 
         # PrefectStateSignals are trapped and turned into States
         except signals.PrefectStateSignal as exc:
-            self.logger.debug(
+            self.logger.info(
                 "{name} signal raised: {rep}".format(
                     name=type(exc).__name__, rep=repr(exc)
                 )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR fixes an issue where Prefect signals raised within Task state handlers were incorrectly interpreted as exceptions - note that this bug was only present when running against a backend.

This PR fixes that and will make it much easier to do, e.g., ad-hoc / custom retries from within state handler logic.


## Importance
<!-- Why is this PR important? -->
Closes #3258 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)