### PR TITLE
Fix set task run name

### DIFF
--- a/changes/issue3605.yaml
+++ b/changes/issue3605.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Solve the collision of task_run_name and prefect context variables [#3605](https://github.com/PrefectHQ/prefect/issues/3605)"
+  - "Task arguments take precedence when generating `task_run_name` - [#3605](https://github.com/PrefectHQ/prefect/issues/3605)"

--- a/changes/issue3605.yaml
+++ b/changes/issue3605.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Solve the collision of task_run_name and prefect context variables [#3605](https://github.com/PrefectHQ/prefect/issues/3605)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -206,9 +206,9 @@ class Task(metaclass=SignatureValidator):
             If a callable function is provided, it should have signature `callable(**kwargs) -> str`
             and at write time all formatting kwargs will be passed and a fully formatted location is
             expected as the return value. The callable can be used for string formatting logic that
-            `.format(**kwargs)` doesn't support. The conflict occurred when prefect context 
-            variables(such as `config` or `parameters`, etc.) shadowed task input variable under 
-            the same name. The issue is solved by adding prefect context values if task doesn't 
+            `.format(**kwargs)` doesn't support. The conflict occurred when prefect context
+            variables(such as `config` or `parameters`, etc.) shadowed task input variable under
+            the same name. The issue is solved by adding prefect context values if task doesn't
             have argument of the same name. **Note**: this only works for tasks running against a
             backend API.
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -202,14 +202,12 @@ class Task(metaclass=SignatureValidator):
             the Prefect logger. Defaults to `False`.
         - task_run_name (Union[str, Callable], optional): a name to set for this task at runtime.
             `task_run_name` strings can be templated formatting strings which will be
-            formatted at runtime with values from `prefect.context`, task inputs, and parameters.
+            formatted at runtime with values from task arguments, `prefect.context`, and flow
+            parameters (in the case of a name conflict between these, earlier values take precedence).
             If a callable function is provided, it should have signature `callable(**kwargs) -> str`
             and at write time all formatting kwargs will be passed and a fully formatted location is
             expected as the return value. The callable can be used for string formatting logic that
-            `.format(**kwargs)` doesn't support. The conflict occurred when prefect context
-            variables(such as `config` or `parameters`, etc.) shadowed task input variable under
-            the same name. The issue is solved by adding prefect context values if task doesn't
-            have argument of the same name. **Note**: this only works for tasks running against a
+            `.format(**kwargs)` doesn't support. **Note**: this only works for tasks running against a
             backend API.
 
     Raises:

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -207,7 +207,9 @@ class Task(metaclass=SignatureValidator):
             and at write time all formatting kwargs will be passed and a fully formatted location is
             expected as the return value. The callable can be used for string formatting logic that
             `.format(**kwargs)` doesn't support. **Note**: this only works for tasks running against a
-            backend API.
+            backend API. The conflict occured when task input variable named as one of prefect
+            context varialbes (such as `config` or `parameters`, etc.). The issue is solved by adding
+            prefect context values if task doesn't have argument of the same name.
 
     Raises:
         - TypeError: if `tags` is of type `str`

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -206,10 +206,11 @@ class Task(metaclass=SignatureValidator):
             If a callable function is provided, it should have signature `callable(**kwargs) -> str`
             and at write time all formatting kwargs will be passed and a fully formatted location is
             expected as the return value. The callable can be used for string formatting logic that
-            `.format(**kwargs)` doesn't support. **Note**: this only works for tasks running against a
-            backend API. The conflict occured when task input variable named as one of prefect
-            context varialbes (such as `config` or `parameters`, etc.). The issue is solved by adding
-            prefect context values if task doesn't have argument of the same name.
+            `.format(**kwargs)` doesn't support. The conflict occurred when prefect context 
+            variables(such as `config` or `parameters`, etc.) shadowed task input variable under 
+            the same name. The issue is solved by adding prefect context values if task doesn't 
+            have argument of the same name. **Note**: this only works for tasks running against a
+            backend API.
 
     Raises:
         - TypeError: if `tags` is of type `str`

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -344,9 +344,9 @@ class CloudTaskRunner(TaskRunner):
         if task_run_name:
             raw_inputs = {k: r.value for k, r in task_inputs.items()}
             formatting_kwargs = {
-                **prefect.context.get("parameters", {}).copy(),
-                **raw_inputs,
+                **prefect.context.get("parameters", {}),
                 **prefect.context,
+                **raw_inputs,
             }
 
             if not isinstance(task_run_name, str):

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1123,7 +1123,6 @@ def test_task_runner_sets_task_name(monkeypatch, cloud_settings):
 def test_task_runner_set_task_name_same_as_prefect_context(client):
     @prefect.task(name="hey", task_run_name=lambda **kwargs: kwargs["config"])
     def test_task(config):
-        print(config)
         return
 
     edge = Edge(Task(), Task(), key="config")

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -1118,3 +1118,13 @@ def test_task_runner_sets_task_name(monkeypatch, cloud_settings):
     assert client.set_task_run_name.called
     assert client.set_task_run_name.call_args[1]["name"] == "name"
     assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"
+
+    task = Task(name="test", task_run_name="config")
+    runner = CloudTaskRunner(task=task)
+    runner.task_run_id = "id"
+
+    runner.set_task_run_name(task_inputs={})
+
+    assert client.set_task_run_name.called
+    assert client.set_task_run_name.call_args[1]["name"] == "config"
+    assert client.set_task_run_name.call_args[1]["task_run_id"] == "id"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Solve the issue [#3605](https://github.com/PrefectHQ/prefect/issues/3605) related to collision of names for task_run and name of variables in prefect.context.



## Changes
<!-- What does this PR change? -->
Keep user defined arguments for task_run_name. Add the prefect context values only for the task arguments with different names. 



## Importance
<!-- Why is this PR important? -->
Avoids name collision between task_run_name and prefect.context variables.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)