### PR TITLE
Update config parsing to not convert timeouts to timedelta

### DIFF
--- a/changes/pr3761.yaml
+++ b/changes/pr3761.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix type-casting for task timeout defaults loaded from config - [#3761](https://github.com/PrefectHQ/prefect/pull/3761)"

--- a/src/prefect/configuration.py
+++ b/src/prefect/configuration.py
@@ -136,8 +136,6 @@ def process_task_defaults(config: Config) -> Config:
     # timeout defaults to None if not set - also check for False because TOML has no NULL
     if defaults.setdefault("timeout", False) is False:
         defaults.timeout = None
-    elif isinstance(defaults.timeout, int):
-        defaults.timeout = datetime.timedelta(seconds=defaults.timeout)
 
     return config
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -294,12 +294,6 @@ class TestProcessTaskDefaults:
         config = configuration.process_task_defaults(config)
         assert config.tasks.defaults.timeout is None
 
-    def test_timeout_is_timedelta_if_int(self):
-        config = Config(default_box=True)
-        config.tasks.defaults.timeout = 5
-        config = configuration.process_task_defaults(config)
-        assert config.tasks.defaults.timeout == datetime.timedelta(seconds=5)
-
     def test_timeout_is_timedelta_if_timedelta(self):
         config = Config(default_box=True)
         config.tasks.defaults.timeout = datetime.timedelta(seconds=5)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If the default task timeout is set in the config, it is parsed into a `timedelta`, but the task initializer enforces that the type is an `int`

## Changes
<!-- What does this PR change? -->

- Removes type casting of config task timeout values
- [x] Adds test coverage for default config values successfully initializing in task

## Importance
<!-- Why is this PR important? -->

Bugfix


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~