### PR TITLE
Display graphql error messages on failure

### DIFF
--- a/changes/pr3632.yaml
+++ b/changes/pr3632.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Display formatted graphql errors on client request failure - [#3632](https://github.com/PrefectHQ/prefect/pull/3632)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -356,7 +356,7 @@ class Client:
         try:
             response.raise_for_status()
         except HTTPError as exc:
-            if response.status_code == 400 and "query" in params:
+            if response.status_code == 400 and params and "query" in params:
                 # Create a custom-formatted err message for graphql errors which always
                 # return a 400 status code and have "query" in the parameter dict
                 try:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -367,7 +367,7 @@ class Client:
                         "This is likely caused by a poorly formatted GraphQL query or "
                         "mutation but the response could not be parsed for more details"
                     )
-                raise ClientError(f"{exc}\n\n{graphql_msg}") from exc
+                raise ClientError(f"{exc}\n{graphql_msg}") from exc
 
             # Server-side and non-graphql errors will be raised without modification
             raise

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -19,7 +19,6 @@ except ImportError:
 import pendulum
 import toml
 from slugify import slugify
-from requests import HTTPError
 
 import prefect
 from prefect.utilities.exceptions import (
@@ -328,6 +327,8 @@ class Client:
         params: Dict[str, JSONLike] = None,
         headers: dict = None,
     ) -> "requests.models.Response":
+        import requests
+
         if prefect.context.config.cloud.get("diagnostics") is True:
             self.logger.debug(f"Preparing request to {url}")
             clean_headers = {
@@ -357,7 +358,7 @@ class Client:
         # Check if request returned a successful status
         try:
             response.raise_for_status()
-        except HTTPError as exc:
+        except requests.HTTPError as exc:
             if response.status_code == 400 and params and "query" in params:
                 # Create a custom-formatted err message for graphql errors which always
                 # return a 400 status code and have "query" in the parameter dict

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -304,6 +304,8 @@ class Client:
             retry_on_api_error=retry_on_api_error,
         )
 
+        # TODO: It looks like this code is never reached because errors are raised
+        #       in self._send_request by default
         if raise_on_error and "errors" in result:
             if "UNAUTHENTICATED" in str(result["errors"]):
                 raise AuthorizationError(result["errors"])

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -309,9 +309,9 @@ def format_graphql_request_error(response: Response) -> str:
     Returns:
         A formatted string
     """
-    params = json.loads(response.request.body or "")
-    query = parse_graphql(params.get("query", {}))
-    variables = parse_graphql(params.get("variables", {}))
+    params = json.loads(response.request.body or "{}")
+    query = parse_graphql(params.get("query", {})) or "null"
+    variables = parse_graphql(params.get("variables", {})) or "null"
 
     content = response.json()
     errors = content.get("errors", [])

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -289,6 +289,20 @@ def with_args(field: Any, arguments: Any) -> str:
     return "{field}({arguments})".format(field=parsed_field, arguments=parsed_arguments)
 
 
+def format_graphql_error(response_text: str) -> str:
+    content = json.loads(response_text)
+    errors = content.get("errors", [])
+    lines = []
+    for error in errors:
+        message = error.get("message", "No error message")
+        extensions = error.get("extensions", {})
+        # Other extensions are possible but we will only include the minimum for now
+        # since stack traces and other info are likely not passed
+        code = extensions.get("code", "UNKNOWN_ERROR")
+        lines.append(f"{code}: {message}")
+    return "\n".join(lines)
+
+
 def compress(input: Any) -> str:
     """
     Convenience function for compressing something before sending

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -291,6 +291,17 @@ def with_args(field: Any, arguments: Any) -> str:
 
 
 def format_graphql_request_error(response: Response) -> str:
+    """
+    Given a http response that contains a graphql error, parse the error messages
+    and create a nicely formatted string summary
+
+    Args:
+        response (requests.Response): The HTTP response with the errors, should have
+            returned a 400
+
+    Returns:
+        A formatted string
+    """
 
     params = json.loads(response.request.body)
     query = parse_graphql(params.get("query", {}))
@@ -307,16 +318,15 @@ def format_graphql_request_error(response: Response) -> str:
         code = extensions.get("code", "UNKNOWN_ERROR")
         error_msgs += f"{code}: {message}\n"
 
-        error_prefix = (
-            "The following error messages were provided by the GraphQL server:\n"
-            if error_msgs
-            else "The server did not provide any error messages."
-        )
+    error_prefix = (
+        "The following error messages were provided by the GraphQL server:\n"
+        if error_msgs
+        else "The server did not provide any error messages."
+    )
 
     return textwrap.dedent(
         f"""
-        {error_prefix}
-        {error_msgs}
+        {error_prefix}{error_msgs}
 
         The GraphQL query was:
         

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -339,7 +339,7 @@ def format_graphql_request_error(response: Response) -> str:
             {multiline_indent(error_paragraph, 12)}
 
         The GraphQL query was:
-        
+
             {multiline_indent(query, 12)}
 
         The passed variables were:

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -309,8 +309,7 @@ def format_graphql_request_error(response: Response) -> str:
     Returns:
         A formatted string
     """
-
-    params = json.loads(response.request.body)
+    params = json.loads(response.request.body or "")
     query = parse_graphql(params.get("query", {}))
     variables = parse_graphql(params.get("variables", {}))
 
@@ -337,7 +336,6 @@ def format_graphql_request_error(response: Response) -> str:
     return textwrap.dedent(
         f"""
         {error_prefix}
-
             {multiline_indent(error_paragraph, 12)}
 
         The GraphQL query was:

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -4,10 +4,12 @@ import json
 import textwrap
 import uuid
 from collections.abc import KeysView, ValuesView
-from typing import Any
-from requests import Response
+from typing import Any, TYPE_CHECKING
 
 from box import Box
+
+if TYPE_CHECKING:
+    import requests
 
 
 def lowercase_first_letter(s: str) -> str:
@@ -297,7 +299,7 @@ def with_args(field: Any, arguments: Any) -> str:
     return "{field}({arguments})".format(field=parsed_field, arguments=parsed_arguments)
 
 
-def format_graphql_request_error(response: Response) -> str:
+def format_graphql_request_error(response: "requests.Response") -> str:
     """
     Given a http response that contains a graphql error, parse the error messages
     and create a nicely formatted string summary

--- a/src/prefect/utilities/graphql.py
+++ b/src/prefect/utilities/graphql.py
@@ -313,8 +313,8 @@ def format_graphql_request_error(response: Response) -> str:
     query = parse_graphql(params.get("query", {}))
     variables = parse_graphql(params.get("variables", {}))
 
-    text = json.loads(response.text)
-    errors = text.get("errors", [])
+    content = response.json()
+    errors = content.get("errors", [])
     error_msgs = []
     for error in errors:
         message = error.get("message", "No error message supplied.")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Displays the content of GraphQL error responses. Builds on #3615 

It looks like when Apollo sends a 400 response it always attaches some error information in the response.text section as a json blob. This json is a list of errors that include messages of what is actually wrong which is really helpful for determining what went wrong with your query.

## Changes
<!-- What does this PR change? -->

- Adds GraphQL error response text parsing and formatting
- Adds GraphQL error check and display to Client._send_request

## Importance
<!-- Why is this PR important? -->

Error messages are hidden without entering a debugger

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)


## Example

```
ClientError: 400 Client Error: Bad Request for url: https://api-dev.prefect.io/graphql

The following error messages were provided by the GraphQL server:

    GRAPHQL_VALIDATION_FAILED: Cannot query field "flow_run" on type "flow". Did you
        mean "flow_runs", "flow_group", or "flow_group_id"?

The GraphQL query was:

    query {
            flow {
                id
                name
                flow_run {
                    state
                    id
            }
        }
    }

The passed variables were:

    null
```