### PR TITLE
Fix GitHub task URL fragments

### DIFF
--- a/docs/core/task_library/github.md
+++ b/docs/core/task_library/github.md
@@ -9,28 +9,28 @@ containing a valid GitHub Access Token.
 
 Task for opening / creating new GitHub Pull Requests using the v3 version of the GitHub REST API.
 
-[API Reference](/api/latest/tasks/github.html#prefect-tasks-github-prs-creategithubpr)
+[API Reference](/api/latest/tasks/github.html#creategithubpr)
 
 ## OpenGitHubIssue <Badge text="task"/>
 
 Task for opening / creating new GitHub issues using the v3 version of the GitHub REST API.
 
-[API Reference](/api/latest/tasks/github.html#prefect-tasks-github-prs-opengithubissue)
+[API Reference](/api/latest/tasks/github.html#opengithubissue)
 
 ## CreateIssueComment <Badge text="task"/>
 
 Task for creating a comment on the specified GitHub issue using the v3 version of the GitHub REST API.
 
-[API Reference](/api/latest/tasks/github.html#prefect-tasks-github-prs-createissuecomment)
+[API Reference](/api/latest/tasks/github.html#createissuecomment)
 
 ## GetRepoInfo <Badge text="task"/>
 
 Task for retrieving GitHub repository information using the v3 version of the GitHub REST API.
 
-[API Reference](/api/latest/tasks/github.html#prefect-tasks-github-prs-getrepoinfo)
+[API Reference](/api/latest/tasks/github.html#getrepoinfo)
 
 ## CreateBranch <Badge text="task"/>
 
 Task for creating new branches in a given GitHub repository using the v3 version of the GitHub REST API.
 
-[API Reference](/api/latest/tasks/github.html#prefect-tasks-github-prs-createbranch)
+[API Reference](/api/latest/tasks/github.html#createbranch)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The current URLs for the GitHub tasks don't seem to work properly. This PR fixes them.

![incorrect-url](https://user-images.githubusercontent.com/17039389/93022142-7924d780-f622-11ea-8648-776e0c4df2c4.gif)



## Changes
<!-- What does this PR change? -->

- Fix `prefect-tasks-github-prs-createbranch-` in the URL fragment.


## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)