### PR TITLE
Fix log filtering in tests

### DIFF
--- a/changes/pr3702.yaml
+++ b/changes/pr3702.yaml
@@ -1,0 +1,5 @@
+fix:
+   - "Fix log filtering in tests - [#3702](https://github.com/PrefectHQ/prefect/pull/3702)"
+
+contributor:
+   - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import sys
@@ -97,15 +98,14 @@ def test_shell_task_env_can_be_set_at_init():
 
 
 def test_shell_logs_non_zero_exit(caplog):
+    caplog.set_level(level=logging.ERROR, logger="prefect.ShellTask")
     with Flow(name="test") as f:
         task = ShellTask()(command="ls surely_a_dir_that_doesnt_exist")
     out = f.run()
     assert out.is_failed()
 
-    error_log = [c for c in caplog.records if c.levelname == "ERROR"]
-    assert len(error_log) == 1
-    assert error_log[0].name == "prefect.ShellTask"
-    assert "Command failed" in error_log[0].message
+    assert len(caplog.records) == 1
+    assert "Command failed" in caplog.records[0].message
 
 
 def test_shell_attaches_result_to_failure(caplog):
@@ -137,6 +137,7 @@ def test_shell_respects_stream_output(caplog, stream_output):
 
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
+    caplog.set_level(level=logging.ERROR, logger="prefect.ShellTask")
     with Flow(name="test") as f:
         task = ShellTask(log_stderr=True, return_all=True)(
             command="ls surely_a_dir_that_doesnt_exist"
@@ -144,12 +145,10 @@ def test_shell_logs_stderr_on_non_zero_exit(caplog):
     out = f.run()
     assert out.is_failed()
 
-    error_log = [c for c in caplog.records if c.levelname == "ERROR"]
-    assert len(error_log) == 2
-    assert error_log[0].name == "prefect.ShellTask"
-    assert "Command failed" in error_log[0].message
-    assert "No such file or directory" in error_log[1].message
-    assert "surely_a_dir_that_doesnt_exist" in error_log[1].message
+    assert len(caplog.records) == 2
+    assert "Command failed" in caplog.records[0].message
+    assert "No such file or directory" in caplog.records[1].message
+    assert "surely_a_dir_that_doesnt_exist" in caplog.records[1].message
 
 
 def test_shell_initializes_and_runs_multiline_cmd():


### PR DESCRIPTION
## Summary
Sometimes log output tests fail due to a mixture of irrelevant logs.
For example:
- [jobs/104977](https://app.circleci.com/pipelines/github/PrefectHQ/prefect/6862/workflows/962381e4-a5f0-4df0-95a8-16971e5d8ac0/jobs/104977)
- [jobs/104730](https://app.circleci.com/pipelines/github/PrefectHQ/prefect/6833/workflows/40f1c93a-aead-434c-9cef-8617ab8bda82/jobs/104730)

I'm not sure, but sometimes `caplog` captures errors from agent.
```Python
[2020-11-20 20:48:01,644] ERROR - agent | Error while managing existing k8s jobs
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 170, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 96, in create_connection
    raise err
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 86, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```

## Changes
- Add filter by logger name.
- Replace manual log filtering with [caplog-fixture](https://docs.pytest.org/en/stable/logging.html#caplog-fixture).

## Importance
Make tests robust.

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)