### PR TITLE
fix(azure): need to use BlobServiceClient with the new version

### DIFF
--- a/changes/issue3562.yaml
+++ b/changes/issue3562.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Use `BlobServiceClient` instead of `BlockBlobService` to connect to azure blob in azure tasks - [#3562](https://github.com/PrefectHQ/prefect/pull/3562)"
+
+contributor:
+  - "[Kfir Stri](https://github.com/kfirstri)"

--- a/src/prefect/tasks/azure/blobstorage.py
+++ b/src/prefect/tasks/azure/blobstorage.py
@@ -56,7 +56,9 @@ class BlobStorageDownload(Task):
         # get Azure credentials
         azure_credentials = Secret(azure_credentials_secret).get()
 
-        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(conn_str=azure_credentials)
+        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(
+            conn_str=azure_credentials
+        )
 
         client = blob_service.get_blob_client(container=container, blob=blob_name)
         content_string = client.download_blob().content_as_text()
@@ -116,7 +118,9 @@ class BlobStorageUpload(Task):
         # get Azure credentials
         azure_credentials = Secret(azure_credentials_secret).get()
 
-        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(conn_str=azure_credentials)
+        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(
+            conn_str=azure_credentials
+        )
 
         # create key if not provided
         if blob_name is None:

--- a/src/prefect/tasks/azure/blobstorage.py
+++ b/src/prefect/tasks/azure/blobstorage.py
@@ -56,7 +56,7 @@ class BlobStorageDownload(Task):
         # get Azure credentials
         azure_credentials = Secret(azure_credentials_secret).get()
 
-        blob_service = azure.storage.blob.BlockBlobService(conn_str=azure_credentials)
+        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(conn_str=azure_credentials)
 
         client = blob_service.get_blob_client(container=container, blob=blob_name)
         content_string = client.download_blob().content_as_text()
@@ -116,7 +116,7 @@ class BlobStorageUpload(Task):
         # get Azure credentials
         azure_credentials = Secret(azure_credentials_secret).get()
 
-        blob_service = azure.storage.blob.BlockBlobService(conn_str=azure_credentials)
+        blob_service = azure.storage.blob.BlobServiceClient.from_connection_string(conn_str=azure_credentials)
 
         # create key if not provided
         if blob_name is None:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
azure-blob-storage library used to have a BlockBlobService class but it was changed to BlobServiceClient, so i changed the Task to create the blob_service using the new class




## Changes
Instead of using `BlockBlobService` I used `BlobServiceClient.from_connection_string(conn_str=azure_credentials)`




## Importance
Today when using the azure tasks the task fails because `BlockBlobService` does not exists




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)