### PR TITLE
Update the default port numbers in the help string

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -231,8 +231,8 @@ def start(
 
     \b
         --postgres-port     TEXT    Port used to serve Postgres, defaults to '5432'
-        --hasura-port       TEXT    Port used to serve Hasura, defaults to '3001'
-        --graphql-port      TEXT    Port used to serve the GraphQL API, defaults to '4001'
+        --hasura-port       TEXT    Port used to serve Hasura, defaults to '3000'
+        --graphql-port      TEXT    Port used to serve the GraphQL API, defaults to '4201'
         --ui-port           TEXT    Port used to serve the UI, defaults to '8080'
         --server-port       TEXT    Port used to serve the Core server, defaults to '4200'
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`prefect server start --help` shows the following help text:

```
      --hasura-port       TEXT    Port used to serve Hasura, defaults to '3001'
      --graphql-port      TEXT    Port used to serve the GraphQL API, defaults to '4001'
```

However, these default values are different from the actual default values defined in `prefect/config.toml`:

```
    [server.graphql]
    host = "0.0.0.0"
    port = "4201"
    host_port = "4201"
...
    [server.hasura]
    host = "localhost"
    port = "3000"
    host_port = "3000"
```

## Changes
<!-- What does this PR change? -->

This PR fixes the help string.


## Importance
<!-- Why is this PR important? -->

The current help string is confusing.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)