### PR TITLE
Don't use `signal.raise` when cancelling tasks

### DIFF
--- a/changes/pr3474.yaml
+++ b/changes/pr3474.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix task cancellation on Python 3.8 to properly interrupt long blocking calls - [#3474](https://github.com/PrefectHQ/prefect/pull/3474)"

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -197,22 +197,18 @@ class CloudFlowRunner(FlowRunner):
                         flow_run_version = flow_run_info.version
                         # If not already leaving context, raise KeyboardInterrupt in the main thread
                         if not exiting_context:
-                            if hasattr(signal, "raise_signal"):
-                                # New in python 3.8
-                                signal.raise_signal(signal.SIGINT)  # type: ignore
-                            else:
-                                if os.name == "nt":
-                                    # This doesn't actually send a signal, so it will only
-                                    # interrupt the next Python bytecode instruction - if the
-                                    # main thread is blocked in a c extension the interrupt
-                                    # won't be seen until that returns.
-                                    from _thread import interrupt_main
+                            if os.name == "nt":
+                                # This doesn't actually send a signal, so it will only
+                                # interrupt the next Python bytecode instruction - if the
+                                # main thread is blocked in a c extension the interrupt
+                                # won't be seen until that returns.
+                                from _thread import interrupt_main
 
-                                    interrupt_main()
-                                else:
-                                    signal.pthread_kill(
-                                        threading.main_thread().ident, signal.SIGINT  # type: ignore
-                                    )
+                                interrupt_main()
+                            else:
+                                signal.pthread_kill(
+                                    threading.main_thread().ident, signal.SIGINT  # type: ignore
+                                )
                         break
                     elif exiting_context:
                         break


### PR DESCRIPTION
This doesn't actually interrupt long running calls like `time.sleep`,
better to use `signal.pthread_kill` everywhere. Long running system
blocking calls like `time.sleep` are unlikely, but still possible,
especially for users trying things out.

Fixes #3424 (partially).

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)