### PR TITLE
Fix a few flaky tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,11 @@ def prefect_home_dir():
 def mthread():
     "Multi-threaded executor using dask distributed"
     with Client(
-        processes=False, scheduler_port=0, dashboard_address=":0", n_workers=2
+        processes=False,
+        scheduler_port=0,
+        dashboard_address=":0",
+        n_workers=1,
+        threads_per_worker=2,
     ) as client:
         yield DaskExecutor(client.scheduler.address)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,11 @@ def mproc_local():
 def mproc():
     "Multi-processing executor using dask distributed"
     with Client(
-        processes=True, scheduler_port=0, dashboard_address=":0", n_workers=2
+        processes=True,
+        scheduler_port=0,
+        dashboard_address=":0",
+        n_workers=2,
+        threads_per_worker=1,
     ) as client:
         yield DaskExecutor(client.scheduler.address)
 

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -44,9 +44,9 @@ def test_timeout_handler_actually_stops_execution(timeout_handler, tmpdir):
         wait_time = 1.5
         max_overhead = 0.1
     else:
-        timeout = 1.5
-        wait_time = 2
-        max_overhead = 1
+        timeout = 2.5
+        wait_time = 3
+        max_overhead = 2
 
     def slow_fn(start_path, finish_path, wait_time):
         with open(start_path, "wb"):

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -2,13 +2,11 @@ import os
 import multiprocessing
 import sys
 import threading
-import tempfile
 import time
 
 import pytest
 
 import prefect
-from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.executors import (
     run_with_thread_timeout,
     run_with_multiprocess_timeout,
@@ -37,30 +35,38 @@ def test_timeout_handler_times_out(timeout_handler):
     sys.platform == "win32", reason="Windows doesn't support any timeout logic"
 )
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
-def test_timeout_handler_actually_stops_execution(timeout_handler):
-    with tempfile.TemporaryDirectory() as call_dir:
-        FILE = os.path.join(call_dir, "test.txt")
-        # Increase timeout for multiprocess because its startup time is slower and
-        # the file was not always created
-        TIMEOUT = 1 if timeout_handler is run_with_thread_timeout else 3
-        WRITES = 6
+def test_timeout_handler_actually_stops_execution(timeout_handler, tmpdir):
+    start_path = str(tmpdir.join("started.txt"))
+    finish_path = str(tmpdir.join("finished.txt"))
 
-        def slow_fn():
-            "Runs for TIMEOUT * 2 seconds, writes to file WRITES times"
-            for _ in range(WRITES):
-                with open(FILE, "a") as f:
-                    f.write("called\n")
-                time.sleep((TIMEOUT * 2) / WRITES)
+    if timeout_handler == run_with_thread_timeout:
+        timeout = 1
+        wait_time = 1.5
+        max_overhead = 0.1
+    else:
+        timeout = 1.5
+        wait_time = 2
+        max_overhead = 1
 
-        with pytest.raises(TimeoutError):
-            # We should get less than WRITES lines -- roughly half expected
-            timeout_handler(slow_fn, timeout=TIMEOUT)
+    def slow_fn(start_path, finish_path, wait_time):
+        with open(start_path, "wb"):
+            pass
+        time.sleep(wait_time)
+        with open(start_path, "wb"):
+            pass
 
-        time.sleep(0.5)
-        with open(FILE, "r") as g:
-            contents = g.read()
+    start_time = time.time()
+    stop_time = start_time + wait_time + max_overhead
+    with pytest.raises(TimeoutError):
+        timeout_handler(
+            slow_fn, args=(start_path, finish_path, wait_time), timeout=timeout
+        )
 
-    assert len(contents.split("\n")) < WRITES
+    # Wait untl after we're sure the task would have finished naturally
+    time.sleep(stop_time - time.time())
+
+    assert os.path.exists(start_path)
+    assert not os.path.exists(finish_path)
 
 
 @pytest.mark.skipif(
@@ -72,7 +78,7 @@ def test_timeout_handler_passes_args_and_kwargs_and_returns(timeout_handler):
         return x, y
 
     assert timeout_handler(
-        just_return, args=[5], kwargs=dict(y="yellow"), timeout=2
+        just_return, args=[5], kwargs=dict(y="yellow"), timeout=10
     ) == (
         5,
         "yellow",
@@ -88,13 +94,13 @@ def test_timeout_handler_doesnt_swallow_bad_args(timeout_handler):
         return x, y
 
     with pytest.raises(TypeError):
-        timeout_handler(do_nothing, timeout=2)
+        timeout_handler(do_nothing, timeout=10)
 
     with pytest.raises(TypeError):
-        timeout_handler(do_nothing, args=[5], kwargs=dict(z=10), timeout=2)
+        timeout_handler(do_nothing, args=[5], kwargs=dict(z=10), timeout=10)
 
     with pytest.raises(TypeError):
-        timeout_handler(do_nothing, args=[5], kwargs=dict(y="s", z=10), timeout=2)
+        timeout_handler(do_nothing, args=[5], kwargs=dict(y="s", z=10), timeout=10)
 
 
 @pytest.mark.skipif(
@@ -106,7 +112,7 @@ def test_timeout_handler_reraises(timeout_handler):
         raise ValueError("test")
 
     with pytest.raises(ValueError, match="test"):
-        timeout_handler(do_something, timeout=2)
+        timeout_handler(do_something, timeout=10)
 
 
 # Define a top-level helper function for a null-op process target, must be defined
@@ -125,8 +131,9 @@ def test_timeout_handler_allows_function_to_spawn_new_process(timeout_handler):
         p.start()
         p.join()
         p.terminate()
+        return "hello"
 
-    assert timeout_handler(my_process, timeout=3) is None
+    assert timeout_handler(my_process, timeout=10) == "hello"
 
 
 @pytest.mark.skipif(
@@ -138,8 +145,9 @@ def test_timeout_handler_allows_function_to_spawn_new_thread(timeout_handler):
         t = threading.Thread(target=lambda: 5)
         t.start()
         t.join()
+        return "hello"
 
-    assert timeout_handler(my_thread, timeout=3) is None
+    assert timeout_handler(my_thread, timeout=10) == "hello"
 
 
 @pytest.mark.skipif(
@@ -147,7 +155,6 @@ def test_timeout_handler_allows_function_to_spawn_new_thread(timeout_handler):
 )
 @pytest.mark.parametrize("timeout_handler", TIMEOUT_HANDLERS)
 def test_timeout_handler_doesnt_do_anything_if_no_timeout(timeout_handler):
-    assert timeout_handler(lambda: 4, timeout=2) == 4
     assert timeout_handler(lambda: 4) == 4
 
 
@@ -160,7 +167,7 @@ def test_timeout_handler_preserves_context(timeout_handler):
         return prefect.context.get("test_key")
 
     with prefect.context(test_key=42):
-        res = timeout_handler(my_fun, args=[2], timeout=2)
+        res = timeout_handler(my_fun, args=[2], timeout=10)
 
     assert res == 42
 
@@ -169,7 +176,7 @@ def test_timeout_handler_preserves_context(timeout_handler):
     sys.platform == "win32", reason="Windows doesn't support any timeout logic"
 )
 def test_run_with_thread_timeout_preserves_logging(caplog):
-    run_with_thread_timeout(prefect.Flow("logs").run, timeout=2)
+    run_with_thread_timeout(prefect.Flow("logs").run, timeout=10)
     assert len(caplog.messages) >= 2  # 1 INFO to start, 1 INFO to end
 
 
@@ -180,7 +187,7 @@ def test_run_with_multiprocess_timeout_preserves_logging(capfd):
     """
     Requires fd capturing because the subprocess output won't be captured by caplog
     """
-    run_with_multiprocess_timeout(prefect.Flow("logs").run, timeout=2)
+    run_with_multiprocess_timeout(prefect.Flow("logs").run, timeout=10)
     stdout = capfd.readouterr().out
     assert "Beginning Flow run" in stdout
     assert "Flow run SUCCESS" in stdout


### PR DESCRIPTION
Hard to know if this is effective without a few tests runs

- Reduce resource usage for dask clusters, to hopefully fix issues on resource constrained CI systems
- Fixup some of the timeout tests to hopefully be less flaky on Circle CI. Note that the changes shouldn't make the tests take any longer (the longer timeouts are for tests that should never timeout).