### PR TITLE
Cache load enhancement

### DIFF
--- a/changes/issue3378.yaml
+++ b/changes/issue3378.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Don't stop execution if the task runner fails to load a cached result - [#3378](https://github.com/PrefectHQ/prefect/issues/3378)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -268,7 +268,7 @@ class CloudTaskRunner(TaskRunner):
                     ):
                         try:
                             return candidate_state.load_result(self.result)
-                        except Exception as exc:
+                        except Exception:
                             location = getattr(
                                 candidate_state._result, "location", None
                             )

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -269,8 +269,12 @@ class CloudTaskRunner(TaskRunner):
                         try:
                             return candidate_state.load_result(self.result)
                         except Exception as exc:
+                            location = getattr(
+                                candidate_state._result, "location", None
+                            )
                             self.logger.warning(
-                                f"Failed to load cached state data from {candidate_state._result.location}."
+                                f"Failed to load cached state data from {location}.",
+                                exc_info=True,
                             )
 
                 self.logger.debug(

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -266,7 +266,12 @@ class CloudTaskRunner(TaskRunner):
                         sanitized_inputs,
                         prefect.context.get("parameters"),
                     ):
-                        return candidate_state.load_result(self.result)
+                        try:
+                            return candidate_state.load_result(self.result)
+                        except Exception as exc:
+                            self.logger.warning(
+                                f"Failed to load cached state data from {candidate_state._result.location}."
+                            )
 
                 self.logger.debug(
                     "Task '{name}': can't use cache because no candidate Cached states "


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Currently, if the data that is referenced by a `Cached` state is deleted by an external process but that state is still considered valid, Prefect will throw an error and fail the task run that is checking against the cached state.  This is undesirable, as a failure to load cached data is equivalent to the cache being invalid and we should treat it as such.

## Changes
<!-- What does this PR change? -->
This PR captures errors to load cached data and logs them, but allows the pipeline to continue on.



## Importance
<!-- Why is this PR important? -->
Much clearer UX and fixes the currently undesirable behavior.

Closes #3378 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)