### PR TITLE
Sort json keys before hashing in `flow.serialized_hash`

### DIFF
--- a/changes/pr3654.yaml
+++ b/changes/pr3654.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fixed bug where `flow.serialized_hash()` could return inconsistent values across new python instances - [#3654](https://github.com/PrefectHQ/prefect/pull/3654)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1478,7 +1478,9 @@ class Flow:
         Returns:
             - str: the hash of the serialized flow
         """
-        return hashlib.sha256(json.dumps(self.serialize(build)).encode()).hexdigest()
+        return hashlib.sha256(
+            json.dumps(self.serialize(build), sort_keys=True).encode()
+        ).hexdigest()
 
     # Diagnostics  ----------------------------------------------------------------
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -7,6 +7,8 @@ import random
 import sys
 import tempfile
 import time
+import subprocess
+import textwrap
 from unittest.mock import MagicMock, patch
 
 import cloudpickle
@@ -1858,6 +1860,34 @@ class TestSerializedHash:
 
     def test_is_different_with_different_flow_name(self):
         assert Flow("foo").serialized_hash() != Flow("bar").serialized_hash()
+
+    def test_is_same_in_new_python_instance(self, tmpdir):
+        contents = textwrap.dedent(
+            """
+        from prefect import task, Flow
+
+        @task
+        def dummy_task():
+            return "nothing interesting"
+
+        with Flow("example-flow") as flow:
+            dummy_task()
+
+        if __name__ == "__main__":
+            print(flow.serialized_hash())
+        """
+        )
+        script = tmpdir.join("flow.py")
+        script.write_text(contents, encoding="utf-8")
+
+        hashes = []
+        for _ in range(2):
+            result = subprocess.run(
+                [sys.executable, script], capture_output=True, check=True
+            )
+            hashes.append(result.stdout)
+
+        assert len(set(hashes)) == 1
 
     def test_is_different_with_modified_flow_name(self):
         f1 = Flow("foo")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1883,10 +1883,11 @@ class TestSerializedHash:
         hashes = []
         for _ in range(2):
             result = subprocess.run(
-                [sys.executable, script], capture_output=True, check=True
+                [sys.executable, script], stdout=subprocess.PIPE, check=True
             )
             hashes.append(result.stdout)
 
+        assert hashes[0]  # Ensure we don't have an empty string or None
         assert len(set(hashes)) == 1
 
     def test_is_different_with_modified_flow_name(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes a bug where runs of `serialized_hash` could give different values in new Python processes due to dict key order.

Was missed in the initial testing because
- The flow used in manual new python process testing had no tasks and that's where the items are very likely to be in a different order
- New python process testing was deemed not worth automating / adding to the codebase

Thanks @jnoynaert for the report and example!
Closes #3653 

## Changes
<!-- What does this PR change? -->

- Adds `sort_keys=True` to the json.dumps call
- Add test coverage for serializing in new processes

## Importance
<!-- Why is this PR important? -->

Serialized hash should not depend on order

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~