### PR TITLE
Fix using location parameter

### DIFF
--- a/changes/pr3726.yaml
+++ b/changes/pr3726.yaml
@@ -1,5 +1,5 @@
 fix:
-  - "Fix using location parameter - [#3726](https://github.com/PrefectHQ/prefect/pull/3726)"
+  - "Properly forward `location` parameter in bigquery tasks - [#3726](https://github.com/PrefectHQ/prefect/pull/3726)"
 
 contributor:
   - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/changes/pr3726.yaml
+++ b/changes/pr3726.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix using location parameter - [#3726](https://github.com/PrefectHQ/prefect/pull/3726)"
+
+contributor:
+  - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/src/prefect/tasks/gcp/bigquery.py
+++ b/src/prefect/tasks/gcp/bigquery.py
@@ -379,7 +379,12 @@ class BigQueryLoadGoogleCloudStorage(Task):
         job_config = bigquery.LoadJobConfig(autodetect=autodetect, **kwargs)
         if schema:
             job_config.schema = schema
-        load_job = client.load_table_from_uri(uri, table_ref, job_config=job_config)
+        load_job = client.load_table_from_uri(
+            uri,
+            table_ref,
+            location=location,
+            job_config=job_config,
+        )
         load_job.result()  # block until job is finished
 
         return load_job
@@ -529,6 +534,7 @@ class BigQueryLoadFile(Task):
                     rewind,
                     size,
                     num_retries,
+                    location=location,
                     job_config=job_config,
                 )
         except IOError:


### PR DESCRIPTION
## Summary
Fix unused location parameters in bigquery tasks.


## Changes
Changed to use location parameters when calling `load_table_from_uri` method and `load_table_from_file` method.


## Importance
Location parameters in bigquery tasks are ignored.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)