### PR TITLE
Make RunGreatExpectationsCheckpoint task accept different parameters (extends #3766)

### DIFF
--- a/changes/pr3753.yaml
+++ b/changes/pr3753.yaml
@@ -4,3 +4,6 @@ task:
 
 deprecation:
   - "Deprecated the `RunGreatExpectationsCheckpoint` task in favor of `RunGreatExpectationsValidation` - [#3766](https://github.com/PrefectHQ/prefect/pull/3766)"
+
+contributor:
+ - "[Sam Bail](https://github.com/spbail)"

--- a/changes/pr3753.yaml
+++ b/changes/pr3753.yaml
@@ -1,3 +1,6 @@
 task:
-  - "Allow the `RunGreatExpectationsCheckpoint` task to load validations and context from memory - [#3753](https://github.com/PrefectHQ/prefect/pull/3753)"
-  - "Add the option to post markdown artifacts from the `RunGreatExpectationsCheckpoint` task - [#3753](https://github.com/PrefectHQ/prefect/pull/3753)"
+  - "Add `RunGreatExpectationsValidation` task - [#3753](https://github.com/PrefectHQ/prefect/pull/3753)"
+  - "Add the option to post markdown artifacts from the `RunGreatExpectationsValidation` task - [#3753](https://github.com/PrefectHQ/prefect/pull/3753)"
+
+deprecation:
+  - "Deprecated the `RunGreatExpectationsCheckpoint` task in favor of `RunGreatExpectationsValidation` - [#3766](https://github.com/PrefectHQ/prefect/pull/3766)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -366,7 +366,7 @@ classes = [
 title = "Great Expectations Task"
 module = "prefect.tasks.great_expectations"
 classes = [
-        "RunGreatExpectationsCheckpoint",
+        "RunGreatExpectationsValidation", "RunGreatExpectationsCheckpoint",
         ]
 
 [pages.tasks.gsheets]

--- a/examples/task_library/great_expectations/great_expectations_flow.py
+++ b/examples/task_library/great_expectations/great_expectations_flow.py
@@ -1,7 +1,7 @@
 from prefect import Flow, Parameter
-from prefect.tasks.great_expectations import RunGreatExpectationsCheckpoint
+from prefect.tasks.great_expectations import RunGreatExpectationsValidation
 
-ge_task = RunGreatExpectationsCheckpoint()
+ge_task = RunGreatExpectationsValidation()
 
 with Flow("great expectations example flow") as flow:
     checkpoint_name = Parameter("checkpoint_name")

--- a/src/prefect/tasks/great_expectations/__init__.py
+++ b/src/prefect/tasks/great_expectations/__init__.py
@@ -6,7 +6,7 @@ learn more about how to initialize a great expectation deployment [on their Gett
 """
 try:
     from prefect.tasks.great_expectations.checkpoints import (
-        RunGreatExpectationsCheckpoint,
+        RunGreatExpectationsValidation,
     )
 except ImportError:
     raise ImportError(

--- a/src/prefect/tasks/great_expectations/__init__.py
+++ b/src/prefect/tasks/great_expectations/__init__.py
@@ -6,7 +6,8 @@ learn more about how to initialize a great expectation deployment [on their Gett
 """
 try:
     from prefect.tasks.great_expectations.checkpoints import (
-        RunGreatExpectationsValidation, RunGreatExpectationsCheckpoint
+        RunGreatExpectationsValidation,
+        RunGreatExpectationsCheckpoint,
     )
 except ImportError:
     raise ImportError(

--- a/src/prefect/tasks/great_expectations/__init__.py
+++ b/src/prefect/tasks/great_expectations/__init__.py
@@ -6,7 +6,7 @@ learn more about how to initialize a great expectation deployment [on their Gett
 """
 try:
     from prefect.tasks.great_expectations.checkpoints import (
-        RunGreatExpectationsValidation,
+        RunGreatExpectationsValidation, RunGreatExpectationsCheckpoint
     )
 except ImportError:
     raise ImportError(

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -122,7 +122,7 @@ class RunGreatExpectationsValidation(Task):
         self.runtime_environment = runtime_environment or dict()
         self.run_name = run_name
         self.run_info_at_end = run_info_at_end
-        self.disable_markdown_artifact = (disable_markdown_artifact,)
+        self.disable_markdown_artifact = disable_markdown_artifact
         self.validation_operator = validation_operator
 
         super().__init__(**kwargs)

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -110,7 +110,7 @@ class RunGreatExpectationsValidation(Task):
         run_name: str = None,
         run_info_at_end: bool = True,
         disable_markdown_artifact: bool = False,
-        validation_operator: str = 'action_list_operator',
+        validation_operator: str = "action_list_operator",
         **kwargs
     ):
         self.checkpoint_name = checkpoint_name
@@ -122,7 +122,7 @@ class RunGreatExpectationsValidation(Task):
         self.runtime_environment = runtime_environment or dict()
         self.run_name = run_name
         self.run_info_at_end = run_info_at_end
-        self.disable_markdown_artifact = disable_markdown_artifact,
+        self.disable_markdown_artifact = (disable_markdown_artifact,)
         self.validation_operator = validation_operator
 
         super().__init__(**kwargs)
@@ -138,7 +138,7 @@ class RunGreatExpectationsValidation(Task):
         "run_name",
         "run_info_at_end",
         "disable_markdown_artifact",
-        "validation_operator"
+        "validation_operator",
     )
     def run(
         self,
@@ -152,7 +152,7 @@ class RunGreatExpectationsValidation(Task):
         run_name: str = None,
         run_info_at_end: bool = True,
         disable_markdown_artifact: bool = False,
-        validation_operator: str = 'action_list_operator'
+        validation_operator: str = "action_list_operator",
     ):
         """
         Task run method.
@@ -191,8 +191,6 @@ class RunGreatExpectationsValidation(Task):
                 The Great Expectations metadata returned from the validation
 
         """
-        if checkpoint_name is None:
-            raise ValueError("You must provide the checkpoint name.")
 
         runtime_environment = runtime_environment or dict()
 
@@ -204,9 +202,21 @@ class RunGreatExpectationsValidation(Task):
             )
 
         # Check that the parameters are mutually exclusive
-        if sum(bool(x) for x in [(expectation_suite_name and batch_kwargs), assets_to_validate, checkpoint_name]) != 1:
-            raise ValueError("Exactly one of expectation_suite_name + batch_kwargs, assets_to_validate, \
-             or checkpoint_name is required to run validation.")
+        if (
+            sum(
+                bool(x)
+                for x in [
+                    (expectation_suite_name and batch_kwargs),
+                    assets_to_validate,
+                    checkpoint_name,
+                ]
+            )
+            != 1
+        ):
+            raise ValueError(
+                "Exactly one of expectation_suite_name + batch_kwargs, assets_to_validate, or "
+                "checkpoint_name is required to run validation."
+            )
 
         # If assets are not provided directly through `assets_to_validate` then they need be loaded
         #   if a checkpoint_name is supplied, then load suite and batch_kwargs from there

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -8,6 +8,9 @@ docs](https://docs.greatexpectations.io/en/latest/tutorials/getting_started/set_
 You can use these task library tasks to interact with your Great Expectations checkpoint from a
 Prefect flow.
 """
+from typing import Optional
+import warnings
+
 import prefect
 from prefect import Task
 from prefect.artifacts import create_markdown
@@ -16,8 +19,6 @@ from prefect.engine import signals
 from prefect.utilities.tasks import defaults_from_attrs
 
 import great_expectations as ge
-
-from typing import Optional
 
 
 class RunGreatExpectationsValidation(Task):
@@ -269,5 +270,110 @@ class RunGreatExpectationsValidation(Task):
             )
 
             create_markdown(markdown_artifact)
+
+        return results
+
+
+class RunGreatExpectationsCheckpoint(Task):
+    """
+    DEPRECATED
+
+    Task for running a Great Expectations checkpoint. For this task to run properly, it must be
+    run above your great_expectations directory or configured with the `context_root_dir` for
+    your great_expectations directory on the local file system of the worker process.
+
+    Args:
+        - checkpoint_name (str): the name of the checkpoint; should match the filename of the
+            checkpoint without .py
+        - context_root_dir (str): the absolute or relative path to the directory holding your
+            `great_expectations.yml`
+        - runtime_environment (dict): a dictionary of great expectation config key-value pairs
+            to overwrite your config in `great_expectations.yml`
+        - run_name (str): the name of this Great Expectation validation run; defaults to the
+            task slug
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
+    """
+
+    def __init__(
+        self,
+        checkpoint_name: str = None,
+        context_root_dir: str = None,
+        runtime_environment: dict = {},
+        run_name: str = None,
+        **kwargs
+    ):
+        warnings.warn(
+            "DEPRECATED: `RunGreatExpectationsCheckpoint` task is deprecated, please use "
+            "`RunGreatExpectationsValidation` instead",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        self.checkpoint_name = checkpoint_name
+        self.context_root_dir = context_root_dir
+        self.runtime_environment = runtime_environment
+        self.run_name = run_name
+
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs(
+        "checkpoint_name", "context_root_dir", "runtime_environment", "run_name"
+    )
+    def run(
+        self,
+        checkpoint_name: str = None,
+        context_root_dir: str = None,
+        runtime_environment: dict = {},
+        run_name: str = None,
+        **kwargs
+    ):
+        """
+        Task run method.
+
+        Args:
+            - checkpoint_name (str): the name of the checkpoint; should match the filename of
+                the checkpoint without .py
+            - context_root_dir (str): the absolute or relative path to the directory holding
+                your `great_expectations.yml`
+            - runtime_environment (dict): a dictionary of great expectation config key-value
+                pairs to overwrite your config in `great_expectations.yml`
+            - run_name (str): the name of this  Great Expectation validation run; defaults to
+                the task slug
+            - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+                constructor
+
+        Raises:
+            - 'signals.VALIDATIONFAIL' if the validation was not a success
+        Returns:
+            - result
+                ('great_expectations.validation_operators.types.validation_operator_result.ValidationOperatorResult'):
+                The Great Expectations metadata returned from the validation
+
+        """
+
+        if checkpoint_name is None:
+            raise ValueError("You must provide the checkpoint name.")
+
+        context = ge.DataContext(
+            context_root_dir=context_root_dir, runtime_environment=runtime_environment
+        )
+        checkpoint = context.get_checkpoint(checkpoint_name)
+
+        batches_to_validate = []
+        for batch in checkpoint["batches"]:
+            batch_kwargs = batch["batch_kwargs"]
+            for suite_name in batch["expectation_suite_names"]:
+                suite = context.get_expectation_suite(suite_name)
+                batch = context.get_batch(batch_kwargs, suite)
+                batches_to_validate.append(batch)
+
+        results = context.run_validation_operator(
+            checkpoint["validation_operator_name"],
+            assets_to_validate=batches_to_validate,
+            run_id={"run_name": prefect.context.get("task_slug")},
+        )
+
+        if results.success is False:
+            raise signals.VALIDATIONFAIL(result=results)
 
         return results

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -21,7 +21,6 @@ class TestInitialization:
             assets_to_validate=["assets"],
             batch_kwargs={"kwargs": "here"},
             expectation_suite_name="name",
-            get_checkpoint_from_context=True,
             context_root_dir="/path/to/somewhere",
             runtime_environment={
                 "plugins_directory": "/path/to/plugins/somewhere/else"
@@ -35,7 +34,6 @@ class TestInitialization:
         assert t.assets_to_validate == ["assets"]
         assert t.batch_kwargs == {"kwargs": "here"}
         assert t.expectation_suite_name == "name"
-        assert t.get_checkpoint_from_context == True
         assert t.context_root_dir == "/path/to/somewhere"
         assert t.runtime_environment == {
             "plugins_directory": "/path/to/plugins/somewhere/else"

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -42,12 +42,23 @@ class TestInitialization:
         assert t.run_info_at_end == False
         assert t.disable_markdown_artifact == True
 
-    # TODO: I'd add a test to check the run method raises if the incorrect
-    # combination of parameters is provided
-    # def test_raises_if_checkpoint_not_provided(self, monkeypatch):
-    #     task = RunGreatExpectationsValidation()
-    #     client = MagicMock()
-    #     great_expectations = MagicMock(client=client)
-    #     monkeypatch.setattr("prefect.tasks.great_expectations", great_expectations)
-    #     with pytest.raises(ValueError, match="checkpoint"):
-    #         task.run()
+    def test_raises_if_params_not_mutually_exclusive(self):
+        task = RunGreatExpectationsValidation(context="test")
+        with pytest.raises(ValueError, match="Exactly"):
+            task.run()
+
+        with pytest.raises(ValueError, match="Exactly"):
+            task.run(expectation_suite_name="name")
+
+        with pytest.raises(ValueError, match="Exactly"):
+            task.run(batch_kwargs={"here"})
+
+        with pytest.raises(ValueError, match="Exactly"):
+            task.run(
+                expectation_suite_name="name",
+                batch_kwargs={"here"},
+                assets_to_validate=["val"],
+            )
+
+        with pytest.raises(ValueError, match="Exactly"):
+            task.run(assets_to_validate=["val"], checkpoint_name="name")

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 import prefect
 from prefect import context
-from prefect.tasks.great_expectations import RunGreatExpectationsCheckpoint
+from prefect.tasks.great_expectations import RunGreatExpectationsValidation
 from prefect.utilities.configuration import set_temporary_config
 import pytest
 import os
@@ -11,11 +11,11 @@ import tempfile
 
 class TestInitialization:
     def test_inits_with_no_args(self):
-        t = RunGreatExpectationsCheckpoint()
+        t = RunGreatExpectationsValidation()
         assert t
 
     def test_kwargs_get_passed_to_task_init(self):
-        t = RunGreatExpectationsCheckpoint(
+        t = RunGreatExpectationsValidation(
             checkpoint_name="checkpoint",
             context=1234,
             assets_to_validate=["assets"],
@@ -44,10 +44,12 @@ class TestInitialization:
         assert t.run_info_at_end == False
         assert t.disable_markdown_artifact == True
 
-    def test_raises_if_checkpoint_not_provided(self, monkeypatch):
-        task = RunGreatExpectationsCheckpoint()
-        client = MagicMock()
-        great_expectations = MagicMock(client=client)
-        monkeypatch.setattr("prefect.tasks.great_expectations", great_expectations)
-        with pytest.raises(ValueError, match="checkpoint"):
-            task.run()
+    # TODO: I'd add a test to check the run method raises if the incorrect
+    # combination of parameters is provided
+    # def test_raises_if_checkpoint_not_provided(self, monkeypatch):
+    #     task = RunGreatExpectationsValidation()
+    #     client = MagicMock()
+    #     great_expectations = MagicMock(client=client)
+    #     monkeypatch.setattr("prefect.tasks.great_expectations", great_expectations)
+    #     with pytest.raises(ValueError, match="checkpoint"):
+    #         task.run()


### PR DESCRIPTION
This is a continuation of #3766 because I was having issues pushing to the remote branch. Original PR content:

## Summary
Some tweaks to the RunGreatExpectationsCheckpoint task (including renaming...) to clarify the types of parameters that can be used to run validation. See discussion for context: https://github.com/PrefectHQ/prefect/discussions/3558

**This is untested, I just wanted to propose the change and discuss!**

## Changes

I think there was some confusion around the use of "checkpoint"! A checkpoint is basically just a pre-configured "bundle" of batch_kwargs + suite name, so it can be used instead of those pairs to run validation. It looks like it was confused with a "validation_operator", which is basically just a pointer to some actions that happen after validation (by default: store the results, render data docs). I made some tweaks to reflect this better in the code:

- Renamed the task to RunGreatExpectationsValidation, since it doesn't just run checkpoints
- Clarified the different possible parameters in the docstring
- Dropped the get_checkpoint_from_context parameter since it's not needed
- Added the validation_operator parameter with a sensible default "action_list_parameter" (that's the default that's setup when running great_expectations init)
- Added a check to ensure that the parameters are mutually exclusive
- Replaced "checkpoint" with "validation_operator" where appropriate

TODO: I just commented out the current test for checkpoint_name, would be awesome if someone could help write a sensible test there.


## Importance
The current version of the task doesn't clearly separate the different ways to run validation and mixes up checkpoints and validation operators, which doesn't match the Great Expectations terminology. I also think the renaming makes sense since it runs more than just checkpoints.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)