### PR TITLE
Docker final build commands

### DIFF
--- a/changes/pr3342.yaml
+++ b/changes/pr3342.yaml
@@ -1,0 +1,4 @@
+enhancement:
+  - "Docker final build commands - [#3342](https://github.com/PrefectHQ/prefect/pull/3342)"
+contributor:
+  - "[David Severin Ryberg](https://github.com/sevberg)"

--- a/changes/pr3342.yaml
+++ b/changes/pr3342.yaml
@@ -1,4 +1,4 @@
 enhancement:
-  - "Docker final build commands - [#3342](https://github.com/PrefectHQ/prefect/pull/3342)"
+  - "Support configuring additional docker build commands on `Docker` storage  - [#3342](https://github.com/PrefectHQ/prefect/pull/3342)"
 contributor:
   - "[David Severin Ryberg](https://github.com/sevberg)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -100,7 +100,8 @@ class Docker(Storage):
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
         - final_build_commands (list[str], optional): list of unstructured Docker build commands
-            which are injected at the end of generated DockerFile (before the health checks)
+            which are injected at the end of generated DockerFile (before the health checks). 
+            Defaults to `None`
         - **kwargs (Any, optional): any additional `Storage` initialization options
 
     Raises:

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -99,7 +99,7 @@ class Docker(Storage):
             if `stored_as_script=True`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - extra_dockerfile_commands (list[str], optional): list of unstructured Docker build commands
+        - extra_dockerfile_commands (list[str], optional): list of Docker build commands
             which are injected at the end of generated DockerFile (before the health checks).
             Defaults to `None`
         - **kwargs (Any, optional): any additional `Storage` initialization options

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -99,7 +99,7 @@ class Docker(Storage):
             if `stored_as_script=True`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - final_build_commands (list[str], optional): list of unstructured Docker build commands 
+        - final_build_commands (list[str], optional): list of unstructured Docker build commands
             which are injected at the end of generated DockerFile (before the health checks)
         - **kwargs (Any, optional): any additional `Storage` initialization options
 
@@ -514,9 +514,13 @@ class Docker(Storage):
         extra_commands = ""
         for cmd in self.extra_commands:
             extra_commands += "RUN {}\n".format(cmd)
-        
+
         # Write final user commands that should be run in the image
-        final_commands = "" if self.final_build_commands is None else str.join("\n", self.final_build_commands) 
+        final_commands = (
+            ""
+            if self.final_build_commands is None
+            else str.join("\n", self.final_build_commands)
+        )
 
         # Write a healthcheck script into the image
         with open(

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -100,7 +100,7 @@ class Docker(Storage):
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
         - final_build_commands (list[str], optional): list of unstructured Docker build commands
-            which are injected at the end of generated DockerFile (before the health checks). 
+            which are injected at the end of generated DockerFile (before the health checks).
             Defaults to `None`
         - **kwargs (Any, optional): any additional `Storage` initialization options
 

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -99,7 +99,7 @@ class Docker(Storage):
             if `stored_as_script=True`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - final_build_commands (list[str], optional): list of unstructured Docker build commands
+        - extra_dockerfile_commands (list[str], optional): list of unstructured Docker build commands
             which are injected at the end of generated DockerFile (before the health checks).
             Defaults to `None`
         - **kwargs (Any, optional): any additional `Storage` initialization options
@@ -128,7 +128,7 @@ class Docker(Storage):
         prefect_directory: str = "/opt/prefect",
         path: str = None,
         stored_as_script: bool = False,
-        final_build_commands: List[str] = None,
+        extra_dockerfile_commands: List[str] = None,
         **kwargs: Any,
     ) -> None:
         self.registry_url = registry_url
@@ -159,7 +159,7 @@ class Docker(Storage):
         self.base_url = base_url or os.environ.get("DOCKER_HOST", default_url)
         self.tls_config = tls_config
         self.build_kwargs = build_kwargs or {}
-        self.final_build_commands = final_build_commands
+        self.extra_dockerfile_commands = final_build_commands
 
         version = prefect.__version__.split("+")
         if prefect_version is None:
@@ -519,8 +519,8 @@ class Docker(Storage):
         # Write final user commands that should be run in the image
         final_commands = (
             ""
-            if self.final_build_commands is None
-            else str.join("\n", self.final_build_commands)
+            if self.extra_dockerfile_commands is None
+            else str.join("\n", self.extra_dockerfile_commands)
         )
 
         # Write a healthcheck script into the image

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -460,11 +460,11 @@ def test_copy_files():
             ), output
 
 
-def test_final_build_commands():
+def test_extra_dockerfile_commands():
     with tempfile.TemporaryDirectory() as directory:
 
         storage = Docker(
-            final_build_commands=[
+            extra_dockerfile_commands=[
                 'RUN echo "I\'m a little tea pot"',
             ],
         )

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -460,6 +460,25 @@ def test_copy_files():
             ), output
 
 
+def test_final_build_commands():
+    with tempfile.TemporaryDirectory() as directory:
+
+        storage = Docker(
+            final_build_commands=[
+                'RUN echo "I\'m a little tea pot"',
+            ],
+        )
+        storage.add_flow(Flow("foo"))
+        dpath = storage.create_dockerfile_object(directory=directory)
+
+        with open(dpath, "r") as dockerfile:
+            output = dockerfile.read()
+
+        assert "COPY {} /path/test_file.txt".format(
+            'RUN echo "I\'m a little tea pot"\n' in output
+        ), output
+
+
 def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
     myfile = "FROM my-own-image:latest\n\nRUN echo 'hi'"
     with tempfile.TemporaryDirectory() as tempdir_outside:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Allows advanced docker build users to inject custom build commands at the end of the generated DockerFile (but before health checks)




## Changes
Adds the argument ```final_build_commands``` to the Docker storage class. This is either "None" or is a list of strings. In the case of the latter, these strings, which are assumed to be Docker build commands, are added to the end of the generated DockerFile




## Importance
Permits more flexibility to Docker building, and allows for more advanced usages that are not currently possible. E.g. copying a local python module first via a COPY statement, and then installing that module within the image




## Checklist
- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)