### PR TITLE
fix logging in MySQL tasks

### DIFF
--- a/src/prefect/contrib/tasks/mysql/mysql.py
+++ b/src/prefect/contrib/tasks/mysql/mysql.py
@@ -83,12 +83,12 @@ class MySQLExecute(Task):
                         conn.commit()
 
             conn.close()
-            logging.debug("Execute Results: ", executed)
+            logging.debug("Execute Results: %s", executed)
             return executed
 
         except (Exception, pymysql.MySQLError) as e:
             conn.close()
-            logging.debug("Execute Error: ", e)
+            logging.debug("Execute Error: %s", e)
             raise e
 
 
@@ -202,10 +202,10 @@ class MySQLFetch(Task):
                         conn.commit()
 
             conn.close()
-            logging.debug("Fetch Results: ", results)
+            logging.debug("Fetch Results: %s", results)
             return results
 
         except (Exception, pymysql.MySQLError) as e:
             conn.close()
-            logging.debug("Fetch Error: ", e)
+            logging.debug("Fetch Error: %s", e)
             raise e


### PR DESCRIPTION
## Summary

This PR fixes logging in MySQL tasks, which could lead to misleading error logs that obscure the true cause of errors being logged.

I found these with `pylint`. You can find them by running the following:

```shell
pylint src/prefect/ | grep logging-too-many-args
```

## Changes

This PR changes cases like this: `logging.debug("error: ", e)` to `logging.debug("error: %s", e)`.

## Importance

The missing formatting strings in the logging statements changed by this PR will result in confusing logs when they're triggered. Consider the following

**without format string**

```python
import logging

try:
    {}["a"]
except Exception as e:
    logging.error("Fetch Error: ", e)
```

```text
--- Logging error ---
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
KeyError: 'a'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jlamb/miniconda3/lib/python3.6/logging/__init__.py", line 994, in emit
    msg = self.format(record)
  File "/Users/jlamb/miniconda3/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "/Users/jlamb/miniconda3/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/Users/jlamb/miniconda3/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "<stdin>", line 4, in <module>
Message: 'Fetch Error: '
Arguments: (KeyError('a',),)
```

**with format string**

```python
import logging

try:
    {}["a"]
except Exception as e:
    logging.error("Fetch Error: %s", str(e))
```

```text
ERROR:root:Fetch Error: 'a'
```

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Thanks for your time and consideration.