### PR TITLE
The `cache_*` args in `Task` aren't deprecated

### DIFF
--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -148,13 +148,13 @@ class Task(metaclass=SignatureValidator):
             attempting to use either state or data from tasks that didn't run. If
             `False`, the task's trigger will be called as normal, with skips
             considered successes. Defaults to `True`.
-        - cache_for (timedelta, optional, DEPRECATED): The amount of time to maintain a cache
+        - cache_for (timedelta, optional): The amount of time to maintain a cache
             of the outputs of this task.  Useful for situations where the containing Flow
             will be rerun multiple times, but this task doesn't need to be.
-        - cache_validator (Callable, optional, DEPRECATED): Validator that will determine
+        - cache_validator (Callable, optional): Validator that will determine
             whether the cache for this task is still valid (only required if `cache_for`
             is provided; defaults to `prefect.engine.cache_validators.duration_only`)
-        - cache_key (str, optional, DEPRECATED): if provided, a `cache_key`
+        - cache_key (str, optional): if provided, a `cache_key`
             serves as a unique identifier for this Task's cache, and can be shared
             across both Tasks _and_ Flows; if not provided, the Task's _name_ will
             be used if running locally, or the Task's database ID if running in


### PR DESCRIPTION
Remove incorrect docstrings noting they were.