### PR TITLE
Expose flow_run_name to .run() method for local runs

### DIFF
--- a/changes/pr3364.yaml
+++ b/changes/pr3364.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Expose flow_run_name to .run() method for local runs - [#3364](https://github.com/PrefectHQ/prefect/pull/3364)"
+
+contributor:
+  - "[Nejc Vesel](https://github.com/veseln)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1009,6 +1009,11 @@ class Flow:
             "flow_run_id", kwargs.pop("flow_run_id", str(uuid.uuid4()))
         )
 
+        # set flow_run_name from args or uuid if flow_run_name is not an argument
+        flow_run_context.setdefault(
+            "flow_run_name", kwargs.pop("flow_run_name", str(uuid.uuid4()))
+        )
+
         # run this flow indefinitely, so long as its schedule has future dates
         while True:
 
@@ -1018,7 +1023,7 @@ class Flow:
                 scheduled_start_time=next_run_time,
                 flow_id=self.name,
                 flow_run_id=flow_run_context["flow_run_id"],
-                flow_run_name=str(uuid.uuid4()),
+                flow_run_name=flow_run_context["flow_run_name"],
             )
 
             if flow_state.is_scheduled():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2856,10 +2856,10 @@ def test_flow_run_name_as_run_param():
     with Flow(name="flow-run-name-from-context") as f:
         flow_run_name = get_flow_run_from_context()
 
-    flow_state = f.run(flow_run_name='test-flow-run')
+    flow_state = f.run(flow_run_name="test-flow-run")
 
     assert flow_state.is_successful()
-    assert flow_state.result[flow_run_name].result == 'test-flow-run'
+    assert flow_state.result[flow_run_name].result == "test-flow-run"
 
 
 class TestSaveLoad:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2848,6 +2848,20 @@ def test_starting_at_arbitrary_loop_index():
     assert flow_state.result[final].result == 100
 
 
+def test_flow_run_name_as_run_param():
+    @task
+    def get_flow_run_from_context():
+        return prefect.context["flow_run_name"]
+
+    with Flow(name="flow-run-name-from-context") as f:
+        flow_run_name = get_flow_run_from_context()
+
+    flow_state = f.run(flow_run_name='test-flow-run')
+
+    assert flow_state.is_successful()
+    assert flow_state.result[flow_run_name].result == 'test-flow-run'
+
+
 class TestSaveLoad:
     def test_save_saves_and_load_loads(self):
         t = Task(name="foo")


### PR DESCRIPTION
When running using Server, it is possible to  set `flow_run_name`, which is currently not
possible when doing local runs. This change allows the user to specify  `flow_run_name` when
calling run, in the same way as it is currently done for `flow_run_id`.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This change allows the user to specify  `flow_run_name` when doing local runs in the same way as it is currently done for `flow_run_id`.

## Changes
<!-- What does this PR change? -->

This PR adds an option of specifying `flow_run_name` when running prefect locally in the same way that 
specifying flow_run_id  is possible. This allows the flow_run_name to be settable and not necessarily auto-generated.   


## Importance
<!-- Why is this PR important? -->
Allowing the user to set the flow_run_name for local runs is important because it brings closer prefect functionality when running locally and when using server. It also allows the user to set `flow_run_name` which enables one to use `flow_run_name` as one of the identifiers when defining target for  persistance. 

` target='{flow_run_name}/...'` (as an example)   

## Tests 
Tests were not added, as I couldn't find where the same  functionality for `flow_run_id` (that is already implemented) was tested,  I would gladly add tests if I could get some help identifying where I should add the tests. 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ x] adds new tests (if appropriate)
- [ x] adds a change file in the `changes/` directory (if appropriate)
- [ x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)