### PR TITLE
Log Record UTC Offset & Converter

### DIFF
--- a/changes/pr3607.yaml
+++ b/changes/pr3607.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add UTC offset to default logging.datefmt; logging timestamp converter now follows Python default behavior  - [#3607](https://github.com/PrefectHQ/prefect/pull/3607)"
+
+contributor:
+  - "[Billy McMonagle](https://github.com/speedyturkey)"

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -94,7 +94,7 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 log_attributes = "[]"
 
 # the timestamp format
-datefmt = "%Y-%m-%d %H:%M:%S"
+datefmt = "%Y-%m-%d %H:%M:%S%z"
 
 # Send logs to Prefect Cloud
 log_to_cloud = false

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -217,7 +217,6 @@ def _create_logger(name: str) -> logging.Logger:
     formatter = logging.Formatter(
         context.config.logging.format, context.config.logging.datefmt
     )
-    formatter.converter = time.gmtime  # type: ignore
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(context.config.logging.level)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR makes logging timestamp format and behavior easier to understand and better aligned with default Python behavior. This PR is an update to #3600, incorporating feedback received.


## Changes
<!-- What does this PR change? -->
1. Adds UTC offset (%z) to the default logging.datefmt setting.
2. Removes override of `logging.Formatter.converter` so that `time.localtime` is used instead of `time.gmtime`.


## Importance
<!-- Why is this PR important? -->
The UTC offset adds useful, explicit information to log records. The logging.display_tz attribute may be appreciated by some users, particularly for local development and testing, since UTC is sometimes difficult for humans to think in.

Removing the `logging.Formatter.converter` override will lead to more expected behavior locally, and will not change cloud logging functionality.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Closes #3556.