### PR TITLE
Nicer support for tasks return multiple results

### DIFF
--- a/changes/pr3697.yaml
+++ b/changes/pr3697.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Improved support for Tasks returning multiple results - [#3697](https://github.com/PrefectHQ/prefect/pull/3697)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -98,7 +98,7 @@ def _infer_run_nout(run: Callable) -> Optional[int]:
     else:
         origin = getattr(ret_type, "__origin__", None)
 
-    if origin is tuple:
+    if origin in (typing.Tuple, tuple):
         # Plain Tuple is a variable-length tuple
         if ret_type in (typing.Tuple, tuple):
             return None

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -92,11 +92,23 @@ def _infer_run_nout(run: Callable) -> Optional[int]:
         return None
     if ret_type is inspect.Parameter.empty:
         return None
-    if typing.get_origin(ret_type) is tuple:
+    # New in python 3.8
+    if hasattr(typing, "get_origin"):
+        origin = typing.get_origin(ret_type)
+    else:
+        origin = getattr(ret_type, "__origin__", None)
+
+    if origin is tuple:
         # Plain Tuple is a variable-length tuple
         if ret_type in (typing.Tuple, tuple):
             return None
-        args = typing.get_args(ret_type)
+
+        # New in python 3.8
+        if hasattr(typing, "get_args"):
+            args = typing.get_args(ret_type)
+        else:
+            args = getattr(ret_type, "__args__", ())
+
         # Empty tuple type has a type arg of the empty tuple
         if len(args) == 1 and args[0] == ():
             return 0

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import uuid
 from datetime import timedelta
-from typing import Any
+from typing import Any, Tuple
 
 import pytest
 
@@ -644,6 +644,60 @@ class TestTaskArgs:
         with pytest.raises(TypeError):
             with Flow(name="test") as f:
                 res = t.map({1, 2, 3, 4})
+
+
+class TestTaskNout:
+    def test_nout_defaults_to_none(self):
+        @task
+        def test(self):
+            pass
+
+        assert test.nout is None
+
+    def test_nout_provided_explicitly(self):
+        @task(nout=2)
+        def test(self):
+            pass
+
+        assert test.nout == 2
+
+    @pytest.mark.parametrize(
+        "ret_type, nout",
+        [
+            (int, None),
+            (Tuple, None),
+            (Tuple[()], 0),
+            (Tuple[int, ...], None),
+            (Tuple[int, int], 2),
+            (Tuple[int, float, str], 3),
+        ],
+    )
+    def test_nout_inferred_from_signature(self, ret_type, nout):
+        @task
+        def test(a) -> ret_type:
+            pass
+
+        assert test.nout == nout
+
+    def test_nout_none_not_iterable(self):
+        @task
+        def test(a):
+            return a + 1, a - 1
+
+        with Flow("test"):
+            with pytest.raises(TypeError, match="Task is not iterable"):
+                a, b = test(1)
+
+    def test_nout_provided_is_iterable(self):
+        @task(nout=2)
+        def test(a):
+            return a + 1, a - 1
+
+        with Flow("test") as flow:
+            a, b = test(1)
+        res = flow.run()
+        assert res.result[a].result == 2
+        assert res.result[b].result == 0
 
 
 @pytest.mark.skip("Result handlers not yet deprecated")


### PR DESCRIPTION
Adds support for annotating tasks that return multiple results, allowing
for result-unpacking. This is a convenience to avoid explicitly
indexing out tasks.

If `nout` isn't provided, it's inferred from the task return type (if
possible), falling back to `None`.

Tasks that have a non-None `nout` are iterable, so they can be used in
result unpacking or iteration, since Prefect knows how long they are. By
default (`nout=None`) tasks are still non-iterable, keeping the expected
behavior.

This makes the following work:

```python
from prefect import Flow, task

@task(nout=2)
def inc_and_dec(x):
    return x + 1, x - 1

@task
def double_and_triple(x : int) -> tuple[int, int]:
    return x * 2, x * 3

with Flow("example"):
    inc, dec = inc_and_dec(1)
    double, triple = double_and_triple(inc)
```

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)