### PR TITLE
Stopped Flow.replace from setting unset reference tasks

### DIFF
--- a/changes/issue3655.yaml
+++ b/changes/issue3655.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fixes Flow.replace freezing reference tasks - [#3655](https://github.com/PrefectHQ/prefect/issues/3655)"
+
+contributor:
+  - "[Ben Fogelson](https://github.com/benfogelson)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -333,12 +333,13 @@ class Flow:
                 validate=False,
             )
 
-        # update auxiliary task collections
-        ref_tasks = self.reference_tasks()
-        new_refs = [t for t in ref_tasks if t != old] + (
-            [new] if old in ref_tasks else []
-        )
-        self.set_reference_tasks(new_refs)
+        if self._reference_tasks:
+            # update auxiliary task collections
+            ref_tasks = self.reference_tasks()
+            new_refs = [t for t in ref_tasks if t != old] + (
+                [new] if old in ref_tasks else []
+            )
+            self.set_reference_tasks(new_refs)
 
         if validate:
             self.validate()

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1726,8 +1726,6 @@ class TestReplace:
         state = f.run()
         assert state.is_successful()
         assert state.result[res].result == [55, 56, 1, 2]
-    
-    
 
 
 class TestGetTasks:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1648,6 +1648,16 @@ class TestReplace:
 
         with pytest.raises(ValueError):
             f.edges_to(t1)
+    
+    def test_replace_leaves_unset_reference_tasks_alone(self):
+        with Flow(name="test") as f:
+            t1 = Task(name="t1")()
+            t2 = Task(name="t2")(upstream_tasks=[t1])
+        t3 = Task(name="t3")
+        f.replace(t1, t3)
+        t4 = Task(name="t4")
+        f.add_task(t4)
+        assert f.reference_tasks() == {t2, t4}
 
     def test_replace_update_slugs(self):
         flow = Flow("test")
@@ -1716,6 +1726,8 @@ class TestReplace:
         state = f.run()
         assert state.is_successful()
         assert state.result[res].result == [55, 56, 1, 2]
+    
+    
 
 
 class TestGetTasks:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1648,7 +1648,7 @@ class TestReplace:
 
         with pytest.raises(ValueError):
             f.edges_to(t1)
-    
+
     def test_replace_leaves_unset_reference_tasks_alone(self):
         with Flow(name="test") as f:
             t1 = Task(name="t1")()


### PR DESCRIPTION
## Summary

Changes `Flow.replace` so that it doesn't set reference tasks on a flow that didn't already have reference tasks set.


## Changes

This PR modifies `Flow.replace` by adding an `if` statement to check whether `Flow._reference_tasks` is set before it updates reference tasks by replacing the old task with the new task.




## Importance

This is discussed in https://github.com/PrefectHQ/prefect/issues/3655

Briefly, the current behavior of `Flow.replace` does not make intuitive sense since it freezes the reference tasks of a flow that didn't have frozen reference tasks.


## Checklist

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)