### PR TITLE
Add AWS CodeCommit storage option

### DIFF
--- a/changes/codecommit.yaml
+++ b/changes/codecommit.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Added storage option for AWS CodeCommit - [#1234](https://github.com/PrefectHQ/prefect/pull/1234)"

--- a/changes/pr3733.yaml
+++ b/changes/pr3733.yaml
@@ -17,4 +17,4 @@
 # Here's an example of a PR that adds an enhancement
 
 enhancement:
-  - "Added storage option for AWS CodeCommit - [#1234](https://github.com/PrefectHQ/prefect/pull/1234)"
+  - "Added storage option for AWS CodeCommit - [#3733](https://github.com/PrefectHQ/prefect/pull/3733)"

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -147,7 +147,7 @@ GitLab server users can point the `host` argument to their personal GitLab insta
 
 [Bitbucket Storage](/api/latest/environments/storage.html#github) is a storage option that uploads flows to a Bitbucket repository as `.py` files.
 
-Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well. 
+Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
 
 ::: tip Sensible Defaults
 Flows registered with this storage option will automatically be labeled with `"bitbucket-flow-storage"`; this helps prevents agents not explicitly authenticated with your Bitbucket repo from attempting to run this flow.
@@ -163,6 +163,17 @@ Bitbucket server users can point the `host` argument to their personal or organi
 
 :::tip Bitbucket Projects
 Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each repo must be associated with a Project. Bitbucket storage requires a `project` argument pointing to the correct project name.
+
+## CodeCommit
+
+[CodeCommit Storage](/api/latest/environments/storage.html#codecommit) is a storage option that uploads flows to a CodeCommit repository as `.py` files.
+
+::: tip Sensible Defaults
+Flows registered with this storage option will automatically be labeled with `"codecommit-flow-storage"`; this helps prevent agents not explicitly authenticated with your AWS deployment from attempting to run this flow.
+:::
+
+:::tip AWS Credentials
+S3 Storage uses AWS credentials the same way as [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) which means both upload (build) and download (local agent) times need to have proper AWS credential configuration.
 :::
 
 ## Docker

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -232,7 +232,7 @@ instance.
 
 ## Bitbucket
 
-[Bitbucket Storage](/api/latest/environments/storage.html#github) is a 
+[Bitbucket Storage](/api/latest/environments/storage.html#github) is a
 storage option that uploads flows to a Bitbucket repository as `.py` files.
 
 ```python
@@ -244,32 +244,62 @@ flow = Flow(
     Bitbucket(
         project="project",                  # name of project
         repo="project.repo",                # name of repo in project
-        path="flows/my_flow.py",            # location of flow file in repo        
+        path="flows/my_flow.py",            # location of flow file in repo
         secrets=["BITBUCKET_ACCESS_TOKEN"]  # name of personal access token secret
     )
 )
 ```
 
 Much of the GitHub example in the [file based
-storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well. 
+storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
 
 ::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with 
-`"bitbucket-flow-storage"`; this helps prevents agents not explicitly 
+Flows registered with this storage option will automatically be labeled with
+`"bitbucket-flow-storage"`; this helps prevents agents not explicitly
 authenticated with your Bitbucket repo from attempting to run this flow.
 :::
 
 :::tip Bitbucket Credentials
-Bitbucket storage uses a [personal access 
-token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) 
+Bitbucket storage uses a [personal access
+token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
 for authenticating with repositories.
 :::
 
-
 :::tip Bitbucket Projects
-Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each repo 
-must be associated with a Project. Bitbucket storage requires a `project` argument 
+Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each repo
+must be associated with a Project. Bitbucket storage requires a `project` argument
 pointing to the correct project name.
+
+## CodeCommit
+
+[CodeCommit Storage](/api/latest/environments/storage.html#codecommit) is a
+storage option that uploads flows to a CodeCommit repository as `.py` files.
+
+```python
+from prefect import Flow
+from prefect.environments.storage import GitLab
+
+flow = Flow(
+    "codecommit-flow",
+    CodeCommit(
+        repo="org/repo",                 # name of repo
+        path="flows/my_flow.py",         # location of flow file in repo
+        commit='dev',                    # branch, tag or commit id
+    )
+)
+```
+
+::: tip Sensible Defaults
+Flows registered with this storage option will automatically be labeled with
+`"codecommit-flow-storage"`; this helps prevent agents not explicitly
+authenticated with your AWS deployment from attempting to run this flow.
+:::
+
+:::tip AWS Credentials
+S3 Storage uses AWS credentials the same way as
+[boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html)
+which means both upload (build) and download (local agent) times need to
+have proper AWS credential configuration.
 :::
 
 ## Docker

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -230,7 +230,7 @@ classes = ["CloudFlowRunner", "CloudTaskRunner"]
 [pages.environments.storage]
 title = "Storage"
 module = "prefect.environments.storage"
-classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket"]
+classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket", "CodeCommit"]
 
 [pages.environments.execution]
 title = "Execution Environments"

--- a/src/prefect/environments/storage/__init__.py
+++ b/src/prefect/environments/storage/__init__.py
@@ -34,6 +34,7 @@ from prefect.environments.storage.s3 import S3
 from prefect.environments.storage.github import GitHub
 from prefect.environments.storage.gitlab import GitLab
 from prefect.environments.storage.bitbucket import Bitbucket
+from prefect.environments.storage.codecommit import CodeCommit
 from prefect.environments.storage.webhook import Webhook
 
 

--- a/src/prefect/environments/storage/codecommit.py
+++ b/src/prefect/environments/storage/codecommit.py
@@ -1,0 +1,155 @@
+from typing import TYPE_CHECKING, Any, Dict
+
+from prefect.environments.storage import Storage
+from prefect.utilities.storage import extract_flow_from_file
+
+if TYPE_CHECKING:
+    from prefect.core.flow import Flow
+
+
+class CodeCommit(Storage):
+    """
+    CodeCommit storage class. This class represents the Storage interface for Flows stored
+    in `.py` files in a CodeCommit repository.
+
+    This class represents a mapping of flow name to file paths contained in the git repo,
+    meaning that all flow files should be pushed independently. A typical workflow using
+    this storage type might look like the following:
+
+    - Compose flow `.py` file where flow has CodeCommit storage:
+
+    ```python
+    flow = Flow("my-flow")
+    flow.storage = CodeCommit(repo="my/repo", path="/flows/flow.py")
+    ```
+
+    - Push this `flow.py` file to the `my/repo` repository under `/flows/flow.py`.
+
+    - Call `prefect register -f flow.py` to register this flow with CodeCommit storage.
+
+    Args:
+        - repo (str): the name of a CodeCommit repository to store this Flow
+        - path (str, optional): a path pointing to a flow file in the repo
+        - commit (str, optional): fully quaified reference that identifies the commit
+          that contains the file. For example, you can specify a full commit ID, a tag,
+          a branch name, or a reference such as refs/heads/master. If none is provided,
+          the head commit is used
+        - client_options (dict, optional): Additional options for the `boto3` client.
+        - **kwargs (Any, optional): any additional `Storage` initialization options
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        path: str = None,
+        commit: str = None,
+        client_options: dict = None,
+        **kwargs: Any
+    ) -> None:
+        self.flows = dict()  # type: Dict[str, str]
+        self._flows = dict()  # type: Dict[str, "Flow"]
+        self.repo = repo
+        self.path = path
+        self.commit = commit
+        self.client_options = client_options
+
+        super().__init__(**kwargs)
+
+    def get_flow(self, flow_location: str = None) -> "Flow":
+        """
+        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
+        If the Flow is not found an error will be logged and `None` will be returned.
+
+        Args:
+            - flow_location (str): the location of a flow within this Storage; in this case,
+                a file path on a repository where a Flow file has been committed. Will use `path` if not
+                provided.
+
+        Returns:
+            - Flow: the requested Flow
+
+        Raises:
+            - ValueError: if the flow is not contained in this storage
+            - UnknownObjectException: if the flow file is unable to be retrieved
+        """
+        if flow_location:
+            if flow_location not in self.flows.values():
+                raise ValueError("Flow is not contained in this Storage")
+        elif self.path:
+            flow_location = self.path
+        else:
+            raise ValueError("No flow location provided")
+
+        client = self._boto3_client
+
+        try:
+            file_contents = client.get_file(
+                repositoryName=self.repo,
+                commitSpecifier=self.commit,
+                filePath=flow_location,
+            )["fileContent"]
+            decoded_contents = file_contents.decode("utf-8")
+        except Exception as exc:
+            self.logger.error(
+                "Error retrieving file contents from {} on repo {}. Ensure the file exists.".format(
+                    flow_location, self.repo
+                )
+            )
+            raise exc
+
+        return extract_flow_from_file(file_contents=decoded_contents)
+
+    def add_flow(self, flow: "Flow") -> str:
+        """
+        Method for storing a new flow as bytes in the local filesytem.
+
+        Args:
+            - flow (Flow): a Prefect Flow to add
+
+        Returns:
+            - str: the location of the added flow in the repo
+
+        Raises:
+            - ValueError: if a flow with the same name is already contained in this storage
+        """
+        if flow.name in self:
+            raise ValueError(
+                'Name conflict: Flow with the name "{}" is already present in this storage.'.format(
+                    flow.name
+                )
+            )
+
+        self.flows[flow.name] = self.path  # type: ignore
+        self._flows[flow.name] = flow
+        return self.path  # type: ignore
+
+    def build(self) -> "Storage":
+        """
+        Build the CodeCommit storage object and run basic healthchecks. Due to this object
+        supporting file based storage no files are committed to the repository during
+        this step. Instead, all files should be committed independently.
+
+        Returns:
+            - Storage: a CodeCommit object that contains information about how and where
+                each flow is stored
+        """
+        self.run_basic_healthchecks()
+
+        return self
+
+    def __contains__(self, obj: Any) -> bool:
+        """
+        Method for determining whether an object is contained within this storage.
+        """
+        if not isinstance(obj, str):
+            return False
+        return obj in self.flows
+
+    @property
+    def _boto3_client(self):  # type: ignore
+        from prefect.utilities.aws import get_boto_client
+
+        kwargs = self.client_options or {}
+        return get_boto_client(
+            resource="codecommit", credentials=None, use_session=False, **kwargs
+        )

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -167,6 +167,8 @@ class BitbucketSchema(ObjectSchema):
     host = fields.String(allow_none=True)
     path = fields.String(allow_none=True)
     ref = fields.String(allow_none=True)
+    flows = fields.Dict(key=fields.Str(), values=fields.Str())
+    secrets = fields.List(fields.Str(), allow_none=True)
 
     @post_load
     def create_object(self, data: dict, **kwargs: Any) -> Bitbucket:

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -31,7 +31,6 @@ DEFAULT_AGENT_LABELS = [
     "github-flow-storage",
     "webhook-flow-storage",
     "gitlab-flow-storage",
-    "codecommit-flow-storage",
 ]
 
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -17,6 +17,7 @@ from prefect.environments.storage import (
     Webhook,
     GitLab,
     Bitbucket,
+    CodeCommit,
 )
 from prefect.run_configs import LocalRun, KubernetesRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
@@ -30,6 +31,7 @@ DEFAULT_AGENT_LABELS = [
     "github-flow-storage",
     "webhook-flow-storage",
     "gitlab-flow-storage",
+    "codecommit-flow-storage",
 ]
 
 
@@ -233,6 +235,7 @@ def test_populate_env_vars_from_run_config(tmpdir):
         Azure(container="test"),
         GitLab("test/repo", path="path/to/flow.py"),
         Bitbucket(project="PROJECT", repo="test-repo", path="test-flow.py"),
+        CodeCommit("test/repo", path="path/to/flow.py"),
         Webhook(
             build_request_kwargs={"url": "test-service/upload"},
             build_request_http_method="POST",

--- a/tests/environments/storage/test_codecommit_storage.py
+++ b/tests/environments/storage/test_codecommit_storage.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from prefect import context, Flow
+from prefect.environments.storage import CodeCommit
+
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+
+
+def test_create_codecommit_storage():
+    storage = CodeCommit(repo="test/repo")
+    assert storage
+    assert storage.logger
+
+
+def test_create_codecommit_storage_init_args():
+    storage = CodeCommit(
+        repo="test/repo",
+        path="flow.py",
+        commit="master",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False},
+        secrets=["auth"],
+    )
+    assert storage
+    assert storage.flows == dict()
+    assert storage.repo == "test/repo"
+    assert storage.path == "flow.py"
+    assert storage.commit == "master"
+    assert storage.client_options == {
+        "endpoint_url": "http://some-endpoint",
+        "use_ssl": False,
+    }
+    assert storage.secrets == ["auth"]
+
+
+def test_serialize_codecommit_storage():
+    storage = CodeCommit(
+        repo="test/repo",
+        path="flow.py",
+        commit="master",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False},
+        secrets=["auth"],
+    )
+    serialized_storage = storage.serialize()
+
+    assert serialized_storage["type"] == "CodeCommit"
+    assert serialized_storage["repo"] == "test/repo"
+    assert serialized_storage["path"] == "flow.py"
+    assert serialized_storage["commit"] == "master"
+    assert serialized_storage["client_options"] == {
+        "endpoint_url": "http://some-endpoint",
+        "use_ssl": False,
+    }
+    assert serialized_storage["secrets"] == ["auth"]
+
+
+def test_codecommit_client_property(monkeypatch):
+    client = MagicMock()
+    boto3 = MagicMock(client=MagicMock(return_value=client))
+    monkeypatch.setattr("boto3.client", boto3)
+
+    storage = CodeCommit(
+        repo="test/repo",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False},
+    )
+
+    credentials = dict(
+        ACCESS_KEY="id", SECRET_ACCESS_KEY="secret", SESSION_TOKEN="session"
+    )
+    with context(secrets=dict(AWS_CREDENTIALS=credentials)):
+        boto3_client = storage._boto3_client
+    assert boto3_client
+    boto3.assert_called_with(
+        "codecommit",
+        aws_access_key_id="id",
+        aws_secret_access_key="secret",
+        aws_session_token="session",
+        endpoint_url="http://some-endpoint",
+        use_ssl=False,
+    )
+
+
+def test_add_flow_to_codecommit_storage():
+    storage = CodeCommit(repo="test/repo", path="flow.py", commit="master")
+
+    f = Flow("test")
+    assert f.name not in storage
+    assert storage.add_flow(f) == "flow.py"
+    assert f.name in storage
+
+
+def test_add_flow_to_codecommit_already_added():
+    storage = CodeCommit(repo="test/repo", path="flow.py", commit="master")
+
+    f = Flow("test")
+    assert f.name not in storage
+    assert storage.add_flow(f) == "flow.py"
+    assert f.name in storage
+
+    with pytest.raises(ValueError):
+        storage.add_flow(f)
+
+
+def test_get_flow_codecommit(monkeypatch):
+    client = MagicMock()
+    d = {"fileContent": b'import prefect; flow = prefect.Flow("test")'}
+    client.__getitem__.side_effect = d.__getitem__
+    boto3 = MagicMock(get_file=MagicMock(return_value=client))
+    monkeypatch.setattr("prefect.environments.storage.CodeCommit._boto3_client", boto3)
+
+    f = Flow("test")
+
+    monkeypatch.setattr(
+        "prefect.environments.storage.github.extract_flow_from_file",
+        MagicMock(return_value=f),
+    )
+
+    with pytest.raises(ValueError):
+        storage = CodeCommit(repo="test/repo")
+        storage.get_flow()
+
+    storage = CodeCommit(repo="test/repo", path="flow", commit="master")
+
+    assert f.name not in storage
+    flow_location = storage.add_flow(f)
+
+    new_flow = storage.get_flow(flow_location)
+    assert new_flow.run()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adds the ability to use AWS CodeCommit as a storage option




## Changes
An additional storage option has been added, which builds on the AWS functionality of the S3 storage option




## Importance
Enables AWS CodeCommit users to incorporate git storage into flows




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)