### PR TITLE
Make RunGreatExpectationsCheckpoint task accept different parameters

### DIFF
--- a/examples/task_library/great_expectations/great_expectations_flow.py
+++ b/examples/task_library/great_expectations/great_expectations_flow.py
@@ -1,7 +1,7 @@
 from prefect import Flow, Parameter
-from prefect.tasks.great_expectations import RunGreatExpectationsCheckpoint
+from prefect.tasks.great_expectations import RunGreatExpectationsValidation
 
-ge_task = RunGreatExpectationsCheckpoint()
+ge_task = RunGreatExpectationsValidation()
 
 with Flow("great expectations example flow") as flow:
     checkpoint_name = Parameter("checkpoint_name")

--- a/src/prefect/tasks/great_expectations/__init__.py
+++ b/src/prefect/tasks/great_expectations/__init__.py
@@ -6,7 +6,7 @@ learn more about how to initialize a great expectation deployment [on their Gett
 """
 try:
     from prefect.tasks.great_expectations.checkpoints import (
-        RunGreatExpectationsCheckpoint,
+        RunGreatExpectationsValidation,
     )
 except ImportError:
     raise ImportError(

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -21,7 +21,6 @@ class TestInitialization:
             assets_to_validate=["assets"],
             batch_kwargs={"kwargs": "here"},
             expectation_suite_name="name",
-            get_checkpoint_from_context=True,
             context_root_dir="/path/to/somewhere",
             runtime_environment={
                 "plugins_directory": "/path/to/plugins/somewhere/else"
@@ -35,7 +34,6 @@ class TestInitialization:
         assert t.assets_to_validate == ["assets"]
         assert t.batch_kwargs == {"kwargs": "here"}
         assert t.expectation_suite_name == "name"
-        assert t.get_checkpoint_from_context == True
         assert t.context_root_dir == "/path/to/somewhere"
         assert t.runtime_environment == {
             "plugins_directory": "/path/to/plugins/somewhere/else"

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 import prefect
 from prefect import context
-from prefect.tasks.great_expectations import RunGreatExpectationsCheckpoint
+from prefect.tasks.great_expectations import RunGreatExpectationsValidation
 from prefect.utilities.configuration import set_temporary_config
 import pytest
 import os
@@ -11,11 +11,11 @@ import tempfile
 
 class TestInitialization:
     def test_inits_with_no_args(self):
-        t = RunGreatExpectationsCheckpoint()
+        t = RunGreatExpectationsValidation()
         assert t
 
     def test_kwargs_get_passed_to_task_init(self):
-        t = RunGreatExpectationsCheckpoint(
+        t = RunGreatExpectationsValidation(
             checkpoint_name="checkpoint",
             context=1234,
             assets_to_validate=["assets"],
@@ -44,10 +44,12 @@ class TestInitialization:
         assert t.run_info_at_end == False
         assert t.disable_markdown_artifact == True
 
-    def test_raises_if_checkpoint_not_provided(self, monkeypatch):
-        task = RunGreatExpectationsCheckpoint()
-        client = MagicMock()
-        great_expectations = MagicMock(client=client)
-        monkeypatch.setattr("prefect.tasks.great_expectations", great_expectations)
-        with pytest.raises(ValueError, match="checkpoint"):
-            task.run()
+    # TODO: I'd add a test to check the run method raises if the incorrect
+    # combination of parameters is provided
+    # def test_raises_if_checkpoint_not_provided(self, monkeypatch):
+    #     task = RunGreatExpectationsValidation()
+    #     client = MagicMock()
+    #     great_expectations = MagicMock(client=client)
+    #     monkeypatch.setattr("prefect.tasks.great_expectations", great_expectations)
+    #     with pytest.raises(ValueError, match="checkpoint"):
+    #         task.run()


### PR DESCRIPTION
## Summary
Some tweaks to the RunGreatExpectationsCheckpoint task (including renaming...) to clarify the types of parameters that can be used to run validation. See discussion for context: https://github.com/PrefectHQ/prefect/discussions/3558

**This is untested, I just wanted to propose the change and discuss!**

## Changes

I think there was some confusion around the use of "checkpoint"! A checkpoint is basically just a pre-configured "bundle" of batch_kwargs + suite name, so it can be used instead of those pairs to run validation. It looks like it was confused with a "validation_operator", which is basically just a pointer to some actions that happen after validation (by default: store the results, render data docs). I made some tweaks to reflect this better in the code:

- Renamed the task to RunGreatExpectationsValidation, since it doesn't just run checkpoints
- Clarified the different possible parameters in the docstring
- Dropped the get_checkpoint_from_context parameter since it's not needed
- Added the validation_operator parameter with a sensible default "action_list_parameter" (that's the default that's setup when running great_expectations init)
- Added a check to ensure that the parameters are mutually exclusive
- Replaced "checkpoint" with "validation_operator" where appropriate

TODO: I just commented out the current test for checkpoint_name, would be awesome if someone could help write a sensible test there.


## Importance
The current version of the task doesn't clearly separate the different ways to run validation and mixes up checkpoints and validation operators, which doesn't match the Great Expectations terminology. I also think the renaming makes sense since it runs more than just checkpoints.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)