### PR TITLE
Ensure `serialized_hash` is resilient to ordering differences

### DIFF
--- a/changes/pr3682.yaml
+++ b/changes/pr3682.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Make `serialized_hash` handle unordered task sets correctly - [#3682](https://github.com/PrefectHQ/prefect/pull/3682)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1472,6 +1472,11 @@ class Flow:
         determining if the flow has changed. If this hash is equal to a previous hash,
         no new information would be passed to the server on a call to `flow.register()`
 
+        Note that this will not always detect code changes since the task code is not
+        included in the serialized flow sent to the server. That said, as long as the
+        flow is "built" during registration, the code changes will be in effect when you
+        run your flow even if a new version is not registered with the server.
+
         Args:
             - build (bool, optional):  if `True`, the flow's environment is built
                 prior to serialization. Passed through to `Flow.serialize()`.
@@ -1479,9 +1484,12 @@ class Flow:
         Returns:
             - str: the hash of the serialized flow
         """
-        return hashlib.sha256(
-            json.dumps(self.serialize(build), sort_keys=True).encode()
-        ).hexdigest()
+        serialized_flow = self.serialize(build)
+        # Sort all the characters from the serialized flow json to get a unique key for
+        # this flow. This eliminates all concerns about the order of items in sets
+        # within the serialized flow but retains a unique key.
+        key = "".join(sorted(json.dumps(serialized_flow)))
+        return hashlib.sha256(key.encode()).hexdigest()
 
     # Diagnostics  ----------------------------------------------------------------
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1900,6 +1900,25 @@ class TestSerializedHash:
         assert hashes[0]  # Ensure we don't have an empty string or None
         assert len(set(hashes)) == 1
 
+    def test_is_same_with_different_task_orders(self):
+        def my_fake_task(foo):
+            pass
+
+        tasks = [task(my_fake_task) for _ in range(5)]
+
+        def make_flow():
+            with Flow("example-flow") as flow:
+                # Shuffle for a higher likelihood of failure
+                random.shuffle(tasks)
+                for i, fake_task in enumerate(tasks):
+                    fake_task(tasks[(i + 1) % len(tasks)])
+            return flow
+
+        flows = [make_flow() for _ in range(10)]
+
+        hashes = {flow.serialized_hash() for flow in flows}
+        assert len(hashes) == 1
+
     def test_is_different_with_modified_flow_name(self):
         f1 = Flow("foo")
         f2 = f1.copy()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`Flow.serialized_hash()` would change depending on the order of tasks (and edges, parameters, reference tasks) which was dynamic because they are stored in a `Set`

See initial implementation #3682 

## Changes
<!-- What does this PR change? -->

- Adds disclaimer about code changes to `serialized_hash`
- Fixes `serialized_hash` handling of unordered sets of objects within the flow

## Importance
<!-- Why is this PR important? -->

Makes `serialized_hash` meaningfully finally.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)