### PR TITLE
Fix for restarting some mapped pipelines

### DIFF
--- a/changes/issue3246.yaml
+++ b/changes/issue3246.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue restarting Mapped pipelines with no result- [#3246](https://github.com/PrefectHQ/prefect/issues/3246)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -423,6 +423,8 @@ class TaskRunner(Runner):
             - ENDRUN: either way, we dont continue past this point
         """
         if state.is_mapped():
+            if len(state.map_states) == 0 and state.n_map_states > 0:
+                state.map_states = [None] * state.n_map_states
             raise ENDRUN(state)
 
         # we can't map if there are no success states with iterables upstream
@@ -537,7 +539,7 @@ class TaskRunner(Runner):
             return state
 
         # the task is mapped, in which case we still proceed so that the children tasks
-        # are generated (note that if the children tasks)
+        # are generated
         elif state.is_mapped():
             self.logger.debug(
                 "Task '%s': task is mapped, but run will proceed so children are generated.",

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -423,8 +423,8 @@ class TaskRunner(Runner):
             - ENDRUN: either way, we dont continue past this point
         """
         if state.is_mapped():
-            if len(state.map_states) == 0 and state.n_map_states > 0:
-                state.map_states = [None] * state.n_map_states
+            if len(state.map_states) == 0 and state.n_map_states > 0:  # type: ignore
+                state.map_states = [None] * state.n_map_states  # type: ignore
             raise ENDRUN(state)
 
         # we can't map if there are no success states with iterables upstream

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1940,6 +1940,17 @@ def test_mapped_tasks_parents_and_children_respond_to_individual_triggers():
     assert state.is_mapped()
 
 
+def test_mapped_tasks_parent_regenerates_child_pipeline():
+    runner = TaskRunner(task=Task())
+    state = runner.run(
+        upstream_states={Edge(Task(), Task(), mapped=True): Success()},
+        is_mapped_parent=True,
+        state=Mapped(n_map_states=10),
+    )
+    assert state.is_mapped()
+    assert len(state.map_states) == 10
+
+
 def test_retry_has_updated_metadata():
     a, b = Success(result=15), Success(result="abc")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR fixes a subtle issue with mapped pipelines: for a Flow that has a `Result` configured, restarting a mapped pipeline will do what you think.  In particular, it can pull the result it is supposed to map over and regenerate the correct width pipeline.  Each child task will learn its Task Run ID from Cloud along with its state, and everything will proceed.  

If you _don't_ have a `Result` configured (e.g., your pipeline doesn't exchange data and state dependencies are all you care about), restarting the mapped pipeline wouldn't quite work as you expect - specifically, because there was no data persisted, Core couldn't regenerate the correct number of child tasks that then ping the API, etc.  So, each mapped task would proceed as if it had 0 children to spawn and your Flow would (incorrectly) end in `Success`.

This PR resolves this situation by checking `n_map_states` against `map_states` on the `Mapped` state object.  Note that the parent task is already in a `Mapped` state _only when_ the pipeline is being rerun.  Now the correct number of children are spawn, regardless of whether there was a result configured.


## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
Closes #3246 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)