### PR TITLE
Serialize task, edges, etc. in deterministic order

### DIFF
--- a/changes/pr3682.yaml
+++ b/changes/pr3682.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Serialize flow tasks, edges, etc. in deterministic order for `serialized_hash` - [#3682](https://github.com/PrefectHQ/prefect/pull/3682)"
+  - "Make `serialized_hash` handle unordered task sets correctly - [#3682](https://github.com/PrefectHQ/prefect/pull/3682)"

--- a/changes/pr3682.yaml
+++ b/changes/pr3682.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Serialize flow tasks, edges, etc. in deterministic order for `serialized_hash` - [#3682](https://github.com/PrefectHQ/prefect/pull/3682)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1445,18 +1445,6 @@ class Flow:
         for task, slug in flow_copy.slugs.items():
             task.slug = slug
 
-        # Convert tasks and edges from sets to sorted lists for determinism
-        # mypy will complain that t.slug is `Optional[str]` but we have enforced this
-        # above so it should be safe. We also need to ignore types here because we are
-        # pushing a list into a `Set` typed attribute
-        flow_copy.tasks = sorted(
-            list(flow_copy.tasks), key=lambda t: t.slug  # type: ignore
-        )  # type: ignore
-        flow_copy.edges = sorted(
-            list(flow_copy.edges),
-            key=lambda e: f"{e.upstream_task.slug}-{e.downstream_task.slug}",
-        )  # type: ignore
-
         serialized = schema(exclude=["storage"]).dump(flow_copy)
 
         if build:

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1446,11 +1446,16 @@ class Flow:
             task.slug = slug
 
         # Convert tasks and edges from sets to sorted lists for determinism
-        flow_copy.tasks = sorted(list(flow_copy.tasks), key=lambda t: t.slug)
+        # mypy will complain that t.slug is `Optional[str]` but we have enforced this
+        # above so it should be safe. We also need to ignore types here because we are
+        # pushing a list into a `Set` typed attribute
+        flow_copy.tasks = sorted(
+            list(flow_copy.tasks), key=lambda t: t.slug  # type: ignore
+        )  # type: ignore
         flow_copy.edges = sorted(
             list(flow_copy.edges),
             key=lambda e: f"{e.upstream_task.slug}-{e.downstream_task.slug}",
-        )
+        )  # type: ignore
 
         serialized = schema(exclude=["storage"]).dump(flow_copy)
 

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -16,6 +16,7 @@ from prefect.utilities.serialization import (
     OneOfSchema,
     to_qualified_name,
     JSONCompatible,
+
 )
 
 
@@ -23,7 +24,7 @@ class BaseEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = Environment
 
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -31,7 +32,7 @@ class LocalEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = LocalEnvironment
 
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -40,7 +41,7 @@ class DaskKubernetesEnvironmentSchema(ObjectSchema):
         object_class = DaskKubernetesEnvironment
 
     docker_secret = fields.String(allow_none=True)
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
     private_registry = fields.Boolean(allow_none=False)
     min_workers = fields.Int()
@@ -51,7 +52,7 @@ class FargateTaskEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = FargateTaskEnvironment
 
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -59,7 +60,7 @@ class KubernetesJobEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = KubernetesJobEnvironment
 
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -69,7 +70,7 @@ class RemoteEnvironmentSchema(ObjectSchema):
 
     executor = fields.String(allow_none=True)
     executor_kwargs = fields.Dict(allow_none=True)
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -78,7 +79,7 @@ class RemoteDaskEnvironmentSchema(ObjectSchema):
         object_class = RemoteDaskEnvironment
 
     address = fields.String()
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -87,7 +88,7 @@ class CustomEnvironmentSchema(ObjectSchema):
         object_class = lambda: Environment
         exclude_fields = ["type"]
 
-    labels = fields.List(fields.String())
+    labels = List(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
     type = fields.Function(

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -16,7 +16,7 @@ from prefect.utilities.serialization import (
     OneOfSchema,
     to_qualified_name,
     JSONCompatible,
-
+    SortedList,
 )
 
 
@@ -24,7 +24,7 @@ class BaseEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = Environment
 
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -32,7 +32,7 @@ class LocalEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = LocalEnvironment
 
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -41,7 +41,7 @@ class DaskKubernetesEnvironmentSchema(ObjectSchema):
         object_class = DaskKubernetesEnvironment
 
     docker_secret = fields.String(allow_none=True)
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
     private_registry = fields.Boolean(allow_none=False)
     min_workers = fields.Int()
@@ -52,7 +52,7 @@ class FargateTaskEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = FargateTaskEnvironment
 
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -60,7 +60,7 @@ class KubernetesJobEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = KubernetesJobEnvironment
 
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -70,7 +70,7 @@ class RemoteEnvironmentSchema(ObjectSchema):
 
     executor = fields.String(allow_none=True)
     executor_kwargs = fields.Dict(allow_none=True)
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -79,7 +79,7 @@ class RemoteDaskEnvironmentSchema(ObjectSchema):
         object_class = RemoteDaskEnvironment
 
     address = fields.String()
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -88,7 +88,7 @@ class CustomEnvironmentSchema(ObjectSchema):
         object_class = lambda: Environment
         exclude_fields = ["type"]
 
-    labels = List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
     type = fields.Function(

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -1,4 +1,4 @@
-from typing import Any, Set
+from typing import Any, List
 
 from marshmallow import fields, post_load, utils
 
@@ -16,18 +16,24 @@ from prefect.utilities.serialization import (
 )
 
 
-def get_parameters(obj: prefect.Flow, context: dict) -> Set:
+def get_parameters(obj: prefect.Flow, context: dict) -> List:
     if isinstance(obj, prefect.Flow):
-        return {p for p in obj.tasks if isinstance(p, prefect.core.parameter.Parameter)}
+        params = {
+            p for p in obj.tasks if isinstance(p, prefect.core.parameter.Parameter)
+        }
     else:
-        return utils.get_value(obj, "parameters")
+        params = utils.get_value(obj, "parameters")
+
+    return sorted(params, key=lambda p: p.slug)
 
 
-def get_reference_tasks(obj: prefect.Flow, context: dict) -> Set:
+def get_reference_tasks(obj: prefect.Flow, context: dict) -> List:
     if isinstance(obj, prefect.Flow):
-        return obj._reference_tasks
+        tasks = obj._reference_tasks
     else:
-        return utils.get_value(obj, "reference_tasks")
+        tasks = utils.get_value(obj, "reference_tasks")
+
+    return sorted(tasks, key=lambda t: t.slug)
 
 
 class FlowSchema(ObjectSchema):

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from marshmallow import fields, post_load, utils
+from marshmallow import fields, post_load, utils, missing
 
 import prefect
 from prefect.serialization.edge import EdgeSchema
@@ -24,6 +24,9 @@ def get_parameters(obj: prefect.Flow, context: dict) -> List:
     else:
         params = utils.get_value(obj, "parameters")
 
+    if params is missing:
+        return params
+
     return sorted(params, key=lambda p: p.slug)
 
 
@@ -33,17 +36,36 @@ def get_reference_tasks(obj: prefect.Flow, context: dict) -> List:
     else:
         tasks = utils.get_value(obj, "reference_tasks")
 
+    if tasks is missing:
+        return tasks
+
     return sorted(tasks, key=lambda t: t.slug)
 
 
 def get_tasks(obj: prefect.Flow, context: dict) -> List:
-    return list(sorted(obj.tasks, key=lambda t: t.slug))
+    if isinstance(obj, prefect.Flow):
+        tasks = obj.tasks
+    else:
+        tasks = utils.get_value(obj, "tasks")
+
+    if tasks is missing:
+        return tasks
+
+    return list(sorted(tasks, key=lambda t: t.slug))
 
 
 def get_edges(obj: prefect.Flow, context: dict) -> List:
+    if isinstance(obj, prefect.Flow):
+        edges = obj.edges
+    else:
+        edges = utils.get_value(obj, "edges")
+
+    if edges is missing:
+        return edges
+
     return list(
         sorted(
-            obj.edges,
+            edges,
             key=lambda e: (e.upstream_task.slug, e.downstream_task.slug),
         )
     )

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -44,7 +44,7 @@ def get_edges(obj: prefect.Flow, context: dict) -> List:
     return list(
         sorted(
             obj.edges,
-            key=lambda e: f"{e.upstream_task.slug}-{e.downstream_task.slug}",
+            key=lambda e: (e.upstream_task.slug, e.downstream_task.slug),
         )
     )
 

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -1,11 +1,16 @@
 from marshmallow import fields
 
-from prefect.utilities.serialization import JSONCompatible, OneOfSchema, ObjectSchema
+from prefect.utilities.serialization import (
+    JSONCompatible,
+    OneOfSchema,
+    ObjectSchema,
+    SortedList,
+)
 from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
 
 
 class RunConfigSchemaBase(ObjectSchema):
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
 
 
 class KubernetesRunSchema(RunConfigSchemaBase):

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -8,6 +8,7 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     StatefulFunctionReference,
     to_qualified_name,
+    SortedList,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ class TaskSchema(TaskMethodsMixin, ObjectSchema):
     name = fields.String(allow_none=True)
     slug = fields.String(allow_none=True)
     description = fields.String(allow_none=True)
-    tags = fields.List(fields.String())
+    tags = SortedList(fields.String())
     max_retries = fields.Integer(allow_none=True)
     retry_delay = fields.TimeDelta(allow_none=True)
     inputs = fields.Method("load_inputs", allow_none=True)
@@ -123,5 +124,5 @@ class ParameterSchema(TaskMethodsMixin, ObjectSchema):
     default = JSONCompatible(allow_none=True)
     required = fields.Boolean(allow_none=True)
     description = fields.String(allow_none=True)
-    tags = fields.List(fields.String())
+    tags = SortedList(fields.String())
     outputs = fields.Method("load_outputs", allow_none=True)

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -241,9 +241,6 @@ class SortedList(fields.List):
         - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
     """
 
-    def __init__(self, cls_or_instance: Union[fields.Field, type], **kwargs: Any):
-        super().__init__(cls_or_instance, **kwargs)
-
     def _serialize(self, value, attr, obj, **kwargs):
         return sorted(super()._serialize(value, attr, obj, **kwargs))
 

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import sys
 import types
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List
 
 import marshmallow_oneofschema
 import pendulum

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import sys
 import types
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Union
 
 import marshmallow_oneofschema
 import pendulum
@@ -229,6 +229,23 @@ class Nested(fields.Nested):
         if value is missing:
             return value
         return super()._serialize(value, attr, obj, **kwargs)
+
+
+class SortedList(fields.List):
+    """
+    An extension of the Marshmallow List field that sorts the serialized object for
+    determinism
+
+    Args:
+        - cls_or_instance (type): the inner field class
+        - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
+    """
+
+    def __init__(self, cls_or_instance: Union[fields.Field, type], **kwargs: Any):
+        super().__init__(cls_or_instance, **kwargs)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return sorted(super()._serialize(value, attr, obj, **kwargs))
 
 
 class OneOfSchema(marshmallow_oneofschema.OneOfSchema):

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -33,12 +33,12 @@ def test_serialize_base_environment():
 
 
 def test_serialize_base_environment_with_labels():
-    env = environments.Environment(labels=["foo", "bar"])
+    env = environments.Environment(labels=["b", "c", "a"])
 
     serialized = BaseEnvironmentSchema().dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["foo", "bar"])
+    assert serialized["labels"] == ["a", "b", "c"]
 
 
 def test_serialize_dask_environment():
@@ -84,7 +84,7 @@ def test_serialize_dask_env_with_custom_specs():
 
 
 def test_serialize_dask_environment_with_labels():
-    env = environments.DaskKubernetesEnvironment(labels=["a", "b", "c"])
+    env = environments.DaskKubernetesEnvironment(labels=["b", "c", "a"])
 
     schema = DaskKubernetesEnvironmentSchema()
     serialized = schema.dump(env)
@@ -93,14 +93,15 @@ def test_serialize_dask_environment_with_labels():
     assert serialized["docker_secret"] is None
     assert serialized["min_workers"] == 1
     assert serialized["max_workers"] == 2
-    assert set(serialized["labels"]) == set(["a", "b", "c"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.private_registry is False
     assert new.docker_secret is None
     assert new.min_workers == 1
     assert new.max_workers == 2
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_dask_environment_with_customized_workers():
@@ -161,16 +162,17 @@ def test_serialize_fargate_task_env_with_kwargs():
 
 
 def test_serialize_fargate_task_environment_with_labels():
-    env = environments.FargateTaskEnvironment(labels=["a", "b", "c"])
+    env = environments.FargateTaskEnvironment(labels=["b", "c", "a"])
 
     schema = FargateTaskEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["a", "b", "c"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_k8s_job_environment(k8s_job_spec_content):
@@ -218,17 +220,18 @@ def test_serialize_k8s_job_environment_with_labels(k8s_job_spec_content):
             file.write(k8s_job_spec_content)
 
         env = environments.KubernetesJobEnvironment(
-            job_spec_file=os.path.join(directory, "job.yaml"), labels=["a", "b", "c"]
+            job_spec_file=os.path.join(directory, "job.yaml"), labels=["b", "c", "a"]
         )
 
         schema = KubernetesJobEnvironmentSchema()
         serialized = schema.dump(env)
         assert serialized
         assert serialized["__version__"] == prefect.__version__
-        assert set(serialized["labels"]) == set(["a", "b", "c"])
+        # labels should be sorted in the serialized obj
+        assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_remote_environment():
@@ -250,7 +253,7 @@ def test_serialize_remote_environment():
 
 
 def test_serialize_remote_environment_with_labels():
-    env = environments.RemoteEnvironment(labels=["bob", "alice"])
+    env = environments.RemoteEnvironment(labels=["b", "c", "a"])
 
     schema = RemoteEnvironmentSchema()
     serialized = schema.dump(env)
@@ -258,12 +261,13 @@ def test_serialize_remote_environment_with_labels():
     assert serialized["__version__"] == prefect.__version__
     assert serialized["executor"] == prefect.config.engine.executor.default_class
     assert serialized["executor_kwargs"] == {}
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.executor == prefect.config.engine.executor.default_class
     assert new.executor_kwargs == {}
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_serialize_remote_dask_environment():
@@ -284,7 +288,7 @@ def test_serialize_remote_dask_environment():
 
 def test_serialize_remote_dask_environment_with_labels():
     env = environments.RemoteDaskEnvironment(
-        address="test", labels=["bob", "alice"], executor_kwargs={"not": "present"}
+        address="test", labels=["b", "c", "a"], executor_kwargs={"not": "present"}
     )
 
     schema = RemoteDaskEnvironmentSchema()
@@ -292,24 +296,26 @@ def test_serialize_remote_dask_environment_with_labels():
     assert serialized
     assert serialized["__version__"] == prefect.__version__
     assert serialized["address"] == "test"
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.address == "test"
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_serialize_local_environment_with_labels():
-    env = environments.LocalEnvironment(labels=["bob", "alice"])
+    env = environments.LocalEnvironment(labels=["b", "c", "a"])
 
     schema = RemoteEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_deserialize_old_env_payload():
@@ -330,7 +336,7 @@ def test_serialize_custom_environment():
     class MyEnv(environments.Environment):
         def __init__(self, x=5):
             self.x = 5
-            super().__init__(labels=["foo", "bar"], metadata={"test": "here"})
+            super().__init__(labels=["b", "c", "a"], metadata={"test": "here"})
 
         def custom_method(self):
             pass
@@ -339,10 +345,10 @@ def test_serialize_custom_environment():
     schema = EnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized["type"] == "CustomEnvironment"
-    assert set(serialized["labels"]) == set(["foo", "bar"])
+    assert serialized["labels"] == ["a", "b", "c"]
     assert serialized["metadata"] == {"test": "here"}
 
     obj = schema.load(serialized)
     assert isinstance(obj, environments.Environment)
-    assert obj.labels == set(["foo", "bar"])
+    assert obj.labels == {"a", "b", "c"}
     assert obj.metadata == {"test": "here"}

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -1,7 +1,15 @@
 import pytest
 
 from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
-from prefect.serialization.run_config import RunConfigSchema
+from prefect.serialization.run_config import RunConfigSchema, RunConfigSchemaBase
+
+
+def test_serialized_run_config_sorts_labels():
+    assert RunConfigSchemaBase().dump({"labels": ["b", "c", "a"]})["labels"] == [
+        "a",
+        "b",
+        "c",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/serialization/test_tasks.py
+++ b/tests/serialization/test_tasks.py
@@ -25,6 +25,10 @@ def test_serialize_task():
     assert isinstance(TaskSchema().dump(Task()), dict)
 
 
+def test_serialize_task_sorts_tags():
+    assert TaskSchema().dump(Task(tags=["b", "a", "c"]))["tags"] == ["a", "b", "c"]
+
+
 def test_deserialize_task():
     task = Task(
         name="hi",
@@ -103,6 +107,14 @@ def test_serialize_parameter():
     ps = ParameterSchema().dump(p)
     assert ps["default"] == None
     assert ps["required"] is True
+
+
+def test_serialize_parameter_sorts_tags():
+    assert TaskSchema().dump(Parameter(name="p", tags=["b", "a", "c"]))["tags"] == [
+        "a",
+        "b",
+        "c",
+    ]
 
 
 def test_deserialize_parameter():

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -18,6 +18,7 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     OneOfSchema,
     StatefulFunctionReference,
+    SortedList,
 )
 
 json_test_values = [
@@ -54,6 +55,14 @@ class TestNestedField:
 
     def test_nested_respects_missing(self):
         assert self.Schema().dump({"child key": False}) == {}
+
+
+class TestSortedList:
+    class Schema(marshmallow.Schema):
+        lst = SortedList(marshmallow.fields.String())
+
+    def test_sorted_list_sorts_strings(self):
+        assert self.Schema().dump({"lst": ["c", "b", "a"]}) == {"lst": ["a", "b", "c"]}
 
 
 class TestJSONCompatibleField:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Much to my shame, `serialized_hash` was still not creating a consistent output. I've now expanded the test cases further and fixed the ordering issues that I thought would be fully resolved in #3654 

Alternate implemntation in #3683 abandoned because of typo anagrams.

## Changes
<!-- What does this PR change? -->

- Adds helpers for `FlowSchema` that sorts tasks and parameters
- `FlowSchema` helpers for reference tasks and parameters return sorted lists instead of sets
- Adds note about serialized_hash not necessarily changing when the code does
- Adds `SortedList` derivative of `marshmallow.fields.List`
- Sorts lists for labels in `run_configs` and `environments`

## Importance
<!-- Why is this PR important? -->

Fixes additional bugs with `serialized_hash`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)