### PR TITLE
run accidentally-skipped tests

### DIFF
--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -341,7 +341,7 @@ def test_populate_worker_pod_yaml_with_private_registry():
         ):
             yaml_obj = environment._populate_worker_pod_yaml(yaml_obj=pod)
 
-    yaml_obj["spec"]["imagePullSecrets"][0] == dict(name="foo-man-docker")
+    assert yaml_obj["spec"]["imagePullSecrets"][0] == dict(name="foo-man-docker")
 
 
 def test_populate_worker_pod_yaml_with_image_pull_secret():
@@ -360,7 +360,7 @@ def test_populate_worker_pod_yaml_with_image_pull_secret():
         ):
             yaml_obj = environment._populate_worker_pod_yaml(yaml_obj=pod)
 
-    yaml_obj["spec"]["imagePullSecrets"][0] == dict(name="mysecret")
+    assert yaml_obj["spec"]["imagePullSecrets"][0] == dict(name="mysecret")
 
 
 def test_initialize_environment_with_spec_populates(monkeypatch):

--- a/tests/schedules/test_schedules.py
+++ b/tests/schedules/test_schedules.py
@@ -40,7 +40,7 @@ def test_create_schedule_emits_events_if_asked():
     assert all([isinstance(e, clocks.ClockEvent) for e in output])
     assert all([e.parameter_defaults == dict() for e in output])
 
-    output == [dt.add(days=1), dt.add(days=2), dt.add(days=3)]
+    assert output == [dt.add(days=1), dt.add(days=2), dt.add(days=3)]
 
 
 def test_create_schedule_multiple_overlapping_clocks():


### PR DESCRIPTION
## Summary 

While working on #3596 , I saw that a handful of tests on `DaskKubernetesEnvironment` looked like they were accidentally missing an `assert`.

This PR fixes those and other tests in `tests/`, so that they'll fail when they should.

## Changes

Added `assert` to a few comparisons in `tests/` that looked like they were intended to be test cases that fail if `False`.

## Importance

The changes in this PR ensure that tests that fail do so loudly, so that problematic changes to the code they cover don't accidentally get merged.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

### Notes for reviewers

After noticing this working on #3596 , I searched for other cases with `pylint`:

```shell
pylint tests/ | grep expression-not-assigned
```

<details><summary>pylint logs with duplicates removed (click me)</summary>

```text
I searched for these with the following comand:

```shell
tests/environments/execution/test_dask_k8s_environment.py:344:4: W0106: Expression "yaml_obj['spec']['imagePullSecrets'][0] == dict(name='foo-man-docker')" is assigned to nothing (expression-not-assigned)
tests/environments/execution/test_dask_k8s_environment.py:363:4: W0106: Expression "yaml_obj['spec']['imagePullSecrets'][0] == dict(name='mysecret')" is assigned to nothing (expression-not-assigned)
tests/schedules/test_schedules.py:43:4: W0106: Expression "output == [dt.add(days=1), dt.add(days=2), dt.add(days=3)]" is assigned to nothing (expression-not-assigned)
```

</details>

Even if you don't want to take on all of `pylint`, I think it would be worth enabling just this check in `prefect`'s continuous integration jobs. It catches the types of issues that are easy for human reviewers to miss, and which can allow bugs in `prefect` to slip through the review process.

I think it would be a good idea to start adding `pylint` to your CI, with PRs that add one or two important error codes at a time to `.pylintrc`, to catch issues like this. The style things `pylint` catches are a matter of taste and not that important, but I've found in my projects that it catches code-correctness things that `flake8` doesn't (for example: #3041, #3307).

Thanks for your time and consideration.