### PR TITLE
Fix MySQL Tasks and add mysql example

### DIFF
--- a/changes/pr3426.yaml
+++ b/changes/pr3426.yaml
@@ -1,0 +1,4 @@
+fix:
+  - "Fix MySQL Tasks breaking on opening a context - [#3426](https://github.com/PrefectHQ/prefect/pull/3426)"
+contributor:
+  - "[Tenzin Choedak](https://github.com/tchoedak)"

--- a/examples/task_library/mysql/mysql_flow.py
+++ b/examples/task_library/mysql/mysql_flow.py
@@ -1,12 +1,12 @@
 from prefect.tasks.mysql.mysql import MySQLFetch, MySQLExecute
 from prefect import Flow, task
 
-EXAMPLE_TABLE = 'user'
-HOST = 'localhost'
+EXAMPLE_TABLE = "user"
+HOST = "localhost"
 PORT = 3306
-DB_NAME = 'ext'
-USER = 'admin'
-PASSWORD = 'admin'
+DB_NAME = "ext"
+USER = "admin"
+PASSWORD = "admin"
 
 
 mysql_fetch = MySQLFetch(
@@ -23,15 +23,15 @@ def print_results(x):
     print(x)
 
 
-with Flow('MySQL Example') as flow:
+with Flow("MySQL Example") as flow:
     # fetch 3 results
     fetch_results = mysql_fetch(
-        query=f'SELECT * FROM {EXAMPLE_TABLE}', fetch='many', fetch_count=3
+        query=f"SELECT * FROM {EXAMPLE_TABLE}", fetch="many", fetch_count=3
     )
     print_results(fetch_results)
 
     # execute a query that returns 3 results
-    exec_results = mysql_exec(query=f'SELECT * FROM {EXAMPLE_TABLE} LIMIT 3')
+    exec_results = mysql_exec(query=f"SELECT * FROM {EXAMPLE_TABLE} LIMIT 3")
     print_results(exec_results)
 
 

--- a/examples/task_library/mysql/mysql_flow.py
+++ b/examples/task_library/mysql/mysql_flow.py
@@ -1,0 +1,38 @@
+from prefect.tasks.mysql.mysql import MySQLFetch, MySQLExecute
+from prefect import Flow, task
+
+EXAMPLE_TABLE = 'user'
+HOST = 'localhost'
+PORT = 3306
+DB_NAME = 'ext'
+USER = 'admin'
+PASSWORD = 'admin'
+
+
+mysql_fetch = MySQLFetch(
+    host=HOST, port=PORT, db_name=DB_NAME, user=USER, password=PASSWORD
+)
+
+mysql_exec = MySQLExecute(
+    host=HOST, port=PORT, db_name=DB_NAME, user=USER, password=PASSWORD
+)
+
+
+@task
+def print_results(x):
+    print(x)
+
+
+with Flow('MySQL Example') as flow:
+    # fetch 3 results
+    fetch_results = mysql_fetch(
+        query=f'SELECT * FROM {EXAMPLE_TABLE}', fetch='many', fetch_count=3
+    )
+    print_results(fetch_results)
+
+    # execute a query that returns 3 results
+    exec_results = mysql_exec(query=f'SELECT * FROM {EXAMPLE_TABLE} LIMIT 3')
+    print_results(exec_results)
+
+
+flow.run()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Fixes #3318 MySQL tasks erroring on attempting to enter a context manager with a connection object. Also adds an example flow that was used to reproduce the issue and validate the fix.


## Changes
- Updated code to open a context with a cursor and not a connection. PyMySQL's connection object isn't meant to be used as a context manager to fix #3318.
- A few other changes included in this as enhancements or additional bug fixes
  - `port` was not used as part of creating a connection with PyMYSQL despite being part of the init kwargs
  - made `query` a *required* argument instead of a keyword argument (I'm not sure but maybe this goes against prefect's design practices - feel free to correct me if so)
  - updated default port to `3306`, which is the most common mysql port by being the default one out of the box.



## Importance
- The MySQL tasks from tasks library will not work within a Flow without this fix.
- MySQL tasks will fail to connect to a MySQL DB whose port is not `3307` (previous default)




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)