### PR TITLE
Hide private methods in api docs

### DIFF
--- a/docs/core/development/documentation.md
+++ b/docs/core/development/documentation.md
@@ -4,23 +4,45 @@ Documentation is incredibly important to Prefect, both for explaining its concep
 
 ## Docstrings
 
-Prefect auto-generates API documentation from docstrings by compiling them to Markdown. For details on properly formatting your docstrings, please see the [code style](./style.md#docstrings) guide.
+Prefect auto-generates API documentation from docstrings by compiling them to
+Markdown. For details on properly formatting your docstrings, please see the
+[code style](./style.md#docstrings) guide.
 
 ## API Reference
 
-Modules, functions, and classes must be explicitly added to the auto-generated documentation. First, update the `docs/outline.toml` file with the following information: - a header that describes the path to the generated Markdown file - a `title` for the generated Markdown file - `module`: an optional path to an importable module, whose docstring will be displayed at the top of the page - `classes`: an optional list of strings specifying all documented classes in the module - `functions`: an optional list of strings specifying all documented standalone functions in the module
+Modules, functions, and classes must be explicitly added to the auto-generated
+documentation. First, update the `docs/outline.toml` file with the following
+information: 
 
-For example, if the stylized module described above was importable at `prefect.utilities.example`, then we might add this to `outline.toml`:
+- a TOML header with the path to the generated Markdown file (e.g. `pages.utilities.example`)
+- `title` (str): the title of the generated docs page
+- `module` (str, optional): the import path to the module being documented. The
+  module docstring will be displayed at the top of the page.
+- `classes` (list or dict, optional): a list of class names in `module` to
+  document (all public methods of these classes will be documented).
+  Alternatively, a dict mapping class names to lists of method names to
+  document can be used (only explicitly listed method names will be
+  documented).
+- `functions` (list, optional): a list of function names in `module` to document
+
+For example, to document a module `prefect.utilities.example` with a class
+`MyClass` and a function `my_function`, you might add the following to
+`outline.toml`:
 
 ```
 [pages.utilities.example]
 title = "Example Module"
 module = "prefect.utilities.example"
-classes = ["Class"]
-functions = ["function"]
+classes = ["MyClass"]
+functions = ["my_function"]
 ```
 
-Most reference docs sections update their sidebars automatically by detecting the files generated from `outline.toml`. However, in some instances you may have to include your file explicitly. To do so, update `docs/.vuepress/config.js` and add it to the appropriate "children" section. The actual `prefect.utilities` section _does_ auto-update its sidebar, but for the sake of example, you would add the new file to the children array like so:
+Most reference docs sections update their sidebars automatically by detecting
+the files generated from `outline.toml`. However, in some instances you may
+have to include your file explicitly. To do so, update
+`docs/.vuepress/config.js` and add it to the appropriate "children" section.
+The actual `prefect.utilities` section _does_ auto-update its sidebar, but for
+the sake of example, you would add the new file to the children array like so:
 
 ```javascript
 {

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -499,32 +499,32 @@ classes = ["LoadTweetReplies"]
 [pages.agent.agent]
 title = "Agent"
 module = "prefect.agent"
-classes = ["Agent"]
+classes = {Agent = ["start"]}
 
 [pages.agent.local]
 title = "Local Agent"
 module = "prefect.agent.local"
-classes = ["LocalAgent"]
+classes = {LocalAgent = ["start"]}
 
 [pages.agent.docker]
 title = "Docker Agent"
 module = "prefect.agent.docker"
-classes = ["DockerAgent"]
+classes = {DockerAgent = ["start"]}
 
 [pages.agent.kubernetes]
 title = "Kubernetes Agent"
 module = "prefect.agent.kubernetes"
-classes = ["KubernetesAgent"]
+classes = {KubernetesAgent = ["start"]}
 
 [pages.agent.fargate]
 title = "Fargate Agent"
 module = "prefect.agent.fargate"
-classes = ["FargateAgent"]
+classes = {FargateAgent = ["start"]}
 
 [pages.agent.ecs]
 title = "ECS Agent"
 module = "prefect.agent.ecs"
-classes = ["ECSAgent"]
+classes = {ECSAgent = ["start"]}
 
 [pages.artifacts.artifacts]
 title = "Artifacts"

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -367,7 +367,7 @@ def test_consistency_of_function_docs(fn):
 
 
 @pytest.mark.parametrize(
-    "obj", [obj for page in OUTLINE for obj in page.get("classes", [])]
+    "obj", [obj for page in OUTLINE for obj, _ in page.get("classes", [])]
 )
 def test_consistency_of_class_docs(obj):
     consistency_check(obj, f"{obj.__module__}.{obj.__name__}")
@@ -378,8 +378,8 @@ def test_consistency_of_class_docs(obj):
     [
         (obj, fn)
         for page in OUTLINE
-        for obj in page.get("classes", [])
-        for fn in get_class_methods(obj)
+        for obj, methods in page.get("classes", [])
+        for fn in get_class_methods(obj, methods)
     ],
 )  # parametrized like this for easy reading of tests
 def test_consistency_of_class_method_docs(obj, fn):
@@ -466,9 +466,9 @@ def test_format_doc_escapes_asteriks_inside_tables():
 all_objects = []
 for page in OUTLINE:
     all_objects.extend(page.get("functions", []))
-    for cls in page.get("classes"):
+    for cls, methods in page.get("classes"):
         all_objects.append(cls)
-        all_objects.extend(get_class_methods(cls))
+        all_objects.extend(get_class_methods(cls, methods))
 
 
 @pytest.mark.parametrize("obj", all_objects)


### PR DESCRIPTION
Previously any non `_`-prefixed method in a class was documented as part
of the api docs. For things like agents (which are more an application
than a class), there were several non-public methods that aren't
`_`-prefixed. Having these in the api docs led some users to be
confused, thinking they could call those internal methods directly.

We now add a way to specify a set of methods to document, and apply this
to the agent api docs to only document the `start` methods.