### PR TITLE
Use `sys.executable` in local agent

### DIFF
--- a/src/prefect/__main__.py
+++ b/src/prefect/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from .cli import cli
+
+    cli()

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -150,6 +150,8 @@ class LocalAgent(Agent):
 
         current_env["PYTHONPATH"] = ":".join(python_path)
 
+        cmd = [sys.executable, "-m"] + get_flow_run_command(flow_run).split(" ")
+
         stdout = sys.stdout if self.show_flow_logs else DEVNULL
 
         # note: we will allow these processes to be orphaned if the agent were to exit
@@ -158,7 +160,7 @@ class LocalAgent(Agent):
         # show flow logs, these log entries will continue to stream to the users terminal
         # until these child processes exit, even if the agent has already exited.
         p = Popen(
-            get_flow_run_command(flow_run).split(" "),
+            cmd,
             stdout=stdout,
             stderr=STDOUT,
             env=current_env,


### PR DESCRIPTION
Explicitly use the python executable path when starting a new flow with
the local agent.

Fixes #3313.


- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)