### PR TITLE
fix typo in DaskCloudProviderEnvironment logs

### DIFF
--- a/changes/pr3354.yaml
+++ b/changes/pr3354.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "fix typo in DaskCloudProviderEnvironment logs - [#3354](https://github.com/PrefectHQ/prefect/pull/3354)"
+
+contributor:
+  - "[James Lamb](https://github.com/jameslamb)"

--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -138,7 +138,7 @@ You can find the URL for the Dask dashboard of your cluster in the Flow logs:
 
 ```
 April 26th 2020 at 12:17:41pm | prefect.DaskCloudProviderEnvironment
-Dask cluster created. Sheduler address: tls://172.33.18.197:8786 Dashboard: http://172.33.18.197:8787
+Dask cluster created. Scheduler address: tls://172.33.18.197:8786 Dashboard: http://172.33.18.197:8787
 ```
 
 #### Setup

--- a/src/prefect/environments/execution/dask/cloud_provider.py
+++ b/src/prefect/environments/execution/dask/cloud_provider.py
@@ -132,7 +132,7 @@ class DaskCloudProviderEnvironment(RemoteDaskEnvironment):
         self.cluster = self._provider_class(**self._provider_kwargs)
         if self.cluster and self.cluster.scheduler and self.cluster.scheduler.address:
             self.logger.info(
-                "Dask cluster created. Sheduler address: {} Dashboard: http://{}:8787 "
+                "Dask cluster created. Scheduler address: {} Dashboard: http://{}:8787 "
                 "(unless port was changed from default of 8787)".format(
                     self.cluster.scheduler.address,
                     urlparse(self.cluster.scheduler.address).hostname,


### PR DESCRIPTION
## Summary 

While reading the docs at https://docs.prefect.io/orchestration/execution/dask_cloud_provider_environment.html tonight, I found what I believe is a typo in a log message from `DaskCloudProviderEnvironment`

## Changes

Changes `sheduler` to `scheduler` in a log message in `DaskCloudProviderEnvironment`.

## Importance

This is a minor PR fix that might improve the experience searching the docs.

## Checklist

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)