### PR TITLE
[client] close #3515 Introduce the property active_tenant_id which handles the tenant initialization

### DIFF
--- a/changes/issue3515.yaml
+++ b/changes/issue3515.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow for setting `Client` headers before loading tenant when running with Prefect Server - [#3515](https://github.com/PrefectHQ/prefect/issues/3515)"
+
+contributor:
+  - "[Emilien Garreau](https://github.com/EmGarr)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -524,7 +524,7 @@ class Agent:
                 "input": {
                     "before": now.isoformat(),
                     "labels": list(self.labels),
-                    "tenant_id": self.client._active_tenant_id,
+                    "tenant_id": self.client.active_tenant_id,
                 }
             },
         )

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -114,7 +114,7 @@ def logout():
     )
 
     client = Client()
-    tenant_id = client._active_tenant_id
+    tenant_id = client.active_tenant_id
 
     if not tenant_id:
         click.secho("No tenant currently active", fg="red")
@@ -135,7 +135,7 @@ def list_tenants():
     client = Client()
 
     tenants = client.get_available_tenants()
-    active_tenant_id = client._active_tenant_id
+    active_tenant_id = client.active_tenant_id
 
     output = []
     for item in tenants:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -101,8 +101,11 @@ class Client:
         self._api_token = (
             api_token
             or prefect.context.config.cloud.get("auth_token", None)
-            or self._load_local_settings().get("api_token")
         )
+
+        # Initialize the tenant and api token if not yet set
+        if not self._api_token and prefect.config.backend == "cloud":
+            self._init_tenant()
 
     def create_tenant(self, name: str, slug: str = None) -> str:
         """
@@ -242,6 +245,10 @@ class Client:
         if prefect.config.backend == "cloud":
             # if no api token was passed, attempt to load state from local storage
             settings = self._load_local_settings()
+
+            if not self._api_token:
+                self._api_token = settings.get("api_token")
+
             self._active_tenant_id = settings.get("active_tenant_id")
             if self._active_tenant_id:
                 try:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -98,9 +98,8 @@ class Client:
         # store api server
         self.api_server = api_server or prefect.context.config.cloud.get("graphql")
 
-        self._api_token = (
-            api_token
-            or prefect.context.config.cloud.get("auth_token", None)
+        self._api_token = api_token or prefect.context.config.cloud.get(
+            "auth_token", None
         )
 
         # Initialize the tenant and api token if not yet set
@@ -248,8 +247,9 @@ class Client:
 
             if not self._api_token:
                 self._api_token = settings.get("api_token")
+            if self._api_token:
+                self._active_tenant_id = settings.get("active_tenant_id")
 
-            self._active_tenant_id = settings.get("active_tenant_id")
             if self._active_tenant_id:
                 try:
                     self.login_to_tenant(tenant_id=self._active_tenant_id)

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -91,7 +91,7 @@ class Client:
         self._access_token = None
         self._refresh_token = None
         self._access_token_expires_at = pendulum.now()
-        self._active_tenant_id: Optional[str] = None
+        self._active_tenant_id = None
         self._attached_headers = {}  # type: Dict[str, str]
         self.logger = create_diagnostic_logger("Diagnostics")
 
@@ -529,7 +529,7 @@ class Client:
             - str: the access token
         """
         if not self._access_token:
-            return self._api_token
+            return self._api_token  # type: ignore
 
         expiration = self._access_token_expires_at or pendulum.now()
         if self._refresh_token and pendulum.now().add(seconds=30) > expiration:
@@ -620,7 +620,7 @@ class Client:
             )  # type: ignore
             self._refresh_token = payload.data.switch_tenant.refresh_token  # type: ignore
 
-        self._active_tenant_id = tenant_id
+        self._active_tenant_id = tenant_id  # type: ignore
 
         # save the tenant setting
         settings = self._load_local_settings()


### PR DESCRIPTION
close #3515

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Developpers using prefect server needs sometimes to attach_headers to the
queries in order to communicate with the server (e.g Basic Auth).

However, the first call to the server happened inside the constructor with the
tenant_id initialization. Since the headers couldn't been attached it results to failures.
This commit fix this issue.

Server protected with BasicAuth
```python
 # Here will have requests.exceptions.HTTPError: 401 Client Error: Unauthorized 
# It is because of the tenant initialization inside the constructor
client = Client()
headers = {'Authorization': "Basic {}".format(PREFECT__SERVER__BASIC_AUTH)}
client.attach_headers(headers)
```

After the commit will have this:

```python
client = Client() # No errors
headers = {'Authorization': "Basic {}".format(PREFECT__SERVER__BASIC_AUTH)}
client.attach_headers(headers)
client.graphql({"query": {"tenant": {"id"}}})
```

## Changes

1. ~tenant initialization is performed during the first call of the public method graphql~
2. ~graphql is split in public and private methods to avoid recursion errors~ 
1. Introduce the property `active_tenant_id` which handle the tenant initialization 


## Importance

Limit the usage of prefect server and cannot be deployed to production with BasicAuth




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] ~adds a change file in the `changes/` directory (if appropriate)~
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)