### PR TITLE
Log Record UTC Offset & Timezone Display

### DIFF
--- a/changes/pr3600.yaml
+++ b/changes/pr3600.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add UTC offset to default logging.datefmt and allow user-configurable logging display timezone - [#3600](https://github.com/PrefectHQ/prefect/pull/3600)"
+
+contributor:
+  - "[Billy McMonagle](https://github.com/speedyturkey)"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -93,6 +93,9 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 # e.g., log_attributes = "['context_var']"
 log_attributes = "[]"
 
+# name of the timezone in which to display log timestamps
+display_tz = "UTC"
+
 # the timestamp format
 datefmt = "%Y-%m-%d %H:%M:%S%z"
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -94,7 +94,7 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 log_attributes = "[]"
 
 # the timestamp format
-datefmt = "%Y-%m-%d %H:%M:%S"
+datefmt = "%Y-%m-%d %H:%M:%S%z"
 
 # Send logs to Prefect Cloud
 log_to_cloud = false

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -93,7 +93,8 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 # e.g., log_attributes = "['context_var']"
 log_attributes = "[]"
 
-# name of the timezone in which to display log timestamps
+# name of the timezone in which to display log timestamps, in tzdata/IANA format
+# For list of valid timezones, see `pytzdata.timezones`
 display_tz = "UTC"
 
 # the timestamp format

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -45,20 +45,28 @@ class PrefectFormatter(logging.Formatter):
         method for display in log records.
     """
 
-    def __init__(self, *args, display_tz: str = "UTC", **kwargs) -> None:
+    def __init__(self, *args: Any, display_tz: str = "UTC", **kwargs: Any) -> None:
         self.display_tz = display_tz
         super().__init__(*args, **kwargs)
 
     def converter(self, timestamp: float) -> pendulum.DateTime:
+        """
+        Return timezone-aware timestamp using specified timezone.
+        Default `converter` implementation returns a `struct_time` object,
+        which does not readily support timezones.
+        """
         return pendulum.from_timestamp(timestamp, tz=self.display_tz)
 
-    def formatTime(self, record, datefmt=None) -> str:
+    def formatTime(self, record: logging.LogRecord, datefmt: str = None) -> str:
+        """
+        Return the creation time of the specified LogRecord as formatted text.
+
+        Differs from `logging.Formatter` implementation due to the need to
+        call `datetime.strftime` instead of `time.strftime`.
+        """
         dt = self.converter(record.created)
-        if datefmt:
-            s = dt.strftime(datefmt)
-        else:
-            s = dt.isoformat()
-        return s
+        formatted_time = dt.strftime(datefmt) if datefmt else dt.isoformat()
+        return formatted_time
 
 
 class CloudHandler(logging.StreamHandler):

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -15,7 +15,7 @@ import sys
 import threading
 import time
 from queue import Empty, Queue
-from typing import Any
+from typing import Any, Optional
 
 import pendulum
 
@@ -49,7 +49,7 @@ class PrefectFormatter(logging.Formatter):
         self.display_tz = display_tz
         super().__init__(*args, **kwargs)
 
-    def converter(self, timestamp: float) -> pendulum.DateTime:
+    def converter(self, timestamp: Optional[float]) -> pendulum.DateTime:  # type: ignore
         """
         Return timezone-aware timestamp using specified timezone.
         Default `converter` implementation returns a `struct_time` object,

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -40,7 +40,8 @@ class PrefectFormatter(logging.Formatter):
     set from `prefect.config`.
 
     Args:
-        - display_tz (str): Typically set from `prefect.config`, used by `formatTime`
+        - display_tz (str): Timezone name in tzdata/IANA format.
+        Typically set from `prefect.config`, used by `formatTime`
         method for display in log records.
     """
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -15,7 +15,7 @@ import sys
 import threading
 import time
 from queue import Empty, Queue
-from typing import Any, Optional
+from typing import Any, Union
 
 import pendulum
 
@@ -49,7 +49,7 @@ class PrefectFormatter(logging.Formatter):
         self.display_tz = display_tz
         super().__init__(*args, **kwargs)
 
-    def converter(self, timestamp: Optional[float]) -> pendulum.DateTime:  # type: ignore
+    def converter(self, timestamp: Union[int, float]) -> pendulum.DateTime:  # type: ignore
         """
         Return timezone-aware timestamp using specified timezone.
         Default `converter` implementation returns a `struct_time` object,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR adds some useful configuration for log timezone display.


## Changes
<!-- What does this PR change? -->
1. Adds UTC offset (`%z`) to the default `logging.datefmt` setting.
2. Adds new attribute `logging.display_tz` with default value of UTC, which allows user to set the timezone used in formatted log records.



## Importance
<!-- Why is this PR important? -->
The UTC offset adds useful, explicit information to log records. The `logging.display_tz` attribute may be appreciated by some users, particularly for local development and testing, since UTC is sometimes difficult for humans to think in.

It is possible that the adding the UTC offset is a good enough fix for the original issue. If the reviewer(s) think the extra complexity of a custom formatter is not worth it for this feature, I'm definitely open to that conversation. Thanks for considering my PR!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Closes #3556
