### PR TITLE
Docs bugfix

### DIFF
--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -185,7 +185,7 @@ def some_failed(
     Args:
         - at_least (Union[int, float], optional): the minimum number of
             upstream failures that must occur for this task to run.  If the
-            provided number is 1, it will be interpreted as a
+            provided number is less than 1, it will be interpreted as a
             percentage, otherwise as an absolute number.
         - at_most (Union[int, float], optional): the maximum number of upstream
            failures to allow for this task to run.  If the provided number is

--- a/src/prefect/triggers.py
+++ b/src/prefect/triggers.py
@@ -185,11 +185,11 @@ def some_failed(
     Args:
         - at_least (Union[int, float], optional): the minimum number of
             upstream failures that must occur for this task to run.  If the
-            provided number is less than 0, it will be interpreted as a
+            provided number is 1, it will be interpreted as a
             percentage, otherwise as an absolute number.
         - at_most (Union[int, float], optional): the maximum number of upstream
            failures to allow for this task to run.  If the provided number is
-           less than 0, it will be interpreted as a percentage, otherwise as an
+           less than 1, it will be interpreted as a percentage, otherwise as an
            absolute number."""
 
     def _some_failed(upstream_states: Dict["core.Edge", "state.State"]) -> bool:
@@ -243,11 +243,11 @@ def some_successful(
     Args:
         - at_least (Union[int, float], optional): the minimum number of
             upstream successes that must occur for this task to run.  If the
-            provided number is less than 0, it will be interpreted as a
+            provided number is less than 1, it will be interpreted as a
             percentage, otherwise as an absolute number.
         - at_most (Union[int, float], optional): the maximum number of upstream
             successes to allow for this task to run.  If the provided number is
-            less than 0, it will be interpreted as a percentage, otherwise as
+            less than 1, it will be interpreted as a percentage, otherwise as
             an absolute number.
     """
 


### PR DESCRIPTION
## Summary
Updates the docs because the args for `some_successful` and `some_failed` stated that percentages were triggerd by numbers <0 instead of <1

## Changes
Minor change to docstrings

## Importance
Reduce confusion!

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)