### PR TITLE
Replace deprecated download_as_string method with download_as_bytes method

### DIFF
--- a/changes/pr3741.yaml
+++ b/changes/pr3741.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Replace deprecated download_as_string method with download_as_bytes method - [#3741](https://github.com/PrefectHQ/prefect/pull/3741)"
+
+contributor:
+  - "[Takayuki Hirayama](https://github.com/yukihira1992)"

--- a/src/prefect/engine/result_handlers/gcs_result_handler.py
+++ b/src/prefect/engine/result_handlers/gcs_result_handler.py
@@ -98,7 +98,7 @@ class GCSResultHandler(ResultHandler):
         """
         try:
             self.logger.debug("Starting to download result from {}...".format(uri))
-            result = self.gcs_bucket.blob(uri).download_as_string()
+            result = self.gcs_bucket.blob(uri).download_as_bytes()
             try:
                 return_val = cloudpickle.loads(base64.b64decode(result))
             except EOFError:

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -94,7 +94,7 @@ class GCSResult(Result):
 
         try:
             self.logger.debug("Starting to download result from {}...".format(location))
-            serialized_value = self.gcs_bucket.blob(location).download_as_string()
+            serialized_value = self.gcs_bucket.blob(location).download_as_bytes()
             try:
                 new.value = new.serializer.deserialize(serialized_value)
             except EOFError:

--- a/tests/engine/results/test_gcs_result.py
+++ b/tests/engine/results/test_gcs_result.py
@@ -45,7 +45,7 @@ class TestGCSResult:
 
     def test_gcs_reads_and_updates_location(self, google_client):
         bucket = MagicMock()
-        bucket.blob.return_value.download_as_string.return_value = b""
+        bucket.blob.return_value.download_as_bytes.return_value = b""
         google_client.return_value.bucket = MagicMock(return_value=bucket)
         result = GCSResult(bucket="foo", location="{thing}/here.txt")
         new_result = result.read("path/to/my/stuff.txt")


### PR DESCRIPTION
## Summary
Fix deprecated method.



## Changes
Replace deprecated [download_as_string](https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.download_as_string) method with download_as_bytes method.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)