### PR TITLE
Write agent command line warnings to stderr

### DIFF
--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -616,13 +616,14 @@ def start(
         retrieved_agent = _agents.get(agent_option, None)
 
         if not retrieved_agent:
-            click.secho("{} is not a valid agent".format(agent_option), fg="red")
+            click.secho("{} is not a valid agent".format(agent_option), fg="red", err=True)
             return
 
         click.secho(
             f"Warning: `prefect agent start {agent_option}` is deprecated, use "
             f"`prefect agent {agent_option} start` instead",
             fg="yellow",
+            err=True
         )
 
         env_vars = dict()
@@ -870,13 +871,14 @@ def install(
     retrieved_agent = supported_agents.get(name, None)
 
     if not retrieved_agent:
-        click.secho("{} is not a supported agent for `install`".format(name), fg="red")
+        click.secho("{} is not a supported agent for `install`".format(name), fg="red", err=True)
         return
 
     click.secho(
         f"Warning: `prefect agent install {name}` is deprecated, use "
         f"`prefect agent {name} install` instead",
         fg="yellow",
+        err=True
     )
 
     env_vars = dict()

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -616,14 +616,16 @@ def start(
         retrieved_agent = _agents.get(agent_option, None)
 
         if not retrieved_agent:
-            click.secho("{} is not a valid agent".format(agent_option), fg="red", err=True)
+            click.secho(
+                "{} is not a valid agent".format(agent_option), fg="red", err=True
+            )
             return
 
         click.secho(
             f"Warning: `prefect agent start {agent_option}` is deprecated, use "
             f"`prefect agent {agent_option} start` instead",
             fg="yellow",
-            err=True
+            err=True,
         )
 
         env_vars = dict()
@@ -871,14 +873,16 @@ def install(
     retrieved_agent = supported_agents.get(name, None)
 
     if not retrieved_agent:
-        click.secho("{} is not a supported agent for `install`".format(name), fg="red", err=True)
+        click.secho(
+            "{} is not a supported agent for `install`".format(name), fg="red", err=True
+        )
         return
 
     click.secho(
         f"Warning: `prefect agent install {name}` is deprecated, use "
         f"`prefect agent {name} install` instead",
         fg="yellow",
-        err=True
+        err=True,
     )
 
     env_vars = dict()


### PR DESCRIPTION
Currently if you run `prefect agent install kubernetes ... | kubectl apply -f -` you get a fairly confusing error:
```
error: error parsing STDIN: error converting YAML to JSON: yaml: found character that cannot start any token
```

The reason is that `Warning: `prefect agent install kubernetes` is deprecated, use `prefect agent kubernetes install` instead`  shows up at the beginning of the stdout block and gets piped through to `kubectl apply`. Writing to stderr instead seems more appropriate here.