### PR TITLE
Fix agent default image when using a non tagged commit

### DIFF
--- a/changes/pr3748.yaml
+++ b/changes/pr3748.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix default image whenever working on a non-tagged commit - [#3748](https://github.com/PrefectHQ/prefect/pull/3748)"

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -32,7 +32,8 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
         else:
             # core_version should always be present, but just in case
             version = flow_run.flow.get("core_version") or "latest"
-            return f"prefecthq/prefect:all_extras-{version}"
+            cleaned_version = version.split("+")[0]
+            return f"prefecthq/prefect:all_extras-{cleaned_version}"
     else:
         environment = EnvironmentSchema().load(flow_run.flow.environment)
         if hasattr(environment, "metadata") and hasattr(environment.metadata, "image"):

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -81,12 +81,13 @@ def test_get_flow_image_run_config_docker_storage():
     assert image == "test/name:tag"
 
 
-def test_get_flow_image_run_config_default_value_from_core_version():
+@pytest.mark.parametrize("version", ["0.13.0", "0.10.0+182.g385a32514.dirty", None])
+def test_get_flow_image_run_config_default_value_from_core_version(version):
     flow_run = GraphQLResult(
         {
             "flow": GraphQLResult(
                 {
-                    "core_version": "0.13.0",
+                    "core_version": version,
                     "storage": Local().serialize(),
                     "run_config": KubernetesRun().serialize(),
                     "id": "id",
@@ -96,7 +97,8 @@ def test_get_flow_image_run_config_default_value_from_core_version():
         }
     )
     image = get_flow_image(flow_run)
-    assert image == "prefecthq/prefect:all_extras-0.13.0"
+    expected_version = version.split("+")[0] if version else "latest"
+    assert image == f"prefecthq/prefect:all_extras-{expected_version}"
 
 
 def test_get_flow_image_run_config_image_on_RunConfig():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
When deploying Flows built off, e.g., the master branch of Prefect, the default image logic pointed to an image that doesn't exist.  This PR falls back to the nearest tag, as determined by versioneer, for the default image to use.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
Fixes edge case



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)