### PR TITLE
Parse env vars with newlines, without requiring escaping \

### DIFF
--- a/changes/issue3603.yaml
+++ b/changes/issue3603.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Parsing backslashes in environment variable values without escape - [#3603](https://github.com/PrefectHQ/prefect/issues/3603)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -206,11 +206,6 @@ def interpolate_config(config: dict, env_var_prefix: str = None) -> Config:
                 if "__" not in env_var:
                     continue
 
-                # env vars with escaped characters are interpreted as literal "\", which
-                # Python helpfully escapes with a second "\". This step makes sure that
-                # escaped characters are properly interpreted.
-                value = cast(str, env_var_value.encode().decode("unicode_escape"))
-
                 # place the env var in the flat config as a compound key
                 if env_var_option.upper().startswith("CONTEXT__SECRETS"):
                     formatted_option = env_var_option.split("__")
@@ -224,7 +219,7 @@ def interpolate_config(config: dict, env_var_prefix: str = None) -> Config:
                     )
 
                 flat_config[config_option] = string_to_type(
-                    cast(str, interpolate_env_vars(value))
+                    cast(str, interpolate_env_vars(env_var_value))
                 )
 
     # interpolate any env vars referenced

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -67,7 +67,7 @@ def config(test_config_file_path, monkeypatch):
     )
     monkeypatch.setenv("PATH", "1/2/3")
     monkeypatch.setenv(
-        "PREFECT_TEST__ENV_VARS__ESCAPED_CHARACTERS", r"line 1\nline 2\rand 3\tand 4"
+        "PREFECT_TEST__ENV_VARS__ESCAPED_CHARACTERS", "line 1\nline 2\rand 3\tand 4"
     )
 
     yield configuration.load_configuration(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Removes the need to escape backslashes when parsing environment variables. See also #3603

## Importance
<!-- Why is this PR important? -->
Makes usage of JSON configs as environment variables easier by respecting the original backslashes. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)