### PR TITLE
Pass PREFECT_CORE_VERSION to Server

### DIFF
--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       PREFECT_SERVER__DATABASE__CONNECTION_URL: ${DB_CONNECTION_URL}
       PREFECT_SERVER__HASURA__ADMIN_SECRET: ${PREFECT_SERVER__HASURA__ADMIN_SECRET:-hasura-secret-admin-secret}
       PREFECT_SERVER__HASURA__HOST: hasura
+      PREFECT_CORE_VERSION: ${PREFECT_CORE_VERSION:-"UNKNOWN"}
     networks:
       - prefect-server
     restart: "always"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -325,6 +325,9 @@ def start(
         )
         env.update(PREFECT_SERVER_DB_CMD=cmd)
 
+    # Pass the Core version so the Server API can return it
+    env.update(PREFECT_CORE_VERSION=prefect.__version__)
+
     proc = None
     try:
         if not skip_pull:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Passes `PREFECT_CORE_VERSION` during `prefect server start` for https://github.com/PrefectHQ/server/pull/126


## Changes
<!-- What does this PR change? -->

- Passes PREFECT_CORE_VERSION to docker-compose
- Adds PREFECT_CORE_VERSION to the server container env


## Importance
<!-- Why is this PR important? -->

Allow core version display in the UI

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~

Manually verified that this value populates when running `prefect server start`

I do not think a changes/ entry is meaningful here.