### PR TITLE
A few mypy fixups

### DIFF
--- a/changes/pr3346.yaml
+++ b/changes/pr3346.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix mypy type checking for tasks created with `prefect.task` - [#3346](https://github.com/PrefectHQ/prefect/pull/3346)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -83,6 +83,9 @@ class instance_property:
     def __init__(self, func: Callable):
         self.func = func
 
+    def __getattr__(self, k: str) -> Any:
+        return getattr(self.func, k)
+
     def __get__(self, obj: Any, cls: Any) -> Any:
         if obj is None:
             raise AttributeError

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -77,6 +77,18 @@ class SignatureValidator(type):
         return type.__new__(cls, name, parents, methods)  # type: ignore
 
 
+class instance_property:
+    """Like property, but only available on instances, not the class"""
+
+    def __init__(self, func: Callable):
+        self.func = func
+
+    def __get__(self, obj: Any, cls: Any) -> Any:
+        if obj is None:
+            raise AttributeError
+        return self.func(obj)
+
+
 class Task(metaclass=SignatureValidator):
     """
     The Task class which is used as the full representation of a unit of work.
@@ -426,7 +438,7 @@ class Task(metaclass=SignatureValidator):
 
         return new
 
-    @property
+    @instance_property
     def __signature__(self) -> inspect.Signature:
         """Dynamically generate the signature, replacing ``*args``/``**kwargs``
         with parameters from ``run``"""

--- a/src/prefect/tasks/core/resource_manager.py
+++ b/src/prefect/tasks/core/resource_manager.py
@@ -1,6 +1,4 @@
-from typing import Any, Callable, Dict
-
-from toolz import curry
+from typing import Any, Callable, Dict, Union, Set, overload
 
 import prefect
 from prefect import Task, Flow
@@ -67,7 +65,7 @@ class ResourceContext:
         self.setup_task = setup_task
         self.cleanup_task = cleanup_task
         self._flow = flow
-        self._tasks = set()
+        self._tasks = set()  # type: Set[Task]
 
     def add_task(self, task: Task, flow: Flow) -> None:
         """Add a new task under the resource manager block.
@@ -82,12 +80,12 @@ class ResourceContext:
             )
         self._tasks.add(task)
 
-    def __enter__(self):
+    def __enter__(self) -> Task:
         self.__prev_resource = prefect.context.get("resource")
         prefect.context.update(resource=self)
         return self.setup_task
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         if self.__prev_resource is None:
             prefect.context.pop("resource", None)
         else:
@@ -200,7 +198,7 @@ class ResourceManager:
             if flow is None:
                 raise ValueError("Could not infer an active Flow context.")
 
-        init_task = prefect.task(self.resource_class, **self.init_task_kwargs)(
+        init_task = prefect.task(self.resource_class, **self.init_task_kwargs)(  # type: ignore
             *args, flow=flow, **kwargs
         )
 
@@ -213,14 +211,39 @@ class ResourceManager:
         return ResourceContext(init_task, setup_task, cleanup_task, flow)
 
 
-@curry
+# To support mypy type checking with optional arguments to `resource_manager`,
+# we need to make use of `typing.overload`
+@overload
 def resource_manager(
     resource_class: Callable,
+    *,
     name: str = None,
     init_task_kwargs: dict = None,
     setup_task_kwargs: dict = None,
     cleanup_task_kwargs: dict = None,
 ) -> ResourceManager:
+    pass
+
+
+@overload
+def resource_manager(
+    *,
+    name: str = None,
+    init_task_kwargs: dict = None,
+    setup_task_kwargs: dict = None,
+    cleanup_task_kwargs: dict = None,
+) -> Callable[[Callable], ResourceManager]:
+    pass
+
+
+def resource_manager(
+    resource_class: Callable = None,
+    *,
+    name: str = None,
+    init_task_kwargs: dict = None,
+    setup_task_kwargs: dict = None,
+    cleanup_task_kwargs: dict = None,
+) -> Union[ResourceManager, Callable[[Callable], ResourceManager]]:
     """A decorator for creating a `ResourceManager` object.
 
     Used as a context manager, `ResourceManager` objects create tasks to setup
@@ -295,10 +318,14 @@ def resource_manager(
     a trigger to always run if the `setup` task succeeds, and won't be set as
     a reference task.
     """
-    return ResourceManager(
-        resource_class,
-        name=name,
-        init_task_kwargs=init_task_kwargs,
-        setup_task_kwargs=setup_task_kwargs,
-        cleanup_task_kwargs=cleanup_task_kwargs,
-    )
+
+    def inner(resource_class: Callable) -> ResourceManager:
+        return ResourceManager(
+            resource_class,
+            name=name,
+            init_task_kwargs=init_task_kwargs,
+            setup_task_kwargs=setup_task_kwargs,
+            cleanup_task_kwargs=cleanup_task_kwargs,
+        )
+
+    return inner if resource_class is None else inner(resource_class)

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -249,6 +249,10 @@ class TestCreateTask:
         )
         assert sig.return_annotation == "Task"
 
+        # doesn't override class signature
+        class_sig = inspect.signature(Test)
+        assert "name" in class_sig.parameters
+
     def test_create_task_with_and_without_cache_for(self):
         t1 = Task()
         assert t1.cache_validator is never_use


### PR DESCRIPTION
- Fix `__signature__` of `Task` types to work on both the class and on
  instances.
- Fix `task` decorator to support type checking. mypy doesn't like
  decorators that accept optional arguments, to handle this we have to
  add additional annotations.
- *Almost* fix `resource_manager` decorator to support type checking.
  This is annoying, mypy assumes (incorrectly) that the output of a
  class decorator is always an instance of the class, even if the
  decorator type signature says otherwise.

Fixes #3056.
Related to, but doesn't fix #3191.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)