### PR TITLE
fixing default DbtKwargs arg to default to empty dict

### DIFF
--- a/changes/issue3280.yaml
+++ b/changes/issue3280.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix default behavior for dbt_kwargs in the dbt task to provide an empty string - [#3280](https://github.com/PrefectHQ/prefect/issues/3280)"

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -70,7 +70,7 @@ class DbtShellTask(ShellTask):
         overwrite_profiles: bool = False,
         profiles_dir: str = None,
         set_profiles_envar: bool = True,
-        dbt_kwargs: dict = {},
+        dbt_kwargs: dict = None,
         helper_script: str = None,
         shell: str = "bash",
         return_all: bool = False,
@@ -83,7 +83,7 @@ class DbtShellTask(ShellTask):
         self.overwrite_profiles = overwrite_profiles
         self.profiles_dir = profiles_dir
         self.set_profiles_envar = set_profiles_envar
-        self.dbt_kwargs = dbt_kwargs
+        self.dbt_kwargs = dbt_kwargs or {}
         super().__init__(
             **kwargs,
             command=command,

--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -70,7 +70,7 @@ class DbtShellTask(ShellTask):
         overwrite_profiles: bool = False,
         profiles_dir: str = None,
         set_profiles_envar: bool = True,
-        dbt_kwargs: dict = None,
+        dbt_kwargs: dict = {},
         helper_script: str = None,
         shell: str = "bash",
         return_all: bool = False,


### PR DESCRIPTION
## Summary
Documentation did not specify that an empty dictionary was required for DbtKwargs to function properly in the dbt task. This change creates an empty dict when none is given.




## Changes
Default behavior in dbt task as requested in #3280 




## Importance
Improves user experience with dbt task.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)