### PR TITLE
Rename KubernetesJob to KubernetesRun

### DIFF
--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -235,7 +235,7 @@ classes = ["DaskKubernetesEnvironment", "DaskCloudProviderEnvironment", "Fargate
 [pages.run_configs]
 title = "Run Configuration"
 module = "prefect.run_configs"
-classes = ["RunConfig", "KubernetesJob"]
+classes = ["RunConfig", "KubernetesRun"]
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/src/prefect/run_configs/__init__.py
+++ b/src/prefect/run_configs/__init__.py
@@ -1,2 +1,2 @@
 from .base import RunConfig
-from .kubernetes import KubernetesJob
+from .kubernetes import KubernetesRun

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -5,7 +5,7 @@ from prefect.utilities.filesystems import parse_path
 from prefect.run_configs.base import RunConfig
 
 
-class KubernetesJob(RunConfig):
+class KubernetesRun(RunConfig):
     """Configure a flow-run to run as a Kubernetes Job.
 
     Note: The functionality here is experimental, and may change between
@@ -20,7 +20,7 @@ class KubernetesJob(RunConfig):
         - job_template_path (str, optional): Path to a job template to use. If
             a local path (no file scheme, or a `file`/`local` scheme), the job
             template will be loaded on initialization and stored on the
-            `KubernetesJob` object as the `job_template` field.  Otherwise the
+            `KubernetesRun` object as the `job_template` field.  Otherwise the
             job template will be loaded at runtime on the agent.  Supported
             runtime file schemes include (`s3`, `gcs`, and `agent` (for paths
             local to the runtime agent)).
@@ -41,14 +41,14 @@ class KubernetesJob(RunConfig):
     Use the defaults set on the agent:
 
     ```python
-    flow.run_config = KubernetesJob()
+    flow.run_config = KubernetesRun()
     ```
 
     Use a local job template, which is stored along with the Flow in Prefect
     Cloud/Server:
 
     ```python
-    flow.run_config = KubernetesJob(
+    flow.run_config = KubernetesRun(
         job_template_path="my_custom_template.yaml"
     )
     ```
@@ -56,7 +56,7 @@ class KubernetesJob(RunConfig):
     Use a job template stored in S3, but override the image and CPU limit:
 
     ```python
-    flow.run_config = KubernetesJob(
+    flow.run_config = KubernetesRun(
         job_template_path="s3://example-bucket/my_custom_template.yaml",
         image="example/my-custom-image:latest",
         cpu_limit=2,

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -1,16 +1,16 @@
 from marshmallow import fields
 
 from prefect.utilities.serialization import JSONCompatible, OneOfSchema, ObjectSchema
-from prefect.run_configs import KubernetesJob
+from prefect.run_configs import KubernetesRun
 
 
 class RunConfigSchemaBase(ObjectSchema):
     labels = fields.List(fields.String())
 
 
-class KubernetesJobSchema(RunConfigSchemaBase):
+class KubernetesRunSchema(RunConfigSchemaBase):
     class Meta:
-        object_class = KubernetesJob
+        object_class = KubernetesRun
 
     job_template_path = fields.String(allow_none=True)
     job_template = JSONCompatible(allow_none=True)
@@ -24,5 +24,5 @@ class KubernetesJobSchema(RunConfigSchemaBase):
 
 class RunConfigSchema(OneOfSchema):
     type_schemas = {
-        "KubernetesJob": KubernetesJobSchema,
+        "KubernetesRun": KubernetesRunSchema,
     }

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -11,7 +11,7 @@ import prefect
 from prefect.agent.kubernetes.agent import KubernetesAgent, read_bytes_from_path
 from prefect.environments import LocalEnvironment
 from prefect.environments.storage import Docker, Local
-from prefect.run_configs import KubernetesJob
+from prefect.run_configs import KubernetesRun
 from prefect.serialization.run_config import RunConfigSchema
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
@@ -981,7 +981,7 @@ class TestK8sAgentRunConfig:
         template = self.read_default_template()
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
-        flow_run = self.build_flow_run(KubernetesJob(job_template=template))
+        flow_run = self.build_flow_run(KubernetesRun(job_template=template))
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
 
@@ -996,7 +996,7 @@ class TestK8sAgentRunConfig:
             yaml.safe_dump(template, f)
         template_path = f"agent://{path}"
 
-        flow_run = self.build_flow_run(KubernetesJob(job_template_path=template_path))
+        flow_run = self.build_flow_run(KubernetesRun(job_template_path=template_path))
 
         mocked_read_bytes = MagicMock(wraps=read_bytes_from_path)
         monkeypatch.setattr(
@@ -1021,7 +1021,7 @@ class TestK8sAgentRunConfig:
             yaml.safe_dump(template, f)
         self.agent.job_template_path = template_path
 
-        flow_run = self.build_flow_run(KubernetesJob())
+        flow_run = self.build_flow_run(KubernetesRun())
         job = self.agent.generate_job_spec(flow_run)
 
         identifier = job["metadata"]["labels"]["prefect.io/identifier"]
@@ -1041,12 +1041,12 @@ class TestK8sAgentRunConfig:
         "run_config, storage, expected",
         [
             (
-                KubernetesJob(),
+                KubernetesRun(),
                 Docker(registry_url="test", image_name="name", image_tag="tag"),
                 "test/name:tag",
             ),
-            (KubernetesJob(image="myimage"), Local(), "myimage"),
-            (KubernetesJob(), Local(), "prefecthq/prefect:all_extras-0.13.0"),
+            (KubernetesRun(image="myimage"), Local(), "myimage"),
+            (KubernetesRun(), Local(), "prefecthq/prefect:all_extras-0.13.0"),
         ],
         ids=["on-storage", "on-run_config", "default"],
     )
@@ -1079,7 +1079,7 @@ class TestK8sAgentRunConfig:
         self.agent.job_template_path = template_path
 
         self.agent.env_vars = {"CUSTOM2": "OVERRIDE2", "CUSTOM3": "VALUE3"}
-        run_config = KubernetesJob(env={"CUSTOM3": "OVERRIDE3", "CUSTOM4": "VALUE4"})
+        run_config = KubernetesRun(env={"CUSTOM3": "OVERRIDE3", "CUSTOM4": "VALUE4"})
 
         flow_run = self.build_flow_run(run_config)
         job = self.agent.generate_job_spec(flow_run)
@@ -1103,7 +1103,7 @@ class TestK8sAgentRunConfig:
 
     def test_generate_job_spec_resources(self):
         flow_run = self.build_flow_run(
-            KubernetesJob(
+            KubernetesRun(
                 cpu_request=1, cpu_limit=2, memory_request="4G", memory_limit="8G"
             )
         )

--- a/tests/run_configs/test_kubernetes.py
+++ b/tests/run_configs/test_kubernetes.py
@@ -3,11 +3,11 @@ import os
 import pytest
 import yaml
 
-from prefect.run_configs import KubernetesJob
+from prefect.run_configs import KubernetesRun
 
 
 def test_no_args():
-    config = KubernetesJob()
+    config = KubernetesRun()
     assert config.job_template_path is None
     assert config.job_template is None
     assert config.image is None
@@ -20,17 +20,17 @@ def test_no_args():
 
 
 def test_labels():
-    config = KubernetesJob(labels=["a", "b"])
+    config = KubernetesRun(labels=["a", "b"])
     assert config.labels == {"a", "b"}
 
 
 def test_cant_specify_both_job_template_and_job_template_path():
     with pytest.raises(ValueError, match="Cannot provide both"):
-        KubernetesJob(job_template={}, job_template_path="/some/path")
+        KubernetesRun(job_template={}, job_template_path="/some/path")
 
 
 def test_remote_job_template_path():
-    config = KubernetesJob(job_template_path="s3://bucket/example.yaml")
+    config = KubernetesRun(job_template_path="s3://bucket/example.yaml")
     assert config.job_template_path == "s3://bucket/example.yaml"
     assert config.job_template is None
 
@@ -54,7 +54,7 @@ def test_local_job_template_path(tmpdir, scheme):
     with open(path, "w") as f:
         yaml.safe_dump(job_template, f)
 
-    config = KubernetesJob(job_template_path=job_template_path)
+    config = KubernetesRun(job_template_path=job_template_path)
 
     assert config.job_template_path is None
     assert config.job_template == job_template
@@ -68,21 +68,21 @@ def test_job_template(kind):
         "metadata": {"labels": {"example": "foo"}},
     }
     arg = job_template if kind is dict else yaml.safe_dump(job_template)
-    config = KubernetesJob(job_template=arg)
+    config = KubernetesRun(job_template=arg)
 
     assert config.job_template_path is None
     assert config.job_template == job_template
 
 
 def test_cpu_limit_and_request_acceptable_types():
-    config = KubernetesJob()
+    config = KubernetesRun()
     assert config.cpu_limit is None
     assert config.cpu_request is None
 
-    config = KubernetesJob(cpu_limit="200m", cpu_request="100m")
+    config = KubernetesRun(cpu_limit="200m", cpu_request="100m")
     assert config.cpu_limit == "200m"
     assert config.cpu_request == "100m"
 
-    config = KubernetesJob(cpu_limit=0.5, cpu_request=0.1)
+    config = KubernetesRun(cpu_limit=0.5, cpu_request=0.1)
     assert config.cpu_limit == "0.5"
     assert config.cpu_request == "0.1"

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -2,15 +2,15 @@ import pytest
 
 from marshmallow import ValidationError
 
-from prefect.run_configs import KubernetesJob
+from prefect.run_configs import KubernetesRun
 from prefect.serialization.run_config import RunConfigSchema
 
 
 @pytest.mark.parametrize(
     "config",
     [
-        KubernetesJob(),
-        KubernetesJob(
+        KubernetesRun(),
+        KubernetesRun(
             job_template_path="s3://bucket/test.yaml",
             image="myimage",
             env={"test": "foo"},
@@ -20,7 +20,7 @@ from prefect.serialization.run_config import RunConfigSchema
             memory_request="2G",
             labels=["a", "b"],
         ),
-        KubernetesJob(
+        KubernetesRun(
             job_template={
                 "apiVersion": "batch/v1",
                 "kind": "Job",

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -2,7 +2,7 @@ import pytest
 
 from prefect.environments import LocalEnvironment
 from prefect.environments.storage import Docker, Local
-from prefect.run_configs import KubernetesJob
+from prefect.run_configs import KubernetesRun
 from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.graphql import GraphQLResult
 
@@ -70,7 +70,7 @@ def test_get_flow_image_run_config_docker_storage():
                     "storage": Docker(
                         registry_url="test", image_name="name", image_tag="tag"
                     ).serialize(),
-                    "run_config": KubernetesJob().serialize(),
+                    "run_config": KubernetesRun().serialize(),
                     "id": "id",
                 }
             ),
@@ -88,7 +88,7 @@ def test_get_flow_image_run_config_default_value_from_core_version():
                 {
                     "core_version": "0.13.0",
                     "storage": Local().serialize(),
-                    "run_config": KubernetesJob().serialize(),
+                    "run_config": KubernetesRun().serialize(),
                     "id": "id",
                 }
             ),
@@ -105,7 +105,7 @@ def test_get_flow_image_run_config_image_on_RunConfig():
             "flow": GraphQLResult(
                 {
                     "storage": Local().serialize(),
-                    "run_config": KubernetesJob(image="myfancyimage").serialize(),
+                    "run_config": KubernetesRun(image="myfancyimage").serialize(),
                     "id": "id",
                 }
             ),


### PR DESCRIPTION
Allows for more consistent naming across `RunConfig` objects. Future implementations will then be `DockerRun`/`LocalRun`/`FargateRun`.