### PR TITLE
specify slack webhook_secret on runtime

### DIFF
--- a/changes/pr3522.yaml
+++ b/changes/pr3522.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Specify Slack webhook secret on runtime - [#3522](https://github.com/PrefectHQ/prefect/pull/3522)"
+
+contributor:
+  - "[Panagiotis Simakis](https://github.com/sp1thas)"

--- a/changes/pr3522.yaml
+++ b/changes/pr3522.yaml
@@ -1,5 +1,5 @@
-enhancement:
-  - "Specify Slack webhook secret on runtime - [#3522](https://github.com/PrefectHQ/prefect/pull/3522)"
+task:
+  - "Allow setting runtime `webook_secret` on `SlackTask` and kwarg for `webhook_secret` retrieved from `PrefectSecret` task - [#3522](https://github.com/PrefectHQ/prefect/pull/3522)"
 
 contributor:
   - "[Panagiotis Simakis](https://github.com/sp1thas)"

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -31,8 +31,8 @@ class SlackTask(Task):
         self.webhook_secret = webhook_secret
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("message")
-    def run(self, message: Union[str, dict] = None) -> None:
+    @defaults_from_attrs("message", "webhook_secret")
+    def run(self, message: Union[str, dict] = None, webhook_secret: str = None) -> None:
         """
         Run method which sends a Slack message.
 
@@ -40,6 +40,9 @@ class SlackTask(Task):
             - message (Union[str,dict], optional): the message to send as either a dictionary
                 or a plain string; if not provided here, will use the value provided at
                 initialization
+            - webhook_secret (str, optional): the name of the Prefect Secret which stores your
+                slack webhook URL; defaults to `"SLACK_WEBHOOK_URL"`; if not provided here,
+                will use the value provided at initialization
 
         Returns:
             - None
@@ -48,7 +51,7 @@ class SlackTask(Task):
         # the 'import prefect' time low
         import requests
 
-        webhook_url = cast(str, Secret(self.webhook_secret).get())
+        webhook_url = cast(str, Secret(webhook_secret).get())
         r = requests.post(
             webhook_url,
             json=message if isinstance(message, dict) else {"text": message},

--- a/src/prefect/tasks/notifications/slack_task.py
+++ b/src/prefect/tasks/notifications/slack_task.py
@@ -32,7 +32,12 @@ class SlackTask(Task):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("message", "webhook_secret")
-    def run(self, message: Union[str, dict] = None, webhook_secret: str = None) -> None:
+    def run(
+        self,
+        message: Union[str, dict] = None,
+        webhook_secret: str = None,
+        webhook_url: str = None,
+    ) -> None:
         """
         Run method which sends a Slack message.
 
@@ -43,6 +48,8 @@ class SlackTask(Task):
             - webhook_secret (str, optional): the name of the Prefect Secret which stores your
                 slack webhook URL; defaults to `"SLACK_WEBHOOK_URL"`; if not provided here,
                 will use the value provided at initialization
+            - webhook_url (str, optional): the value of a Slack webhook URL that is returned from an
+                upstream `PrefectSecret` task. If specified then the `webhook_secret` will not be used.
 
         Returns:
             - None
@@ -51,7 +58,7 @@ class SlackTask(Task):
         # the 'import prefect' time low
         import requests
 
-        webhook_url = cast(str, Secret(webhook_secret).get())
+        webhook_url = webhook_url or cast(str, Secret(webhook_secret).get())
         r = requests.post(
             webhook_url,
             json=message if isinstance(message, dict) else {"text": message},


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Specify the `webhook_secret` of the `SlackTask` on runtime.




## Changes
<!-- What does this PR change? -->
This PR changes the `SlackTask.run` method by adding the `webhook_secret` argument.



## Importance
<!-- Why is this PR important? -->
User will have the ability to provide the slack `webhook_secret` dynamically based previous tasks.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)