### PR TITLE
Update path to config file in docs

### DIFF
--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -23,7 +23,7 @@ You can set this directly in the UI on the Home page:
 
 ![UI Endpoint Setting](/orchestration/server/server-endpoint.png)
 
-...or by setting `apollo_url` in `./prefect/config.toml` on whatever machine you're running Prefect Server:
+...or by setting `apollo_url` in `~/.prefect/config.toml` on whatever machine you're running Prefect Server:
 
 ```
 [server]


### PR DESCRIPTION

## Summary

Minor documentation change



## Changes

Shows the correct path to the config file





## Importance

Important because if your config file is in the wrong location, the server won't pick it up. And you might have to clear data from your browser before if will pick it up from the correct location in the future if you do it wrong the first time.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

(No checkboxes needed for this documentation change)

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)