### PR TITLE
Fix multiprocessing timeout

### DIFF
--- a/changes/pr3511.yaml
+++ b/changes/pr3511.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix multiprocessing scheduler failure while running tasks with timeouts - [#3511](https://github.com/PrefectHQ/prefect/pull/3511)"
+
+contributor:
+  - "[Michael Adkins](https://github.com/madkinsz)"

--- a/changes/pr3511.yaml
+++ b/changes/pr3511.yaml
@@ -1,5 +1,2 @@
 fix:
   - "Fix multiprocessing scheduler failure while running tasks with timeouts - [#3511](https://github.com/PrefectHQ/prefect/pull/3511)"
-
-contributor:
-  - "[Michael Adkins](https://github.com/madkinsz)"

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -185,7 +185,7 @@ def multiprocessing_timeout(
 
     # Set internal kwargs for the helper function
     request = {
-        "func": fn,
+        "fn": fn,
         "args": args,
         "kwargs": kwargs,
         "context": prefect.context.to_dict(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def mthread():
         # know if processes are being used before `flow.run` is called so we patch
         # the class with an indicator
         executor.__processes = False
-        yield
+        yield executor
 
 
 @pytest.fixture()
@@ -76,7 +76,7 @@ def mproc():
         # know if processes are being used before `flow.run` is called so we patch
         # the class with an indicator
         executor.__processes = True
-        yield
+        yield executor
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def local():
 @pytest.fixture()
 def sync():
     "Synchronous dask (not dask.distributed) executor"
-    yield LocalDaskExecutor()
+    yield LocalDaskExecutor(scheduler="sync")
+
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,7 @@ def mthread():
     with Client(
         processes=False, scheduler_port=0, dashboard_address=":0", n_workers=2
     ) as client:
-        executor = DaskExecutor(client.scheduler.address)
-        # Since the cluster can't be inspected until the client is started we can't
-        # know if processes are being used before `flow.run` is called so we patch
-        # the class with an indicator
-        executor.__processes = False
-        yield executor
+        yield DaskExecutor(client.scheduler.address)
 
 
 @pytest.fixture()
@@ -71,12 +66,7 @@ def mproc():
     with Client(
         processes=True, scheduler_port=0, dashboard_address=":0", n_workers=2
     ) as client:
-        executor = DaskExecutor(client.scheduler.address)
-        # Since the cluster can't be inspected until the client is started we can't
-        # know if processes are being used before `flow.run` is called so we patch
-        # the class with an indicator
-        executor.__processes = True
-        yield executor
+        yield DaskExecutor(client.scheduler.address)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ def sync():
     yield LocalDaskExecutor(scheduler="sync")
 
 
+@pytest.fixture()
+def mproc_local():
+    "Multiprocessing executor using local dask (not distributed cluster)"
+    yield LocalDaskExecutor(scheduler="processes")
 
 @pytest.fixture(scope="session")
 def mproc():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2955,13 +2955,9 @@ def test_timeout_actually_stops_execution(
     # Determine if the executor is distributed and using daemonic processes which
     # cannot be cancelled and throw a warning instead. The `__processes` property
     # is injected in `conftest.py`
-    daemon_process = isinstance(
+    in_daemon_process = isinstance(
         executor, DaskExecutor
-    ) and executor.client.scheduler.address.startswith("inproc")
-    assert_daemon_warning = pytest.warns(
-        UserWarning,
-        match="daemonic subprocess .* can only enforce a soft timeout limit",
-    )
+    ) and not executor.address.startswith("inproc")
 
     with tempfile.TemporaryDirectory() as call_dir:
         # Note: a real file must be used in the case of "mthread"

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2955,7 +2955,10 @@ def test_timeout_actually_stops_execution(
     # Determine if the executor is distributed and using daemonic processes which
     # cannot be cancelled and throw a warning instead. The `__processes` property
     # is injected in `conftest.py`
-    daemon_process = isinstance(executor, DaskExecutor) and executor.__processes
+    daemon_process = (
+        isinstance(executor, DaskExecutor)
+        and executor.client.scheduler.address.startswith("inproc")
+    )
     assert_daemon_warning = pytest.warns(
         UserWarning,
         match="daemonic subprocess .* can only enforce a soft timeout limit",

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2928,7 +2928,9 @@ class TestSaveLoad:
     sys.platform == "win32" or sys.version_info.minor == 6,
     reason="Windows doesn't support any timeout logic",
 )
-@pytest.mark.parametrize("executor", ["local", "sync", "mthread"], indirect=True)
+@pytest.mark.parametrize(
+    "executor", ["local", "sync", "mthread", "mproc"], indirect=True
+)
 def test_timeout_actually_stops_execution(executor):
     # Note: this is a potentially brittle test! In some cases (local and sync) signal.alarm
     # is used as the mechanism for timing out a task. This passes off the job of measuring

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2955,10 +2955,9 @@ def test_timeout_actually_stops_execution(
     # Determine if the executor is distributed and using daemonic processes which
     # cannot be cancelled and throw a warning instead. The `__processes` property
     # is injected in `conftest.py`
-    daemon_process = (
-        isinstance(executor, DaskExecutor)
-        and executor.client.scheduler.address.startswith("inproc")
-    )
+    daemon_process = isinstance(
+        executor, DaskExecutor
+    ) and executor.client.scheduler.address.startswith("inproc")
     assert_daemon_warning = pytest.warns(
         UserWarning,
         match="daemonic subprocess .* can only enforce a soft timeout limit",

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2953,7 +2953,7 @@ def test_timeout_actually_stops_execution(
     SLEEP_TIME = 3
 
     # Determine if the executor is distributed and using daemonic processes which
-    # cannot be cancelled and throw a warning instead. The `__processes` property 
+    # cannot be cancelled and throw a warning instead. The `__processes` property
     # is injected in `conftest.py`
     daemon_process = isinstance(executor, DaskExecutor) and executor.__processes
     assert_daemon_warning = pytest.warns(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2952,8 +2952,7 @@ def test_timeout_actually_stops_execution(
     SLEEP_TIME = 3
 
     # Determine if the executor is distributed and using daemonic processes which
-    # cannot be cancelled and throw a warning instead. The `__processes` property
-    # is injected in `conftest.py`
+    # cannot be cancelled and throw a warning instead.
     in_daemon_process = isinstance(
         executor, DaskExecutor
     ) and not executor.address.startswith("inproc")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2982,7 +2982,7 @@ def test_timeout_actually_stops_execution(
 
         # Sleep so 'invalid' will be written if the task is not killed, subtracting the
         # actual runtime to speed up the test a little
-        time.sleep(max(0, SLEEP_TIME - (stop_time - start_time)))
+        time.sleep(max(1, SLEEP_TIME - (stop_time - start_time)))
 
         assert os.path.exists(FILE)
         with open(FILE, "r") as f:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2963,7 +2963,7 @@ def test_timeout_actually_stops_execution(
         # Note: a real file must be used in the case of "mthread"
         FILE = os.path.join(call_dir, "test.txt")
 
-        @prefect.task(timeout=1)
+        @prefect.task(timeout=2)
         def slow_fn():
             with open(FILE, "w") as f:
                 f.write("called!")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import time
 from unittest.mock import MagicMock, patch
+from contextlib import nullcontext
 
 import cloudpickle
 import pendulum
@@ -22,7 +23,7 @@ from prefect.core.task import Task
 from prefect.tasks.core import constants
 from prefect.core.parameter import Parameter
 from prefect.engine.cache_validators import all_inputs, partial_inputs_only
-from prefect.engine.executors import LocalExecutor
+from prefect.engine.executors import LocalExecutor, DaskExecutor
 from prefect.engine.result import Result
 from prefect.engine.results import LocalResult, PrefectResult
 from prefect.engine.result_handlers import LocalResultHandler, ResultHandler
@@ -2929,9 +2930,11 @@ class TestSaveLoad:
     reason="Windows doesn't support any timeout logic",
 )
 @pytest.mark.parametrize(
-    "executor", ["local", "sync", "mthread", "mproc"], indirect=True
+    "executor", ["local", "sync", "mthread", "mproc_local", "mproc"], indirect=True
 )
-def test_timeout_actually_stops_execution(executor):
+def test_timeout_actually_stops_execution(
+    executor,
+):
     # Note: this is a potentially brittle test! In some cases (local and sync) signal.alarm
     # is used as the mechanism for timing out a task. This passes off the job of measuring
     # the time for the timeout to the OS, which uses the "wallclock" as reference (the real
@@ -2945,6 +2948,19 @@ def test_timeout_actually_stops_execution(executor):
     # the task implementation" we got, but instead do a simple task (create a file) and sleep.
     # This will drastically reduce the brittleness of the test (but not completely).
 
+    # The amount of time to sleep before writing 'invalid' to the file
+    # lower values will decrease test time but increase chances of intermittent failure
+    SLEEP_TIME = 3
+
+    # Determine if the executor is distributed and using daemonic processes which
+    # cannot be cancelled and throw a warning instead. The `__processes` property 
+    # is injected in `conftest.py`
+    daemon_process = isinstance(executor, DaskExecutor) and executor.__processes
+    assert_daemon_warning = pytest.warns(
+        UserWarning,
+        match="daemonic subprocess .* can only enforce a soft timeout limit",
+    )
+
     with tempfile.TemporaryDirectory() as call_dir:
         # Note: a real file must be used in the case of "mthread"
         FILE = os.path.join(call_dir, "test.txt")
@@ -2953,7 +2969,7 @@ def test_timeout_actually_stops_execution(executor):
         def slow_fn():
             with open(FILE, "w") as f:
                 f.write("called!")
-            time.sleep(2)
+            time.sleep(SLEEP_TIME)
             with open(FILE, "a") as f:
                 f.write("invalid")
 
@@ -2962,13 +2978,18 @@ def test_timeout_actually_stops_execution(executor):
         assert not os.path.exists(FILE)
 
         start_time = time.time()
-        state = flow.run(executor=executor)
+        with assert_daemon_warning if daemon_process else nullcontext():
+            state = flow.run(executor=executor)
         stop_time = time.time()
-        time.sleep(max(0, 3 - (stop_time - start_time)))
+
+        # Sleep so 'invalid' will be written if the task is not killed, subtracting the
+        # actual runtime to speed up the test a little
+        time.sleep(max(0, SLEEP_TIME - (stop_time - start_time)))
 
         assert os.path.exists(FILE)
         with open(FILE, "r") as f:
-            assert "invalid" not in f.read()
+            # `invalid` should only be in the file if a daemon process was used
+            assert ("invalid" in f.read()) == daemon_process
 
     assert state.is_failed()
     assert isinstance(state.result[slow_fn], TimedOut)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The value retrieval in the `multiprocessing_timeout` was using a locally defined helper function
which could not be serialized by the native Python pickler resulting in an error running tasks with
a timeout while using a process based scheduler.

#### Example
```python
from prefect import task, Flow
from prefect.engine.executors import LocalDaskExecutor
from random import randint

@task
def foo(x):
    return [randint(0, i) for i in range(x)]

@task(timeout=10)
def bar(y):
    return y * 2

with Flow("foobar") as flow:
    y = foo(10)
    z = bar.map(y) 

if __name__ == "__main__":
    state = flow.run(executor=LocalDaskExecutor())
```

Results in the error `AttributeError: Can't pickle local object 'multiprocessing_timeout.<locals>.retrieve_value'`

Also fixes a timeout issue with function pickling similar to https://github.com/PrefectHQ/prefect/issues/2634

## Changes
<!-- What does this PR change? -->

- Moves the `multiprocessing_timeout.retrieve_value` function to a top-level function
- Renames `retrieve_value` to `multiprocessing_safe_retrieve_value`
- `multiprocessing_safe_retrieve_value` takes a cloudpickle serialized callable so tasks defined in scripts can be passed
- Adds the `mproc` and `mproc_local` executors to the flow timeout test
- Minor documentation improvements in the `multiprocessing_timeout` function
- Adds a `__processes` attribute to distributed test executors
- Adds a local multiprocess test executor
- Fixes the synchronous test executor to use the correct scheduler
- Adds test coverage for daemon process / soft limit timeout enforcement

## Importance
<!-- Why is this PR important? -->

- Fixes a bug in multiprocessing timeouts
- Improves user experience when defining timeout tasks in scripts

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)