### PR TITLE
[docs] add Azure, GCP to dask-cloudprovider docs

### DIFF
--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -10,9 +10,10 @@ the [Dask Cloud Provider](https://cloudprovider.dask.org/) project to create a D
 workers using cloud provider services, e.g. AWS Fargate. This Environment aims to provide a very
 easy way to achieve high scalability without the complexity of Kubernetes.
 
-:::tip AWS Only
-Dask Cloud Provider currently only supports AWS using either Fargate or ECS.
-Support for AzureML is [coming soon](https://github.com/dask/dask-cloudprovider/pull/67).
+:::tip AWS, Azure Only
+Dask Cloud Provider currently supports AWS (using either Fargate or ECS)
+and Azure (using AzureML).
+Support for GCP is [coming soon](https://github.com/dask/dask-cloudprovider/pull/131).
 :::
 
 :::warning Security Considerations


### PR DESCRIPTION
## Summary

Updates the documentation on using `dask-cloudprovider` for a `DaskExecutor`. That project now supports Azure, and has an open PR for GCP.

## Changes

Updates the documentation on using `dask-cloudprovider` for a `DaskExecutor`. That project now supports Azure (https://github.com/dask/dask-cloudprovider/pull/67), and has an open PR for GCP (https://github.com/dask/dask-cloudprovider/pull/131).

## Importance

This PR updates a note in the document that is currently inaccurate (says that Azure support is "coming soon" in `dask-cloudprovider`). It also mentions that support for GCP is coming soon.

This update allows users to answer the question "how can I get started with Prefect + Dask on `<major cloud provider>`.

## Checklist

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

### Notes for Reviewers

This PR comes from this Prefect community slack conversation: Coming from this thread in prefect slack: https://prefect-community.slack.com/archives/CL09KU1K7/p1604555659065000.

Thanks for your time and consideration.