### PR TITLE
Fix state attempting to read result from absent upstream result

### DIFF
--- a/changes/issue3618.yaml
+++ b/changes/issue3618.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix state attempting to read result from absent upstream result - [#3618](https://github.com/PrefectHQ/prefect/issues/3618)"

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -119,7 +119,8 @@ class State:
 
         result_reader = result or self._result
 
-        known_location = self._result.location or getattr(result, "location", None)  # type: ignore
+        known_location = self._result.location  # type: ignore
+
         if self._result.value is None and known_location is not None:  # type: ignore
             self._result = result_reader.read(known_location)  # type: ignore
         return self

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -617,28 +617,6 @@ class TestResultInterface:
         assert new_state._result.location is None
 
     @pytest.mark.parametrize("cls", all_states)
-    def test_state_load_result_reads_if_location_is_provided(self, cls):
-        class MyResult(Result):
-            def read(self, *args, **kwargs):
-                self.value = "bar"
-                return self
-
-        state = cls(result=Result())
-        assert state.message is None
-        assert state.result is None
-        assert state._result.location is None
-
-        new_state = state.load_result(MyResult(location="foo"))
-        assert new_state.message is None
-
-        if not new_state.is_mapped():
-            assert new_state.result == "bar"
-            assert new_state._result.location == "foo"
-        else:
-            assert new_state.result is None
-            assert not new_state._result.location
-
-    @pytest.mark.parametrize("cls", all_states)
     def test_state_load_cached_results_calls_read(self, cls):
         """
         This test ensures that the read logic of the provided result is


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

A flow like the following would fail in cases where `b` attempts to load the result from the upstream.

```python
@task
def a():
    return None

@task
def b(foo):
    print(foo)

result = LocalResult(
    location="{flow_name}/"
    "{scheduled_start_time:%d-%m_%H-%M-%S}/"
    "{task_full_name}-{task_run_id}.prefect_result",
)
```

In a normal run when a task returns `None` a result isn't written and the location is also set to `None`. In the state `load_results` function it sees that the location is None and then also attempts to use the original default (unformatted) location from the upstream state's result. 

## Changes
Removes the getattr for the default result location because there shouldn't be a case where the result doesn't already have a location serialized if needed.




## Importance
Closes #3618



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

cc @cicdw 