### PR TITLE
Raise better error for invalid functions used with cloud

### DIFF
--- a/changes/pr3540.yaml
+++ b/changes/pr3540.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Raise a better error message when trying to register a flow with a schedule using custom filter functions - [#3450](https://github.com/PrefectHQ/prefect/pull/3540)"

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -394,7 +394,7 @@ class StatefulFunctionReference(fields.Field):
 
         if not valid_bases and self.reject_invalid:
             raise ValidationError(
-                "When running wth Prefect Cloud/Server, custom functions aren't supported "
+                "When running with Prefect Cloud/Server, custom functions aren't supported "
                 f"for `{type(obj).__name__}.{attr}`. Unable to serialize `{value!r}`."
             )
         else:

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -382,19 +382,21 @@ class StatefulFunctionReference(fields.Field):
 
         try:
             qual_name = to_qualified_name(value)
-        except Exception as exc:
-            raise ValidationError(
-                f"Invalid function reference, function required, got {value}"
-            ) from exc
+        except Exception:
+            valid_bases = []
+        else:
+            # sort matches such that the longest / most specific match comes first
+            valid_bases = sorted(
+                [fn for fn in self.valid_functions if qual_name.startswith(fn)],
+                key=lambda k: len(k),
+                reverse=True,
+            )
 
-        # sort matches such that the longest / most specific match comes first
-        valid_bases = sorted(
-            [fn for fn in self.valid_functions if qual_name.startswith(fn)],
-            key=lambda k: len(k),
-            reverse=True,
-        )
         if not valid_bases and self.reject_invalid:
-            raise ValidationError("Invalid function reference: {}".format(value))
+            raise ValidationError(
+                "When running wth Prefect Cloud/Server, custom functions aren't supported "
+                f"for `{type(obj).__name__}.{attr}`. Unable to serialize `{value!r}`."
+            )
         else:
             base_name = next(filter(None, valid_bases)) if valid_bases else qual_name
 

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -240,7 +240,9 @@ class TestStatefulFunctionReferenceField:
         assert serialized["f"]["kwargs"] == {"x": 1, "y": 2, "z": 99}
 
     def test_serialize_invalid_fn(self):
-        with pytest.raises(marshmallow.ValidationError):
+        with pytest.raises(
+            marshmallow.ValidationError, match="custom functions aren't supported"
+        ):
             self.Schema().dump(dict(f=fn2))
 
     def test_serialize_invalid_fn_without_validation(self):
@@ -283,7 +285,9 @@ class TestStatefulFunctionReferenceField:
             def __call__(self, a, b):
                 return a + b
 
-        with pytest.raises(marshmallow.ValidationError, match="function required"):
+        with pytest.raises(
+            marshmallow.ValidationError, match="custom functions aren't supported"
+        ):
             self.Schema().dump(dict(f=Foo()))
 
     def test_serialize_none(self):


### PR DESCRIPTION
When using Prefect with Cloud/Server, custom functions aren't supported
for fields in schedules (e.g. filters), as these functions are run as
part of Cloud/Server's infrastructure. Previously if a user tried to use
a custom function here, registering the flow would raise an opaque
"invalid function" error message, we now provide a more helpful message.

Fixes #3495.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)