### PR TITLE
Prep for release of 0.13.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.13.10 <Badge text="beta" type="success" />
+
+Released on October 6, 2020.
+
+### Enhancements
+
+- Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
+- Add `set_task_run_name` Client function - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
+- Use 'from' to explicitly chain exceptions - [#3306](https://github.com/PrefectHQ/prefect/pull/3306)
+- Update error message when registering flow to non-existant project - [#3418](https://github.com/PrefectHQ/prefect/pull/3418)
+- Add `flow.run_config`, an *experimental* design for configuring deployed flows - [#3333](https://github.com/PrefectHQ/prefect/pull/3333)
+- Allow python path in Local storage - [#3351](https://github.com/PrefectHQ/prefect/pull/3351)
+- Enable agent registration for server users - [#3385](https://github.com/PrefectHQ/prefect/pull/3385)
+- Added FROM to explicitly chain exceptions in src/prefect/utilities - [#3429](https://github.com/PrefectHQ/prefect/pull/3429)
+
+### Task Library
+
+- Add keypair auth for snowflake - [#3404](https://github.com/PrefectHQ/prefect/pull/3404)
+- Add new `RenameFlowRunTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285).
+
+### Fixes
+
+- Fix mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
+- Fix Fargate Agent not parsing cpu and memory provided as integers - [#3423](https://github.com/PrefectHQ/prefect/pull/3423)
+- Fix MySQL Tasks breaking on opening a context - [#3426](https://github.com/PrefectHQ/prefect/pull/3426)
+
+### Contributors
+
+- [Ian Fridge](https://github.com/fridgei)
+- [Jack D. Sundberg](https://github.com/jacksund)
+- [Juan Calderon-Perez](https://github.com/gabrielcalderon)
+- [Max Del Giudice](https://github.com/madelgi)
+- [Paras Luthra](https://github.com/luthrap)
+- [Tenzin Choedak](https://github.com/tchoedak)
+
 ## 0.13.9 <Badge text="beta" type="success" />
 
 Released on September 29, 2020.

--- a/changes/issue2100.yaml
+++ b/changes/issue2100.yaml
@@ -1,6 +1,0 @@
-enhancement:
-  - "Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
-  - "Add `set_task_run_name` Client function - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"
-
-fix:
-  - "Fix mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)"

--- a/changes/issue3306.yaml
+++ b/changes/issue3306.yaml
@@ -1,4 +1,0 @@
-enhancement:
-  - "Use 'from' to explicitly chain exceptions - [#3306](https://github.com/PrefectHQ/prefect/pull/3306)"
-contributor:
-  - "[Paras Luthra](https://github.com/luthrap)"

--- a/changes/pr1111.yaml
+++ b/changes/pr1111.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Update error message when registering flow to non-existant project - [#3418](https://github.com/PrefectHQ/prefect/pull/3418)"

--- a/changes/pr3333.yaml
+++ b/changes/pr3333.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Add `flow.run_config`, an *experimental* design for configuring deployed flows - [#3333](https://github.com/PrefectHQ/prefect/pull/3333)"

--- a/changes/pr3351.yaml
+++ b/changes/pr3351.yaml
@@ -1,4 +1,0 @@
-enhancement:
-  - "Allow python path in Local storage - [#3351](https://github.com/PrefectHQ/prefect/pull/3351)"
-contributor:
-  - "[Jack D. Sundberg](https://github.com/jacksund)"

--- a/changes/pr3385.yaml
+++ b/changes/pr3385.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Enable agent registration for server users - [#3385](https://github.com/PrefectHQ/prefect/pull/3385)"

--- a/changes/pr3404.yaml
+++ b/changes/pr3404.yaml
@@ -1,5 +1,0 @@
-task:
-  - "Add keypair auth for snowflake - [#3404](https://github.com/PrefectHQ/prefect/pull/3404)"
-
-contributor:
-  - "[Ian Fridge](https://github.com/fridgei)"

--- a/changes/pr3423.yaml
+++ b/changes/pr3423.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Fix Fargate Agent not parsing cpu and memory provided as integers - [#3423](https://github.com/PrefectHQ/prefect/pull/3423)"

--- a/changes/pr3426.yaml
+++ b/changes/pr3426.yaml
@@ -1,4 +1,0 @@
-fix:
-  - "Fix MySQL Tasks breaking on opening a context - [#3426](https://github.com/PrefectHQ/prefect/pull/3426)"
-contributor:
-  - "[Tenzin Choedak](https://github.com/tchoedak)"

--- a/changes/pr3429.yaml
+++ b/changes/pr3429.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Added FROM to explicitly chain exceptions in src/prefect/utilities - [#3429](https://github.com/PrefectHQ/prefect/pull/3429)"
-
-contributor:
-  - "[Juan Calderon-Perez](https://github.com/gabrielcalderon)"

--- a/changes/pr3431.yml
+++ b/changes/pr3431.yml
@@ -1,5 +1,0 @@
-task:
-    - "Add new `RenameFlowRunTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285)."
-
-contributor:
-    - "[Max Del Giudice](https://github.com/madelgi)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -74,7 +74,7 @@ module.exports = {
       {
         text: 'API Reference',
         items: [
-          { text: 'Latest (0.13.9)', link: '/api/latest/' },
+          { text: 'Latest (0.13.10)', link: '/api/latest/' },
           { text: '0.12.6', link: '/api/0.12.6/' },
           { text: '0.11.5', link: '/api/0.11.5/' },
           { text: '0.10.7', link: '/api/0.10.7/' },


### PR DESCRIPTION
# Changelog

## 0.13.10 

Released on October 6, 2020.

### Enhancements

- Add option to template task run name at runtime when using backend API - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
- Add `set_task_run_name` Client function - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
- Use 'from' to explicitly chain exceptions - [#3306](https://github.com/PrefectHQ/prefect/pull/3306)
- Update error message when registering flow to non-existant project - [#3418](https://github.com/PrefectHQ/prefect/pull/3418)
- Add `flow.run_config`, an *experimental* design for configuring deployed flows - [#3333](https://github.com/PrefectHQ/prefect/pull/3333)
- Allow python path in Local storage - [#3351](https://github.com/PrefectHQ/prefect/pull/3351)
- Enable agent registration for server users - [#3385](https://github.com/PrefectHQ/prefect/pull/3385)
- Added FROM to explicitly chain exceptions in src/prefect/utilities - [#3429](https://github.com/PrefectHQ/prefect/pull/3429)

### Task Library

- Add keypair auth for snowflake - [#3404](https://github.com/PrefectHQ/prefect/pull/3404)
- Add new `RenameFlowRunTask` for renaming a currently running flow - [#3285](https://github.com/PrefectHQ/prefect/issues/3285).

### Fixes

- Fix mypy typing for `target` kwarg on base Task class - [#2100](https://github.com/PrefectHQ/prefect/issues/2100)
- Fix Fargate Agent not parsing cpu and memory provided as integers - [#3423](https://github.com/PrefectHQ/prefect/pull/3423)
- Fix MySQL Tasks breaking on opening a context - [#3426](https://github.com/PrefectHQ/prefect/pull/3426)

### Contributors

- [Ian Fridge](https://github.com/fridgei)
- [Jack D. Sundberg](https://github.com/jacksund)
- [Juan Calderon-Perez](https://github.com/gabrielcalderon)
- [Max Del Giudice](https://github.com/madelgi)
- [Paras Luthra](https://github.com/luthrap)
- [Tenzin Choedak](https://github.com/tchoedak)
