### PR TITLE
Add `stream_output` and a result on failure to `ShellTask`

### DIFF
--- a/changes/pr3649.yaml
+++ b/changes/pr3649.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "ShellTask returns output on failure - [#3649](https://github.com/PrefectHQ/prefect/pull/3649)"
+  - "ShellTask allows streaming of output independently of the number of lines returned - [#3649](https://github.com/PrefectHQ/prefect/pull/3649)"

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -108,6 +108,34 @@ def test_shell_logs_non_zero_exit(caplog):
     assert "Command failed" in error_log[0].message
 
 
+def test_shell_attaches_result_to_failure(caplog):
+    def assert_fail_result(task, state):
+        assert state.result["returncode"] == 1
+        assert state.result["output"] == [
+            "foo" "ls: surely_a_dir_that_doesnt_exist: No such file or directory"
+        ]
+
+    with Flow(name="test") as f:
+        task = ShellTask(on_failure=assert_fail_result)(
+            command="echo foo && ls surely_a_dir_that_doesnt_exist"
+        )
+    out = f.run()
+    assert out.is_failed()
+
+
+@pytest.mark.parametrize("stream_output", [True, False])
+def test_shell_respects_stream_output(caplog, stream_output):
+
+    with Flow(name="test") as f:
+        ShellTask(stream_output=stream_output)(
+            command="echo foo && echo bar",
+        )
+    f.run()
+
+    stdout_in_log = "foo" in caplog.messages and "bar" in caplog.messages
+    assert stdout_in_log == stream_output
+
+
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     with Flow(name="test") as f:
         task = ShellTask(log_stderr=True, return_all=True)(

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -110,10 +110,10 @@ def test_shell_logs_non_zero_exit(caplog):
 
 def test_shell_attaches_result_to_failure(caplog):
     def assert_fail_result(task, state):
-        assert state.result["returncode"] == 1
-        assert state.result["output"] == [
-            "foo" "ls: surely_a_dir_that_doesnt_exist: No such file or directory"
-        ]
+        assert (
+            state.result == "foo"
+            "ls: surely_a_dir_that_doesnt_exist: No such file or directory"
+        )
 
     with Flow(name="test") as f:
         task = ShellTask(on_failure=assert_fail_result)(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds some better handling of output to `ShellTask`

Closes #3614
Closes #3584 

## Changes
<!-- What does this PR change? -->

- Adds the output result to the `FAIL` signal state for inspection on failure cases
- Adds notes about inconsistencies / handling that need to be fixed but are breaking changes
- Adds `stream_output` to log printed lines as they come independent of return settings

## Importance
<!-- Why is this PR important? -->

- The `ShellTask` is a bit neglected and was hard to inspect in failure cases.
- Setup for future `ShellCommand` but fixes pressing problems

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)