### PR TITLE
Set master as the default github storage ref

### DIFF
--- a/changes/pr3764.yaml
+++ b/changes/pr3764.yaml
@@ -1,0 +1,2 @@
+fix:
+  - 'Fix the `ref` default on GitHub storage - [#3764](https://github.com/PrefectHQ/prefect/pull/3764)'

--- a/src/prefect/environments/storage/github.py
+++ b/src/prefect/environments/storage/github.py
@@ -36,7 +36,7 @@ class GitHub(Storage):
     """
 
     def __init__(
-        self, repo: str, path: str = None, ref: str = None, **kwargs: Any
+        self, repo: str, path: str = None, ref: str = "master", **kwargs: Any
     ) -> None:
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "Flow"]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes a UX bug where the docs stated the `ref` field on GitHub storage would default to `master` but that wasn't happening.



## Changes
<!-- What does this PR change? -->
Defaults the `GitHub` storage ref to `master`, as stated in the doc string. 



## Importance
<!-- Why is this PR important? -->
The docs state this string is optional and will default to `master`, which is the default GitHub branch - this wasn't performing as expected. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)