### PR TITLE
Fix Fargate task definition environment and role validation

### DIFF
--- a/changes/pr3514.yaml
+++ b/changes/pr3514.yaml
@@ -1,0 +1,5 @@
+fix:
+ - "Update Fargate task definition validation - [#3514](https://github.com/PrefectHQ/prefect/pull/3514)"
+
+contributor:
+  - "[Spencer Ellinor](https://github.com/zpencerq)"

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -1,3 +1,4 @@
+import operator
 import os
 import warnings
 from typing import TYPE_CHECKING, Callable, List
@@ -301,18 +302,28 @@ class FargateTaskEnvironment(Environment, _RunMixin):
                 },
             }
 
-        givenContainerDefinitions = [
-            format_container_definition(container_definition)
-            for container_definition in task_definition_kwargs["containerDefinitions"]
-        ]
-        expectedContainerDefinitions = [
-            format_container_definition(container_definition)
-            for container_definition in existing_task_definition["containerDefinitions"]
-        ]
+        givenContainerDefinitions = sorted(
+            [
+                format_container_definition(container_definition)
+                for container_definition in task_definition_kwargs[
+                    "containerDefinitions"
+                ]
+            ],
+            key=operator.itemgetter("name"),
+        )
+        expectedContainerDefinitions = sorted(
+            [
+                format_container_definition(container_definition)
+                for container_definition in existing_task_definition[
+                    "containerDefinitions"
+                ]
+            ],
+            key=operator.itemgetter("name"),
+        )
 
         containerDifferences = [
             "containerDefinition.{idx}.{key} -> Given: {given}, Expected: {expected}".format(
-                idx=idx,
+                idx=container_definition.get("name", idx),
                 key=key,
                 given=value,
                 expected=existing_container_definition.get(key),

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -1,17 +1,14 @@
 from unittest.mock import MagicMock
 
-
 import cloudpickle
-import pytest
-
 import prefect
+import pytest
+from botocore.exceptions import ClientError
 from prefect import Flow, config
 from prefect.engine.executors import LocalDaskExecutor
 from prefect.environments import FargateTaskEnvironment
 from prefect.environments.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
-
-from botocore.exceptions import ClientError
 
 
 def test_create_fargate_task_environment():
@@ -325,6 +322,60 @@ def test_setup_definition_changed(monkeypatch):
                 ),
             )
         )
+
+    assert boto3_client.describe_task_definition.called
+    assert not boto3_client.register_task_definition.called
+
+
+def test_validate_definition_not_changed_when_env_out_of_order(monkeypatch):
+    existing_task_definition = {
+        "containerDefinitions": [
+            {
+                "environment": [
+                    {
+                        "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
+                        "value": "prefect.engine.cloud.CloudFlowRunner",
+                    },
+                    {"name": "PREFECT__CLOUD__USE_LOCAL_SECRETS", "value": "false"},
+                    {
+                        "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
+                        "value": "prefect.engine.cloud.CloudTaskRunner",
+                    },
+                    {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
+                    {
+                        "name": "PREFECT__LOGGING__EXTRA_LOGGERS",
+                        "value": str(config.logging.extra_loggers),
+                    },
+                    # This is added first in _render_task_definition_kwargs, so it's at the end now
+                    {"name": "PREFECT__CLOUD__GRAPHQL", "value": config.cloud.graphql},
+                ],
+                "name": "flow-container",
+                "image": "test/image:tag",
+                "command": [
+                    "/bin/sh",
+                    "-c",
+                    "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
+                ],
+            }
+        ],
+        "memory": 256,
+        "cpu": 512,
+    }
+
+    boto3_client = MagicMock()
+    boto3_client.describe_task_definition.return_value = {
+        "taskDefinition": existing_task_definition
+    }
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=boto3_client))
+
+    environment = FargateTaskEnvironment(memory=256, cpu=512)
+
+    environment.setup(
+        Flow(
+            "test",
+            storage=Docker(registry_url="test", image_name="image", image_tag="tag"),
+        )
+    )
 
     assert boto3_client.describe_task_definition.called
     assert not boto3_client.register_task_definition.called


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Expands and fixes upon #3451

Properly fixes previous FargateTaskEnvironment task definition validation around `Environment` by refactoring the comparisons.

Expands the validation to include ARNs as well (you can reference them by name when created  but the name gets converted to the ARN form in the taskDefinition in AWS and will clash in validation later). To play it safe, I also went through the AWS documentation and reformat the fields that could possibly be re-ordered by AWS incase users are using task definitions with more than one container.

Tests are included to verify the implementation.

### The root issue
Essentially, the data structure storing environment variables is a hashmap that isn't ordered, so each `describe_task_definition` call can potentially return the environment variables out of order, breaking the validation. Furthermore, roles can be provided as names which are saved as `ARN`s.

## Changes
Makes the task definition validation in the FargateTaskEnvironment more correcter.
* Updates ENV comparison by converting the (name, value) `list` into a `dict` (applies this change to all `object array` type fields before doing any comparison to avoid future errors)
* Adds alternative equality for `roleArns` since they can be provided as role names which get realized as fully qualified `ARN`s when saved in the ECS `taskDefinition`.


## Importance
The existing validation is incorrectly blocking flow runs 😓 
This change should actually fix the validation to work properly.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)