### PR TITLE
Enable upload for file based storage when using S3 and GCS

### DIFF
--- a/changes/pr3482.yaml
+++ b/changes/pr3482.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Enable automatic script upload for file-based storage when using S3 and GCS - [#3482](https://github.com/PrefectHQ/prefect/pull/3482)"

--- a/docs/core/idioms/file-based.md
+++ b/docs/core/idioms/file-based.md
@@ -162,7 +162,7 @@ not set then a key will be automatically generated for the storage of the flow)
 flow.storage = S3(
     bucket="my-flow-bucket",
     stored_as_script=True,
-    script_path="my_flow.py"  # Local file that you want uploaded to the bucket
+    local_script_path="my_flow.py"  # Local file that you want uploaded to the bucket
 )
 
 # or

--- a/docs/core/idioms/file-based.md
+++ b/docs/core/idioms/file-based.md
@@ -170,7 +170,7 @@ flow.storage = S3(
 flow.storage = GCS(
     bucket="my-flow-bucket",
     stored_as_script=True,
-    script_path="my_flow.py"  # Local file that you want uploaded to the bucket
+    local_script_path="my_flow.py"  # Local file that you want uploaded to the bucket
 )
 ```
 

--- a/docs/core/idioms/file-based.md
+++ b/docs/core/idioms/file-based.md
@@ -22,7 +22,6 @@ pip install 'prefect[github]'
 ```
 :::
 
-
 In this example we will walk through a potential workflow you may use when registering flows with
 [GitHub](/api/latest/environments/storage.html#github) storage. This example takes place in a GitHub
 repository with the following structure:
@@ -81,7 +80,7 @@ Now that the file exists on the repo the flow needs to be registered with a Pref
 Core's server or Prefect Cloud).
 
 ```bash
-prefect register flow -f flows/my_flow.py
+prefect register flow -f flows/my_flow.py -p MyProject
 Result check: OK
 Flow: http://localhost:8080/flow/9f5f7bea-186e-44d1-a746-417239663614
 ```
@@ -95,7 +94,7 @@ If you change any of the structure of your flow such as task names, rearrange ta
 will need to reregister that flow.
 :::
 
-::: tip GitLab users 
+::: tip GitLab users
 This example applies to GitLab as well. To use GitLab storage, install the `gitlab` extra:
 
 ```bash
@@ -104,6 +103,7 @@ pip install 'prefect[gitlab]'
 
 You can replace `GitHub` instances in the example above with `GitLab`, use the `"GITLAB_ACCESS_TOKEN"` secret rather than `"GITHUB_ACCESS_TOKEN"`, and then you may run the example as written.
 :::
+
 ### File based Docker storage
 
 ```python
@@ -129,4 +129,54 @@ flow.storage = Docker(
     path="/location/in/image/my_flow.py",
     stored_as_script=True
 )
+```
+
+### File based cloud storage
+
+File based storage of flows is also supported for flows stored in S3 and GCS buckets. The following
+snippet shows S3 and GCS storage options where a flow is stored as a script and the `key` points to the
+specific file path in the bucket.
+
+```python
+flow.storage = S3(
+    bucket="my-flow-bucket",
+    stored_as_script=True,
+    key="flow_path/in_bucket.py"
+)
+
+# or
+
+flow.storage = GCS(
+    bucket="my-flow-bucket",
+    stored_as_script=True,
+    key="flow_path/in_bucket.py"
+)
+```
+
+Storing flows this way is similar to the git-based flow storage where users manually have to upload the
+flows to the buckets and then set a key to match. There is another option where flows scripts can be
+automatically uploaded to the buckets by providing a file path to the storage object. (Note: if `key` is
+not set then a key will be automatically generated for the storage of the flow)
+
+```python{4,12}
+flow.storage = S3(
+    bucket="my-flow-bucket",
+    stored_as_script=True,
+    script_path="my_flow.py"  # Local file that you want uploaded to the bucket
+)
+
+# or
+
+flow.storage = GCS(
+    bucket="my-flow-bucket",
+    stored_as_script=True,
+    script_path="my_flow.py"  # Local file that you want uploaded to the bucket
+)
+```
+
+The script location can also be provided when registering the flow through the
+[`register`](/api/latest/cli/register.html) CLI command through the `--file/-f` option:
+
+```bash
+prefect register flow -f my_flow.py -p MyProject
 ```

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -81,8 +81,8 @@ def flow(file, name, project, label):
     """
 
     # Don't run extra `run` and `register` functions inside file
-    with prefect.context({"loading_flow": True}):
-        file_path = os.path.abspath(file)
+    file_path = os.path.abspath(file)
+    with prefect.context({"loading_flow": True, "script_path": file_path}):
         flow = extract_flow_from_file(file_path=file_path, flow_name=name)
 
     if getattr(flow, "run_config", None) is not None:

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -82,7 +82,7 @@ def flow(file, name, project, label):
 
     # Don't run extra `run` and `register` functions inside file
     file_path = os.path.abspath(file)
-    with prefect.context({"loading_flow": True, "script_path": file_path}):
+    with prefect.context({"loading_flow": True, "local_script_path": file_path}):
         flow = extract_flow_from_file(file_path=file_path, flow_name=name)
 
     if getattr(flow, "run_config", None) is not None:

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -29,6 +29,10 @@ class Storage(metaclass=ABCMeta):
             configuration at `flows.defaults.storage.add_default_labels`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
+        - script_path (str, optional): the path to a local script to upload when `stored_as_scipt` is set
+            to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
+            neither are set then script will not be uploaded and users should manually place the script
+            file in the desired location.
     """
 
     def __init__(
@@ -38,10 +42,13 @@ class Storage(metaclass=ABCMeta):
         labels: List[str] = None,
         add_default_labels: bool = None,
         stored_as_script: bool = False,
+        script_path: str = None,
     ) -> None:
         self.result = result
         self.secrets = secrets or []
         self.stored_as_script = stored_as_script
+        self.script_path = script_path or prefect.context.get("script_path", None)
+
         self._labels = labels or []
         if add_default_labels is None:
             self.add_default_labels = config.flows.defaults.storage.add_default_labels

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -29,7 +29,7 @@ class Storage(metaclass=ABCMeta):
             configuration at `flows.defaults.storage.add_default_labels`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - script_path (str, optional): the path to a local script to upload when `stored_as_scipt` is set
+        - script_path (str, optional): the path to a local script to upload when `stored_as_script` is set
             to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
             neither are set then script will not be uploaded and users should manually place the script
             file in the desired location.

--- a/src/prefect/environments/storage/base.py
+++ b/src/prefect/environments/storage/base.py
@@ -29,10 +29,6 @@ class Storage(metaclass=ABCMeta):
             configuration at `flows.defaults.storage.add_default_labels`.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - script_path (str, optional): the path to a local script to upload when `stored_as_script` is set
-            to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
-            neither are set then script will not be uploaded and users should manually place the script
-            file in the desired location.
     """
 
     def __init__(
@@ -42,12 +38,10 @@ class Storage(metaclass=ABCMeta):
         labels: List[str] = None,
         add_default_labels: bool = None,
         stored_as_script: bool = False,
-        script_path: str = None,
     ) -> None:
         self.result = result
         self.secrets = secrets or []
         self.stored_as_script = stored_as_script
-        self.script_path = script_path or prefect.context.get("script_path", None)
 
         self._labels = labels or []
         if add_default_labels is None:

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -59,14 +59,12 @@ class GCS(Storage):
         self.bucket = bucket
         self.key = key
         self.project = project
-        self.local_script_path = local_script_path or prefect.context.get("local_script_path", None)
+        self.local_script_path = local_script_path or prefect.context.get(
+            "local_script_path", None
+        )
 
         result = GCSResult(bucket=bucket)
-        super().__init__(
-            result=result,
-            stored_as_script=stored_as_script,
-            **kwargs
-        )
+        super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
 
     @property
     def default_labels(self) -> List[str]:

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -36,7 +36,7 @@ class GCS(Storage):
             if not provided, the project will be inferred from your Google Cloud credentials.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - script_path (str, optional): the path to a local script to upload when `stored_as_scipt` is set
+        - script_path (str, optional): the path to a local script to upload when `stored_as_script` is set
             to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
             neither are set then script will not be uploaded and users should manually place the script
             file in the desired `key` location in a GCS bucket.

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -36,6 +36,10 @@ class GCS(Storage):
             if not provided, the project will be inferred from your Google Cloud credentials.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
+        - script_path (str, optional): the path to a local script to upload when `stored_as_scipt` is set
+            to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
+            neither are set then script will not be uploaded and users should manually place the script
+            file in the desired `key` location in a GCS bucket.
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
@@ -45,6 +49,7 @@ class GCS(Storage):
         key: str = None,
         project: str = None,
         stored_as_script: bool = False,
+        script_path: str = None,
         **kwargs: Any
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
@@ -55,7 +60,12 @@ class GCS(Storage):
         self.project = project
 
         result = GCSResult(bucket=bucket)
-        super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
+        super().__init__(
+            result=result,
+            stored_as_script=stored_as_script,
+            script_path=script_path,
+            **kwargs
+        )
 
     @property
     def default_labels(self) -> List[str]:
@@ -151,10 +161,24 @@ class GCS(Storage):
         self.run_basic_healthchecks()
 
         if self.stored_as_script:
-            if not self.key:
-                raise ValueError(
-                    "A `key` must be provided to show where flow `.py` file is stored in GCS."
-                )
+            if self.script_path:
+                for flow_name, flow in self._flows.items():
+                    self.logger.info(
+                        "Uploading script {} to {} in {}".format(
+                            self.script_path, self.flows[flow.name], self.bucket
+                        )
+                    )
+
+                    bucket = self._gcs_client.get_bucket(self.bucket)
+                    blob = bucket.blob(blob_name=self.flows[flow_name])
+                    with open(self.script_path) as file_obj:
+                        blob.upload_from_file(file_obj)
+            else:
+                if not self.key:
+                    raise ValueError(
+                        "A `key` must be provided to show where flow `.py` file is stored in GCS or "
+                        "provide a `script_path` pointing to a local script that contains the flow."
+                    )
             return self
 
         for flow_name, flow in self._flows.items():

--- a/src/prefect/environments/storage/gcs.py
+++ b/src/prefect/environments/storage/gcs.py
@@ -40,7 +40,7 @@ class GCS(Storage):
         - local_script_path (str, optional): the path to a local script to upload when `stored_as_script`
             is set to `True`. If not set then the value of `local_script_path` from `prefect.context` is
             used. If neither are set then script will not be uploaded and users should manually place the
-            script file in the desired `key` location in an GCS bucket.
+            script file in the desired `key` location in a GCS bucket.
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -5,7 +5,6 @@ import cloudpickle
 import pendulum
 from slugify import slugify
 
-import prefect
 from prefect.engine.results import S3Result
 from prefect.environments.storage import Storage
 from prefect.utilities.storage import extract_flow_from_file

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -184,6 +184,7 @@ class S3(Storage):
                                 self.bucket, err
                             )
                         )
+                        raise err
             else:
                 if not self.key:
                     raise ValueError(

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -53,12 +53,16 @@ class S3(Storage):
         self._flows = dict()  # type: Dict[str, "Flow"]
         self.bucket = bucket
         self.key = key
-        self.script_path = script_path or prefect.context.get("script_path", None)
 
         self.client_options = client_options
 
         result = S3Result(bucket=bucket)
-        super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
+        super().__init__(
+            result=result,
+            stored_as_script=stored_as_script,
+            script_path=script_path,
+            **kwargs,
+        )
 
     @property
     def default_labels(self) -> List[str]:

--- a/src/prefect/environments/storage/s3.py
+++ b/src/prefect/environments/storage/s3.py
@@ -31,7 +31,7 @@ class S3(Storage):
             is only useful when storing a single Flow using this storage object.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
-        - script_path (str, optional): the path to a local script to upload when `stored_as_scipt` is set
+        - script_path (str, optional): the path to a local script to upload when `stored_as_script` is set
             to `True`. If not set then the value of `script_path` from `prefect.context` is used. If
             neither are set then script will not be uploaded and users should manually place the script
             file in the desired `key` location in an S3 bucket.

--- a/tests/environments/storage/test_gcs_storage.py
+++ b/tests/environments/storage/test_gcs_storage.py
@@ -126,7 +126,7 @@ class TestGCSStorage:
         bucket_mock.get_blob.assert_called_with("a-place")
         assert blob_mock.download_as_string.call_count == 1
 
-    def test_build_no_upload_if_file_and_no_script_path(self, google_client):
+    def test_build_no_upload_if_file_and_no_local_script_path(self, google_client):
         storage = GCS(bucket="awesome-bucket", stored_as_script=True)
 
         with pytest.raises(ValueError):
@@ -146,7 +146,7 @@ class TestGCSStorage:
         storage = GCS(
             bucket="awesome-bucket",
             stored_as_script=True,
-            script_path=f"{tmpdir}/flow.py",
+            local_script_path=f"{tmpdir}/flow.py",
             key="key",
         )
 

--- a/tests/environments/storage/test_gcs_storage.py
+++ b/tests/environments/storage/test_gcs_storage.py
@@ -126,7 +126,7 @@ class TestGCSStorage:
         bucket_mock.get_blob.assert_called_with("a-place")
         assert blob_mock.download_as_string.call_count == 1
 
-    def test_build_no_upload_if_file(self, google_client):
+    def test_build_no_upload_if_file_and_no_script_path(self, google_client):
         storage = GCS(bucket="awesome-bucket", stored_as_script=True)
 
         with pytest.raises(ValueError):
@@ -134,6 +134,31 @@ class TestGCSStorage:
 
         storage = GCS(bucket="awesome-bucket", stored_as_script=True, key="myflow.py")
         assert storage == storage.build()
+
+    def test_upload_script_if_path(self, google_client, tmpdir):
+        blob_mock = MagicMock()
+        bucket_mock = MagicMock(blob=MagicMock(return_value=blob_mock))
+        google_client.return_value.get_bucket = MagicMock(return_value=bucket_mock)
+
+        with open(f"{tmpdir}/flow.py", "w") as tmpfile:
+            tmpfile.write("foo")
+
+        storage = GCS(
+            bucket="awesome-bucket",
+            stored_as_script=True,
+            script_path=f"{tmpdir}/flow.py",
+            key="key",
+        )
+
+        f = Flow("awesome-flow")
+        assert f.name not in storage
+        assert storage.add_flow(f)
+        assert f.name in storage
+        assert storage.build()
+
+        bucket_mock.blob.assert_called_with(blob_name=storage.flows[f.name])
+        blob_mock.upload_from_file.called
+        assert blob_mock.upload_from_file.call_args[0]
 
     def test_upload_single_flow_to_gcs(self, google_client):
         blob_mock = MagicMock()

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -130,7 +130,7 @@ def test_build_script_upload(monkeypatch):
     monkeypatch.setattr("prefect.environments.storage.S3._boto3_client", boto3)
 
     storage = S3(
-        bucket="bucket", stored_as_script=True, script_path="local.py", key="key"
+        bucket="bucket", stored_as_script=True, local_script_path="local.py", key="key"
     )
 
     f = Flow("test")

--- a/tests/environments/storage/test_s3_storage.py
+++ b/tests/environments/storage/test_s3_storage.py
@@ -114,7 +114,7 @@ def test_upload_flow_to_s3(monkeypatch):
     assert f.name in storage
 
 
-def test_build_no_upload_if_file(monkeypatch):
+def test_build_no_upload_if_file_and_no_script(monkeypatch):
     storage = S3(bucket="bucket", stored_as_script=True)
 
     with pytest.raises(ValueError):
@@ -122,6 +122,30 @@ def test_build_no_upload_if_file(monkeypatch):
 
     storage = S3(bucket="bucket", stored_as_script=True, key="flow.py")
     assert storage == storage.build()
+
+
+def test_build_script_upload(monkeypatch):
+    client = MagicMock()
+    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
+    monkeypatch.setattr("prefect.environments.storage.S3._boto3_client", boto3)
+
+    storage = S3(
+        bucket="bucket", stored_as_script=True, script_path="local.py", key="key"
+    )
+
+    f = Flow("test")
+    assert f.name not in storage
+    assert storage.add_flow(f)
+    assert storage.build()
+    assert f.name in storage
+
+    assert boto3.upload_file.called
+    assert boto3.upload_file.call_args[0] == ("local.py", "bucket", "key")
+
+    boto3.upload_file.side_effect = ClientError({}, None)
+
+    with pytest.raises(ClientError):
+        storage.build()
 
 
 def test_upload_flow_to_s3_client_error(monkeypatch):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
It is the expected behavior for some users that when they call

```bash
prefect register flow -f my_flow.py -p Project
```

That this will also upload their flow to their desired storage location in S3 and GCS. While this was previously true with pickle-based storage we did not perform the automatic upload for these cloud storage options and this PR adds that.


## Changes
Adds a `script_path` kwarg to the S3 and GCS storage classes to be used in tandem with `store_as_script`. The value can either be set manually in a script:

```python
flow.storage = S3(
    bucket="my-flow-bucket",
    stored_as_script=True,
    script_path="my_flow.py"  # Local file that you want uploaded to the bucket
)
```

or it will pull the value of the flow file when calling the `register flow` CLI command from context.

## Importance
Enables some expected behavior for these classes.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)