### PR TITLE
KubernetesAgent retries on connection errors

### DIFF
--- a/changes/pr3344.yaml
+++ b/changes/pr3344.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Support submission retries within the k8s agent - [#3344](https://github.com/PrefectHQ/prefect/pull/3344)"


### PR DESCRIPTION
For errors with the connection (connection dropped, timeouts, etc...) we
can retry submitting jobs a few times. If a previous submission
succeeded (the job was created) but then errored to the client
additional submission attempts will return a 409 error, which we now
interpret as a success. This should help when deployed in setups with
network issues.

For now we retry a max of 3 times, with a fixed 1 second delay between
each attempt.

Still needs tests.

Fixes #3278.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)