### PR TITLE
Parameter scheduling

### DIFF
--- a/changes/issue2510.yaml
+++ b/changes/issue2510.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "Allow for scheduling the same flow at the same time with multiple parameter values - [#2510](https://github.com/PrefectHQ/prefect/issues/2510)"

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -18,7 +18,12 @@ class ClockEvent:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, (ClockEvent, datetime)):
             return False
-        return self.start_time == other
+        if isinstance(other, datetime):
+            return self.start_time == other
+        return (
+            self.start_time == other.start_time
+            and self.parameter_defaults == other.parameter_defaults
+        )
 
     def __gt__(self, other: Union[datetime, "ClockEvent"]) -> bool:
         if not isinstance(other, (ClockEvent, datetime)):

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -41,19 +41,11 @@ class TestClockEvent:
         assert e.start_time == now
         assert e.parameter_defaults == dict(x=42, z=[1, 2, 3])
 
-    @pytest.mark.parametrize(
-        "dt,params",
-        list(
-            itertools.product(
-                [pendulum.now("UTC").add(hours=1), pendulum.now("UTC").add(hours=-2)],
-                [None, dict(x=1)],
-            )
-        ),
-    )
-    def test_clock_event_comparisons_are_datetime_comparisons(self, dt, params):
+    def test_clock_event_comparisons_are_datetime_comparisons(self):
         now = pendulum.now("UTC")
+        dt = now.add(hours=1)
 
-        e = clocks.ClockEvent(now, parameter_defaults=params)
+        e = clocks.ClockEvent(now)
         e2 = clocks.ClockEvent(dt)
 
         ## compare to raw datetimes
@@ -67,6 +59,26 @@ class TestClockEvent:
         assert (e == e2) == (e.start_time == e2.start_time)
         assert (e < e2) == (e.start_time < e2.start_time)
         assert (e > e2) == (e.start_time > e2.start_time)
+
+    def test_clock_event_comparisons_take_parameters_into_account(self):
+        now = pendulum.now("UTC")
+        dt = now.add(hours=1)
+
+        e = clocks.ClockEvent(now, parameter_defaults=dict(a=1))
+        e2 = clocks.ClockEvent(dt)
+        e3 = clocks.ClockEvent(dt, parameter_defaults=dict(a=2))
+
+        ## compare to raw datetimes
+        assert e2 == dt
+        assert e == now
+        assert e3 == dt
+        assert e2 > now
+        assert e3 > now
+
+        ## compare to each other
+        assert e2 != e3
+        assert e2 > e
+        assert e3 > e
 
 
 class TestIntervalClock:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR extends the scheduling logic to account for clocks that emit the exact same time but different parameter sets.  In particular, because we do a sort / unique filter on clock events, this ended up being as simple as adjusting the `__eq__` logic for ClockEvents!

## Importance
<!-- Why is this PR important? -->
Closes #2510

**NOTE**: For anyone following this, this will not be compatible with Server or Cloud until this change makes it way into the Server / Cloud deployments.  If you are running Server, you'll need to upgrade the version of Prefect within your images or wait until the next release and swap out your images.  

For Cloud users, this change will be automatically available when the next release of Core goes live next week

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)