### PR TITLE
Remove default labels on storage types and local agent

### DIFF
--- a/changes/pr3800.yaml
+++ b/changes/pr3800.yaml
@@ -1,6 +1,6 @@
 breaking:
   - "Removed setting of default labels on storage objects and the local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
 
-deprecated:
+deprecation:
   - "Deprecated use of `storage_labels` boolean kwarg on local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
   - "Deprecated use of `--storage-labels` option from agent `start` CLI command - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"

--- a/changes/pr3800.yaml
+++ b/changes/pr3800.yaml
@@ -1,0 +1,6 @@
+breaking:
+  - "Removed setting of default labels on storage objects and the local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
+
+deprecated:
+  - "Deprecated use of `storage_labels` boolean kwarg on local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
+  - "Deprecated use of `--storage-labels` option from agent `start` CLI command - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"

--- a/changes/prlbl.yaml
+++ b/changes/prlbl.yaml
@@ -1,0 +1,4 @@
+breaking:
+  - "Removed setting of default labels on storage objects and the local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
+  - "Removed `storage_labels` boolean kwarg from local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
+  - "Removed `--storage-labels` option from agent `start` CLI command - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"

--- a/changes/prlbl.yaml
+++ b/changes/prlbl.yaml
@@ -1,4 +1,0 @@
-breaking:
-  - "Removed setting of default labels on storage objects and the local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
-  - "Removed `storage_labels` boolean kwarg from local agent - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"
-  - "Removed `--storage-labels` option from agent `start` CLI command - [#3800](https://github.com/PrefectHQ/prefect/pull/3800)"

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -3,6 +3,7 @@ import socket
 import sys
 from subprocess import STDOUT, Popen, DEVNULL
 from typing import Iterable, List
+import warnings
 
 from prefect import config
 from prefect.agent import Agent
@@ -56,6 +57,8 @@ class LocalAgent(Agent):
         - hostname_label (boolean, optional): a boolean specifying whether this agent should
             auto-label itself with the hostname of the machine it is running on.  Useful for
             flows which are stored on the local filesystem.
+        - storage_labels (boolean, optional, DEPRECATED): a boolean specifying whether this agent should
+            auto-label itself with all of the storage options labels.
     """
 
     def __init__(
@@ -70,6 +73,7 @@ class LocalAgent(Agent):
         max_polls: int = None,
         agent_address: str = None,
         no_cloud_logs: bool = False,
+        storage_labels: bool = None,
     ) -> None:
         self.processes = set()
         self.import_paths = import_paths or []
@@ -92,6 +96,13 @@ class LocalAgent(Agent):
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)
+
+        if storage_labels is not None:
+            warnings.warn(
+                "Use of `storage_labels` kwarg is deprecated and the local agent no longer has "
+                "default labels.",
+                stacklevel=2,
+            )
 
         self.logger.debug(f"Import paths: {self.import_paths}")
         self.logger.debug(f"Show flow logs: {self.show_flow_logs}")

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -56,8 +56,6 @@ class LocalAgent(Agent):
         - hostname_label (boolean, optional): a boolean specifying whether this agent should
             auto-label itself with the hostname of the machine it is running on.  Useful for
             flows which are stored on the local filesystem.
-        - storage_labels (boolean, optional): a boolean specifying whether this agent should
-            auto-label itself with all of the storage options labels.
     """
 
     def __init__(
@@ -72,7 +70,6 @@ class LocalAgent(Agent):
         max_polls: int = None,
         agent_address: str = None,
         no_cloud_logs: bool = False,
-        storage_labels: bool = True,
     ) -> None:
         self.processes = set()
         self.import_paths = import_paths or []
@@ -95,19 +92,6 @@ class LocalAgent(Agent):
         if hostname_label and (hostname not in self.labels):
             assert isinstance(self.labels, list)
             self.labels.append(hostname)
-
-        if storage_labels:
-            all_storage_labels = [
-                "azure-flow-storage",
-                "gcs-flow-storage",
-                "s3-flow-storage",
-                "github-flow-storage",
-                "webhook-flow-storage",
-                "gitlab-flow-storage",
-            ]
-            for label in all_storage_labels:
-                if label not in self.labels:
-                    self.labels.append(label)
 
         self.logger.debug(f"Import paths: {self.import_paths}")
         self.logger.debug(f"Show flow logs: {self.show_flow_logs}")

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -140,11 +140,6 @@ def local():
     is_flag=True,
 )
 @click.option(
-    "--storage-labels/--no-storage-labels",
-    default=True,
-    help="Add all storage labels to the LocalAgent",
-)
-@click.option(
     "--hostname-label/--no-hostname-label",
     default=True,
     help="Add hostname to the LocalAgent's labels",

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -140,6 +140,11 @@ def local():
     is_flag=True,
 )
 @click.option(
+    "--storage-labels/--no-storage-labels",
+    default=None,
+    help="Add all storage labels to the LocalAgent. DEPRECATED",
+)
+@click.option(
     "--hostname-label/--no-hostname-label",
     default=True,
     help="Add hostname to the LocalAgent's labels",
@@ -425,6 +430,11 @@ _agents = {
     hidden=True,
 )
 @click.option(
+    "--storage-labels/--no-storage-labels",
+    default=None,
+    help="Add all storage labels to the LocalAgent. DEPRECATED",
+)
+@click.option(
     "--hostname-label/--no-hostname-label",
     default=True,
     help="Add hostname to the LocalAgent's labels",
@@ -527,6 +537,7 @@ def start(
     max_polls,
     agent_address,
     hostname_label,
+    storage_labels,
 ):
     """
     Start an agent.
@@ -648,6 +659,7 @@ def start(
                 show_flow_logs=show_flow_logs,
                 no_cloud_logs=no_cloud_logs,
                 hostname_label=hostname_label,
+                storage_labels=storage_labels,
             ).start()
         elif agent_option == "docker":
             from_qualified_name(retrieved_agent)(

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -425,12 +425,6 @@ _agents = {
     hidden=True,
 )
 @click.option(
-    "--storage-labels/--no-storage-labels",
-    default=True,
-    help="Add all storage labels to the LocalAgent",
-    hidden=True,
-)
-@click.option(
     "--hostname-label/--no-hostname-label",
     default=True,
     help="Add hostname to the LocalAgent's labels",
@@ -532,7 +526,6 @@ def start(
     no_docker_interface,
     max_polls,
     agent_address,
-    storage_labels,
     hostname_label,
 ):
     """
@@ -581,8 +574,6 @@ def start(
                                     (available for Local and Docker agents only)
         --hostname-label            Add hostname to the Agent's labels
                                         (Default to True. Disable with --no-hostname-label option)
-        --storage-labels            Add all storage labels to the Agent
-                                        (Default to True. Disable with --no-storage-labels option)
 
     \b
     Docker Agent:
@@ -657,7 +648,6 @@ def start(
                 show_flow_logs=show_flow_logs,
                 no_cloud_logs=no_cloud_logs,
                 hostname_label=hostname_label,
-                storage_labels=storage_labels,
             ).start()
         elif agent_option == "docker":
             from_qualified_name(retrieved_agent)(

--- a/src/prefect/storage/azure.py
+++ b/src/prefect/storage/azure.py
@@ -60,10 +60,6 @@ class Azure(Storage):
         )
         super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["azure-flow-storage"]
-
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/storage/azure.py
+++ b/src/prefect/storage/azure.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 
 import cloudpickle
 import pendulum

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -66,10 +66,6 @@ class GCS(Storage):
         result = GCSResult(bucket=bucket)
         super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["gcs-flow-storage"]
-
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 
 import cloudpickle
 import pendulum

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 
 
 from prefect.storage import Storage

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -46,10 +46,6 @@ class GitHub(Storage):
 
         super().__init__(**kwargs)
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["github-flow-storage"]
-
     def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 from urllib.parse import quote_plus
 
 from prefect.storage import Storage

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -55,10 +55,6 @@ class GitLab(Storage):
 
         super().__init__(**kwargs)
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["gitlab-flow-storage"]
-
     def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object, returns the underlying Flow (if possible).

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -66,10 +66,6 @@ class S3(Storage):
             **kwargs,
         )
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["s3-flow-storage"]
-
     def get_flow(self, flow_location: str = None) -> "Flow":
         """
         Given a flow_location within this Storage object or S3, returns the underlying Flow

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -1,5 +1,5 @@
 import io
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict
 
 import cloudpickle
 import pendulum

--- a/src/prefect/storage/webhook.py
+++ b/src/prefect/storage/webhook.py
@@ -232,10 +232,6 @@ class Webhook(Storage):
 
         super().__init__(stored_as_script=stored_as_script, **kwargs)
 
-    @property
-    def default_labels(self) -> List[str]:
-        return ["webhook-flow-storage"]
-
     def get_flow(self, flow_location: str = "placeholder") -> "Flow":
         """
         Get the flow from storage. This method will call

--- a/src/prefect/storage/webhook.py
+++ b/src/prefect/storage/webhook.py
@@ -4,7 +4,7 @@ import string
 import warnings
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional
 
 from requests import Session
 from requests.adapters import HTTPAdapter

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -25,12 +25,6 @@ from prefect.utilities.graphql import GraphQLResult
 
 DEFAULT_AGENT_LABELS = [
     socket.gethostname(),
-    "azure-flow-storage",
-    "gcs-flow-storage",
-    "s3-flow-storage",
-    "github-flow-storage",
-    "webhook-flow-storage",
-    "gitlab-flow-storage",
 ]
 
 
@@ -50,7 +44,7 @@ def test_local_agent_init():
 
 
 def test_local_agent_deduplicates_labels():
-    agent = LocalAgent(labels=["azure-flow-storage"])
+    agent = LocalAgent(labels=[socket.gethostname()])
     assert sorted(agent.labels) == sorted(DEFAULT_AGENT_LABELS)
 
 
@@ -67,17 +61,6 @@ def test_local_agent_config_options():
     assert agent.processes == set()
     assert agent.import_paths == ["test_path"]
     assert set(agent.labels) == {"test_label", *DEFAULT_AGENT_LABELS}
-
-
-def test_local_agent_config_no_storage_labels():
-    agent = LocalAgent(
-        labels=["test_label"],
-        storage_labels=False,
-    )
-    assert set(agent.labels) == {
-        socket.gethostname(),
-        "test_label",
-    }
 
 
 @pytest.mark.parametrize("hostname_label", [True, False])

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -46,11 +46,10 @@ def test_help(cmd):
         (
             "local",
             "prefect.agent.local.LocalAgent",
-            "-p path1 -p path2 -f --no-storage-labels --no-hostname-label",
+            "-p path1 -p path2 -f --no-hostname-label",
             {
                 "import_paths": ["path1", "path2"],
                 "show_flow_logs": True,
-                "storage_labels": False,
                 "hostname_label": False,
             },
         ),

--- a/tests/environments/execution/test_dask_cloud_provider.py
+++ b/tests/environments/execution/test_dask_cloud_provider.py
@@ -5,6 +5,7 @@ import cloudpickle
 import pytest
 
 pytest.importorskip("dask_cloudprovider")
+pytest.importorskip("dask_cloudprovider.aws")
 
 from distributed.deploy import Cluster
 

--- a/tests/storage/test_webhook_storage.py
+++ b/tests/storage/test_webhook_storage.py
@@ -64,7 +64,6 @@ def test_create_webhook_storage():
     assert storage.get_flow_request_kwargs == get_flow_request_kwargs
     assert storage.get_flow_request_http_method == "GET"
     assert storage.secrets == []
-    assert storage.default_labels == ["webhook-flow-storage"]
     assert storage.stored_as_script is False
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
`0.14.0`: Removes the default labels on all storage options that had them and on the local agent. This does not, however, remove the hostname label on the local storage and local agent.




## Changes
- Removed setting of default labels on storage objects and the local agent
- Removed `storage_labels` boolean kwarg from local agent
- Removed `--storage-labels` option from agent `start` CLI command




## Importance
This has been a slightly confusing safety net that is no longer necessary now that all storage options can be used with all agents.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)