### PR TITLE
Allow custom exporter for ExecuteNotebook task 

### DIFF
--- a/changes/pr3725.yaml
+++ b/changes/pr3725.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow custom exporter for ExecuteNotebook task - [#3725](https://github.com/PrefectHQ/prefect/pull/3725)"
+
+contributor:
+  - "[Swier Heeres](https://github.com/swierh)"

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -42,9 +42,10 @@ class ExecuteNotebook(Task):
         self.parameters = parameters
         self.output_format = output_format
         self.kernel_name = kernel_name
+        self.exporter_kwargs = exporter_kwargs
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("path", "parameters", "output_format")
+    @defaults_from_attrs("path", "parameters", "output_format", "exporter_kwargs")
     def run(
         self,
         path: str = None,

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -22,7 +22,7 @@ class ExecuteNotebook(Task):
             nbconvert Exporter name.
             Valid exporter names: asciidoc, custom, html, latex, markdown,
             notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
-        - exporter_kwargs (dict, optional): The arguments used for initializing 
+        - exporter_kwargs (dict, optional): The arguments used for initializing
             the exporter.
         - kernel_name (string, optional): kernel name to run the notebook with.
             If not provided, the default kernel will be used.
@@ -63,7 +63,7 @@ class ExecuteNotebook(Task):
             nbconvert Exporter name.
             Valid exporter names: asciidoc, custom, html, latex, markdown,
             notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
-        - exporter_kwargs (dict, optional): The arguments used for initializing 
+        - exporter_kwargs (dict, optional): The arguments used for initializing
             the exporter.
         """
         nb: nbformat.NotebookNode = pm.execute_notebook(

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -19,7 +19,7 @@ class ExecuteNotebook(Task):
         - parameters (dict, optional): dictionary of parameters to use for the notebook
             Can also be provided at runtime
         - output_format (str, optional): Notebook output format, should be a valid
-            nbconvert Exporter name.
+            nbconvert Exporter name. 'json' is treated as 'notebook'.
             Valid exporter names: asciidoc, custom, html, latex, markdown,
             notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
         - exporter_kwargs (dict, optional): The arguments used for initializing
@@ -60,7 +60,7 @@ class ExecuteNotebook(Task):
             a cloud storage path
         - parameters (dict, optional): dictionary of parameters to use for the notebook
         - output_format (str, optional): Notebook output format, should be a valid
-            nbconvert Exporter name.
+            nbconvert Exporter name. 'json' is treated as 'notebook'.
             Valid exporter names: asciidoc, custom, html, latex, markdown,
             notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
         - exporter_kwargs (dict, optional): The arguments used for initializing
@@ -69,6 +69,8 @@ class ExecuteNotebook(Task):
         nb: nbformat.NotebookNode = pm.execute_notebook(
             path, "-", parameters=parameters, kernel_name=self.kernel_name
         )
+        if output_format == "json":
+            output_format = "notebook"
 
         if exporter_kwargs is None:
             exporter_kwargs = {}

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -1,4 +1,3 @@
-
 import nbconvert
 import nbformat
 import papermill as pm
@@ -20,7 +19,10 @@ class ExecuteNotebook(Task):
         - parameters (dict, optional): dictionary of parameters to use for the notebook
             Can also be provided at runtime
         - output_format (str, optional): Notebook output format.
+            This argument is gnored if `exporter` is provided.
             Currently supported: json, html (default: json)
+        - exporter (nbconvert.Exporter, optional): The exporter that is used for
+            exporting the notebook, regardless of `output_format`.
         - kernel_name (string, optional): kernel name to run the notebook with.
             If not provided, the default kernel will be used.
         - **kwargs: additional keyword arguments to pass to the Task constructor
@@ -57,7 +59,7 @@ class ExecuteNotebook(Task):
             a cloud storage path
         - parameters (dict, optional): dictionary of parameters to use for the notebook
         - output_format (str, optional): Notebook output format.
-            THis argument is gnored if `exporter` is provided.
+            This argument is gnored if `exporter` is provided.
             Currently supported: json, html (default: json)
         - exporter (nbconvert.Exporter, optional): The exporter that is used for
             exporting the notebook, regardless of `output_format`.

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -1,3 +1,4 @@
+
 import nbconvert
 import nbformat
 import papermill as pm
@@ -46,7 +47,7 @@ class ExecuteNotebook(Task):
         path: str = None,
         parameters: dict = None,
         output_format: str = None,
-        exporter: nbconvert.Exporter = None
+        exporter: nbconvert.Exporter = None,
     ) -> str:
         """
         Run a Jupyter notebook and output as HTML or JSON

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -1,7 +1,6 @@
 import nbconvert
 import nbformat
 import papermill as pm
-from typing import Union
 
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -18,11 +18,12 @@ class ExecuteNotebook(Task):
             Can also be provided post-initialization by calling this task instance
         - parameters (dict, optional): dictionary of parameters to use for the notebook
             Can also be provided at runtime
-        - output_format (str, optional): Notebook output format.
-            This argument is gnored if `exporter` is provided.
-            Currently supported: json, html (default: json)
-        - exporter (nbconvert.Exporter, optional): The exporter that is used for
-            exporting the notebook, regardless of `output_format`.
+        - output_format (str, optional): Notebook output format, should be a valid
+            nbconvert Exporter name.
+            Valid exporter names: asciidoc, custom, html, latex, markdown,
+            notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
+        - exporter_kwargs (dict, optional): The arguments used for initializing 
+            the exporter.
         - kernel_name (string, optional): kernel name to run the notebook with.
             If not provided, the default kernel will be used.
         - **kwargs: additional keyword arguments to pass to the Task constructor
@@ -32,8 +33,8 @@ class ExecuteNotebook(Task):
         self,
         path: str = None,
         parameters: dict = None,
-        output_format: str = "json",
-        exporter: nbconvert.Exporter = None,
+        output_format: str = "notebook",
+        exporter_kwargs: dict = None,
         kernel_name: str = None,
         **kwargs
     ):
@@ -49,7 +50,7 @@ class ExecuteNotebook(Task):
         path: str = None,
         parameters: dict = None,
         output_format: str = None,
-        exporter: nbconvert.Exporter = None,
+        exporter_kwargs: dict = None,
     ) -> str:
         """
         Run a Jupyter notebook and output as HTML or JSON
@@ -58,25 +59,20 @@ class ExecuteNotebook(Task):
         - path (string, optional): path to fetch the notebook from; can also be
             a cloud storage path
         - parameters (dict, optional): dictionary of parameters to use for the notebook
-        - output_format (str, optional): Notebook output format.
-            This argument is gnored if `exporter` is provided.
-            Currently supported: json, html (default: json)
-        - exporter (nbconvert.Exporter, optional): The exporter that is used for
-            exporting the notebook, regardless of `output_format`.
+        - output_format (str, optional): Notebook output format, should be a valid
+            nbconvert Exporter name.
+            Valid exporter names: asciidoc, custom, html, latex, markdown,
+            notebook, pdf, python, rst, script, slides, webpdf. (default: notebook)
+        - exporter_kwargs (dict, optional): The arguments used for initializing 
+            the exporter.
         """
         nb: nbformat.NotebookNode = pm.execute_notebook(
             path, "-", parameters=parameters, kernel_name=self.kernel_name
         )
 
-        if exporter is not None:
-            (body, resources) = exporter.from_notebook_node(nb)
-            return body
+        if exporter_kwargs is None:
+            exporter_kwargs = {}
 
-        if output_format == "json":
-            return nbformat.writes(nb)
-        if output_format == "html":
-            html_exporter = nbconvert.HTMLExporter()
-            (body, resources) = html_exporter.from_notebook_node(nb)
-            return body
-
-        raise NotImplementedError("Notebook output %s not supported", output_format)
+        exporter = nbconvert.get_exporter(output_format)
+        body, resources = nbconvert.export(exporter, nb, **exporter_kwargs)
+        return body

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -53,7 +53,7 @@ class ExecuteNotebook(Task):
         exporter_kwargs: dict = None,
     ) -> str:
         """
-        Run a Jupyter notebook and output as HTML or JSON
+        Run a Jupyter notebook and output as HTML, notebook, or other formats.
 
         Args:
         - path (string, optional): path to fetch the notebook from; can also be

--- a/tests/tasks/jupyter/sample_notebook.ipynb
+++ b/tests/tasks/jupyter/sample_notebook.ipynb
@@ -22,6 +22,15 @@
    "source": [
     "print(f\"a*b={a*b}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell contains commented Python code"
+   ]
   }
  ],
  "metadata": {

--- a/tests/tasks/jupyter/test_jupyter.py
+++ b/tests/tasks/jupyter/test_jupyter.py
@@ -30,6 +30,17 @@ def test_jupyter_json_output():
     task = ExecuteNotebook(
         "tests/tasks/jupyter/sample_notebook.ipynb",
         parameters=dict(a=5),
+        output_format="json",
+    )
+    output = task.run()
+    _ = json.loads(output)  # try loading the JSON string
+    assert "a*b=10" in output
+
+
+def test_jupyter_notebook_output():
+    task = ExecuteNotebook(
+        "tests/tasks/jupyter/sample_notebook.ipynb",
+        parameters=dict(a=5),
         output_format="notebook",
     )
     output = task.run()

--- a/tests/tasks/jupyter/test_jupyter.py
+++ b/tests/tasks/jupyter/test_jupyter.py
@@ -30,7 +30,7 @@ def test_jupyter_json_output():
     task = ExecuteNotebook(
         "tests/tasks/jupyter/sample_notebook.ipynb",
         parameters=dict(a=5),
-        output_format="json",
+        output_format="notebook",
     )
     output = task.run()
     _ = json.loads(output)  # try loading the JSON string

--- a/tests/tasks/jupyter/test_jupyter.py
+++ b/tests/tasks/jupyter/test_jupyter.py
@@ -1,4 +1,5 @@
 import json
+from nbconvert import HTMLExporter
 
 from prefect.tasks.jupyter import ExecuteNotebook
 
@@ -8,6 +9,18 @@ def test_jupyter_html_output():
         "tests/tasks/jupyter/sample_notebook.ipynb",
         parameters=dict(a=5),
         output_format="html",
+    )
+    output = task.run()
+    assert "a*b=10" in output
+
+
+def test_jupyter_custom_exporter():
+    exporter = HTMLExporter()
+
+    task = ExecuteNotebook(
+        "tests/tasks/jupyter/sample_notebook.ipynb",
+        parameters=dict(a=5),
+        exporter=exporter,
     )
     output = task.run()
     assert "a*b=10" in output

--- a/tests/tasks/jupyter/test_jupyter.py
+++ b/tests/tasks/jupyter/test_jupyter.py
@@ -1,5 +1,4 @@
 import json
-from nbconvert import HTMLExporter
 
 from prefect.tasks.jupyter import ExecuteNotebook
 
@@ -12,18 +11,19 @@ def test_jupyter_html_output():
     )
     output = task.run()
     assert "a*b=10" in output
+    assert "# This cell contains commented Python code" in output
 
 
-def test_jupyter_custom_exporter():
-    exporter = HTMLExporter()
-
+def test_jupyter_html_output_with_exporter_kwargs():
     task = ExecuteNotebook(
         "tests/tasks/jupyter/sample_notebook.ipynb",
         parameters=dict(a=5),
-        exporter=exporter,
+        output_format="html",
+        exporter_kwargs={"exclude_input": True},
     )
     output = task.run()
     assert "a*b=10" in output
+    assert "# This cell contains commented Python code" not in output
 
 
 def test_jupyter_json_output():


### PR DESCRIPTION
## Summary

ExecuteNotebook task now takes an optional `exporter` argument that (when provided) is used to export the notebook.

Fixes #3687

## Changes

The ExecuteNotebook task now takes an optional `exporter` argument that (when provided) is used to export the notebook.

## Importance

This allows for custom exporters to any format, and not just html or json. In addition, it allows for an html-export with non-default HTMLExporter arguments.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)