### PR TITLE
Dont use asserts for control flow

### DIFF
--- a/changes/pr3352.yaml
+++ b/changes/pr3352.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug in `flow.visualize()` where no output would be generated when running with `PYTHONOPTIMIZE=1` - [#3352](https://github.com/PrefectHQ/prefect/pull/3352)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1383,8 +1383,11 @@ class Flow:
             try:
                 from IPython import get_ipython
 
-                assert get_ipython().config.get("IPKernelApp") is not None
+                in_ipython = get_ipython().config.get("IPKernelApp") is not None
             except Exception:
+                in_ipython = False
+
+            if not in_ipython:
                 with tempfile.NamedTemporaryFile(delete=False) as tmp:
                     tmp.close()
                     try:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1232,7 +1232,16 @@ def test_skip_validation_in_init_with_kwarg():
     assert Flow(name="test", edges=[e1, e2], validate=False)
 
 
-@pytest.mark.xfail(raises=ImportError, reason="viz extras not installed.")
+try:
+    import graphviz
+
+    graphviz.pipe("dot", "png", b"graph {a -- b}", quiet=True)
+    no_graphviz = False
+except Exception:
+    no_graphviz = True
+
+
+@pytest.mark.skipif(no_graphviz, reason="viz extras not installed.")
 class TestFlowVisualize:
     def test_visualize_raises_informative_importerror_without_python_graphviz(
         self, monkeypatch
@@ -1242,6 +1251,7 @@ class TestFlowVisualize:
 
         with monkeypatch.context() as m:
             m.setattr(sys, "path", "")
+            m.delitem(sys.modules, "graphviz", raising=False)
             with pytest.raises(ImportError, match=r"pip install 'prefect\[viz\]'"):
                 f.visualize()
 


### PR DESCRIPTION
Python assert statements may be dropped dropped by the compiler if running with `-O`/`PYTHONOTIMIZE=1`. As such, they shouldn't be used for control flow, as they might not be executed.

Fixes a bug in `flow.visualize()` where no output would be generated if asserts are optimized out.

Also fixes the `flow.visualize` tests to properly use `pytest.skipif`, rather than xfailing them unconditionally (which makes them useless as tests).

Fixes #2918.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)