### PR TITLE
Better error for JSON incompatible parameter defaults

### DIFF
--- a/changes/pr3549.yaml
+++ b/changes/pr3549.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Raise a better error message when trying to register a flow with parameters with JSON-incompatible defaults - [#3549](https://github.com/PrefectHQ/prefect/pull/3549)"

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -71,11 +71,15 @@ class TestJSONCompatibleField:
         assert serialized["j"] == value
 
     def test_validate_on_dump(self):
-        with pytest.raises(marshmallow.ValidationError):
+        with pytest.raises(
+            marshmallow.ValidationError, match="must be JSON compatible"
+        ):
             self.Schema().dump({"j": lambda: 1})
 
     def test_validate_on_load(self):
-        with pytest.raises(marshmallow.ValidationError):
+        with pytest.raises(
+            marshmallow.ValidationError, match="must be JSON compatible"
+        ):
             self.Schema().load({"j": lambda: 1})
 
 


### PR DESCRIPTION
When using Prefect Cloud/Server, `Parameter` defaults have to be JSON
serializable. Previously registering a flow with JSON incompatible
Parameter defaults would error with an opaque `"Value is not
JSON-compatible"` error. We now raise a better error message providing
some context. This has come up in the community slack a few times.

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)