### PR TITLE
More robust cancellation on Dask

### DIFF
--- a/changes/pr3770.yaml
+++ b/changes/pr3770.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix rare cancellation bug when running with external Dask cluster - [#3770](https://github.com/PrefectHQ/prefect/pull/3770)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >= 7.0
-cloudpickle >=0.6.0
+cloudpickle >=1.3.0
 croniter >= 0.3.24, <1.0
 dask >= 2.17.0
 distributed >= 2.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click >= 7.0
 cloudpickle >=0.6.0
 croniter >= 0.3.24, <1.0
-dask >= 2.15.0
-distributed >= 2.15.0
+dask >= 2.17.0
+distributed >= 2.17.0
 docker >=3.4.1
 importlib_resources >= 3.0.0; python_version < '3.9'
 marshmallow >= 3.0.0b19

--- a/tests/engine/executors/test_executors.py
+++ b/tests/engine/executors/test_executors.py
@@ -251,7 +251,7 @@ class TestDaskExecutor:
 
         def record_times():
             start_time = time.time()
-            time.sleep(random.random() * 0.25 + 0.5)
+            time.sleep(0.75)
             end_time = time.time()
             return start_time, end_time
 
@@ -427,7 +427,7 @@ class TestDaskExecutor:
             assert isinstance(post, DaskExecutor)
             assert post.client is None
             assert post._futures is None
-            assert post._should_run_var is None
+            assert post._should_run_event is None
 
     def test_executor_logs_worker_events(self, caplog):
         caplog.set_level(logging.DEBUG, logger="prefect")
@@ -482,7 +482,7 @@ class TestDaskExecutor:
 
         assert executor.client is None
         assert executor._futures is None
-        assert executor._should_run_var is None
+        assert executor._should_run_event is None
 
     def test_temporary_cluster_forcefully_cancels_pending_tasks(self, tmpdir):
         filname = tmpdir.join("signal")


### PR DESCRIPTION
Previously when running with a `DaskExecutor` connected to an external
dask cluster (one with an `address` passed in), a temporary
`distributed.Variable` was used to check if the task's flow-run was
still active. Before each prefect task started, it would check this
variable to determine if it should actually run. This helped provide a
stronger cancellation mechanism than distributed currently provides
(tasks submitted to distributed can be cancelled only if they haven't
arrived at a worker yet).

This worked well for many workloads, but ran into corner cases on
clusters experiencing high load:

- Distributed's comms can have some flaky behavior under high load,
  leading to periodic connection errors. These can be remedied by
  bumping the connection timeout, but not all users know to do that.
- Due to historical reasons, the implementation of
  `distributed.Variable` has some behaviors that are undesirable for our
  use case. The methods exposed don't make it easy to check the value of
  a variable that may have already been deleted in a bounded amount of
  time without causing issues if the cluster is under high load (due to
  the way timeouts are implemented).

Both of these issues could result in a task being wrongly cancelled,
causing issues downstream. We remedy this with the following:

- We only cancel tasks that we know for sure are cancelled - if any
  error occurs when checking for cancellation we assume not cancelled.
  In most cases this is fine (errors are rare, and usually due to the
  cluster shutting down which would cancel the task anyway). At worst we
  end up doing slightly more work.
- We switch to using a `distributed.Event` which better matches the
  behaviors we want. This wasn't used before since it would have
  required a new version of `distributed`. That version is now 6 months
  old, so we're fine to use it :). I've bumped the minimum requirements
  accordingly.

This change shouldn't affect most users, but should lead to more
reliable behaviors for those who are running extremely stressed dask
clusters.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)