### PR TITLE
Support for flows with `flow.environment = None`

### DIFF
--- a/changes/pr3750.yaml
+++ b/changes/pr3750.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "Add `UniversalRun` run-config that works with all agents - [#3750](https://github.com/PrefectHQ/prefect/pull/3750)"
+  - "Support flows that have no run-config or environment - [#3750](https://github.com/PrefectHQ/prefect/pull/3750)"

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -64,6 +64,30 @@ Prefect has a number of different `RunConfig` implementations - we'll briefly
 cover each below. See [the API
 documentation](/api/latest/run_configs.md) for more information.
 
+### UniversalRun
+
+[UniversalRun](/api/latest/environments/run_config.md#universalrun) configures
+flow runs that can be deployed on any agent. This is the default `RunConfig`
+used if flow-labels are specified. It can be useful if agent-side configuration
+is sufficient. Only configuring the flow's labels is exposed - to configure
+backend specific fields use one of the other `RunConfig` types.
+
+#### Examples
+
+Use the defaults set on the agent:
+
+```python
+from prefect.run_configs import UniversalRun
+
+flow.run_config = UniversalRun()
+```
+
+Configure labels for this flow:
+
+```python
+flow.run_config = UniversalRun(labels=["label-1", "label-2"])
+```
+
 ### LocalRun
 
 [LocalRun](/api/latest/environments/run_config.md#localrun) configures flow

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -240,7 +240,7 @@ classes = ["DaskKubernetesEnvironment", "DaskCloudProviderEnvironment", "Fargate
 [pages.run_configs]
 title = "Run Configuration"
 module = "prefect.run_configs"
-classes = ["RunConfig", "LocalRun", "DockerRun", "KubernetesRun", "ECSRun"]
+classes = ["RunConfig", "UniversalRun", "LocalRun", "DockerRun", "KubernetesRun", "ECSRun"]
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -8,7 +8,7 @@ import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Generator, Iterable, Set, Optional, cast
+from typing import Any, Generator, Iterable, Set, Optional, cast, Callable
 from urllib.parse import urlparse
 
 import pendulum
@@ -19,6 +19,8 @@ from prefect import config
 from prefect.client import Client
 from prefect.engine.state import Failed, Submitted
 from prefect.serialization import state
+from prefect.serialization.run_config import RunConfigSchema
+from prefect.run_configs import RunConfig
 from prefect.utilities.context import context
 from prefect.utilities.exceptions import AuthorizationError
 from prefect.utilities.graphql import GraphQLResult, with_args
@@ -680,6 +682,38 @@ class Agent:
             state=Failed(message=str(exc)),
         )
         self.logger.error("Error while deploying flow: {}".format(repr(exc)))
+
+    def _get_run_config(
+        self, flow_run: GraphQLResult, run_config_cls: Callable
+    ) -> Optional[RunConfig]:
+        """
+        Get a run_config for the flow, if present.
+
+        Args:
+            - flow_run (GraphQLResult): A GraphQLResult flow run object
+            - run_config_cls (Callable): The expected run-config class
+
+        Returns:
+            - RunConfig: The flow run's run-config. Returns None if an
+                environment-based flow.
+        """
+        # If the flow is using a run_config, load it
+        if getattr(flow_run.flow, "run_config", None) is not None:
+            run_config = RunConfigSchema().load(flow_run.flow.run_config)
+            if not isinstance(run_config, run_config_cls):
+                msg = (
+                    "Flow run %s has a `run_config` of type `%s`, only `%s` is supported"
+                    % (flow_run.id, type(run_config).__name__, run_config_cls.__name__)
+                )
+                self.logger.error(msg)
+                raise TypeError(msg)
+        elif getattr(flow_run.flow, "environment", None) is None:
+            # No environment, use default run_config
+            run_config = run_config_cls()
+        else:
+            run_config = None
+
+        return run_config
 
     def deploy_flow(self, flow_run: GraphQLResult) -> str:
         """

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -351,6 +351,7 @@ class DockerAgent(Agent):
         import docker
 
         run_config = self._get_run_config(flow_run, DockerRun)
+        assert run_config is None or isinstance(run_config, DockerRun)  # mypy
 
         image = get_flow_image(flow_run=flow_run)
         env_vars = self.populate_env_vars(flow_run, image, run_config=run_config)

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -8,7 +8,6 @@ import yaml
 from prefect import config
 from prefect.agent import Agent
 from prefect.run_configs import ECSRun
-from prefect.serialization.run_config import RunConfigSchema
 from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.filesystems import read_bytes_from_path
 from prefect.utilities.graphql import GraphQLResult
@@ -291,24 +290,7 @@ class ECSAgent(Agent):
         """
         self.logger.info("Deploying flow run %r", flow_run.id)
 
-        # Load and validate the flow's run_config
-        if getattr(flow_run.flow, "run_config", None) is not None:
-            run_config = RunConfigSchema().load(flow_run.flow.run_config)
-            if not isinstance(run_config, ECSRun):
-                self.logger.error(
-                    "Flow run %s has a `run_config` of type `%s`, only `ECSRun` is supported",
-                    flow_run.id,
-                    type(run_config).__name__,
-                )
-                raise TypeError(
-                    "Unsupported RunConfig type: %s" % type(run_config).__name__
-                )
-        else:
-            self.logger.error(
-                "Flow run %s has a null `run_config`, only `ECSRun` is supported",
-                flow_run.id,
-            )
-            raise ValueError("Flow is missing a `run_config`")
+        run_config = self._get_run_config(flow_run, ECSRun)
 
         taskdef_arn = self.get_task_definition_arn(flow_run, run_config)
         if taskdef_arn is None:

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -291,6 +291,7 @@ class ECSAgent(Agent):
         self.logger.info("Deploying flow run %r", flow_run.id)
 
         run_config = self._get_run_config(flow_run, ECSRun)
+        assert isinstance(run_config, ECSRun)  # mypy
 
         taskdef_arn = self.get_task_definition_arn(flow_run, run_config)
         if taskdef_arn is None:

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -278,6 +278,7 @@ class KubernetesAgent(Agent):
             - dict: a dictionary representation of a k8s job for flow execution
         """
         run_config = self._get_run_config(flow_run, KubernetesRun)
+        assert run_config is None or isinstance(run_config, KubernetesRun)  # mypy
         if run_config is not None:
             return self.generate_job_spec_from_run_config(flow_run, run_config)
         else:

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -43,7 +43,7 @@ from prefect.engine.result_handlers import ResultHandler
 from prefect.engine.results import ResultHandlerResult
 from prefect.environments import Environment
 from prefect.environments.storage import Storage, get_default_storage_class
-from prefect.run_configs import RunConfig
+from prefect.run_configs import RunConfig, UniversalRun
 from prefect.utilities import diagnostics, logging
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.notifications import callback_factory
@@ -1639,6 +1639,9 @@ class Flow:
 
         if self.storage is None:
             self.storage = get_default_storage_class()(**kwargs)
+
+        if self.environment is None and self.run_config is None:
+            self.run_config = UniversalRun()
 
         # add auto-labels for various types of storage
         for obj in [self.environment, self.run_config]:

--- a/src/prefect/run_configs/__init__.py
+++ b/src/prefect/run_configs/__init__.py
@@ -1,4 +1,4 @@
-from .base import RunConfig
+from .base import RunConfig, UniversalRun
 from .kubernetes import KubernetesRun
 from .local import LocalRun
 from .docker import DockerRun

--- a/src/prefect/run_configs/base.py
+++ b/src/prefect/run_configs/base.py
@@ -7,7 +7,7 @@ class RunConfig:
     """
     Base class for RunConfigs.
 
-    An "run config" is an object for configuring a flow run, which maps to a
+    A "run config" is an object for configuring a flow run, which maps to a
     specific agent backend.
 
     Args:
@@ -28,3 +28,34 @@ class RunConfig:
         """
         schema = prefect.serialization.run_config.RunConfigSchema()
         return schema.dump(self)
+
+
+class UniversalRun(RunConfig):
+    """
+    Configure a flow-run to run universally on any Agent.
+
+    Unlike the other agent-specific `RunConfig` classes (e.g. `LocalRun` for
+    the Local Agent), the `UniversalRun` run config is compatible with any
+    agent. This can be useful for flows that don't require any custom
+    configuration other than flow labels, allowing for transitioning a flow
+    between agent types without any config changes.
+
+    Args:
+        - labels (Iterable[str], optional): an iterable of labels to apply to this
+            run config. Labels are string identifiers used by Prefect Agents
+            for selecting valid flow runs when polling for work
+
+    Examples:
+
+    Use the defaults set on the agent:
+
+    ```python
+    flow.run_config = UniversalRun()
+    ```
+
+    Configure additional labels:
+
+    ```python
+    flow.run_config = UniversalRun(labels=["label-1", "label-2"])
+    ```
+    """

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -90,6 +90,8 @@ class KubernetesRun(RunConfig):
             if isinstance(job_template, str):
                 job_template = yaml.safe_load(job_template)
 
+        assert job_template is None or isinstance(job_template, dict)  # mypy
+
         if cpu_limit is not None:
             cpu_limit = str(cpu_limit)
         if cpu_request is not None:

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -6,11 +6,16 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     SortedList,
 )
-from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
+from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun, UniversalRun
 
 
 class RunConfigSchemaBase(ObjectSchema):
     labels = SortedList(fields.String())
+
+
+class UniversalRunSchema(RunConfigSchemaBase):
+    class Meta:
+        object_class = UniversalRun
 
 
 class KubernetesRunSchema(RunConfigSchemaBase):
@@ -64,4 +69,5 @@ class RunConfigSchema(OneOfSchema):
         "ECSRun": ECSRunSchema,
         "LocalRun": LocalRunSchema,
         "DockerRun": DockerRunSchema,
+        "UniversalRun": UniversalRunSchema,
     }

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -39,7 +39,7 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
         # core_version should always be present, but just in case
         version = flow_run.flow.get("core_version") or "latest"
         return f"prefecthq/prefect:all_extras-{version}"
-    elif getattr(flow_run.flow, "environment", None) is not None:
+    else:
         environment = EnvironmentSchema().load(flow_run.flow.environment)
         if hasattr(environment, "metadata") and hasattr(environment.metadata, "image"):
             return environment.metadata.get("image")

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -22,18 +22,24 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
     from prefect.serialization.run_config import RunConfigSchema
     from prefect.serialization.environment import EnvironmentSchema
 
+    has_run_config = getattr(flow_run.flow, "run_config", None) is not None
+    has_environment = getattr(flow_run.flow, "environment", None) is not None
+
     storage = StorageSchema().load(flow_run.flow.storage)
-    if getattr(flow_run.flow, "run_config", None) is not None:
-        run_config = RunConfigSchema().load(flow_run.flow.run_config)
+    # Not having an environment implies run-config based flow, even if
+    # run_config is None.
+    if has_run_config or not has_environment:
         if isinstance(storage, Docker):
             return storage.name
-        elif getattr(run_config, "image", None) is not None:
-            return run_config.image
-        else:
-            # core_version should always be present, but just in case
-            version = flow_run.flow.get("core_version") or "latest"
-            return f"prefecthq/prefect:all_extras-{version}"
-    else:
+        elif has_run_config:
+            run_config = RunConfigSchema().load(flow_run.flow.run_config)
+            if getattr(run_config, "image", None) is not None:
+                return run_config.image
+        # No image found on run-config, and no environment present. Use default.
+        # core_version should always be present, but just in case
+        version = flow_run.flow.get("core_version") or "latest"
+        return f"prefecthq/prefect:all_extras-{version}"
+    elif getattr(flow_run.flow, "environment", None) is not None:
         environment = EnvironmentSchema().load(flow_run.flow.environment)
         if hasattr(environment, "metadata") and hasattr(environment.metadata, "image"):
             return environment.metadata.get("image")

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -10,7 +10,7 @@ from prefect.agent.ecs.agent import (
     DEFAULT_TASK_DEFINITION_PATH,
 )
 from prefect.environments.storage import Local, Docker
-from prefect.run_configs import ECSRun, LocalRun
+from prefect.run_configs import ECSRun, LocalRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.filesystems import read_bytes_from_path
 from prefect.utilities.graphql import GraphQLResult
@@ -577,7 +577,7 @@ class TestDeployFlow:
         ):
             self.deploy_flow(LocalRun())
 
-    @pytest.mark.parametrize("run_config", [ECSRun(), None])
+    @pytest.mark.parametrize("run_config", [ECSRun(), UniversalRun(), None])
     def test_deploy_flow_registers_taskdef_if_not_found(self, run_config, aws):
         aws.resourcegroupstaggingapi.get_resources.return_value = {
             "ResourceTagMappingList": []

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -11,7 +11,7 @@ import prefect
 from prefect.agent.kubernetes.agent import KubernetesAgent, read_bytes_from_path
 from prefect.environments import LocalEnvironment
 from prefect.environments.storage import Docker, Local
-from prefect.run_configs import KubernetesRun, LocalRun
+from prefect.run_configs import KubernetesRun, LocalRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
@@ -1015,11 +1015,12 @@ class TestK8sAgentRunConfig:
             }
         )
 
-    def test_generate_job_spec_null_environment_uses_default_run_config(self):
+    @pytest.mark.parametrize("run_config", [None, UniversalRun()])
+    def test_generate_job_spec_null_or_univeral_run_config(self, run_config):
         self.agent.generate_job_spec_from_run_config = MagicMock(
             wraps=self.agent.generate_job_spec_from_run_config
         )
-        flow_run = self.build_flow_run(None)
+        flow_run = self.build_flow_run(run_config)
         self.agent.generate_job_spec(flow_run)
         assert self.agent.generate_job_spec_from_run_config.called
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -9,7 +9,7 @@ from testfixtures import compare, LogCapture
 
 from prefect.agent.local import LocalAgent
 from prefect.environments.storage import Docker, Local, Azure, GCS, S3, Webhook, GitLab
-from prefect.run_configs import LocalRun, KubernetesRun
+from prefect.run_configs import LocalRun, KubernetesRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
@@ -337,7 +337,8 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
     assert len(agent.processes) == 0
 
 
-def test_local_agent_deploy_null_run_config(monkeypatch):
+@pytest.mark.parametrize("run_config", [None, UniversalRun()])
+def test_local_agent_deploy_null_or_univeral_run_config(monkeypatch, run_config):
     popen = MagicMock()
     monkeypatch.setattr("prefect.agent.local.agent.Popen", popen)
 
@@ -349,7 +350,7 @@ def test_local_agent_deploy_null_run_config(monkeypatch):
                 "id": "id",
                 "flow": {
                     "storage": Local().serialize(),
-                    "run_config": None,
+                    "run_config": run_config.serialize() if run_config else None,
                     "id": "foo",
                     "core_version": "0.13.0",
                 },

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -315,7 +315,10 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
 
     agent = LocalAgent()
 
-    with pytest.raises(TypeError, match="Unsupported RunConfig type: Kubernetes"):
+    with pytest.raises(
+        TypeError,
+        match="`run_config` of type `KubernetesRun`, only `LocalRun` is supported",
+    ):
         agent.deploy_flow(
             flow_run=GraphQLResult(
                 {
@@ -332,6 +335,30 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
 
     assert not popen.called
     assert len(agent.processes) == 0
+
+
+def test_local_agent_deploy_null_run_config(monkeypatch):
+    popen = MagicMock()
+    monkeypatch.setattr("prefect.agent.local.agent.Popen", popen)
+
+    agent = LocalAgent()
+
+    agent.deploy_flow(
+        flow_run=GraphQLResult(
+            {
+                "id": "id",
+                "flow": {
+                    "storage": Local().serialize(),
+                    "run_config": None,
+                    "id": "foo",
+                    "core_version": "0.13.0",
+                },
+            },
+        )
+    )
+
+    assert popen.called
+    assert len(agent.processes) == 1
 
 
 @pytest.mark.parametrize("working_dir", [None, "existing"])

--- a/tests/run_configs/test_universal.py
+++ b/tests/run_configs/test_universal.py
@@ -1,0 +1,11 @@
+from prefect.run_configs import UniversalRun
+
+
+def test_no_args():
+    config = UniversalRun()
+    assert config.labels == set()
+
+
+def test_all_args(tmpdir):
+    config = UniversalRun(labels=["a", "b"])
+    assert config.labels == {"a", "b"}

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
+from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun, UniversalRun
 from prefect.serialization.run_config import RunConfigSchema, RunConfigSchemaBase
 
 
@@ -10,6 +10,13 @@ def test_serialized_run_config_sorts_labels():
         "b",
         "c",
     ]
+
+
+@pytest.mark.parametrize("config", [UniversalRun(), UniversalRun(labels=["a", "b"])])
+def test_serialize_universal_run(config):
+    msg = RunConfigSchema().dump(config)
+    config2 = RunConfigSchema().load(msg)
+    assert sorted(config.labels) == sorted(config2.labels)
 
 
 @pytest.mark.parametrize(

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -2,7 +2,7 @@ import pytest
 
 from prefect.environments import LocalEnvironment
 from prefect.environments.storage import Docker, Local
-from prefect.run_configs import KubernetesRun
+from prefect.run_configs import KubernetesRun, LocalRun
 from prefect.utilities.agent import get_flow_image, get_flow_run_command
 from prefect.utilities.graphql import GraphQLResult
 
@@ -62,7 +62,8 @@ def test_get_flow_image_raises_on_missing_info():
         get_flow_image(flow_run=flow_run)
 
 
-def test_get_flow_image_run_config_docker_storage():
+@pytest.mark.parametrize("run_config", [KubernetesRun(), LocalRun(), None])
+def test_get_flow_image_run_config_docker_storage(run_config):
     flow_run = GraphQLResult(
         {
             "flow": GraphQLResult(
@@ -70,7 +71,7 @@ def test_get_flow_image_run_config_docker_storage():
                     "storage": Docker(
                         registry_url="test", image_name="name", image_tag="tag"
                     ).serialize(),
-                    "run_config": KubernetesRun().serialize(),
+                    "run_config": run_config.serialize() if run_config else None,
                     "id": "id",
                 }
             ),
@@ -81,14 +82,15 @@ def test_get_flow_image_run_config_docker_storage():
     assert image == "test/name:tag"
 
 
-def test_get_flow_image_run_config_default_value_from_core_version():
+@pytest.mark.parametrize("run_config", [KubernetesRun(), LocalRun(), None])
+def test_get_flow_image_run_config_default_value_from_core_version(run_config):
     flow_run = GraphQLResult(
         {
             "flow": GraphQLResult(
                 {
                     "core_version": "0.13.0",
                     "storage": Local().serialize(),
-                    "run_config": KubernetesRun().serialize(),
+                    "run_config": run_config.serialize() if run_config else None,
                     "id": "id",
                 }
             ),


### PR DESCRIPTION
This adds support for flows with no `environment` AND no `run_config`.

Currently all flow's have an environment created by default. If a user explicitly sets a `run_config` on a flow, the new `run_config` based configuration is used, otherwise the default `environment` is used.

In 0.14.0 we plan to remove the default `environment`, so flow's will by default have `run_config=None, environment=None`. This change adds support for that, without removing the default (yet).

The new logic is now:

- If a flow has a run-config configured, use that. Agents check that the run-config set on the flow matches the type they support.
- If a flow has no environment, the agent will create the default `RunConfig` for that agent type. This means that a flow registered with no `run_config` configured on it is runable by all agents (storage and labels dependent), matching the existing behavior. A `UniversalRun` run-config is created on the client side in this case, so that a flow with nothing else created can still store the auto-generated labels present on `Storage` objects.
- If a flow has an `environment`, the old environment-based code path is taken.

Some other changes were needed throughout to get registration to work (mostly in `flow.register`.

Note that the `UniversalRun` run config is exposed as a new run config option, for those who want to configure labels on a flow but don't want to bind that flow to a specific agent type. This can be useful if all config can be handled on the agent, with nothing backend-specific on the flow. I wouldn't expect this to be used much (it was only added to be the default), but some users may find it useful. Backend-specific functionality still requires a backend-specific run config.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)