### PR TITLE
Fix S3 gzip compression test

### DIFF
--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -79,7 +79,6 @@ class TestS3Upload:
     def test_gzip_compression(self, monkeypatch):
         task = S3Upload("bucket")
         byte_string = b"col1,col2,col3\nfake,data,1\nfalse,info,2\n"
-        gzip_data = gzip.compress(byte_string)
 
         client = MagicMock()
         boto3 = MagicMock(client=MagicMock(return_value=client))
@@ -88,7 +87,7 @@ class TestS3Upload:
         task.run(byte_string, key="key", compression="gzip")
         args, kwargs = client.upload_fileobj.call_args_list[0]
         gzip_data_stream = args[0]
-        assert gzip_data_stream.read() == gzip_data
+        assert gzip.decompress(gzip_data_stream.read()) == byte_string
 
     def test_raises_on_invalid_compression_method(self, monkeypatch):
         task = S3Upload("test")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes a broken test for the S3Upload class. See [3329](https://github.com/PrefectHQ/prefect/issues/3329).

## Changes

I guess `gzip` uses the current timestamp when compressing data -- looks like `compress` offers an `mtime` argument to override this, but I think the better option would be to just decompress the result and compare it with the original bytes, rather than comparing compressed data.


## Importance
<!-- Why is this PR important? -->

Good to not have a test that sometimes breaks!


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)