### PR TITLE
Only send the idempotency_key during registration if set

### DIFF
--- a/changes/pr3624.yaml
+++ b/changes/pr3624.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix breaking change in flow registration with old server versions - [#3624](https://github.com/PrefectHQ/prefect/pull/3624)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -795,17 +795,20 @@ class Client:
 
         if compressed:
             serialized_flow = compress(serialized_flow)
+
+        inputs = dict(
+            project_id=(project[0].id if project else None),
+            serialized_flow=serialized_flow,
+            set_schedule_active=set_schedule_active,
+            version_group_id=version_group_id,
+        )
+        # Add newly added inputs only when set for backwards compatibility
+        if idempotency_key is not None:
+            inputs.update(idempotency_key=idempotency_key)
+
         res = self.graphql(
             create_mutation,
-            variables=dict(
-                input=dict(
-                    project_id=(project[0].id if project else None),
-                    serialized_flow=serialized_flow,
-                    set_schedule_active=set_schedule_active,
-                    version_group_id=version_group_id,
-                    idempotency_key=idempotency_key,
-                )
-            ),
+            variables=dict(input=inputs),
             retry_on_api_error=False,
         )  # type: Any
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Does not add idempotency_key to the create_flow mutation inputs unless it is set

## Changes
<!-- What does this PR change? -->

- Updates the dict of inputs for the create_flow mutation call in Client.register conditionally

## Importance
<!-- Why is this PR important? -->

Fixes the breaking change introduced by adding idempotency keys


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~