### PR TITLE
Fix display of docker errors during storage build

### DIFF
--- a/changes/pr3693.yaml
+++ b/changes/pr3693.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Docker storage build error logs were not always displayed - [#3693](https://github.com/PrefectHQ/prefect/pull/3693)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -653,9 +653,14 @@ class Docker(Storage):
         for item in generator:
             item = item.decode("utf-8")
             for line in item.split("\n"):
-                if line:
-                    output = json.loads(line).get("stream") or json.loads(line).get(
-                        "errorDetail", {}
-                    ).get("message")
-                    if output and output != "\n":
-                        print(output.strip("\n"))
+                if not line:
+                    continue
+                parsed = json.loads(line)
+                # Parse several possible schemas
+                output = (
+                    parsed.get("stream")
+                    or parsed.get("message")
+                    or parsed.get("errorDetail", {}).get("message")
+                ).strip("\n")
+                if output:
+                    print(output)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes missing display of docker error messages during image build. On docker-py version 4.3.1 and Docker version 19.03.13, build 4484c46d9d the message for a syntax error in the dockerfile was in a format we did not check for. This gave me a `ValueError` suggesting a healthcheck had failed when really there was a dockerfile syntax error that was hidden.


## Changes
<!-- What does this PR change? -->

- Adds a check for "message" in the docker build output parsing

## Importance
<!-- Why is this PR important? -->

Helps debug bad Docker storage setups

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~