### PR TITLE
Nice warning if passing task to Task constructor

### DIFF
--- a/changes/pr3691.yaml
+++ b/changes/pr3691.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Raise nice warning if user passes `Task` instance to `Task` constructor, rather than when calling the `Task` (or using `Task.map`/`Task.set_dependencies`) - [#3691](https://github.com/PrefectHQ/prefect/pull/3691)"

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -48,15 +48,8 @@ def consistency_check(obj, obj_name):
     except ValueError:
         doc_args = set()
 
-    standalone, varargs, kwonly, kwargs, varkwargs = get_call_signature(obj)
-    actual_args = (
-        set()
-        .union(standalone)
-        .union(varargs)
-        .union([k for k, v in kwonly])
-        .union([k for k, v in kwargs])
-        .union(varkwargs)
-    )
+    items = get_call_signature(obj)
+    actual_args = {(a if isinstance(a, str) else a[0]) for a in items}
 
     undocumented = actual_args.difference(doc_args)
     # If the sig contains **kwargs, any keyword is valid


### PR DESCRIPTION
A common user mistake when usint class-based tasks is to pass dependent
tasks as arguments to the task constructor, rather than when calling the
task (or using methods like `.map`/`.bind`/`.set_dependencies`). We now
raise a nice warning in this case. We don't error outright in case the
user actually intended this (although my guess is this case is rare).

Also cleans up a few linting errors in the `test_task.py` file.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)