### PR TITLE
Fix DockerAgent with show_flow_logs

### DIFF
--- a/changes/pr3339.yaml
+++ b/changes/pr3339.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `DockerAgent` with `--show-flow-logs` to work on windows/osx (with python >= 3.8) - [#3339](https://github.com/PrefectHQ/prefect/pull/3339)"


### PR DESCRIPTION
When running on platforms using `spawn` as the default multiprocessing
context (windows, and osx for python >= 3.8), all arguments to
`multiprocessing.Process` need to be pickleable.

Fixes #3288.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)