### PR TITLE
Display error details when `create project` fails

### DIFF
--- a/changes/pr3589.yaml
+++ b/changes/pr3589.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Display exception information on `prefect create project` failure - [#3589](https://github.com/PrefectHQ/prefect/pull/3589)"

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -46,7 +46,8 @@ def project(name, description):
     """
     try:
         Client().create_project(project_name=name, project_description=description)
-    except ClientError:
+    except ClientError as exc:
+        click.echo(str(exc))
         click.secho("Error creating project", fg="red")
         return
 

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -47,7 +47,7 @@ def project(name, description):
     try:
         Client().create_project(project_name=name, project_description=description)
     except ClientError as exc:
-        click.echo(str(exc))
+        click.echo(f"{type(exc).__name__}: {exc}")
         click.secho("Error creating project", fg="red")
         return
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`prefect create project` would not display helpful information on failure to determine the cause.

## Changes
<!-- What does this PR change? -->

- Adds a `click.echo` statement to display the stringified exception


## Examples

Before
```
❯ prefect create project "idempotency"                              
Error creating project
```

After
```
❯ prefect create project "idempotency"
ClientError: Malformed response received from Cloud - please ensure that you have an API token properly configured.
Error creating project
```

```
❯ prefect create project "idempotency"
AuthorizationError: [{'path': ['create_project'], 'message': 'AuthenticationError: Forbidden', 'extensions': {'code': 'UNAUTHENTICATED'}}]
Error creating project
```
--> This last one could be displayed better but this is really a matter of improving our string representation of the AuthenticationError class rather than a fix here

## Importance
<!-- Why is this PR important? -->

Enables better debugging during failed requests

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~