### PR TITLE
Fix dask-cloudprovider tests

### DIFF
--- a/changes/pr3672.yaml
+++ b/changes/pr3672.yaml
@@ -1,2 +1,2 @@
 enhancement:
-  - "Add debug logging for Docker tasks PullImage and BuildImage" - [#3672](https://github.com/PrefectHQ/prefect/pull/3672)"
+  - "Add debug logging for Docker tasks PullImage and BuildImage - [#3672](https://github.com/PrefectHQ/prefect/pull/3672)"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras = {
         "azureml-sdk >= 1.0.65, < 1.1",
         "azure-cosmos >= 3.1.1, <3.2",
     ],
-    "dask_cloudprovider": ["dask_cloudprovider >= 0.2.0, < 1.0"],
+    "dask_cloudprovider": ["dask_cloudprovider[aws] >= 0.2.0, < 1.0"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],

--- a/tests/environments/execution/test_dask_cloud_provider.py
+++ b/tests/environments/execution/test_dask_cloud_provider.py
@@ -10,7 +10,7 @@ from distributed.deploy import Cluster
 
 from prefect.environments.execution import DaskCloudProviderEnvironment
 
-from dask_cloudprovider import FargateCluster
+from dask_cloudprovider.aws import FargateCluster
 
 
 def test_create_environment():


### PR DESCRIPTION
The import path changed to local-only (instead of top-level) in the
latest release. Local imports are backwards compatible, so this should
work for all versions.