### PR TITLE
Use generators instead of list-comprehensions for any/all

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -140,7 +140,7 @@ class Agent:
 
         logger = logging.getLogger(self.name)
         logger.setLevel(config.cloud.agent.get("level"))
-        if not any([isinstance(h, logging.StreamHandler) for h in logger.handlers]):
+        if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
             ch = logging.StreamHandler(sys.stdout)
             formatter = logging.Formatter(context.config.logging.format)
             formatter.converter = time.gmtime  # type: ignore

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -492,7 +492,7 @@ class FlowRunner(Runner):
                     )
 
                 # handle mapped tasks
-                if any([edge.mapped for edge in upstream_states.keys()]):
+                if any(edge.mapped for edge in upstream_states.keys()):
 
                     # wait on upstream states to determine the width of the pipeline
                     # this is the key to depth-first execution

--- a/src/prefect/utilities/notifications/jira_notification.py
+++ b/src/prefect/utilities/notifications/jira_notification.py
@@ -122,7 +122,7 @@ def jira_notifier(
     ignore_states = ignore_states or []
     only_states = only_states or []
 
-    if any([isinstance(new_state, ignored) for ignored in ignore_states]):
+    if any(isinstance(new_state, ignored) for ignored in ignore_states):
         return new_state
 
     if only_states and not any(

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -219,7 +219,7 @@ def gmail_notifier(
     ignore_states = ignore_states or []
     only_states = only_states or []
 
-    if any([isinstance(new_state, ignored) for ignored in ignore_states]):
+    if any(isinstance(new_state, ignored) for ignored in ignore_states):
         return new_state
 
     if only_states and not any(
@@ -297,7 +297,7 @@ def slack_notifier(
     ignore_states = ignore_states or []
     only_states = only_states or []
 
-    if any([isinstance(new_state, ignored) for ignored in ignore_states]):
+    if any(isinstance(new_state, ignored) for ignored in ignore_states):
         return new_state
 
     if only_states and not any(

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2440,6 +2440,8 @@ class TestFlowRunMethod:
 
         f.run()
 
+        assert all(s.is_successful() for s in flow_state.result[res].map_states)
+
         first_run = storage["y"][0]
         second_run = storage["y"][1]
         third_run = storage["y"][2]

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2440,8 +2440,6 @@ class TestFlowRunMethod:
 
         f.run()
 
-        assert all(s.is_successful() for s in flow_state.result[res].map_states)
-
         first_run = storage["y"][0]
         second_run = storage["y"][1]
         third_run = storage["y"][2]

--- a/tests/core/test_task_map.py
+++ b/tests/core/test_task_map.py
@@ -89,7 +89,7 @@ def test_map_spawns_new_tasks(executor):
     assert m.is_mapped()
     assert isinstance(m.map_states, list)
     assert len(m.map_states) == 3
-    assert all([isinstance(ms, Success) for ms in m.map_states])
+    assert all(isinstance(ms, Success) for ms in m.map_states)
     assert m.result == [2, 3, 4]
 
 
@@ -486,7 +486,7 @@ def test_map_tracks_non_mapped_upstream_tasks(executor):
 
     s = f.run(executor=executor)
     assert s.is_failed()
-    assert all([sub.is_failed() for sub in s.result[res].map_states])
+    assert all(sub.is_failed() for sub in s.result[res].map_states)
     assert all(
         [
             isinstance(sub, prefect.engine.state.TriggerFailed)

--- a/tests/core/test_task_operators.py
+++ b/tests/core/test_task_operators.py
@@ -123,7 +123,7 @@ class TestMagicInteractionMethods:
 
             (t1 | t2 | t3 | t4)
 
-        assert all([e in f.edges for e in [Edge(t1, t2), Edge(t2, t3), Edge(t3, t4)]])
+        assert all(e in f.edges for e in [Edge(t1, t2), Edge(t2, t3), Edge(t3, t4)])
 
 
 class TestMagicOperatorMethods:

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -976,7 +976,7 @@ def test_non_keyed_states_are_hydrated_correctly_with_retries(monkeypatch, tmpdi
         len([tr for tr in client.task_runs.values() if tr.task_slug == flow.slugs[t1]])
         == 4
     )
-    assert all([tr.state.is_successful() for tr in client.task_runs.values()])
+    assert all(tr.state.is_successful() for tr in client.task_runs.values())
 
 
 def test_slug_mismatch_raises_informative_error(monkeypatch):

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -746,7 +746,7 @@ def test_pull_image(capsys, monkeypatch):
     captured = capsys.readouterr()
     printed_lines = [line for line in captured.out.split("\n") if line != ""]
 
-    assert any(["100 test\r" in line for line in printed_lines])
+    assert any("100 test\r" in line for line in printed_lines)
 
 
 def test_pull_image_raises_if_error_encountered(monkeypatch):
@@ -775,7 +775,7 @@ def test_push_image(capsys, monkeypatch):
     captured = capsys.readouterr()
     printed_lines = [line for line in captured.out.split("\n") if line != ""]
 
-    assert any(["100 test\r" in line for line in printed_lines])
+    assert any("100 test\r" in line for line in printed_lines)
 
 
 def test_push_image_raises_if_error_encountered(monkeypatch):

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -174,8 +174,8 @@ class TestIntervalClock:
             timedelta(days=1), start_date=start_date, parameter_defaults=params
         )
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.parameter_defaults == params for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.parameter_defaults == params for e in output)
         assert output == [
             today.add(days=1),
             today.add(days=2),
@@ -191,8 +191,8 @@ class TestIntervalClock:
             timedelta(days=1), start_date=start_date, labels=labels
         )
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.labels == labels for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.labels == labels for e in output)
         assert output == [
             today.add(days=1),
             today.add(days=2),
@@ -272,7 +272,7 @@ class TestIntervalClockDaylightSavingsTime:
             timedelta(minutes=1, seconds=15), start_date=start_date
         )
         next_4 = islice(c.events(after=current_date), 4)
-        assert all([d > current_date for d in next_4])
+        assert all(d > current_date for d in next_4)
 
     @pytest.mark.parametrize("serialize", [True, False])
     def test_interval_clock_hourly_daylight_savings_time_forward_with_UTC(
@@ -417,8 +417,8 @@ class TestCronClock:
         c = clocks.CronClock(every_day, parameter_defaults=params)
 
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.parameter_defaults == params for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.parameter_defaults == params for e in output)
 
         assert output == [
             pendulum.today("UTC").add(days=1),
@@ -432,8 +432,8 @@ class TestCronClock:
         c = clocks.CronClock(every_day, labels=labels)
 
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.labels == labels for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.labels == labels for e in output)
 
         assert output == [
             pendulum.today("UTC").add(days=1),
@@ -686,8 +686,8 @@ class TestDatesClock:
         c = clocks.DatesClock([start_date], parameter_defaults=params)
 
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.parameter_defaults == params for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.parameter_defaults == params for e in output)
 
         assert output == [start_date]
         assert islice(c.events(), 1) == [start_date]
@@ -699,8 +699,8 @@ class TestDatesClock:
         c = clocks.DatesClock([start_date], labels=labels)
 
         output = islice(c.events(), 3)
-        assert all([isinstance(e, clocks.ClockEvent) for e in output])
-        assert all([e.labels == labels for e in output])
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.labels == labels for e in output)
 
         assert output == [start_date]
         assert islice(c.events(), 1) == [start_date]

--- a/tests/schedules/test_schedules.py
+++ b/tests/schedules/test_schedules.py
@@ -28,7 +28,7 @@ def test_create_schedule():
     s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(days=1))])
     output = s.next(3, after=dt)
 
-    assert all([not isinstance(e, clocks.ClockEvent) for e in output])
+    assert all(not isinstance(e, clocks.ClockEvent) for e in output)
     assert output == [dt.add(days=1), dt.add(days=2), dt.add(days=3)]
 
 
@@ -37,8 +37,8 @@ def test_create_schedule_emits_events_if_asked():
     s = schedules.Schedule(clocks=[clocks.IntervalClock(timedelta(days=1))])
     output = s.next(3, after=dt, return_events=True)
 
-    assert all([isinstance(e, clocks.ClockEvent) for e in output])
-    assert all([e.parameter_defaults == dict() for e in output])
+    assert all(isinstance(e, clocks.ClockEvent) for e in output)
+    assert all(e.parameter_defaults == dict() for e in output)
 
     assert output == [dt.add(days=1), dt.add(days=2), dt.add(days=3)]
 
@@ -54,7 +54,7 @@ def test_create_schedule_multiple_overlapping_clocks():
         ]
     )
     output = s.next(6, after=dt)
-    assert all([not isinstance(e, clocks.ClockEvent) for e in output])
+    assert all(not isinstance(e, clocks.ClockEvent) for e in output)
 
     assert output == [
         dt.add(days=1),
@@ -102,8 +102,8 @@ def test_create_schedule_multiple_overlapping_clocks_emit_events_if_asked():
         ]
     )
     output = s.next(6, after=dt, return_events=True)
-    assert all([isinstance(e, clocks.ClockEvent) for e in output])
-    assert all([e.parameter_defaults == dict() for e in output])
+    assert all(isinstance(e, clocks.ClockEvent) for e in output)
+    assert all(e.parameter_defaults == dict() for e in output)
     assert output == [
         dt.add(days=1),
         dt.add(days=2),
@@ -124,7 +124,7 @@ def test_create_schedule_multiple_overlapping_clocks_emit_events_with_correct_pa
     dt = pendulum.datetime(2019, 1, 1)
     output = s.next(6, after=dt, return_events=True)
 
-    assert all([isinstance(e, clocks.ClockEvent) for e in output])
+    assert all(isinstance(e, clocks.ClockEvent) for e in output)
     assert [e.parameter_defaults["x"] for e in output] == [1, 0, 1, 1, 0, 1]
     assert [e.start_time for e in output] == [
         dt.add(hours=12),

--- a/tests/serialization/test_schedules.py
+++ b/tests/serialization/test_schedules.py
@@ -37,8 +37,8 @@ def test_serialize_schedule_with_parameters():
 
     output = s2.next(3, after=dt, return_events=True)
 
-    assert all([e.labels is None for e in output])
-    assert all([isinstance(e, clocks.ClockEvent) for e in output])
+    assert all(e.labels is None for e in output)
+    assert all(isinstance(e, clocks.ClockEvent) for e in output)
 
 
 def test_serialize_schedule_with_labels():
@@ -56,7 +56,7 @@ def test_serialize_schedule_with_labels():
 
     output = s2.next(3, after=dt, return_events=True)
 
-    assert all([isinstance(e, clocks.ClockEvent) for e in output])
+    assert all(isinstance(e, clocks.ClockEvent) for e in output)
 
 
 def test_serialize_complex_schedule():

--- a/tests/tasks/azureml/test_datastore.py
+++ b/tests/tasks/azureml/test_datastore.py
@@ -209,7 +209,7 @@ class TestDatastoreUpload:
         datastore = MagicMock()
         path = ["foo/bar", "my/path"]
 
-        assert not any([os.path.isdir(path_item) for path_item in path])
+        assert not any(os.path.isdir(path_item) for path_item in path)
         task = DatastoreUpload(datastore=datastore, path=path)
 
         task.run()

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -581,9 +581,9 @@ class TestBuildImageTask(DockerLoggingTestingUtilityMixin):
         monkeypatch.setattr("docker.APIClient", api)
 
         return_value = task.run(path="test")
-        assert all([isinstance(value, dict) for value in return_value])
-        assert all([len(value) >= 1 for value in return_value])
-        assert all([key for value in return_value for key in value])
+        assert all(isinstance(value, dict) for value in return_value)
+        assert all(len(value) >= 1 for value in return_value)
+        assert all(key for value in return_value for key in value)
 
     def test_image_is_replaced(self, monkeypatch):
         task = BuildImage(path="original")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Changes unnecessary list comprehensions within `any`/`all` calls to generators which will exit early on failure.

I noticed this in #3121 


## Importance
<!-- Why is this PR important? -->

Speeds up failure and success cases, best practice, 20 second regex to do :)

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)