### PR TITLE
Add option to template task run name at runtime when using backend API

### DIFF
--- a/changes/issue2100.yaml
+++ b/changes/issue2100.yaml
@@ -1,2 +1,4 @@
 enhancement:
   - "Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
+  - "Add `set_task_run_name` Client function - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
+  - "Update mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"

--- a/changes/issue2100.yaml
+++ b/changes/issue2100.yaml
@@ -1,4 +1,6 @@
 enhancement:
   - "Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
   - "Add `set_task_run_name` Client function - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
-  - "Update mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
+
+fix:
+  - "Fix mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"

--- a/changes/issue2100.yaml
+++ b/changes/issue2100.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow for templatable task run names when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"

--- a/changes/issue2100.yaml
+++ b/changes/issue2100.yaml
@@ -1,2 +1,2 @@
 enhancement:
-  - "Allow for templatable task run names when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
+  - "Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1273,7 +1273,9 @@ class Client:
             }
         }
 
-        result = self.graphql(mutation, variables=dict(input=dict(task_run_id=task_run_id, name=name)))
+        result = self.graphql(
+            mutation, variables=dict(input=dict(task_run_id=task_run_id, name=name))
+        )
 
         return result.data.set_task_run_name.success
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1259,10 +1259,11 @@ class Client:
         Set the name of a task run
 
         Args:
-            - task_run_id (str): the id for this task run
+            - task_run_id (str): the id of a task run
+            - name (str): a name for this task run
 
         Returns:
-            - State: a Prefect State object
+            - bool: whether or not the task run name was updated
         """
         mutation = {
             "mutation($input: set_task_run_name_input!)": {

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1254,6 +1254,28 @@ class Client:
             state=state,
         )
 
+    def set_task_run_name(self, task_run_id: str, name: str) -> bool:
+        """
+        Set the name of a task run
+
+        Args:
+            - task_run_id (str): the id for this task run
+
+        Returns:
+            - State: a Prefect State object
+        """
+        mutation = {
+            "mutation($input: set_task_run_name_input!)": {
+                "set_task_run_name(input: $input)": {
+                    "success": True,
+                }
+            }
+        }
+
+        result = self.graphql(mutation, variables=dict(input=dict(task_run_id=task_run_id, name=name)))
+
+        return result.data.set_task_run_name.success
+
     def get_task_run_state(self, task_run_id: str) -> "prefect.engine.state.State":
         """
         Retrieves the current state for a task run.

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Union,
 )
 
 import prefect
@@ -217,6 +218,7 @@ class Task(metaclass=SignatureValidator):
         log_stdout: bool = False,
         result: "Result" = None,
         target: str = None,
+        task_run_name: Union[str, Callable] = None,
     ):
         self.name = name or type(self).__name__
         self.slug = slug
@@ -310,6 +312,8 @@ class Task(metaclass=SignatureValidator):
                 )
             self.result = self.result.copy()
             self.result.location = self.target
+
+        self.task_run_name = task_run_name
 
         if state_handlers and not isinstance(state_handlers, collections.abc.Sequence):
             raise TypeError("state_handlers should be iterable.")

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -175,7 +175,7 @@ class Task(metaclass=SignatureValidator):
             is provided, it should have signature `callable(**kwargs) -> str` and at write
             time all formatting kwargs will be passed and a fully formatted location is
             expected as the return value.  Can be used for string formatting logic that
-            `.format(**kwargs)` doesn't support
+            `.format(**kwargs)` supports.
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
             that will be called whenever the task changes state, providing an
             opportunity to inspect or modify the new state. The handler
@@ -189,6 +189,13 @@ class Task(metaclass=SignatureValidator):
             Task enters a failure state
         - log_stdout (bool, optional): Toggle whether or not to send stdout messages to
             the Prefect logger. Defaults to `False`.
+        - task_run_name (Union[str, Callable], optional): a name to set for this task at runtime.
+            `task_run_name` strings can be templated formatting strings which will be
+            formatted at runtime with values from `prefect.context`. If a callable function
+            is provided, it should have signature `callable(**kwargs) -> str` and at write
+            time all formatting kwargs will be passed and a fully formatted location is
+            expected as the return value. Can be used for string formatting logic that
+            `.format(**kwargs)` supports. Note: this only works for tasks running against a backend API.
 
     Raises:
         - TypeError: if `tags` is of type `str`
@@ -217,7 +224,7 @@ class Task(metaclass=SignatureValidator):
         on_failure: Callable = None,
         log_stdout: bool = False,
         result: "Result" = None,
-        target: str = None,
+        target: Union[str, Callable] = None,
         task_run_name: Union[str, Callable] = None,
     ):
         self.name = name or type(self).__name__

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -318,9 +318,9 @@ class Task(metaclass=SignatureValidator):
                     stacklevel=2,
                 )
             self.result = self.result.copy()
-            self.result.location = self.target
+            self.result.location = self.target  # type: ignore
 
-        self.task_run_name = task_run_name
+        self.task_run_name = task_run_name  # type: ignore
 
         if state_handlers and not isinstance(state_handlers, collections.abc.Sequence):
             raise TypeError("state_handlers should be iterable.")
@@ -433,7 +433,7 @@ class Task(metaclass=SignatureValidator):
                     stacklevel=2,
                 )
             new.result = new.result.copy()
-            new.result.location = new.target
+            new.result.location = new.target  # type: ignore
 
         new.tags = copy.deepcopy(self.tags).union(set(new.tags))
         tags = set(prefect.context.get("tags", set()))

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -174,8 +174,8 @@ class Task(metaclass=SignatureValidator):
             formatted at runtime with values from `prefect.context`. If a callable function
             is provided, it should have signature `callable(**kwargs) -> str` and at write
             time all formatting kwargs will be passed and a fully formatted location is
-            expected as the return value.  Can be used for string formatting logic that
-            `.format(**kwargs)` supports.
+            expected as the return value. The callable can be used for string formatting logic that
+            `.format(**kwargs)` doesn't support.
         - state_handlers (Iterable[Callable], optional): A list of state change handlers
             that will be called whenever the task changes state, providing an
             opportunity to inspect or modify the new state. The handler
@@ -191,11 +191,12 @@ class Task(metaclass=SignatureValidator):
             the Prefect logger. Defaults to `False`.
         - task_run_name (Union[str, Callable], optional): a name to set for this task at runtime.
             `task_run_name` strings can be templated formatting strings which will be
-            formatted at runtime with values from `prefect.context`. If a callable function
-            is provided, it should have signature `callable(**kwargs) -> str` and at write
-            time all formatting kwargs will be passed and a fully formatted location is
-            expected as the return value. Can be used for string formatting logic that
-            `.format(**kwargs)` supports. Note: this only works for tasks running against a backend API.
+            formatted at runtime with values from `prefect.context`, task inputs, and parameters.
+            If a callable function is provided, it should have signature `callable(**kwargs) -> str`
+            and at write time all formatting kwargs will be passed and a fully formatted location is
+            expected as the return value. The callable can be used for string formatting logic that
+            `.format(**kwargs)` doesn't support. **Note**: this only works for tasks running against a
+            backend API.
 
     Raises:
         - TypeError: if `tags` is of type `str`

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -327,7 +327,7 @@ class CloudTaskRunner(TaskRunner):
         Sets the name for this task run by calling the `set_task_run_name` mutation.
 
         Args:
-            - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
+            - task_inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
                 to the task's `run()` arguments.
         """
         task_run_name = self.task.task_run_name

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -345,7 +345,9 @@ class CloudTaskRunner(TaskRunner):
             else:
                 task_run_name = task_run_name.format(**formatting_kwargs)
 
-            self.client.set_task_run_name(task_run_id=self.task_run_id, name=task_run_name)
+            self.client.set_task_run_name(
+                task_run_id=self.task_run_id, name=task_run_name  # type: ignore
+            )
 
     @tail_recursive
     def run(

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -324,7 +324,11 @@ class CloudTaskRunner(TaskRunner):
 
     def set_task_run_name(self, task_inputs: Dict[str, Result]) -> None:
         """
-        Backend!
+        Sets the name for this task run by calling the `set_task_run_name` mutation.
+
+        Args:
+            - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
+                to the task's `run()` arguments.
         """
         task_run_name = self.task.task_run_name
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -268,7 +268,7 @@ class TaskRunner(Runner):
                         state, upstream_states=upstream_states
                     )
 
-                # set task run name based on ........
+                # dynamically set task run name
                 self.set_task_run_name(task_inputs=task_inputs)
 
                 if self.task.target:
@@ -662,7 +662,11 @@ class TaskRunner(Runner):
 
     def set_task_run_name(self, task_inputs: Dict[str, Result]) -> None:
         """
-        Set task run name .....
+        Sets the name for this task run.
+
+        Args:
+            - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
+                to the task's `run()` arguments.
         """
         pass
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -664,7 +664,7 @@ class TaskRunner(Runner):
         Sets the name for this task run.
 
         Args:
-            - inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
+            - task_inputs (Dict[str, Result]): a dictionary of inputs whose keys correspond
                 to the task's `run()` arguments.
         """
         pass

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -262,10 +262,14 @@ class TaskRunner(Runner):
                     state=state, upstream_states=upstream_states
                 )
 
+
                 if is_mapped_parent:
                     state = self.check_task_ready_to_map(
                         state, upstream_states=upstream_states
                     )
+
+                # set task run name based on ........
+                self.set_task_run_name(task_inputs=task_inputs)
 
                 if self.task.target:
                     # check to see if there is a Result at the task's target
@@ -655,6 +659,12 @@ class TaskRunner(Runner):
 
         """
         return state, upstream_states
+
+    def set_task_run_name(self, task_inputs: Dict[str, Result]) -> None:
+        """
+        Set task run name .....
+        """
+        pass
 
     @call_state_handlers
     def check_target(self, state: State, inputs: Dict[str, Result]) -> State:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -179,7 +179,7 @@ class TaskRunner(Runner):
         # If provided, use task's target as result location
         if self.task.target:
             if not isinstance(self.task.target, str):
-                self.result._formatter = self.task.target
+                self.result._formatter = self.task.target  # type: ignore
                 self.result.location = None
             else:
                 self.result.location = self.task.target
@@ -261,7 +261,6 @@ class TaskRunner(Runner):
                 task_inputs = self.get_task_inputs(
                     state=state, upstream_states=upstream_states
                 )
-
 
                 if is_mapped_parent:
                     state = self.check_task_ready_to_map(
@@ -697,8 +696,8 @@ class TaskRunner(Runner):
             if not isinstance(target, str):
                 target = target(**formatting_kwargs)
 
-            if result.exists(target, **formatting_kwargs):
-                known_location = target.format(**formatting_kwargs)
+            if result.exists(target, **formatting_kwargs):  # type: ignore
+                known_location = target.format(**formatting_kwargs)  # type: ignore
                 new_res = result.read(known_location)
                 cached_state = Cached(
                     result=new_res,
@@ -740,7 +739,7 @@ class TaskRunner(Runner):
                 state = Pending("Cache was invalid; ready to run.")
 
         if self.task.cache_for is not None:
-            candidate_states = []
+            candidate_states = []  # type: ignore
             if prefect.context.get("caches"):
                 candidate_states = prefect.context.caches.get(
                     self.task.cache_key or self.task.name, []

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1047,6 +1047,7 @@ def test_set_task_run_name(patch_posts, cloud_api):
 
     assert result == True
 
+
 def test_get_task_run_state(patch_posts, cloud_api, runner_token):
     query_resp = {
         "task_run_by_pk": {

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1037,6 +1037,16 @@ def test_get_task_run_info_with_error(patch_post):
         )
 
 
+def test_set_task_run_name(patch_posts, cloud_api):
+    mutation_resp = {"data": {"set_task_run_name": {"success": True}}}
+
+    post = patch_posts(mutation_resp)
+
+    client = Client()
+    result = client.set_task_run_name(task_run_id="76-salt", name="name")
+
+    assert result == True
+
 def test_get_task_run_state(patch_posts, cloud_api, runner_token):
     query_resp = {
         "task_run_by_pk": {

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -299,6 +299,16 @@ class TestCreateTask:
         s = Task(log_stdout=True)
         assert s.log_stdout is True
 
+    def test_create_task_with_task_run_name(self):
+        t1 = Task()
+        assert t1.task_run_name is None
+
+        t2 = Task(task_run_name="test")
+        assert t2.task_run_name == "test"
+
+        t2 = Task(task_run_name=lambda: 42)
+        assert t2.task_run_name() == 42
+
 
 def test_task_has_logger():
     t = Task()

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1051,6 +1051,7 @@ def test_task_runner_handles_version_lock_error(monkeypatch):
     with pytest.raises(ENDRUN):
         res = runner.call_runner_target_handlers(Pending(), Running())
 
+
 def test_task_runner_sets_task_name(monkeypatch, cloud_settings):
 
     client = MagicMock()
@@ -1068,7 +1069,6 @@ def test_task_runner_sets_task_name(monkeypatch, cloud_settings):
     assert client.set_task_run_name.called
     assert client.set_task_run_name.call_args[1]["name"] == "asdf"
     assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"
-
 
     task = Task(name="test", task_run_name="{map_index}")
     runner = CloudTaskRunner(task=task)

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1050,3 +1050,45 @@ def test_task_runner_handles_version_lock_error(monkeypatch):
     client.get_task_run_state.return_value = s
     with pytest.raises(ENDRUN):
         res = runner.call_runner_target_handlers(Pending(), Running())
+
+def test_task_runner_sets_task_name(monkeypatch, cloud_settings):
+
+    client = MagicMock()
+    monkeypatch.setattr(
+        "prefect.engine.cloud.task_runner.Client", MagicMock(return_value=client)
+    )
+    client.set_task_run_name = MagicMock()
+
+    task = Task(name="test", task_run_name="asdf")
+    runner = CloudTaskRunner(task=task)
+    runner.task_run_id = "id"
+
+    runner.set_task_run_name(task_inputs={})
+
+    assert client.set_task_run_name.called
+    assert client.set_task_run_name.call_args[1]["name"] == "asdf"
+    assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"
+
+
+    task = Task(name="test", task_run_name="{map_index}")
+    runner = CloudTaskRunner(task=task)
+    runner.task_run_id = "id"
+
+    class Temp:
+        value = 100
+
+    runner.set_task_run_name(task_inputs={"map_index": Temp()})
+
+    assert client.set_task_run_name.called
+    assert client.set_task_run_name.call_args[1]["name"] == "100"
+    assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"
+
+    task = Task(name="test", task_run_name=lambda **kwargs: "name")
+    runner = CloudTaskRunner(task=task)
+    runner.task_run_id = "id"
+
+    runner.set_task_run_name(task_inputs={})
+
+    assert client.set_task_run_name.called
+    assert client.set_task_run_name.call_args[1]["name"] == "name"
+    assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR supersedes #2974
Closes #2100 

With the recent introduction of the `set_task_run_name` mutation in the GraphQL API we can now use this to set the name of task runs dynamically at run time. This means that a code snippet like this:

```python
@task
def get_values():
    return ['a', 's', 'd', 'f']

@task(log_stdout=True, task_run_name=lambda **kwargs: f"{kwargs['v']}")
def p(v):
    print(v)

with Flow("task_run_names") as flow:
    vals = get_values()
    p.map(vals)
```

Will automatically name all of the mapped tasks based on their inputs `a`, `s`, `d`, `f` instead of the index!

![image](https://user-images.githubusercontent.com/40716964/94866335-24000880-040d-11eb-99e1-796d2b81a623.png)


## Changes
Adds a new kwarg called `task_run_name` to the Task class that can now take in a string or callable to update the task run name at runtime.



## Importance
Lots of users have requested this!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)