### PR TITLE
Fix Fargate Agent not handling int provided cpu and memory

### DIFF
--- a/changes/pr3423.yaml
+++ b/changes/pr3423.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Fargate Agent not parsing cpu and memory provided as integers - [#3423](https://github.com/PrefectHQ/prefect/pull/3423)"

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -199,7 +199,6 @@ class FargateAgent(Agent):
         )
         self.logger.debug(f"External kwargs S3 key: {self.external_kwargs_s3_key}")
 
-
     def _override_kwargs(
         self,
         flow_run: GraphQLResult,

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -199,6 +199,7 @@ class FargateAgent(Agent):
         )
         self.logger.debug(f"External kwargs S3 key: {self.external_kwargs_s3_key}")
 
+
     def _override_kwargs(
         self,
         flow_run: GraphQLResult,
@@ -362,6 +363,11 @@ class FargateAgent(Agent):
                         pass
                 task_definition_kwargs.update({key: item})
                 self.logger.debug("{} = {}".format(key, item))
+
+        # Special case for int provided cpu and memory
+        for key in definition_kwarg_list_no_eval:
+            if isinstance(task_definition_kwargs.get(key, ""), int):
+                task_definition_kwargs[key] = str(task_definition_kwargs[key])
 
         task_run_kwargs = {}
         for key, item in user_kwargs.items():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Starting the fargate agent through the CLI could lead to issues in parsing of the cpu and memory values. This is due to the fact that boto3 required these values to be strings however natively they appear as integers. e.g.:

```
["prefect", "agent", "start", "fargate", "cpu=256", "memory=1024"]
```

Normally we exclude the literal parsing of these values because they are expected to be strings however we need to special case when they are actually provided as integers.


## Importance
This fix will unblock some users attempting to do this however the new RunConfig pattern will completely resolve and simplify all of the Fargate agent parsing so much.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)