### PR TITLE
Fix LocalAgent PYTHONPATH construction on Windows

### DIFF
--- a/changes/pr3551.yaml
+++ b/changes/pr3551.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix LocalAgent PYTHONPATH construction on Windows - [#3551](https://github.com/PrefectHQ/prefect/pull/3551)"

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -225,7 +225,7 @@ class LocalAgent(Agent):
             python_path.append(os.environ["PYTHONPATH"])
         if self.import_paths:
             python_path.extend(self.import_paths)
-        env["PYTHONPATH"] = ":".join(python_path)
+        env["PYTHONPATH"] = os.pathsep.join(python_path)
 
         # 4. Values set on the agent via `--env`
         env.update(self.env_vars)

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -93,12 +93,11 @@ def test_populate_env_vars():
     env_vars = agent.populate_env_vars(
         GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})
     )
-    python_path = env_vars.pop("PYTHONPATH", "")
-    assert os.getcwd() in python_path
 
     expected = os.environ.copy()
     expected.update(
         {
+            "PYTHONPATH": os.getcwd() + os.pathsep + expected.get("PYTHONPATH", ""),
             "PREFECT__CLOUD__API": "https://api.prefect.io",
             "PREFECT__CLOUD__AUTH_TOKEN": "TEST_TOKEN",
             "PREFECT__CLOUD__AGENT__LABELS": str(DEFAULT_AGENT_LABELS),

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -87,8 +87,13 @@ def test_local_agent_uses_ip_if_dockerdesktop_hostname(monkeypatch):
     assert "IP" in agent.labels
 
 
-def test_populate_env_vars():
+def test_populate_env_vars(monkeypatch):
     agent = LocalAgent()
+
+    # The python path may be a single item and we want to ensure the correct separator
+    # is added so we will ensure PYTHONPATH has an item in it to start
+    if not os.environ.get("PYTHONPATH", ""):
+        monkeypatch.setenv("PYTHONPATH", "foobar")
 
     env_vars = agent.populate_env_vars(
         GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds support for windows python path creation by using `os.pathsep`

Closes #3544 

## Changes
<!-- What does this PR change? -->

- Uses `os.pathsep` instead of `:` to build the python path

## Importance
<!-- Why is this PR important? -->

Fixes a bug on Windows.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)