### PR TITLE
[docs] clarify how LocalResult works with a remote executor

### DIFF
--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -12,6 +12,12 @@ class LocalResult(Result):
     """
     Result that is written to and retrieved from the local file system.
 
+    **Note**: "local" refers to where the flow's tasks execute, which is not
+    necessarily the same as the place that `flow.run()` runs from. So, for
+    example, if you use a `LocalEnvironment` with a `DaskExecutor` pointed at
+    a remote Dask cluster, `LocalResult` files will be written to the Dask
+    workers' file system.
+
     **Note**: If this result raises a `PermissionError` that could mean it is attempting
     to write results to a directory that it is not permissioned for. In that case it may be
     helpful to specify a specific `dir` for that result instance.


### PR DESCRIPTION
## Summary

This PR comes out of a discussion in Prefect Community Slack today: https://prefect-community.slack.com/archives/CL09KU1K7/p1603751503170700.

## Changes

Updates the documentation for `LocalResult` to describe what "local" means when you are using a remote executor.

## Importance

This PR clarifies something in the `LocalResult` documentation that I think can be confusing in hybrid execution cases. 

@bhperry and I were trying to use `LocalResult`  to get the result of a flow run today and were surprised when it worked differently than we'd expected

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Thanks for your time and consideration.