### PR TITLE
Update ordering on all formatting kwargs for templated objects

### DIFF
--- a/changes/pr3627.yaml
+++ b/changes/pr3627.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Task arguments take precedence when generating templated targets and locations - [#3627](https://github.com/PrefectHQ/prefect/pull/3627)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -697,8 +697,8 @@ class TaskRunner(Runner):
             raw_inputs = {k: r.value for k, r in inputs.items()}
             formatting_kwargs = {
                 **prefect.context.get("parameters", {}).copy(),
-                **raw_inputs,
                 **prefect.context,
+                **raw_inputs,
             }
 
             if not isinstance(target, str):
@@ -875,8 +875,8 @@ class TaskRunner(Runner):
             try:
                 formatting_kwargs = {
                     **prefect.context.get("parameters", {}).copy(),
-                    **raw_inputs,
                     **prefect.context,
+                    **raw_inputs,
                 }
                 result = self.result.write(value, **formatting_kwargs)
             except NotImplementedError:
@@ -958,8 +958,8 @@ class TaskRunner(Runner):
                         raw_inputs = {k: r.value for k, r in inputs.items()}
                         formatting_kwargs = {
                             **prefect.context.get("parameters", {}).copy(),
-                            **raw_inputs,
                             **prefect.context,
+                            **raw_inputs,
                         }
                         loop_result = self.result.write(
                             loop_result.value, **formatting_kwargs

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -1177,6 +1177,23 @@ class TestRunTaskStep:
         assert new_state.is_successful()
         assert new_state._result.location.endswith("2.txt")
 
+    def test_result_formatting_with_templated_inputs_inputs_take_precedence(
+        self, tmpdir
+    ):
+        result = LocalResult(dir=tmpdir, location="{config}.txt")
+
+        @prefect.task(checkpoint=True, result=result, slug="1234567")
+        def fn(config):
+            return config
+
+        edge = Edge(Task(), fn, key="config")
+        with set_temporary_config({"flows.checkpointing": True}):
+            new_state = TaskRunner(task=fn).run(
+                state=None, upstream_states={edge: Success(result=Result(2))}
+            )
+        assert new_state.is_successful()
+        assert new_state._result.location.endswith("2.txt")
+
     def test_result_formatting_with_input_named_value(self, tmpdir):
         result = LocalResult(dir=tmpdir, location="{value}.txt")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Following the work in #3622 , this PR updates _all_ templating logic to follow the same precedence: parameters, then context, then inputs.


## Changes
<!-- What does this PR change? -->
Updates the handling of conflicting keys when templating results.



## Importance
<!-- Why is this PR important? -->
Match user expectations better.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)