### PR TITLE
Update deployments extension to AppsV1Api

### DIFF
--- a/changes/pr3637.yaml
+++ b/changes/pr3637.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Update kubernetes deployment reference in tasks & utilities- [#3637](https://github.com/PrefectHQ/prefect/pull/3637)"
+
+contributor:
+  - "[Brad McElroy](https://github.com/limx0)"

--- a/changes/pr3637.yaml
+++ b/changes/pr3637.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Update kubernetes deployment reference in tasks & utilities- [#3637](https://github.com/PrefectHQ/prefect/pull/3637)"
+  - "Update deployments extension to AppsV1Api - [#3637](https://github.com/PrefectHQ/prefect/pull/3637)"
 
 contributor:
   - "[Brad McElroy](https://github.com/limx0)"

--- a/src/prefect/tasks/kubernetes/deployment.py
+++ b/src/prefect/tasks/kubernetes/deployment.py
@@ -91,7 +91,7 @@ class CreateNamespacedDeployment(Task):
             )
 
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 
@@ -187,7 +187,7 @@ class DeleteNamespacedDeployment(Task):
             raise ValueError("The name of a Kubernetes deployment must be provided.")
 
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 
@@ -273,7 +273,7 @@ class ListNamespacedDeployment(Task):
                 of the deployments which are found
         """
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 
@@ -379,7 +379,7 @@ class PatchNamespacedDeployment(Task):
             raise ValueError("The name of a Kubernetes deployment must be provided.")
 
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 
@@ -475,7 +475,7 @@ class ReadNamespacedDeployment(Task):
             raise ValueError("The name of a Kubernetes deployment must be provided.")
 
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 
@@ -583,7 +583,7 @@ class ReplaceNamespacedDeployment(Task):
             raise ValueError("The name of a Kubernetes deployment must be provided.")
 
         api_client = cast(
-            client.ExtensionsV1beta1Api,
+            client.AppsV1Api,
             get_kubernetes_client("deployment", kubernetes_api_key_secret),
         )
 

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -13,13 +13,11 @@ K8S_CLIENTS = {
     "job": client.BatchV1Api,
     "pod": client.CoreV1Api,
     "service": client.CoreV1Api,
-    "deployment": client.ExtensionsV1beta1Api,
+    "deployment": client.AppsV1Api,
 }
 
 
-KubernetesClient = Union[
-    client.BatchV1Api, client.CoreV1Api, client.ExtensionsV1beta1Api
-]
+KubernetesClient = Union[client.BatchV1Api, client.CoreV1Api, client.AppsV1Api]
 
 
 def get_kubernetes_client(

--- a/tests/utilities/test_kubernetes.py
+++ b/tests/utilities/test_kubernetes.py
@@ -26,7 +26,7 @@ class TestGetKubernetesClient:
             ("job", client.BatchV1Api),
             ("pod", client.CoreV1Api),
             ("service", client.CoreV1Api),
-            ("deployment", client.ExtensionsV1beta1Api),
+            ("deployment", client.AppsV1Api),
         ],
     )
     def test_returns_correct_kubernetes_client(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes https://github.com/PrefectHQ/prefect/issues/3636

## Changes
<!-- What does this PR change? -->
This PR updates the kubernetes tasks & utilities for deployments to AppsV1Api, which is required for newer cluster versions of kubernetes.  

## Importance
<!-- Why is this PR important? -->
Refer https://github.com/PrefectHQ/prefect/issues/3636


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)