### PR TITLE
Always rerun resource-manager tasks on flow-run restart

### DIFF
--- a/changes/pr3689.yaml
+++ b/changes/pr3689.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Rerun `resource_manager` tasks when restarting flows from failed - [#3689](https://github.com/PrefectHQ/prefect/pull/3689)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -427,6 +427,24 @@ class FlowRunner(Runner):
                 ):
                     task_states[task] = task_state = Success(result=task.value)
 
+                # Always restart completed resource setup/cleanup tasks unless
+                # they were explicitly cached.
+                # TODO: we only need to rerun these tasks if any pending
+                # downstream tasks depend on them.
+                if (
+                    isinstance(
+                        task,
+                        (
+                            prefect.tasks.core.resource_manager.ResourceSetupTask,
+                            prefect.tasks.core.resource_manager.ResourceCleanupTask,
+                        ),
+                    )
+                    and task_state is not None
+                    and task_state.is_finished()
+                    and not task_state.is_cached()
+                ):
+                    task_states[task] = task_state = Pending()
+
                 # if the state is finished, don't run the task, just use the provided state if
                 # the state is cached / mapped, we still want to run the task runner pipeline
                 # steps to either ensure the cache is still valid / or to recreate the mapped


### PR DESCRIPTION
Tasks created by a resourcemanager shouldn't be cached by default (since
they contain references to inherently transient resources). As such,
when restarting a flow from failed, we usually always want to rerun all
required resource tasks, even if they succeeded in a previous run. Users
can still opt-out of rerunning be enabling checkpointing for their
resource tasks, but by default checkpointing is off.

This provides a nicer behavior in the case of failures. For example, say
a flow creates a temporary Dask cluster using a resource manager, then
runs tasks `A`, `B` and `C` relying on that cluster. If task `B` fails,
the cluster will be nicely shutdown, with all resource-manager tasks
succeeding. If the user then restarts the flow from failed, we want to
recreate the dask cluster resource before retrying task `B`, even though
the resource-manager tasks succeeded in the first flow run.

This is achieved by always rerunning resource-manager tasks when
present, unless they were explicitly cached. In the future we can filter
this further by only rerunning resource-manager tasks that have
downstream tasks that still need to be rerun, but for now this eager
behavior seems fine.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)