### PR TITLE
Add `image` to `prefect.context` for flow runs

### DIFF
--- a/changes/pr3746.yaml
+++ b/changes/pr3746.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add the image used for a flow-run to the flow run environment as `prefect.context.image` - [#3746](https://github.com/PrefectHQ/prefect/pull/3746)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -366,7 +366,7 @@ class DockerAgent(Agent):
             run_config = None
 
         image = get_flow_image(flow_run=flow_run)
-        env_vars = self.populate_env_vars(flow_run, run_config=run_config)
+        env_vars = self.populate_env_vars(flow_run, image, run_config=run_config)
 
         if not self.no_pull and len(image.split("/")) > 1:
             self.logger.info("Pulling image {}...".format(image))
@@ -461,13 +461,14 @@ class DockerAgent(Agent):
         self.processes.append(proc)
 
     def populate_env_vars(
-        self, flow_run: GraphQLResult, run_config: DockerRun = None
+        self, flow_run: GraphQLResult, image: str, run_config: DockerRun = None
     ) -> dict:
         """
         Populate metadata and variables in the environment variables for a flow run
 
         Args:
             - flow_run (GraphQLResult): A flow run object
+            - image (str): The image for this flow
             - run_config (DockerRun, optional): The `run_config` for the flow, if any.
 
         Returns:
@@ -504,6 +505,7 @@ class DockerAgent(Agent):
                 "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,  # type: ignore
+                "PREFECT__CONTEXT__IMAGE": image,
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
                 "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.log_to_cloud).lower(),
                 "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -441,7 +441,7 @@ class ECSAgent(Agent):
             containers.append(container)
 
         # Set flow image
-        container["image"] = get_flow_image(flow_run)
+        container["image"] = image = get_flow_image(flow_run)
 
         # Set flow run command
         container["command"] = ["/bin/sh", "-c", get_flow_run_command(flow_run)]
@@ -456,6 +456,7 @@ class ECSAgent(Agent):
         # - Values in the task definition template
         env = {
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
+            "PREFECT__CONTEXT__IMAGE": image,
             "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
             "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
         }

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -458,7 +458,7 @@ class KubernetesAgent(Agent):
         container = containers[0]
 
         # Set container image
-        container["image"] = get_flow_image(flow_run)
+        container["image"] = image = get_flow_image(flow_run)
 
         # Set flow run command
         container["args"] = [get_flow_run_command(flow_run)]
@@ -479,6 +479,7 @@ class KubernetesAgent(Agent):
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
+                "PREFECT__CONTEXT__IMAGE": image,
                 "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.log_to_cloud).lower(),
                 "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
                 "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -110,7 +110,7 @@ def test_populate_env_vars_from_agent_config(api):
     agent = DockerAgent(env_vars=dict(AUTH_THING="foo"))
 
     env_vars = agent.populate_env_vars(
-        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})
+        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}), "test-image"
     )
 
     assert env_vars["AUTH_THING"] == "foo"
@@ -120,7 +120,7 @@ def test_populate_env_vars(api):
     agent = DockerAgent()
 
     env_vars = agent.populate_env_vars(
-        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})
+        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}), "test-image"
     )
 
     expected_vars = {
@@ -129,6 +129,7 @@ def test_populate_env_vars(api):
         "PREFECT__CLOUD__AGENT__LABELS": "[]",
         "PREFECT__CONTEXT__FLOW_RUN_ID": "id",
         "PREFECT__CONTEXT__FLOW_ID": "foo",
+        "PREFECT__CONTEXT__IMAGE": "test-image",
         "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
         "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
         "PREFECT__LOGGING__LEVEL": "INFO",
@@ -143,7 +144,7 @@ def test_populate_env_vars_includes_agent_labels(api):
     agent = DockerAgent(labels=["42", "marvin"])
 
     env_vars = agent.populate_env_vars(
-        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})
+        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}), "test-image"
     )
     assert env_vars["PREFECT__CLOUD__AGENT__LABELS"] == "['42', 'marvin']"
 
@@ -153,7 +154,7 @@ def test_populate_env_vars_sets_log_to_cloud(flag, api):
     agent = DockerAgent(labels=["42", "marvin"], no_cloud_logs=flag)
 
     env_vars = agent.populate_env_vars(
-        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}})
+        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}), "test-image"
     )
     assert env_vars["PREFECT__LOGGING__LOG_TO_CLOUD"] == str(not flag).lower()
 
@@ -173,7 +174,8 @@ def test_populate_env_vars_from_run_config(api):
                 "flow": {"id": "foo", "run_config": run.serialize()},
             }
         ),
-        run,
+        "test-image",
+        run_config=run,
     )
     assert env_vars["KEY1"] == "VAL1"
     assert env_vars["KEY2"] == "OVERRIDE"

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -369,6 +369,7 @@ class TestGenerateTaskDefinition:
 
     def test_generate_task_definition_environment(self):
         run_config = ECSRun(
+            image="test-image",
             task_definition={
                 "containerDefinitions": [
                     {
@@ -393,6 +394,7 @@ class TestGenerateTaskDefinition:
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
             "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+            "PREFECT__CONTEXT__IMAGE": "test-image",
             "CUSTOM1": "VALUE1",
             "CUSTOM2": "VALUE2",
         }

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1118,7 +1118,9 @@ class TestK8sAgentRunConfig:
         self.agent.job_template_path = template_path
 
         self.agent.env_vars = {"CUSTOM2": "OVERRIDE2", "CUSTOM3": "VALUE3"}
-        run_config = KubernetesRun(env={"CUSTOM3": "OVERRIDE3", "CUSTOM4": "VALUE4"})
+        run_config = KubernetesRun(
+            image="test-image", env={"CUSTOM3": "OVERRIDE3", "CUSTOM4": "VALUE4"}
+        )
 
         flow_run = self.build_flow_run(run_config)
         job = self.agent.generate_job_spec(flow_run)
@@ -1130,6 +1132,7 @@ class TestK8sAgentRunConfig:
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
             "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
             "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
+            "PREFECT__CONTEXT__IMAGE": "test-image",
             "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.agent.log_to_cloud).lower(),
             "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
             "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",


### PR DESCRIPTION
For flow runs deployed by the k8s, ECS, and docker agent, we now add the
image used by the flow run to the environment as
`PREFECT__CONTEXT__IMAGE`. This lets users access the flow-run image
inside the flow run as `prefect.context.image`.

This can be used when creating a `DaskExecutor` to ensure the dask
cluster uses the same image as the flow runner (where the dask client
lives). For example:

```python
import prefect
from dask_cloudprovider.aws import FargateCluster
from prefect.engine.executors import DaskExecutor

executor = DaskExecutor(
    cluster_class=lambda: FargateCluster(image=prefect.context.image),
    adapt_kwargs={"maximum": 10},
)
```

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)