### PR TITLE
Clock labels

### DIFF
--- a/changes/pr3483.yaml
+++ b/changes/pr3483.yaml
@@ -1,2 +1,5 @@
 feature:
   - "Allow for schedules that emit custom Flow Run labels - [#3483](https://github.com/PrefectHQ/prefect/pull/3483)"
+
+enhancement:
+  - "Allow for passing labels to `client.create_flow_run` - [#3483](https://github.com/PrefectHQ/prefect/pull/3483)"

--- a/changes/pr3483.yaml
+++ b/changes/pr3483.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "Allow for schedules that emit custom Flow Run labels - [#3483](https://github.com/PrefectHQ/prefect/pull/3483)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -904,6 +904,7 @@ class Client:
         flow_id: str = None,
         context: dict = None,
         parameters: dict = None,
+        labels: List[str] = None,
         scheduled_start_time: datetime.datetime = None,
         idempotency_key: str = None,
         run_name: str = None,
@@ -918,6 +919,7 @@ class Client:
             - flow_id (str, optional): the id of the Flow you wish to schedule
             - context (dict, optional): the run context
             - parameters (dict, optional): a dictionary of parameter values to pass to the flow run
+            - labels (List[str], optional): a list of labels to apply to the flow run
             - scheduled_start_time (datetime, optional): the time to schedule the execution
                 for; if not provided, defaults to now
             - idempotency_key (str, optional): an idempotency key; if provided, this run will
@@ -951,6 +953,8 @@ class Client:
             inputs = dict(version_group_id=version_group_id)  # type: ignore
         if parameters is not None:
             inputs.update(parameters=parameters)  # type: ignore
+        if labels is not None:
+            inputs.update(labels=labels)  # type: ignore
         if context is not None:
             inputs.update(context=context)  # type: ignore
         if idempotency_key is not None:

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -11,9 +11,15 @@ class ClockEvent:
     Base class for events emitted by Clocks.
     """
 
-    def __init__(self, start_time: datetime, parameter_defaults: dict = None) -> None:
+    def __init__(
+        self,
+        start_time: datetime,
+        parameter_defaults: dict = None,
+        labels: List[str] = None,
+    ) -> None:
         self.start_time = start_time
         self.parameter_defaults = parameter_defaults or dict()
+        self.labels = labels or []
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, (ClockEvent, datetime)):
@@ -23,6 +29,7 @@ class ClockEvent:
         return (
             self.start_time == other.start_time
             and self.parameter_defaults == other.parameter_defaults
+            and self.labels == other.labels
         )
 
     def __gt__(self, other: Union[datetime, "ClockEvent"]) -> bool:
@@ -56,6 +63,8 @@ class Clock:
         - parameter_defaults (dict, optional): an optional dictionary of default Parameter
             values; if provided, these values will be passed as the Parameter values for all
             Flow Runs which are run on this clock's events
+        - labels (List[str], optional): a list of labels to apply to all flow runs generated
+            from this Clock
 
     """
 
@@ -64,6 +73,7 @@ class Clock:
         start_date: datetime = None,
         end_date: datetime = None,
         parameter_defaults: dict = None,
+        labels: List[str] = None,
     ):
         if start_date is not None:
             start_date = pendulum.instance(start_date)
@@ -72,6 +82,7 @@ class Clock:
         self.start_date = start_date
         self.end_date = end_date
         self.parameter_defaults = parameter_defaults or dict()
+        self.labels = labels or []
 
     def events(self, after: datetime = None) -> Iterable[ClockEvent]:
         """
@@ -114,6 +125,8 @@ class IntervalClock(Clock):
         - parameter_defaults (dict, optional): an optional dictionary of default Parameter
             values; if provided, these values will be passed as the Parameter values for all
             Flow Runs which are run on this clock's events
+        - labels (List[str], optional): a list of labels to apply to all flow runs generated
+            from this Clock
 
     Raises:
         - TypeError: if start_date is not a datetime
@@ -126,6 +139,7 @@ class IntervalClock(Clock):
         start_date: datetime = None,
         end_date: datetime = None,
         parameter_defaults: dict = None,
+        labels: List[str] = None,
     ):
         if not isinstance(interval, timedelta):
             raise TypeError("Interval must be a timedelta.")
@@ -137,6 +151,7 @@ class IntervalClock(Clock):
             start_date=start_date,
             end_date=end_date,
             parameter_defaults=parameter_defaults,
+            labels=labels,
         )
 
     def events(self, after: datetime = None) -> Iterable[ClockEvent]:
@@ -217,6 +232,8 @@ class CronClock(Clock):
         - parameter_defaults (dict, optional): an optional dictionary of default Parameter
             values; if provided, these values will be passed as the Parameter values for all
             Flow Runs which are run on this clock's events
+        - labels (List[str], optional): a list of labels to apply to all flow runs generated
+            from this Clock
 
     Raises:
         - ValueError: if the cron string is invalid
@@ -228,6 +245,7 @@ class CronClock(Clock):
         start_date: datetime = None,
         end_date: datetime = None,
         parameter_defaults: dict = None,
+        labels: List[str] = None,
     ):
         # build cron object to check the cron string - will raise an error if it's invalid
         if not croniter.is_valid(cron):
@@ -237,6 +255,7 @@ class CronClock(Clock):
             start_date=start_date,
             end_date=end_date,
             parameter_defaults=parameter_defaults,
+            labels=labels,
         )
 
     def events(self, after: datetime = None) -> Iterable[ClockEvent]:
@@ -310,13 +329,21 @@ class DatesClock(Clock):
         - parameter_defaults (dict, optional): an optional dictionary of default Parameter
             values; if provided, these values will be passed as the Parameter values for all
             Flow Runs which are run on this clock's events
+        - labels (List[str], optional): a list of labels to apply to all flow runs generated
+            from this Clock
     """
 
-    def __init__(self, dates: List[datetime], parameter_defaults: dict = None):
+    def __init__(
+        self,
+        dates: List[datetime],
+        parameter_defaults: dict = None,
+        labels: List[str] = None,
+    ):
         super().__init__(
             start_date=min(dates),
             end_date=max(dates),
             parameter_defaults=parameter_defaults,
+            labels=labels,
         )
         self.dates = dates
 

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -202,7 +202,9 @@ class IntervalClock(Clock):
             if self.end_date and next_date > self.end_date:
                 break
             yield ClockEvent(
-                start_time=next_date, parameter_defaults=self.parameter_defaults
+                start_time=next_date,
+                parameter_defaults=self.parameter_defaults,
+                labels=self.labels,
             )
             interval += self.interval
 
@@ -316,7 +318,9 @@ class CronClock(Clock):
                 break
             dates.add(next_date)
             yield ClockEvent(
-                start_time=next_date, parameter_defaults=self.parameter_defaults
+                start_time=next_date,
+                parameter_defaults=self.parameter_defaults,
+                labels=self.labels,
             )
 
 
@@ -360,7 +364,11 @@ class DatesClock(Clock):
         if after is None:
             after = pendulum.now("UTC")
         yield from (
-            ClockEvent(start_time=date, parameter_defaults=self.parameter_defaults)
+            ClockEvent(
+                start_time=date,
+                parameter_defaults=self.parameter_defaults,
+                labels=self.labels,
+            )
             for date in sorted(self.dates)
             if date > after
         )

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -42,6 +42,7 @@ class IntervalClockSchema(ObjectSchema):
     parameter_defaults = fields.Dict(
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )
+    labels = fields.List(fields.Str(), allow_none=True)
 
     @post_dump
     def _interval_validation(self, data: dict, **kwargs: Any) -> dict:
@@ -74,6 +75,7 @@ class CronClockSchema(ObjectSchema):
     parameter_defaults = fields.Dict(
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )
+    labels = fields.List(fields.Str(), allow_none=True)
 
 
 class DatesClockSchema(ObjectSchema):
@@ -84,6 +86,7 @@ class DatesClockSchema(ObjectSchema):
     parameter_defaults = fields.Dict(
         key=fields.Str(), values=JSONCompatible(), allow_none=True
     )
+    labels = fields.List(fields.Str(), allow_none=True)
 
 
 class ClockSchema(OneOfSchema):

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -33,6 +33,7 @@ class TestClockEvent:
 
         assert e.start_time == now
         assert e.parameter_defaults == dict()
+        assert e.labels == []
 
     def test_clock_event_accepts_parameters(self):
         now = pendulum.now("UTC")
@@ -40,6 +41,15 @@ class TestClockEvent:
 
         assert e.start_time == now
         assert e.parameter_defaults == dict(x=42, z=[1, 2, 3])
+        assert e.labels == []
+
+    def test_clock_event_accepts_labels(self):
+        now = pendulum.now("UTC")
+        e = clocks.ClockEvent(now, labels=["dev", "staging"])
+
+        assert e.start_time == now
+        assert e.parameter_defaults == dict()
+        assert e.labels == ["dev", "staging"]
 
     def test_clock_event_comparisons_are_datetime_comparisons(self):
         now = pendulum.now("UTC")
@@ -80,6 +90,26 @@ class TestClockEvent:
         assert e2 > e
         assert e3 > e
 
+    def test_clock_event_comparisons_take_labels_into_account(self):
+        now = pendulum.now("UTC")
+        dt = now.add(hours=1)
+
+        e = clocks.ClockEvent(now, labels=["dev"])
+        e2 = clocks.ClockEvent(dt)
+        e3 = clocks.ClockEvent(dt, labels=["staging"])
+
+        ## compare to raw datetimes
+        assert e2 == dt
+        assert e == now
+        assert e3 == dt
+        assert e2 > now
+        assert e3 > now
+
+        ## compare to each other
+        assert e2 != e3
+        assert e2 > e
+        assert e3 > e
+
 
 class TestIntervalClock:
     def test_create_interval_clock(self):
@@ -87,6 +117,7 @@ class TestIntervalClock:
             start_date=pendulum.now("UTC"), interval=timedelta(days=1)
         )
         assert c.parameter_defaults == dict()
+        assert c.labels == []
 
     def test_create_interval_clock_with_parameters(self):
         c = clocks.IntervalClock(
@@ -95,6 +126,14 @@ class TestIntervalClock:
             parameter_defaults=dict(x=42),
         )
         assert c.parameter_defaults == dict(x=42)
+
+    def test_create_interval_clock_with_labels(self):
+        c = clocks.IntervalClock(
+            start_date=pendulum.now("UTC"),
+            interval=timedelta(days=1),
+            labels=["foo"],
+        )
+        assert c.labels == ["foo"]
 
     def test_create_interval_clock_without_interval(self):
         with pytest.raises(TypeError):
@@ -106,6 +145,7 @@ class TestIntervalClock:
         assert c.interval == timedelta(hours=1)
         assert c.end_date is None
         assert c.parameter_defaults == dict()
+        assert c.labels == []
 
     def test_end_date(self):
         c = clocks.IntervalClock(
@@ -115,6 +155,7 @@ class TestIntervalClock:
         assert c.interval == timedelta(hours=1)
         assert c.end_date == pendulum.datetime(2020, 1, 1)
         assert c.parameter_defaults == dict()
+        assert c.labels == []
 
     def test_interval_clock_interval_must_be_positive(self):
         with pytest.raises(ValueError, match="greater than 0"):
@@ -135,6 +176,23 @@ class TestIntervalClock:
         output = islice(c.events(), 3)
         assert all([isinstance(e, clocks.ClockEvent) for e in output])
         assert all([e.parameter_defaults == params for e in output])
+        assert output == [
+            today.add(days=1),
+            today.add(days=2),
+            today.add(days=3),
+        ]
+
+    @pytest.mark.parametrize("labels", [[], ["dev"]])
+    def test_interval_clock_events_with_labels(self, labels):
+        """Test that default after is *now*"""
+        start_date = pendulum.datetime(2018, 1, 1)
+        today = pendulum.today("UTC")
+        c = clocks.IntervalClock(
+            timedelta(days=1), start_date=start_date, labels=labels
+        )
+        output = islice(c.events(), 3)
+        assert all([isinstance(e, clocks.ClockEvent) for e in output])
+        assert all([e.labels == labels for e in output])
         assert output == [
             today.add(days=1),
             today.add(days=2),
@@ -326,10 +384,15 @@ class TestCronClock:
     def test_create_cron_clock(self):
         c = clocks.CronClock("* * * * *")
         assert c.parameter_defaults == dict()
+        assert c.labels == []
 
     def test_create_cron_clock_with_parameters(self):
         c = clocks.CronClock("* * * * *", parameter_defaults=dict(x=42))
         assert c.parameter_defaults == dict(x=42)
+
+    def test_create_cron_clock_with_labels(self):
+        c = clocks.CronClock("* * * * *", labels=["dev", "foo"])
+        assert c.labels == ["dev", "foo"]
 
     def test_create_cron_clock_with_invalid_cron_string_raises_error(self):
         with pytest.raises(Exception):
@@ -349,6 +412,21 @@ class TestCronClock:
         output = islice(c.events(), 3)
         assert all([isinstance(e, clocks.ClockEvent) for e in output])
         assert all([e.parameter_defaults == params for e in output])
+
+        assert output == [
+            pendulum.today("UTC").add(days=1),
+            pendulum.today("UTC").add(days=2),
+            pendulum.today("UTC").add(days=3),
+        ]
+
+    @pytest.mark.parametrize("labels", [[], ["foo"]])
+    def test_cron_clock_events(self, labels):
+        every_day = "0 0 * * *"
+        c = clocks.CronClock(every_day, labels=labels)
+
+        output = islice(c.events(), 3)
+        assert all([isinstance(e, clocks.ClockEvent) for e in output])
+        assert all([e.labels == labels for e in output])
 
         assert output == [
             pendulum.today("UTC").add(days=1),
@@ -547,6 +625,7 @@ class TestDatesClock:
         clock = clocks.DatesClock(dates=[now])
         assert clock.start_date == clock.end_date == now
         assert clock.parameter_defaults == dict()
+        assert clock.labels == []
 
     def test_create_dates_clock_multiple_dates(self):
         now = pendulum.now("UTC")
@@ -554,6 +633,7 @@ class TestDatesClock:
         assert clock.start_date == now
         assert clock.end_date == now.add(days=2)
         assert clock.parameter_defaults == dict()
+        assert clock.labels == []
 
     def test_create_dates_clock_multiple_dates_with_parameters(self):
         now = pendulum.now("UTC")
@@ -563,6 +643,16 @@ class TestDatesClock:
         assert clock.start_date == now
         assert clock.end_date == now.add(days=2)
         assert clock.parameter_defaults == dict(y=99)
+
+    def test_create_dates_clock_multiple_dates_with_labels(self):
+        now = pendulum.now("UTC")
+        clock = clocks.DatesClock(
+            dates=[now.add(days=1), now.add(days=2), now], labels=["dev", "staging"]
+        )
+        assert clock.start_date == now
+        assert clock.end_date == now.add(days=2)
+        assert clock.parameter_defaults == dict()
+        assert clock.labels == ["dev", "staging"]
 
     def test_start_date_must_be_provided(self):
         with pytest.raises(TypeError):
@@ -577,6 +667,19 @@ class TestDatesClock:
         output = islice(c.events(), 3)
         assert all([isinstance(e, clocks.ClockEvent) for e in output])
         assert all([e.parameter_defaults == params for e in output])
+
+        assert output == [start_date]
+        assert islice(c.events(), 1) == [start_date]
+
+    @pytest.mark.parametrize("labels", [[], ["foo", "bar"]])
+    def test_dates_clock_events_with_labels(self, labels):
+        """Test that default after is *now*"""
+        start_date = pendulum.today("UTC").add(days=1)
+        c = clocks.DatesClock([start_date], labels=labels)
+
+        output = islice(c.events(), 3)
+        assert all([isinstance(e, clocks.ClockEvent) for e in output])
+        assert all([e.labels == labels for e in output])
 
         assert output == [start_date]
         assert islice(c.events(), 1) == [start_date]

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -40,6 +40,24 @@ def test_serialize_schedule_with_parameters():
     assert all([isinstance(e, clocks.ClockEvent) for e in output])
 
 
+def test_serialize_schedule_with_labels():
+    dt = pendulum.datetime(2099, 1, 1)
+    s = schedules.Schedule(
+        clocks=[
+            clocks.IntervalClock(timedelta(hours=1), labels=["dev"]),
+            clocks.CronClock("0 8 * * *", labels=["prod"]),
+        ]
+    )
+    s2 = serialize_and_deserialize(s)
+
+    assert s2.clocks[0].labels == ["dev"]
+    assert s2.clocks[1].labels == ["prod"]
+
+    output = s2.next(3, after=dt, return_events=True)
+
+    assert all([isinstance(e, clocks.ClockEvent) for e in output])
+
+
 def test_serialize_complex_schedule():
     dt = pendulum.datetime(2019, 1, 3)
     s = schedules.Schedule(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR exposes the ability to emit per-clock flow run labels, in addition to exposing `labels` on `Client.create_flow_run`.  This will enable the ability for users to schedule Flows to run simultaneously in different places / through different agents, and moreover will allow users to create ad-hoc runs with unique label sets as needed.


## Importance
<!-- Why is this PR important? -->
This is a new feature that enables a pattern that wasn't possible before; *please note* this will not be available in Cloud / Server until the scheduler logic has been updated and released!  We will try to have this released prior to the next release of Core 👍 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)