### PR TITLE
Replace characters in API doc build that cause rendering issues

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -15,6 +15,7 @@ Each entry in `OUTLINE` is a dictionary with the following key/value pairs:
 On a development installation of Prefect, run `python generate_docs.py` from inside the `docs/` folder.
 """
 import builtins
+import html
 import importlib
 import inspect
 import os
@@ -292,7 +293,7 @@ def get_call_signature(obj):
                 default = repr(default)
 
             # Replace from repr because it can cause HTML errors in rendering
-            default = default.replace("<", "&lt;").replace(">", "&gt;")
+            default = html.escape(default)
             items.append((p.name, default))
         else:
             items.append(p.name)

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -290,6 +290,9 @@ def get_call_signature(obj):
                 default = f'"{default}"'
             else:
                 default = repr(default)
+
+            # Replace from repr because it can cause HTML errors in rendering
+            default = default.replace("<", "&lt;").replace(">", "&gt;")
             items.append((p.name, default))
         else:
             items.append(p.name)


### PR DESCRIPTION
Currently in some of the API docs when rendering defaults with the class's `repr` it will cause it to not render due to the use of `<` and `>`. 

Current:
![image](https://user-images.githubusercontent.com/40716964/101547264-fd63ce00-3977-11eb-8271-4b56cd5cd774.png)

With fix:
![image](https://user-images.githubusercontent.com/40716964/101547281-03f24580-3978-11eb-87cb-d744ef43d53d.png)
