### PR TITLE
Refactor dependencies included in Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,36 @@ jobs:
           paths:
             - coverage
 
+  # Test task library explicitly
+  test_task_library:
+    docker:
+      - image: python:3.8
+        auth:
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PW
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install zsh for tests
+          command: apt-get update && apt-get install -y zsh
+
+      - run:
+          name: Install graphviz
+          command: apt-get update && apt-get install -y graphviz
+
+      - run:
+          name: Upgrade pip
+          command: pip install "pip==20.2.4"
+
+      - run:
+          name: Install Prefect
+          command: pip install ".[all_extras]"
+
+      - run:
+          name: Run tests
+          command: pytest tests/tasks -vvrfEsx
+
   # ----------------------------------
   # Run unit tests in Python 3.6-3.8
   # ----------------------------------
@@ -202,11 +232,11 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[test_ci]"
+          command: pip install ".[all_orchestration_extras]"
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx --cov=prefect --cov-report=xml:/tmp/workspace/coverage/python36-coverage.xml
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --cov=prefect --cov-report=xml:/tmp/workspace/coverage/python36-coverage.xml
 
       - persist_to_workspace:
           root: *workspace_root
@@ -236,11 +266,11 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[test_ci]"
+          command: pip install ".[all_orchestration_extras]"
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx
 
   test_38:
     docker:
@@ -265,11 +295,11 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[test_ci]"
+          command: pip install ".[all_orchestration_extras]"
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx
 
   test_39:
     docker:
@@ -301,7 +331,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx
 
   upload_coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,8 @@ jobs:
       tag_latest:
         type: boolean
         default: false
+      extras:
+        type: string
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       PYTHON_TAG: python<< parameters.python_version >>
@@ -424,6 +426,8 @@ jobs:
     parameters:
       python_version:
         type: string
+      extras:
+        type: string
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       EXTRAS: << parameters.extras >>
@@ -468,8 +472,6 @@ jobs:
           password: $DOCKER_HUB_PW
     parameters:
       python_version:
-        type: string
-      extras:
         type: string
       tag_latest:
         type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[test_ci]"
+          command: pip install ".[task_library_ci]"
 
       - run:
           name: Run tests
@@ -232,7 +232,7 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[all_orchestration_extras]"
+          command: pip install ".[base_library_ci]"
 
       - run:
           name: Run tests
@@ -266,7 +266,7 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[all_orchestration_extras]"
+          command: pip install ".[base_library_ci]"
 
       - run:
           name: Run tests
@@ -295,7 +295,7 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[all_orchestration_extras]"
+          command: pip install ".[base_library_ci]"
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
           paths:
             - coverage
 
-  # Test task library explicitly
+  # test task library explicitly
   test_task_library:
     docker:
       - image: python:3.8
@@ -198,7 +198,7 @@ jobs:
 
       - run:
           name: Install Prefect
-          command: pip install ".[all_extras]"
+          command: pip install ".[test_ci]"
 
       - run:
           name: Run tests
@@ -360,6 +360,7 @@ jobs:
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       PYTHON_TAG: python<< parameters.python_version >>
+      EXTRAS: << parameters.extras >>
     steps:
       - checkout
       - run:
@@ -423,6 +424,7 @@ jobs:
         type: string
     environment:
       PYTHON_VERSION: << parameters.python_version >>
+      EXTRAS: << parameters.extras >>
     steps:
       - checkout
       - run:
@@ -456,7 +458,7 @@ jobs:
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
             docker push prefecthq/prefect:master
 
-  build_all_extras_docker_image:
+  build_core_docker_image:
     docker:
       - image: docker
         auth:
@@ -472,7 +474,6 @@ jobs:
         default: false
     environment:
       PYTHON_VERSION: << parameters.python_version >>
-      EXTRAS: << parameters.extras >>
     steps:
       - checkout
       - run:
@@ -486,7 +487,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build all_extras image
+          name: Build core image
           command: |
             set -u
             docker build \
@@ -495,18 +496,18 @@ jobs:
               --build-arg PREFECT_VERSION=$CIRCLE_TAG \
               --build-arg PYTHON_VERSION=$PYTHON_VERSION \
               --build-arg EXTRAS=$EXTRAS \
-              -t prefecthq/prefect:all_extras-${CIRCLE_TAG} \
-              -t prefecthq/prefect:all_extras \
+              -t prefecthq/prefect:core-${CIRCLE_TAG} \
+              -t prefecthq/prefect:core \
               .
       - run:
           name: Test image
           command: |
-            docker run -dit prefecthq/prefect:all_extras-${CIRCLE_TAG} /bin/bash -c 'curl -fL0 https://raw.githubusercontent.com/PrefectHQ/prefect/master/examples/retries_with_mapping.py | python'
+            docker run -dit prefecthq/prefect:core-${CIRCLE_TAG} /bin/bash -c 'curl -fL0 https://raw.githubusercontent.com/PrefectHQ/prefect/master/examples/retries_with_mapping.py | python'
       - run:
-          name: Push all_extras tag
+          name: Push core tag
           command: |
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
-            docker push prefecthq/prefect:all_extras-${CIRCLE_TAG}
+            docker push prefecthq/prefect:core-${CIRCLE_TAG}
       - when:
           condition: << parameters.tag_latest >>
           steps:
@@ -514,7 +515,7 @@ jobs:
                 name: Push latest tag
                 command: |
                   docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
-                  docker push prefecthq/prefect:all_extras
+                  docker push prefecthq/prefect:core
 
 
   promote_server_artifacts:
@@ -589,6 +590,7 @@ workflows:
       - test_39
       - test_lower_prefect
       - test_vanilla_prefect
+      - test_task_library
       - upload_coverage:
           requires:
             - test_36
@@ -605,6 +607,7 @@ workflows:
     jobs:
       - build_master_docker_image:
           python_version: '3.7'
+          extras: 'all_orchestration_extras'
           filters:
             branches:
               only: master
@@ -613,6 +616,7 @@ workflows:
     jobs:
       - build_docker_image:
           python_version: '3.6'
+          extras: 'all_orchestration_extras'
           filters:
             branches:
               ignore: /.*/
@@ -620,6 +624,7 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - build_docker_image:
           python_version: '3.7'
+          extras: 'all_orchestration_extras'
           tag_latest: true
           filters:
             branches:
@@ -628,6 +633,7 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - build_docker_image:
           python_version: '3.8'
+          extras: 'all_orchestration_extras'
           filters:
             branches:
               ignore: /.*/
@@ -639,9 +645,8 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
-      - build_all_extras_docker_image:
+      - build_core_docker_image:
           python_version: '3.8'
-          extras: 'all_extras'
           tag_latest: true
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,7 @@ jobs:
               --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
               --build-arg PREFECT_VERSION=$CIRCLE_TAG \
               --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+              --build-arg EXTRAS=$EXTRAS \
               -t prefecthq/prefect:${CIRCLE_TAG}-${PYTHON_TAG} \
               -t prefecthq/prefect:latest-${PYTHON_TAG} \
               .
@@ -452,6 +453,7 @@ jobs:
               --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
               --build-arg PREFECT_VERSION=$CIRCLE_SHA1 \
               --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+              --build-arg EXTRAS=$EXTRAS \
               -t prefecthq/prefect:master \
               .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,6 +394,7 @@ jobs:
                 name: Tag latest image
                 command: |
                   docker tag prefecthq/prefect:${CIRCLE_TAG}-${PYTHON_TAG} prefecthq/prefect:latest
+                  docker tag prefecthq/prefect:${CIRCLE_TAG}-${PYTHON_TAG} prefecthq/prefect:${CIRCLE_TAG}
       - run:
           name: Test image
           command: |
@@ -412,6 +413,7 @@ jobs:
                 command: |
                   docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
                   docker push prefecthq/prefect:latest
+                  docker push prefecthq/prefect:${CIRCLE_TAG}
 
   build_master_docker_image:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:${PYTHON_VERSION}-slim
 
 # Build Arguments
 ARG PREFECT_VERSION
-ARG EXTRAS=kubernetes
+ARG EXTRAS
 ARG GIT_SHA
 ARG BUILD_DATE
 

--- a/changes/pr3804.yaml
+++ b/changes/pr3804.yaml
@@ -1,4 +1,4 @@
-enhancements:
+enhancement:
   - "Add orchestration-based dependencies to the `prefecthq/prefect` Docker image - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"
   - "Add a slimmed down `prefecthq/prefect:core` Docker image that only contains base dependencies - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"
   - "Docker storage now installs all orchestration-based dependencies when using default image - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"

--- a/changes/pr3804.yaml
+++ b/changes/pr3804.yaml
@@ -1,0 +1,7 @@
+enhancements:
+  - "Add orchestration-based dependencies to the `prefecthq/prefect` Docker image - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"
+  - "Add a slimmed down `prefecthq/prefect:core` Docker image that only contains base dependencies - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"
+  - "Docker storage now installs all orchestration-based dependencies when using default image - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"
+
+breaking:
+  - "Stop building the `prefecthq/prefect:all_extras` image and switch flow deployment default to using `prefecthq/prefect:{core_version}` - [#3804](https://github.com/PrefectHQ/prefect/pull/3804)"

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,6 @@ coverage:
 ignore:
   - "src/prefect/contrib/**/*"
   - "src/prefect/tasks/**/*"
+  - "src/prefect/environments/**/*"
+  - "src/utilities/notifications/jira_notification.py"
+  - "src/engine/serializers.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,5 +18,3 @@ ignore:
   - "src/prefect/contrib/**/*"
   - "src/prefect/tasks/**/*"
   - "src/prefect/environments/**/*"
-  - "src/utilities/notifications/jira_notification.py"
-  - "src/engine/serializers.py"

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -68,7 +68,7 @@ Before running the server for the first time, run:
 
 ```
 prefect backend server
-``` 
+```
 
 This configures Prefect for local orchestration, and saves the configuration in your local `~/.prefect` directory. 
 
@@ -106,5 +106,5 @@ Image tag breakdown:
 | X.Y.Z-python3.8  |          X.Y.Z           |            3.8 |
 | X.Y.Z-python3.7  |          X.Y.Z           |            3.7 |
 | X.Y.Z-python3.6  |          X.Y.Z           |            3.6 |
-| all_extras       | most recent PyPi version |            3.8 |
-| all_extras-X.Y.Z |          X.Y.Z           |            3.8 |
+| core             | most recent PyPi version |            3.8 |
+| core-X.Y.Z       |          X.Y.Z           |            3.8 |

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -289,11 +289,11 @@ Prefect has a couple [default secrets](/core/concepts/secrets.html#default-secre
 ```python
 flow.storage = S3(bucket="my-flows", secrets=["AWS_CREDENTIALS"])
 
-flow.environment = LocalEnvironment(metadata={"image": "prefecthq/prefect:all_extras"})
+flow.environment = LocalEnvironment(metadata={"image": "prefecthq/prefect"})
 ```
 
 ::: warning Dependencies
 It is important to make sure that the `image` set in the environment's metadata contains the dependencies required to use the storage option. For example, using `S3` storage requires Prefect's `aws` dependencies.
 
-These are generally packaged with custom built images or optionally you could use the `prefecthq/prefect:all_extras` image which contains all of Prefect's optional extra packages.
+These are generally packaged with custom built images or optionally you could use the `prefecthq/prefect` image which contains all of Prefect's orchestration extras.
 :::

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ extras["all_orchestration_extras"] = [
 # CI extras to control dependencies for tests
 extras["task_library_ci"] = sum(extras.values(), [])
 extras["task_library_ci"] = [
-    r for r in extras["test_ci"] if not r.startswith("dask_cloudprovider")
+    r for r in extras["task_library_ci"] if not r.startswith("dask_cloudprovider")
 ]
 
 extras["base_library_ci"] = extras["all_orchestration_extras"] + extras["test"]

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ extras["task_library_ci"] = [
     r for r in extras["task_library_ci"] if not r.startswith("dask_cloudprovider")
 ]
 
-extras["base_library_ci"] = extras["all_orchestration_extras"] + extras["test"]
+extras["base_library_ci"] = extras["all_orchestration_extras"] + extras["dev"]
 
 cmdclass = {
     "verify_version": VerifyVersionCommand,

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,6 @@ if sys.version_info < (3, 6):
 
 extras["all_extras"] = sum(extras.values(), [])
 
-# CI extras to control dependencies for tests
-extras["test_ci"] = sum(extras.values(), [])
-extras["test_ci"] = [
-    r for r in extras["test_ci"] if not r.startswith("dask_cloudprovider")
-]
-
 # Extras for docker image builds to include for orchestration
 extras["all_orchestration_extras"] = [
     "atlassian-python-api >= 2.0.1",
@@ -92,6 +86,14 @@ extras["all_orchestration_extras"] = [
     "python-gitlab >= 2.5.0, < 3.0",
     "PyGithub >= 1.51, < 2.0",
 ]
+
+# CI extras to control dependencies for tests
+extras["task_library_ci"] = sum(extras.values(), [])
+extras["task_library_ci"] = [
+    r for r in extras["test_ci"] if not r.startswith("dask_cloudprovider")
+]
+
+extras["base_library_ci"] = extras["all_orchestration_extras"] + extras["test"]
 
 cmdclass = {
     "verify_version": VerifyVersionCommand,

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ extras = {
     "dremio": ["pyarrow>=0.15.1"],
 }
 
+
 if sys.version_info < (3, 6):
     extras["dev"].remove("black")
 
@@ -79,6 +80,17 @@ extras["all_extras"] = sum(extras.values(), [])
 extras["test_ci"] = sum(extras.values(), [])
 extras["test_ci"] = [
     r for r in extras["test_ci"] if not r.startswith("dask_cloudprovider")
+]
+
+# Extras for docker image builds to include for orchestration
+extras["all_orchestration_extras"] = [
+    "atlassian-python-api >= 2.0.1",
+    "azure-storage-blob >= 12.1.0, < 13.0",
+    "boto3 >= 1.9, < 2.0",
+    "kubernetes >= 9.0.0a1, <= 11.0.0b2",
+    "google-cloud-storage >= 1.13, < 2.0",
+    "python-gitlab >= 2.5.0, < 3.0",
+    "PyGithub >= 1.51, < 2.0",
 ]
 
 cmdclass = {

--- a/setup.py
+++ b/setup.py
@@ -28,33 +28,43 @@ install_requires = open("requirements.txt").read().strip().split("\n")
 dev_requires = open("dev-requirements.txt").read().strip().split("\n")
 test_requires = open("test-requirements.txt").read().strip().split("\n")
 
+orchestration_extras = {
+    "aws": ["boto3 >= 1.9, < 2.0"],
+    "azure": ["azure-storage-blob >= 12.1.0, < 13.0"],
+    "bitbucket": ["atlassian-python-api >= 2.0.1"],
+    "gcp": ["google-cloud-storage >= 1.13, < 2.0"],
+    "github": ["PyGithub >= 1.51, < 2.0"],
+    "gitlab": ["python-gitlab >= 2.5.0, < 3.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1, <= 11.0.0b2"],
+}
+
 extras = {
     "airtable": ["airtable-python-wrapper >= 0.11, < 0.12"],
-    "aws": ["boto3 >= 1.9, < 2.0"],
+    "aws": orchestration_extras["aws"],
     "azure": [
         "azure-storage-blob >= 12.1.0, < 13.0",
         "azureml-sdk >= 1.0.65, < 1.1",
         "azure-cosmos >= 3.1.1, <3.2",
     ],
-    "bitbucket": ["atlassian-python-api >= 2.0.1"],
+    "bitbucket": orchestration_extras["bitbucket"],
     "dask_cloudprovider": ["dask_cloudprovider[aws] >= 0.2.0, < 1.0"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],
     "gcp": [
         "google-cloud-bigquery >= 1.6.0, < 2.0",
-        "google-cloud-storage >= 1.13, < 2.0",
-    ],
-    "github": ["PyGithub >= 1.51, < 2.0"],
-    "gitlab": ["python-gitlab >= 2.5.0, < 3.0"],
+    ]
+    + orchestration_extras["gcp"],
+    "github": orchestration_extras["github"],
+    "gitlab": orchestration_extras["gitlab"],
     "google": [
         "google-cloud-bigquery >= 1.6.0, < 2.0",
-        "google-cloud-storage >= 1.13, < 2.0",
-    ],
+    ]
+    + orchestration_extras["gcp"],
     "gsheets": ["gspread >= 3.6.0"],
     "jira": ["jira >= 2.0.0"],
     "jupyter": ["papermill >= 2.2.0", "nbconvert >= 6.0.7"],
-    "kubernetes": ["kubernetes >= 9.0.0a1, <= 11.0.0b2", "dask-kubernetes >= 0.8.0"],
+    "kubernetes": ["dask-kubernetes >= 0.8.0"] + orchestration_extras["kubernetes"],
     "pandas": ["pandas >= 1.0.1"],
     "postgres": ["psycopg2-binary >= 2.8.2"],
     "mysql": ["pymysql >= 0.9.3"],
@@ -77,15 +87,7 @@ if sys.version_info < (3, 6):
 extras["all_extras"] = sum(extras.values(), [])
 
 # Extras for docker image builds to include for orchestration
-extras["all_orchestration_extras"] = [
-    "atlassian-python-api >= 2.0.1",
-    "azure-storage-blob >= 12.1.0, < 13.0",
-    "boto3 >= 1.9, < 2.0",
-    "kubernetes >= 9.0.0a1, <= 11.0.0b2",
-    "google-cloud-storage >= 1.13, < 2.0",
-    "python-gitlab >= 2.5.0, < 3.0",
-    "PyGithub >= 1.51, < 2.0",
-]
+extras["all_orchestration_extras"] = sum(orchestration_extras.values(), [])
 
 # CI extras to control dependencies for tests
 extras["task_library_ci"] = sum(extras.values(), [])
@@ -93,7 +95,12 @@ extras["task_library_ci"] = [
     r for r in extras["task_library_ci"] if not r.startswith("dask_cloudprovider")
 ]
 
-extras["base_library_ci"] = extras["all_orchestration_extras"] + extras["dev"]
+extras["base_library_ci"] = (
+    extras["all_orchestration_extras"]
+    + extras["dev"]
+    + extras["pandas"]
+    + extras["jira"]
+)
 
 cmdclass = {
     "verify_version": VerifyVersionCommand,

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -788,12 +788,10 @@ class Client:
                 flow.environment.metadata["image"] = flow.storage.name
                 serialized_flow = flow.serialize(build=False)
 
-            # If no image ever set, default metadata to all_extras image on current version
+            # If no image ever set, default metadata to image on current version
             if not flow.environment.metadata.get("image"):
                 version = prefect.__version__.split("+")[0]
-                flow.environment.metadata[
-                    "image"
-                ] = f"prefecthq/prefect:all_extras-{version}"
+                flow.environment.metadata["image"] = f"prefecthq/prefect:{version}"
                 serialized_flow = flow.serialize(build=False)
 
         # verify that the serialized flow can be deserialized

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -203,7 +203,7 @@ class Docker(Storage):
         self.installation_commands.append(
             f"pip show prefect || "
             f"pip install git+https://github.com/PrefectHQ/prefect.git"
-            f"@{self.prefect_version}#egg=prefect[kubernetes]"
+            f"@{self.prefect_version}#egg=prefect[all_orchestration_extras]"
         )
 
         not_absolute = [

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -39,7 +39,7 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
         # core_version should always be present, but just in case
         version = flow_run.flow.get("core_version") or "latest"
         cleaned_version = version.split("+")[0]
-        return f"prefecthq/prefect:all_extras-{cleaned_version}"
+        return f"prefecthq/prefect:{cleaned_version}"
     else:
         environment = EnvironmentSchema().load(flow_run.flow.environment)
         if hasattr(environment, "metadata") and hasattr(environment.metadata, "image"):

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -264,11 +264,7 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
         image = "testing/on-storage:tag"
     else:
         storage = Local()
-        image = (
-            "on-run-config"
-            if run_kind == "docker"
-            else "prefecthq/prefect:all_extras-0.13.11"
-        )
+        image = "on-run-config" if run_kind == "docker" else "prefecthq/prefect:0.13.11"
 
     if run_kind == "docker":
         env = {"TESTING": "VALUE"}

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -329,7 +329,7 @@ class TestGenerateTaskDefinition:
                 "test/name:tag",
             ),
             (ECSRun(image="myimage"), Local(), "myimage"),
-            (ECSRun(), Local(), "prefecthq/prefect:all_extras-0.13.0"),
+            (ECSRun(), Local(), "prefecthq/prefect:0.13.0"),
         ],
         ids=["on-storage", "on-run_config", "default"],
     )

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1173,7 +1173,7 @@ class TestK8sAgentRunConfig:
                 "test/name:tag",
             ),
             (KubernetesRun(image="myimage"), Local(), "myimage"),
-            (KubernetesRun(), Local(), "prefecthq/prefect:all_extras-0.13.0"),
+            (KubernetesRun(), Local(), "prefecthq/prefect:0.13.0"),
         ],
         ids=["on-storage", "on-run_config", "default"],
     )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -519,7 +519,7 @@ def test_client_register_docker_image_name(patch_post, compressed, monkeypatch, 
 
 
 @pytest.mark.parametrize("compressed", [True, False])
-def test_client_register_default_all_extras_image(
+def test_client_register_default_prefect_image(
     patch_post, compressed, monkeypatch, tmpdir
 ):
     if compressed:
@@ -571,7 +571,7 @@ def test_client_register_default_all_extras_image(
             "serialized_flow"
         ]
     assert serialized_flow["storage"] is not None
-    assert "all_extras" in serialized_flow["environment"]["metadata"]["image"]
+    assert "prefecthq/prefect" in serialized_flow["environment"]["metadata"]["image"]
 
 
 @pytest.mark.parametrize("compressed", [True, False])

--- a/tests/storage/test_docker_storage.py
+++ b/tests/storage/test_docker_storage.py
@@ -577,7 +577,7 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
             (
                 "FROM python:3.6-slim",
                 "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*",
-                "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@424be6b5ed8d3be85064de4b95b5c3d7cb665510#egg=prefect[kubernetes]",
+                "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@424be6b5ed8d3be85064de4b95b5c3d7cb665510#egg=prefect[all_orchestration_extras]",
             ),
         ),
     ],

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -100,7 +100,7 @@ def test_get_flow_image_run_config_default_value_from_core_version(run_config, v
     )
     image = get_flow_image(flow_run)
     expected_version = version.split("+")[0] if version else "latest"
-    assert image == f"prefecthq/prefect:all_extras-{expected_version}"
+    assert image == f"prefecthq/prefect:{expected_version}"
 
 
 def test_get_flow_image_run_config_image_on_RunConfig():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
With `0.14.0` approaching we have the opportunity to better package dependencies in our base image. This PR makes various updates to some CI steps (including tests and image builds). It also updates places where the previous `all_extras` image was being used.

**Note**: We should cut a release candidate of `0.14.0` to ensure that the image building jobs function properly.

## Changes
- Adds CI job for only testing the task library
- Ignores testing the task library in the 3.6-9 jobs
- Removes building the `all_extras` Docker image
- Adds a build of the `core` image that only contains the prefect core base dependencies
- Adds all orchestration extras to the standard `prefect/prefect` image
- Docker storage now installs all orchestration dependencies
- Deployed flows now default to using the `prefect/prefect` image with the orchestration extras installed instead of `all_extras`


## Importance
This gives us a better packaging experience of what we consider important deployment dependencies. Those include packages that service things like storage and agents.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)