### PR TITLE
Add kwarg for creating link artifact in StartFlowRun task

### DIFF
--- a/changes/pr3692.yaml
+++ b/changes/pr3692.yaml
@@ -1,5 +1,5 @@
 task:
-  - "Add option to `StartFlowRun` task to create link artifact for started flow run - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"
+  - "Add enhancement to `StartFlowRun` task to create link artifact for started flow run - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"
 
 enhancement:
-  - "Add option to toggle hostname in Client `get_cloud_url` function - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"
+  - "Always use tenant slug in output of Client `get_cloud_url` function - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"

--- a/changes/pr3692.yaml
+++ b/changes/pr3692.yaml
@@ -1,2 +1,5 @@
 task:
   - "Add option to `StartFlowRun` task to create link artifact for started flow run - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"
+
+enhancement:
+  - "Add option to toggle hostname in Client `get_cloud_url` function - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"

--- a/changes/pr3692.yaml
+++ b/changes/pr3692.yaml
@@ -1,0 +1,2 @@
+task:
+  - "Add option to `StartFlowRun` task to create link artifact for started flow run - [#3692](https://github.com/PrefectHQ/prefect/pull/3692)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -846,9 +846,7 @@ class Client:
 
         return flow_id
 
-    def get_cloud_url(
-        self, subdirectory: str, id: str, as_user: bool = True, hostname: bool = True
-    ) -> str:
+    def get_cloud_url(self, subdirectory: str, id: str, as_user: bool = True) -> str:
         """
         Convenience method for creating Prefect Cloud URLs for a given subdirectory.
 
@@ -857,8 +855,6 @@ class Client:
             - id (str): the ID of the page
             - as_user (bool, optional): whether this query is being made from a USER scoped token;
                 defaults to `True`. Only used internally for queries made from RUNNERs
-            - hostname (bool, optional): whether or not to include the hostname in the URL. e.g.
-                `cloud.prefect.io` or `localhost:8080`. Defaults to `True`
 
         Returns:
             - str: the URL corresponding to the appropriate base URL, tenant slug, subdirectory
@@ -880,17 +876,15 @@ class Client:
         tenant_slug = self.get_default_tenant_slug(as_user=as_user and using_cloud_api)
 
         # For various API versions parse out `api-` for direct UI link
-        base_url = ""
-        if hostname:
-            base_url = (
-                (
-                    re.sub("api-", "", prefect.config.cloud.api)
-                    if re.search("api-", prefect.config.cloud.api)
-                    else re.sub("api", "cloud", prefect.config.cloud.api)
-                )
-                if using_cloud_api
-                else prefect.config.server.ui.endpoint
+        base_url = (
+            (
+                re.sub("api-", "", prefect.config.cloud.api)
+                if re.search("api-", prefect.config.cloud.api)
+                else re.sub("api", "cloud", prefect.config.cloud.api)
             )
+            if using_cloud_api
+            else prefect.config.server.ui.endpoint
+        )
 
         return "/".join([base_url.rstrip("/"), tenant_slug, subdirectory, id])
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -876,7 +876,7 @@ class Client:
         """
 
         # Search for matching cloud API because we can't guarantee that the backend config is set
-        using_cloud_api = bool(re.search(".prefect.io", prefect.config.cloud.api))
+        using_cloud_api = ".prefect.io" in prefect.config.cloud.api
         tenant_slug = self.get_default_tenant_slug(as_user=as_user and using_cloud_api)
 
         # For various API versions parse out `api-` for direct UI link

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -169,7 +169,7 @@ class StartFlowRun(Task):
         self.logger.debug(f"Flow Run {flow_run_id} created.")
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
-        run_link = client.get_cloud_url("flow-run", flow_run_id, hostname=False)
+        run_link = client.get_cloud_url("flow-run", flow_run_id)
         create_link(urlparse(run_link).path)
 
         if not self.wait:

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -32,7 +32,7 @@ class StartFlowRun(Task):
         - scheduled_start_time (datetime, optional): the time to schedule the execution
             for; if not provided, defaults to now
         - create_link_artifact (bool, optional): create a link artifact that links to the
-            created flow run page in the UI. Defaults to `False`.
+            created flow run page in the UI. Defaults to `True`.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
@@ -45,7 +45,7 @@ class StartFlowRun(Task):
         new_flow_context: dict = None,
         run_name: str = None,
         scheduled_start_time: datetime.datetime = None,
-        create_link_artifact: bool = False,
+        create_link_artifact: bool = True,
         **kwargs: Any,
     ):
         self.flow_name = flow_name
@@ -78,7 +78,7 @@ class StartFlowRun(Task):
         new_flow_context: dict = None,
         run_name: str = None,
         scheduled_start_time: datetime.datetime = None,
-        create_link_artifact: bool = False,
+        create_link_artifact: bool = True,
     ) -> str:
         """
         Run method for the task; responsible for scheduling the specified flow run.
@@ -100,7 +100,7 @@ class StartFlowRun(Task):
             - scheduled_start_time (datetime, optional): the time to schedule the execution
                 for; if not provided, defaults to now
             - create_link_artifact (bool, optional): create a link artifact that links to the
-                created flow run page in the UI. Defaults to `False`.
+                created flow run page in the UI. Defaults to `True`.
 
         Returns:
             - str: the ID of the newly-scheduled flow run
@@ -177,7 +177,7 @@ class StartFlowRun(Task):
 
         if create_link_artifact:
             self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
-            run_link = client.get_cloud_url("flow-run", flow_run_id)
+            run_link = client.get_cloud_url("flow-run", flow_run_id, hostname=False)
             create_link(run_link)
 
         if not self.wait:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1347,6 +1347,29 @@ def test_get_cloud_url_as_user(patch_post, cloud_api):
         assert url == "http://cloud.prefect.io/tslug/flow-run/id2"
 
 
+def test_get_cloud_url_no_hostname(patch_post, cloud_api):
+    response = {
+        "data": {"user": [{"default_membership": {"tenant": {"slug": "tslug"}}}]}
+    }
+
+    patch_post(response)
+
+    with set_temporary_config(
+        {
+            "cloud.api": "http://api.prefect.io",
+            "cloud.auth_token": "secret_token",
+            "backend": "cloud",
+        }
+    ):
+        client = Client()
+
+        url = client.get_cloud_url(subdirectory="flow", id="id", hostname=False)
+        assert url == "/tslug/flow/id"
+
+        url = client.get_cloud_url(subdirectory="flow-run", id="id2", hostname=False)
+        assert url == "/tslug/flow-run/id2"
+
+
 def test_get_cloud_url_not_as_user(patch_post, cloud_api):
     response = {"data": {"tenant": [{"slug": "tslug"}]}}
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1347,29 +1347,6 @@ def test_get_cloud_url_as_user(patch_post, cloud_api):
         assert url == "http://cloud.prefect.io/tslug/flow-run/id2"
 
 
-def test_get_cloud_url_no_hostname(patch_post, cloud_api):
-    response = {
-        "data": {"user": [{"default_membership": {"tenant": {"slug": "tslug"}}}]}
-    }
-
-    patch_post(response)
-
-    with set_temporary_config(
-        {
-            "cloud.api": "http://api.prefect.io",
-            "cloud.auth_token": "secret_token",
-            "backend": "cloud",
-        }
-    ):
-        client = Client()
-
-        url = client.get_cloud_url(subdirectory="flow", id="id", hostname=False)
-        assert url == "/tslug/flow/id"
-
-        url = client.get_cloud_url(subdirectory="flow-run", id="id2", hostname=False)
-        assert url == "/tslug/flow-run/id2"
-
-
 def test_get_cloud_url_not_as_user(patch_post, cloud_api):
     response = {"data": {"tenant": [{"slug": "tslug"}]}}
 

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -22,6 +22,7 @@ def client(monkeypatch):
     )
     yield cloud_client
 
+
 @pytest.fixture()
 def artifacts_client(monkeypatch):
     c = MagicMock(
@@ -176,7 +177,7 @@ class TestStartFlowRunCloud:
             flow_name="Test Flow",
             parameters={"test": "ing"},
             run_name="test-run",
-            create_link_artifact=True
+            create_link_artifact=True,
         )
         with prefect.context(running_with_backend=True, task_run_id="trid"):
             task.run(create_link_artifact=False)
@@ -186,11 +187,8 @@ class TestStartFlowRunCloud:
             task.run()
 
             artifacts_client.create_task_run_artifact.assert_called_once_with(
-                data={"link": "flow/run/url"},
-                kind="link",
-                task_run_id="trid"
+                data={"link": "flow/run/url"}, kind="link", task_run_id="trid"
             )
-
 
 
 class TestStartFlowRunServer:

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -15,11 +15,20 @@ def client(monkeypatch):
             )
         ),
         create_flow_run=MagicMock(return_value="xyz890"),
+        get_cloud_url=MagicMock(return_value="flow/run/url"),
     )
     monkeypatch.setattr(
         "prefect.tasks.prefect.flow_run.Client", MagicMock(return_value=cloud_client)
     )
     yield cloud_client
+
+@pytest.fixture()
+def artifacts_client(monkeypatch):
+    c = MagicMock(
+        create_task_run_artifact=MagicMock(return_value="id"),
+    )
+    monkeypatch.setattr("prefect.artifacts.Client", MagicMock(return_value=c))
+    yield c
 
 
 def test_deprecated_old_name():
@@ -160,6 +169,28 @@ class TestStartFlowRunCloud:
         client.graphql = MagicMock(return_value=MagicMock(data=MagicMock(flow=[])))
         with pytest.raises(ValueError, match="Flow 'Test Flow' not found."):
             task.run()
+
+    def test_flow_run_link_artifact(self, client, artifacts_client, cloud_api):
+        task = StartFlowRun(
+            project_name="Test Project",
+            flow_name="Test Flow",
+            parameters={"test": "ing"},
+            run_name="test-run",
+            create_link_artifact=True
+        )
+        with prefect.context(running_with_backend=True, task_run_id="trid"):
+            task.run(create_link_artifact=False)
+
+            assert not artifacts_client.create_task_run_artifact.called
+
+            task.run()
+
+            artifacts_client.create_task_run_artifact.assert_called_once_with(
+                data={"link": "flow/run/url"},
+                kind="link",
+                task_run_id="trid"
+            )
+
 
 
 class TestStartFlowRunServer:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Now that there is an artifact API for creating things like links we can take advantage of it in some places like the task library. This serves as an initial addition where we can create a link artifact for the `StartFlowRun` task that links to the created flow run in the UI.



## Changes
Adds a new kwarg `create_link_artifact` to the `StartFlowRun` task. When set to `True` this will post a link artifact that looks something like `https://cloud.prefect.io/my-tenant-slug/flow-run/424242-ca-94611-111-55` (or localhost for server users).





## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)