### PR TITLE
Allow chaining of imperative task dependency calls

### DIFF
--- a/changes/issue3695.yaml
+++ b/changes/issue3695.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "Allow chaining of `Task` imperative dependency calls - [#3696](https://github.com/PrefectHQ/prefect/pull/3696)"
+

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -635,7 +635,7 @@ class Task(metaclass=SignatureValidator):
         keyword_tasks: Mapping[str, object] = None,
         mapped: bool = False,
         validate: bool = None,
-    ) -> None:
+    ) -> "Task":
         """
         Set dependencies for a flow either specified or in the current context using this task
 
@@ -653,7 +653,7 @@ class Task(metaclass=SignatureValidator):
                 configuration file.
 
         Returns:
-            - None
+            - self
 
         Raises:
             - ValueError: if no flow is specified and no flow can be found in the current context
@@ -673,9 +673,11 @@ class Task(metaclass=SignatureValidator):
             mapped=mapped,
         )
 
+        return self
+
     def set_upstream(
         self, task: object, flow: "Flow" = None, key: str = None, mapped: bool = False
-    ) -> None:
+    ) -> "Task":
         """
         Sets the provided task as an upstream dependency of this task.
 
@@ -690,7 +692,7 @@ class Task(metaclass=SignatureValidator):
             - mapped (bool, optional): Whether this dependency is mapped; defaults to `False`
 
         Returns:
-            - None
+            - self
 
         Raises:
             - ValueError: if no flow is specified and no flow can be found in the current context
@@ -701,9 +703,11 @@ class Task(metaclass=SignatureValidator):
         else:
             self.set_dependencies(flow=flow, upstream_tasks=[task], mapped=mapped)
 
+        return self
+
     def set_downstream(
         self, task: "Task", flow: "Flow" = None, key: str = None, mapped: bool = False
-    ) -> None:
+    ) -> "Task":
         """
         Sets the provided task as a downstream dependency of this task.
 
@@ -715,6 +719,9 @@ class Task(metaclass=SignatureValidator):
                 will be passed to the downstream task's `run()` method under this keyword argument.
             - mapped (bool, optional): Whether this dependency is mapped; defaults to `False`
 
+        Returns:
+            - self
+
         Raises:
             - ValueError: if no flow is specified and no flow can be found in the current context
         """
@@ -725,6 +732,8 @@ class Task(metaclass=SignatureValidator):
             )  # type: ignore
         else:
             task.set_dependencies(flow=flow, upstream_tasks=[self], mapped=mapped)
+
+        return self
 
     def inputs(self) -> Dict[str, Dict]:
         """

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -529,6 +529,21 @@ class TestDependencies:
             t2.set_upstream(t1, **props)
             assert Edge(t1, t2, **props) in f.edges
 
+    def test_set_dependencies_stream_allows_chaining(self):
+        t1 = Task()
+        t2 = Task()
+        t3 = Task()
+        with Flow(name="test") as f:
+            t1_result = t1()
+            t2_result = t2()
+            t3_result = t3()
+
+            assert t1_result.set_downstream(t2_result) is t1_result
+            assert t3_result.set_upstream(t2_result) is t3_result
+            assert (
+                t3_result.set_dependencies(f, upstream_tasks=[t1_result]) is t3_result
+            )
+
 
 class TestSerialization:
     def test_serialization(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Returns `self` from imperative task dependency calls so they can be changed

Closes #3695 

## Changes
<!-- What does this PR change? -->

- Changes return types of `set_upstream`, `set_downstream`, and `set_dependencies` from `None` to `Task`
- Returns `self` from all the above

## Importance
<!-- Why is this PR important? -->

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)