### PR TITLE
Submit flow runs based on order of scheduled start time

### DIFF
--- a/changes/issue3165.yaml
+++ b/changes/issue3165.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Agents now submit flow runs in order of scheduled start times - [#3165](https://github.com/PrefectHQ/prefect/issues/3165)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -21,7 +21,7 @@ from prefect.engine.state import Failed, Submitted
 from prefect.serialization import state
 from prefect.utilities.context import context
 from prefect.utilities.exceptions import AuthorizationError
-from prefect.utilities.graphql import EnumValue, GraphQLResult, with_args
+from prefect.utilities.graphql import GraphQLResult, with_args
 
 ascii_name = r"""
  ____            __           _        _                    _

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -21,7 +21,7 @@ from prefect.engine.state import Failed, Submitted
 from prefect.serialization import state
 from prefect.utilities.context import context
 from prefect.utilities.exceptions import AuthorizationError
-from prefect.utilities.graphql import GraphQLResult, with_args
+from prefect.utilities.graphql import EnumValue, GraphQLResult, with_args
 
 ascii_name = r"""
  ____            __           _        _                    _
@@ -554,7 +554,10 @@ class Agent:
                                     },
                                 },
                             ],
-                        }
+                        },
+                        "order_by": {
+                            "scheduled_start_time": EnumValue("asc"),
+                        },
                     },
                 ): {
                     "id": True,

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -555,9 +555,6 @@ class Agent:
                                 },
                             ],
                         },
-                        "order_by": {
-                            "scheduled_start_time": EnumValue("asc"),
-                        },
                     },
                 ): {
                     "id": True,
@@ -565,6 +562,7 @@ class Agent:
                     "state": True,
                     "serialized_state": True,
                     "parameters": True,
+                    "scheduled_start_time": True,
                     "flow": {
                         "id",
                         "name",
@@ -591,7 +589,11 @@ class Agent:
         if target_flow_run_ids:
             self.logger.debug("Querying flow run metadata")
             result = self.client.graphql(query)
-            return result.data.flow_run  # type: ignore
+
+            # Return flow runs sorted by scheduled start time
+            return sorted(
+                result.data.flow_run, key=lambda flow_run: flow_run.scheduled_start_time
+            )
         else:
             return []
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -143,7 +143,7 @@ def test_query_flow_runs(monkeypatch, cloud_api):
         return_value=MagicMock(
             data=MagicMock(
                 get_runs_in_queue=MagicMock(flow_run_ids=["id"]),
-                flow_run=[{"id": "id"}],
+                flow_run=[GraphQLResult({"id": "id", "scheduled_start_time": 1})],
             )
         )
     )
@@ -153,7 +153,7 @@ def test_query_flow_runs(monkeypatch, cloud_api):
 
     agent = Agent()
     flow_runs = agent.query_flow_runs()
-    assert flow_runs == [{"id": "id"}]
+    assert flow_runs == [GraphQLResult({"id": "id", "scheduled_start_time": 1})]
 
 
 def test_query_flow_runs_ignores_currently_submitting_runs(monkeypatch, cloud_api):
@@ -161,7 +161,7 @@ def test_query_flow_runs_ignores_currently_submitting_runs(monkeypatch, cloud_ap
         return_value=MagicMock(
             data=MagicMock(
                 get_runs_in_queue=MagicMock(flow_run_ids=["id1", "id2"]),
-                flow_run=[{"id1": "id1"}],
+                flow_run=[GraphQLResult({"id": "id", "scheduled_start_time": 1})],
             )
         )
     )
@@ -178,6 +178,30 @@ def test_query_flow_runs_ignores_currently_submitting_runs(monkeypatch, cloud_ap
         'id: { _in: ["id1"] }'
         in list(gql_return.call_args_list[1][0][0]["query"].keys())[0]
     )
+
+
+def test_query_flow_runs_ordered_by_start_time(monkeypatch, cloud_api):
+    gql_return = MagicMock(
+        return_value=MagicMock(
+            data=MagicMock(
+                get_runs_in_queue=MagicMock(flow_run_ids=["id"]),
+                flow_run=[
+                    GraphQLResult({"id": "id2", "scheduled_start_time": 200}),
+                    GraphQLResult({"id": "id", "scheduled_start_time": 1}),
+                ],
+            )
+        )
+    )
+    client = MagicMock()
+    client.return_value.graphql = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", client)
+
+    agent = Agent()
+    flow_runs = agent.query_flow_runs()
+    assert flow_runs == [
+        GraphQLResult({"id": "id", "scheduled_start_time": 1}),
+        GraphQLResult({"id": "id2", "scheduled_start_time": 200}),
+    ]
 
 
 def test_query_flow_runs_does_not_use_submitting_flow_runs_directly(
@@ -345,6 +369,7 @@ def test_agent_process(monkeypatch, cloud_api):
                                     }
                                 )
                             ],
+                            "scheduled_start_time": 1,
                         }
                     )
                 ],


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
`get_runs_in_queue` will return flow runs in order however when we do the additional query to get flow run information order is not guaranteed. This updates that function to sort the flow runs after returned from the query

Closes #3165 

## Changes
Adds `sorted` call on flow run information query in the agent deployment process, ordered by `scheduled_start_time`



## Importance
It is ideal to have work run in the order it is scheduled under circumstances (such as) where agents go down and come back online



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)