### PR TITLE
Add documentation for DaskKubernetesEnvironment close #3334

### DIFF
--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -55,6 +55,9 @@ class DaskKubernetesEnvironment(Environment):
             defaults to False Only used when a custom scheduler spec is not provided. Enabling
             this may cause ClientErrors to appear when multiple Dask workers try to run the
             same Prefect Task.
+            `Warning`:  `work_stealing` if provided won't be appended to your custom
+            `scheduler_spec_file`. If wanted, don't forget to add it in your container env
+            (`DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING`).
         - scheduler_logs (bool, optional): log all Dask scheduler logs, defaults to False
         - private_registry (bool, optional, DEPRECATED): a boolean specifying whether your
             Flow's Docker container will be in a private Docker registry; if so, requires a
@@ -75,6 +78,9 @@ class DaskKubernetesEnvironment(Environment):
         - image_pull_secret (str, optional): optional name of an `imagePullSecret` to use for
             the scheduler and worker pods. For more information go
             [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+            `Warning`:  `image_pull_secret` if provided won't be appended to your custom
+            `worker_spec_file` or `scheduler_spec_file`. If you want it, don't forget to add it in
+            your spec files.
         - log_k8s_errors (bool, optional): optional toggle to also log Kubernetes errors that may occur
             using the Prefect logger. Defaults to `False`.
     """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Following issue #3334, update the documentation of `DaskKubernetesEnvironment` for two arguments:

- image_pull_secret
- work_stealing

The documentation explains that those arguments are not applied to your custom `scheduler` and `worker` spec files, if provided.



## Changes
Update the documentation




## Importance
I add to read the source code to understand that those two arguments were not applied to my custom spec files.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~~[x] adds new tests (if appropriate)~~
- ~~[x] adds a change file in the `changes/` directory (if appropriate)~~
- [x ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)