### PR TITLE
Fixed validation for containerDefinitions environment

### DIFF
--- a/changes/pr3452.yaml
+++ b/changes/pr3452.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fix containerDefinitions environment validation - [#3452](https://github.com/PrefectHQ/prefect/pull/3452)"
+
+contributor:
+  - "[Alessandro Lollo](https://github.com/https://github.com/AlessandroLollo)"

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -252,8 +252,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             "containerDefinition.{idx}.{key} -> Given: {given}, Expected: {expected}".format(
                 idx=idx,
                 key=key,
-                given=value,
-                expected=existing_container_definition.get(key),
+                given=sorted(value) if key == "environment" else value,
+                expected=sorted(existing_container_definition.get(key)) if key == "environment" else existing_container_definition.get(key),
             )
             for idx, (
                 container_definition,
@@ -277,7 +277,7 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             for key in _DEFINITION_KWARG_LIST
             if key != "containerDefinitions"
             and key in task_definition_kwargs
-            and existing_task_definition.get(key) != task_definition_kwargs[key]
+            and ((existing_task_definition.get(key) != task_definition_kwargs[key] and key != "environment") or (sorted(existing_task_definition.get(key)) != sorted(task_definition_kwargs[key])) and key == "environment")
         ]
 
         differences = containerDifferences + otherDifferences

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -253,7 +253,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
                 idx=idx,
                 key=key,
                 given=sorted(value) if key == "environment" else value,
-                expected=sorted(existing_container_definition.get(key)) if key == "environment" else existing_container_definition.get(key),
+                expected=sorted(existing_container_definition.get(key)) if key == "environment"
+                else existing_container_definition.get(key),
             )
             for idx, (
                 container_definition,
@@ -277,7 +278,9 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             for key in _DEFINITION_KWARG_LIST
             if key != "containerDefinitions"
             and key in task_definition_kwargs
-            and ((existing_task_definition.get(key) != task_definition_kwargs[key] and key != "environment") or (sorted(existing_task_definition.get(key)) != sorted(task_definition_kwargs[key])) and key == "environment")
+            and ((existing_task_definition.get(key) != task_definition_kwargs[key] and key != "environment") or
+                 (sorted(existing_task_definition.get(key)) != sorted(task_definition_kwargs[key]))
+                 and key == "environment")
         ]
 
         differences = containerDifferences + otherDifferences

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -252,8 +252,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             "containerDefinition.{idx}.{key} -> Given: {given}, Expected: {expected}".format(
                 idx=idx,
                 key=key,
-                given=sorted(value) if key == "environment" else value,
-                expected=sorted(existing_container_definition.get(key))
+                given=sorted(list(value)) if key == "environment" else value,
+                expected=sorted(list(existing_container_definition.get(key)))
                 if key == "environment"
                 else existing_container_definition.get(key),
             )
@@ -285,8 +285,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
                     and key != "environment"
                 )
                 or (
-                    sorted(existing_task_definition.get(key))
-                    != sorted(task_definition_kwargs[key])
+                    sorted(list(existing_task_definition.get(key)))
+                    != sorted(list(task_definition_kwargs[key]))
                 )
                 and key == "environment"
             )

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -253,7 +253,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
                 idx=idx,
                 key=key,
                 given=sorted(value) if key == "environment" else value,
-                expected=sorted(existing_container_definition.get(key)) if key == "environment"
+                expected=sorted(existing_container_definition.get(key))
+                if key == "environment"
                 else existing_container_definition.get(key),
             )
             for idx, (
@@ -278,9 +279,17 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             for key in _DEFINITION_KWARG_LIST
             if key != "containerDefinitions"
             and key in task_definition_kwargs
-            and ((existing_task_definition.get(key) != task_definition_kwargs[key] and key != "environment") or
-                 (sorted(existing_task_definition.get(key)) != sorted(task_definition_kwargs[key]))
-                 and key == "environment")
+            and (
+                (
+                    existing_task_definition.get(key) != task_definition_kwargs[key]
+                    and key != "environment"
+                )
+                or (
+                    sorted(existing_task_definition.get(key))
+                    != sorted(task_definition_kwargs[key])
+                )
+                and key == "environment"
+            )
         ]
 
         differences = containerDifferences + otherDifferences

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -252,8 +252,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
             "containerDefinition.{idx}.{key} -> Given: {given}, Expected: {expected}".format(
                 idx=idx,
                 key=key,
-                given=sorted(list(value)) if key == "environment" else value,
-                expected=sorted(list(existing_container_definition.get(key)))
+                given=sorted([value]) if key == "environment" else value,
+                expected=sorted([existing_container_definition.get(key)])
                 if key == "environment"
                 else existing_container_definition.get(key),
             )
@@ -285,8 +285,8 @@ class FargateTaskEnvironment(Environment, _RunMixin):
                     and key != "environment"
                 )
                 or (
-                    sorted(list(existing_task_definition.get(key)))
-                    != sorted(list(task_definition_kwargs[key]))
+                    sorted([existing_task_definition.get(key)])
+                    != sorted([task_definition_kwargs[key]])
                 )
                 and key == "environment"
             )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixed validation of containerDefinitions' environment



## Changes
<!-- What does this PR change? -->
For containerDefinitions' `environment`, the validation now uses `sorted` since `environment` is a list of dict.



## Importance
<!-- Why is this PR important? -->
This PR fixes the validation phase for the task definition `environment`, which otherwise fails if the existing `environment` and the flow's `environments` have dicts in different order



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)