### PR TITLE
[PoC] Slack notification templates

### DIFF
--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -317,7 +317,7 @@ def slack_notifier(
     import requests
 
     form_data = slack_message_formatter(
-        tracked_obj, new_state, message_template, backend_info, message_vars
+        tracked_obj, new_state, backend_info, message_template, message_vars
     )
     r = requests.post(webhook_url, json=form_data)
     if not r.ok:

--- a/tests/utilities/notifications/test_notifications.py
+++ b/tests/utilities/notifications/test_notifications.py
@@ -111,6 +111,17 @@ def test_formatter_formats_states_with_string_message(state):
     assert json.loads(json.dumps(orig)) == orig
 
 
+def test_formatter_formats_template_with_extra_variables():
+    orig = slack_message_formatter(
+        Task(),
+        Running(),
+        template="{state} with {foo} and {bar} but not foobar",
+        template_vars=dict(foo="foo!", bar=10, foobar="extra and unused"),
+    )
+    assert orig["attachments"][0]["text"] == "Running with foo! and 10 but not foobar"
+    assert json.loads(json.dumps(orig)) == orig
+
+
 @pytest.mark.parametrize(
     "state",
     [


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Implements notification message templates for just slack notifications for API discussion.

When fully implemented, closes https://github.com/PrefectHQ/prefect/issues/3531


## Changes
<!-- What does this PR change? -->

- Adds `template` and `template_vars` to slack notifications

## Importance
<!-- Why is this PR important? -->

Users want to amend notifications to include extra information but the best API for this is not entirely clear. This PoC will help us determine the best way to implement this as a feature.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)