### PR TITLE
Update error message when registering to non-existant project

### DIFF
--- a/changes/pr1111.yaml
+++ b/changes/pr1111.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Update error message when registering flow to non-existant project - [#3418](https://github.com/PrefectHQ/prefect/pull/3418)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -726,7 +726,7 @@ class Client:
 
         if not project:
             raise ValueError(
-                'Project {} not found. Run `client.create_project("{}")` to create it.'.format(
+                'Project {} not found. Run `prefect create project {}` to create it.'.format(
                     project_name, project_name
                 )
             )

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -726,7 +726,7 @@ class Client:
 
         if not project:
             raise ValueError(
-                'Project {} not found. Run `prefect create project {}` to create it.'.format(
+                "Project {} not found. Run `prefect create project '{}'` to create it.".format(
                     project_name, project_name
                 )
             )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -572,7 +572,7 @@ def test_client_register_with_bad_proj_name(patch_post, monkeypatch, cloud_api):
     with pytest.raises(ValueError) as exc:
         flow_id = client.register(flow, project_name="my-default-project")
     assert "not found" in str(exc.value)
-    assert "client.create_project" in str(exc.value)
+    assert "prefect create project 'my-default-project'" in str(exc.value)
 
 
 def test_client_register_with_flow_that_cant_be_deserialized(patch_post, monkeypatch):


### PR DESCRIPTION
Updates the error text to use the CLI function instead of the Client call when directing users to create the project.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)