### PR TITLE
Skip project creation if the project already exists

### DIFF
--- a/changes/pr3630.yaml
+++ b/changes/pr3630.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Adds `skip_if_exists parameter` to `Client.create_project` and `--skip-if-exists` flag to `prefect create project` so that users can skip creating projects that already exist. - [#3630](https://github.com/PrefectHQ/prefect/pull/3630)"
+  - `Client.create_project` and `prefect create project` will skip creating the project if the project already exists. - [#3630](https://github.com/PrefectHQ/prefect/pull/3630)"
 
 contributor:
   - "[Amanda Wee](https://github.com/amanda-wee)"

--- a/changes/pr3630.yaml
+++ b/changes/pr3630.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Adds `skip_if_exists parameter` to `Client.create_project` and `--skip-if-exists` flag to `prefect create project` so that users can skip creating projects that already exist. - [#3630](https://github.com/PrefectHQ/prefect/pull/3630)"
+
+contributor:
+  - "[Amanda Wee](https://github.com/amanda-wee)"

--- a/changes/pr3630.yaml
+++ b/changes/pr3630.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - `Client.create_project` and `prefect create project` will skip creating the project if the project already exists. - [#3630](https://github.com/PrefectHQ/prefect/pull/3630)"
+  - "`Client.create_project` and `prefect create project` will skip creating the project if the project already exists. - [#3630](https://github.com/PrefectHQ/prefect/pull/3630)"
 
 contributor:
   - "[Amanda Wee](https://github.com/amanda-wee)"

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -52,7 +52,7 @@ def project(name, description, skip_if_exists):
 
     """
     try:
-        project_id = Client().create_project(
+        Client().create_project(
             project_name=name,
             project_description=description,
             skip_if_exists=skip_if_exists,

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -31,15 +31,10 @@ def create():
 @create.command(hidden=True)
 @click.argument("name", required=True)
 @click.option("--description", "-d", help="Project description to create", hidden=True)
-@click.option(
-    "--skip-if-exists",
-    is_flag=True,
-    help="Skip creating the project if it already exists",
-    hidden=True,
-)
-def project(name, description, skip_if_exists):
+def project(name, description):
     """
-    Create projects with the Prefect API that organize flows.
+    Create projects with the Prefect API that organize flows. Does nothing if
+    the project already exists.
 
     \b
     Arguments:
@@ -48,14 +43,12 @@ def project(name, description, skip_if_exists):
     \b
     Options:
         --description, -d   TEXT    A project description
-        --skip-if-exists            Skip creating the project if it already exists
 
     """
     try:
         Client().create_project(
             project_name=name,
             project_description=description,
-            skip_if_exists=skip_if_exists,
         )
     except ClientError as exc:
         click.echo(f"{type(exc).__name__}: {exc}")

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -62,8 +62,4 @@ def project(name, description, skip_if_exists):
         click.secho("Error creating project", fg="red")
         return
 
-    if project_id:
-        message = "{} created".format(name)
-    else:
-        message = "skipped creating {} as it already exists".format(name)
-    click.secho(message, fg="green")
+    click.secho("{} created".format(name), fg="green")

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -31,7 +31,13 @@ def create():
 @create.command(hidden=True)
 @click.argument("name", required=True)
 @click.option("--description", "-d", help="Project description to create", hidden=True)
-def project(name, description):
+@click.option(
+    "--skip-if-exists",
+    is_flag=True,
+    help="Skip creating the project if it already exists",
+    hidden=True,
+)
+def project(name, description, skip_if_exists):
     """
     Create projects with the Prefect API that organize flows.
 
@@ -42,13 +48,22 @@ def project(name, description):
     \b
     Options:
         --description, -d   TEXT    A project description
+        --skip-if-exists            Skip creating the project if it already exists
 
     """
     try:
-        Client().create_project(project_name=name, project_description=description)
+        project_id = Client().create_project(
+            project_name=name,
+            project_description=description,
+            skip_if_exists=skip_if_exists,
+        )
     except ClientError as exc:
         click.echo(f"{type(exc).__name__}: {exc}")
         click.secho("Error creating project", fg="red")
         return
 
-    click.secho("{} created".format(name), fg="green")
+    if project_id:
+        message = "{} created".format(name)
+    else:
+        message = "skipped creating {} as it already exists".format(name)
+    click.secho(message, fg="green")

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -46,10 +46,7 @@ def project(name, description):
 
     """
     try:
-        Client().create_project(
-            project_name=name,
-            project_description=description,
-        )
+        Client().create_project(project_name=name, project_description=description)
     except ClientError as exc:
         click.echo(f"{type(exc).__name__}: {exc}")
         click.secho("Error creating project", fg="red")

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -929,7 +929,7 @@ class Client:
             - skip_if_exists (bool, optional): skip creating the project if it already exists
 
         Returns:
-            - str: the ID of the newly-created project or an empty string if it already exists
+            - str: the ID of the newly-created or pre-existing project
 
         Raises:
             - ClientError: if the project creation failed
@@ -953,7 +953,15 @@ class Client:
             )  # type: Any
         except ClientError as exc:
             if skip_if_exists and "'Uniqueness violation.'" in str(exc):
-                return ""
+                project_query = {
+                    "query": {
+                        with_args(
+                            "project", {"where": {"name": {"_eq": project_name}}}
+                        ): {"id": True}
+                    }
+                }
+                res = self.graphql(project_query)
+                return res.data.project[0].id
             raise
 
         return res.data.create_project.id

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -914,19 +914,13 @@ class Client:
             slug = res.get("data").tenant[0].slug
         return slug
 
-    def create_project(
-        self,
-        project_name: str,
-        project_description: str = None,
-        skip_if_exists: bool = False,
-    ) -> str:
+    def create_project(self, project_name: str, project_description: str = None) -> str:
         """
-        Create a new Project
+        Create a new project if a project with the name provided does not already exist
 
         Args:
-            - project_name (str): the project that should contain this flow
+            - project_name (str): the project that should be created
             - project_description (str, optional): the project description
-            - skip_if_exists (bool, optional): skip creating the project if it already exists
 
         Returns:
             - str: the ID of the newly-created or pre-existing project
@@ -952,7 +946,7 @@ class Client:
                 ),
             )  # type: Any
         except ClientError as exc:
-            if skip_if_exists and "'Uniqueness violation.'" in str(exc):
+            if "'Uniqueness violation.'" in str(exc):
                 project_query = {
                     "query": {
                         with_args(

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -49,3 +49,12 @@ def test_create_project_description(patch_post, cloud_api):
     result = runner.invoke(create, ["project", "test", "-d", "description"])
     assert result.exit_code == 0
     assert "test created" in result.output
+
+
+def test_create_project_skip_if_exists(patch_post):
+    patch_post(dict(data=dict(create_project=dict(id=""))))
+
+    runner = CliRunner()
+    result = runner.invoke(create, ["project", "test", "--skip-if-exists"])
+    assert result.exit_code == 0
+    assert "skipped creating test as it already exists" in result.output

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -51,7 +51,7 @@ def test_create_project_description(patch_post, cloud_api):
     assert "test created" in result.output
 
 
-def test_create_project_skip_if_exists(patch_posts):
+def test_create_project_that_already_exists(patch_posts):
     patch_posts(
         [
             {
@@ -65,6 +65,6 @@ def test_create_project_skip_if_exists(patch_posts):
     )
 
     runner = CliRunner()
-    result = runner.invoke(create, ["project", "test", "--skip-if-exists"])
+    result = runner.invoke(create, ["project", "test"])
     assert result.exit_code == 0
     assert "test created" in result.output

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -51,10 +51,20 @@ def test_create_project_description(patch_post, cloud_api):
     assert "test created" in result.output
 
 
-def test_create_project_skip_if_exists(patch_post):
-    patch_post(dict(data=dict(create_project=dict(id=""))))
+def test_create_project_skip_if_exists(patch_posts):
+    patch_posts(
+        [
+            {
+                "errors": [
+                    {"message": "Uniqueness violation.", "path": ["create_project"]}
+                ],
+                "data": {"create_project": None},
+            },
+            {"data": {"project": [{"id": "proj-id"}]}},
+        ]
+    )
 
     runner = CliRunner()
     result = runner.invoke(create, ["project", "test", "--skip-if-exists"])
     assert result.exit_code == 0
-    assert "skipped creating test as it already exists" in result.output
+    assert "test created" in result.output

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -593,6 +593,28 @@ def test_client_register_with_bad_proj_name(patch_post, monkeypatch, cloud_api):
     assert "prefect create project 'my-default-project'" in str(exc.value)
 
 
+def test_client_create_project_that_already_exists(patch_post, monkeypatch):
+    patch_post(
+        {
+            "errors": [
+                {"message": "Uniqueness violation.", "path": ["create_project"]}
+            ],
+            "data": {"create_project": None},
+        }
+    )
+
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+
+    with set_temporary_config({"cloud.auth_token": "secret_token", "backend": "cloud"}):
+        client = Client()
+    project_id = client.create_project(
+        project_name="my-default-project", skip_if_exists=True
+    )
+    assert project_id == ""
+
+
 def test_client_register_with_flow_that_cant_be_deserialized(patch_post, monkeypatch):
     patch_post({"data": {"project": [{"id": "proj-id"}]}})
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -612,32 +612,8 @@ def test_client_create_project_that_already_exists(patch_posts, monkeypatch):
 
     with set_temporary_config({"cloud.auth_token": "secret_token", "backend": "cloud"}):
         client = Client()
-    project_id = client.create_project(
-        project_name="my-default-project", skip_if_exists=True
-    )
+    project_id = client.create_project(project_name="my-default-project")
     assert project_id == "proj-id"
-
-
-def test_client_create_project_that_already_exists_without_skipping(
-    patch_post, monkeypatch
-):
-    patch_post(
-        {
-            "errors": [
-                {"message": "Uniqueness violation.", "path": ["create_project"]}
-            ],
-            "data": {"create_project": None},
-        }
-    )
-
-    monkeypatch.setattr(
-        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
-    )
-
-    with set_temporary_config({"cloud.auth_token": "secret_token", "backend": "cloud"}):
-        client = Client()
-    with pytest.raises(ClientError, match="'Uniqueness violation.'"):
-        client.create_project(project_name="my-default-project", skip_if_exists=False)
 
 
 def test_client_register_with_flow_that_cant_be_deserialized(patch_post, monkeypatch):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -593,14 +593,17 @@ def test_client_register_with_bad_proj_name(patch_post, monkeypatch, cloud_api):
     assert "prefect create project 'my-default-project'" in str(exc.value)
 
 
-def test_client_create_project_that_already_exists(patch_post, monkeypatch):
-    patch_post(
-        {
-            "errors": [
-                {"message": "Uniqueness violation.", "path": ["create_project"]}
-            ],
-            "data": {"create_project": None},
-        }
+def test_client_create_project_that_already_exists(patch_posts, monkeypatch):
+    patch_posts(
+        [
+            {
+                "errors": [
+                    {"message": "Uniqueness violation.", "path": ["create_project"]}
+                ],
+                "data": {"create_project": None},
+            },
+            {"data": {"project": [{"id": "proj-id"}]}},
+        ]
     )
 
     monkeypatch.setattr(
@@ -612,7 +615,7 @@ def test_client_create_project_that_already_exists(patch_post, monkeypatch):
     project_id = client.create_project(
         project_name="my-default-project", skip_if_exists=True
     )
-    assert project_id == ""
+    assert project_id == "proj-id"
 
 
 def test_client_create_project_that_already_exists_without_skipping(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Change `Client.create_project` and `prefect create project`to skip creating the project if it already exists, returning/printing as if the project had been created


## Changes
<!-- What does this PR change? -->
- Change `Client.create_project` such that if the project to be created already exists, then it has no net effect and the id of the existing project is returned.
- Change `prefect create project` to regard an attempt to create a project that already exists as successful, skipping the creation of the project.


## Importance
<!-- Why is this PR important? -->
Enables users to easily automate project creation (e.g., at startup in an ECS task) while continuing to receive errors unrelated to the project having been previously created. This meshes nicely with the introduction of the idempotency key for `flow.register` and `flow.serialized_hash()` in 0.13.14.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)