### PR TITLE
Use exist_ok flag in os.makedirs to avoid race condition

### DIFF
--- a/changes/pr3679.yml
+++ b/changes/pr3679.yml
@@ -1,0 +1,5 @@
+fix:
+  - "Use `exist_ok` flag in `os.makedirs` to avoid race condition in local storage class - [#3679](https://github.com/PrefectHQ/prefect/pull/3679)"
+
+contributor:
+  - "[R Max Espinoza](https://github.com/rmax)"

--- a/src/prefect/environments/storage/local.py
+++ b/src/prefect/environments/storage/local.py
@@ -55,8 +55,7 @@ class Local(Storage):
 
         if validate:
             abs_directory = os.path.abspath(os.path.expanduser(directory))
-            if not os.path.exists(abs_directory):
-                os.makedirs(abs_directory)
+            os.makedirs(abs_directory, exist_ok=True)
         else:
             abs_directory = directory
 


### PR DESCRIPTION
## Summary

Related to https://github.com/PrefectHQ/prefect/discussions/3678

There is a potential race condition between `os.path.exists` and `os.makedirs`.
`os.makedirs` provides the `exist_ok` flag and already handles race condition case when other thread may
have created the directory between the exists check and the makedirs
call. See
https://github.com/python/cpython/blob/48b069a003ba6c684a9ba78493fbbec5e89f10b8/Lib/os.py#L214-L218

## Changes

Replaces `os.path.exists` by `exist_ok` flag.

## Importance

I faced this issue when writing tests for a custom agent that used local storage. More details in https://github.com/PrefectHQ/prefect/discussions/3678

Workaround is to use `validate=False` and create the directory before instantiating the local storage class.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)