### PR TITLE
Add ref option to GitHub storage for specifying branches

### DIFF
--- a/changes/issue3638.yaml
+++ b/changes/issue3638.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add `ref` option to GitHub storage for specifying branches other than master - [#3638](https://github.com/PrefectHQ/prefect/issues/3638)"

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -124,6 +124,7 @@ class GitHubSchema(ObjectSchema):
         object_class = GitHub
 
     repo = fields.String(allow_none=False)
+    ref = fields.String(allow_none=False)
     path = fields.String(allow_none=True)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)

--- a/tests/environments/storage/test_github_storage.py
+++ b/tests/environments/storage/test_github_storage.py
@@ -15,11 +15,14 @@ def test_create_github_storage():
 
 
 def test_create_github_storage_init_args():
-    storage = GitHub(repo="test/repo", path="flow.py", secrets=["auth"])
+    storage = GitHub(
+        repo="test/repo", path="flow.py", ref="my_branch", secrets=["auth"]
+    )
     assert storage
     assert storage.flows == dict()
     assert storage.repo == "test/repo"
     assert storage.path == "flow.py"
+    assert storage.ref == "my_branch"
     assert storage.secrets == ["auth"]
 
 
@@ -87,5 +90,5 @@ def test_get_flow_github(monkeypatch):
     assert f.name not in storage
     flow_location = storage.add_flow(f)
 
-    new_flow = storage.get_flow(flow_location)
+    new_flow = storage.get_flow(flow_location, ref="my_branch")
     assert new_flow.run()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Closes #3638 



## Changes
Adds a `ref` kwarg to github storage at initialization and when calling `get_flow`



## Importance
This now matches the functionality currently present in GitLab storage and allows users to grab flows from other branches



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)