### PR TITLE
Add ECS run config and agent

### DIFF
--- a/changes/pr3585.yaml
+++ b/changes/pr3585.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add new `ECSAgent` and `ECSRun` run config - [#3585](https://github.com/PrefectHQ/prefect/pull/3585)"

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -169,7 +169,7 @@ def format_lists(doc):
         for item, descr in list_items:
             block += f"{li_tag}`{item}`:{descr}</li>"
         list_block = f"{ul_tag}{block}</ul>"
-        doc = doc.replace(items + "\n\n", list_block, 1).replace(items, list_block, 1)
+        doc = doc.replace(items + "\n", list_block, 1).replace(items, list_block, 1)
     return doc.replace("\n\nRaises:", "Raises:")
 
 

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -516,6 +516,11 @@ title = "Fargate Agent"
 module = "prefect.agent.fargate"
 classes = ["FargateAgent"]
 
+[pages.agent.ecs]
+title = "ECS Agent"
+module = "prefect.agent.ecs"
+classes = ["ECSAgent"]
+
 [pages.utilities.collections]
 title = "Collections"
 module = "prefect.utilities.collections"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -235,7 +235,7 @@ classes = ["DaskKubernetesEnvironment", "DaskCloudProviderEnvironment", "Fargate
 [pages.run_configs]
 title = "Run Configuration"
 module = "prefect.run_configs"
-classes = ["RunConfig", "LocalRun", "DockerRun", "KubernetesRun"]
+classes = ["RunConfig", "LocalRun", "DockerRun", "KubernetesRun", "ECSRun"]
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -293,11 +293,11 @@ def test_format_list_on_normal_doc():
         '<li class="args">'
         "`x (bool)`: it's x\n        </li>"
         '<li class="args">'
-        "`y (bool)`: it's y</li></ul>    "
+        "`y (bool)`: it's y</li></ul>\n    "
         'Returns:\n        <ul class="args">'
         '<li class="args">whatever you want</li></ul>'
         '\n\n    Raises:\n        <ul class="args">'
-        '<li class="args">`NotImplementedError`: because it doesnt exist</li></ul>    '
+        '<li class="args">`NotImplementedError`: because it doesnt exist</li></ul>\n    '
         'References:\n        <ul class="args">'
         '<li class="args">`Example`: https://example.com\n    </li></ul>'
         ""

--- a/src/prefect/agent/__init__.py
+++ b/src/prefect/agent/__init__.py
@@ -6,3 +6,4 @@ import prefect.agent.docker
 import prefect.agent.fargate
 import prefect.agent.kubernetes
 import prefect.agent.local
+import prefect.agent.ecs

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -280,6 +280,10 @@ class Agent:
             self.cleanup()
 
     def setup(self) -> None:
+        print(ascii_name)
+
+        self.on_startup()
+
         self.agent_connect()
 
         if self.agent_address:
@@ -357,6 +361,13 @@ class Agent:
         )
         self._heartbeat_thread.start()
 
+    def on_startup(self) -> None:
+        """
+        Invoked when the agent is starting up.
+
+        Intended as a hook for child classes to optionally implement.
+        """
+
     def on_shutdown(self) -> None:
         """
         Invoked when the event loop is exiting and the agent is shutting down. Intended
@@ -367,7 +378,6 @@ class Agent:
         """
         Verify agent connection to Prefect API by querying
         """
-        print(ascii_name)
         self.logger.info(
             "Starting {} with labels {}".format(type(self).__name__, self.labels)
         )

--- a/src/prefect/agent/ecs/__init__.py
+++ b/src/prefect/agent/ecs/__init__.py
@@ -1,0 +1,1 @@
+from prefect.agent.ecs.agent import ECSAgent

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -1,0 +1,194 @@
+import json
+from typing import Iterable
+
+from prefect.agent import Agent
+
+
+def parse_run_task_options(opts: list) -> dict:
+    """Parse `--run-task-option` inputs to `prefect agent start`.
+
+    Args:
+        - opts (list): A list of strings formatted as `"{key}={value}"`,
+            where value may be a JSON-compatible value.
+
+    Returns:
+        - dict: the parsed parameters
+    """
+    run_task_kwargs = {}
+    for item in opts:
+        try:
+            key, value = item.split("=")
+        except Exception:
+            raise ValueError(f"Malformed --run-task-option `{item}`") from None
+        try:
+            value = json.loads(value)
+        except Exception as exc:
+            # If it looks like a list/dict then it's poorly formatted
+            if any(c in value for c in "{}[]"):
+                raise ValueError(
+                    f"Error parsing --run-task-option value `{item}`: {str(exc)}"
+                ) from None
+        run_task_kwargs[key] = value
+    return run_task_kwargs
+
+
+class ECSAgent(Agent):
+    """
+    Agent which deploys flow runs as ECS tasks.
+
+    **Note**: if AWS authentication kwargs such as `aws_access_key_id` and `aws_secret_key_id`
+    are not provided they will be read from the environment.
+
+    Args:
+        - agent_config_id (str, optional): An optional agent configuration ID that can be used to set
+            configuration based on an agent from a backend API. If set all configuration values will be
+            pulled from backend agent configuration.
+        - name (str, optional): An optional name to give this agent. Can also be set through
+            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
+        - labels (List[str], optional): a list of labels, which are arbitrary string
+            identifiers used by Prefect Agents when polling for work
+        - env_vars (dict, optional): a dictionary of environment variables and values that will
+            be set on each flow run that this agent submits for execution
+        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
+            for flow runs; defaults to infinite
+        - agent_address (str, optional):  Address to serve internal api at. Currently this is
+            just health checks for use by an orchestration layer. Leave blank for no api server
+            (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
+            and all deployed flow runs
+        - default_task_definition (str, optional): The name of a default task definition to
+            use when one isn't specified on a flow. Can provide either the `family:revision`,
+            just the `family` (in which case the latest active revision is used), or the full
+            task definition ARN. If provided, the definition must already be registered. If
+            not provided, a default task definition will be registered and used.
+        - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
+            client. Defaults to the value set in the environment variable
+            `AWS_ACCESS_KEY_ID` or `None`
+        - aws_secret_access_key (str, optional): AWS secret access key for connecting
+            the boto3 client. Defaults to the value set in the environment variable
+            `AWS_SECRET_ACCESS_KEY` or `None`
+        - aws_session_token (str, optional): AWS session key for connecting the boto3
+            client. Defaults to the value set in the environment variable
+            `AWS_SESSION_TOKEN` or `None`
+        - region_name (str, optional): AWS region name for connecting the boto3 client.
+            Defaults to the value set in the environment variable `AWS_DEFAULT_REGION` or `None`
+        - cluster (str, optional): The AWS cluster to use, defaults to `"default"` if not provided.
+        - launch_type (str, optional): The launch type to use, either `"FARGATE"` (default) or `"EC2"`.
+        - run_task_kwargs (dict, optional): Keyword arguments to pass to `run_task` when starting a task.
+        - botocore_config (dict, optional): botocore configuration options to be passed to the
+            boto3 client.
+            https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    def __init__(  # type: ignore
+        self,
+        agent_config_id: str = None,
+        name: str = None,
+        labels: Iterable[str] = None,
+        env_vars: dict = None,
+        max_polls: int = None,
+        agent_address: str = None,
+        no_cloud_logs: bool = False,
+        default_task_definition: str = None,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        aws_session_token: str = None,
+        region_name: str = None,
+        cluster: str = None,
+        launch_type: str = None,
+        run_task_kwargs: dict = None,
+        botocore_config: dict = None,
+    ) -> None:
+        super().__init__(
+            agent_config_id=agent_config_id,
+            name=name,
+            labels=labels,
+            env_vars=env_vars,
+            max_polls=max_polls,
+            agent_address=agent_address,
+            no_cloud_logs=no_cloud_logs,
+        )
+
+        from botocore.config import Config
+
+        self.cluster = cluster
+        self.launch_type = launch_type.upper() if launch_type else "FARGATE"
+        self.run_task_kwargs = run_task_kwargs.copy() if run_task_kwargs else {}
+        self.default_task_definition = default_task_definition
+        self.boto_kwargs = dict(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            region_name=region_name,
+            config=Config(**(botocore_config or {})),
+        )
+        self.ecs_client = None
+
+    def on_startup(self):
+        from prefect.utilities.aws import get_boto_client
+
+        self.ecs_client = get_boto_client("ecs", **self.boto_kwargs)
+
+        if not self.default_task_definition:
+            self.register_default_task_definition()
+
+        self.logger.info(
+            "Using default task definition: %r", self.default_task_definition
+        )
+
+        if self.launch_type == "FARGATE" and not self.run_task_kwargs.get(
+            "networkConfiguration"
+        ):
+            self.run_task_kwargs[
+                "networkConfiguration"
+            ] = self.get_default_network_configuration()
+
+    def register_default_task_definition(self):
+        try:
+            self.ecs_client.describe_task_definition(taskDefinition="prefect-default")
+            exists = True
+        except Exception:
+            exists = False
+
+        if not exists:
+            self.logger.info("Registering default task definition `prefect-default`")
+            self.ecs_client.register_task_definition(
+                family="prefect-default",
+                networkMode="awsvpc",
+                cpu="1024",
+                memory="2048",
+                containerDefinitions=[
+                    {"name": "flow", "image": "prefecthq/prefect:latest"}
+                ],
+            )
+
+        self.default_task_definition = "prefect-default"
+
+    def get_default_network_configuration(self):
+        from prefect.utilities.aws import get_boto_client
+
+        self.logger.debug("Inferring default `networkConfiguration`...")
+
+        ec2 = get_boto_client("ec2", **self.boto_kwargs)
+        vpcs = ec2.describe_vpcs(Filters=[{"Name": "isDefault", "Values": ["true"]}])[
+            "Vpcs"
+        ]
+        if vpcs:
+            vpc_id = vpcs[0]["VpcId"]
+            subnets = ec2.describe_subnets(
+                Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+            )["Subnets"]
+            if subnets:
+                config = {
+                    "subnets": [s["SubnetId"] for s in subnets],
+                    "assignPublicIp": "ENABLED",
+                }
+                self.logger.debug("Using networkConfiguration=%r", config)
+                return config
+
+        msg = (
+            "Failed to infer default networkConfiguration, please explicitly "
+            "configure using `--run-param networkConfiguration=...`"
+        )
+        self.logger.error(msg)
+        raise ValueError(msg)

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -1,7 +1,23 @@
+import os
 import json
-from typing import Iterable
+from copy import deepcopy
+from typing import Iterable, Dict, Any
 
+import slugify
+import yaml
+
+from prefect import config
 from prefect.agent import Agent
+from prefect.run_configs import ECSRun
+from prefect.serialization.run_config import RunConfigSchema
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
+from prefect.utilities.filesystems import read_bytes_from_path
+from prefect.utilities.graphql import GraphQLResult
+
+
+DEFAULT_TASK_DEFINITION_PATH = os.path.join(
+    os.path.dirname(__file__), "task_definition.yaml"
+)
 
 
 def parse_run_task_options(opts: list) -> dict:
@@ -36,48 +52,66 @@ class ECSAgent(Agent):
     """
     Agent which deploys flow runs as ECS tasks.
 
-    **Note**: if AWS authentication kwargs such as `aws_access_key_id` and `aws_secret_key_id`
-    are not provided they will be read from the environment.
+    **Note**: if AWS authentication kwargs such as `aws_access_key_id` and
+    `aws_secret_access_key` are not provided they will be read from the
+    environment.
 
     Args:
-        - agent_config_id (str, optional): An optional agent configuration ID that can be used to set
-            configuration based on an agent from a backend API. If set all configuration values will be
-            pulled from backend agent configuration.
-        - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string
-            identifiers used by Prefect Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will
-            be set on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
-            for flow runs; defaults to infinite
-        - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server
-            (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
-            and all deployed flow runs
-        - default_task_definition (str, optional): The name of a default task definition to
-            use when one isn't specified on a flow. Can provide either the `family:revision`,
-            just the `family` (in which case the latest active revision is used), or the full
-            task definition ARN. If provided, the definition must already be registered. If
-            not provided, a default task definition will be registered and used.
-        - aws_access_key_id (str, optional): AWS access key id for connecting the boto3
-            client. Defaults to the value set in the environment variable
-            `AWS_ACCESS_KEY_ID` or `None`
-        - aws_secret_access_key (str, optional): AWS secret access key for connecting
-            the boto3 client. Defaults to the value set in the environment variable
-            `AWS_SECRET_ACCESS_KEY` or `None`
-        - aws_session_token (str, optional): AWS session key for connecting the boto3
-            client. Defaults to the value set in the environment variable
-            `AWS_SESSION_TOKEN` or `None`
-        - region_name (str, optional): AWS region name for connecting the boto3 client.
-            Defaults to the value set in the environment variable `AWS_DEFAULT_REGION` or `None`
-        - cluster (str, optional): The AWS cluster to use, defaults to `"default"` if not provided.
-        - launch_type (str, optional): The launch type to use, either `"FARGATE"` (default) or `"EC2"`.
-        - run_task_kwargs (dict, optional): Keyword arguments to pass to `run_task` when starting a task.
-        - botocore_config (dict, optional): botocore configuration options to be passed to the
-            boto3 client.
-            https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+        - agent_config_id (str, optional): An optional agent configuration ID
+            that can be used to set configuration based on an agent from a
+            backend API. If set all configuration values will be pulled from
+            the backend agent configuration.
+        - name (str, optional): An optional name to give this agent. Can also
+            be set through the environment variable `PREFECT__CLOUD__AGENT__NAME`.
+            Defaults to "agent".
+        - labels (List[str], optional): A list of labels, which are arbitrary
+            string identifiers used by Prefect Agents when polling for work.
+        - env_vars (dict, optional): A dictionary of environment variables and
+            values that will be set on each flow run that this agent submits
+            for execution.
+        - max_polls (int, optional): Maximum number of times the agent will
+            poll Prefect Cloud for flow runs; defaults to infinite.
+        - agent_address (str, optional):  Address to serve internal api at.
+            Currently this is just health checks for use by an orchestration
+            layer. Leave blank for no api server (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend
+            for this agent and all deployed flow runs
+        - task_definition_path (str, optional): Path to a task definition
+            template to use when defining new tasks. If not provided, the
+            default template will be used.
+        - aws_access_key_id (str, optional): AWS access key id for connecting
+            the boto3 client. If not provided, will be loaded from your
+            environment (via either the `AWS_ACCESS_KEY_ID` environment
+            variable, or the `~/.aws/config` file). See [the boto3 credentials
+            docs][1] for more information.
+        - aws_secret_access_key (str, optional): AWS secret access key for
+            connecting the boto3 client. If not provided, will be loaded from
+            your environment (via either the `AWS_SECRET_ACCESS_KEY`
+            environment variable, or the `~/.aws/config` file).
+            See [the boto3 credentials docs][1] for more information.
+        - aws_session_token (str, optional): AWS session key for connecting the
+            boto3 client. If not provided, will be loaded from your environment
+            (via either the `AWS_SESSION_TOKEN` environment variable, or the
+            `~/.aws/config` file). See [the boto3 credentials docs][1] for more
+            information.
+        - region_name (str, optional): AWS region name to launch ECS tasks in.
+            If not provided, will be loaded from your environment (via either
+            the `AWS_DEFAULT_REGION` environment variable, or the
+            `~/.aws/config` file). See [the boto3 configuration docs][2] for
+            more information.
+        - cluster (str, optional): The AWS cluster to use, defaults to
+            `"default"` if not provided.
+        - launch_type (str, optional): The launch type to use, either
+            `"FARGATE"` (default) or `"EC2"`.
+        - run_task_kwargs (dict, optional): Extra keyword arguments to pass to
+            `run_task` when starting a task.
+        - botocore_config (dict, optional): Additional botocore configuration
+            options to be passed to the boto3 client. See [the boto3
+            configuration docs][2] for more information.
+
+    [1]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+
+    [2]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
     """
 
     def __init__(  # type: ignore
@@ -89,7 +123,7 @@ class ECSAgent(Agent):
         max_polls: int = None,
         agent_address: str = None,
         no_cloud_logs: bool = False,
-        default_task_definition: str = None,
+        task_definition_path: str = None,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: str = None,
@@ -114,26 +148,33 @@ class ECSAgent(Agent):
         self.cluster = cluster
         self.launch_type = launch_type.upper() if launch_type else "FARGATE"
         self.run_task_kwargs = run_task_kwargs.copy() if run_task_kwargs else {}
-        self.default_task_definition = default_task_definition
+        self.task_definition_path = task_definition_path or DEFAULT_TASK_DEFINITION_PATH
+
+        # Load boto configuration. We want to use the standard retry mode by
+        # default (which isn't boto's default due to backwards compatibility).
+        # The logic below lets the user override our default retry mode either
+        # in `botocore_config` or in their aws config file.
+        #
+        # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
+        # for more info.
+        boto_config = Config(**botocore_config or {})
+        if not boto_config.retries:
+            boto_config.retries = {"mode": "standard"}
+
         self.boto_kwargs = dict(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
             region_name=region_name,
-            config=Config(**(botocore_config or {})),
-        )
-        self.ecs_client = None
+            config=boto_config,
+        )  # type: Dict[str, Any]
 
-    def on_startup(self):
+    def on_startup(self) -> None:
         from prefect.utilities.aws import get_boto_client
 
         self.ecs_client = get_boto_client("ecs", **self.boto_kwargs)
-
-        if not self.default_task_definition:
-            self.register_default_task_definition()
-
-        self.logger.info(
-            "Using default task definition: %r", self.default_task_definition
+        self.rgtag_client = get_boto_client(
+            "resourcegroupstaggingapi", **self.boto_kwargs
         )
 
         if self.launch_type == "FARGATE" and not self.run_task_kwargs.get(
@@ -143,28 +184,7 @@ class ECSAgent(Agent):
                 "networkConfiguration"
             ] = self.get_default_network_configuration()
 
-    def register_default_task_definition(self):
-        try:
-            self.ecs_client.describe_task_definition(taskDefinition="prefect-default")
-            exists = True
-        except Exception:
-            exists = False
-
-        if not exists:
-            self.logger.info("Registering default task definition `prefect-default`")
-            self.ecs_client.register_task_definition(
-                family="prefect-default",
-                networkMode="awsvpc",
-                cpu="1024",
-                memory="2048",
-                containerDefinitions=[
-                    {"name": "flow", "image": "prefecthq/prefect:latest"}
-                ],
-            )
-
-        self.default_task_definition = "prefect-default"
-
-    def get_default_network_configuration(self):
+    def get_default_network_configuration(self) -> dict:
         from prefect.utilities.aws import get_boto_client
 
         self.logger.debug("Inferring default `networkConfiguration`...")
@@ -192,3 +212,203 @@ class ECSAgent(Agent):
         )
         self.logger.error(msg)
         raise ValueError(msg)
+
+    def deploy_flow(self, flow_run: GraphQLResult) -> str:
+        """
+        Deploy flow runs on to a k8s cluster as jobs
+
+        Args:
+            - flow_run (GraphQLResult): A GraphQLResult flow run object
+
+        Returns:
+            - str: Information about the deployment
+        """
+        self.logger.info("Deploying flow run %r", flow_run.id)
+
+        # Load and validate the flow's run_config
+        if getattr(flow_run.flow, "run_config", None) is not None:
+            run_config = RunConfigSchema().load(flow_run.flow.run_config)
+            if not isinstance(run_config, ECSRun):
+                self.logger.error(
+                    "Flow run %s has a `run_config` of type `%s`, only `ECSRun` is supported",
+                    flow_run.id,
+                    type(run_config).__name__,
+                )
+                raise TypeError(
+                    "Unsupported RunConfig type: %s" % type(run_config).__name__
+                )
+        else:
+            self.logger.error(
+                "Flow run %s has a null `run_config`, only `ECSRun` is supported",
+                flow_run.id,
+            )
+            raise TypeError("Flow is missing a `run_config`")
+
+        # Check if a task definition already exists
+        taskdef_arn = self.lookup_task_definition_arn(flow_run)
+        if not taskdef_arn:
+            # Register a new task definition
+            self.logger.debug(
+                "Registering new task definition for flow %s", flow_run.flow.id
+            )
+            taskdef = self.generate_task_definition(flow_run, run_config)
+            resp = self.ecs_client.register_task_definition(**taskdef)
+            taskdef_arn = resp["taskDefinition"]["taskDefinitionArn"]
+            self.logger.debug(
+                "Registered task definition %s for flow %s",
+                taskdef_arn,
+                flow_run.flow.id,
+            )
+        else:
+            self.logger.debug(
+                "Using task definition %s for flow %s", taskdef_arn, flow_run.flow.id
+            )
+
+        # Get kwargs to pass to run_task
+        kwargs = self.get_run_task_kwargs(flow_run, run_config)
+
+        resp = self.ecs_client.run_task(task_definition=taskdef_arn, **kwargs)
+        if resp.get("tasks"):
+            task_arn = resp["tasks"][0]["taskArn"]
+            self.logger.debug("Started task %r for flow run %r", task_arn, flow_run.id)
+            return f"Task {task_arn}"
+
+        raise ValueError(
+            "Failed to start task for flow run {0}. Failures: {1}".format(
+                flow_run.id, resp.get("failures")
+            )
+        )
+
+    def get_task_definition_tags(self, flow_run: GraphQLResult) -> dict:
+        return {
+            "prefect:flow-id": flow_run.flow.id,
+            "prefect:flow-version": str(flow_run.flow.version),
+        }
+
+    def lookup_task_definition_arn(self, flow_run: GraphQLResult) -> str:
+        tags = self.get_task_definition_tags(flow_run)
+
+        from botocore.exceptions import ClientError
+
+        try:
+            res = self.rgtag_client.get_resources(
+                TagFilters=[{"Key": k, "Values": [v]} for k, v in tags.items()],
+                ResourceTypeFilters=["ecs:task-definition"],
+            )
+            if res["ResourceTagMappingList"]:
+                return res["ResourceTagMappingList"][0]["ResourceARN"]
+            return ""
+        except ClientError:
+            return ""
+
+    def generate_task_definition(
+        self, flow_run: GraphQLResult, run_config: ECSRun
+    ) -> Dict[str, Any]:
+        if run_config.task_definition:
+            taskdef = deepcopy(run_config.task_definition)
+        else:
+            task_definition_path = (
+                run_config.task_definition_path or self.task_definition_path
+            )
+            self.logger.debug(
+                "Loading task definition template from %r", task_definition_path
+            )
+            template_bytes = read_bytes_from_path(task_definition_path)
+            taskdef = yaml.safe_load(template_bytes)
+
+        slug = slugify.slugify(
+            flow_run.flow.name,
+            max_length=255 - len("prefect-"),
+            word_boundary=True,
+            save_order=True,
+        )
+        family = f"prefect-{slug}"
+
+        tags = self.get_task_definition_tags(flow_run)
+
+        taskdef["family"] = family
+
+        taskdef_tags = [{"key": k, "value": v} for k, v in tags.items()]
+        for entry in taskdef.get("tags", []):
+            if entry["key"] not in tags:
+                taskdef_tags.append(entry)
+        taskdef["tags"] = taskdef_tags
+
+        # Get the flow container (creating one if it doesn't already exist)
+        containers = taskdef.setdefault("containerDefinitions", [])
+        for container in containers:
+            if container.get("name") == "flow":
+                break
+        else:
+            container = {"name": "flow"}
+            containers.append(container)
+
+        # Set flow image
+        container["image"] = get_flow_image(flow_run)
+
+        # Set flow run command
+        container["command"] = [get_flow_run_command(flow_run)]
+
+        # Populate static environment variables from the following sources,
+        # with precedence:
+        # - Static environment variables, hardcoded below
+        # - Values in the task definition template
+        env = {
+            "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
+            "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
+            "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+        }
+        container_env = [{"name": k, "value": v} for k, v in env.items()]
+        for entry in container.get("environment", []):
+            if entry["name"] not in env:
+                container_env.append(entry)
+        container["environment"] = container_env
+
+        # Set resource requirements, if provided
+        if run_config.cpu:
+            taskdef["cpu"] = run_config.cpu
+        elif run_config.memory:
+            taskdef["memory"] = run_config.memory
+
+        return taskdef
+
+    def get_run_task_kwargs(
+        self, flow_run: GraphQLResult, run_config: ECSRun
+    ) -> Dict[str, Any]:
+        out = deepcopy(self.run_task_kwargs)
+        out["launchType"] = self.launch_type
+        out["cluster"] = self.cluster
+
+        overrides = out.setdefault("overrides", {})
+        container_overrides = overrides.setdefault("containerOverrides", [])
+        for container in container_overrides:
+            if container.get("name") == "flow":
+                break
+        else:
+            container = {"name": "flow"}
+            container_overrides.append(container)
+
+        # Populate environment variables from the following sources,
+        # with precedence:
+        # - Dynamic values required for flow execution, hardcoded below
+        # - Values set on the ECSRun object
+        # - Values set using the `--env` CLI flag on the agent
+        env = self.env_vars.copy()
+        if run_config.env:
+            env.update(run_config.env)
+        env.update(
+            {
+                "PREFECT__CLOUD__API": config.cloud.api,
+                "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
+                "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
+                "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.log_to_cloud).lower(),
+                "PREFECT__CLOUD__AUTH_TOKEN": config.cloud.agent.auth_token,
+            }
+        )
+        container_env = [{"name": k, "value": v} for k, v in env.items()]
+        for entry in container.get("environment", []):
+            if entry["name"] not in env:
+                container_env.append(entry)
+        container["environment"] = container_env
+
+        return out

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -298,7 +298,7 @@ class ECSAgent(Agent):
                 "Flow run %s has a null `run_config`, only `ECSRun` is supported",
                 flow_run.id,
             )
-            raise TypeError("Flow is missing a `run_config`")
+            raise ValueError("Flow is missing a `run_config`")
 
         # Check if a task definition already exists
         taskdef_arn = self.lookup_task_definition_arn(flow_run)

--- a/src/prefect/agent/ecs/task_definition.yaml
+++ b/src/prefect/agent/ecs/task_definition.yaml
@@ -1,0 +1,5 @@
+networkMode: awsvpc
+cpu: 1024
+memory: 2048
+containerDefinitions:
+  - name: flow

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -622,6 +622,10 @@ def ecs():
     help="The launch type to use, defaults to FARGATE",
 )
 @click.option(
+    "--task-role-arn",
+    help="The default task role ARN to use for ECS tasks started by this agent.",
+)
+@click.option(
     "--task-definition",
     help=(
         "Path to a task definition template to use when defining new tasks "
@@ -645,6 +649,7 @@ def start(
     log_level,
     cluster,
     launch_type,
+    task_role_arn,
     task_definition,
     run_task_kwargs,
 ):
@@ -670,6 +675,7 @@ def start(
             no_cloud_logs=no_cloud_logs,
             cluster=cluster,
             launch_type=launch_type,
+            task_role_arn=task_role_arn,
             task_definition_path=task_definition,
             run_task_kwargs_path=run_task_kwargs,
         )

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -622,10 +622,10 @@ def ecs():
     help="The launch type to use, defaults to FARGATE",
 )
 @click.option(
-    "--default-task-definition",
+    "--task-definition",
     help=(
-        "The default task definition to use for flow runs that don't specify a "
-        "`task_definition` directly. Defaults to `prefect-default`."
+        "Path to a task definition template to use when defining new tasks "
+        "instead of the default."
     ),
 )
 @click.option(
@@ -651,7 +651,7 @@ def start(
     log_level,
     cluster,
     launch_type,
-    default_task_definition,
+    task_definition,
     run_task_option,
 ):
     """Start an ECS agent"""
@@ -675,7 +675,7 @@ def start(
             max_polls=max_polls,
             agent_address=agent_address,
             no_cloud_logs=no_cloud_logs,
-            default_task_definition=default_task_definition,
+            task_definition_path=task_definition,
             cluster=cluster,
             launch_type=launch_type,
             run_task_kwargs=run_task_kwargs,

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -656,8 +656,8 @@ def start(
     """Start an ECS agent"""
     from prefect.agent.ecs.agent import ECSAgent
 
-    labels = list(set(label))
-    env_vars = dict(zip(e.split("=", 2) for e in env))
+    labels = sorted(set(label))
+    env_vars = dict(e.split("=", 2) for e in env)
 
     tmp_config = {
         "cloud.agent.auth_token": token or config.cloud.agent.auth_token,

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -629,14 +629,8 @@ def ecs():
     ),
 )
 @click.option(
-    "--run-task-option",
-    "-r",
-    multiple=True,
-    help=(
-        "Additional options to pass to `run_task` for all flows. Can be passed "
-        "multiple times to configure multiple options. Structured values "
-        "can be passed as JSON."
-    ),
+    "--run-task-kwargs",
+    help="Path to a yaml file containing extra kwargs to pass to `run_task`",
 )
 def start(
     token,
@@ -652,14 +646,13 @@ def start(
     cluster,
     launch_type,
     task_definition,
-    run_task_option,
+    run_task_kwargs,
 ):
     """Start an ECS agent"""
-    from prefect.agent.ecs.agent import ECSAgent, parse_run_task_options
+    from prefect.agent.ecs.agent import ECSAgent
 
     labels = list(set(label))
     env_vars = dict(zip(e.split("=", 2) for e in env))
-    run_task_kwargs = parse_run_task_options(run_task_option)
 
     tmp_config = {
         "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
@@ -675,9 +668,9 @@ def start(
             max_polls=max_polls,
             agent_address=agent_address,
             no_cloud_logs=no_cloud_logs,
-            task_definition_path=task_definition,
             cluster=cluster,
             launch_type=launch_type,
-            run_task_kwargs=run_task_kwargs,
+            task_definition_path=task_definition,
+            run_task_kwargs_path=run_task_kwargs,
         )
         agent.start()

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -549,3 +549,135 @@ def install(
             show_flow_logs=show_flow_logs,
         )
         click.echo(conf)
+
+
+@agent.group()
+def ecs():
+    """Manage Prefect ECS agents."""
+
+
+# TODO: this duplicates the CLI parameters from the `start` command above.
+# When the other agents are ported over to `prefect agent <type> start`
+# we'll deduplicate this logic.
+@ecs.command()
+@click.option(
+    "--token", "-t", required=False, help="A Prefect Cloud API token with RUNNER scope."
+)
+@click.option("--api", "-a", required=False, help="A Prefect API URL.")
+@click.option(
+    "--agent-config-id",
+    help="An agent ID to link this agent instance with",
+)
+@click.option(
+    "--name",
+    "-n",
+    help="A name to use for the agent",
+)
+@click.option(
+    "--label",
+    "-l",
+    multiple=True,
+    help="Labels the agent will use to query for flow runs.",
+)
+@click.option(
+    "--env",
+    "-e",
+    multiple=True,
+    help="Environment variables to set on each submitted flow run.",
+)
+@click.option(
+    "--max-polls",
+    help=(
+        "Maximum number of times the agent should poll the Prefect API for flow "
+        "runs. Default is no limit"
+    ),
+    type=int,
+)
+@click.option(
+    "--agent-address",
+    help="Address to serve internal api server at. Defaults to no server.",
+    type=str,
+)
+@click.option(
+    "--no-cloud-logs",
+    is_flag=True,
+    help="Turn off logging for all flows run through this agent.",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default=None,
+    help=(
+        "The agent log level to use. Defaults to the value configured in your "
+        "environment."
+    ),
+)
+@click.option(
+    "--cluster",
+    help="The cluster to use. If not provided, your default cluster will be used",
+)
+@click.option(
+    "--launch-type",
+    type=click.Choice(["FARGATE", "EC2"], case_sensitive=False),
+    help="The launch type to use, defaults to FARGATE",
+)
+@click.option(
+    "--default-task-definition",
+    help=(
+        "The default task definition to use for flow runs that don't specify a "
+        "`task_definition` directly. Defaults to `prefect-default`."
+    ),
+)
+@click.option(
+    "--run-task-option",
+    "-r",
+    multiple=True,
+    help=(
+        "Additional options to pass to `run_task` for all flows. Can be passed "
+        "multiple times to configure multiple options. Structured values "
+        "can be passed as JSON."
+    ),
+)
+def start(
+    token,
+    api,
+    agent_config_id,
+    name,
+    label,
+    env,
+    max_polls,
+    agent_address,
+    no_cloud_logs,
+    log_level,
+    cluster,
+    launch_type,
+    default_task_definition,
+    run_task_option,
+):
+    """Start an ECS agent"""
+    from prefect.agent.ecs.agent import ECSAgent, parse_run_task_options
+
+    labels = list(set(label))
+    env_vars = dict(zip(e.split("=", 2) for e in env))
+    run_task_kwargs = parse_run_task_options(run_task_option)
+
+    tmp_config = {
+        "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
+        "cloud.agent.level": log_level or config.cloud.agent.level,
+        "cloud.api": api or config.cloud.api,
+    }
+    with set_temporary_config(tmp_config):
+        agent = ECSAgent(
+            agent_config_id=agent_config_id,
+            name=name,
+            labels=labels,
+            env_vars=env_vars,
+            max_polls=max_polls,
+            agent_address=agent_address,
+            no_cloud_logs=no_cloud_logs,
+            default_task_definition=default_task_definition,
+            cluster=cluster,
+            launch_type=launch_type,
+            run_task_kwargs=run_task_kwargs,
+        )
+        agent.start()

--- a/src/prefect/run_configs/__init__.py
+++ b/src/prefect/run_configs/__init__.py
@@ -2,3 +2,4 @@ from .base import RunConfig
 from .kubernetes import KubernetesRun
 from .local import LocalRun
 from .docker import DockerRun
+from .ecs import ECSRun

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -1,0 +1,102 @@
+from typing import Union, Iterable
+
+from prefect.run_configs.base import RunConfig
+
+
+class ECSRun(RunConfig):
+    """Configure a flow-run to run as an ECS Task.
+
+    Note: The functionality here is experimental, and may change between
+    versions without notice. Use at your own risk.
+
+    ECS Tasks are composed of task definitions and runtime parameters. An
+    `ECSRun` object is used to configure the latter only. The task definitions
+    themselves are either managed by the Prefect ECS Agent or will need to be
+    registered manually external to Prefect.
+
+    Args:
+        - task_definition (str, optional): The task definition to use for this
+            task. Can provide either the `family:revision`, just the `family`
+            (in which case the latest active revision is used), or the full
+            task definition ARN. If not provided, the default task definition
+            on the agent is used.
+        - image (str, optional): The image to use for this task. If not
+            provided, will be either inferred from the flow's storage (if using
+            `Docker` storage), or use the default configured on the agent.
+        - env (dict, optional): Additional environment variables to set on the task.
+        - cpu (int or str, optional): The amount of CPU available to the task. Can
+            be ether an integer in CPU units (e.g. `1024`), or a string using
+            vCPUs (e.g. `"1 vcpu"`). If provided, this will override the
+            task-level CPU settings when starting the task. Note that ECS
+            imposes strict limits on what values this can take, see the [ECS
+            documentation][1] for more information.
+        - memory (int or str, optional): The amount of memory available to the
+            task. Can be ether an integer in MiB (e.g. `1024`), or a string
+            with units (e.g. `"1 GB"`). If provided, this will override the
+            task-level memory settings when starting the task. Note that ECS
+            imposes strict limits on what values this can take, see the [ECS
+            documentation][1] for more information.
+        - run_task_kwargs (dict, optional): Additional keyword arguments to
+            pass to `run_task` when starting this task. See the
+            [ECS.Client.run_task][2] docs for more information.
+        - labels (Iterable[str], optional): An iterable of labels to apply to this
+            run config. Labels are string identifiers used by Prefect Agents
+            for selecting valid flow runs when polling for work
+
+    Examples:
+
+    Use the defaults set on the agent:
+
+    ```python
+    flow.run_config = ECSRun()
+    ```
+
+    Use the default task definition, but override the image and CPU:
+
+    ```python
+    flow.run_config = ECSRun(
+        image="example/my-custom-image:latest",
+        cpu="2 vcpu",
+    )
+    ```
+
+    Use an explicit task definition, and also configure some overrides to pass
+    to `run_task`:
+
+    ```python
+    flow.run_config = ECSRun(
+        task_definition="my-task-definition:1",
+        run_task_kwargs={"overrides": {"taskRoleArn": "..."}},
+    )
+    ```
+
+    [1]: https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-cpu-memory-error.html
+
+    [2]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/\
+ecs.html#ECS.Client.run_task
+    """
+
+    def __init__(
+        self,
+        *,
+        task_definition: str = None,
+        image: str = None,
+        env: dict = None,
+        cpu: Union[int, str] = None,
+        memory: Union[int, str] = None,
+        run_task_kwargs: dict = None,
+        labels: Iterable[str] = None,
+    ) -> None:
+        super().__init__(labels=labels)
+
+        if cpu is not None:
+            cpu = str(cpu)
+        if memory is not None:
+            memory = str(memory)
+
+        self.task_definition = task_definition
+        self.image = image
+        self.env = env
+        self.cpu = cpu
+        self.memory = memory
+        self.run_task_kwargs = run_task_kwargs

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -1,6 +1,9 @@
 from typing import Union, Iterable
 
+import yaml
+
 from prefect.run_configs.base import RunConfig
+from prefect.utilities.filesystems import parse_path
 
 
 class ECSRun(RunConfig):
@@ -9,36 +12,48 @@ class ECSRun(RunConfig):
     Note: The functionality here is experimental, and may change between
     versions without notice. Use at your own risk.
 
-    ECS Tasks are composed of task definitions and runtime parameters. An
-    `ECSRun` object is used to configure the latter only. The task definitions
-    themselves are either managed by the Prefect ECS Agent or will need to be
-    registered manually external to Prefect.
+    ECS Tasks are composed of task definitions and runtime parameters.
+
+    Task definitions can be configured using either the `task_definition` or
+    `task_definition_path` parameters. If neither is specified, the default
+    configured on the agent will be used. At runtime this task definition will
+    be registered once per flow version - subsequent runs of the same flow
+    version will reuse the existing definition.
+
+    Runtime parameters can be specified via `run_task_kwargs`. These will be
+    merged with any runtime parameters configured on the agent when starting
+    the task.
 
     Args:
-        - task_definition (str, optional): The task definition to use for this
-            task. Can provide either the `family:revision`, just the `family`
-            (in which case the latest active revision is used), or the full
-            task definition ARN. If not provided, the default task definition
-            on the agent is used.
+        - task_definition (dict, optional): An in-memory task definition spec
+            to use. See the [ECS.Client.register_task_definition][3] docs for
+            more information on task definitions. Note that this definition
+            will be stored directly in Prefect Cloud/Server - use
+            `task_definition_path` instead if you wish to avoid this.
+        - task_definition_path (str, optional): Path to a task definition spec
+            to use. If a local path (no file scheme, or a `file`/`local`
+            scheme), the task definition will be loaded on initialization and
+            stored on the `ECSRun` object as the `task_definition` field.
+            Otherwise the task definition will be loaded at runtime on the
+            agent.  Supported runtime file schemes include (`s3`, `gcs`, and
+            `agent` (for paths local to the runtime agent)).
         - image (str, optional): The image to use for this task. If not
             provided, will be either inferred from the flow's storage (if using
             `Docker` storage), or use the default configured on the agent.
         - env (dict, optional): Additional environment variables to set on the task.
         - cpu (int or str, optional): The amount of CPU available to the task. Can
             be ether an integer in CPU units (e.g. `1024`), or a string using
-            vCPUs (e.g. `"1 vcpu"`). If provided, this will override the
-            task-level CPU settings when starting the task. Note that ECS
-            imposes strict limits on what values this can take, see the [ECS
-            documentation][1] for more information.
+            vCPUs (e.g. `"1 vcpu"`). Note that ECS imposes strict limits on
+            what values this can take, see the [ECS documentation][2] for more
+            information.
         - memory (int or str, optional): The amount of memory available to the
             task. Can be ether an integer in MiB (e.g. `1024`), or a string
-            with units (e.g. `"1 GB"`). If provided, this will override the
-            task-level memory settings when starting the task. Note that ECS
-            imposes strict limits on what values this can take, see the [ECS
-            documentation][1] for more information.
+            with units (e.g. `"1 GB"`). Note that ECS imposes strict limits on
+            what values this can take, see the [ECS documentation][2] for more
+            information.
         - run_task_kwargs (dict, optional): Additional keyword arguments to
             pass to `run_task` when starting this task. See the
-            [ECS.Client.run_task][2] docs for more information.
+            [ECS.Client.run_task][3] docs for more information.
         - labels (Iterable[str], optional): An iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
             for selecting valid flow runs when polling for work
@@ -60,26 +75,30 @@ class ECSRun(RunConfig):
     )
     ```
 
-    Use an explicit task definition, and also configure some overrides to pass
-    to `run_task`:
+    Use an explicit task definition stored in s3, but override the image and CPU:
 
     ```python
     flow.run_config = ECSRun(
-        task_definition="my-task-definition:1",
-        run_task_kwargs={"overrides": {"taskRoleArn": "..."}},
+        task_definition="s3://bucket/path/to/task.yaml",
+        image="example/my-custom-image:latest",
+        cpu="2 vcpu",
     )
     ```
 
-    [1]: https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-cpu-memory-error.html
+    [1]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/\
+ecs.html#ECS.Client.register_task_definition
 
-    [2]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/\
+    [2]: https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-cpu-memory-error.html
+
+    [3]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/\
 ecs.html#ECS.Client.run_task
     """
 
     def __init__(
         self,
         *,
-        task_definition: str = None,
+        task_definition: dict = None,
+        task_definition_path: str = None,
         image: str = None,
         env: dict = None,
         cpu: Union[int, str] = None,
@@ -89,12 +108,24 @@ ecs.html#ECS.Client.run_task
     ) -> None:
         super().__init__(labels=labels)
 
+        if task_definition is not None and task_definition_path is not None:
+            raise ValueError(
+                "Cannot provide both `task_definition` and `task_definition_path`"
+            )
+        if task_definition_path is not None:
+            parsed = parse_path(task_definition_path)
+            if parsed.scheme == "file":
+                with open(parsed.path) as f:
+                    task_definition = yaml.safe_load(f)
+                    task_definition_path = None
+
         if cpu is not None:
             cpu = str(cpu)
         if memory is not None:
             memory = str(memory)
 
         self.task_definition = task_definition
+        self.task_definition_path = task_definition_path
         self.image = image
         self.env = env
         self.cpu = cpu

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -51,6 +51,9 @@ class ECSRun(RunConfig):
             with units (e.g. `"1 GB"`). Note that ECS imposes strict limits on
             what values this can take, see the [ECS documentation][2] for more
             information.
+        - task_role_arn (str, optional): The name or full ARN for the IAM role
+            to use for this task. If not provided, the default on the agent
+            will be used (if configured).
         - run_task_kwargs (dict, optional): Additional keyword arguments to
             pass to `run_task` when starting this task. See the
             [ECS.Client.run_task][3] docs for more information.
@@ -103,6 +106,7 @@ ecs.html#ECS.Client.run_task
         env: dict = None,
         cpu: Union[int, str] = None,
         memory: Union[int, str] = None,
+        task_role_arn: str = None,
         run_task_kwargs: dict = None,
         labels: Iterable[str] = None,
     ) -> None:
@@ -130,4 +134,5 @@ ecs.html#ECS.Client.run_task
         self.env = env
         self.cpu = cpu
         self.memory = memory
+        self.task_role_arn = task_role_arn
         self.run_task_kwargs = run_task_kwargs

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -32,6 +32,7 @@ class ECSRunSchema(RunConfigSchemaBase):
     env = fields.Dict(keys=fields.String(), allow_none=True)
     cpu = fields.String(allow_none=True)
     memory = fields.String(allow_none=True)
+    task_role_arn = fields.String(allow_none=True)
     run_task_kwargs = JSONCompatible(allow_none=True)
 
 

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -1,7 +1,7 @@
 from marshmallow import fields
 
 from prefect.utilities.serialization import JSONCompatible, OneOfSchema, ObjectSchema
-from prefect.run_configs import KubernetesRun, LocalRun, DockerRun
+from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
 
 
 class RunConfigSchemaBase(ObjectSchema):
@@ -20,6 +20,18 @@ class KubernetesRunSchema(RunConfigSchemaBase):
     cpu_request = fields.String(allow_none=True)
     memory_limit = fields.String(allow_none=True)
     memory_request = fields.String(allow_none=True)
+
+
+class ECSRunSchema(RunConfigSchemaBase):
+    class Meta:
+        object_class = ECSRun
+
+    task_definition = fields.String(allow_none=True)
+    image = fields.String(allow_none=True)
+    env = fields.Dict(keys=fields.String(), allow_none=True)
+    cpu = fields.String(allow_none=True)
+    memory = fields.String(allow_none=True)
+    run_task_kwargs = JSONCompatible(allow_none=True)
 
 
 class LocalRunSchema(RunConfigSchemaBase):
@@ -41,6 +53,7 @@ class DockerRunSchema(RunConfigSchemaBase):
 class RunConfigSchema(OneOfSchema):
     type_schemas = {
         "KubernetesRun": KubernetesRunSchema,
+        "ECSRun": ECSRunSchema,
         "LocalRun": LocalRunSchema,
         "DockerRun": DockerRunSchema,
     }

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -26,7 +26,8 @@ class ECSRunSchema(RunConfigSchemaBase):
     class Meta:
         object_class = ECSRun
 
-    task_definition = fields.String(allow_none=True)
+    task_definition_path = fields.String(allow_none=True)
+    task_definition = JSONCompatible(allow_none=True)
     image = fields.String(allow_none=True)
     env = fields.Dict(keys=fields.String(), allow_none=True)
     cpu = fields.String(allow_none=True)

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -516,14 +516,14 @@ def test_lookup_task_definition_arn(aws, kind):
         aws.resourcegroupstaggingapi.get_resources.return_value = {
             "ResourceTagMappingList": []
         }
-        expected = ""
+        expected = None
     else:
         from botocore.exceptions import ClientError
 
         aws.resourcegroupstaggingapi.get_resources.side_effect = ClientError(
             {}, "GetResources"
         )
-        expected = ""
+        expected = None
 
     flow_run = GraphQLResult({"flow": GraphQLResult({"id": "flow-id", "version": 1})})
     agent = ECSAgent()

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -1,0 +1,495 @@
+from unittest.mock import MagicMock
+
+import box
+import pytest
+import yaml
+
+from prefect.agent.ecs.agent import (
+    merge_run_task_kwargs,
+    ECSAgent,
+    DEFAULT_TASK_DEFINITION_PATH,
+)
+from prefect.environments.storage import Local, Docker
+from prefect.run_configs import ECSRun
+from prefect.utilities.configuration import set_temporary_config
+from prefect.utilities.filesystems import read_bytes_from_path
+from prefect.utilities.graphql import GraphQLResult
+
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+
+
+@pytest.fixture
+def default_task_definition():
+    with open(DEFAULT_TASK_DEFINITION_PATH) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(autouse=True)
+def mock_cloud_config(cloud_api):
+    with set_temporary_config(
+        {"cloud.agent.auth_token": "TEST_TOKEN", "logging.log_to_cloud": True}
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def aws(monkeypatch):
+    ec2 = MagicMock()
+    ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "test-vpc-id"}]}
+    ec2.describe_subnets.return_value = {
+        "Subnets": [{"SubnetId": "test-subnet-id-1"}, {"SubnetId": "test-subnet-id-2"}]
+    }
+
+    clients = dict(
+        ecs=MagicMock(), ec2=ec2, s3=MagicMock(), resourcegroupstaggingapi=MagicMock()
+    )
+
+    def get_client(key, **kwargs):
+        if key not in clients:
+            raise ValueError("Unknown client type!")
+        return clients[key]
+
+    boto3_client = MagicMock(side_effect=get_client)
+    monkeypatch.setattr("boto3.client", boto3_client)
+    return box.Box(clients)
+
+
+class TestMergeRunTaskKwargs:
+    def test_merge_run_task_kwargs_no_op(self):
+        assert merge_run_task_kwargs({}, {}) == {}
+
+    def test_merge_run_task_kwargs_top_level(self):
+        opt1 = {"cluster": "testing", "launchType": "FARGATE"}
+        opt2 = {"cluster": "new", "enableECSManagedTags": False}
+        assert merge_run_task_kwargs(opt1, {}) == opt1
+        assert merge_run_task_kwargs({}, opt1) == opt1
+        assert merge_run_task_kwargs(opt1, opt2) == {
+            "cluster": "new",
+            "launchType": "FARGATE",
+            "enableECSManagedTags": False,
+        }
+
+    def test_merge_run_task_kwargs_overrides(self):
+        opt1 = {"overrides": {"cpu": "1024", "memory": "2048"}}
+        opt2 = {"overrides": {"cpu": "2048", "taskRoleArn": "testing"}}
+        assert merge_run_task_kwargs(opt1, {}) == opt1
+        assert merge_run_task_kwargs(opt1, {"overrides": {}}) == opt1
+        assert merge_run_task_kwargs({}, opt1) == opt1
+        assert merge_run_task_kwargs({"overrides": {}}, opt1) == opt1
+        assert merge_run_task_kwargs(opt1, opt2) == {
+            "overrides": {"cpu": "2048", "memory": "2048", "taskRoleArn": "testing"}
+        }
+
+    def test_merge_run_task_kwargs_container_overrides(self):
+        opt1 = {}
+        opt2 = {"overrides": {}}
+        opt3 = {"overrides": {"containerOverrides": []}}
+        opt4 = {
+            "overrides": {
+                "taskRoleArn": "my-task-role",
+                "containerOverrides": [{"name": "a", "cpu": 1, "memory": 2}],
+            }
+        }
+        opt5 = {
+            "overrides": {
+                "executionRoleArn": "my-ex-role",
+                "containerOverrides": [{"name": "a", "cpu": 3, "memoryReservation": 4}],
+            }
+        }
+        opt6 = {
+            "overrides": {
+                "executionRoleArn": "my-ex-role",
+                "containerOverrides": [{"name": "b", "cpu": 5}],
+            }
+        }
+        assert merge_run_task_kwargs(opt4, opt1) == opt4
+        assert merge_run_task_kwargs(opt4, opt2) == opt4
+        assert merge_run_task_kwargs(opt4, opt3) == opt4
+        assert merge_run_task_kwargs(opt1, opt4) == opt4
+        assert merge_run_task_kwargs(opt2, opt4) == opt4
+        assert merge_run_task_kwargs(opt3, opt4) == opt4
+        assert merge_run_task_kwargs(opt4, opt5) == {
+            "overrides": {
+                "taskRoleArn": "my-task-role",
+                "executionRoleArn": "my-ex-role",
+                "containerOverrides": [
+                    {"name": "a", "cpu": 3, "memory": 2, "memoryReservation": 4}
+                ],
+            }
+        }
+        assert merge_run_task_kwargs(opt4, opt6) == {
+            "overrides": {
+                "taskRoleArn": "my-task-role",
+                "executionRoleArn": "my-ex-role",
+                "containerOverrides": [
+                    {"name": "a", "cpu": 1, "memory": 2},
+                    {"name": "b", "cpu": 5},
+                ],
+            }
+        }
+
+
+def test_boto_kwargs():
+    # Defaults to loaded from environment
+    agent = ECSAgent()
+    keys = [
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "region_name",
+    ]
+    for k in keys:
+        assert agent.boto_kwargs[k] is None
+    assert agent.boto_kwargs["config"].retries == {"mode": "standard"}
+
+    # Explicit parametes are passed on
+    kwargs = dict(zip(keys, "abcd"))
+    agent = ECSAgent(
+        botocore_config={"retries": {"mode": "adaptive", "max_attempts": 2}}, **kwargs
+    )
+    for k, v in kwargs.items():
+        assert agent.boto_kwargs[k] == v
+    assert agent.boto_kwargs["config"].retries == {
+        "mode": "adaptive",
+        "max_attempts": 2,
+    }
+
+
+def test_agent_defaults(default_task_definition):
+    agent = ECSAgent()
+    assert agent.agent_config_id is None
+    assert set(agent.labels) == set()
+    assert agent.name == "agent"
+    assert agent.cluster is None
+    assert agent.launch_type == "FARGATE"
+    assert agent.task_role_arn is None
+
+
+class TestAgentTaskDefinitionPath:
+    def test_task_definition_path_default(self, default_task_definition):
+        agent = ECSAgent()
+        assert agent.task_definition == default_task_definition
+
+    def test_task_definition_path_local(self, tmpdir):
+        task_definition = {"networkMode": "awsvpc", "cpu": 2048, "memory": 4096}
+        path = str(tmpdir.join("task.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(task_definition, f)
+
+        agent = ECSAgent(task_definition_path=path)
+        assert agent.task_definition == task_definition
+
+    def test_task_definition_path_remote(self, monkeypatch):
+        task_definition = {"networkMode": "awsvpc", "cpu": 2048, "memory": 4096}
+        data = yaml.safe_dump(task_definition)
+
+        mock = MagicMock(wraps=read_bytes_from_path, return_value=data)
+        monkeypatch.setattr("prefect.agent.ecs.agent.read_bytes_from_path", mock)
+
+        agent = ECSAgent(task_definition_path="s3://bucket/test.yaml")
+        assert agent.task_definition == task_definition
+        assert mock.call_args[0] == ("s3://bucket/test.yaml",)
+
+
+class TestAgentRunTaskKwargsPath:
+    def test_run_task_kwargs_path_default(self):
+        agent = ECSAgent(launch_type="EC2")
+        assert agent.run_task_kwargs == {}
+
+    def test_run_task_kwargs_path_local(self, tmpdir):
+        run_task_kwargs = {"overrides": {"taskRoleArn": "my-task-role"}}
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(run_task_kwargs, f)
+
+        agent = ECSAgent(launch_type="EC2", run_task_kwargs_path=path)
+        assert agent.run_task_kwargs == run_task_kwargs
+
+    def test_run_task_kwargs_path_remote(self, monkeypatch):
+        run_task_kwargs = {"overrides": {"taskRoleArn": "my-task-role"}}
+        data = yaml.safe_dump(run_task_kwargs)
+        s3_path = "s3://bucket/kwargs.yaml"
+
+        def mock(path):
+            return data if path == s3_path else read_bytes_from_path(path)
+
+        monkeypatch.setattr("prefect.agent.ecs.agent.read_bytes_from_path", mock)
+        agent = ECSAgent(launch_type="EC2", run_task_kwargs_path=s3_path)
+        assert agent.run_task_kwargs == run_task_kwargs
+
+
+class TestInferNetworkConfiguration:
+    def test_infer_network_configuration(self):
+        agent = ECSAgent()
+        assert agent.run_task_kwargs == {
+            "networkConfiguration": {
+                "awsvpcConfiguration": {
+                    "subnets": ["test-subnet-id-1", "test-subnet-id-2"],
+                    "assignPublicIp": "ENABLED",
+                }
+            }
+        }
+
+    def test_infer_network_configuration_not_called_if_configured(self, aws, tmpdir):
+        run_task_kwargs = {
+            "networkConfiguration": {"awsvpcConfiguration": {"subnets": ["one", "two"]}}
+        }
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(run_task_kwargs, f)
+
+        agent = ECSAgent(run_task_kwargs_path=path)
+        assert agent.run_task_kwargs == run_task_kwargs
+        assert not aws.ec2.mock_calls
+
+    def test_infer_network_configuration_not_called_if_using_ec2(self, aws):
+        agent = ECSAgent(launch_type="EC2")
+        assert agent.launch_type == "EC2"
+        assert agent.run_task_kwargs == {}
+        assert not aws.ec2.mock_calls
+
+    def test_infer_network_configuration_errors(self, aws):
+        aws.ec2.describe_vpcs.return_value = {"Vpcs": []}
+        with pytest.raises(
+            ValueError, match="Failed to infer default networkConfiguration"
+        ):
+            ECSAgent()
+
+
+class TestGenerateTaskDefinition:
+    def generate_task_definition(self, run_config, storage=None, **kwargs):
+        if storage is None:
+            storage = Local()
+        agent = ECSAgent(**kwargs)
+        flow_run = GraphQLResult(
+            {
+                "flow": GraphQLResult(
+                    {
+                        "storage": storage.serialize(),
+                        "run_config": run_config.serialize(),
+                        "id": "flow-id",
+                        "version": 1,
+                        "name": "Test Flow",
+                        "core_version": "0.13.0",
+                    }
+                ),
+                "id": "flow-run-id",
+            }
+        )
+        return agent.generate_task_definition(flow_run, run_config)
+
+    @pytest.mark.parametrize("use_path", [False, True])
+    def test_generate_task_definition_uses_run_config_task_definition(
+        self, use_path, tmpdir
+    ):
+        task_definition = {
+            "tags": [{"key": "mykey", "value": "myvalue"}],
+            "cpu": "2048",
+            "memory": "4096",
+        }
+
+        if use_path:
+            path = str(tmpdir.join("test.yaml"))
+            with open(path, "w") as f:
+                yaml.safe_dump(task_definition, f)
+            run_config = ECSRun(task_definition_path=path)
+        else:
+            run_config = ECSRun(task_definition=task_definition)
+
+        res = self.generate_task_definition(run_config)
+        assert any(e == {"key": "mykey", "value": "myvalue"} for e in res["tags"])
+        assert res["memory"] == "4096"
+        assert res["cpu"] == "2048"
+
+    def test_generate_task_definition_family_and_tags(self):
+        taskdef = self.generate_task_definition(ECSRun())
+        assert taskdef["family"] == "prefect-test-flow"
+        assert sorted(taskdef["tags"], key=lambda x: x["key"]) == [
+            {"key": "prefect:flow-id", "value": "flow-id"},
+            {"key": "prefect:flow-version", "value": "1"},
+        ]
+
+    @pytest.mark.parametrize(
+        "run_config, storage, expected",
+        [
+            (
+                ECSRun(),
+                Docker(registry_url="test", image_name="name", image_tag="tag"),
+                "test/name:tag",
+            ),
+            (ECSRun(image="myimage"), Local(), "myimage"),
+            (ECSRun(), Local(), "prefecthq/prefect:all_extras-0.13.0"),
+        ],
+        ids=["on-storage", "on-run_config", "default"],
+    )
+    def test_generate_task_definition_image(self, run_config, storage, expected):
+        taskdef = self.generate_task_definition(run_config, storage)
+        assert taskdef["containerDefinitions"][0]["image"] == expected
+
+    def test_generate_task_definition_command(self):
+        taskdef = self.generate_task_definition(ECSRun())
+        assert taskdef["containerDefinitions"][0]["command"] == [
+            "/bin/sh",
+            "-c",
+            "prefect execute flow-run",
+        ]
+
+    def test_generate_task_definition_resources(self):
+        taskdef = self.generate_task_definition(ECSRun(cpu="2048", memory="4096"))
+        assert taskdef["cpu"] == "2048"
+        assert taskdef["memory"] == "4096"
+
+    @pytest.mark.parametrize(
+        "on_run_config, on_agent, expected",
+        [
+            (None, None, None),
+            ("task-role-1", None, "task-role-1"),
+            (None, "task-role-2", "task-role-2"),
+            ("task-role-1", "task-role-2", "task-role-1"),
+        ],
+    )
+    def test_generate_task_definition_task_role_arn(
+        self, on_run_config, on_agent, expected
+    ):
+        taskdef = self.generate_task_definition(
+            ECSRun(task_role_arn=on_run_config), task_role_arn=on_agent
+        )
+        assert taskdef.get("taskRoleArn") == expected
+
+    def test_generate_task_definition_environment(self):
+        run_config = ECSRun(
+            task_definition={
+                "containerDefinitions": [
+                    {
+                        "name": "flow",
+                        "environment": [
+                            {"name": "CUSTOM1", "value": "VALUE1"},
+                            {"name": "CUSTOM2", "value": "VALUE2"},
+                        ],
+                    }
+                ]
+            },
+            env={"CUSTOM4": "VALUE4"},
+        )
+
+        taskdef = self.generate_task_definition(
+            run_config, env_vars={"CUSTOM3": "VALUE3"}
+        )
+        env_list = taskdef["containerDefinitions"][0]["environment"]
+        env = {item["name"]: item["value"] for item in env_list}
+        # Agent and run-config level envs are only set at runtime
+        assert env == {
+            "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
+            "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
+            "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+            "CUSTOM1": "VALUE1",
+            "CUSTOM2": "VALUE2",
+        }
+
+    def test_generate_task_definition_multiple_containers(self):
+        """A container with the name "flow" is used for prefect stuff"""
+        run_config = ECSRun(
+            task_definition={
+                "containerDefinitions": [
+                    {"name": "other", "image": "other-image"},
+                    {"name": "flow", "cpu": 1234},
+                ]
+            },
+            image="flow-image",
+        )
+        taskdef = self.generate_task_definition(run_config)
+        assert taskdef["containerDefinitions"][0]["name"] == "other"
+        assert taskdef["containerDefinitions"][0]["image"] == "other-image"
+        assert taskdef["containerDefinitions"][1]["name"] == "flow"
+        assert taskdef["containerDefinitions"][1]["cpu"] == 1234
+        assert taskdef["containerDefinitions"][1]["image"] == "flow-image"
+
+
+class TestGetRunTaskKwargs:
+    def get_run_task_kwargs(self, run_config, **kwargs):
+        agent = ECSAgent(**kwargs)
+        flow_run = GraphQLResult(
+            {
+                "flow": GraphQLResult(
+                    {
+                        "storage": Local().serialize(),
+                        "run_config": run_config.serialize(),
+                        "id": "flow-id",
+                        "version": 1,
+                        "name": "Test Flow",
+                        "core_version": "0.13.0",
+                    }
+                ),
+                "id": "flow-run-id",
+            }
+        )
+        return agent.get_run_task_kwargs(flow_run, run_config)
+
+    @pytest.mark.parametrize("launch_type", ["EC2", "FARGATE"])
+    @pytest.mark.parametrize("cluster", [None, "my-cluster"])
+    def test_get_run_task_kwargs_common(self, launch_type, cluster):
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(), launch_type=launch_type, cluster=cluster
+        )
+        assert kwargs["launchType"] == launch_type
+        assert kwargs.get("cluster") == cluster
+        assert ("networkConfiguration" in kwargs) == (launch_type == "FARGATE")
+        assert kwargs["overrides"]["containerOverrides"][0]["name"] == "flow"
+
+    def test_get_run_task_kwargs_merges(self, tmpdir):
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump({"overrides": {"cpu": "1024", "memory": "2048"}}, f)
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(
+                run_task_kwargs={"overrides": {"cpu": "2048", "taskRoleArn": "testing"}}
+            ),
+            launch_type="EC2",
+            run_task_kwargs_path=path,
+        )
+        del kwargs["overrides"]["containerOverrides"]  # These are checked below
+        assert kwargs == {
+            "launchType": "EC2",
+            "overrides": {"cpu": "2048", "memory": "2048", "taskRoleArn": "testing"},
+        }
+
+    def test_get_run_task_kwargs_environment(self, tmpdir):
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "overrides": {
+                        "containerOverrides": [
+                            {
+                                "name": "flow",
+                                "environment": [
+                                    {"name": "CUSTOM1", "value": "VALUE1"},
+                                    {"name": "CUSTOM2", "value": "VALUE2"},
+                                ],
+                            }
+                        ]
+                    }
+                },
+                f,
+            )
+
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(env={"CUSTOM3": "OVERRIDE3", "CUSTOM4": "VALUE4"}),
+            env_vars={"CUSTOM2": "OVERRIDE2", "CUSTOM3": "VALUE3"},
+            run_task_kwargs_path=path,
+        )
+        env_list = kwargs["overrides"]["containerOverrides"][0]["environment"]
+        env = {item["name"]: item["value"] for item in env_list}
+        assert env == {
+            "PREFECT__CLOUD__API": "https://api.prefect.io",
+            "PREFECT__CLOUD__AUTH_TOKEN": "TEST_TOKEN",
+            "PREFECT__CLOUD__AGENT__LABELS": "[]",
+            "PREFECT__CONTEXT__FLOW_RUN_ID": "flow-run-id",
+            "PREFECT__CONTEXT__FLOW_ID": "flow-id",
+            "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
+            "CUSTOM1": "VALUE1",
+            "CUSTOM2": "OVERRIDE2",  # agent envs override agent run-task-kwargs
+            "CUSTOM3": "OVERRIDE3",  # run-config envs override agent
+            "CUSTOM4": "VALUE4",
+        }

--- a/tests/run_configs/test_ecs.py
+++ b/tests/run_configs/test_ecs.py
@@ -14,6 +14,7 @@ def test_no_args():
     assert config.env is None
     assert config.cpu is None
     assert config.memory is None
+    assert config.task_role_arn is None
     assert config.run_task_kwargs is None
     assert config.labels == set()
 
@@ -25,6 +26,7 @@ def test_all_args():
         env={"HELLO": "WORLD"},
         cpu=1024,
         memory=2048,
+        task_role_arn="my-task-role",
         run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
         labels=["a", "b"],
     )
@@ -33,6 +35,7 @@ def test_all_args():
     assert config.env == {"HELLO": "WORLD"}
     assert config.cpu == "1024"
     assert config.memory == "2048"
+    assert config.task_role_arn == "my-task-role"
     assert config.run_task_kwargs == {"overrides": {"taskRoleArn": "example"}}
     assert config.labels == {"a", "b"}
 

--- a/tests/run_configs/test_ecs.py
+++ b/tests/run_configs/test_ecs.py
@@ -1,0 +1,50 @@
+from prefect.run_configs import ECSRun
+
+
+def test_no_args():
+    config = ECSRun()
+    assert config.task_definition is None
+    assert config.image is None
+    assert config.env is None
+    assert config.cpu is None
+    assert config.memory is None
+    assert config.run_task_kwargs is None
+    assert config.labels == set()
+
+
+def test_all_args():
+    config = ECSRun(
+        task_definition="my-definition",
+        image="myimage",
+        env={"HELLO": "WORLD"},
+        cpu=1024,
+        memory=2048,
+        run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
+        labels=["a", "b"],
+    )
+    assert config.task_definition == "my-definition"
+    assert config.image == "myimage"
+    assert config.env == {"HELLO": "WORLD"}
+    assert config.cpu == "1024"
+    assert config.memory == "2048"
+    assert config.run_task_kwargs == {"overrides": {"taskRoleArn": "example"}}
+    assert config.labels == {"a", "b"}
+
+
+def test_labels():
+    config = ECSRun(labels=["a", "b"])
+    assert config.labels == {"a", "b"}
+
+
+def test_cpu_and_memory_acceptable_types():
+    config = ECSRun()
+    assert config.cpu is None
+    assert config.memory is None
+
+    config = ECSRun(cpu="1 vcpu", memory="1 GB")
+    assert config.cpu == "1 vcpu"
+    assert config.memory == "1 GB"
+
+    config = ECSRun(cpu=1024, memory=2048)
+    assert config.cpu == "1024"
+    assert config.memory == "2048"

--- a/tests/run_configs/test_ecs.py
+++ b/tests/run_configs/test_ecs.py
@@ -1,9 +1,15 @@
+import os
+
+import pytest
+import yaml
+
 from prefect.run_configs import ECSRun
 
 
 def test_no_args():
     config = ECSRun()
     assert config.task_definition is None
+    assert config.task_definition_path is None
     assert config.image is None
     assert config.env is None
     assert config.cpu is None
@@ -14,7 +20,7 @@ def test_no_args():
 
 def test_all_args():
     config = ECSRun(
-        task_definition="my-definition",
+        task_definition_path="s3://path/to/task.yaml",
         image="myimage",
         env={"HELLO": "WORLD"},
         cpu=1024,
@@ -22,7 +28,7 @@ def test_all_args():
         run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
         labels=["a", "b"],
     )
-    assert config.task_definition == "my-definition"
+    assert config.task_definition_path == "s3://path/to/task.yaml"
     assert config.image == "myimage"
     assert config.env == {"HELLO": "WORLD"}
     assert config.cpu == "1024"
@@ -34,6 +40,54 @@ def test_all_args():
 def test_labels():
     config = ECSRun(labels=["a", "b"])
     assert config.labels == {"a", "b"}
+
+
+def test_cant_specify_both_task_definition_and_task_definition_path():
+    with pytest.raises(ValueError, match="Cannot provide both"):
+        ECSRun(task_definition={}, task_definition_path="/some/path")
+
+
+def test_remote_task_definition_path():
+    config = ECSRun(task_definition_path="s3://bucket/example.yaml")
+    assert config.task_definition_path == "s3://bucket/example.yaml"
+    assert config.task_definition is None
+
+
+@pytest.mark.parametrize("scheme", ["local", "file", None])
+def test_local_task_definition_path(tmpdir, scheme):
+    task_definition = {
+        "containerDefinitions": [
+            {"name": "flow", "environment": [{"name": "TEST", "value": "VALUE"}]}
+        ]
+    }
+    path = str(tmpdir.join("test.yaml"))
+    if scheme is None:
+        task_definition_path = path
+    else:
+        # With a scheme, unix-style slashes are required
+        task_definition_path = f"{scheme}://" + os.path.splitdrive(path)[1].replace(
+            "\\", "/"
+        )
+
+    with open(path, "w") as f:
+        yaml.safe_dump(task_definition, f)
+
+    config = ECSRun(task_definition_path=task_definition_path)
+
+    assert config.task_definition_path is None
+    assert config.task_definition == task_definition
+
+
+def test_task_definition():
+    task_definition = {
+        "containerDefinitions": [
+            {"name": "flow", "environment": [{"name": "TEST", "value": "VALUE"}]}
+        ]
+    }
+    config = ECSRun(task_definition=task_definition)
+
+    assert config.task_definition_path is None
+    assert config.task_definition == task_definition
 
 
 def test_cpu_and_memory_acceptable_types():

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect.run_configs import KubernetesRun, LocalRun, DockerRun
+from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
 from prefect.serialization.run_config import RunConfigSchema
 
 
@@ -81,5 +81,36 @@ def test_serialize_docker_run(config):
     config2 = RunConfigSchema().load(msg)
     assert sorted(config.labels) == sorted(config2.labels)
     fields = ["env", "image"]
+    for field in fields:
+        assert getattr(config, field) == getattr(config2, field)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        ECSRun(),
+        ECSRun(
+            task_definition="my-definition",
+            image="myimage",
+            env={"test": "foo"},
+            cpu="1 vcpu",
+            memory="1 GB",
+            run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
+            labels=["a", "b"],
+        ),
+    ],
+)
+def test_serialize_ecs_run(config):
+    msg = RunConfigSchema().dump(config)
+    config2 = RunConfigSchema().load(msg)
+    assert sorted(config.labels) == sorted(config2.labels)
+    fields = [
+        "task_definition",
+        "image",
+        "env",
+        "cpu",
+        "memory",
+        "run_task_kwargs",
+    ]
     for field in fields:
         assert getattr(config, field) == getattr(config2, field)

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -95,6 +95,7 @@ def test_serialize_docker_run(config):
             env={"test": "foo"},
             cpu="1 vcpu",
             memory="1 GB",
+            task_role_arn="my-task-role",
             run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
             labels=["a", "b"],
         ),
@@ -121,6 +122,7 @@ def test_serialize_ecs_run(config):
         "env",
         "cpu",
         "memory",
+        "task_role_arn",
         "run_task_kwargs",
     ]
     for field in fields:

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -90,13 +90,23 @@ def test_serialize_docker_run(config):
     [
         ECSRun(),
         ECSRun(
-            task_definition="my-definition",
+            task_definition_path="s3://bucket/test.yaml",
             image="myimage",
             env={"test": "foo"},
             cpu="1 vcpu",
             memory="1 GB",
             run_task_kwargs={"overrides": {"taskRoleArn": "example"}},
             labels=["a", "b"],
+        ),
+        ECSRun(
+            task_definition={
+                "containerDefinitions": [
+                    {
+                        "name": "flow",
+                        "environment": [{"name": "TEST", "value": "VALUE"}],
+                    }
+                ]
+            }
         ),
     ],
 )
@@ -106,6 +116,7 @@ def test_serialize_ecs_run(config):
     assert sorted(config.labels) == sorted(config2.labels)
     fields = [
         "task_definition",
+        "task_definition_path",
         "image",
         "env",
         "cpu",


### PR DESCRIPTION
This PR adds `RunConfig` support for flows running on ECS. It adds:

- A new `ECSRun` run config, for configuring flow runs on ECS
- A new `ECSAgent` for running `ECSRun` based flows
- A new CLI option `prefect agent ecs start` for starting the ECS agent

A new agent was used rather than modifying the existing fargate agent, as:

- The configuration options we wanted to expose at the agent level were completely different than those the fargate agent currently exposes. Maintaining backwards compatibility while transitioning to the new model would be difficult.
- Since the agent can deploy on either fargate or ec2, the "ECS" prefix makes more sense than the "fargate" prefix

Note that the ECS agent uses a `prefect agent <name> start` pattern instead of `prefect agent start <name>`. We plan to transition the other agents to this pattern as well (but haven't done so in this PR). Since this agent is new, it made sense to start with the new pattern from the get-go.

Like other run-config based flows, configuration of a flow run comes from two sources:

- Agent-side configuration, which configures defaults for all flow runs started by the agent
- Flow-side configuration, which provides options to override config values on a per-flow basis

## Agent side configuration

There are a few things a user might want to configure at the agent level:

### AWS credentials

AWS credentials are loaded using boto3's normal methods (environment variables or an `~/.aws/config` file. Given appropriate credentials, a new user can run:

```
prefect agent ecs start
```

with no other configuration, and things will "just work". Note that this *doesn't* include S3 access, so it will only work with flows using `Docker` storage. To enable S3 access, the user will also need to configure a `taskRoleArn` for the tasks (more on that later). I don't think we should do this for the user, but we should provide thorough documentation on how to go about creating and configuring this task role in our docs.

### Default parameters to pass to `register_task_definition`

If a user wants to override the default task definition template, they can pass in a path to a custom template via `--task-definition`. This takes a path to a yaml file containing any default options to pass to `register_task_definition` for a new flow. Note that the path could be local to the agent, or remote on e.g. `s3`. Prefect ships with a default template, so providing this isn't required.

### Default parameters to pass to `run_task`

If a user wants to override the default parametesr to pass to `run_task`, they can use the `--run-task-option`/`-r` flags, which take a `parameter=value` argument. Structured values can be passed in as json, and multiple options can be provided by passing duplicate parameters. For example:

```python
prefect agent ecs start -r overrides='{"taskRoleArn": "..."}'
```

**I'm not 100% happy with the ergonomics of this, so better suggestions welcome (perhaps these should be passed in via a file instead, like the task definition?).**

## Flow-side configuration

A user wanting to use run a flow on ECS needs to configure `flow.run_config` with an `ECSRun`. Like other run configs, an empty run-config will use all the agent-side defaults:

```python
from prefect.run_configs import ECSRun

# Use the agent-side defaults
flow.run_config = ECSRun()
```

The `ECSRun` class exposes two ways of overriding the task definition parameters configured on the agent:

- `task_definition`: A task definition spec to use (passed in as a dict). This will be stored in prefect cloud/server directly along with the flow.
- `task_definition_path`: A path to a task definition to use. If a local path, this will be loaded on init and stored as `task_definition` above (we accept local paths for ergonomics, so users won't have to do `open(...).read()` themselves). Remote paths can also be used (e.g. `s3://`), in which case they'll be loaded by the agent at runtime. This lets users who don't want to store a task definition in prefect cloud (for e.g. security reasons) use s3 instead.

For example:

```python
# Use a task definition stored on s3
flow.run_config = ECSRun(task_definition_path="s3://path/to/mydef.yaml")

# Use a task definition stored in memory
flow.run_config = ECSRun(task_definition={...})
```

If either option is provided, it will override the default task definition template configured on the agent via `--task-definition`.

For common things a user might want to override (`image`, `cpu`, `memory`, environment variables), we provide nice shorthand configuration options, which will be applied when registering/starting a task:

```python
flow.run_config = ECSRun(image="my-fancy-image", env={"HELLO": "WORLD"})
```

We also expose `run_task_kwargs`, which lets a user override any additional parameters to pass to `run_task` on startup. Note that we currently provide no way to store these outside of prefect cloud/server's database. IMO there's nothing "secretive" that could be passed in to `run_task` that couldn't also be configured on a task definition instead.

## Runtime Execution

When an ECS flow run is picked up by the agent, the following process occurs:

- The agent checks if an existing task definition has already been registered for this flow + version, based on tags stored on the task definition.
- If a task definition doesn't already exist, a new one is registered. The task definition is initialized from the template configured on either the `run_config` (if present) or the agent. Additional parameters required by prefect (environment variables, image, command, ...) are added to the template along with any options specified on the `run_config`.
- The parameters to `run_task` are inferred by merging defaults on the agent and additional options specified on the `run_config`.
- `run_task` is called with the parameters above and the task definition arn.

This scheme means that a new task definition is created for every flow version. *Note that if the task definition template changes on the agent, a flow that has already had a task definition registered for it won't see the changes on the agent until a new version of the flow is registered and run* (the agent wouldn't register a new task definition until then). Runtime options and environment variables passed in via `--env` will be applied to all task runs regardless. I think I'm ok with this (it's the simplest thing to implement). We could also workaround this by hashing the default template and storing a hash in a tag on the task definition to force re-registration on agent-side changes. This seems overly complex to me though.

Checklist:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)