### PR TITLE
Fix DaskKubernetesEnvironment overwriting log attributes for custom specs

### DIFF
--- a/changes/issue3231.yaml
+++ b/changes/issue3231.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Fix `DaskKubernetesEnvironment` overwriting log level for custom specs - [#3231](https://github.com/PrefectHQ/prefect/issues/3231)"
+  - "Fix `DaskKubernetesEnvironment` overwriting log attributed for custom specs - [#3231](https://github.com/PrefectHQ/prefect/issues/3231)"

--- a/changes/issue3231.yaml
+++ b/changes/issue3231.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Fix `DaskKubernetesEnvironment` overwriting log attributed for custom specs - [#3231](https://github.com/PrefectHQ/prefect/issues/3231)"
+  - "Fix `DaskKubernetesEnvironment` overwriting log attributes for custom specs - [#3231](https://github.com/PrefectHQ/prefect/issues/3231)"

--- a/changes/issue3231.yaml
+++ b/changes/issue3231.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `DaskKubernetesEnvironment` overwriting log level for custom specs - [#3231](https://github.com/PrefectHQ/prefect/issues/3231)"

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -489,6 +489,10 @@ class DaskKubernetesEnvironment(Environment):
                 "value": "prefect.engine.executors.DaskExecutor",
             },
             {
+                "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
+                "value": str(prefect.config.logging.log_to_cloud).lower(),
+            },
+            {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
                 "value": self._extra_loggers(),
             },
@@ -543,6 +547,10 @@ class DaskKubernetesEnvironment(Environment):
             {
                 "name": "PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS",
                 "value": "prefect.engine.executors.DaskExecutor",
+            },
+            {
+                "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
+                "value": str(prefect.config.logging.log_to_cloud).lower(),
             },
             {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -489,14 +489,6 @@ class DaskKubernetesEnvironment(Environment):
                 "value": "prefect.engine.executors.DaskExecutor",
             },
             {
-                "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
-                "value": str(prefect.config.logging.log_to_cloud).lower(),
-            },
-            {
-                "name": "PREFECT__LOGGING__LEVEL",
-                "value": str(prefect.config.logging.level),
-            },
-            {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
                 "value": self._extra_loggers(),
             },
@@ -551,14 +543,6 @@ class DaskKubernetesEnvironment(Environment):
             {
                 "name": "PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS",
                 "value": "prefect.engine.executors.DaskExecutor",
-            },
-            {
-                "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
-                "value": str(prefect.config.logging.log_to_cloud).lower(),
-            },
-            {
-                "name": "PREFECT__LOGGING__LEVEL",
-                "value": str(prefect.config.logging.level),
             },
             {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -45,8 +45,11 @@ class DaskKubernetesEnvironment(Environment):
     - `PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS`
     - `PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS`
     - `PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS`
+    - `PREFECT__LOGGING__LEVEL`
     - `PREFECT__LOGGING__LOG_TO_CLOUD`
     - `PREFECT__LOGGING__EXTRA_LOGGERS`
+
+    Note: the logging attributes are only populated if they are not already provided.
 
     Args:
         - min_workers (int, optional): the minimum allowed number of Dask worker pods; defaults to 1

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -488,9 +488,17 @@ class DaskKubernetesEnvironment(Environment):
                 "name": "PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS",
                 "value": "prefect.engine.executors.DaskExecutor",
             },
+        ]
+
+        # Logging env vars
+        log_vars = [
             {
                 "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
                 "value": str(prefect.config.logging.log_to_cloud).lower(),
+            },
+            {
+                "name": "PREFECT__LOGGING__LEVEL",
+                "value": str(prefect.config.logging.level),
             },
             {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
@@ -505,6 +513,11 @@ class DaskKubernetesEnvironment(Environment):
             env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
 
         env.extend(env_values)
+
+        # Append logging env vars if not already present
+        for var in log_vars:
+            if not any(d.get("name") == var.get("name") for d in env):
+                env.append(var)
 
         # set image
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"] = docker_name
@@ -548,9 +561,17 @@ class DaskKubernetesEnvironment(Environment):
                 "name": "PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS",
                 "value": "prefect.engine.executors.DaskExecutor",
             },
+        ]
+
+        # Logging env vars
+        log_vars = [
             {
                 "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
                 "value": str(prefect.config.logging.log_to_cloud).lower(),
+            },
+            {
+                "name": "PREFECT__LOGGING__LEVEL",
+                "value": str(prefect.config.logging.level),
             },
             {
                 "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
@@ -565,6 +586,11 @@ class DaskKubernetesEnvironment(Environment):
             env = yaml_obj["spec"]["containers"][0]["env"]
 
         env.extend(env_values)
+
+        # Append logging env vars if not already present
+        for var in log_vars:
+            if not any(d.get("name") == var.get("name") for d in env):
+                env.append(var)
 
         # set image
         yaml_obj["spec"]["containers"][0]["image"] = prefect.context.get(

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -418,8 +418,9 @@ def test_populate_custom_worker_spec_yaml(log_flag):
     assert env[5]["value"] == "prefect.engine.cloud.CloudTaskRunner"
     assert env[6]["value"] == "prefect.engine.executors.DaskExecutor"
     assert env[7]["value"] == str(log_flag).lower()
+    assert env[8]["value"] == "INFO"
     assert (
-        env[8]["value"]
+        env[9]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
@@ -465,8 +466,9 @@ def test_populate_custom_scheduler_spec_yaml(log_flag):
     assert env[7]["value"] == "prefect.engine.cloud.CloudTaskRunner"
     assert env[8]["value"] == "prefect.engine.executors.DaskExecutor"
     assert env[9]["value"] == str(log_flag).lower()
+    assert env[10]["value"] == "INFO"
     assert (
-        env[10]["value"]
+        env[11]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
@@ -474,6 +476,87 @@ def test_populate_custom_scheduler_spec_yaml(log_flag):
         yaml_obj["spec"]["template"]["spec"]["containers"][0]["image"]
         == "test1/test2:test3"
     )
+
+
+@pytest.mark.parametrize("log_flag", [True, False])
+def test_populate_custom_yaml_specs_with_logging_vars(log_flag):
+    environment = DaskKubernetesEnvironment()
+
+    file_path = os.path.dirname(prefect.environments.execution.dask.k8s.__file__)
+
+    log_vars = [
+        {
+            "name": "PREFECT__LOGGING__LOG_TO_CLOUD",
+            "value": "YES",
+        },
+        {
+            "name": "PREFECT__LOGGING__LEVEL",
+            "value": "NO",
+        },
+        {
+            "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+            "value": "MAYBE",
+        },
+    ]
+
+    with open(path.join(file_path, "job.yaml")) as job_file:
+        job = yaml.safe_load(job_file)
+        job["spec"]["template"]["spec"]["containers"][0]["env"] = []
+        job["spec"]["template"]["spec"]["containers"][0]["env"].extend(log_vars)
+
+    with set_temporary_config(
+        {
+            "cloud.graphql": "gql_test",
+            "cloud.auth_token": "auth_test",
+            "logging.log_to_cloud": log_flag,
+            "logging.extra_loggers": ["test_logger"],
+        }
+    ):
+        with prefect.context(flow_run_id="id_test", namespace="namespace_test"):
+            yaml_obj = environment._populate_scheduler_spec_yaml(
+                yaml_obj=job, docker_name="test1/test2:test3"
+            )
+
+    assert yaml_obj["metadata"]["name"] == "prefect-dask-job-{}".format(
+        environment.identifier_label
+    )
+
+    env = yaml_obj["spec"]["template"]["spec"]["containers"][0]["env"]
+
+    assert env[0]["value"] == "YES"
+    assert env[1]["value"] == "NO"
+    assert env[2]["value"] == "MAYBE"
+    assert len(env) == 12
+
+    # worker
+    with open(path.join(file_path, "worker_pod.yaml")) as pod_file:
+        pod = yaml.safe_load(pod_file)
+        pod["spec"]["containers"][0]["env"] = []
+        pod["spec"]["containers"][0]["env"].extend(log_vars)
+
+    with set_temporary_config(
+        {
+            "cloud.graphql": "gql_test",
+            "cloud.auth_token": "auth_test",
+            "logging.log_to_cloud": log_flag,
+            "logging.extra_loggers": ["test_logger"],
+        }
+    ):
+        with prefect.context(flow_run_id="id_test", image="my_image"):
+            yaml_obj = environment._populate_worker_spec_yaml(yaml_obj=pod)
+
+    assert (
+        yaml_obj["metadata"]["labels"]["prefect.io/identifier"]
+        == environment.identifier_label
+    )
+    assert yaml_obj["metadata"]["labels"]["prefect.io/flow_run_id"] == "id_test"
+
+    env = yaml_obj["spec"]["containers"][0]["env"]
+
+    assert env[0]["value"] == "YES"
+    assert env[1]["value"] == "NO"
+    assert env[2]["value"] == "MAYBE"
+    assert len(env) == 10
 
 
 def test_roundtrip_cloudpickle():

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -418,9 +418,8 @@ def test_populate_custom_worker_spec_yaml(log_flag):
     assert env[5]["value"] == "prefect.engine.cloud.CloudTaskRunner"
     assert env[6]["value"] == "prefect.engine.executors.DaskExecutor"
     assert env[7]["value"] == str(log_flag).lower()
-    assert env[8]["value"] == "INFO"
     assert (
-        env[9]["value"]
+        env[8]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 
@@ -466,9 +465,8 @@ def test_populate_custom_scheduler_spec_yaml(log_flag):
     assert env[7]["value"] == "prefect.engine.cloud.CloudTaskRunner"
     assert env[8]["value"] == "prefect.engine.executors.DaskExecutor"
     assert env[9]["value"] == str(log_flag).lower()
-    assert env[10]["value"] == "INFO"
     assert (
-        env[11]["value"]
+        env[10]["value"]
         == "['test_logger', 'dask_kubernetes.core', 'distributed.deploy.adaptive']"
     )
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
The log attributes used to be hard enforced and I think this setting was a relic of that. When providing custom specs for the worker and scheduler in the `DaskKubernetesEnvironment` it should not be overwriting the user provided values for anything log related. These values were being set to whatever the default value was on the pod that was executing the environment. This led to undesirable behavior because it was unclear that needing to set things like `PREFECT__LOGGING__LEVEL` on the Agent was propagating the change down to the scheduler and workers.

Closes #3231 


## Changes
Removes the hardcoded log settings on user provided scheduler and worker specs



## Importance
Allows users to set log level, log to cloud, and extra loggers on their custom specs for the DaskKubernetesEnvironment



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)