### PR TITLE
Fix PicklingError in BigQueryLoadFile and BigQueryLoadGoogleCloudStorage #3657

### DIFF
--- a/changes/pr3724.yaml
+++ b/changes/pr3724.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix PicklingError in BigQueryLoadFile and BigQueryLoadGoogleCloudStorage  - [#3724](https://github.com/PrefectHQ/prefect/pull/3724)"
+
+contributor:
+  - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -382,6 +382,10 @@ class BigQueryLoadGoogleCloudStorage(Task):
         load_job = client.load_table_from_uri(uri, table_ref, job_config=job_config)
         load_job.result()  # block until job is finished
 
+        # remove unpickleable attributes
+        load_job._client = None
+        load_job._completion_lock = None
+
         return load_job
 
 
@@ -535,6 +539,10 @@ class BigQueryLoadFile(Task):
             raise IOError(f"Can't open and read from {path.as_posix()}.")
 
         load_job.result()  # block until job is finished
+
+        # remove unpickleable attributes
+        load_job._client = None
+        load_job._completion_lock = None
 
         return load_job
 


### PR DESCRIPTION
## Summary
Fix issue #3657 

After remove `_client` and `_completion_lock`, the LoadJob object is pickleable.

```python
import cloudpickle
from google.cloud import bigquery

client = bigquery.Client()
table_ref = client.dataset('dataset').table('table')
job_config = bigquery.LoadJobConfig(
    source_format=bigquery.SourceFormat.CSV,
)
with open('data.csv', 'rb') as f:
    load_job = client.load_table_from_file(
        f,
        table_ref,
        job_config=job_config,
    )

load_job.result()

# remove unpickleable attributes
load_job._client = None
load_job._completion_lock

# this code works
cloudpickle.dumps(load_job)
```

## Changes
Override unpickleable attributes with None before return from the run method.


## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)