### PR TITLE
Add FlowRunRename task 

### DIFF
--- a/changes/pr3431.yml
+++ b/changes/pr3431.yml
@@ -1,5 +1,5 @@
 task:
-    - "Add new `FlowRunRenameTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
+    - "Add new `RenameFlowRunTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
 
 contributor:
     - "[Max Del Giudice](https://github.com/madelgi)"

--- a/changes/pr3431.yml
+++ b/changes/pr3431.yml
@@ -1,5 +1,5 @@
 task:
-    - "Add new `FlowRunRename` task for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
+    - "Add new `FlowRunRenameTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
 
 contributor:
     - "[Max Del Giudice](https://github.com/madelgi)"

--- a/changes/pr3431.yml
+++ b/changes/pr3431.yml
@@ -1,0 +1,5 @@
+task:
+    - "Add new `FlowRunRename` task for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
+
+contributor:
+    - "[Max Del Giudice](https://github.com/madelgi)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -276,7 +276,7 @@ classes = ["DatasetCreateFromDelimitedFiles",
 [pages.tasks.prefect]
 title = "Prefect Tasks"
 module = "prefect.tasks.prefect"
-classes = ["FlowRunTask"]
+classes = ["FlowRunTask", "FlowRunRenameTask"]
 
 [pages.tasks.github]
 title = "GitHub Tasks"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -276,7 +276,7 @@ classes = ["DatasetCreateFromDelimitedFiles",
 [pages.tasks.prefect]
 title = "Prefect Tasks"
 module = "prefect.tasks.prefect"
-classes = ["FlowRunTask", "FlowRunRenameTask"]
+classes = ["FlowRunTask", "RenameFlowRunTask"]
 
 [pages.tasks.github]
 title = "GitHub Tasks"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1069,6 +1069,31 @@ class Client:
         }
         self.graphql(mutation, raise_on_error=True)
 
+    def set_flow_run_name(self, flow_run_id: str, name: str) -> bool:
+        """
+        Set the name of a flow run.
+
+        Args:
+            - flow_run_id (str): the id of a flow run
+            - name (str): a name for this flow run
+
+        Returns:
+            - bool: whether or not the flow run name was updated
+        """
+        mutation = {
+            "mutation($input: set_flow_run_name_input!)": {
+                "set_flow_run_name(input: $input)": {
+                    "success": True,
+                }
+            }
+        }
+
+        result = self.graphql(
+            mutation, variables=dict(input=dict(flow_run_id=flow_run_id, name=name))
+        )
+
+        return result.data.set_flow_run_name.success
+
     def get_flow_run_state(self, flow_run_id: str) -> "prefect.engine.state.State":
         """
         Retrieves the current state for a flow run.

--- a/src/prefect/tasks/prefect/__init__.py
+++ b/src/prefect/tasks/prefect/__init__.py
@@ -3,4 +3,4 @@ Tasks for interacting with the Prefect API
 """
 
 from prefect.tasks.prefect.flow_run import FlowRunTask
-from prefect.tasks.prefect.flow_run_rename import FlowRunRenameTask
+from prefect.tasks.prefect.flow_run_rename import RenameFlowRunTask

--- a/src/prefect/tasks/prefect/__init__.py
+++ b/src/prefect/tasks/prefect/__init__.py
@@ -3,3 +3,4 @@ Tasks for interacting with the Prefect API
 """
 
 from prefect.tasks.prefect.flow_run import FlowRunTask
+from prefect.tasks.prefect.flow_run_rename import FlowRunRenameTask

--- a/src/prefect/tasks/prefect/flow_run_rename.py
+++ b/src/prefect/tasks/prefect/flow_run_rename.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from prefect import Task
+from prefect.client import Client
+from prefect.utilities.tasks import defaults_from_attrs
+
+
+class FlowRunRenameTask(Task):
+    """
+    Task used to rename a running flow.
+
+    Args:
+        - flow_run_id (str, optional): The ID of the flow run to rename.
+        - flow_run_name (str, optional): The new flow run name.
+    """
+
+    def __init__(
+        self,
+        flow_run_id: str = None,
+        flow_run_name: str = None,
+        **kwargs: Any,
+    ):
+        self.flow_run_id = flow_run_id
+        self.flow_run_name = flow_run_name
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs("flow_run_id", "flow_run_name")
+    def run(self, flow_run_id: str, flow_run_name: str) -> bool:
+        """
+        Args:
+            - flow_run_id (str, optional): The ID of the flow run to rename
+            - flow_run_name (str, optional): The new flow run name
+
+        Returns:
+            - bool: Boolean representing whether the flow run was renamed successfully or not.
+
+        Raises:
+            - ValueError: If flow_run_id or name is not provided
+
+        Example:
+            ```python
+            from prefect.tasks.prefect.flow_rename import FlowRenameTask
+
+            rename_flow = FlowRenameTask(flow_run_id="id123", flow_name="A new flow run name")
+            ```
+        """
+        if flow_run_id is None:
+            raise ValueError("Must provide a flow run ID.")
+        if flow_run_name is None:
+            raise ValueError("Must provide a flow name.")
+
+        client = Client()
+        return client.set_flow_run_name(flow_run_id, flow_run_name)

--- a/src/prefect/tasks/prefect/flow_run_rename.py
+++ b/src/prefect/tasks/prefect/flow_run_rename.py
@@ -5,7 +5,7 @@ from prefect.client import Client
 from prefect.utilities.tasks import defaults_from_attrs
 
 
-class FlowRunRenameTask(Task):
+class RenameFlowRunTask(Task):
     """
     Task used to rename a running flow.
 

--- a/src/prefect/tasks/prefect/flow_run_rename.py
+++ b/src/prefect/tasks/prefect/flow_run_rename.py
@@ -12,6 +12,7 @@ class FlowRunRenameTask(Task):
     Args:
         - flow_run_id (str, optional): The ID of the flow run to rename.
         - flow_run_name (str, optional): The new flow run name.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
     def __init__(

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -696,6 +696,17 @@ def test_client_register_flow_id_no_output(
     assert captured.out == "Result check: OK\n"
 
 
+def test_set_flow_run_name(patch_posts, cloud_api):
+    mutation_resp = {"data": {"set_flow_run_name": {"success": True}}}
+
+    post = patch_posts(mutation_resp)
+
+    client = Client()
+    result = client.set_flow_run_name(flow_run_id="74-salt", name="name")
+
+    assert result == True
+
+
 def test_get_flow_run_info(patch_post):
     response = {
         "flow_run_by_pk": {

--- a/tests/tasks/prefect/test_flow_run_rename.py
+++ b/tests/tasks/prefect/test_flow_run_rename.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import MagicMock
+
+import prefect
+from prefect.tasks.prefect.flow_run_rename import FlowRunRenameTask
+
+
+def test_flow_run_rename_task(monkeypatch):
+    client = MagicMock()
+    client.set_flow_run_name = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "prefect.tasks.prefect.flow_run_rename.Client", MagicMock(return_value=client)
+    )
+
+    task = FlowRunRenameTask(flow_run_id="id123", flow_run_name="a_new_name!")
+
+    # Verify correct initialization
+    assert task.flow_run_id == "id123"
+    assert task.flow_run_name == "a_new_name!"
+
+    # Verify client called with arguments
+    task.run()
+    assert client.set_flow_run_name.called
+    assert client.set_flow_run_name.call_args[0][0] == "id123"
+    assert client.set_flow_run_name.call_args[0][1] == "a_new_name!"
+
+
+def test_missing_flow_run_id():
+    task = FlowRunRenameTask()
+    with pytest.raises(ValueError, match="Must provide a flow run ID."):
+        task.run(flow_run_name="a_new_name!")
+
+
+def test_missing_flow_run_name():
+    task = FlowRunRenameTask()
+    with pytest.raises(ValueError, match="Must provide a flow name."):
+        task.run(flow_run_id="id123")

--- a/tests/tasks/prefect/test_flow_run_rename.py
+++ b/tests/tasks/prefect/test_flow_run_rename.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 import prefect
-from prefect.tasks.prefect.flow_run_rename import FlowRunRenameTask
+from prefect.tasks.prefect.flow_run_rename import RenameFlowRunTask
 
 
 def test_flow_run_rename_task(monkeypatch):
@@ -12,7 +12,7 @@ def test_flow_run_rename_task(monkeypatch):
         "prefect.tasks.prefect.flow_run_rename.Client", MagicMock(return_value=client)
     )
 
-    task = FlowRunRenameTask(flow_run_id="id123", flow_run_name="a_new_name!")
+    task = RenameFlowRunTask(flow_run_id="id123", flow_run_name="a_new_name!")
 
     # Verify correct initialization
     assert task.flow_run_id == "id123"
@@ -26,12 +26,12 @@ def test_flow_run_rename_task(monkeypatch):
 
 
 def test_missing_flow_run_id():
-    task = FlowRunRenameTask()
+    task = RenameFlowRunTask()
     with pytest.raises(ValueError, match="Must provide a flow run ID."):
         task.run(flow_run_name="a_new_name!")
 
 
 def test_missing_flow_run_name():
-    task = FlowRunRenameTask()
+    task = RenameFlowRunTask()
     with pytest.raises(ValueError, match="Must provide a flow name."):
         task.run(flow_run_id="id123")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adds a `FlowRunRename` task for renaming running flows

## Changes
Update the `prefect` task module to allow users to rename a currently running flow.

## Importance
Expands the `prefect` task module in a useful way, as specified in #3285


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)