### PR TITLE
Add Bitbucket storage

### DIFF
--- a/changes/issue3343.yaml
+++ b/changes/issue3343.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Support Bitbucket as storage option - [#3711](https://github.com/PrefectHQ/prefect/pull/3711)"
+
+contributor:
+  - "[Phillip Choi](https://github.com/philz-catz)"

--- a/docs/core/idioms/file-based.md
+++ b/docs/core/idioms/file-based.md
@@ -104,6 +104,25 @@ pip install 'prefect[gitlab]'
 You can replace `GitHub` instances in the example above with `GitLab`, use the `"GITLAB_ACCESS_TOKEN"` secret rather than `"GITHUB_ACCESS_TOKEN"`, and then you may run the example as written.
 :::
 
+:::tip Bitbucket users
+Similarly, to use Bitbucket based storage, install the `bitbucket` extra:
+
+```bash
+pip install 'prefect[bitbucket]'
+```
+
+Bitbucket storage also operates largely the same way. Replace `GitHub` with `Bitbucket` and use the `BITBUCKET_ACCESS_TOKEN` secret.  However, Bitbucket requires an additional argument: `project`.  The `flow.storage` in the above example would be declared as follows for Bitbucket storage:
+
+```python
+flow.storage = Bitbucket(
+    project="project",              # name of project that repo resides in
+    repo="org/repo",                 # name of repo
+    path="flows/my_flow.py",        # location of flow file in repo
+    secrets=["BITBUCKET_ACCESS_TOKEN"]  # name of personal access token secret
+)
+```
+:::
+
 ### File based Docker storage
 
 ```python

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -143,6 +143,28 @@ GitLab storage uses a [personal access token](https://docs.gitlab.com/ee/user/pr
 GitLab server users can point the `host` argument to their personal GitLab instance.
 :::
 
+## Bitbucket
+
+[Bitbucket Storage](/api/latest/environments/storage.html#github) is a storage option that uploads flows to a Bitbucket repository as `.py` files.
+
+Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well. 
+
+::: tip Sensible Defaults
+Flows registered with this storage option will automatically be labeled with `"bitbucket-flow-storage"`; this helps prevents agents not explicitly authenticated with your Bitbucket repo from attempting to run this flow.
+:::
+
+:::tip Bitbucket Credentials
+Bitbucket storage uses a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) for authenticating with repositories.
+:::
+
+:::tip Bitbucket Server
+Bitbucket server users can point the `host` argument to their personal or organization Bitbucket instance.
+:::
+
+:::tip Bitbucket Projects
+Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each repo must be associated with a Project. Bitbucket storage requires a `project` argument pointing to the correct project name.
+:::
+
 ## Docker
 
 [Docker Storage](/api/latest/environments/storage.html#docker) is a storage option that puts flows inside of a Docker image and pushes them to a container registry. This method of Storage has deployment compatability with the [Docker Agent](/orchestration/agents/docker.html), [Kubernetes Agent](/orchestration/agents/kubernetes.html), and [Fargate Agent](/orchestration/agents/fargate.html).

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -230,6 +230,48 @@ GitLab server users can point the `host` argument to their personal GitLab
 instance.
 :::
 
+## Bitbucket
+
+[Bitbucket Storage](/api/latest/environments/storage.html#github) is a 
+storage option that uploads flows to a Bitbucket repository as `.py` files.
+
+```python
+from prefect import Flow
+from prefect.environments.storage import Bitbucket
+
+flow = Flow(
+    "bitbucket-flow",
+    Bitbucket(
+        project="project",                  # name of project
+        repo="project.repo",                # name of repo in project
+        path="flows/my_flow.py",            # location of flow file in repo        
+        secrets=["BITBUCKET_ACCESS_TOKEN"]  # name of personal access token secret
+    )
+)
+```
+
+Much of the GitHub example in the [file based
+storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well. 
+
+::: tip Sensible Defaults
+Flows registered with this storage option will automatically be labeled with 
+`"bitbucket-flow-storage"`; this helps prevents agents not explicitly 
+authenticated with your Bitbucket repo from attempting to run this flow.
+:::
+
+:::tip Bitbucket Credentials
+Bitbucket storage uses a [personal access 
+token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) 
+for authenticating with repositories.
+:::
+
+
+:::tip Bitbucket Projects
+Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each repo 
+must be associated with a Project. Bitbucket storage requires a `project` argument 
+pointing to the correct project name.
+:::
+
 ## Docker
 
 [Docker Storage](/api/latest/environments/storage.md#docker) is a storage

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -225,7 +225,7 @@ classes = ["CloudFlowRunner", "CloudTaskRunner"]
 [pages.environments.storage]
 title = "Storage"
 module = "prefect.environments.storage"
-classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket]
+classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket"]
 
 [pages.environments.execution]
 title = "Execution Environments"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -225,7 +225,7 @@ classes = ["CloudFlowRunner", "CloudTaskRunner"]
 [pages.environments.storage]
 title = "Storage"
 module = "prefect.environments.storage"
-classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab"]
+classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket]
 
 [pages.environments.execution]
 title = "Execution Environments"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extras = {
         "azureml-sdk >= 1.0.65, < 1.1",
         "azure-cosmos >= 3.1.1, <3.2",
     ],
+    "bitbucket": ["atlassian-python-api >= 2.0.1"],
     "dask_cloudprovider": ["dask_cloudprovider[aws] >= 0.2.0, < 1.0"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -105,7 +105,6 @@ class LocalAgent(Agent):
                 "github-flow-storage",
                 "webhook-flow-storage",
                 "gitlab-flow-storage",
-                "bitbucket-flow-storage",
             ]
             for label in all_storage_labels:
                 if label not in self.labels:

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -105,6 +105,7 @@ class LocalAgent(Agent):
                 "github-flow-storage",
                 "webhook-flow-storage",
                 "gitlab-flow-storage",
+                "bitbucket-flow-storage",
             ]
             for label in all_storage_labels:
                 if label not in self.labels:

--- a/src/prefect/environments/storage/__init__.py
+++ b/src/prefect/environments/storage/__init__.py
@@ -33,6 +33,7 @@ from prefect.environments.storage.gcs import GCS
 from prefect.environments.storage.s3 import S3
 from prefect.environments.storage.github import GitHub
 from prefect.environments.storage.gitlab import GitLab
+from prefect.environments.storage.bitbucket import Bitbucket
 from prefect.environments.storage.webhook import Webhook
 
 

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -92,7 +92,7 @@ class Bitbucket(Storage):
         except:
             self.logger.error("Error in retrieve Bitbucket repo files.")
             raise
-        # Bitbucket API returns raw files only.
+
         return extract_flow_from_file(file_contents=contents)
 
     def add_flow(self, flow: "Flow") -> str:

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -57,6 +57,8 @@ class Bitbucket(Storage):
         self.path = path
         self.ref = ref
 
+        super().__init__(**kwargs)
+
     def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -111,6 +111,10 @@ class Bitbucket(Storage):
                 )
                 raise
             else:
+                self.logger.error(
+                    f"Error retrieving file contents at {flow_location} in {self.repo}@{ref} inside project {self.project}. "
+                    "Please check arguments passed to Bitbucket storage."
+                )
                 raise
 
         return extract_flow_from_file(file_contents=contents)

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -1,0 +1,144 @@
+from typing import TYPE_CHECKING, Any, Dict, List
+from urllib.parse import quote_plus
+
+from prefect.environments.storage import Storage
+from prefect.utilities.storage import extract_flow_from_file
+
+if TYPE_CHECKING:
+    from prefect.core.flow import Flow
+
+
+class Bitbucket(Storage):
+    """
+    Bitbucket storage class. This class represents the Storage interface for Flows stored
+    in `.py` files in a Bitbucket repository.
+    This class represents a mapping of flow name to file paths contained in the git repo,
+    meaning that all flow files should be pushed independently. A typical workflow using
+    this storage type might look like the following:
+    - Compose flow `.py` file where flow has Bitbucket storage:
+    ```python
+    flow = Flow("my-flow")
+    flow.storage = Bitbucket(project="my/project",repo="my/repo", path="/flows/flow.py", ref="my-branch")
+    ```
+    - Push this `flow.py` file to the `my/repo` repository under `/flows/flow.py`.
+    - Call `prefect register -f flow.py` to register this flow with Bitbucket storage.
+    Args:
+        - project (str): Project that the repository will be in.  Not equivalent to a GitHub project;
+            required value for all Bitbucket repositories.
+        - repo (str): the repository name, with complete taxonomy.
+        - host (str, optional): If using Bitbucket server, the server host. If not specified, defaults
+            to Bitbucket cloud.
+        - path (str, optional): a path pointing to a flow file in the repo
+        - ref (str, optional): a commit SHA-1 value or branch name
+        - **kwargs (Any, optional): any additional `Storage` initialization options
+    """
+
+    def __init__(
+        self,
+        project: str,
+        repo: str,
+        host: str = None,
+        path: str = None,
+        ref: str = None,
+        **kwargs: Any,
+    ) -> None:
+        self.flows = dict()  # type: Dict[str, str]
+        self._flows = dict()  # type: Dict[str, "Flow"]
+        self.project = project
+        self.repo = repo
+        self.host = host
+        self.path = path
+        self.ref = ref
+
+        super().__init__(**kwargs)
+
+    @property
+    def default_labels(self) -> List[str]:
+        return ["bitbucket-flow-storage"]
+
+    def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
+        """
+        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
+        If the Flow is not found an error will be logged and `None` will be returned.
+        Args:
+            - flow_location (str): the location of a flow within this Storage; in this case,
+                a file path on a repository where a Flow file has been committed. Will use `path` if not
+                provided.
+            - ref (str, optional): a commit SHA-1 value or branch name. Defaults to 'master' if
+                not specified
+        Returns:
+            - Flow: the requested Flow. Atlassian API retrieves raw, decoded files.
+        Raises:
+            - ValueError: if the flow is not contained in this storage
+            - UnknownObjectException: if the flow file is unable to be retrieved
+        """
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.path:
+            flow_location = self.path
+        else:
+            raise ValueError("No flow location provided")
+
+        ref = ref if ref else (self.ref if self.ref else "master")
+
+        try:
+            contents = self._bitbucket_client.get_content_of_file(
+                self.project,
+                self.repo,
+                flow_location,
+                at=ref,
+            )
+        except:
+            self.logger.error("Error in retrieve Bitbucket repo files.")
+            raise
+        # Bitbucket API returns raw files only.
+        return extract_flow_from_file(file_contents=contents)
+
+    def add_flow(self, flow: "Flow") -> str:
+        """
+        Method for storing a new flow as bytes in the local filesytem.
+        Args:
+            - flow (Flow): a Prefect Flow to add
+        Returns:
+            - str: the location of the added flow in the repo
+        Raises:
+            - ValueError: if a flow with the same name is already contained in this storage
+        """
+        if flow.name in self:
+            raise ValueError(
+                'Name conflict: Flow with the name "{}" is already present in this storage.'.format(
+                    flow.name
+                )
+            )
+
+        self.flows[flow.name] = self.path  # type: ignore
+        self._flows[flow.name] = flow
+        return self.path  # type: ignore
+
+    def build(self) -> "Storage":
+        """
+        Build the Bitbucket storage object and run basic healthchecks. Due to this object
+        supporting file based storage no files are committed to the repository during
+        this step. Instead, all files should be committed independently.
+        Returns:
+            - Storage: a Bitbucket object that contains information about how and where
+                each flow is stored
+        """
+        self.run_basic_healthchecks()
+
+        return self
+
+    def __contains__(self, obj: Any) -> bool:
+        """
+        Method for determining whether an object is contained within this storage.
+        """
+        if not isinstance(obj, str):
+            return False
+        return obj in self.flows
+
+    @property
+    def _bitbucket_client(self):  # type: ignore
+        from prefect.utilities.git import get_bitbucket_client
+
+        return get_bitbucket_client(host=self.host)

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List
-from urllib.error import URLError
+from urllib.error import HTTPError
 
 from prefect.environments.storage import Storage
 from prefect.utilities.storage import extract_flow_from_file
@@ -12,16 +12,22 @@ class Bitbucket(Storage):
     """
     Bitbucket storage class. This class represents the Storage interface for Flows stored
     in `.py` files in a Bitbucket repository.
+
     This class represents a mapping of flow name to file paths contained in the git repo,
     meaning that all flow files should be pushed independently. A typical workflow using
     this storage type might look like the following:
+
     - Compose flow `.py` file where flow has Bitbucket storage:
+
     ```python
     flow = Flow("my-flow")
-    flow.storage = Bitbucket(project="my/project",repo="my/repo", path="/flows/flow.py", ref="my-branch")
+    flow.storage = Bitbucket(project="my.project",repo="my.repo", path="/flows/flow.py", ref="my-branch")
     ```
-    - Push this `flow.py` file to the `my/repo` repository under `/flows/flow.py`.
+
+    - Push this `flow.py` file to the `my.repo` repository under `/flows/flow.py` inside "my.project" project.
+
     - Call `prefect register -f flow.py` to register this flow with Bitbucket storage.
+
     Args:
         - project (str): Project that the repository will be in.  Not equivalent to a GitHub project;
             required value for all Bitbucket repositories.
@@ -60,14 +66,17 @@ class Bitbucket(Storage):
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).
         If the Flow is not found an error will be logged and `None` will be returned.
+
         Args:
             - flow_location (str): the location of a flow within this Storage; in this case,
                 a file path on a repository where a Flow file has been committed. Will use `path` if not
                 provided.
             - ref (str, optional): a commit SHA-1 value or branch name. Defaults to 'master' if
                 not specified
+
         Returns:
-            - Flow: the requested Flow. Atlassian API retrieves raw, decoded files.
+            - Flow: the requested Flow; Atlassian API retrieves raw, decoded files.
+
         Raises:
             - ValueError: if the flow is not contained in this storage
             - HTTPError: if flow is unable to access the Bitbucket repository
@@ -80,6 +89,7 @@ class Bitbucket(Storage):
         else:
             raise ValueError("No flow location provided")
 
+        # Use ref argument if exists, else use attribute, else default to 'master'
         ref = ref if ref else (self.ref if self.ref else "master")
 
         try:
@@ -108,10 +118,13 @@ class Bitbucket(Storage):
     def add_flow(self, flow: "Flow") -> str:
         """
         Method for storing a new flow as bytes in the local filesytem.
+
         Args:
             - flow (Flow): a Prefect Flow to add
+
         Returns:
             - str: the location of the added flow in the repo
+
         Raises:
             - ValueError: if a flow with the same name is already contained in this storage
         """
@@ -131,6 +144,7 @@ class Bitbucket(Storage):
         Build the Bitbucket storage object and run basic healthchecks. Due to this object
         supporting file based storage no files are committed to the repository during
         this step. Instead, all files should be committed independently.
+
         Returns:
             - Storage: a Bitbucket object that contains information about how and where
                 each flow is stored

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -57,12 +57,6 @@ class Bitbucket(Storage):
         self.path = path
         self.ref = ref
 
-        super().__init__(**kwargs)
-
-    @property
-    def default_labels(self) -> List[str]:
-        return ["bitbucket-flow-storage"]
-
     def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 from urllib.error import HTTPError
 
 from prefect.environments.storage import Storage

--- a/src/prefect/environments/storage/bitbucket.py
+++ b/src/prefect/environments/storage/bitbucket.py
@@ -24,7 +24,8 @@ class Bitbucket(Storage):
     flow.storage = Bitbucket(project="my.project",repo="my.repo", path="/flows/flow.py", ref="my-branch")
     ```
 
-    - Push this `flow.py` file to the `my.repo` repository under `/flows/flow.py` inside "my.project" project.
+    - Push this `flow.py` file to the `my.repo` repository under `/flows/flow.py` inside "my.project"
+        project.
 
     - Call `prefect register -f flow.py` to register this flow with Bitbucket storage.
 
@@ -112,8 +113,8 @@ class Bitbucket(Storage):
                 raise
             else:
                 self.logger.error(
-                    f"Error retrieving file contents at {flow_location} in {self.repo}@{ref} inside project {self.project}. "
-                    "Please check arguments passed to Bitbucket storage."
+                    f"Error retrieving contents at {flow_location} in {self.repo}@{ref}. "
+                    "Please check arguments passed to Bitbucket storage and verify project exists."
                 )
                 raise
 

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -11,6 +11,7 @@ from prefect.environments.storage import (
     Storage,
     GitHub,
     GitLab,
+    Bitbucket,
     Webhook,
 )
 from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
@@ -150,6 +151,26 @@ class GitLabSchema(ObjectSchema):
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> GitHub:
+        flows = data.pop("flows", dict())
+        base_obj = super().create_object(data)
+        base_obj.flows = flows
+        return base_obj
+
+
+class BitbucketSchema(ObjectSchema):
+    class Meta:
+        object_class = Bitbucket
+
+    project = fields.String(allow_none=False)
+    repo = fields.String(allow_none=False)
+    host = fields.String(allow_none=True)
+    path = fields.String(allow_none=True)
+    ref = fields.String(allow_none=True)
+    flows = fields.Dict(key=fields.Str(), values=fields.Str())
+    secrets = fields.List(fields.Str(), allow_none=True)
+
+    @post_load
+    def create_object(self, data: dict, **kwargs: Any) -> Bitbucket:
         flows = data.pop("flows", dict())
         base_obj = super().create_object(data)
         base_obj.flows = flows

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -212,5 +212,6 @@ class StorageSchema(OneOfSchema):
         "S3": S3Schema,
         "GitHub": GitHubSchema,
         "GitLab": GitLabSchema,
+        "Bitbucket": BitbucketSchema,
         "Webhook": WebhookSchema,
     }

--- a/src/prefect/utilities/git.py
+++ b/src/prefect/utilities/git.py
@@ -132,5 +132,8 @@ def get_bitbucket_client(
         host = "https://bitbucket.org"
 
     session = requests.Session()
-    session.headers["Authorization"] = "Bearer " + access_token
+    if access_token is None:
+        session.headers["Authorization"] = "Bearer "]
+    else:
+        session.headers["Authorization"] = "Bearer " + access_token
     return Bitbucket(host, session=session, **kwargs)

--- a/src/prefect/utilities/git.py
+++ b/src/prefect/utilities/git.py
@@ -133,7 +133,7 @@ def get_bitbucket_client(
 
     session = requests.Session()
     if access_token is None:
-        session.headers["Authorization"] = "Bearer "]
+        session.headers["Authorization"] = "Bearer "
     else:
         session.headers["Authorization"] = "Bearer " + access_token
     return Bitbucket(host, session=session, **kwargs)

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -8,7 +8,16 @@ from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
-from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab
+from prefect.environments.storage import (
+    Docker,
+    Local,
+    Azure,
+    GCS,
+    S3,
+    Webhook,
+    GitLab,
+    Bitbucket,
+)
 from prefect.run_configs import LocalRun, KubernetesRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
@@ -21,6 +30,7 @@ DEFAULT_AGENT_LABELS = [
     "github-flow-storage",
     "webhook-flow-storage",
     "gitlab-flow-storage",
+    "bitbucket-flow-storage",
 ]
 
 
@@ -223,6 +233,7 @@ def test_populate_env_vars_from_run_config(tmpdir):
         S3(bucket="test"),
         Azure(container="test"),
         GitLab("test/repo", path="path/to/flow.py"),
+        Bitbucket(project="PROJECT", repo="test-repo", path="test-flow.py"),
         Webhook(
             build_request_kwargs={"url": "test-service/upload"},
             build_request_http_method="POST",

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -8,16 +8,7 @@ from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
-from prefect.environments.storage import (
-    Docker,
-    Local,
-    Azure,
-    GCS,
-    S3,
-    Webhook,
-    GitLab,
-    Bitbucket,
-)
+from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab, Bitbucket
 from prefect.run_configs import LocalRun, KubernetesRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -8,7 +8,16 @@ from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
-from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab, Bitbucket
+from prefect.environments.storage import (
+    Docker,
+    Local,
+    Azure,
+    GCS,
+    S3,
+    Webhook,
+    GitLab,
+    Bitbucket,
+)
 from prefect.run_configs import LocalRun, KubernetesRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -8,7 +8,16 @@ from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
-from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab
+from prefect.environments.storage import (
+    Docker,
+    Local,
+    Azure,
+    GCS,
+    S3,
+    Webhook,
+    GitLab,
+    Bitbucket,
+)
 from prefect.run_configs import LocalRun, KubernetesRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -8,16 +8,7 @@ from testfixtures.popen import MockPopen
 from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
-from prefect.environments.storage import (
-    Docker,
-    Local,
-    Azure,
-    GCS,
-    S3,
-    Webhook,
-    GitLab,
-    Bitbucket,
-)
+from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab
 from prefect.run_configs import LocalRun, KubernetesRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -30,7 +30,6 @@ DEFAULT_AGENT_LABELS = [
     "github-flow-storage",
     "webhook-flow-storage",
     "gitlab-flow-storage",
-    "bitbucket-flow-storage",
 ]
 
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -18,7 +18,7 @@ from prefect.environments.storage import (
     GitLab,
     Bitbucket,
 )
-from prefect.run_configs import LocalRun, KubernetesRun
+from prefect.run_configs import LocalRun, KubernetesRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
@@ -325,7 +325,10 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
 
     agent = LocalAgent()
 
-    with pytest.raises(TypeError, match="Unsupported RunConfig type: Kubernetes"):
+    with pytest.raises(
+        TypeError,
+        match="`run_config` of type `KubernetesRun`, only `LocalRun` is supported",
+    ):
         agent.deploy_flow(
             flow_run=GraphQLResult(
                 {
@@ -342,6 +345,31 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
 
     assert not popen.called
     assert len(agent.processes) == 0
+
+
+@pytest.mark.parametrize("run_config", [None, UniversalRun()])
+def test_local_agent_deploy_null_or_univeral_run_config(monkeypatch, run_config):
+    popen = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.Popen", popen)
+
+    agent = LocalAgent()
+
+    agent.deploy_flow(
+        flow_run=GraphQLResult(
+            {
+                "id": "id",
+                "flow": {
+                    "storage": Local().serialize(),
+                    "run_config": run_config.serialize() if run_config else None,
+                    "id": "foo",
+                    "core_version": "0.13.0",
+                },
+            },
+        )
+    )
+
+    assert popen.called
+    assert len(agent.processes) == 1
 
 
 @pytest.mark.parametrize("working_dir", [None, "existing"])

--- a/tests/environments/storage/test_bitbucket_storage.py
+++ b/tests/environments/storage/test_bitbucket_storage.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from prefect import context, Flow
+from prefect.environments.storage import Bitbucket
+
+pytest.importorskip("bitbucket")
+
+
+def test_create_bitbucket_storage():
+    storage = BitBucket(project="PROJECT", repo="test-repo")
+    assert storage
+    assert storage.logger
+
+
+def test_create_bitbucket_storage_init_args():
+    storage = Bitbucket(
+        project="PROJECT", repo="test-repo", path="test-flow.py", secrets=["auth"]
+    )
+    assert storage
+    assert storage.project == "PROJECT"
+    assert storage.repo == "test-repo"
+    assert storage.path == "test-flow.py"
+    assert storage.secrets == ["auth"]
+
+
+def test_bitbucket_client_cloud(monkeypatch):
+    bitbucket = MagicMock()
+    monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+
+    storage = Bitbucket(project="PROJECT", repo="test-repo")
+
+    credentials = "ACCESS_TOKEN"
+    with context(secrets=dict(BITBUCKET_ACCESS_TOKEN=credentials)):
+        bitbucket_client = storage._bitbucket_client
+
+    assert bitbucket_client
+    bitbucket.assert_called_with("https://bitbucket.com", private_token="ACCESS_TOKEN")
+
+
+def test_bitbucket_client_server(monkeypatch):
+    bitbucket = MagicMock()
+    monkeypatch.setattr("prefect.utilities.git.Bitbucket")
+
+    storage = Bitbucket(
+        project="PROJECT",
+        repo="transamerica.finance.actarial.prefect-flows",
+        host="http://bitbucket.us.aegon.com",
+    )
+
+    credentials = "ACCESS_TOKEN"
+    with context(secrets=dict(BITBUCKET_ACCESS_TOKEN=credentials)):
+        bitbucket_client = storage._bitbucket_client
+
+    assert bitbucket_client
+    bitbucket.assert_called_with(
+        "http://bitbucket.us.aegon.com", private_token="ACCESS_TOKEN"
+    )
+
+
+def test_add_flow_to_bitbucket_storage():
+    storage = Bitbucket(repo="test-repo", path="test-flow.py")
+
+    f = Flow("Test")
+    assert f.name not in storage
+    assert storage.add_flow(f) == "test-flow.py"
+    assert f.name in storage
+
+    with pytest.raises(ValueError) as ex:
+        storage.add_flow(f)
+
+    assert "Name conflict" in str(ex.value)
+
+
+def test_get_flow_bitbucket(monkeypatch):
+    f = Flow("test")
+
+    bitbucket = MagicMock()
+    monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+
+    monkeypatch.setattr(
+        "prefect.environments.storage.bitbucket.extract_flow_from_file",
+        MagicMock(return_value=f),
+    )
+
+    with pytest.rases(ValueError) as ex:
+        storage = Bitbucket(project="PROJECT", repo="test-repo")
+        storage.get_flow()
+
+    assert "No flow location provided" in str(ex.value)
+
+    storage = Bitbucket(project="PROJECT", repo="test-repo", path="test-flow.py")
+
+    assert f.name not in storage
+    flow_location = storage.add_flow(f)
+
+    new_flow = storage.get_flow(flow_location)
+    assert new_flow.run()

--- a/tests/environments/storage/test_bitbucket_storage.py
+++ b/tests/environments/storage/test_bitbucket_storage.py
@@ -37,13 +37,13 @@ def test_bitbucket_client_cloud(monkeypatch):
         bitbucket_client = storage._bitbucket_client
 
     assert bitbucket_client
-    assert bitbucket.call_args[0][0] == "http://bitbucket.org"
+    assert bitbucket.call_args[0][0] == "https://bitbucket.org"
     assert bitbucket.call_args[1]["session"].headers["Authorization"] == "ACCESS_TOKEN"
 
 
 def test_bitbucket_client_server(monkeypatch):
     bitbucket = MagicMock()
-    monkeypatch.setattr("prefect.utilities.git.Bitbucket")
+    monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
 
     storage = Bitbucket(
         project="PROJECT",
@@ -61,9 +61,9 @@ def test_bitbucket_client_server(monkeypatch):
 
 
 def test_add_flow_to_bitbucket_storage():
-    storage = Bitbucket(repo="test-repo", path="test-flow.py")
+    storage = Bitbucket(project="PROJECT", repo="test-repo", path="test-flow.py")
 
-    f = Flow("Test")
+    f = Flow("test")
     assert f.name not in storage
     assert storage.add_flow(f) == "test-flow.py"
     assert f.name in storage
@@ -85,7 +85,7 @@ def test_get_flow_bitbucket(monkeypatch):
         MagicMock(return_value=f),
     )
 
-    with pytest.rases(ValueError) as ex:
+    with pytest.raises(ValueError) as ex:
         storage = Bitbucket(project="PROJECT", repo="test-repo")
         storage.get_flow()
 

--- a/tests/environments/storage/test_bitbucket_storage.py
+++ b/tests/environments/storage/test_bitbucket_storage.py
@@ -5,11 +5,12 @@ import pytest
 from prefect import context, Flow
 from prefect.environments.storage import Bitbucket
 
-pytest.importorskip("bitbucket")
+
+pytest.importorskip("atlassian")
 
 
 def test_create_bitbucket_storage():
-    storage = BitBucket(project="PROJECT", repo="test-repo")
+    storage = Bitbucket(project="PROJECT", repo="test-repo")
     assert storage
     assert storage.logger
 
@@ -36,7 +37,8 @@ def test_bitbucket_client_cloud(monkeypatch):
         bitbucket_client = storage._bitbucket_client
 
     assert bitbucket_client
-    bitbucket.assert_called_with("https://bitbucket.org", private_token="ACCESS_TOKEN")
+    assert bitbucket.call_args[0][0] == "http://bitbucket.org"
+    assert bitbucket.call_args[1]["session"].headers["Authorization"] == "ACCESS_TOKEN"
 
 
 def test_bitbucket_client_server(monkeypatch):
@@ -54,9 +56,8 @@ def test_bitbucket_client_server(monkeypatch):
         bitbucket_client = storage._bitbucket_client
 
     assert bitbucket_client
-    bitbucket.assert_called_with(
-        "http://localhost:1234", private_token="ACCESS_TOKEN"
-    )
+    assert bitbucket.call_args[0][0] == "http://localhose:1234"
+    assert bitbucket.call_args[1]["session"].headers["Authorization"] == "ACCESS_TOKEN"
 
 
 def test_add_flow_to_bitbucket_storage():

--- a/tests/environments/storage/test_bitbucket_storage.py
+++ b/tests/environments/storage/test_bitbucket_storage.py
@@ -38,7 +38,10 @@ def test_bitbucket_client_cloud(monkeypatch):
 
     assert bitbucket_client
     assert bitbucket.call_args[0][0] == "https://bitbucket.org"
-    assert bitbucket.call_args[1]["session"].headers["Authorization"] == "ACCESS_TOKEN"
+    assert (
+        bitbucket.call_args[1]["session"].headers["Authorization"]
+        == "Bearer ACCESS_TOKEN"
+    )
 
 
 def test_bitbucket_client_server(monkeypatch):
@@ -56,8 +59,11 @@ def test_bitbucket_client_server(monkeypatch):
         bitbucket_client = storage._bitbucket_client
 
     assert bitbucket_client
-    assert bitbucket.call_args[0][0] == "http://localhose:1234"
-    assert bitbucket.call_args[1]["session"].headers["Authorization"] == "ACCESS_TOKEN"
+    assert bitbucket.call_args[0][0] == "http://localhost:1234"
+    assert (
+        bitbucket.call_args[1]["session"].headers["Authorization"]
+        == "Bearer ACCESS_TOKEN"
+    )
 
 
 def test_add_flow_to_bitbucket_storage():

--- a/tests/environments/storage/test_bitbucket_storage.py
+++ b/tests/environments/storage/test_bitbucket_storage.py
@@ -36,7 +36,7 @@ def test_bitbucket_client_cloud(monkeypatch):
         bitbucket_client = storage._bitbucket_client
 
     assert bitbucket_client
-    bitbucket.assert_called_with("https://bitbucket.com", private_token="ACCESS_TOKEN")
+    bitbucket.assert_called_with("https://bitbucket.org", private_token="ACCESS_TOKEN")
 
 
 def test_bitbucket_client_server(monkeypatch):
@@ -45,8 +45,8 @@ def test_bitbucket_client_server(monkeypatch):
 
     storage = Bitbucket(
         project="PROJECT",
-        repo="transamerica.finance.actarial.prefect-flows",
-        host="http://bitbucket.us.aegon.com",
+        repo="test-repo",
+        host="http://localhost:1234",
     )
 
     credentials = "ACCESS_TOKEN"
@@ -55,7 +55,7 @@ def test_bitbucket_client_server(monkeypatch):
 
     assert bitbucket_client
     bitbucket.assert_called_with(
-        "http://bitbucket.us.aegon.com", private_token="ACCESS_TOKEN"
+        "http://localhost:1234", private_token="ACCESS_TOKEN"
     )
 
 

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -16,6 +16,7 @@ from prefect.serialization.storage import (
     S3Schema,
     WebhookSchema,
     GitLabSchema,
+    BitbucketSchema,
 )
 
 
@@ -382,4 +383,37 @@ def test_gitlab_full_serialize():
     assert serialized["host"] == "http://localhost:1234"
     assert serialized["path"] == "path/to/flow.py"
     assert serialized["ref"] == "test-branch"
+    assert serialized["secrets"] == ["token"]
+
+
+def test_bitbucket_empty_serialize():
+    # Testing that empty serialization occurs without error or weirdness in attributes.
+    bitbucket = storage.Bitbucket(project="PROJECT", repo="test-repo")
+    serialized = BitbucketSchema().dump(bitbucket)
+    assert serialized["__version__"] == prefect.__version__
+    assert serialized["project"] == "PROJECT"
+    assert serialized["repo"] == "test-repo"
+    assert not serialized["host"]
+    assert not serialized["path"]
+    assert not serialized["ref"]
+    assert serialized["secrets"] == []
+
+
+def test_bitbucket_full_serialize():
+    bitbucket = storage.Bitbucket(
+        project="PROJECT",
+        repo="test-repo",
+        path="test-flow.py",
+        host="http://localhost:7990",
+        ref="develop",
+        secrets=["token"],
+    )
+
+    serialized = BitbucketSchema().dump(bitbucket)
+    assert serialized["__version__"] == prefect.__version__
+    assert serialized["project"] == "PROJECT"
+    assert serialized["repo"] == "test-repo"
+    assert serialized["path"] == "test-flow.py"
+    assert serialized["host"] == "http://localhost:7990"
+    assert serialized["ref"] == "develop"
     assert serialized["secrets"] == ["token"]

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -136,7 +136,7 @@ class TestGetBitbucketClient:
 
         bitbucket = MagicMock()
         monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
-        get_bitbucket_client
+        get_bitbucket_client()
         assert bitbucket.call_args[1]["session"].headers["Authorization"] is None
 
         monkeypatch.setenv("BITBUCKET_ACCESS_TOKEN", "TOKEN")
@@ -146,11 +146,11 @@ class TestGetBitbucketClient:
     def test_default_to_cloud(self, monkeypatch):
         bitbucket = MagicMock()
         monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
-        get_bitbucket_client
+        get_bitbucket_client()
         assert bitbucket.call_args[0][0] == "https://bitbucket.org"
 
     def test_specify_host(self, monkeypatch):
         bitbucket = MagicMock()
         monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
         get_bitbucket_client(host="http://localhost:1234")
-        assert gitlab.call_args[0][0] == "http://localhost:1234"
+        assert bitbucket.call_args[0][0] == "http://localhost:1234"

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -137,11 +137,13 @@ class TestGetBitbucketClient:
         bitbucket = MagicMock()
         monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
         get_bitbucket_client()
-        assert bitbucket.call_args[1]["session"].headers["Authorization"] is None
+        assert bitbucket.call_args[1]["session"].headers["Authorization"] == "Bearer "
 
         monkeypatch.setenv("BITBUCKET_ACCESS_TOKEN", "TOKEN")
-        get_bitbucket_client
-        assert bitbucket.call_args[1]["session"].headers["Authorization"] == "TOKEN"
+        get_bitbucket_client()
+        assert (
+            bitbucket.call_args[1]["session"].headers["Authorization"] == "Bearer TOKEN"
+        )
 
     def test_default_to_cloud(self, monkeypatch):
         bitbucket = MagicMock()

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -19,11 +19,7 @@ except ImportError:
     Bitbucket = None
 
 import prefect
-from prefect.utilities.git import (
-    get_github_client,
-    get_gitlab_client,
-    get_bitbucket_client,
-)
+from prefect.utilities.git import get_github_client, get_gitlab_client, get_bitbucket_client
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -13,9 +13,17 @@ try:
 except ImportError:
     Gitlab = None
 
+try:
+    from atlassian import Bitbucket
+except ImportError:
+    Bitbucket = None
 
 import prefect
-from prefect.utilities.git import get_github_client, get_gitlab_client
+from prefect.utilities.git import (
+    get_github_client,
+    get_gitlab_client,
+    get_bitbucket_client,
+)
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -107,7 +107,7 @@ class TestGetGitLabClient:
 class TestGetBitbucketClient:
     def test_uses_context_secrets(self, monkeypatch):
         bitbucket = MagicMock()
-        monkeypatch.setattr("prefect.utilities.git.Bitbucket", gitlab)
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(secrets=dict(BITBUCKET_ACCESS_TOKEN="ACCESS_TOKEN")):
                 get_bitbucket_client()

--- a/tests/utilities/test_git.py
+++ b/tests/utilities/test_git.py
@@ -19,7 +19,11 @@ except ImportError:
     Bitbucket = None
 
 import prefect
-from prefect.utilities.git import get_github_client, get_gitlab_client, get_bitbucket_client
+from prefect.utilities.git import (
+    get_github_client,
+    get_gitlab_client,
+    get_bitbucket_client,
+)
 from prefect.utilities.configuration import set_temporary_config
 
 
@@ -96,4 +100,57 @@ class TestGetGitLabClient:
         gitlab = MagicMock()
         monkeypatch.setattr("prefect.utilities.git.Gitlab", gitlab)
         get_gitlab_client(host="http://localhost:1234")
+        assert gitlab.call_args[0][0] == "http://localhost:1234"
+
+
+@pytest.mark.skipif(Bitbucket is None, reason="requires Bitbucket extra")
+class TestGetBitbucketClient:
+    def test_uses_context_secrets(self, monkeypatch):
+        bitbucket = MagicMock()
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", gitlab)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(secrets=dict(BITBUCKET_ACCESS_TOKEN="ACCESS_TOKEN")):
+                get_bitbucket_client()
+
+        assert (
+            bitbucket.call_args[1]["session"].headers["Authorization"]
+            == "Bearer ACCESS_TOKEN"
+        )
+
+    def test_prefers_passed_credentials_over_secrets(self, monkeypatch):
+        bitbucket = MagicMock()
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+        desired_credentials = {"BITBUCKET_ACCESS_TOKEN": "PROVIDED_KEY"}
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(secrets=dict(BITBUCKET_ACCESS_TOKEN="ACCESS_TOKEN")):
+                get_bitbucket_client(desired_credentials)
+
+        assert (
+            bitbucket.call_args[1]["session"].headers["Authorization"]
+            == "Bearer PROVIDED_KEY"
+        )
+
+    def test_creds_default_to_environment(self, monkeypatch):
+        if "BITBUCKET_ACCESS_TOKEN" in os.environ:
+            del os.environ["BITBUCKET_ACCESS_TOKEN"]
+
+        bitbucket = MagicMock()
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+        get_bitbucket_client
+        assert bitbucket.call_args[1]["session"].headers["Authorization"] is None
+
+        monkeypatch.setenv("BITBUCKET_ACCESS_TOKEN", "TOKEN")
+        get_bitbucket_client
+        assert bitbucket.call_args[1]["session"].headers["Authorization"] == "TOKEN"
+
+    def test_default_to_cloud(self, monkeypatch):
+        bitbucket = MagicMock()
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+        get_bitbucket_client
+        assert bitbucket.call_args[0][0] == "https://bitbucket.org"
+
+    def test_specify_host(self, monkeypatch):
+        bitbucket = MagicMock()
+        monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
+        get_bitbucket_client(host="http://localhost:1234")
         assert gitlab.call_args[0][0] == "http://localhost:1234"


### PR DESCRIPTION
## Summary
Add support for Bitbucket as a file-based storage option alongside GitHub and GitLab.


## Changes
Uses atlassian-python-api package ([https://github.com/atlassian-api/atlassian-python-api]) to allow Bitbucket to be used as a storage option.

Implementation is identical to GitLab but includes additional argument necessary for Bitbucket:

- 'project' : Bitbucket organizes repositories into Projects and each repo requires an associated project


## Importance
Bitbucket is a popular Git distribution and support has been requested (Issue #3343).



## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)