### PR TITLE
Catch & log errors in heartbeat thread

### DIFF
--- a/changes/pr3521.yaml
+++ b/changes/pr3521.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug in k8s where the resource-manager would sometimes silently crash on errors - [#3521](https://github.com/PrefectHQ/prefect/pull/3521)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -218,7 +218,10 @@ class KubernetesAgent(Agent):
         """
         Check status of jobs created by this agent, delete completed jobs and failed containers.
         """
-        self.manage_jobs()
+        try:
+            self.manage_jobs()
+        except Exception:
+            self.logger.error("Error while managing existing k8s jobs", exc_info=True)
         super().heartbeat()
 
     def deploy_flow(self, flow_run: GraphQLResult) -> str:


### PR DESCRIPTION
Previously an error in the heartbeat thread would silently kill the
thread. We now catch and log them, and continue looping.

This fixes a bug where a non-api error (e.g. a socket error) in the k8s
agent resource manager would kill the resource manager.

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)