### PR TITLE
Better error for `flow.register` in flow context

### DIFF
--- a/changes/pr3467.yaml
+++ b/changes/pr3467.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Raise a better error when calling `flow.register()` from within a `Flow` context - [#3467](https://github.com/PrefectHQ/prefect/pull/3467)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -357,7 +357,6 @@ class Flow:
         with prefect.context(flow=self, _unused_task_tracker=unused_task_tracker):
             yield self
 
-        # constants are not tracked at the flow level
         if unused_task_tracker.difference(self.tasks):
             warnings.warn(
                 "Tasks were created but not added to the flow: "
@@ -1582,6 +1581,19 @@ class Flow:
         Returns:
             - str: the ID of the flow that was registered
         """
+        if hasattr(self, "_ctx"):
+            raise ValueError(
+                "Don't call `flow.register()` from within a `Flow` context manager.\n\n"
+                "Do:\n\n"
+                "  with Flow(...) as flow:\n"
+                "      ...\n"
+                "  flow.register(...)\n\n"
+                "Don't:\n\n"
+                "  with Flow(...) as flow:\n"
+                "      ...\n"
+                "      flow.register(...)"
+            )
+
         if prefect.context.get("loading_flow", False):
             warnings.warn(
                 "Attempting to call `flow.register` during execution of flow file will lead "

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2665,8 +2665,13 @@ class TestFlowRegister:
         assert "foo" in f.environment.labels
         assert len(f.environment.labels) == 2
 
-    def test_flow_register_passes_kwargs_to_storage(self, monkeypatch):
-        monkeypatch.setattr("prefect.Client", MagicMock())
+    def test_flow_register_errors_if_in_flow_context(self):
+        with pytest.raises(ValueError) as exc:
+            with Flow("test") as flow:
+                flow.register()
+        assert "`flow.register()` from within a `Flow` context manager" in str(
+            exc.value
+        )
 
 
 def test_bad_flow_runner_code_still_returns_state_obj():


### PR DESCRIPTION
Previously this would raise an error due to pickle failing. We could
have fixed it so pickle worked, but I'd argue that the flow context
should always exit before registering the flow (we do correctness checks
for the user on flow context exit). We now raise a nicer error message.

Reported via slack: https://prefect-community.slack.com/archives/C014Z8DPDSR/p1602257752136900

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)