### PR TITLE
Stream log output from Kubernetes RunNamespacedJob

### DIFF
--- a/changes/pr-3715.yaml
+++ b/changes/pr-3715.yaml
@@ -1,0 +1,8 @@
+feature:
+  - "Add ReadNamespacedPodLogs which reads or streams logs from Kubernetes pod - [#3715](https://github.com/PrefectHQ/prefect/pull/3715)"
+
+enhancement:
+  - "Stream log output from Kubernetes RunNamespacedJob - [#3715](https://github.com/PrefectHQ/prefect/pull/3715)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -303,6 +303,7 @@ classes = [
         "ListNamespacedPod",
         "PatchNamespacedPod",
         "ReadNamespacedPod",
+        "ReadNamespacedPodLogs",
         "ReplaceNamespacedPod",
         "CreateNamespacedService",
         "DeleteNamespacedService",

--- a/src/prefect/tasks/kubernetes/__init__.py
+++ b/src/prefect/tasks/kubernetes/__init__.py
@@ -30,6 +30,7 @@ try:
         PatchNamespacedPod,
         ReadNamespacedPod,
         ReplaceNamespacedPod,
+        ReadNamespacedPodLogs,
     )
     from prefect.tasks.kubernetes.service import (
         CreateNamespacedService,

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -1,12 +1,14 @@
 import time
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from kubernetes import client
+from multiprocessing.pool import ThreadPool
 
 from prefect import Task
 from prefect.engine import signals
 from prefect.utilities.tasks import defaults_from_attrs
 from prefect.utilities.kubernetes import get_kubernetes_client
+from prefect.tasks.kubernetes.pod import ReadNamespacedPodLogs
 
 
 class CreateNamespacedJob(Task):
@@ -613,9 +615,12 @@ class RunNamespacedJob(Task):
         - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
             which stored your Kubernetes API Key; this Secret must be a string and in
             BearerToken format
-        - job_status_pool_interval (int, optional): The interval given in seconds
+        - job_status_poll_interval (int, optional): The interval given in seconds
             indicating how often the Kubernetes API will be requested about the status
             of the job being performed, defaults to the `5` seconds
+        - log_level (str, optional): Log level used when outputting logs from the job
+            should be one of `debug`, `info`, `warn`, `error`, 'critical' or `None` to
+            disable output completely. Defaults to `None`.
         - delete_job_after_completion (bool, optional): boolean value determining whether
             resources related to a given job will be removed from the Kubernetes cluster
             after completion, defaults to the `True` value
@@ -629,7 +634,8 @@ class RunNamespacedJob(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
-        job_status_pool_interval: int = 5,
+        job_status_poll_interval: int = 5,
+        log_level: Optional[str] = None,
         delete_job_after_completion: bool = True,
         **kwargs: Any,
     ):
@@ -637,7 +643,8 @@ class RunNamespacedJob(Task):
         self.namespace = namespace
         self.kube_kwargs = kube_kwargs or {}
         self.kubernetes_api_key_secret = kubernetes_api_key_secret
-        self.job_status_pool_interval = job_status_pool_interval
+        self.job_status_poll_interval = job_status_poll_interval
+        self.log_level = log_level
         self.delete_job_after_completion = delete_job_after_completion
 
         super().__init__(**kwargs)
@@ -647,7 +654,8 @@ class RunNamespacedJob(Task):
         "namespace",
         "kube_kwargs",
         "kubernetes_api_key_secret",
-        "job_status_pool_interval",
+        "job_status_poll_interval",
+        "log_level",
         "delete_job_after_completion",
     )
     def run(
@@ -656,7 +664,8 @@ class RunNamespacedJob(Task):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
-        job_status_pool_interval: int = 5,
+        job_status_poll_interval: int = 5,
+        log_level: Optional[str] = None,
         delete_job_after_completion: bool = True,
     ) -> None:
         """
@@ -672,9 +681,12 @@ class RunNamespacedJob(Task):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
-            - job_status_pool_interval (int, optional): The interval given in seconds
+            - job_status_poll_interval (int, optional): The interval given in seconds
                 indicating how often the Kubernetes API will be requested about the status
-                of the job being performed, defaults to the `5` seconds
+                of the job being performed, defaults to the `5` seconds.
+            - log_level (str, optional): Log level used when outputting logs from the job
+                should be one of `debug`, `info`, `warn`, `error`, 'critical' or `None` to
+                disable output completely. Defaults to `None`.
             - delete_job_after_completion (bool, optional): boolean value determining whether
                 resources related to a given job will be removed from the Kubernetes cluster
                 after completion, defaults to the `True` value
@@ -685,6 +697,8 @@ class RunNamespacedJob(Task):
         """
         if not body:
             raise ValueError("A dictionary representing a V1Job must be provided.")
+        if log_level is not None and getattr(self.logger, log_level, None) is None:
+            raise ValueError("A valid log_level must be provided.")
 
         body = {**self.body, **(body or {})}
         kube_kwargs = {**self.kube_kwargs, **(kube_kwargs or {})}
@@ -695,34 +709,76 @@ class RunNamespacedJob(Task):
                 "The job name must be defined in the body under the metadata key."
             )
 
-        api_client = cast(
+        api_client_job = cast(
             client.BatchV1Api, get_kubernetes_client("job", kubernetes_api_key_secret)
         )
 
-        api_client.create_namespaced_job(namespace=namespace, body=body, **kube_kwargs)
+        api_client_pod = cast(
+            client.CoreV1Api, get_kubernetes_client("pod", kubernetes_api_key_secret)
+        )
+
+        api_client_job.create_namespaced_job(
+            namespace=namespace, body=body, **kube_kwargs
+        )
         self.logger.info(f"Job {job_name} has been created.")
 
-        completed = False
-        while not completed:
-            res = api_client.read_namespaced_job_status(
-                name=job_name, namespace=namespace
-            )
+        pool = ThreadPool()
+        pod_log_streams = dict()
 
-            if res.status.active:
-                time.sleep(job_status_pool_interval)
-            else:
-                if res.status.failed:
+        try:
+            completed = False
+            while not completed:
+                job = api_client_job.read_namespaced_job_status(
+                    name=job_name, namespace=namespace
+                )
+
+                if log_level is not None:
+                    func_log = getattr(self.logger, log_level)
+
+                    pod_selector = (
+                        f"controller-uid={job.metadata.labels['controller-uid']}"
+                    )
+                    pods_list = api_client_pod.list_namespaced_pod(
+                        namespace=namespace, label_selector=pod_selector
+                    )
+
+                    for pod in pods_list.items:
+                        pod_name = pod.metadata.name
+
+                        # Can't start logs when phase is pending
+                        if pod.status.phase == "Pending":
+                            continue
+                        if pod_name in pod_log_streams:
+                            continue
+
+                        read_pod_logs = ReadNamespacedPodLogs(
+                            pod_name=pod_name,
+                            namespace=namespace,
+                            kubernetes_api_key_secret=kubernetes_api_key_secret,
+                            func_stream=lambda log: func_log(f"{pod_name}: {log}"),
+                        )
+
+                        self.logger.info(f"Started following logs for {pod_name}")
+                        pod_log_streams[pod_name] = pool.apply_async(read_pod_logs.run)
+
+                if job.status.active:
+                    time.sleep(job_status_poll_interval)
+                elif job.status.failed:
                     raise signals.FAIL(
                         f"Job {job_name} failed, check Kubernetes pod logs for more information."
                     )
-                elif res.status.succeeded:
+                elif job.status.succeeded:
                     self.logger.info(f"Job {job_name} has been completed.")
-                    completed = True
+                    break
 
-        if delete_job_after_completion:
-            api_client.delete_namespaced_job(
-                name=job_name,
-                namespace=namespace,
-                body=client.V1DeleteOptions(propagation_policy="Foreground"),
-            )
-            self.logger.info(f"Job {job_name} has been deleted.")
+            if delete_job_after_completion:
+                api_client_job.delete_namespaced_job(
+                    name=job_name,
+                    namespace=namespace,
+                    body=client.V1DeleteOptions(propagation_policy="Foreground"),
+                )
+                self.logger.info(f"Job {job_name} has been deleted.")
+        finally:
+            if pool:
+                pool.close()
+                pool = None

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -722,10 +722,9 @@ class RunNamespacedJob(Task):
         )
         self.logger.info(f"Job {job_name} has been created.")
 
-        pool = ThreadPoolExecutor()
-        pod_log_streams = dict()
+        pod_log_streams = {}
 
-        try:
+        with ThreadPoolExecutor() as pool:
             completed = False
             while not completed:
                 job = api_client_job.read_namespaced_job_status(
@@ -778,7 +777,3 @@ class RunNamespacedJob(Task):
                     body=client.V1DeleteOptions(propagation_policy="Foreground"),
                 )
                 self.logger.info(f"Job {job_name} has been deleted.")
-        finally:
-            if pool:
-                pool.shutdown()
-                pool = None

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -722,6 +722,10 @@ class RunNamespacedJob(Task):
         )
         self.logger.info(f"Job {job_name} has been created.")
 
+        # TODO: if a job has more active pods than the threadpool has threads
+        # logs will no longer be streamed live for all pods. Using an async
+        # k8s client would help remedy this.
+        # https://github.com/PrefectHQ/prefect/pull/3715#discussion_r538324514
         pool = ThreadPool()
         pod_log_streams = dict()
 
@@ -755,7 +759,7 @@ class RunNamespacedJob(Task):
                             pod_name=pod_name,
                             namespace=namespace,
                             kubernetes_api_key_secret=kubernetes_api_key_secret,
-                            func_stream=lambda log: func_log(f"{pod_name}: {log}"),
+                            on_log_entry=lambda log: func_log(f"{pod_name}: {log}"),
                         )
 
                         self.logger.info(f"Started following logs for {pod_name}")

--- a/src/prefect/tasks/kubernetes/pod.py
+++ b/src/prefect/tasks/kubernetes/pod.py
@@ -666,18 +666,13 @@ class ReadNamespacedPodLogs(Task):
         # Note that watching an API resource can expire. The method tries to
         # resume automatically once from the last result, but if that last result
         # is too old as well, an `ApiException` exception will be thrown with
-        # ``code`` 410. In that case you have to recover yourself, probably
-        # by listing the API resource to obtain the latest state and then
-        # watching from that state on by setting ``resource_version`` to
-        # one returned from listing.
-        resource_version = None
+        # ``code`` 410.
         while True:
             try:
                 stream = Watch().stream(
                     api_client.read_namespaced_pod_log,
                     name=pod_name,
                     namespace=namespace,
-                    resource_version=resource_version,
                 )
 
                 for log in stream:
@@ -687,6 +682,3 @@ class ReadNamespacedPodLogs(Task):
             except ApiException as exception:
                 if exception.status != 410:
                     raise
-
-                pod = api_client.read_namespaced_pod(name=pod_name, namespace=namespace)
-                resource_version = pod.metadata.resource_version

--- a/tests/tasks/kubernetes/test_pod.py
+++ b/tests/tasks/kubernetes/test_pod.py
@@ -478,9 +478,6 @@ class TestReadNamespacedPodLogs:
         assert stream.call_args[0][0] == api_client.read_namespaced_pod_log
         assert stream.call_args[1]["name"] == "test"
 
-        assert api_client.read_namespaced_pod.call_count == 1
-        assert api_client.read_namespaced_pod.call_args[1]["name"] == "test"
-
         assert on_log_entry.call_count == 1
         assert on_log_entry.call_args[0][0] == "msg 2"
 

--- a/tests/tasks/kubernetes/test_pod.py
+++ b/tests/tasks/kubernetes/test_pod.py
@@ -10,8 +10,11 @@ from prefect.tasks.kubernetes import (
     PatchNamespacedPod,
     ReadNamespacedPod,
     ReplaceNamespacedPod,
+    ReadNamespacedPodLogs,
 )
 from prefect.utilities.configuration import set_temporary_config
+
+from kubernetes.client.rest import ApiException
 
 
 @pytest.fixture
@@ -29,6 +32,17 @@ def api_client(monkeypatch):
         MagicMock(return_value=client),
     )
     return client
+
+
+@pytest.fixture
+def stream(monkeypatch):
+    stream = MagicMock(return_value=["msg"])
+    monkeypatch.setattr(
+        "kubernetes.watch.watch.Watch.stream",
+        stream,
+    )
+
+    return stream
 
 
 class TestCreateNamespacedPodTask:
@@ -404,3 +418,81 @@ class TestReplaceNamespacedPodTask:
 
         task.run(kube_kwargs={"test": "a"})
         assert api_client.replace_namespaced_pod.call_args[1]["test"] == "a"
+
+
+class TestReadNamespacedPodLogs:
+    def _func_stream(message):
+        pass
+
+    def test_empty_initialization(self, kube_secret):
+        task = ReadNamespacedPodLogs()
+        assert not task.pod_name
+        assert task.namespace == "default"
+        assert task.func_stream == None
+        assert task.kubernetes_api_key_secret == "KUBERNETES_API_KEY"
+
+    def test_filled_initialization(self, kube_secret):
+        task = ReadNamespacedPodLogs(
+            pod_name="test",
+            namespace="test",
+            func_stream=self._func_stream,
+            kubernetes_api_key_secret="test",
+        )
+        assert task.pod_name == "test"
+        assert task.namespace == "test"
+        assert task.func_stream == self._func_stream
+        assert task.kubernetes_api_key_secret == "test"
+
+    def test_empty_name_raises_error(self, kube_secret):
+        task = ReadNamespacedPodLogs()
+        with pytest.raises(ValueError):
+            task.run()
+
+    def test_log_is_read_once(self, kube_secret, api_client):
+        task = ReadNamespacedPodLogs(pod_name="test")
+
+        task.run()
+        assert api_client.read_namespaced_pod_log.call_count == 1
+        assert api_client.read_namespaced_pod_log.call_args[1]["name"] == "test"
+
+    def test_log_is_streamed(self, kube_secret, api_client, stream):
+        func_stream = MagicMock()
+        task = ReadNamespacedPodLogs(pod_name="test", func_stream=func_stream)
+
+        task.run()
+        assert stream.call_count == 1
+        assert stream.call_args[0][0] == api_client.read_namespaced_pod_log
+        assert stream.call_args[1]["name"] == "test"
+
+        assert func_stream.call_count == 1
+        assert func_stream.call_args[0][0] == "msg"
+
+    def test_log_stream_retry_on_410(self, kube_secret, api_client, stream):
+        stream.side_effect = [ApiException(status=410), ["msg 2"]]
+
+        func_stream = MagicMock()
+        task = ReadNamespacedPodLogs(pod_name="test", func_stream=func_stream)
+
+        task.run()
+        assert stream.call_count == 2
+        assert stream.call_args[0][0] == api_client.read_namespaced_pod_log
+        assert stream.call_args[1]["name"] == "test"
+
+        assert api_client.read_namespaced_pod.call_count == 1
+        assert api_client.read_namespaced_pod.call_args[1]["name"] == "test"
+
+        assert func_stream.call_count == 1
+        assert func_stream.call_args[0][0] == "msg 2"
+
+    def test_log_stream_raise_on_non_410(self, kube_secret, api_client, stream):
+        stream.side_effect = [ValueError, ["msg 2"]]
+
+        func_stream = MagicMock()
+        task = ReadNamespacedPodLogs(pod_name="test", func_stream=func_stream)
+
+        with pytest.raises(ValueError):
+            task.run()
+
+        assert stream.call_count == 1
+        assert stream.call_args[0][0] == api_client.read_namespaced_pod_log
+        assert stream.call_args[1]["name"] == "test"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR opens a watch on `read_namespaced_pod_log` such that the logging output of the created job is forwarded to prefect. No more black box ⬛!


## Changes
<!-- What does this PR change? -->

Replaces the polling for status on a job, to a watch to forward the logging from the job.


## Importance
<!-- Why is this PR important? -->

Gives insight in what the job is doing.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)