### PR TITLE
Use value_

### DIFF
--- a/changes/issue3034.yaml
+++ b/changes/issue3034.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with result templating that failed on task arguments named 'value' - [#3034](https://github.com/PrefectHQ/prefect/issues/3034)"

--- a/src/prefect/engine/result/base.py
+++ b/src/prefect/engine/result/base.py
@@ -257,12 +257,12 @@ class Result(ResultInterface):
             "see https://docs.prefect.io/core/concepts/results.html"
         )
 
-    def write(self, value: Any, **kwargs: Any) -> "Result":
+    def write(self, value_: Any, **kwargs: Any) -> "Result":
         """
         Serialize and write the result to the target location.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the location template
                 to determine the location to write to

--- a/src/prefect/engine/results/azure_result.py
+++ b/src/prefect/engine/results/azure_result.py
@@ -75,12 +75,12 @@ class AzureResult(Result):
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Writes the result value to a blob storage in Azure.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the location template
                 to determine the location to write to
@@ -89,7 +89,7 @@ class AzureResult(Result):
             - Result: a new Result instance with the appropriately formatted location
         """
         new = self.format(**kwargs)
-        new.value = value
+        new.value = value_
 
         self.logger.debug("Starting to upload result to {}...".format(new.location))
 

--- a/src/prefect/engine/results/constant_result.py
+++ b/src/prefect/engine/results/constant_result.py
@@ -25,12 +25,12 @@ class ConstantResult(Result):
         """
         return self
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Will return the repr of the underlying value, purely for convenience.
 
         Args:
-            - value (Any): unused, for interface compatibility
+            - value_ (Any): unused, for interface compatibility
             - **kwargs (optional): unused, for interface compatibility
 
         Raises:

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -55,12 +55,12 @@ class GCSResult(Result):
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Writes the result value to a location in GCS and returns the resulting URI.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the location template
                 to determine the location to write to
@@ -70,7 +70,7 @@ class GCSResult(Result):
         """
 
         new = self.format(**kwargs)
-        new.value = value
+        new.value = value_
         self.logger.debug("Starting to upload result to {}...".format(new.location))
         binary_data = new.serializer.serialize(new.value)
 

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -84,13 +84,13 @@ class LocalResult(Result):
 
         return new
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Writes the result to a location in the local file system and returns a new `Result`
         object with the result's location.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the location template
                 to determine the location to write to
@@ -99,7 +99,7 @@ class LocalResult(Result):
             - Result: returns a new `Result` with both `value` and `location` attributes
         """
         new = self.format(**kwargs)
-        new.value = value
+        new.value = value_
         assert new.location is not None
 
         self.logger.debug("Starting to upload result to {}...".format(new.location))

--- a/src/prefect/engine/results/prefect_result.py
+++ b/src/prefect/engine/results/prefect_result.py
@@ -43,12 +43,12 @@ class PrefectResult(Result):
         new.location = location
         return new
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         JSON serializes `self.value` and returns `self`.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): unused, for compatibility with the interface
 
@@ -56,7 +56,7 @@ class PrefectResult(Result):
             - Result: returns a new `Result` with both `value` and `location` attributes
         """
         new = self.copy()
-        new.value = value
+        new.value = value_
         new.location = self.serializer.serialize(new.value).decode("utf-8")
         return new
 

--- a/src/prefect/engine/results/result_handler_result.py
+++ b/src/prefect/engine/results/result_handler_result.py
@@ -74,19 +74,19 @@ class ResultHandlerResult(Result):
         new.value = self.result_handler.read(location)
         return new
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Exposes the write method of the underlying custom result handler fitting the Result
         interface.
 
         Args:
-            - value (Any): the value to write and attach to the result
+            - value_ (Any): the value to write and attach to the result
             - **kwargs (Any, optional): unused, for interface compatibility
 
         Returns:
             - Result: returns a copy of this Result with the location and value set
         """
         new = self.copy()
-        new.location = self.result_handler.write(value)
-        new.value = value
+        new.location = self.result_handler.write(value_)
+        new.value = value_
         return new

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -80,12 +80,12 @@ class S3Result(Result):
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Writes the result to a location in S3 and returns the resulting URI.
 
         Args:
-            - value (Any): the value to write; will then be stored as the `value` attribute
+            - value_ (Any): the value to write; will then be stored as the `value` attribute
                 of the returned `Result` instance
             - **kwargs (optional): if provided, will be used to format the location template
                 to determine the location to write to
@@ -95,7 +95,7 @@ class S3Result(Result):
         """
 
         new = self.format(**kwargs)
-        new.value = value
+        new.value = value_
         self.logger.debug("Starting to upload result to {}...".format(new.location))
         binary_data = new.serializer.serialize(new.value)
 

--- a/src/prefect/engine/results/secret_result.py
+++ b/src/prefect/engine/results/secret_result.py
@@ -39,12 +39,12 @@ class SecretResult(Result):
         new.location = location
         return new
 
-    def write(self, value: Any, **kwargs: Any) -> Result:
+    def write(self, value_: Any, **kwargs: Any) -> Result:
         """
         Secret results cannot be written to; provided for interface compatibility.
 
         Args:
-            - value (Any): unused, for interface compatibility
+            - value_ (Any): unused, for interface compatibility
             - **kwargs (optional): unused, for interface compatibility
 
         Raises:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1174,6 +1174,21 @@ class TestRunTaskStep:
         assert new_state.is_successful()
         assert new_state._result.location.endswith("2.txt")
 
+    def test_result_formatting_with_input_named_value(self, tmpdir):
+        result = LocalResult(dir=tmpdir, location="{value}.txt")
+
+        @prefect.task(checkpoint=True, result=result, slug="1234567")
+        def fn(value):
+            return value + 1
+
+        edge = Edge(Task(), fn, key="value")
+        with set_temporary_config({"flows.checkpointing": True}):
+            new_state = TaskRunner(task=fn).run(
+                state=None, upstream_states={edge: Success(result=Result(2))}
+            )
+        assert new_state.is_successful()
+        assert new_state._result.location.endswith("2.txt")
+
     @pytest.mark.parametrize("checkpoint", [True, None])
     def test_success_state_with_checkpointing_in_context(self, checkpoint):
         @prefect.task(checkpoint=checkpoint, result=PrefectResult())


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Once we began templating using task keyword argument names as well, we introduced a minor bug where any task with an argument named "value" would fail at runtime; this was caused by our Result classes all using `value` as the kwarg name for `result.write`, and so the two kwargs were competing. 


## Changes
<!-- What does this PR change? -->
This PR updates the internally used kwarg name to `value_` to prevent overshadowing user kwargs.



## Importance
<!-- Why is this PR important? -->
Closes #3034 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)