### PR TITLE
Secret names not required to init tasks

### DIFF
--- a/changes/pr3641.yaml
+++ b/changes/pr3641.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "`PrefectSecret` and `EnvVarSecret` tasks no longer require secret names be provided at flow creation time - [#3641](https://github.com/PrefectHQ/prefect/pull/3641)"

--- a/src/prefect/tasks/secrets/base.py
+++ b/src/prefect/tasks/secrets/base.py
@@ -3,7 +3,6 @@ import warnings
 from prefect.client.secrets import Secret as _Secret
 from prefect.core.task import Task
 from prefect.engine.results import SecretResult
-from prefect.utilities.tasks import defaults_from_attrs
 
 
 class SecretBase(Task):
@@ -36,18 +35,17 @@ class PrefectSecret(SecretBase):
     the Prefect Secrets API (which has the ability to toggle between local vs. Cloud secrets).
 
     Args:
-        - name (str): The name of the underlying secret
+        - name (str, optional): The name of the underlying secret
         - **kwargs (Any, optional): additional keyword arguments to pass to the Task constructor
 
     Raises:
         - ValueError: if a `result` keyword is passed
     """
 
-    def __init__(self, name, **kwargs):
-        kwargs["name"] = name
-        super().__init__(**kwargs)
+    def __init__(self, name=None, **kwargs):
+        self.secret_name = name
+        super().__init__(name=name, **kwargs)
 
-    @defaults_from_attrs("name")
     def run(self, name: str = None):
         """
         The run method for Secret Tasks.  This method actually retrieves and returns the
@@ -63,6 +61,10 @@ class PrefectSecret(SecretBase):
         Returns:
             - Any: the underlying value of the Prefect Secret
         """
+        if name is None:
+            name = self.secret_name
+        if name is None:
+            raise ValueError("A secret name must be provided.")
         return _Secret(name).get()
 
 

--- a/tests/tasks/secrets/test_env_var.py
+++ b/tests/tasks/secrets/test_env_var.py
@@ -4,11 +4,6 @@ import prefect
 from prefect.tasks.secrets import EnvVarSecret
 
 
-def test_create_envvarsecret_requires_name():
-    with pytest.raises(TypeError, match="required positional argument: 'name'"):
-        EnvVarSecret()
-
-
 def test_init_with_name():
     e = EnvVarSecret(name="FOO")
     assert e.name == "FOO"
@@ -35,6 +30,18 @@ def test_run_secret_with_new_name_at_runtime(monkeypatch):
     monkeypatch.setenv("FOO", "1")
     e = EnvVarSecret(name="FOO")
     assert e.run(name="BAR") is None
+
+
+def test_secret_name_set_at_runtime(monkeypatch):
+    monkeypatch.setenv("FOO", "1")
+    e = EnvVarSecret()
+    assert e.run("FOO") == "1"
+
+
+def test_secret_raises_if_no_name_provided():
+    e = EnvVarSecret()
+    with pytest.raises(ValueError, match="secret name must be provided"):
+        e.run()
 
 
 def test_run_secret_with_new_name_at_runtime_and_raise_missing(monkeypatch):


### PR DESCRIPTION
Previously `PrefectSecret` and `EnvVarSecret` tasks required a default
name set, even if that name was always overridden at runtime. We now
relax that constraint so a user can init a secret task without a name
and only provide the name at runtime later.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)