### PR TITLE
Fix for bytes GCSUpload 

### DIFF
--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -1,6 +1,7 @@
 import uuid
 import warnings
 from typing import Union
+import io
 
 from google.cloud.exceptions import NotFound
 
@@ -166,8 +167,7 @@ class GCSDownload(GCSBaseTask):
 
 class GCSUpload(GCSBaseTask):
     """
-    Task template for uploading data to Google Cloud Storage.  Requires the data already
-    be a string.
+    Task template for uploading data to Google Cloud Storage.  Data can be a string or bytes.
 
     Args:
         - bucket (str): default bucket name to upload to
@@ -281,7 +281,7 @@ class GCSUpload(GCSBaseTask):
                 gcs_blob.content_type = content_type
             if content_encoding:
                 gcs_blob.content_encoding = content_encoding
-            gcs_blob.upload_from_file(data)
+            gcs_blob.upload_from_file(io.BytesIO(data))
         return gcs_blob.name
 
 


### PR DESCRIPTION

## Summary
Fix for PR 3508 (https://github.com/PrefectHQ/prefect/pull/3508).  

Sorry, I realised I made a mistake there and should have wrapped data in BytesIO so it is delivered as a binary stream.

I have hopefully sorted my local testing setup so this won't happen for future PRs :)



## Changes
* Imports io library to gcs tasks file
* Uses io.BytesIO to deliver the bytes data as a binary stream to the upload_from_file function.




## Importance
* Make the GCSUpload with bytes more functional.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)