### PR TITLE
Fix multiprocess based timeout handler on linux

### DIFF
--- a/changes/pr3256.yaml
+++ b/changes/pr3256.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Fix multiprocess based timeout handler on linux hanging during execution of mapped tasks - [#3526](https://github.com/PrefectHQ/prefect/pull/3526)"
+  - "Fix multiprocess based timeout handler on linux ` - [#3526](https://github.com/PrefectHQ/prefect/pull/3526)"

--- a/changes/pr3256.yaml
+++ b/changes/pr3256.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix multiprocess based timeout handler on linux hanging during execution of mapped tasks - [#3526](https://github.com/PrefectHQ/prefect/pull/3526)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -545,7 +545,7 @@ functions = ["diagnostic_info", "flow_information", "system_information", "confi
 [pages.utilities.executors]
 title = "Executors"
 module = "prefect.utilities.executors"
-functions = ["timeout_handler"]
+functions = ["run_with_timeout_handler"]
 
 [pages.utilities.gcp]
 title = "Google Utilities"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -545,7 +545,7 @@ functions = ["diagnostic_info", "flow_information", "system_information", "confi
 [pages.utilities.executors]
 title = "Executors"
 module = "prefect.utilities.executors"
-functions = ["run_with_timeout_handler"]
+functions = ["run_task_with_timeout_handler"]
 
 [pages.utilities.gcp]
 title = "Google Utilities"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -545,7 +545,7 @@ functions = ["diagnostic_info", "flow_information", "system_information", "confi
 [pages.utilities.executors]
 title = "Executors"
 module = "prefect.utilities.executors"
-functions = ["run_task_with_timeout_handler"]
+functions = ["run_task_with_timeout"]
 
 [pages.utilities.gcp]
 title = "Google Utilities"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -41,7 +41,7 @@ from prefect.utilities.executors import (
     run_with_heartbeat,
     tail_recursive,
 )
-from prefect.utilities.compatability import nullcontext
+from prefect.utilities.compatibility import nullcontext
 
 
 TaskRunnerInitializeResult = NamedTuple(

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -12,7 +12,6 @@ from typing import (
     Tuple,
 )
 
-
 import pendulum
 
 import prefect

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -835,13 +835,11 @@ class TaskRunner(Runner):
             )
 
             with log_context:
-                # Always use the `timeout_handler` which will just call immediately
-                # if the timeout isn't set
-                value = prefect.utilities.executors.run_with_timeout_handler(
-                    fn=self.task.run,
+                # Run the task with handling for the `task.timeout` setting
+                value = prefect.utilities.executors.run_task_with_timeout_handler(
+                    task=self.task,
                     args=(),
                     kwargs=raw_inputs,
-                    timeout=self.task.timeout,
                     logger=self.logger,
                 )
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1,5 +1,6 @@
-from contextlib import redirect_stdout, nullcontext
+from contextlib import redirect_stdout
 from dask.base import tokenize
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -10,6 +11,7 @@ from typing import (
     Set,
     Tuple,
 )
+
 
 import pendulum
 
@@ -825,23 +827,27 @@ class TaskRunner(Runner):
                     name=prefect.context.get("task_full_name", self.task.name)
                 )
             )
-            # Create a stdout redirect if the task has log_stdout enabled
-            log_context = (
-                redirect_stdout(  # type: ignore
-                    prefect.utilities.logging.RedirectToLog(self.logger)
-                )
-                if getattr(self.task, "log_stdout", False)
-                else nullcontext()
+
+            # Note: Instead of using partial here, a contextlib.nullcontext could be
+            # used but this is not supported by py 3.6 so we will create this call
+            # then call it twice instead
+            run_task_with_timeout_handler = partial(
+                prefect.utilities.executors.run_task_with_timeout_handler,
+                task=self.task,
+                args=(),
+                kwargs=raw_inputs,
+                logger=self.logger,
             )
 
-            with log_context:  # type: ignore
-                # Run the task with handling for the `task.timeout` setting
-                value = prefect.utilities.executors.run_task_with_timeout_handler(
-                    task=self.task,
-                    args=(),
-                    kwargs=raw_inputs,
-                    logger=self.logger,
-                )
+            # Create a stdout redirect if the task has log_stdout enabled
+            if getattr(self.task, "log_stdout", False):
+                with redirect_stdout(  # type: ignore
+                    prefect.utilities.logging.RedirectToLog(self.logger)
+                ):
+                    value = run_task_with_timeout_handler()
+
+            else:
+                value = run_task_with_timeout_handler()
 
         # inform user of timeout
         except TimeoutError as exc:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -831,7 +831,7 @@ class TaskRunner(Runner):
             # used but this is not supported by py 3.6 so we will create this call
             # then call it twice instead
             run_task_with_timeout_handler = partial(
-                prefect.utilities.executors.run_task_with_timeout_handler,
+                prefect.utilities.executors.run_task_with_timeout,
                 task=self.task,
                 args=(),
                 kwargs=raw_inputs,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -834,7 +834,7 @@ class TaskRunner(Runner):
                 else nullcontext()
             )
 
-            with log_context:
+            with log_context:  # type: ignore
                 # Run the task with handling for the `task.timeout` setting
                 value = prefect.utilities.executors.run_task_with_timeout_handler(
                     task=self.task,

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -1,5 +1,6 @@
 from contextlib import redirect_stdout
 from dask.base import tokenize
+from contextlib import AbstractContextManager
 from typing import (
     Any,
     Callable,
@@ -829,12 +830,10 @@ class TaskRunner(Runner):
 
             # Create a stdout redirect if the task has log_stdout enabled
             log_context = (
-                redirect_stdout(  # type: ignore
-                    prefect.utilities.logging.RedirectToLog(self.logger)
-                )
+                redirect_stdout(prefect.utilities.logging.RedirectToLog(self.logger))
                 if getattr(self.task, "log_stdout", False)
                 else nullcontext()
-            )
+            )  # type: AbstractContextManager
 
             with log_context:
                 value = prefect.utilities.executors.run_task_with_timeout(

--- a/src/prefect/utilities/compatability.py
+++ b/src/prefect/utilities/compatability.py
@@ -11,10 +11,11 @@ import sys
 if sys.version_info < (3, 7):
 
     from contextlib import contextmanager
+    from typing import Iterator
 
     @contextmanager
-    def nullcontext():
-        pass
+    def nullcontext() -> Iterator[None]:
+        yield
 
 
 else:

--- a/src/prefect/utilities/compatability.py
+++ b/src/prefect/utilities/compatability.py
@@ -1,0 +1,22 @@
+"""
+Functions that exist for compatability with different python versions. These should
+only be used internally.
+"""
+
+import sys
+
+
+# Provide `nullcontext`
+
+if sys.version_info < (3, 7):
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nullcontext():
+        pass
+
+
+else:
+
+    from contextlib import nullcontext

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -1,5 +1,5 @@
 """
-Functions that exist for compatability with different python versions. These should
+Functions that exist for compatibility with different python versions. These should
 only be used internally.
 """
 
@@ -20,4 +20,4 @@ if sys.version_info < (3, 7):
 
 else:
 
-    from contextlib import nullcontext
+    from contextlib import nullcontext  # noqa: F401

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -259,7 +259,7 @@ def run_with_multiprocess_timeout(
         raise TimeoutError(f"Execution timed out for {name}.")
 
 
-def run_task_with_timeout_handler(
+def run_task_with_timeout(
     task: "Task",
     args: Sequence = (),
     kwargs: Mapping = None,

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -81,7 +81,7 @@ def run_with_heartbeat(
 
 def run_with_thread_timeout(
     fn: Callable,
-    args: Sequence,
+    args: Sequence = (),
     kwargs: Mapping = None,
     timeout: int = None,
     logger: Logger = None,
@@ -187,7 +187,7 @@ def multiprocessing_safe_run_and_retrieve(
 
 def run_with_multiprocess_timeout(
     fn: Callable,
-    args: Sequence,
+    args: Sequence = (),
     kwargs: Mapping = None,
     timeout: int = None,
     logger: Logger = None,
@@ -261,7 +261,7 @@ def run_with_multiprocess_timeout(
 
 def run_task_with_timeout_handler(
     task: "Task",
-    args: Sequence,
+    args: Sequence = (),
     kwargs: Mapping = None,
     logger: Logger = None,
 ) -> Any:
@@ -282,7 +282,7 @@ def run_task_with_timeout_handler(
         - task (Task): the task to execute
             `task.timeout` specifies the number of seconds to allow `task.run` to run
             for before terminating
-        - args (Sequence): arguments to pass to the function
+        - args (Sequence): arguments ``to pass to the function
         - kwargs (Mapping): keyword arguments to pass to the function
         - logger (Logger): an optional logger to use. If not passed, a logger for the
             `prefect.run_task_with_timeout_handler` namespace will be created.
@@ -295,6 +295,7 @@ def run_task_with_timeout_handler(
     """
     logger = logger or get_logger("run_task_with_timeout_handler")
     name = prefect.context.get("task_full_name", task.name)
+    kwargs = kwargs or {}
 
     # if no timeout, just run the function
     if task.timeout is None:

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -110,7 +110,7 @@ def run_with_thread_timeout(
         - TimeoutError: if function execution exceeds the allowed timeout
         - ValueError: if run from outside the main thread
     """
-    logger = logger or get_logger("run_with_thread_timeout")
+    logger = logger or get_logger()
     name = name or f"Function '{fn.__name__}'"
     kwargs = kwargs or {}
 
@@ -166,7 +166,7 @@ def multiprocessing_safe_run_and_retrieve(
     """
     request = cloudpickle.loads(payload)
 
-    logger = get_logger("multiprocessing_safe_run_and_retrieve")
+    logger = get_logger()
 
     fn: Callable = request["fn"]
     context: dict = request.get("context", {})
@@ -216,7 +216,7 @@ def run_with_multiprocess_timeout(
         - AssertionError: if run from a daemonic process
         - TimeoutError: if function execution exceeds the allowed timeout
     """
-    logger = logger or get_logger("run_with_multiprocess_timeout")
+    logger = logger or get_logger()
     name = name or f"Function '{fn.__name__}'"
     kwargs = kwargs or {}
 
@@ -282,7 +282,7 @@ def run_task_with_timeout_handler(
         - task (Task): the task to execute
             `task.timeout` specifies the number of seconds to allow `task.run` to run
             for before terminating
-        - args (Sequence): arguments ``to pass to the function
+        - args (Sequence): arguments to pass to the function
         - kwargs (Mapping): keyword arguments to pass to the function
         - logger (Logger): an optional logger to use. If not passed, a logger for the
             `prefect.run_task_with_timeout_handler` namespace will be created.
@@ -293,7 +293,7 @@ def run_task_with_timeout_handler(
     Raises:
         - TimeoutError: if function execution exceeds the allowed timeout
     """
-    logger = logger or get_logger("run_task_with_timeout_handler")
+    logger = logger or get_logger()
     name = prefect.context.get("task_full_name", task.name)
     kwargs = kwargs or {}
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -307,8 +307,9 @@ def run_task_with_timeout(
     if not sys.platform.startswith("win"):
 
         if threading.current_thread() is threading.main_thread():
-            # This case is typically when using the LocalDaskExecutor with a
-            # process-based scheduler because then each worker is in the main thread
+            # This case is typically encountered when using a non-parallel or local
+            # multiprocess scheduler because then each worker is in the main
+            # thread
             logger.debug(f"Task '{name}': Attaching thread based timeout handler...")
             return run_with_thread_timeout(
                 task.run,
@@ -320,8 +321,8 @@ def run_task_with_timeout(
             )
 
         elif multiprocessing.current_process().daemon is False:
-            # This case is typically when using the LocalDaskExecutor with a
-            # thread-based scheduler or the DaskExecutor with processes disabled
+            # This case is typically encountered when using a multithread distributed
+            # executor
             logger.debug(f"Task '{name}': Attaching process based timeout handler...")
             return run_with_multiprocess_timeout(
                 task.run,
@@ -333,8 +334,8 @@ def run_task_with_timeout(
             )
 
         # We are in a daemonic process and cannot enforce a timeout
-        # This case is typically when using the distributed DaskExecutor with processes
-        # enabled
+        # This case is typically encountered when using a multiprocess distributed
+        # executor
         soft_timeout_reason = "in a daemonic subprocess"
     else:
         # We are in windows and cannot enforce a timeout

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -240,6 +240,8 @@ def run_with_multiprocess_timeout(
     logger.debug(f"{name}: Sending execution to a new process...")
     p.start()
     logger.debug(f"{name}: Waiting for process to return with {timeout}s timeout...")
+    if not p.is_alive():
+        raise RuntimeError("Process is not alive!")
     p.join(timeout)
     p.terminate()
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -234,16 +234,15 @@ def run_with_multiprocess_timeout(
     }
     payload = cloudpickle.dumps(request)
 
-    p = multiprocessing.Process(
+    spawn_mp = multiprocessing.get_context("spawn")
+    exec_proc = spawn_mp.Process(
         target=multiprocessing_safe_run_and_retrieve, args=(queue, payload)
     )
     logger.debug(f"{name}: Sending execution to a new process...")
-    p.start()
+    exec_proc.start()
     logger.debug(f"{name}: Waiting for process to return with {timeout}s timeout...")
-    if not p.is_alive():
-        raise RuntimeError("Process is not alive!")
-    p.join(timeout)
-    p.terminate()
+    exec_proc.join(timeout)
+    exec_proc.terminate()
 
     # Handle the process result, if the queue is empty the function did not finish
     # before the timeout

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -243,8 +243,13 @@ def timeout_handler(
     Raises:
         - TimeoutError: if function execution exceeds the allowed timeout
     """
+
+    logger = get_logger()
+    logger.info("Entering timeout handler selection...")
+
     # if no timeout, just run the function
     if timeout is None:
+        logger.info("Skipping timeout handler because timeout is empty...")
         return fn(*args, **kwargs)
 
     # if we are running the main thread, use a signal to stop execution at the
@@ -252,8 +257,10 @@ def timeout_handler(
     # a subprocess to kill at the appropriate time
     if not sys.platform.startswith("win"):
         if threading.current_thread() is threading.main_thread():
+            logger.info("Selected thread based timeout handler")
             return main_thread_timeout(fn, *args, timeout=timeout, **kwargs)
         elif multiprocessing.current_process().daemon is False:
+            logger.info("Selected multiprocessing based timeout handler")
             return multiprocessing_timeout(fn, *args, timeout=timeout, **kwargs)
 
         soft_timeout_reason = "in a daemonic subprocess"
@@ -267,6 +274,7 @@ def timeout_handler(
         "but continue running in the background."
     )
 
+    logger.info("Falling back to daemonic soft limit timeout handler")
     warnings.warn(msg, stacklevel=2)
     executor = ThreadPoolExecutor()
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -172,7 +172,7 @@ def multiprocessing_safe_run_and_retrieve(
     context: dict = request.get("context", {})
     args: Sequence = request.get("args", [])
     kwargs: Mapping = request.get("kwargs", {})
-    name: dict = request.get("name", f"Function '{fn.__name__}'")
+    name: str = request.get("name", f"Function '{fn.__name__}'")
 
     try:
         with prefect.context(context):

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -110,7 +110,7 @@ def run_with_thread_timeout(
         - TimeoutError: if function execution exceeds the allowed timeout
         - ValueError: if run from outside the main thread
     """
-    logger = logger or get_logger("prefect.executors.run_with_thread_timeout")
+    logger = logger or get_logger("run_with_thread_timeout")
     name = name or f"Function '{fn.__name__}'"
 
     if timeout is None:
@@ -165,7 +165,7 @@ def multiprocessing_safe_run_and_retrieve(
     """
     request = cloudpickle.loads(payload)
 
-    logger = get_logger("prefect.executors.multiprocessing_safe_run_and_retrieve")
+    logger = get_logger("multiprocessing_safe_run_and_retrieve")
 
     fn: Callable = request["fn"]
     context: dict = request.get("context", {})
@@ -215,7 +215,7 @@ def run_with_multiprocess_timeout(
         - AssertionError: if run from a daemonic process
         - TimeoutError: if function execution exceeds the allowed timeout
     """
-    logger = logger or get_logger("prefect.executors.run_with_multiprocess_timeout")
+    logger = logger or get_logger("run_with_multiprocess_timeout")
     name = name or f"Function '{fn.__name__}'"
 
     if timeout is None:
@@ -291,7 +291,7 @@ def run_task_with_timeout_handler(
     Raises:
         - TimeoutError: if function execution exceeds the allowed timeout
     """
-    logger = logger or get_logger("prefect.run_task_with_timeout_handler")
+    logger = logger or get_logger("run_task_with_timeout_handler")
     name = prefect.context.get("task_full_name", task.name)
 
     # if no timeout, just run the function

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -307,6 +307,9 @@ def test_task_runner_accepts_dictionary_of_edges():
     sys.platform == "win32", reason="Windows doesn't support any timeout logic"
 )
 def test_timeout_actually_stops_execution():
+    # Note this replicates test coverage from
+    # `tests.core.test_flow.test_timeout_actually_stops_execution`
+
     # Note: this is a potentially brittle test! In some cases (local and sync) signal.alarm
     # is used as the mechanism for timing out a task. This passes off the job of measuring
     # the time for the timeout to the OS, which uses the "wallclock" as reference (the real

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -23,6 +23,9 @@ from prefect.utilities.executors import (
 TIMEOUT_HANDLERS = [run_with_thread_timeout, run_with_multiprocess_timeout]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_times_out(timeout_handler):
     slow_fn = lambda: time.sleep(2)
@@ -60,6 +63,9 @@ def test_timeout_handler_actually_stops_execution(timeout_handler):
     assert len(contents.split("\n")) < WRITES
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_passes_args_and_kwargs_and_returns(timeout_handler):
     def just_return(x, y=None):
@@ -73,6 +79,9 @@ def test_timeout_handler_passes_args_and_kwargs_and_returns(timeout_handler):
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_doesnt_swallow_bad_args(timeout_handler):
     def do_nothing(x, y=None):
@@ -88,6 +97,9 @@ def test_timeout_handler_doesnt_swallow_bad_args(timeout_handler):
         timeout_handler(do_nothing, args=[5], kwargs=dict(y="s", z=10), timeout=2)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_reraises(timeout_handler):
     def do_something():
@@ -136,6 +148,9 @@ def test_timeout_handler_doesnt_do_anything_if_no_timeout(timeout_handler):
     assert timeout_handler(lambda: 4) == 4
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_preserves_context(timeout_handler):
     def my_fun(x, **kwargs):
@@ -147,11 +162,17 @@ def test_timeout_handler_preserves_context(timeout_handler):
     assert res == 42
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 def test_run_with_thread_timeout_preserves_logging(caplog):
     run_with_thread_timeout(prefect.Flow("logs").run, timeout=2)
     assert len(caplog.messages) >= 2  # 1 INFO to start, 1 INFO to end
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 def test_run_with_multiprocess_timeout_preserves_logging(capfd):
     """
     Requires fd capturing because the subprocess output won't be captured by caplog

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -142,6 +142,9 @@ def test_timeout_handler_allows_function_to_spawn_new_thread(timeout_handler):
     assert timeout_handler(my_thread, timeout=2) is None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_doesnt_do_anything_if_no_timeout(timeout_handler):
     assert timeout_handler(lambda: 4, timeout=2) == 4

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -126,7 +126,7 @@ def test_timeout_handler_allows_function_to_spawn_new_process(timeout_handler):
         p.join()
         p.terminate()
 
-    assert timeout_handler(my_process, timeout=2) is None
+    assert timeout_handler(my_process, timeout=3) is None
 
 
 @pytest.mark.skipif(
@@ -139,7 +139,7 @@ def test_timeout_handler_allows_function_to_spawn_new_thread(timeout_handler):
         t.start()
         t.join()
 
-    assert timeout_handler(my_thread, timeout=2) is None
+    assert timeout_handler(my_thread, timeout=3) is None
 
 
 @pytest.mark.skipif(

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -17,8 +17,9 @@ from prefect.utilities.executors import (
 )
 
 
-# We will test the low-level timeout handlers here and `run_task_with_timeout_handler`
+# We will test the low-level timeout handlers here and `run_task_with_timeout`
 # is covered in `tests.core.test_flow.test_timeout_actually_stops_execution`
+# and `tests.engine.test_task_runner.test_timeout_actually_stops_execution`
 TIMEOUT_HANDLERS = [run_with_thread_timeout, run_with_multiprocess_timeout]
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Resolves issues on Linux with the `multiprocessing_timeout_handler` which is used during `LocalDaskExecutor(scheduler="threads")` calls. Execution was hanging during execution of mapped tasks and appears to be an issue with the `fork` process implementation in Python and I'm not sure it's worth trying to hunt down.

Cleans up timeout handling in general.

Closes #3506 

## Changes
<!-- What does this PR change? -->

- Refactors the timeout handlers in `prefect.utilities.executors`
- Uses `spawn` instead of `fork` to create a process based timeout handler
- Unifies timeout handler interfaces
- Adds logging to timeout handlers
- Adds `prefect.utilities.compatibility` with `nullcontext`

## Importance
<!-- Why is this PR important? -->

- Fixes a bug with multiprocess timeout handling and the threaded scheduler
- Improves readability and inspectability of timeout handling

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)