### PR TITLE
Fix docker storage bug when output is `None`

### DIFF
--- a/changes/pr3717.yaml
+++ b/changes/pr3717.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Fix bug with docker storage throwing exception while trying to display output - [#3717](https://github.com/PrefectHQ/prefect/pull/3717)"

--- a/changes/pr3717.yaml
+++ b/changes/pr3717.yaml
@@ -1,2 +1,2 @@
-enhancement:
+fix:
   - "Fix bug with docker storage throwing exception while trying to display output - [#3717](https://github.com/PrefectHQ/prefect/pull/3717)"

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -655,6 +655,8 @@ class Docker(Storage):
                 if not line:
                     continue
                 parsed = json.loads(line)
+                if not isinstance(parsed, dict):
+                    continue
                 # Parse several possible schemas
                 output = (
                     parsed.get("stream")

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -644,7 +644,8 @@ class Docker(Storage):
                 print(line.get("status"), line.get("progress"), end="\r")
         print("")
 
-    def _parse_generator_output(self, generator: Iterable) -> None:
+    @staticmethod
+    def _parse_generator_output(generator: Iterable) -> None:
         """
         Parses and writes a Docker command's output to stdout
         """

--- a/src/prefect/environments/storage/docker.py
+++ b/src/prefect/environments/storage/docker.py
@@ -659,6 +659,7 @@ class Docker(Storage):
                     parsed.get("stream")
                     or parsed.get("message")
                     or parsed.get("errorDetail", {}).get("message")
+                    or ""
                 ).strip("\n")
                 if output:
                     print(output)

--- a/tests/environments/storage/test_docker_storage.py
+++ b/tests/environments/storage/test_docker_storage.py
@@ -814,15 +814,6 @@ def test_push_image_raises_if_error_encountered(monkeypatch):
         storage.push_image(image_name="test", image_tag="test")
 
 
-def test_parse_output():
-    storage = Docker(base_image="python:3.6")
-
-    with pytest.raises(AttributeError):
-        storage._parse_generator_output([b'"{}"\n'])
-
-    assert storage
-
-
 def test_docker_storage_name():
     storage = Docker(base_image="python:3.6")
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes bug introduced in #3693 where an error is raised due to `None` values during docker storage build output parsing.


## Changes
<!-- What does this PR change? -->

- Adds a default for `output` as an empty string instead of `None`
- Changes output parsing to a static method (does not use `self`)
- Adds test coverage for output parsing

## Importance
<!-- Why is this PR important? -->

Bugfix


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~