### PR TITLE
A few fixups for timeout handling

### DIFF
--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -30,7 +30,7 @@ TIMEOUT_HANDLERS = [run_with_thread_timeout, run_with_multiprocess_timeout]
 def test_timeout_handler_times_out(timeout_handler):
     slow_fn = lambda: time.sleep(2)
     with pytest.raises(TimeoutError):
-        timeout_handler(slow_fn, timeout=2)
+        timeout_handler(slow_fn, timeout=1)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
A few quick fixups for #3526.

- Use the logger for the task in the subprocess-based timeout
- Quiet log level
- Fix one test where timeout was == to execution time.