### PR TITLE
add cursor_type param to task, unit test

### DIFF
--- a/changes/pr3574.yaml
+++ b/changes/pr3574.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add option to select `cursor_type` for MySQLFetch task - [#3574](https://github.com/PrefectHQ/prefect/pull/3574)"
+
+contributor:
+  - "[Michael Marinaccio](https://github.com/mmarinaccio)"

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -196,9 +196,7 @@ class MySQLFetch(Task):
         elif isinstance(cursor_type, str):
             cursor_class = cursor_types.get(cursor_type.lower())
         else:
-            raise TypeError(
-                f"'cursor_type' must be of type str or a full cursor class, got {type(cursor_type)}"
-            )
+            cursor_class = None
 
         if not cursor_class:
             raise TypeError(

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -108,7 +108,8 @@ class MySQLFetch(Task):
         - query (str, optional): query to execute against database
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset of the query, defaults to "utf8mb4"
-        - cursor_type (Union[str, Callable], optional): cursor type you want to use (defaults to standard Cursor class)
+        - cursor_type (Union[str, Callable], optional): The cursor type to use.
+            Can be `'cursor'` (the default), `'dictcursor'`, or a full cursor class.
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -164,7 +165,8 @@ class MySQLFetch(Task):
             - query (str, optional): query to execute against database
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - charset (str, optional): charset of the query, defaults to "utf8mb4"
-            - cursor_type (Union[str, Callable], optional): cursor type you want to use (defaults to standard Cursor class)
+            - cursor_type (Union[str, Callable], optional): The cursor type to use.
+                Can be `'cursor'` (the default), `'dictcursor'`, or a full cursor class.
 
         Returns:
             - results (tuple or list of tuples): records from provided query

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -109,7 +109,8 @@ class MySQLFetch(Task):
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset of the query, defaults to "utf8mb4"
         - cursor_type (Union[str, Callable], optional): The cursor type to use.
-            Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`, or a full cursor class.
+            Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
+            or a full cursor class.
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -166,7 +167,8 @@ class MySQLFetch(Task):
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - charset (str, optional): charset of the query, defaults to "utf8mb4"
             - cursor_type (Union[str, Callable], optional): The cursor type to use.
-                Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`, or a full cursor class.
+                Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
+                or a full cursor class.
 
         Returns:
             - results (tuple or list of tuples): records from provided query
@@ -200,7 +202,8 @@ class MySQLFetch(Task):
 
         if not cursor_class:
             raise TypeError(
-                f"'cursor_type' should be one of {list(cursor_types.keys())} or a full cursor class, got {cursor_type}"
+                f"'cursor_type' should be one of {list(cursor_types.keys())} or a "
+                f"full cursor class, got {cursor_type}"
             )
 
         conn = pymysql.connect(

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -34,7 +34,7 @@ class MySQLExecute(Task):
         query: str = None,
         commit: bool = False,
         charset: str = "utf8mb4",
-        **kwargs: Any
+        **kwargs: Any,
     ):
         self.db_name = db_name
         self.user = user
@@ -126,7 +126,7 @@ class MySQLFetch(Task):
         commit: bool = False,
         charset: str = "utf8mb4",
         cursor_type: Union[str, Callable] = "cursor",
-        **kwargs: Any
+        **kwargs: Any,
     ):
         self.db_name = db_name
         self.user = user
@@ -141,7 +141,9 @@ class MySQLFetch(Task):
         self.cursor_type = cursor_type
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("fetch", "fetch_count", "query", "commit", "charset", "cursor_type")
+    @defaults_from_attrs(
+        "fetch", "fetch_count", "query", "commit", "charset", "cursor_type"
+    )
     def run(
         self,
         query: str,
@@ -180,16 +182,18 @@ class MySQLFetch(Task):
 
         cursor_types = {
             "cursor": pymysql.cursors.Cursor,
-            "dictcursor": pymysql.cursors.DictCursor
+            "dictcursor": pymysql.cursors.DictCursor,
         }
 
         if callable(cursor_type):
             cursor_class = cursor_type
         else:
             cursor_class = cursor_types.get(cursor_type.lower())
-        
+
         if cursor_class is None or cursor_class not in cursor_types.values():
-            raise TypeError(f"'cursor_type' should be one of ('cursor', 'dictcursor') or the callable equivalent, got {cursor_type}")
+            raise TypeError(
+                f"'cursor_type' should be one of ('cursor', 'dictcursor') or the callable equivalent, got {cursor_type}"
+            )
 
         conn = pymysql.connect(
             host=self.host,
@@ -198,7 +202,7 @@ class MySQLFetch(Task):
             db=self.db_name,
             charset=self.charset,
             port=self.port,
-            cursorclass=cursor_class
+            cursorclass=cursor_class,
         )
 
         try:

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -178,15 +178,18 @@ class MySQLFetch(Task):
                 "The 'fetch' parameter must be one of the following - ('one', 'many', 'all')"
             )
 
-        if cursor_type not in {"cursor", "dict_cursor"}:
-            raise ValueError(
-                f"Unsupported cursor_type '{cursor_type}'. Please choose one of the following - ('cursor', 'dict_cursor')"
-            )
+        cursor_types = {
+            "cursor": pymysql.cursors.Cursor,
+            "dictcursor": pymysql.cursors.DictCursor
+        }
 
-        if cursor_type == "cursor":
-            cursor_class = pymysql.cursors.Cursor
+        if callable(cursor_type):
+            cursor_class = cursor_type
         else:
-            cursor_class = pymysql.cursors.DictCursor
+            cursor_class = cursor_types.get(cursor_type.lower())
+        
+        if cursor_class is None or cursor_class not in cursor_types.values():
+            raise TypeError(f"'cursor_type' should be one of ('cursor', 'dictcursor') or the callable equivalent, got {cursor_type}")
 
         conn = pymysql.connect(
             host=self.host,

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -3,7 +3,7 @@ from prefect.utilities.tasks import defaults_from_attrs
 
 import pymysql.cursors
 import logging
-from typing import Any
+from typing import Any, Callable, Union
 
 
 class MySQLExecute(Task):
@@ -108,7 +108,7 @@ class MySQLFetch(Task):
         - query (str, optional): query to execute against database
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset of the query, defaults to "utf8mb4"
-        - cursor_type (str, optional): cursor type you want to use (defaults to standard Cursor class)
+        - cursor_type (Union[str, Callable], optional): cursor type you want to use (defaults to standard Cursor class)
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -125,7 +125,7 @@ class MySQLFetch(Task):
         query: str = None,
         commit: bool = False,
         charset: str = "utf8mb4",
-        cursor_type: str = "cursor",
+        cursor_type: Union[str, Callable] = "cursor",
         **kwargs: Any
     ):
         self.db_name = db_name
@@ -149,7 +149,7 @@ class MySQLFetch(Task):
         fetch_count: int = 10,
         commit: bool = False,
         charset: str = "utf8mb4",
-        cursor_type: str = "cursor",
+        cursor_type: Union[str, Callable] = "cursor",
     ) -> Any:
         """
         Task run method. Executes a query against MySQL database and fetches results.
@@ -162,7 +162,7 @@ class MySQLFetch(Task):
             - query (str, optional): query to execute against database
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - charset (str, optional): charset of the query, defaults to "utf8mb4"
-            - cursor_type (str, optional): cursor type you want to use (defaults to standard Cursor class)
+            - cursor_type (Union[str, Callable], optional): cursor type you want to use (defaults to standard Cursor class)
 
         Returns:
             - results (tuple or list of tuples): records from provided query

--- a/tests/tasks/mysql/test_mysql.py
+++ b/tests/tasks/mysql/test_mysql.py
@@ -54,21 +54,21 @@ class TestMySQLFetch:
         assert task.cursor_type == pymysql.cursors.DictCursor
 
     def test_unsupported_cursor_type_str_param_raises(self):
-        cursor_type = "sscursor"
+        cursor_type = "unsupportedcursor"
+
         task = MySQLFetch(db_name="test", user="test", password="test", host="test")
         with pytest.raises(
             TypeError,
-            match=f"'cursor_type' should be one of \('cursor', 'dictcursor'\) or the callable equivalent, got {cursor_type}",
+            match=f"'cursor_type' should be one of \['cursor', 'dictcursor', 'sscursor', 'ssdictcursor'\] or a full cursor class, got {cursor_type}",
         ):
             task.run(query="SELECT * FROM some_table", cursor_type=cursor_type)
 
-    def test_unsupported_cursor_type_class_param_raises(self):
-        cursor_type = pymysql.cursors.SSCursor
+    def test_bad_cursor_type_param_raises(self):
+        cursor_type = ["cursor"]
+
         task = MySQLFetch(db_name="test", user="test", password="test", host="test")
         with pytest.raises(
             TypeError,
-            match=f"'cursor_type' should be one of \('cursor', 'dictcursor'\) or the callable equivalent, got {cursor_type}",
+            match=f"'cursor_type' must be of type str or a full cursor class, got {type(cursor_type)}",
         ):
-            task.run(
-                query="SELECT * FROM some_table", cursor_type=pymysql.cursors.SSCursor
-            )
+            task.run(query="SELECT * FROM some_table", cursor_type=["cursor"])

--- a/tests/tasks/mysql/test_mysql.py
+++ b/tests/tasks/mysql/test_mysql.py
@@ -31,3 +31,11 @@ class TestMySQLFetch:
             match="The 'fetch' parameter must be one of the following - \('one', 'many', 'all'\)",
         ):
             task.run(query="SELECT * FROM some_table", fetch="not a valid parameter")
+
+    def test_bad_cursor_type_param_raises(self):
+        task = MySQLFetch(db_name="test", user="test", password="test", host="test", cursor_type="cursor")
+        with pytest.raises(
+            ValueError,
+            match="Unsupported cursor_type 'invalid cursor'. Please choose one of the following - \('cursor', 'dict_cursor'\)",
+        ):
+            task.run(query="SELECT * FROM some_table", cursor_type="invalid cursor")

--- a/tests/tasks/mysql/test_mysql.py
+++ b/tests/tasks/mysql/test_mysql.py
@@ -34,11 +34,23 @@ class TestMySQLFetch:
             task.run(query="SELECT * FROM some_table", fetch="not a valid parameter")
 
     def test_construction_with_cursor_type_str(self):
-        task = MySQLFetch(db_name="test", user="test", password="test", host="test", cursor_type='dictcursor')
+        task = MySQLFetch(
+            db_name="test",
+            user="test",
+            password="test",
+            host="test",
+            cursor_type="dictcursor",
+        )
         assert task.cursor_type == "dictcursor"
 
     def test_construction_with_cursor_type_class(self):
-        task = MySQLFetch(db_name="test", user="test", password="test", host="test", cursor_type=pymysql.cursors.DictCursor)
+        task = MySQLFetch(
+            db_name="test",
+            user="test",
+            password="test",
+            host="test",
+            cursor_type=pymysql.cursors.DictCursor,
+        )
         assert task.cursor_type == pymysql.cursors.DictCursor
 
     def test_unsupported_cursor_type_str_param_raises(self):
@@ -57,4 +69,6 @@ class TestMySQLFetch:
             TypeError,
             match=f"'cursor_type' should be one of \('cursor', 'dictcursor'\) or the callable equivalent, got {cursor_type}",
         ):
-            task.run(query="SELECT * FROM some_table", cursor_type=pymysql.cursors.SSCursor)
+            task.run(
+                query="SELECT * FROM some_table", cursor_type=pymysql.cursors.SSCursor
+            )

--- a/tests/tasks/mysql/test_mysql.py
+++ b/tests/tasks/mysql/test_mysql.py
@@ -63,7 +63,7 @@ class TestMySQLFetch:
         ):
             task.run(query="SELECT * FROM some_table", cursor_type=cursor_type)
 
-    def test_bad_cursor_type_param_raises(self):
+    def test_bad_cursor_type_param_type_raises(self):
         cursor_type = ["cursor"]
 
         task = MySQLFetch(db_name="test", user="test", password="test", host="test")

--- a/tests/tasks/mysql/test_mysql.py
+++ b/tests/tasks/mysql/test_mysql.py
@@ -64,11 +64,9 @@ class TestMySQLFetch:
             task.run(query="SELECT * FROM some_table", cursor_type=cursor_type)
 
     def test_bad_cursor_type_param_type_raises(self):
-        cursor_type = ["cursor"]
-
         task = MySQLFetch(db_name="test", user="test", password="test", host="test")
         with pytest.raises(
             TypeError,
-            match=f"'cursor_type' must be of type str or a full cursor class, got {type(cursor_type)}",
+            match=f"'cursor_type' should be one of \['cursor', 'dictcursor', 'sscursor', 'ssdictcursor'\] or a full cursor class, got \['cursor'\]",
         ):
             task.run(query="SELECT * FROM some_table", cursor_type=["cursor"])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Add support for the Pymysql `DictCursor` class in `MySQLFetch`.



## Changes
This PR adds an extra `cursor_type` argument to `MySQLFetch`, for which the user can define `"cursor"`, `"dict_cursor"`, or leave blank. A new conditional has also been added to the task's `run` method to choose the corresponding cursor class which is then set in `pymysql.connect`.




## Importance
There are cases where it's useful to have column names as part of the mysql fetch response, especially in the context of task mapping where downstream tasks behave or build new queries according to the particular column / values inputted. In such a case, without the dict cursor, downstream tasks must be aware of the schema or simply have hardcoded the index value of the column being observed.




## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)