### PR TITLE
Fix docs core/getting_started/next-steps.md

### DIFF
--- a/changes/pr3701.yaml
+++ b/changes/pr3701.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix docs core/getting_started/next-steps.md - [#3701](https://github.com/PrefectHQ/prefect/pull/3701)"
+
+contributor:
+  - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/docs/core/getting_started/next-steps.md
+++ b/docs/core/getting_started/next-steps.md
@@ -41,10 +41,10 @@ with Flow("Spark") as flow:
     # define data dependencies
     cluster = create_cluster()
     submitted = run_spark_job(cluster)
-    tear_down_cluster(cluster)
+    result = tear_down_cluster(cluster)
 
     # wait for the job to finish before tearing down the cluster
-    tear_down_cluster.set_upstream(submitted)
+    result.set_upstream(submitted)
 
 ```
 


### PR DESCRIPTION
## Summary
The example code in [docs/core/getting_started/next-step.md](https://github.com/PrefectHQ/prefect/blob/master/docs/core/getting_started/next-steps.md) does not work.
```python
from prefect import task, Flow

@task
def create_cluster():
    cluster = create_spark_cluster()
    return cluster

@task
def run_spark_job(cluster):
    submit_job(cluster)

@task
def tear_down_cluster(cluster):
    tear_down(cluster)


with Flow("Spark") as flow:
    # define data dependencies
    cluster = create_cluster()
    submitted = run_spark_job(cluster)
    tear_down_cluster(cluster)

    # wait for the job to finish before tearing down the cluster
    tear_down_cluster.set_upstream(submitted)
```
Calling `set_upstream` method of a task itself, instead of a return value, makes an unintended copy of the task.
And this code raises TypeError: `TypeError: tear_down_cluster() missing 1 required positional argument: 'cluster'`

This is a DAG of original code.
![original](https://user-images.githubusercontent.com/25164598/99896200-a2707c80-2cd1-11eb-919b-15bf46fa79c7.png)

## Changes
<!-- What does this PR change? -->
Fix example code.
Call `set_upstream` method to a return value of `tear_down_cluster` task instead of `tear_down_cluster` task itself.

This is a DAG of fixed code.
![fixed](https://user-images.githubusercontent.com/25164598/99896256-26c2ff80-2cd2-11eb-8c43-26b8e007ccfe.png)

## Importance
The example code in docs does not work.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)