### PR TITLE
Don't set log level in k8s agent w/ KubernetesRun

### DIFF
--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -448,11 +448,11 @@ class KubernetesAgent(Agent):
         container["args"] = [get_flow_run_command(flow_run)]
 
         # Populate environment variables from the following sources,
-        # with reverse precedence (later sources override).
-        # - Values in the job template
+        # with precedence:
+        # - Values required for flow execution, hardcoded below
+        # - Values set on the KubernetesRun object
         # - Values set using the `--env` CLI flag on the agent
-        # - Values set on the job configuration
-        # - Hardcoded values below, provided they're not already set
+        # - Values in the job template
         env = self.env_vars.copy()
         if run_config.env:
             env.update(run_config.env)
@@ -463,7 +463,6 @@ class KubernetesAgent(Agent):
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
-                "PREFECT__LOGGING__LEVEL": config.logging.level,
                 "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.log_to_cloud).lower(),
                 "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
                 "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1091,7 +1091,6 @@ class TestK8sAgentRunConfig:
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
             "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
-            "PREFECT__LOGGING__LEVEL": prefect.config.logging.level,
             "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.agent.log_to_cloud).lower(),
             "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
             "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",


### PR DESCRIPTION
When using the new `KubernetesRun` config, we don't set the logging
level by default in the k8s agent. This makes it easier for users to
configure the logging level, as the agent doesn't always override it.
We only apply this change to flows using the `KubernetesRun` run
conifiguration as it's new and experimental. Users using other config
mechansisms may be relying on the existing behavior.