### PR TITLE
Update docker.md registry_url examples

### DIFF
--- a/docs/orchestration/tutorial/docker.md
+++ b/docs/orchestration/tutorial/docker.md
@@ -34,7 +34,11 @@ Docker Storage accepts an optional keyword argument `registry_url` if this is no
 If you do specify a registry URL then the image will be pushed to a container registry upon flow registration.
 
 ```python
-flow.storage = Docker(registry_url="docker.io/<dockerhub_user>/<dockerhub_repo>")
+# Docker Hub (docker.io)
+flow.storage = Docker(registry_url="<dockerhub_user>/")
+
+# GCR (gcr.io), etc.
+flow.storage = Docker(registry_url="gcr.io/<project_id>/")
 ```
 
 ## Running a Docker Agent


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The `Docker(registry_url=...)` example in the documentation "[Flow with Docker](https://docs.prefect.io/orchestration/tutorial/docker.html#pushing-to-a-registry)" does not work.
I needed to delete "docker.io/" to get it working.

## Changes
<!-- What does this PR change? -->

Documentation changes only.

## Importance
<!-- Why is this PR important? -->

Without modification, I got the following error:

```
[2020-09-17 22:55:41] INFO - prefect.Docker | Building the flow's Docker storage...
Step 1/9 : FROM prefecthq/prefect:0.13.7-python3.8
...
Successfully built dbe32999e1ce
Successfully tagged k24d/myflow:2020-09-17t22-55-39-290448-00-00
Traceback (most recent call last):
...
ValueError: Your docker image failed to build!  Your flow might have failed one of its deployment health checks - please ensure that all necessary files and dependencies have been included.
```

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)