### PR TITLE
use explicit exception chaining in client

### DIFF
--- a/changes/issue3306.yaml
+++ b/changes/issue3306.yaml
@@ -1,0 +1,5 @@
+enhancement:
+    - "Use explicit exception chaining [#3306](https://github.com/PrefectHQ/prefect/issues/3306)"
+
+contributor:
+    - "[James Lamb](https://github.com/jameslamb)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -404,14 +404,14 @@ class Client:
         # parse the response
         try:
             json_resp = response.json()
-        except JSONDecodeError:
+        except JSONDecodeError as exc:
             if prefect.config.backend == "cloud" and "Authorization" not in headers:
                 raise ClientError(
                     "Malformed response received from Cloud - please ensure that you "
                     "have an API token properly configured."
-                )
+                ) from exc
             else:
-                raise ClientError("Malformed response received from API.")
+                raise ClientError("Malformed response received from API.") from exc
 
         # check if there was an API_ERROR code in the response
         if "API_ERROR" in str(json_resp.get("errors")) and retry_on_api_error:
@@ -548,8 +548,8 @@ class Client:
         elif tenant_id:
             try:
                 uuid.UUID(tenant_id)
-            except ValueError:
-                raise ValueError("The `tenant_id` must be a valid UUID.")
+            except ValueError as exc:
+                raise ValueError("The `tenant_id` must be a valid UUID.") from exc
 
         tenant = self.graphql(
             {
@@ -754,7 +754,7 @@ class Client:
                 "Flow could not be deserialized successfully. Error was: {}".format(
                     repr(exc)
                 )
-            )
+            ) from exc
 
         if compressed:
             serialized_flow = compress(serialized_flow)

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -152,7 +152,7 @@ class Secret:
                             f"The secret {self.name} was not found.  Please ensure that it "
                             f"was set correctly in your tenant: https://docs.prefect.io/"
                             f"orchestration/concepts/secrets.html"
-                        )
+                        ) from exc
                     else:
                         raise exc
                 # the result object is a Box, so we recursively restore builtin


### PR DESCRIPTION
## Summary

Adds explicit exception chaining so that exception stack traces are a bit easier to comprehend. See #3306 for a lot more detail and background discussion on this.

Thanks for your time and consideration!

## Changes

Uses explicit exception chaining like `raise RuntimeError("whatever") from exc` in all the places in `src/prefect/client/*` that are missing it.

You can confirm that they were all caught by running the following from the root of the repo:

```shell
pylint src/prefect/client | grep raise-missing-from
```

## Importance

This pull request will make some of `prefect`'s stack traces a bit easier to understand, to improve the user experience in debugging.

## Checklist

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)