### PR TITLE
allow for a keypair and not just user:password

### DIFF
--- a/changes/pr3404.yaml
+++ b/changes/pr3404.yaml
@@ -1,2 +1,5 @@
-enhancement:
+task:
   - "Add keypair auth for snowflake - [#3404](https://github.com/PrefectHQ/prefect/pull/3404)"
+
+contributor:
+  - "[Ian Fridge](https://github.com/fridgei)"

--- a/changes/pr3404.yaml
+++ b/changes/pr3404.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add keypair auth for snowflake - [#3404](https://github.com/PrefectHQ/prefect/pull/3404)"

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -12,8 +12,10 @@ class SnowflakeQuery(Task):
         - account (str): snowflake account name, see snowflake connector
              package documentation for details
         - user (str): user name used to authenticate
-        - password (str, optional): password used to authenticate.  password or private_lkey must be present
-        - private_key (rsa.RSAPrivateKey): pem to authenticate.  password or private_key must be present
+        - password (str, optional): password used to authenticate.
+            password or private_lkey must be present
+        - private_key (rsa.RSAPrivateKey): pem to authenticate.
+            password or private_key must be present
         - database (str, optional): name of the default database to use
         - schema (int, optional): name of the default schema to use
         - role (str, optional): name of the default role to use

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -11,8 +11,8 @@ class SnowflakeQuery(Task):
         - account (str): snowflake account name, see snowflake connector
              package documentation for details
         - user (str): user name used to authenticate
-        - password (str, optional): password used to authenticate
-        - private_key (rsa.RSAPrivateKey): pem to authenticate
+        - password (str, optional): password used to authenticate.  password or private_lkey must be present
+        - private_key (rsa.RSAPrivateKey): pem to authenticate.  password or private_key must be present
         - database (str, optional): name of the default database to use
         - schema (int, optional): name of the default schema to use
         - role (str, optional): name of the default role to use

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -3,7 +3,6 @@ import snowflake.connector as sf
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 
-
 class SnowflakeQuery(Task):
     """
     Task for executing a query against a snowflake database.
@@ -12,7 +11,8 @@ class SnowflakeQuery(Task):
         - account (str): snowflake account name, see snowflake connector
              package documentation for details
         - user (str): user name used to authenticate
-        - password (str): password used to authenticate
+        - password (str, optional): password used to authenticate
+        - private_key (rsa.RSAPrivateKey): pem to authenticate
         - database (str, optional): name of the default database to use
         - schema (int, optional): name of the default schema to use
         - role (str, optional): name of the default role to use
@@ -30,7 +30,8 @@ class SnowflakeQuery(Task):
         self,
         account: str,
         user: str,
-        password: str,
+        password: str = None,
+        private_key: bytes = None,
         database: str = None,
         schema: str = None,
         role: str = None,
@@ -50,6 +51,7 @@ class SnowflakeQuery(Task):
         self.query = query
         self.data = data
         self.autocommit = autocommit
+        self.private_key = private_key
         super().__init__(**kwargs)
 
     @defaults_from_attrs("query", "data", "autocommit")
@@ -80,6 +82,7 @@ class SnowflakeQuery(Task):
             "account": self.account,
             "user": self.user,
             "password": self.password,
+            "private_key": self.private_key,
             "database": self.database,
             "schema": self.schema,
             "role": self.role,

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -3,6 +3,7 @@ import snowflake.connector as sf
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 
+
 class SnowflakeQuery(Task):
     """
     Task for executing a query against a snowflake database.

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -14,7 +14,7 @@ class SnowflakeQuery(Task):
         - user (str): user name used to authenticate
         - password (str, optional): password used to authenticate.
             password or private_lkey must be present
-        - private_key (rsa.RSAPrivateKey): pem to authenticate.
+        - private_key (bytes, optional): pem to authenticate.
             password or private_key must be present
         - database (str, optional): name of the default database to use
         - schema (int, optional): name of the default schema to use


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
The snowflake connector will only accept user name and password as an authentication method.  We use key pair authentication for our snowflake connectors.

https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication


## Changes
The PR makes the password optional and adds an additional optional bytes object of the keypair. 



## Importance
Many snowflakes users use keypair authentication.  Without that feature, I would have to maintain my own snowflake task going forward.  I would much rather use code maintained by the community.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x ] adds a change file in the `changes/` directory (if appropriate)
- [ x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)