### PR TITLE
Add prefect task to cancel a flow

### DIFF
--- a/changes/issue3484.yaml
+++ b/changes/issue3484.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add cancel flow run task - [#3484](https://github.com/PrefectHQ/prefect/issues/3484)"
+
+contributor:
+  - "[Mariia Kerimova](https://github.com/mashun4ek)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -276,7 +276,7 @@ classes = ["DatasetCreateFromDelimitedFiles",
 [pages.tasks.prefect]
 title = "Prefect Tasks"
 module = "prefect.tasks.prefect"
-classes = ["FlowRunTask", "RenameFlowRunTask"]
+classes = ["FlowRunTask", "RenameFlowRunTask", "CancelFlowRunTask"]
 
 [pages.tasks.github]
 title = "GitHub Tasks"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1326,7 +1326,7 @@ class Client:
             }
         }
         result = self.graphql(
-            mutation, variables=dict(input=dict(task_run_id=task_run_id))
+            mutation, variables=dict(input=dict(flow_run_id=flow_run_id))
         )
         return result.data.cancel_flow_run.success
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1308,6 +1308,28 @@ class Client:
 
         return result.data.set_task_run_name.success
 
+    def cancel_flow_run(self, flow_run_id: str) -> bool:
+        """
+        Cancel the flow by id
+
+        Args:
+            - flow_run_id (str): the id of the flow
+
+        Returns:
+            - bool: whether or not the flow run was canceled
+        """
+        mutation = {
+            "mutation($input: cancel_flow_run_id_input!)": {
+                "cancel_flow_run(input: $input)": {
+                    "success": True,
+                }
+            }
+        }
+        result = self.graphql(
+            mutation, variables=dict(input=dict(task_run_id=task_run_id))
+        )
+        return result.data.cancel_flow_run.success
+
     def get_task_run_state(self, task_run_id: str) -> "prefect.engine.state.State":
         """
         Retrieves the current state for a task run.

--- a/src/prefect/tasks/prefect/__init__.py
+++ b/src/prefect/tasks/prefect/__init__.py
@@ -4,3 +4,4 @@ Tasks for interacting with the Prefect API
 
 from prefect.tasks.prefect.flow_run import FlowRunTask
 from prefect.tasks.prefect.flow_run_rename import RenameFlowRunTask
+from prefect.tasks.prefect.flow_run_cancel import CancelFlowRunTask

--- a/src/prefect/tasks/prefect/flow_run_cancel.py
+++ b/src/prefect/tasks/prefect/flow_run_cancel.py
@@ -9,7 +9,7 @@ class CancelFlowRunTask(Task):
     Task to cancel a flow.
 
     Args:
-        - flow_id_to_cancel (str, optional): The ID of the flow to cancel
+        - flow_run_id_to_cancel (str, optional): The ID of the flow to cancel
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 

--- a/src/prefect/tasks/prefect/flow_run_cancel.py
+++ b/src/prefect/tasks/prefect/flow_run_cancel.py
@@ -1,0 +1,38 @@
+from prefect import Task
+from prefect.client import Client
+from typing import Any
+import prefect
+
+
+class CancelFlowRunTask(Task):
+    """
+    Task to cancel a running flow.
+
+    Args:
+        - flow_run_id (str, optional): The ID of the flow run to cancel
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+    """
+
+    def __init__(
+        self,
+        flow_run_id: str = None,
+        **kwargs: Any,
+    ):
+        self.flow_run_id = flow_run_id
+        super().__init__(**kwargs)
+
+    def run(self, flow_run_id: str = None):
+        """
+        Args:
+            - flow_run_id (str, optional): The ID of the flow run to cancel
+
+        Returns:
+            - bool: Boolean representing whether the flow run was canceled successfully or not
+        """
+        # if id is not provided, use current flow id
+        if flow_run_id is None:
+            flow_run_id = prefect.context["flow_run_id"]
+        if flow_run_id is None:
+            raise ValueError("Can't delete a flow without flow ID. Provide flow ID.")
+        client = Client()
+        return client.cancel_flow_run(flow_run_id)

--- a/src/prefect/tasks/prefect/flow_run_cancel.py
+++ b/src/prefect/tasks/prefect/flow_run_cancel.py
@@ -24,17 +24,17 @@ class CancelFlowRunTask(Task):
     def run(self, flow_run_id_to_cancel: str = None):
         """
         Args:
-            - flow_id_to_cancel (str, optional): The ID of the flow to cancel
+            - flow_run_id_to_cancel (str, optional): The ID of the flow to cancel
 
         Returns:
             - bool: Boolean representing whether the flow was canceled successfully or not
         """
         current_flow_run_id = prefect.context.get("flow_run_id", "")
-        if current_flow_run_id=="":
+        if current_flow_run_id == "":
             raise ValueError("Can't retrieve current flow ID.")
         # if id is not provided, use current flow id
         if self.flow_run_id_to_cancel is None:
             self.flow_run_id_to_cancel = prefect.context.get("flow_run_id", "")
-            
+
         client = Client()
         return client.cancel_flow_run(self.flow_run_id_to_cancel)

--- a/src/prefect/tasks/prefect/flow_run_cancel.py
+++ b/src/prefect/tasks/prefect/flow_run_cancel.py
@@ -31,8 +31,8 @@ class CancelFlowRunTask(Task):
         """
         # if id is not provided, use current flow id
         if flow_run_id is None:
-            flow_run_id = prefect.context["flow_run_id"]
-        if flow_run_id is None:
+            flow_run_id = prefect.context.get("flow_run_id", "")
+        if flow_run_id is None or flow_run_id == "":
             raise ValueError("Can't delete a flow without flow ID. Provide flow ID.")
         client = Client()
         return client.cancel_flow_run(flow_run_id)

--- a/src/prefect/tasks/prefect/flow_run_cancel.py
+++ b/src/prefect/tasks/prefect/flow_run_cancel.py
@@ -6,33 +6,35 @@ import prefect
 
 class CancelFlowRunTask(Task):
     """
-    Task to cancel a running flow.
+    Task to cancel a flow.
 
     Args:
-        - flow_run_id (str, optional): The ID of the flow run to cancel
+        - flow_id_to_cancel (str, optional): The ID of the flow to cancel
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
     def __init__(
         self,
-        flow_run_id: str = None,
+        flow_run_id_to_cancel: str = None,
         **kwargs: Any,
     ):
-        self.flow_run_id = flow_run_id
+        self.flow_run_id_to_cancel = flow_run_id_to_cancel
         super().__init__(**kwargs)
 
-    def run(self, flow_run_id: str = None):
+    def run(self, flow_run_id_to_cancel: str = None):
         """
         Args:
-            - flow_run_id (str, optional): The ID of the flow run to cancel
+            - flow_id_to_cancel (str, optional): The ID of the flow to cancel
 
         Returns:
-            - bool: Boolean representing whether the flow run was canceled successfully or not
+            - bool: Boolean representing whether the flow was canceled successfully or not
         """
+        current_flow_run_id = prefect.context.get("flow_run_id", "")
+        if current_flow_run_id=="":
+            raise ValueError("Can't retrieve current flow ID.")
         # if id is not provided, use current flow id
-        if flow_run_id is None:
-            flow_run_id = prefect.context.get("flow_run_id", "")
-        if flow_run_id is None or flow_run_id == "":
-            raise ValueError("Can't delete a flow without flow ID. Provide flow ID.")
+        if self.flow_run_id_to_cancel is None:
+            self.flow_run_id_to_cancel = prefect.context.get("flow_run_id", "")
+            
         client = Client()
-        return client.cancel_flow_run(flow_run_id)
+        return client.cancel_flow_run(self.flow_run_id_to_cancel)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -707,6 +707,17 @@ def test_set_flow_run_name(patch_posts, cloud_api):
     assert result == True
 
 
+def test_cancel_flow_run(patch_posts, cloud_api):
+    mutation_resp = {"data": {"cancel_flow_run": {"success": True}}}
+
+    post = patch_posts(mutation_resp)
+
+    client = Client()
+    result = client.cancel_flow_run(flow_run_id="74-salt")
+
+    assert result == True
+
+
 def test_get_flow_run_info(patch_post):
     response = {
         "flow_run_by_pk": {

--- a/tests/tasks/prefect/test_flow_run_cancel.py
+++ b/tests/tasks/prefect/test_flow_run_cancel.py
@@ -5,7 +5,7 @@ import prefect
 from prefect.tasks.prefect.flow_run_cancel import CancelFlowRunTask
 
 
-def test_flow_run_rename_task(monkeypatch):
+def test_flow_run_cancel(monkeypatch):
     client = MagicMock()
     client.cancel_flow_run = MagicMock(return_value=True)
     monkeypatch.setattr(

--- a/tests/tasks/prefect/test_flow_run_cancel.py
+++ b/tests/tasks/prefect/test_flow_run_cancel.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 import prefect
+from prefect import Flow
 from prefect.tasks.prefect.flow_run_cancel import CancelFlowRunTask
 
 
@@ -16,6 +17,8 @@ def test_flow_run_cancel(monkeypatch):
     # Verify correct initialization
     assert task.flow_run_id == "id123"
     # Verify client called with arguments
-    task.run()
+    flow = Flow("TestContext")
+    flow.add_task(task)
+    flow.run()
     assert client.cancel_flow_run.called
     assert client.cancel_flow_run.call_args[0][0] == "id123"

--- a/tests/tasks/prefect/test_flow_run_cancel.py
+++ b/tests/tasks/prefect/test_flow_run_cancel.py
@@ -12,13 +12,13 @@ def test_flow_run_cancel(monkeypatch):
     monkeypatch.setattr(
         "prefect.tasks.prefect.flow_run_cancel.Client", MagicMock(return_value=client)
     )
-    task = CancelFlowRunTask(flow_run_id="id123")
+    flow_cancel_task = CancelFlowRunTask(flow_run_id_to_cancel="id123")
 
     # Verify correct initialization
-    assert task.flow_run_id == "id123"
+    assert flow_cancel_task.flow_run_id_to_cancel == "id123"
     # Verify client called with arguments
     flow = Flow("TestContext")
-    flow.add_task(task)
+    flow.add_task(flow_cancel_task)
     flow.run()
     assert client.cancel_flow_run.called
     assert client.cancel_flow_run.call_args[0][0] == "id123"

--- a/tests/tasks/prefect/test_flow_run_cancel.py
+++ b/tests/tasks/prefect/test_flow_run_cancel.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import MagicMock
+
+import prefect
+from prefect.tasks.prefect.flow_run_cancel import CancelFlowRunTask
+
+
+def test_flow_run_rename_task(monkeypatch):
+    client = MagicMock()
+    client.cancel_flow_run = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "prefect.tasks.prefect.flow_run_rename.Client", MagicMock(return_value=client)
+    )
+    task = CancelFlowRunTask(flow_run_id="id123")
+
+    # Verify correct initialization
+    assert task.flow_run_id == "id123"
+    # Verify client called with arguments
+    task.run()
+    assert client.cancel_flow_run.called
+    assert client.cancel_flow_run.call_args[0][0] == "id123"
+
+
+def test_missing_flow_run_id():
+    task = CancelFlowRunTask()
+    with prefect.context(flow_run_id=None):
+        with pytest.raises(
+            ValueError, match="Can't delete a flow without flow ID. Provide a flow ID."
+        ):
+            task.run()

--- a/tests/tasks/prefect/test_flow_run_cancel.py
+++ b/tests/tasks/prefect/test_flow_run_cancel.py
@@ -9,7 +9,7 @@ def test_flow_run_rename_task(monkeypatch):
     client = MagicMock()
     client.cancel_flow_run = MagicMock(return_value=True)
     monkeypatch.setattr(
-        "prefect.tasks.prefect.flow_run_rename.Client", MagicMock(return_value=client)
+        "prefect.tasks.prefect.flow_run_cancel.Client", MagicMock(return_value=client)
     )
     task = CancelFlowRunTask(flow_run_id="id123")
 
@@ -19,12 +19,3 @@ def test_flow_run_rename_task(monkeypatch):
     task.run()
     assert client.cancel_flow_run.called
     assert client.cancel_flow_run.call_args[0][0] == "id123"
-
-
-def test_missing_flow_run_id():
-    task = CancelFlowRunTask()
-    with prefect.context(flow_run_id=None):
-        with pytest.raises(
-            ValueError, match="Can't delete a flow without flow ID. Provide a flow ID."
-        ):
-            task.run()


### PR DESCRIPTION
## Summary
Add prefect task `CancelFlowRunTask` to cancel a flow. 




## Changes
Add a new task to prefect task library for canceling the flow.




## Importance
Expand the prefect task library and enable canceling the flow by flow_id or current flow id, issue #3484.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)