### PR TITLE
Restructure prefect agent cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ prefect server start
 
 Once all components are running, you can view the UI by visiting [http://localhost:8080](http://localhost:8080).
 
-Please note that executing flows from the server requires at least one Prefect Agent to be running: `prefect agent start`.
+Please note that executing flows from the server requires at least one Prefect Agent to be running: `prefect agent local start`.
 
 Finally, to register any flow with the server, call `flow.register()`. For more detail, please see the [orchestration docs](https://docs.prefect.io/orchestration/).
 

--- a/changes/pr3610.yaml
+++ b/changes/pr3610.yaml
@@ -1,0 +1,3 @@
+deprecation:
+  - "Deprecate `prefect agent start <kind>` in favor of `prefect agent <kind> start` - [#3610](https://github.com/PrefectHQ/prefect/pull/3610)"
+  - "Deprecate `prefect agent install <kind>` in favor of `prefect agent <kind> install` - [#3610](https://github.com/PrefectHQ/prefect/pull/3610)"

--- a/docs/core/getting_started/first-steps.md
+++ b/docs/core/getting_started/first-steps.md
@@ -205,7 +205,7 @@ You can use the URL returned from the `register()` call to navigate directly to 
 Start a [local agent](/orchestration/agents/local.md) that can communicate between the server and your flow code.
 
 ```bash
-prefect agent start
+prefect agent local start
 ```
 
 And then trigger your flow from the UI using the ["Run" button](/orchestration/ui/flow.md#run)! You will see the agent pick up your work:

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -76,7 +76,7 @@ prefect server start
 
 Once all components are running, you can view the UI by opening a browser and visiting [http://localhost:8080](http://localhost:8080).
 
-Please note that executing flows from the server requires at least one Prefect Agent to be running: `prefect agent start`.
+Please note that executing flows from the server requires at least one Prefect Agent to be running: `prefect agent local start`.
 
 Finally, to register any flow with the server, call `flow.register()`. For more detail, please see the [orchestration docs](https://docs.prefect.io/orchestration/).
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -27,7 +27,6 @@ import toml
 import toolz
 from slugify import slugify
 
-import prefect
 from tokenizer import format_code
 
 OUTLINE_PATH = os.path.join(os.path.dirname(__file__), "outline.toml")
@@ -218,35 +217,49 @@ def create_methods_table(members, title):
 def create_commands_table(commands):
     import click
 
-    table = ""
+    full_commands = []
     for cmd in commands:
+        full_commands.append((cmd.name, cmd))
+        if hasattr(cmd, "commands"):
+            for subcommand in sorted(cmd.commands):
+                full_commands.append(
+                    (f"{cmd.name} {subcommand}", cmd.commands[subcommand])
+                )
+
+    table = ""
+    for name, cmd in full_commands:
         with click.Context(cmd) as ctx:
-            table += f"<h3>{cmd.name}</h3>\n"
-            help_text = cmd.get_help(ctx).split("\n", 2)[2]
+            table += format_command_doc(name, ctx, cmd)
+    return table
 
-            options = help_text.split("Options:")
-            arguments = options[0].split("Arguments:")
-            if len(arguments) > 1:
-                table += arguments[0]
 
-                block = (
-                    "<pre><code>"
-                    + "Arguments:"
-                    + arguments[1].replace("\n", "<br>").replace("*", r"\*")
-                    + "</code></pre>"
-                )
-                table += block
-            else:
-                table += options[0]
+def format_command_doc(name, ctx, cmd):
+    table = f"<h3>{name}</h3>\n"
+    help_text = cmd.get_help(ctx).split("\n", 2)[2]
 
-            if len(options) > 2:
-                block = (
-                    "<pre><code>"
-                    + "Options:"
-                    + options[1].replace("\n", "<br>").replace("*", r"\*")
-                    + "</code></pre>"
-                )
-                table += block
+    options = help_text.split("Options:")
+    arguments = options[0].split("Arguments:")
+    if len(arguments) > 1:
+        table += arguments[0]
+
+        block = (
+            "<pre><code>"
+            + "Arguments:"
+            + arguments[1].replace("\n", "<br>").replace("*", r"\*")
+            + "</code></pre>"
+        )
+        table += block
+    else:
+        table += options[0]
+
+    if len(options) > 1:
+        block = (
+            "<pre><code>"
+            + "Options:"
+            + options[1].replace("\n", "<br>").replace("*", r"\*")
+            + "</code></pre>"
+        )
+        table += block
     return table
 
 
@@ -425,7 +438,7 @@ if __name__ == "__main__":
         shutil.rmtree("api/latest", ignore_errors=True)
         os.makedirs("api/latest", exist_ok=True)
 
-        ## UPDATE README
+        # UPDATE README
         with open("api/latest/README.md", "w+") as f:
             f.write(
                 textwrap.dedent(
@@ -447,7 +460,8 @@ if __name__ == "__main__":
 
                 # API Reference
 
-                This API reference is automatically generated from Prefect's source code and unit-tested to ensure it's up to date.
+                This API reference is automatically generated from Prefect's source code
+                and unit-tested to ensure it's up to date.
 
                 """
             )
@@ -459,7 +473,7 @@ if __name__ == "__main__":
                 f.write(readme)
                 f.write(auto_generated_footer)
 
-        ## UPDATE CHANGELOG
+        # UPDATE CHANGELOG
         with open("api/latest/changelog.md", "w+") as f:
             f.write(
                 textwrap.dedent(

--- a/docs/orchestration/agents/docker.md
+++ b/docs/orchestration/agents/docker.md
@@ -13,7 +13,7 @@ The Docker Agent requires an accessible Docker daemon. So if you are using this 
 ### Usage
 
 ```
-$ prefect agent start docker
+$ prefect agent docker start
 
  ____            __           _        _                    _
 |  _ \ _ __ ___ / _| ___  ___| |_     / \   __ _  ___ _ __ | |_
@@ -33,7 +33,7 @@ The Docker Agent can be started either through the Prefect CLI or by importing t
 ::: tip Tokens <Badge text="Cloud"/>
 There are a few ways in which you can specify a `RUNNER` API token:
 
-- command argument `prefect agent start docker -t MY_TOKEN`
+- command argument `prefect agent docker start -t MY_TOKEN`
 - environment variable `export PREFECT__CLOUD__AGENT__AUTH_TOKEN=MY_TOKEN`
 - token will be used from `prefect.config.cloud.auth_token` if not provided from one of the two previous methods
 

--- a/docs/orchestration/agents/fargate.md
+++ b/docs/orchestration/agents/fargate.md
@@ -15,7 +15,7 @@ When running the Fargate you may optionally provide `AWS_ACCESS_KEY_ID`, `AWS_SE
 ### Usage
 
 ```
-$ prefect agent start fargate
+$ prefect agent fargate start
 
  ____            __           _        _                    _
 |  _ \ _ __ ___ / _| ___  ___| |_     / \   __ _  ___ _ __ | |_
@@ -35,7 +35,7 @@ The Fargate Agent can be started either through the Prefect CLI or by importing 
 ::: tip Tokens <Badge text="Cloud"/>
 There are a few ways in which you can specify a `RUNNER` API token:
 
-- command argument `prefect agent start fargate -t MY_TOKEN`
+- command argument `prefect agent fargate start -t MY_TOKEN`
 - environment variable `export PREFECT__CLOUD__AGENT__AUTH_TOKEN=MY_TOKEN`
 - token will be used from `prefect.config.cloud.auth_token` if not provided from one of the two previous methods
 
@@ -52,7 +52,7 @@ $ export AWS_ACCESS_KEY_ID=MY_ACCESS
 $ export AWS_SECRET_ACCESS_KEY=MY_SECRET
 $ export AWS_SESSION_TOKEN=MY_SESSION
 $ export REGION_NAME=MY_REGION
-$ prefect agent start fargate
+$ prefect agent fargate start
 ```
 
 In a Python process:
@@ -480,7 +480,7 @@ $ export cpu=256
 $ export memory=512
 $ export networkConfiguration="{'awsvpcConfiguration': {'assignPublicIp': 'ENABLED', 'subnets': ['my_subnet_id'], 'securityGroups': []}}"
 
-$ prefect agent start fargate
+$ prefect agent fargate start
 ```
 
 :::warning Outbound Traffic
@@ -489,14 +489,14 @@ If you encounter issues with Fargate raising errors in cases of client timeouts 
 
 #### Prefect CLI Using Kwargs
 
-All configuration options for the Fargate Agent can also be provided to the `prefect agent start fargate` CLI command. They must match the camel casing used by boto3 but both the single kwarg as well as with the standard prefix of `--` are accepted. This means that `taskRoleArn=""` is the same as `--taskRoleArn=""`.
+All configuration options for the Fargate Agent can also be provided to the `prefect agent fargate start` CLI command. They must match the camel casing used by boto3 but both the single kwarg as well as with the standard prefix of `--` are accepted. This means that `taskRoleArn=""` is the same as `--taskRoleArn=""`.
 
 ```bash
 $ export AWS_ACCESS_KEY_ID=...
 $ export AWS_SECRET_ACCESS_KEY=...
 $ export REGION_NAME=us-east-1
 
-$ prefect agent start fargate cpu=256 memory=512 networkConfiguration="{'awsvpcConfiguration': {'assignPublicIp': 'ENABLED', 'subnets': ['my_subnet_id'], 'securityGroups': []}}"
+$ prefect agent fargate start cpu=256 memory=512 networkConfiguration="{'awsvpcConfiguration': {'assignPublicIp': 'ENABLED', 'subnets': ['my_subnet_id'], 'securityGroups': []}}"
 ```
 
 Kwarg values can also be provided through environment variables. This is useful in situations where case sensitive environment variables are desired or when using templating tools like Terraform to deploy your Agent.
@@ -509,5 +509,5 @@ $ export CPU=256
 $ export MEMORY=512
 $ export NETWORK_CONFIGURATION="{'awsvpcConfiguration': {'assignPublicIp': 'ENABLED', 'subnets': ['my_subnet_id'], 'securityGroups': []}}"
 
-$ prefect agent start fargate cpu=$CPU memory=$MEMORY networkConfiguration=$NETWORK_CONFIGURATION
+$ prefect agent fargate start cpu=$CPU memory=$MEMORY networkConfiguration=$NETWORK_CONFIGURATION
 ```

--- a/docs/orchestration/agents/kubernetes.md
+++ b/docs/orchestration/agents/kubernetes.md
@@ -44,7 +44,7 @@ roleRef:
 ### Usage
 
 ```
-$ prefect agent start kubernetes
+$ prefect agent kubernetes start
 
  ____            __           _        _                    _
 |  _ \ _ __ ___ / _| ___  ___| |_     / \   __ _  ___ _ __ | |_
@@ -70,7 +70,7 @@ The Kubernetes Agent can be started either through the Prefect CLI or by importi
 ::: tip Tokens <Badge text="Cloud"/>
 There are a few ways in which you can specify a `RUNNER` API token:
 
-- command argument `prefect agent start kubernetes -t MY_TOKEN`
+- command argument `prefect agent kubernetes start -t MY_TOKEN`
 - environment variable `export PREFECT__CLOUD__AGENT__AUTH_TOKEN=MY_TOKEN`
 - token will be used from `prefect.config.cloud.auth_token` if not provided from one of the two previous methods
 
@@ -81,57 +81,41 @@ There are a few ways in which you can specify a `RUNNER` API token:
 The Prefect CLI provides commands for installing agents on their respective platforms.
 
 ```
-$ prefect agent install --help
-Usage: prefect agent install [OPTIONS] NAME
+$ prefect agent kubernetes install --help
+Usage: prefect agent kubernetes install [OPTIONS]
 
-  Install an agent. Outputs configuration text which can be used to install
-  on various platforms. The Prefect image version will default to your local
-  `prefect.__version__`
-
-  Arguments:
-      name                        TEXT    The name of an agent to install (e.g.
-                                          `kubernetes`, `local`)
-
-  Options:
-      --token, -t                 TEXT    A Prefect Cloud API token
-      --label, -l                 TEXT    Labels the agent will use to query for flow runs
-                                          Multiple values supported e.g. `-l label1 -l label2`
-      --env, -e                   TEXT    Environment variables to set on each submitted flow
-                                          run. Note that equal signs in environment variable
-                                          values are not currently supported from the CLI.
-                                          Multiple values supported e.g. `-e AUTH=token -e
-                                          PKG_SETTING=true`
-
-  Kubernetes Agent Options:
-      --api, -a                   TEXT    A Prefect API URL
-      --namespace, -n             TEXT    Agent namespace to launch workloads
-      --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
-      --resource-manager                  Enable resource manager on install
-      --rbac                              Enable default RBAC on install
-      --latest                            Use the `latest` Prefect image
-      --mem-request               TEXT    Requested memory for Prefect init job
-      --mem-limit                 TEXT    Limit memory for Prefect init job
-      --cpu-request               TEXT    Requested CPU for Prefect init job
-      --cpu-limit                 TEXT    Limit CPU for Prefect init job
-      --image-pull-policy         TEXT    imagePullPolicy for Prefect init job
-      --service-account-name      TEXT    Name of Service Account for Prefect init job
-      --backend                   TEST    Prefect backend to use for this agent
-                                          Defaults to the backend currently set in config.
-
-  Local Agent Options:
-      --import-path, -p           TEXT    Absolute import paths to provide to the local agent.
-                                          Multiple values supported e.g. `-p /root/my_scripts
-                                          -p /utilities`
-      --show-flow-logs, -f                Display logging output from flows run by the agent
+  Generate a supervisord.conf file for a Local agent
 
 Options:
-  -h, --help  Show this message and exit.
+  -t, --token TEXT               A Prefect Cloud API token with RUNNER scope.
+  -l, --label TEXT               Labels the agent will use to query for flow
+                                 runs.
+
+  -e, --env TEXT                 Environment variables to set on each
+                                 submitted flow run.
+
+  -a, --api TEXT                 A Prefect API URL.
+  -n, --namespace TEXT           Agent namespace to launch workloads.
+  -i, --image-pull-secrets TEXT  Name of image pull secrets to use for
+                                 workloads.
+
+  --resource-manager             Enable resource manager.
+  --rbac                         Enable default RBAC.
+  --latest                       Use the latest Prefect image.
+  --mem-request TEXT             Requested memory for Prefect init job.
+  --mem-limit TEXT               Limit memory for Prefect init job.
+  --cpu-request TEXT             Requested CPU for Prefect init job.
+  --cpu-limit TEXT               Limit CPU for Prefect init job.
+  --image-pull-policy TEXT       imagePullPolicy for Prefect init job
+  --service-account-name TEXT    Name of Service Account for Prefect init job
+  -b, --backend TEXT             Prefect backend to use for this agent.
+  -h, --help                     Show this message and exit.
 ```
 
 Running the following command will install the Prefect Agent on your cluster:
 
 ```
-$ prefect agent install kubernetes -t MY_TOKEN | kubectl apply -f -
+$ prefect agent kubernetes install -t MY_TOKEN | kubectl apply -f -
 ```
 
 :::tip RBAC
@@ -172,7 +156,7 @@ If you are using Amazon EKS for your kubernetes deployment and you need S3 acces
 To specify a set of labels for a Kubernetes Agent during install you may specify various `--label` arguments.
 
 ```
-$ prefect agent install kubernetes -t MY_TOKEN --label dev --label staging
+$ prefect agent kubernetes install -t MY_TOKEN --label dev --label staging
 ```
 
 This will update the `PREFECT__CLOUD__AGENT__LABELS` environment variable on the Agent deployment YAML to include a string representation of a the list of labels. This means that providing the `dev` and `staging` labels above would be represented as:

--- a/docs/orchestration/agents/local.md
+++ b/docs/orchestration/agents/local.md
@@ -62,7 +62,7 @@ flow.register(project_name="Hello, World!")
 This flow is registered with the Prefect API with the actual flow code stored in your local `~/.prefect/flows` directory. We can now start a local agent from the CLI and tell it to look for scheduled runs for the _Welcome Flow_.
 
 ```
-$ prefect agent start -t TOKEN -l welcome-flow
+$ prefect agent local start -t TOKEN -l welcome-flow
 
  ____            __           _        _                    _
 |  _ \ _ __ ___ / _| ___  ___| |_     / \   __ _  ___ _ __ | |_
@@ -82,7 +82,7 @@ The agent is started with the `-l/--label` _welcome-flow_. All flows stored loca
 ::: tip Tokens <Badge text="Cloud"/>
 There are a few ways in which you can specify a `RUNNER` API token:
 
-- command argument `prefect agent start -t MY_TOKEN`
+- command argument `prefect agent local start -t MY_TOKEN`
 - environment variable `export PREFECT__CLOUD__AGENT__AUTH_TOKEN=MY_TOKEN`
 - token will be used from `prefect.config.cloud.auth_token` if not provided from one of the two previous methods
   :::
@@ -92,35 +92,22 @@ There are a few ways in which you can specify a `RUNNER` API token:
 The Prefect CLI provides commands for installing agents on their respective platforms.
 
 ```
-$ prefect agent install --help
-Usage: prefect agent install [OPTIONS] NAME
+$ prefect agent local install --help
+Usage: prefect agent local install [OPTIONS]
 
-  Install an agent. Outputs configuration text which can be used to install
-  on various platforms. The Prefect image version will default to your local
-  `prefect.__version__`
-
-  Arguments:
-      name                        TEXT    The name of an agent to install (e.g. `kubernetes`, `local`)
-
-  Options:
-      --token, -t                 TEXT    A Prefect Cloud API token
-      --label, -l                 TEXT    Labels the agent will use to query for flow runs
-                                          Multiple values supported e.g. `-l label1 -l label2`
-
-  Kubernetes Agent Options:
-      --api, -a                   TEXT    A Prefect Cloud API URL
-      --namespace, -n             TEXT    Agent namespace to launch workloads
-      --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
-      --resource-manager                  Enable resource manager on install
-      --rbac                              Enable default RBAC on install
-
-  Local Agent Options:
-      --import-path, -p           TEXT    Absolute import paths to provide to the local agent.
-                                          Multiple values supported e.g. `-p /root/my_scripts -p /utilities`
-      --show-flow-logs, -f                Display logging output from flows run by the agent
+  Generate a supervisord.conf file for a Local agent
 
 Options:
-  -h, --help  Show this message and exit.
+  -t, --token TEXT        A Prefect Cloud API token with RUNNER scope.
+  -l, --label TEXT        Labels the agent will use to query for flow runs.
+  -e, --env TEXT          Environment variables to set on each submitted flow
+                          run.
+
+  -p, --import-path TEXT  Import paths the local agent will add to all flow
+                          runs.
+
+  -f, --show-flow-logs    Display logging output from flows run by the agent.
+  -h, --help              Show this message and exit.
 ```
 
 The local agent installation outputs a file for [Supervisor](http://supervisord.org/installing.html) to manage the process. Since you're already using Prefect, Supervisor can be quickly and easily installed with `pip install supervisor`. For more information on Supervisor installation visit their [documentation](http://supervisord.org/installing.html).
@@ -128,7 +115,7 @@ The local agent installation outputs a file for [Supervisor](http://supervisord.
 The Prefect CLI has an installation command for the local agent which will output a `supervisord.conf` file that you can save and run using Supervisor. To see the contents of what this file will look like run the following command:
 
 ```bash
-$ prefect agent install local --token $YOUR_RUNNER_TOKEN
+$ prefect agent local install --token $YOUR_RUNNER_TOKEN
 ```
 
 This will give you output that you can provide to Supervisor in order to run your local agent. To run this for the first time save this output to a file called `supervisord.conf` and run the following command to start your local agent from the `supervisord.conf` file:

--- a/docs/orchestration/agents/overview.md
+++ b/docs/orchestration/agents/overview.md
@@ -28,33 +28,11 @@ If Prefect is already [installed](../../core/getting_started/installation.html) 
 
 ### Usage
 
-Prefect agents can easily be configured through the CLI.
+Prefect agents can be started via the CLI, using `prefect agent <AGENT TYPE> start`. For example:
 
 ```
-$ prefect agent
-Usage: prefect agent [OPTIONS] COMMAND [ARGS]...
-
-  Manage Prefect agents.
-
-  Usage:
-      $ prefect agent [COMMAND]
-
-  Arguments:
-      start       Start a Prefect agent
-      install     Output platform-specific agent installation configs
-
-  Examples:
-      $ prefect agent start
-      ...agent begins running in process...
-
-      $ prefect agent start kubernetes --token MY_TOKEN
-      ...agent begins running in process...
-
-      $ prefect agent install kubernetes --token MY_TOKEN --namespace metrics
-      ...k8s yaml output...
-
-Options:
-  -h, --help  Show this message and exit.
+$ prefect agent local start
+...
 ```
 
 All Prefect Agents are also extendable as Python objects and can be used programatically!
@@ -86,7 +64,7 @@ DockerAgent(labels=["dev", "staging"]).start()
 - Arguments to the CLI:
 
 ```
-$ prefect agent start --label dev --label staging
+$ prefect agent <AGENT TYPE> start --label dev --label staging
 ```
 
 - As an environment variable:
@@ -111,7 +89,7 @@ A few ways to enable:
 - Passing an argument to the CLI:
 
 ```
-$ prefect agent start --agent-address http://localhost:8080
+$ prefect agent <AGENT TYPE> start --agent-address http://localhost:8080
 ```
 
 - Setting an environment variable:

--- a/docs/orchestration/concepts/tokens.md
+++ b/docs/orchestration/concepts/tokens.md
@@ -101,7 +101,7 @@ There are a few ways in which you can give a `RUNNER` token to an agent. Each me
 - Provide the token when the agent is started via the CLI. This method means the token will need to be provided each time the agent is started.
 
 ```
-$ prefect agent start -t TOKEN_VALUE
+$ prefect agent <AGENT TYPE> start -t TOKEN_VALUE
 ```
 
 - Specify the token as an environment variable. This method means the token will only be available to processes which have the variable set.

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -234,7 +234,7 @@ Make sure that the agent's labels match the desired labels for the flow storage 
 
 ```bash
 # starting a kubernetes agent that will pull flows stored in S3
-prefect agent start kubernetes -l s3-flow-storage
+prefect agent kubernetes start -l s3-flow-storage
 ```
 
 ::: tip Default Labels

--- a/docs/orchestration/recipes/third_party_auth.md
+++ b/docs/orchestration/recipes/third_party_auth.md
@@ -67,7 +67,7 @@ This off-the-shelf experience generally only applies to interfaces that are nati
 Recall that users can autopopulate Prefect context with values through the use of environment variables.  In particular, all secrets can be set by providing an appropriate value to `PREFECT__CONTEXT__SECRETS__XXXX` in your runtime environment.  One way of achieving this through Prefect is by configuring your agent(s) to pass the appropriate value to each flow run it submits.  Using a Docker Agent as an example:
 
 ```
-prefect agent start docker \\
+prefect agent docker start \\
     -e PREFECT__CONTEXT__SECRETS__AWS_CREDENTIALS=${AWS_CREDENTIALS}
 ```
 

--- a/docs/orchestration/tutorial/docker.md
+++ b/docs/orchestration/tutorial/docker.md
@@ -46,7 +46,7 @@ flow.storage = Docker(registry_url="gcr.io/<project_id>/")
 Start the Docker Agent to executing Flow Runs scheduled by the Prefect API:
 
 ```bash
-prefect agent start docker
+prefect agent docker start
 ```
 
 :::tip Runner Token <Badge text="Cloud"/>

--- a/docs/orchestration/tutorial/k8s.md
+++ b/docs/orchestration/tutorial/k8s.md
@@ -30,7 +30,7 @@ flow.register(project_name="Hello, World!")
 The Kubernetes Agent can be run directly on your machine if you are currently authenticated with a Kubernetes cluster.
 
 ```bash
-prefect agent start kubernetes
+prefect agent kubernetes start
 ```
 
 :::tip Runner Token <Badge text="Cloud"/>
@@ -76,7 +76,7 @@ roleRef:
 For a high availability set up you should install the Kubernetes Agent into your cluster.
 
 ```bash
-prefect agent install kubernetes -t <YOUR_RUNNER_TOKEN> --rbac | kubectl apply -f -
+prefect agent kubernetes install -t <YOUR_RUNNER_TOKEN> --rbac | kubectl apply -f -
 ```
 
 Once the Agent has been created on your cluster it create Jobs on that cluster for each flow run. For more information on the Kubernetes Agent visit the [documentation](/orchestration/agents/kubernetes.html).

--- a/docs/orchestration/tutorial/multiple.md
+++ b/docs/orchestration/tutorial/multiple.md
@@ -23,7 +23,7 @@ flow.register(project_name="Hello, World!")
 In another terminal, start the local agent:
 
 ```bash
-prefect agent start
+prefect agent local start
 ```
 
 ::: tip Runner Token <Badge text="Cloud"/>
@@ -50,7 +50,7 @@ Note: For more information on Supervisor installation visit the [documentation](
 The Prefect CLI has an installation command for the local agent which will output a `supervisord.conf` file that you can save and run using Supervisor.
 
 ```bash
-prefect agent install local --token <YOUR_RUNNER_TOKEN> > supervisord.conf
+prefect agent local install --token <YOUR_RUNNER_TOKEN> > supervisord.conf
 ```
 
 ::: warning No token necessary for Core server

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -31,7 +31,7 @@ classes = ["Secret"]
 [pages.cli.agent]
 title = "agent"
 module = "prefect.cli.agent"
-commands = ["start", "install"]
+commands = ["local", "docker", "kubernetes", "ecs", "fargate"]
 
 [pages.cli.auth]
 title = "auth"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -40,12 +40,12 @@ class DockerAgent(Agent):
 
     Environment variables may be set on the agent to be provided to each flow run's container:
     ```
-    prefect agent start docker --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
+    prefect agent docker start --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
     ```
 
     The default Docker daemon may be overridden by providing a different `base_url`:
     ```
-    prefect agent start docker --base-url "tcp://0.0.0.0:2375"
+    prefect agent docker start --base-url "tcp://0.0.0.0:2375"
     ```
 
     Args:

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -31,12 +31,12 @@ class FargateAgent(Agent):
 
     Environment variables may be set on the agent to be provided to each flow run's Fargate task:
     ```
-    prefect agent start fargate --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
+    prefect agent fargate start --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
     ```
 
     boto3 kwargs being provided to the Fargate Agent:
     ```
-    prefect agent start fargate \\
+    prefect agent fargate start \\
         networkConfiguration="{\\
             'awsvpcConfiguration': {\\
                 'assignPublicIp': 'ENABLED',\\

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -38,13 +38,13 @@ class KubernetesAgent(Agent):
 
     Environment variables may be set on the agent to be provided to each flow run's job:
     ```
-    prefect agent start kubernetes --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
+    prefect agent kubernetes start --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
     ```
 
     These can also be used to control the k8s job spec that describes the flow run jobs.
     For example, to set the k8s secret used to pull images from a non-public registry:
     ```
-    prefect agent start kubernetes --env IMAGE_PULL_SECRETS=my-img-pull-secret
+    prefect agent kubernetes start --env IMAGE_PULL_SECRETS=my-img-pull-secret
     ```
 
     For details on the available environment variables for customizing the job spec,
@@ -52,7 +52,7 @@ class KubernetesAgent(Agent):
 
     Specifying a namespace for the agent will create flow run jobs in that namespace:
     ```
-    prefect agent start kubernetes --namespace dev
+    prefect agent kubernetes start --namespace dev
     ```
 
     Args:

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           image: prefecthq/prefect:latest
           imagePullPolicy: Always
           command: ["/bin/bash", "-c"]
-          args: ["prefect agent start kubernetes"]
+          args: ["prefect agent kubernetes start"]
           env:
             - name: PREFECT__CLOUD__AGENT__AUTH_TOKEN
               value: ""

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -21,7 +21,7 @@ class LocalAgent(Agent):
 
     Optional import paths may be specified to append dependency modules to the PATH:
     ```
-    prefect agent start local --import-path "/usr/local/my_module" --import-path "~/other_module"
+    prefect agent local start --import-path "/usr/local/my_module" --import-path "~/other_module"
 
     # Now the local scripts/packages my_module and other_module will be importable in
     # the flow's subprocess
@@ -29,7 +29,7 @@ class LocalAgent(Agent):
 
     Environment variables may be set on the agent to be provided to each flow run's subprocess:
     ```
-    prefect agent start local --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
+    prefect agent local start --env MY_SECRET_KEY=secret --env OTHER_VAR=$OTHER_VAR
     ```
 
     Args:

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -256,6 +256,7 @@ class LocalAgent(Agent):
     def generate_supervisor_conf(
         token: str = None,
         labels: Iterable[str] = None,
+        env_vars: dict = None,
         import_paths: List[str] = None,
         show_flow_logs: bool = False,
     ) -> str:
@@ -266,6 +267,8 @@ class LocalAgent(Agent):
             - token (str, optional): A `RUNNER` token to give the agent
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work
+            - env_vars (dict, optional): a dictionary of environment variables and values that
+                will be set on each flow run that this agent submits for execution
             - import_paths (List[str], optional): system paths which will be provided to each
                 Flow's runtime environment; useful for Flows which import from locally hosted
                 scripts or packages
@@ -279,6 +282,7 @@ class LocalAgent(Agent):
         # Use defaults if not provided
         token = token or ""
         labels = labels or []
+        env_vars = env_vars or {}
         import_paths = import_paths or []
 
         with open(
@@ -289,16 +293,11 @@ class LocalAgent(Agent):
         add_opts = ""
         add_opts += "-t {token} ".format(token=token) if token else ""
         add_opts += "-f " if show_flow_logs else ""
-        add_opts += (
-            " ".join("-l {label} ".format(label=label) for label in labels)
-            if labels
-            else ""
+        add_opts += " ".join("-l {label} ".format(label=label) for label in labels)
+        add_opts += " ".join(
+            "-e {k}={v} ".format(k=k, v=v) for k, v in env_vars.items()
         )
-        add_opts += (
-            " ".join("-p {path}".format(path=path) for path in import_paths)
-            if import_paths
-            else ""
-        )
+        add_opts += " ".join("-p {path}".format(path=path) for path in import_paths)
         conf = conf.replace("{{OPTS}}", add_opts)
         return conf
 

--- a/src/prefect/agent/local/supervisord.conf
+++ b/src/prefect/agent/local/supervisord.conf
@@ -35,7 +35,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:prefect-agent]
-command=prefect agent start local {{OPTS}}
+command=prefect agent local start {{OPTS}}
 
 ; you can add as many programs as you'd like
 ; including multiple Prefect Agents

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -4,41 +4,386 @@ from prefect import config
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.serialization import from_qualified_name
 
+COMMON_START_OPTIONS = [
+    click.option(
+        "--token",
+        "-t",
+        required=False,
+        help="A Prefect Cloud API token with RUNNER scope.",
+    ),
+    click.option("--api", "-a", required=False, help="A Prefect API URL."),
+    click.option(
+        "--agent-config-id",
+        help="An agent ID to link this agent instance with",
+    ),
+    click.option(
+        "--name",
+        "-n",
+        help="A name to use for the agent",
+    ),
+    click.option(
+        "--label",
+        "-l",
+        multiple=True,
+        help="Labels the agent will use to query for flow runs.",
+    ),
+    click.option(
+        "--env",
+        "-e",
+        multiple=True,
+        help="Environment variables to set on each submitted flow run.",
+    ),
+    click.option(
+        "--max-polls",
+        help=(
+            "Maximum number of times the agent should poll the Prefect API for flow "
+            "runs. Default is no limit"
+        ),
+        type=int,
+    ),
+    click.option(
+        "--agent-address",
+        help="Address to serve internal api server at. Defaults to no server.",
+        type=str,
+    ),
+    click.option(
+        "--no-cloud-logs",
+        is_flag=True,
+        help="Turn off logging for all flows run through this agent.",
+    ),
+    click.option(
+        "--log-level",
+        type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+        default=None,
+        help=(
+            "The agent log level to use. Defaults to the value configured in your "
+            "environment."
+        ),
+    ),
+]
+
+
+COMMON_INSTALL_OPTIONS = [
+    click.option(
+        "--token",
+        "-t",
+        help="A Prefect Cloud API token with RUNNER scope.",
+    ),
+    click.option(
+        "--label",
+        "-l",
+        multiple=True,
+        help="Labels the agent will use to query for flow runs.",
+    ),
+    click.option(
+        "--env",
+        "-e",
+        multiple=True,
+        help="Environment variables to set on each submitted flow run.",
+    ),
+]
+
+
+def add_options(options):
+    """A decorator for adding a list of options to a click command"""
+
+    def decorator(func):
+        for opt in reversed(options):
+            func = opt(func)
+        return func
+
+    return decorator
+
+
+def start_agent(agent_cls, token, api, label, env, log_level, **kwargs):
+    labels = sorted(set(label))
+    env_vars = dict(e.split("=", 2) for e in env)
+
+    tmp_config = {
+        "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
+        "cloud.agent.level": log_level or config.cloud.agent.level,
+        "cloud.api": api or config.cloud.api,
+    }
+    with set_temporary_config(tmp_config):
+        agent = agent_cls(labels=labels, env_vars=env_vars, **kwargs)
+        agent.start()
+
+
+@click.group()
+def agent():
+    """Manage Prefect agents."""
+
+
+###############
+# Local Agent #
+###############
+
+
+@agent.group()
+def local():
+    """Manage Prefect Local agents."""
+
+
+@local.command()
+@add_options(COMMON_START_OPTIONS)
+@click.option(
+    "--import-path",
+    "-p",
+    "import_paths",
+    multiple=True,
+    help="Import paths the local agent will add to all flow runs.",
+)
+@click.option(
+    "--show-flow-logs",
+    "-f",
+    help="Display logging output from flows run by the agent.",
+    is_flag=True,
+)
+@click.option(
+    "--storage-labels/--no-storage-labels",
+    default=True,
+    help="Add all storage labels to the LocalAgent",
+)
+@click.option(
+    "--hostname-label/--no-hostname-label",
+    default=True,
+    help="Add hostname to the LocalAgent's labels",
+)
+def start(import_paths, **kwargs):
+    """Start a local agent"""
+    from prefect.agent.local import LocalAgent
+
+    start_agent(LocalAgent, import_paths=list(import_paths), **kwargs)
+
+
+@local.command()
+@add_options(COMMON_INSTALL_OPTIONS)
+@click.option(
+    "--import-path",
+    "-p",
+    "import_paths",
+    multiple=True,
+    help="Import paths the local agent will add to all flow runs.",
+)
+@click.option(
+    "--show-flow-logs",
+    "-f",
+    help="Display logging output from flows run by the agent.",
+    is_flag=True,
+)
+def install(label, env, import_paths, **kwargs):
+    """Generate a supervisord.conf file for a Local agent"""
+    from prefect.agent.local import LocalAgent
+
+    conf = LocalAgent.generate_supervisor_conf(
+        labels=sorted(set(label)),
+        env_vars=dict(e.split("=", 2) for e in env),
+        import_paths=list(import_paths),
+        **kwargs,
+    )
+    click.echo(conf)
+
+
+################
+# Docker Agent #
+################
+
+
+@agent.group()
+def docker():
+    """Manage Prefect Docker agents."""
+
+
+@docker.command()
+@add_options(COMMON_START_OPTIONS)
+@click.option("--base-url", "-b", help="Docker daemon base URL.")
+@click.option("--no-pull", is_flag=True, help="Disable pulling images in the agent")
+@click.option(
+    "--show-flow-logs",
+    "-f",
+    help="Display logging output from flows run by the agent.",
+    is_flag=True,
+)
+@click.option(
+    "--volume",
+    "volumes",
+    multiple=True,
+    help=(
+        "Host paths for Docker bind mount volumes attached to each Flow "
+        "container. Can be provided multiple times to pass multiple volumes "
+        "(e.g. `--volume /volume1 --volume /volume2`)"
+    ),
+)
+@click.option(
+    "--network",
+    help="Add containers to an existing docker network",
+)
+@click.option(
+    "--no-docker-interface",
+    is_flag=True,
+    help=(
+        "Disable the check of a Docker interface on this machine. "
+        "Note: This is mostly relevant for some Docker-in-Docker "
+        "setups that users may be running their agent with."
+    ),
+)
+def start(volumes, no_docker_interface, **kwargs):
+    """Start a docker agent"""
+    from prefect.agent.docker import DockerAgent
+
+    start_agent(
+        DockerAgent,
+        volumes=list(volumes),
+        docker_interface=not no_docker_interface,
+        **kwargs,
+    )
+
+
+####################
+# Kubernetes Agent #
+####################
+
+
+@agent.group()
+def kubernetes():
+    """Manage Prefect Kubernetes agents."""
+
+
+@kubernetes.command()
+@add_options(COMMON_START_OPTIONS)
+@click.option(
+    "--namespace",
+    help="Kubernetes namespace to deploy in. Defaults to `default`.",
+)
+@click.option(
+    "--job-template",
+    "job_template_path",
+    help="Path to a kubernetes job template to use instead of the default.",
+)
+def start(**kwargs):
+    """Start a Kubernetes agent"""
+    from prefect.agent.kubernetes import KubernetesAgent
+
+    start_agent(KubernetesAgent, **kwargs)
+
+
+@kubernetes.command()
+@add_options(COMMON_INSTALL_OPTIONS)
+@click.option("--api", "-a", required=False, help="A Prefect API URL.")
+@click.option("--namespace", "-n", help="Agent namespace to launch workloads.")
+@click.option(
+    "--image-pull-secrets",
+    "-i",
+    help="Name of image pull secrets to use for workloads.",
+)
+@click.option(
+    "--resource-manager",
+    "resource_manager_enabled",
+    is_flag=True,
+    help="Enable resource manager.",
+)
+@click.option("--rbac", is_flag=True, help="Enable default RBAC.")
+@click.option("--latest", is_flag=True, help="Use the latest Prefect image.")
+@click.option("--mem-request", help="Requested memory for Prefect init job.")
+@click.option("--mem-limit", help="Limit memory for Prefect init job.")
+@click.option("--cpu-request", help="Requested CPU for Prefect init job.")
+@click.option("--cpu-limit", help="Limit CPU for Prefect init job.")
+@click.option("--image-pull-policy", help="imagePullPolicy for Prefect init job")
+@click.option(
+    "--service-account-name", help="Name of Service Account for Prefect init job"
+)
+@click.option("--backend", "-b", help="Prefect backend to use for this agent.")
+def install(label, env, **kwargs):
+    """Generate a supervisord.conf file for a Local agent"""
+    from prefect.agent.kubernetes import KubernetesAgent
+
+    deployment = KubernetesAgent.generate_deployment_yaml(
+        labels=sorted(set(label)), env_vars=dict(e.split("=", 2) for e in env), **kwargs
+    )
+    click.echo(deployment)
+
+
+#################
+# Fargate Agent #
+#################
+
+
+@agent.group()
+def fargate():
+    """Manage Prefect Fargate agents."""
+
+
+@fargate.command(
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True)
+)
+@add_options(COMMON_START_OPTIONS)
+@click.pass_context
+def start(ctx, **kwargs):
+    """Start a Fargate agent"""
+    from prefect.agent.fargate import FargateAgent
+
+    for item in ctx.args:
+        k, v = item.replace("--", "").split("=", 2)
+        kwargs[k] = v
+
+    start_agent(FargateAgent, **kwargs)
+
+
+#############
+# ECS Agent #
+#############
+
+
+@agent.group()
+def ecs():
+    """Manage Prefect ECS agents."""
+
+
+@ecs.command()
+@add_options(COMMON_START_OPTIONS)
+@click.option(
+    "--cluster",
+    help="The cluster to use. If not provided, your default cluster will be used",
+)
+@click.option(
+    "--launch-type",
+    type=click.Choice(["FARGATE", "EC2"], case_sensitive=False),
+    help="The launch type to use, defaults to FARGATE",
+)
+@click.option(
+    "--task-role-arn",
+    help="The default task role ARN to use for ECS tasks started by this agent.",
+)
+@click.option(
+    "--task-definition",
+    "task_definition_path",
+    help=(
+        "Path to a task definition template to use when defining new tasks "
+        "instead of the default."
+    ),
+)
+@click.option(
+    "--run-task-kwargs",
+    "run_task_kwargs_path",
+    help="Path to a yaml file containing extra kwargs to pass to `run_task`",
+)
+def start(**kwargs):
+    """Start an ECS agent"""
+    from prefect.agent.ecs import ECSAgent
+
+    start_agent(ECSAgent, **kwargs)
+
+
+#############################
+# Deprecated Agent Commands #
+#############################
+
 _agents = {
     "fargate": "prefect.agent.fargate.FargateAgent",
     "docker": "prefect.agent.docker.DockerAgent",
     "kubernetes": "prefect.agent.kubernetes.KubernetesAgent",
     "local": "prefect.agent.local.LocalAgent",
 }
-
-
-@click.group(hidden=True)
-def agent():
-    """
-    Manage Prefect agents.
-
-    \b
-    Usage:
-        $ prefect agent [COMMAND]
-
-    \b
-    Arguments:
-        start       Start a Prefect agent
-        install     Output platform-specific agent installation configs
-
-    \b
-    Examples:
-        $ prefect agent start
-        ...agent begins running in process...
-
-    \b
-        $ prefect agent start kubernetes --token MY_TOKEN
-        ...agent begins running in process...
-
-    \b
-        $ prefect agent install kubernetes --token MY_TOKEN --namespace metrics
-        ...k8s yaml output...
-    """
 
 
 @agent.command(
@@ -183,6 +528,8 @@ def start(
     """
     Start an agent.
 
+    DEPRECATED: use `prefect agent <agent-type> start` instead.
+
     \b
     Arguments:
         agent-option    TEXT    The name of an agent to start (e.g. `docker`, `kubernetes`,
@@ -251,7 +598,6 @@ def start(
         Any of the configuration options outlined in the docs can be provided here
         https://docs.prefect.io/orchestration/agents/fargate.html#configuration
     """
-
     # Split context
     kwargs = dict()
     for item in ctx.args:
@@ -273,12 +619,18 @@ def start(
             click.secho("{} is not a valid agent".format(agent_option), fg="red")
             return
 
+        click.secho(
+            f"Warning: `prefect agent start {agent_option}` is deprecated, use "
+            f"`prefect agent {agent_option} start` instead",
+            fg="yellow",
+        )
+
         env_vars = dict()
         for env_var in env:
             k, v = env_var.split("=")
             env_vars[k] = v
 
-        labels = list(set(label))
+        labels = sorted(set(label))
 
         if agent_option == "local":
             from_qualified_name(retrieved_agent)(
@@ -301,6 +653,7 @@ def start(
                 labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
+                no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
                 base_url=base_url,
                 no_pull=no_pull,
@@ -316,8 +669,9 @@ def start(
                 labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
+                no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
-                **kwargs
+                **kwargs,
             ).start()
         elif agent_option == "kubernetes":
             from_qualified_name(retrieved_agent)(
@@ -328,6 +682,7 @@ def start(
                 labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
+                no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
             ).start()
         else:
@@ -337,6 +692,7 @@ def start(
                 labels=labels,
                 env_vars=env_vars,
                 max_polls=max_polls,
+                no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
             ).start()
 
@@ -461,6 +817,8 @@ def install(
     Install an agent. Outputs configuration text which can be used to install on various
     platforms. The Prefect image version will default to your local `prefect.__version__`
 
+    DEPRECATED: use `prefect agent <agent-type> install` instead.
+
     \b
     Arguments:
         name                        TEXT    The name of an agent to install (e.g.
@@ -515,12 +873,18 @@ def install(
         click.secho("{} is not a supported agent for `install`".format(name), fg="red")
         return
 
+    click.secho(
+        f"Warning: `prefect agent install {name}` is deprecated, use "
+        f"`prefect agent {name} install` instead",
+        fg="yellow",
+    )
+
     env_vars = dict()
     for env_var in env:
         k, v = env_var.split("=")
         env_vars[k] = v
 
-    labels = list(set(label))
+    labels = sorted(set(label))
     if name == "kubernetes":
         deployment = from_qualified_name(retrieved_agent).generate_deployment_yaml(
             token=token,
@@ -545,138 +909,8 @@ def install(
         conf = from_qualified_name(retrieved_agent).generate_supervisor_conf(
             token=token,
             labels=labels,
+            env_vars=env_vars,
             import_paths=list(import_path),
             show_flow_logs=show_flow_logs,
         )
         click.echo(conf)
-
-
-@agent.group()
-def ecs():
-    """Manage Prefect ECS agents."""
-
-
-# TODO: this duplicates the CLI parameters from the `start` command above.
-# When the other agents are ported over to `prefect agent <type> start`
-# we'll deduplicate this logic.
-@ecs.command()
-@click.option(
-    "--token", "-t", required=False, help="A Prefect Cloud API token with RUNNER scope."
-)
-@click.option("--api", "-a", required=False, help="A Prefect API URL.")
-@click.option(
-    "--agent-config-id",
-    help="An agent ID to link this agent instance with",
-)
-@click.option(
-    "--name",
-    "-n",
-    help="A name to use for the agent",
-)
-@click.option(
-    "--label",
-    "-l",
-    multiple=True,
-    help="Labels the agent will use to query for flow runs.",
-)
-@click.option(
-    "--env",
-    "-e",
-    multiple=True,
-    help="Environment variables to set on each submitted flow run.",
-)
-@click.option(
-    "--max-polls",
-    help=(
-        "Maximum number of times the agent should poll the Prefect API for flow "
-        "runs. Default is no limit"
-    ),
-    type=int,
-)
-@click.option(
-    "--agent-address",
-    help="Address to serve internal api server at. Defaults to no server.",
-    type=str,
-)
-@click.option(
-    "--no-cloud-logs",
-    is_flag=True,
-    help="Turn off logging for all flows run through this agent.",
-)
-@click.option(
-    "--log-level",
-    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
-    default=None,
-    help=(
-        "The agent log level to use. Defaults to the value configured in your "
-        "environment."
-    ),
-)
-@click.option(
-    "--cluster",
-    help="The cluster to use. If not provided, your default cluster will be used",
-)
-@click.option(
-    "--launch-type",
-    type=click.Choice(["FARGATE", "EC2"], case_sensitive=False),
-    help="The launch type to use, defaults to FARGATE",
-)
-@click.option(
-    "--task-role-arn",
-    help="The default task role ARN to use for ECS tasks started by this agent.",
-)
-@click.option(
-    "--task-definition",
-    help=(
-        "Path to a task definition template to use when defining new tasks "
-        "instead of the default."
-    ),
-)
-@click.option(
-    "--run-task-kwargs",
-    help="Path to a yaml file containing extra kwargs to pass to `run_task`",
-)
-def start(
-    token,
-    api,
-    agent_config_id,
-    name,
-    label,
-    env,
-    max_polls,
-    agent_address,
-    no_cloud_logs,
-    log_level,
-    cluster,
-    launch_type,
-    task_role_arn,
-    task_definition,
-    run_task_kwargs,
-):
-    """Start an ECS agent"""
-    from prefect.agent.ecs.agent import ECSAgent
-
-    labels = sorted(set(label))
-    env_vars = dict(e.split("=", 2) for e in env)
-
-    tmp_config = {
-        "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
-        "cloud.agent.level": log_level or config.cloud.agent.level,
-        "cloud.api": api or config.cloud.api,
-    }
-    with set_temporary_config(tmp_config):
-        agent = ECSAgent(
-            agent_config_id=agent_config_id,
-            name=name,
-            labels=labels,
-            env_vars=env_vars,
-            max_polls=max_polls,
-            agent_address=agent_address,
-            no_cloud_logs=no_cloud_logs,
-            cluster=cluster,
-            launch_type=launch_type,
-            task_role_arn=task_role_arn,
-            task_definition_path=task_definition,
-            run_task_kwargs_path=run_task_kwargs,
-        )
-        agent.start()

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -394,12 +394,16 @@ def test_generate_supervisor_conf():
     agent = LocalAgent()
 
     conf = agent.generate_supervisor_conf(
-        token="token", labels=["label"], import_paths=["path"]
+        token="token",
+        labels=["label"],
+        import_paths=["path"],
+        env_vars={"TESTKEY": "TESTVAL"},
     )
 
     assert "-t token" in conf
     assert "-l label" in conf
     assert "-p path" in conf
+    assert "-e TESTKEY=TESTVAL" in conf
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
+from importlib import import_module
 
 from click.testing import CliRunner
 import pytest
@@ -13,7 +14,24 @@ pytest.importorskip("kubernetes")
 
 
 @pytest.mark.parametrize(
-    "cmd", ["agent", "agent start", "agent install", "agent ecs", "agent ecs start"]
+    "cmd",
+    [
+        "agent",
+        "agent start",
+        "agent install",
+        "agent local",
+        "agent local start",
+        "agent local install",
+        "agent docker",
+        "agent docker start",
+        "agent kubernetes",
+        "agent kubernetes start",
+        "agent kubernetes install",
+        "agent fargate",
+        "agent fargate start",
+        "agent ecs",
+        "agent ecs start",
+    ],
 )
 def test_help(cmd):
     args = cmd.split()
@@ -21,310 +39,122 @@ def test_help(cmd):
     assert result.exit_code == 0
 
 
-def test_agent_start_fails_no_token(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start"])
-    assert result.exit_code == 1
-
-
-def test_docker_agent_start_token(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker", "-t", "test"])
-    assert result.exit_code == 0
-
-
-def test_docker_agent_start_verbose(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker", "-v"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_api(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "local", "--api", "test_api"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_local(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "local"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_local_import_paths(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.local.LocalAgent.start", start)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "local", "-p", "test"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_docker(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_kubernetes(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.kubernetes.KubernetesAgent.start", start)
-
-    get_jobs = MagicMock(return_value=[])
-    monkeypatch.setattr(
-        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
-        get_jobs,
-    )
-
-    k8s_config = MagicMock()
-    monkeypatch.setattr("kubernetes.config", k8s_config)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "kubernetes"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_kubernetes_namespace(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.kubernetes.KubernetesAgent.start", start)
-
-    get_jobs = MagicMock(return_value=[])
-    monkeypatch.setattr(
-        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
-        get_jobs,
-    )
-
-    k8s_config = MagicMock()
-    monkeypatch.setattr("kubernetes.config", k8s_config)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "kubernetes", "--namespace", "test"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_kubernetes_kwargs_ignored(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.kubernetes.KubernetesAgent.start", start)
-
-    get_jobs = MagicMock(return_value=[])
-    monkeypatch.setattr(
-        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
-        get_jobs,
-    )
-
-    k8s_config = MagicMock()
-    monkeypatch.setattr("kubernetes.config", k8s_config)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "kubernetes", "test_kwarg=ignored"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_fargate(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.fargate.FargateAgent.start", start)
-
-    boto3_client = MagicMock()
-    monkeypatch.setattr("boto3.client", boto3_client)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "fargate"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_fargate_kwargs(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.fargate.FargateAgent.start", start)
-
-    boto3_client = MagicMock()
-    monkeypatch.setattr("boto3.client", boto3_client)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "fargate", "taskRoleArn=test"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_fargate_kwargs_received(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.fargate.FargateAgent.start", start)
-
-    fargate_agent = MagicMock()
-    monkeypatch.setattr("prefect.agent.fargate.FargateAgent", fargate_agent)
-
-    boto3_client = MagicMock()
-    monkeypatch.setattr("boto3.client", boto3_client)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        agent,
-        [
-            "start",
+@pytest.mark.parametrize("deprecated", [False, True])
+@pytest.mark.parametrize(
+    "name, import_path, extra_cmd, extra_kwargs",
+    [
+        (
+            "local",
+            "prefect.agent.local.LocalAgent",
+            "-p path1 -p path2 -f --no-storage-labels --no-hostname-label",
+            {
+                "import_paths": ["path1", "path2"],
+                "show_flow_logs": True,
+                "storage_labels": False,
+                "hostname_label": False,
+            },
+        ),
+        (
+            "docker",
+            "prefect.agent.docker.DockerAgent",
+            (
+                "--base-url testurl --no-pull --show-flow-logs --volume volume1 "
+                "--volume volume2 --network testnetwork --no-docker-interface"
+            ),
+            {
+                "base_url": "testurl",
+                "volumes": ["volume1", "volume2"],
+                "network": "testnetwork",
+                "no_pull": True,
+                "show_flow_logs": True,
+                "docker_interface": False,
+            },
+        ),
+        (
+            "kubernetes",
+            "prefect.agent.kubernetes.KubernetesAgent",
+            "--namespace TESTNAMESPACE --job-template testtemplate.yaml",
+            {
+                "namespace": "TESTNAMESPACE",
+                "job_template_path": "testtemplate.yaml",
+            },
+        ),
+        (
             "fargate",
-            "taskRoleArn=arn",
-            "--volumes=vol",
-            "--agent-address=http://localhost:8000",
-        ],
+            "prefect.agent.fargate.FargateAgent",
+            "--launchType=EC2 --taskRoleArn=my-task-role",
+            {"launchType": "EC2", "taskRoleArn": "my-task-role"},
+        ),
+        (
+            "ecs",
+            "prefect.agent.ecs.ECSAgent",
+            (
+                "--cluster TEST-CLUSTER --launch-type EC2 --task-role-arn TEST-TASK-ROLE-ARN "
+                "--task-definition task-definition-path.yaml --run-task-kwargs "
+                "run-task-kwargs-path.yaml"
+            ),
+            {
+                "cluster": "TEST-CLUSTER",
+                "launch_type": "EC2",
+                "task_role_arn": "TEST-TASK-ROLE-ARN",
+                "task_definition_path": "task-definition-path.yaml",
+                "run_task_kwargs_path": "run-task-kwargs-path.yaml",
+            },
+        ),
+    ],
+)
+def test_agent_start(
+    name, import_path, extra_cmd, extra_kwargs, deprecated, monkeypatch
+):
+    if name == "ecs" and deprecated:
+        pytest.skip("No deprecated version for ECS agent")
+
+    command = ["start", name] if deprecated else [name, "start"]
+    command.extend(
+        (
+            "--token TEST-TOKEN --api TEST-API --agent-config-id TEST-AGENT-CONFIG-ID "
+            "--name TEST-NAME -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
+            "--max-polls 10 --agent-address 127.0.0.1:8080"
+        ).split()
     )
-    assert result.exit_code == 0
+    if deprecated:
+        command.append("--verbose")
+    else:
+        command.extend(["--log-level", "debug"])
+    command.extend(extra_cmd.split())
 
-    assert fargate_agent.called
-    fargate_agent.assert_called_with(
-        agent_config_id=None,
-        agent_address="http://localhost:8000",
-        labels=[],
-        env_vars=dict(),
-        max_polls=None,
-        name=None,
-        taskRoleArn="arn",
-        volumes="vol",
-    )
+    expected_kwargs = {
+        "agent_config_id": "TEST-AGENT-CONFIG-ID",
+        "name": "TEST-NAME",
+        "labels": ["label1", "label2"],
+        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
+        "max_polls": 10,
+        "agent_address": "127.0.0.1:8080",
+        "no_cloud_logs": False,
+        **extra_kwargs,
+    }
 
+    agent_obj = MagicMock()
 
-def test_agent_start_with_env_vars(monkeypatch, cloud_api):
-    docker_agent = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent", docker_agent)
+    def check_config(*args, **kwargs):
+        assert prefect.config.cloud.agent.auth_token == "TEST-TOKEN"
+        assert prefect.config.cloud.agent.level == "DEBUG"
+        assert prefect.config.cloud.api == "TEST-API"
+        return agent_obj
 
-    runner = CliRunner()
-    result = runner.invoke(
-        agent, ["start", "docker", "-e", "KEY=VAL", "-e", "SETTING=false"]
-    )
-    assert result.exit_code == 0
+    module, cls_name = import_path.rsplit(".", 1)
+    cls = getattr(import_module(module), cls_name)
+    agent_cls = create_autospec(cls, side_effect=check_config)
+    monkeypatch.setattr(import_path, agent_cls)
 
-    docker_agent.assert_called_with(
-        agent_config_id=None,
-        agent_address="",
-        base_url=None,
-        env_vars={"KEY": "VAL", "SETTING": "false"},
-        max_polls=None,
-        labels=[],
-        name=None,
-        no_pull=False,
-        show_flow_logs=False,
-        volumes=[],
-        network=None,
-        docker_interface=True,
-    )
+    result = CliRunner().invoke(agent, command)
+    if deprecated:
+        assert f"Warning: `prefect agent start {name}` is deprecated" in result.output
 
-
-def test_agent_start_with_max_polls(monkeypatch, cloud_api):
-    docker_agent = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent", docker_agent)
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker", "--max-polls", "5"])
-    assert result.exit_code == 0
-
-    docker_agent.assert_called_with(
-        agent_config_id=None,
-        agent_address="",
-        base_url=None,
-        env_vars={},
-        max_polls=5,
-        labels=[],
-        name=None,
-        no_pull=False,
-        show_flow_logs=False,
-        volumes=[],
-        network=None,
-        docker_interface=True,
-    )
-
-
-def test_agent_start_name(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker", "--name", "test_agent"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_max_polls(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(agent, ["start", "docker", "--max-polls", "1"])
-    assert result.exit_code == 0
-
-
-def test_agent_start_docker_vars(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(
-        agent, ["start", "docker", "-t", "test", "--base-url", "url", "--no-pull"]
-    )
-    assert result.exit_code == 0
-
-
-def test_agent_start_docker_labels(monkeypatch, cloud_api):
-    start = MagicMock()
-    monkeypatch.setattr("prefect.agent.docker.DockerAgent.start", start)
-
-    docker_client = MagicMock()
-    monkeypatch.setattr(
-        "prefect.agent.docker.agent.DockerAgent._get_docker_client",
-        MagicMock(return_value=docker_client),
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(
-        agent, ["start", "docker", "-t", "test", "--label", "label1", "-l", "label2"]
-    )
-    assert result.exit_code == 0
+    kwargs = agent_cls.call_args[1]
+    for k, v in expected_kwargs.items():
+        assert kwargs[k] == v
+    assert agent_obj.start.called
 
 
 def test_agent_start_fails(monkeypatch, cloud_api):
@@ -337,17 +167,91 @@ def test_agent_start_fails(monkeypatch, cloud_api):
     assert "TEST is not a valid agent" in result.output
 
 
-def test_agent_install_local(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(agent, ["install", "local"])
-    assert result.exit_code == 0
+@pytest.mark.parametrize("deprecated", [False, True])
+def test_agent_local_install(monkeypatch, deprecated):
+    from prefect.agent.local import LocalAgent
+
+    command = ["install", "local"] if deprecated else ["local", "install"]
+    command.extend(
+        (
+            "--token TEST-TOKEN -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
+            "-p path1 -p path2 --show-flow-logs"
+        ).split()
+    )
+
+    expected_kwargs = {
+        "token": "TEST-TOKEN",
+        "labels": ["label1", "label2"],
+        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
+        "import_paths": ["path1", "path2"],
+        "show_flow_logs": True,
+    }
+
+    generate = MagicMock(wraps=LocalAgent.generate_supervisor_conf)
+    monkeypatch.setattr(
+        "prefect.agent.local.LocalAgent.generate_supervisor_conf", generate
+    )
+
+    result = CliRunner().invoke(agent, command)
+
+    if deprecated:
+        assert f"Warning: `prefect agent install local` is deprecated" in result.output
+
+    kwargs = generate.call_args[1]
+    assert kwargs == expected_kwargs
     assert "supervisord" in result.output
 
 
-def test_agent_install_kubernetes(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(agent, ["install", "kubernetes"])
-    assert result.exit_code == 0
+@pytest.mark.parametrize("deprecated", [False, True])
+def test_agent_kubernetes_install(monkeypatch, deprecated):
+    from prefect.agent.kubernetes import KubernetesAgent
+
+    command = ["install", "kubernetes"] if deprecated else ["kubernetes", "install"]
+    command.extend(
+        (
+            "--token TEST-TOKEN -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
+            "--api TEST_API --namespace TEST_NAMESPACE --resource-manager --rbac "
+            "--latest --image-pull-secrets secret-test --mem-request mem_req "
+            "--mem-limit mem_lim --cpu-request cpu_req --cpu-limit cpu_lim "
+            "--image-pull-policy custom_policy --service-account-name svc_name "
+            "-b backend-test"
+        ).split()
+    )
+
+    expected_kwargs = {
+        "token": "TEST-TOKEN",
+        "labels": ["label1", "label2"],
+        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
+        "api": "TEST_API",
+        "namespace": "TEST_NAMESPACE",
+        "resource_manager_enabled": True,
+        "rbac": True,
+        "latest": True,
+        "image_pull_secrets": "secret-test",
+        "mem_request": "mem_req",
+        "mem_limit": "mem_lim",
+        "cpu_request": "cpu_req",
+        "cpu_limit": "cpu_lim",
+        "image_pull_policy": "custom_policy",
+        "service_account_name": "svc_name",
+        "backend": "backend-test",
+    }
+
+    generate = MagicMock(wraps=KubernetesAgent.generate_deployment_yaml)
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.KubernetesAgent.generate_deployment_yaml", generate
+    )
+
+    result = CliRunner().invoke(agent, command)
+
+    if deprecated:
+        assert (
+            f"Warning: `prefect agent install kubernetes` is deprecated"
+            in result.output
+        )
+
+    kwargs = generate.call_args[1]
+    assert kwargs == expected_kwargs
     assert "apiVersion" in result.output
 
 
@@ -356,190 +260,3 @@ def test_agent_install_fails_non_valid_agent(cloud_api):
     result = runner.invoke(agent, ["install", "fake_agent"])
     assert result.exit_code == 0
     assert "fake_agent is not a supported agent for `install`" in result.output
-
-
-def test_agent_install_k8s_passes_args(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(
-        agent,
-        [
-            "install",
-            "kubernetes",
-            "--token",
-            "TEST_TOKEN",
-            "--api",
-            "TEST_API",
-            "--namespace",
-            "TEST_NAMESPACE",
-            "--resource-manager",
-            "--rbac",
-            "--latest",
-            "--image-pull-secrets",
-            "secret-test",
-            "--mem-request",
-            "mem_req",
-            "--mem-limit",
-            "mem_lim",
-            "--cpu-request",
-            "cpu_req",
-            "--cpu-limit",
-            "cpu_limt",
-            "--image-pull-policy",
-            "custom_policy",
-            "--service-account-name",
-            "svc_name",
-            "--label",
-            "test_label1",
-            "-l",
-            "test_label2",
-            "-b",
-            "backend-test",
-            "-e",
-            "ENVTEST=TESTENV",
-            "-e",
-            "ENVTEST2=TESTENV2",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "TEST_TOKEN" in result.output
-    assert "TEST_API" in result.output
-    assert "TEST_NAMESPACE" in result.output
-    assert "resource-manager" in result.output
-    assert "rbac" in result.output
-    assert "latest" in result.output
-    assert "mem_req" in result.output
-    assert "mem_lim" in result.output
-    assert "cpu_req" in result.output
-    assert "cpu_lim" in result.output
-    assert "custom_policy" in result.output
-    assert "svc_name" in result.output
-    assert "secret-test" in result.output
-    assert "test_label1" in result.output
-    assert "test_label2" in result.output
-    assert "backend-test" in result.output
-
-    # Environment Variables
-    assert "ENVTEST" in result.output
-    assert "TESTENV" in result.output
-    assert "ENVTEST2" in result.output
-    assert "TESTENV2" in result.output
-
-
-def test_agent_install_k8s_no_resource_manager(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(
-        agent,
-        [
-            "install",
-            "kubernetes",
-            "--token",
-            "TEST_TOKEN",
-            "--api",
-            "TEST_API",
-            "--namespace",
-            "TEST_NAMESPACE",
-            "--image-pull-secrets",
-            "secret-test",
-            "--rbac",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "TEST_TOKEN" in result.output
-    assert "TEST_API" in result.output
-    assert "TEST_NAMESPACE" in result.output
-    assert "resource-manager" not in result.output
-    assert "rbac" in result.output
-    assert "secret-test" in result.output
-
-
-def test_agent_install_local_passes_args(cloud_api):
-    runner = CliRunner()
-    result = runner.invoke(
-        agent,
-        [
-            "install",
-            "local",
-            "--token",
-            "TEST_TOKEN",
-            "--label",
-            "test_label1",
-            "-l",
-            "test_label2",
-            "--import-path",
-            "my_path",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "TEST_TOKEN" in result.output
-    assert "test_label1" in result.output
-    assert "test_label2" in result.output
-    assert "my_path" in result.output
-
-
-def test_ecs_agent_start(monkeypatch):
-    agent_obj = MagicMock()
-
-    def check_config(*args, **kwargs):
-        assert prefect.config.cloud.agent.auth_token == "TEST-TOKEN"
-        assert prefect.config.cloud.agent.level == "DEBUG"
-        assert prefect.config.cloud.api == "TEST-API"
-        return agent_obj
-
-    ecs_agent = MagicMock(side_effect=check_config)
-    monkeypatch.setattr("prefect.agent.ecs.agent.ECSAgent", ecs_agent)
-
-    result = CliRunner().invoke(
-        agent,
-        [
-            "ecs",
-            "start",
-            "--token",
-            "TEST-TOKEN",
-            "--api",
-            "TEST-API",
-            "--agent-config-id",
-            "TEST-AGENT-CONFIG-ID",
-            "--name",
-            "TEST-NAME",
-            "-l",
-            "label1",
-            "-l",
-            "label2",
-            "-e",
-            "KEY1=VALUE1",
-            "-e",
-            "KEY2=VALUE2",
-            "--max-polls",
-            "10",
-            "--agent-address",
-            "127.0.0.1:8080",
-            "--log-level",
-            "debug",
-            "--cluster",
-            "TEST-CLUSTER",
-            "--launch-type",
-            "EC2",
-            "--task-role-arn",
-            "TEST-TASK-ROLE-ARN",
-            "--task-definition",
-            "task-definition-path.yaml",
-            "--run-task-kwargs",
-            "run-task-kwargs-path.yaml",
-        ],
-    )
-    kwargs = ecs_agent.call_args[1]
-    assert kwargs == {
-        "agent_config_id": "TEST-AGENT-CONFIG-ID",
-        "name": "TEST-NAME",
-        "labels": ["label1", "label2"],
-        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
-        "max_polls": 10,
-        "agent_address": "127.0.0.1:8080",
-        "no_cloud_logs": False,
-        "cluster": "TEST-CLUSTER",
-        "launch_type": "EC2",
-        "task_role_arn": "TEST-TASK-ROLE-ARN",
-        "task_definition_path": "task-definition-path.yaml",
-        "run_task_kwargs_path": "run-task-kwargs-path.yaml",
-    }
-    assert agent_obj.start.called


### PR DESCRIPTION
- Deprecates `prefect agent start <kind>` in favor of `prefect agent <kind> start`
- Deprecates `prefect agent install <kind>` in favor of `prefect agent <kind> install`
- Updates the documentation to use the new commands only
- Adds the new agent commands to the api docs
- Updates the test suite to provide better coverage of the agent CLI
- Fix a few bugs in the agent CLI

---

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)