### PR TITLE
Add idempotency key to flow registration

### DIFF
--- a/changes/pr3590.yaml
+++ b/changes/pr3590.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "`flow.register` accepts an idempotency key to prevent excessive flow versions from being created - [#3590](https://github.com/PrefectHQ/prefect/pull/3590)"

--- a/changes/pr3590.yaml
+++ b/changes/pr3590.yaml
@@ -1,2 +1,3 @@
 feature:
   - "`flow.register` accepts an idempotency key to prevent excessive flow versions from being created - [#3590](https://github.com/PrefectHQ/prefect/pull/3590)"
+  - "Added `flow.serialized_hash()` for easy generation of hash keys from the serialized flow - [#3590](https://github.com/PrefectHQ/prefect/pull/3590)"

--- a/docs/orchestration/tutorial/first.md
+++ b/docs/orchestration/tutorial/first.md
@@ -40,16 +40,11 @@ Registration only sends data about the existence and format of your flow; **no a
 :::tip Deduplicating registration calls
 Each call to `flow.register()` will bump the version of the flow in the backend.
 If you are registering flows using automation, you may want to pass an `idempotency_key` which will only create a new version when the key changes.
-For example:
+For example, we can take advantage of the hash of the serialized flow to only register a new version of the flow when it has changed:
 ```python
-MY_INTERNAL_FLOW_VERSION = "1.0.1"
-# This constant needs to be manually bumped for re-registration
-# and could instead be generated from the last commit to the
-# flow file or another indicator
-
 flow.register(
    project_name="Hello, World!",
-   idempotency_key=MY_INTERNAL_FLOW_VERSION
+   idempotency_key=flow.serialized_hash(),
 )
 ```
 :::

--- a/docs/orchestration/tutorial/first.md
+++ b/docs/orchestration/tutorial/first.md
@@ -37,6 +37,16 @@ flow.register(project_name="Hello, World!")
 Registration only sends data about the existence and format of your flow; **no actual code from the flow is sent to the Prefect API**. Your code remains safe, secure, and private in your own infrastructure!
 :::
 
+:::tip De-duplicating registration
+Each call to `flow.register()` will bump the version of the flow in the UI. 
+If you are registering flows using automation, you may want to pass an `idempotency_key` which will only create a new version when the key changes.
+For example:
+```python
+MY_INTERNAL_FLOW_VERSION = "1.0.1"  # This needs to be manually bumped for re-registration
+flow.register(project_name="Hello, World!", idempotency_key=MY_INTERNAL_FLOW_VERSION)
+```
+:::
+
 ## Run Flow with the Prefect API
 
 Now that your flow is registered with the Prefect API, we will use an Agent to watch for flow runs that are scheduled by the Prefect API and execute them accordingly.

--- a/docs/orchestration/tutorial/first.md
+++ b/docs/orchestration/tutorial/first.md
@@ -37,13 +37,20 @@ flow.register(project_name="Hello, World!")
 Registration only sends data about the existence and format of your flow; **no actual code from the flow is sent to the Prefect API**. Your code remains safe, secure, and private in your own infrastructure!
 :::
 
-:::tip De-duplicating registration
-Each call to `flow.register()` will bump the version of the flow in the UI. 
+:::tip Deduplicating registration calls
+Each call to `flow.register()` will bump the version of the flow in the backend.
 If you are registering flows using automation, you may want to pass an `idempotency_key` which will only create a new version when the key changes.
 For example:
 ```python
-MY_INTERNAL_FLOW_VERSION = "1.0.1"  # This needs to be manually bumped for re-registration
-flow.register(project_name="Hello, World!", idempotency_key=MY_INTERNAL_FLOW_VERSION)
+MY_INTERNAL_FLOW_VERSION = "1.0.1"
+# This constant needs to be manually bumped for re-registration
+# and could instead be generated from the last commit to the
+# flow file or another indicator
+
+flow.register(
+   project_name="Hello, World!",
+   idempotency_key=MY_INTERNAL_FLOW_VERSION
+)
 ```
 :::
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -650,6 +650,7 @@ class Client:
         version_group_id: str = None,
         compressed: bool = True,
         no_url: bool = False,
+        idempotency_key: str = None,
     ) -> str:
         """
         Push a new flow to Prefect Cloud
@@ -669,6 +670,9 @@ class Client:
                 `True` compressed
             - no_url (bool, optional): if `True`, the stdout from this function will not
                 contain the URL link to the newly-registered flow in the Cloud UI
+            - idempotency_key (optional, str): a key that, if matching the most recent
+                registration call for this flow group, will prevent the creation of
+                another flow version and return the existing flow id instead.
 
         Returns:
             - str: the ID of the newly-registered flow
@@ -766,6 +770,7 @@ class Client:
                     serialized_flow=serialized_flow,
                     set_schedule_active=set_schedule_active,
                     version_group_id=version_group_id,
+                    idempotency_key=idempotency_key,
                 )
             ),
             retry_on_api_error=False,

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1578,10 +1578,9 @@ class Flow:
                 Flow's project and name will be used.
             - no_url (bool, optional): if `True`, the stdout from this function will not
                 contain the URL link to the newly-registered flow in the Cloud UI
-            - idempotency_key (str, optional): an optional idempotency key for this flow
-                to prevent multiple sequential creations within the version group. For
-                example, if flow.register(idempotency_key="foo") is called twice only
-                one flow will be registered.
+            - idempotency_key (str, optional): a key that, if matching the most recent
+                registration call for this flow group, will prevent the creation of
+                another flow version and return the existing flow id instead.
             - **kwargs (Any): if instantiating a Storage object from default settings, these
                 keyword arguments will be passed to the initialization method of the default
                 Storage class

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -2,7 +2,9 @@ import collections
 import collections.abc
 import copy
 import functools
+import hashlib
 import inspect
+import json
 import os
 import tempfile
 import time
@@ -1462,6 +1464,21 @@ class Flow:
         serialized.update(schema(only=["storage"]).dump({"storage": storage}))
 
         return serialized
+
+    def serialized_hash(self, build: bool = False) -> str:
+        """
+        Generate a deterministic hash of the serialized flow. This is useful for
+        determining if the flow has changed. If this hash is equal to a previous hash,
+        no new information would be passed to the server on a call to `flow.register()`
+
+        Args:
+            - build (bool, optional):  if `True`, the flow's environment is built
+                prior to serialization. Passed through to `Flow.serialize()`.
+
+        Returns:
+            - str: the hash of the serialized flow
+        """
+        return hashlib.sha256(json.dumps(self.serialize(build)).encode()).hexdigest()
 
     # Diagnostics  ----------------------------------------------------------------
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1556,6 +1556,7 @@ class Flow:
         set_schedule_active: bool = True,
         version_group_id: str = None,
         no_url: bool = False,
+        idempotency_key: str = None,
         **kwargs: Any,
     ) -> Union[str, None]:
         """
@@ -1577,6 +1578,10 @@ class Flow:
                 Flow's project and name will be used.
             - no_url (bool, optional): if `True`, the stdout from this function will not
                 contain the URL link to the newly-registered flow in the Cloud UI
+            - idempotency_key (str, optional): an optional idempotency key for this flow
+                to prevent multiple sequential creations within the version group. For
+                example, if flow.register(idempotency_key="foo") is called twice only
+                one flow will be registered.
             - **kwargs (Any): if instantiating a Storage object from default settings, these
                 keyword arguments will be passed to the initialization method of the default
                 Storage class
@@ -1627,6 +1632,7 @@ class Flow:
             set_schedule_active=set_schedule_active,
             version_group_id=version_group_id,
             no_url=no_url,
+            idempotency_key=idempotency_key,
         )
         return registered_flow
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -263,6 +263,7 @@ def test_client_register(patch_post, compressed, monkeypatch, tmpdir):
         compressed=compressed,
         version_group_id=str(uuid.uuid4()),
         no_url=True,
+        idempotency_key="foo",
     )
     assert flow_id == "long-id"
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds idempotency keys to flow registration exposing the API in https://github.com/PrefectHQ/server/pull/116 to allow sequential registration calls for the same flow without actually re-registering.

## Changes
<!-- What does this PR change? -->

- Adds `idempotency_key: str = None` to `flow.register` and `client.register` 
- Adds `flow.serialized_hash()` to return a stringified hash of the serialized flow
- Adds a brief description [to the docs here](https://deploy-preview-3590--prefect-docs.netlify.app/orchestration/tutorial/first.html#register-flow-with-the-prefect-api)

## Importance
<!-- Why is this PR important? -->

- Users register flows repeatedly with automation and do not want to needlessly bump versions

## Example

```python
> from prefect import Flow
> with Flow("empty") as flow:
>     pass

> flow.register(project_name="idempotency")
Result check: OK
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 52a3f839-07af-430b-93a6-8e1de478c8fe
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id

> flow.register(project_name="idempotency", idempotency_key="foo")
Result check: OK
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 782834c8-581c-4294-86ea-84f9e721f7ab
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id

> flow.register(project_name="idempotency", idempotency_key="foo")
Result check: OK
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 782834c8-581c-4294-86ea-84f9e721f7ab
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> same key sequentially, same id, no new flow created

> flow.register(project_name="idempotency", idempotency_key="bar")
Result check: OK
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 9cf9ec0d-0160-4639-b5d0-efd34fededc5
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id when different key is passed

> flow.register(project_name="idempotency")
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 090a3594-7356-4f4e-8775-a4438f4710fa
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id when no key is passed

> flow.register(project_name="idempotency")
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 090a3594-7356-4f4e-8775-a4438f4710fa
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id when no key is passed twice

> flow.register(project_name="idempotency", idempotency_key="bar")
Result check: OK
Flow URL: https://dev.prefect.io/michael-dev/flow/5676f6d5-d218-4a61-82fc-25a5b9a229ec
 └── ID: 6134545d-a7f8-4272-893e-8b1740fb3fb1
 └── Project: idempotency
 └── Labels: ['mzmbp.local']
--> new id because last key was empty
```


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## Future work

- Perhaps a full tutorial/example of using last commit ids to have idempotent flow registration