### PR TITLE
Add option to specify run_name for FlowRUnTask

### DIFF
--- a/changes/pr3393.yaml
+++ b/changes/pr3393.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add option to specify run_name for FlowRUnTask - [#3393](https://github.com/PrefectHQ/prefect/pull/3393)"
+
+contributor:
+  - "[Nejc Vesel](https://github.com/veseln)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -48,7 +48,7 @@ class FlowRunTask(Task):
             kwargs.setdefault("name", f"Flow {flow_name}")
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("flow_name", "project_name", "parameters", "new_flow_context")
+    @defaults_from_attrs("flow_name", "project_name", "parameters", "new_flow_context", "run_name")
     def run(
         self,
         flow_name: str = None,

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -49,7 +49,9 @@ class FlowRunTask(Task):
             kwargs.setdefault("name", f"Flow {flow_name}")
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("flow_name", "project_name", "parameters", "new_flow_context", "run_name")
+    @defaults_from_attrs(
+        "flow_name", "project_name", "parameters", "new_flow_context", "run_name"
+    )
     def run(
         self,
         flow_name: str = None,

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -35,12 +35,14 @@ class FlowRunTask(Task):
         parameters: dict = None,
         wait: bool = False,
         new_flow_context: dict = None,
+        run_name: str = None,
         **kwargs: Any,
     ):
         self.flow_name = flow_name
         self.project_name = project_name
         self.parameters = parameters
         self.new_flow_context = new_flow_context
+        self.run_name = run_name
         self.wait = wait
         if flow_name:
             kwargs.setdefault("name", f"Flow {flow_name}")
@@ -54,6 +56,7 @@ class FlowRunTask(Task):
         parameters: dict = None,
         idempotency_key: str = None,
         new_flow_context: dict = None,
+        run_name: str = None,
     ) -> str:
         """
         Run method for the task; responsible for scheduling the specified flow run.
@@ -71,6 +74,7 @@ class FlowRunTask(Task):
                 flow run; if provided, ensures that only one run is created if this task is retried
                 or rerun with the same inputs.  If not provided, the current flow run ID will be used.
             - new_flow_context (dict, optional): the optional run context for the new flow run
+            - run_name (str, optional): name to be set for the flow run
 
         Returns:
             - str: the ID of the newly-scheduled flow run
@@ -139,6 +143,7 @@ class FlowRunTask(Task):
             parameters=parameters,
             idempotency_key=idem_key or idempotency_key,
             context=new_flow_context,
+            run_name=run_name,
         )
 
         self.logger.debug(f"Flow Run {flow_run_id} created.")

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -31,6 +31,7 @@ class TestFlowRunTaskCloud:
             flow_name="Test Flow",
             new_flow_context={"foo": "bar"},
             parameters={"test": "ing"},
+            run_name="test-run",
         )
         assert task.name == "My Flow Run Task"
         assert task.checkpoint is False
@@ -38,6 +39,7 @@ class TestFlowRunTaskCloud:
         assert task.flow_name == "Test Flow"
         assert task.new_flow_context == {"foo": "bar"}
         assert task.parameters == {"test": "ing"}
+        assert task.run_name == "test-run"
 
     def test_flow_run_task(self, client, cloud_api):
         # verify that create_flow_run was called
@@ -45,6 +47,7 @@ class TestFlowRunTaskCloud:
             project_name="Test Project",
             flow_name="Test Flow",
             parameters={"test": "ing"},
+            run_name="test-run",
         )
         # verify that run returns the new flow run ID
         assert task.run() == "xyz890"
@@ -59,6 +62,7 @@ class TestFlowRunTaskCloud:
             parameters={"test": "ing"},
             idempotency_key=None,
             context=None,
+            run_name=None,
         )
 
     def test_flow_run_task_with_flow_run_id(self, client, cloud_api):
@@ -79,6 +83,7 @@ class TestFlowRunTaskCloud:
             parameters={"test": "ing"},
             idempotency_key="test-id",
             context=None,
+            run_name=None,
         )
 
     def test_idempotency_key_uses_map_index_if_present(self, client, cloud_api):
@@ -91,7 +96,11 @@ class TestFlowRunTaskCloud:
 
         # verify create_flow_run was called with the correct arguments
         client.create_flow_run.assert_called_once_with(
-            flow_id="abc123", idempotency_key="test-id-4", parameters=None, context=None
+            flow_id="abc123",
+            idempotency_key="test-id-4",
+            parameters=None,
+            context=None,
+            run_name=None,
         )
 
     def test_flow_run_task_without_flow_name(self, cloud_api):
@@ -124,17 +133,22 @@ class TestFlowRunTaskCoreServer:
             flow_name="Test Flow",
             new_flow_context={"foo": "bar"},
             parameters={"test": "ing"},
+            run_name="test-run",
         )
         assert task.name == "My Flow Run Task"
         assert task.checkpoint is False
         assert task.flow_name == "Test Flow"
         assert task.new_flow_context == {"foo": "bar"}
         assert task.parameters == {"test": "ing"}
+        assert task.run_name == "test-run"
 
     def test_flow_run_task(self, client, server_api):
         # verify that create_flow_run was called
         task = FlowRunTask(
-            flow_name="Test Flow", project_name="Demo", parameters={"test": "ing"}
+            flow_name="Test Flow",
+            project_name="Demo",
+            parameters={"test": "ing"},
+            run_name="test-run",
         )
         # verify that run returns the new flow run ID
         assert task.run() == "xyz890"
@@ -148,6 +162,7 @@ class TestFlowRunTaskCoreServer:
             parameters={"test": "ing"},
             idempotency_key=None,
             context=None,
+            run_name=None,
         )
 
     def test_flow_run_task_without_flow_name(self, server_api):
@@ -181,4 +196,5 @@ class TestFlowRunTaskCoreServer:
             parameters={"test": "ing"},
             idempotency_key="test-id",
             context=None,
+            run_name=None,
         )

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -62,7 +62,7 @@ class TestFlowRunTaskCloud:
             parameters={"test": "ing"},
             idempotency_key=None,
             context=None,
-            run_name=None,
+            run_name="test-run",
         )
 
     def test_flow_run_task_with_flow_run_id(self, client, cloud_api):
@@ -162,7 +162,7 @@ class TestFlowRunTaskCoreServer:
             parameters={"test": "ing"},
             idempotency_key=None,
             context=None,
-            run_name=None,
+            run_name="test-run",
         )
 
     def test_flow_run_task_without_flow_name(self, server_api):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Add an option of specifying run_name when using FlowRunTask 


## Changes
<!-- What does this PR change? -->
It changes FlowRunTask by adding an optional parameter that allows setting run_name


## Importance
<!-- Why is this PR important? -->
It is important, because having an option to set the name for your flow is beneficial for people that rely on flow names for tracking the flows. Having an option to set the flow name, allows more flexibility. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)