### PR TITLE
Surface pod failures and container errors in jobs deployed with the Kubernetes Agent

### DIFF
--- a/changes/issue3747.yaml
+++ b/changes/issue3747.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Surface pod failures and container errors in jobs deployed with the Kubernetes Agent - [3747](https://github.com/PrefectHQ/prefect/issues/3747)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -215,7 +215,7 @@ class KubernetesAgent(Agent):
                             self.client.set_flow_run_state(
                                 flow_run_id=flow_run_id,
                                 state=Failed(
-                                    message="Kubernetes Error: the pods {} failed for this job".format(
+                                    message="Kubernetes Error: pods {} failed for this job".format(
                                         failed_pods
                                     )
                                 ),

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -213,7 +213,7 @@ class KubernetesAgent(Agent):
                                 if status.state.terminated:
                                     msg = textwrap.dedent(
                                         f"""
-                                        Found failed container: {status.name}
+                                        Failed container '{status.name}' in pod '{pod.metadata.name}'
                                             Exit code: {status.state.terminated.exit_code}
                                             Message: {status.state.terminated.message}
                                             Reason: {status.state.terminated.reason}
@@ -243,7 +243,6 @@ class KubernetesAgent(Agent):
                                     )
                                 ),
                             )
-                        return
 
                     # Delete job if it is successful or failed
                     if delete_job:

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -962,6 +962,53 @@ def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
     agent.manage_jobs()
 
 
+def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
+    gql_return = MagicMock(
+        return_value=MagicMock(data=MagicMock(set_flow_run_state=None))
+    )
+    client = MagicMock()
+    client.return_value.graphql = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", client)
+
+    job_mock = MagicMock()
+    job_mock.metadata.labels = {
+        "prefect.io/identifier": "id",
+        "prefect.io/flow_run_id": "fr",
+    }
+    job_mock.metadata.name = "my_job"
+    job_mock.status.failed = True
+    job_mock.status.succeeded = False
+    batch_client = MagicMock()
+    list_job = MagicMock()
+    list_job.metadata._continue = 0
+    list_job.items = [job_mock]
+    batch_client.list_namespaced_job.return_value = list_job
+    monkeypatch.setattr(
+        "kubernetes.client.BatchV1Api", MagicMock(return_value=batch_client)
+    )
+
+    pod = MagicMock()
+    pod.metadata.name = "pod_name"
+    pod.status.phase = "Failed"
+
+    pod2 = MagicMock()
+    pod2.metadata.name = "pod_name"
+    pod2.status.phase = "Success"
+
+    core_client = MagicMock()
+    list_pods = MagicMock()
+    list_pods.items = [pod, pod2]
+    core_client.list_namespaced_pod.return_value = list_pods
+    monkeypatch.setattr(
+        "kubernetes.client.CoreV1Api", MagicMock(return_value=core_client)
+    )
+
+    agent = KubernetesAgent()
+    agent.manage_jobs()
+
+    assert core_client.list_namespaced_pod.called
+
+
 def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api):
     job_mock = MagicMock()
     job_mock.metadata.labels = {

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -920,36 +920,29 @@ def test_k8s_agent_manage_jobs_pass(monkeypatch, cloud_api):
     agent.heartbeat()
 
 
-def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
-    gql_return = MagicMock(
-        return_value=MagicMock(data=MagicMock(set_flow_run_state=None))
-    )
-    client = MagicMock()
-    client.return_value.graphql = gql_return
-    monkeypatch.setattr("prefect.agent.agent.Client", client)
-
+def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api):
     job_mock = MagicMock()
     job_mock.metadata.labels = {
         "prefect.io/identifier": "id",
         "prefect.io/flow_run_id": "fr",
     }
     job_mock.metadata.name = "my_job"
-    job_mock.status.failed = False
-    job_mock.status.succeeded = False
+    job_mock.status.failed = True
+    job_mock.status.succeeded = True
     batch_client = MagicMock()
     list_job = MagicMock()
     list_job.metadata._continue = 0
     list_job.items = [job_mock]
     batch_client.list_namespaced_job.return_value = list_job
+    batch_client.delete_namespaced_job.return_value = None
     monkeypatch.setattr(
         "kubernetes.client.BatchV1Api", MagicMock(return_value=batch_client)
     )
 
     pod = MagicMock()
     pod.metadata.name = "pod_name"
-    c_status = MagicMock()
-    c_status.state.waiting.reason = "ErrImagePull"
-    pod.status.container_statuses = [c_status]
+    pod.status.phase = "Success"
+
     core_client = MagicMock()
     list_pods = MagicMock()
     list_pods.items = [pod]
@@ -960,6 +953,8 @@ def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
 
     agent = KubernetesAgent()
     agent.manage_jobs()
+
+    assert batch_client.delete_namespaced_job.called
 
 
 def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
@@ -1019,29 +1014,46 @@ def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     assert core_client.list_namespaced_pod.called
 
 
-def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api):
+def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
+    gql_return = MagicMock(
+        return_value=MagicMock(data=MagicMock(set_flow_run_state=None))
+    )
+    client = MagicMock()
+    client.return_value.graphql = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", client)
+
     job_mock = MagicMock()
     job_mock.metadata.labels = {
         "prefect.io/identifier": "id",
         "prefect.io/flow_run_id": "fr",
     }
     job_mock.metadata.name = "my_job"
-    job_mock.status.failed = True
-    job_mock.status.succeeded = True
+    job_mock.status.failed = False
+    job_mock.status.succeeded = False
     batch_client = MagicMock()
     list_job = MagicMock()
     list_job.metadata._continue = 0
     list_job.items = [job_mock]
     batch_client.list_namespaced_job.return_value = list_job
-    batch_client.delete_namespaced_job.return_value = None
     monkeypatch.setattr(
         "kubernetes.client.BatchV1Api", MagicMock(return_value=batch_client)
     )
 
+    pod = MagicMock()
+    pod.metadata.name = "pod_name"
+    c_status = MagicMock()
+    c_status.state.waiting.reason = "ErrImagePull"
+    pod.status.container_statuses = [c_status]
+    core_client = MagicMock()
+    list_pods = MagicMock()
+    list_pods.items = [pod]
+    core_client.list_namespaced_pod.return_value = list_pods
+    monkeypatch.setattr(
+        "kubernetes.client.CoreV1Api", MagicMock(return_value=core_client)
+    )
+
     agent = KubernetesAgent()
     agent.manage_jobs()
-
-    assert batch_client.delete_namespaced_job.called
 
 
 class TestK8sAgentRunConfig:

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -960,7 +960,11 @@ def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api):
 def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     gql_return = MagicMock(
         return_value=MagicMock(
-            data=MagicMock(set_flow_run_state=None, write_run_logs=None)
+            data=MagicMock(
+                set_flow_run_state=None,
+                write_run_logs=None,
+                get_flow_run_state=prefect.engine.state.Success(),
+            )
         )
     )
     client = MagicMock()

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -964,7 +964,9 @@ def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
 
 def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     gql_return = MagicMock(
-        return_value=MagicMock(data=MagicMock(set_flow_run_state=None))
+        return_value=MagicMock(
+            data=MagicMock(set_flow_run_state=None, write_run_logs=None)
+        )
     )
     client = MagicMock()
     client.return_value.graphql = gql_return
@@ -990,6 +992,14 @@ def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     pod = MagicMock()
     pod.metadata.name = "pod_name"
     pod.status.phase = "Failed"
+    terminated = MagicMock()
+    terminated.exit_code = "code"
+    terminated.message = "message"
+    terminated.reason = "reason"
+    terminated.signal = "signal"
+    c_status = MagicMock()
+    c_status.state.terminated = terminated
+    pod.status.container_statuses = [c_status]
 
     pod2 = MagicMock()
     pod2.metadata.name = "pod_name"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Related to some of the points outlined in #3747 

This adds a step to the k8s agent's `manage_jobs` to report on failed jobs and container errors. Previously if there were a container errors the flow run would stay in a running state until it was picked back up by lazarus and repeated multiple times. Now if there are container errors causing to pod failure it will be reported. Also the container status is reported as a log in this case.

Example:
![image](https://user-images.githubusercontent.com/40716964/100906156-df3d3000-3496-11eb-9cd0-c741f203b40e.png)

![image](https://user-images.githubusercontent.com/40716964/100924986-626a8000-34af-11eb-8eb4-0a0306eeac24.png)


Open to enhancements that would make this particular action more beneficial / any other information we can expose.


## Changes
Adds a step to the k8s agent's `manage_jobs` to report on failed jobs and container errors.


## Importance
More efforts to remove any black boxes in flow deployment!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)