### PR TITLE
Simplify default k8s job template

### DIFF
--- a/changes/pr3805.yaml
+++ b/changes/pr3805.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Prefect kubernetes agent no longer relies on existence of any fields in configured Kubernetes Job Template - [#3805](https://github.com/PrefectHQ/prefect/pull/3805)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -561,6 +561,9 @@ class KubernetesAgent(Agent):
         if image_pull_secrets is not None:
             pod_template["imagePullSecrets"] = [{"name": s} for s in image_pull_secrets]
 
+        # Default restartPolicy to Never
+        _get_or_create(job, "spec.template.spec.restartPolicy", "Never")
+
         # Get the first container, which is used for the prefect job
         containers = _get_or_create(job, "spec.template.spec.containers", [])
         if not containers:
@@ -571,7 +574,7 @@ class KubernetesAgent(Agent):
         container["image"] = image = get_flow_image(flow_run)
 
         # Set flow run command
-        container["args"] = [get_flow_run_command(flow_run)]
+        container["args"] = get_flow_run_command(flow_run).split()
 
         # Populate environment variables from the following sources,
         # with precedence:

--- a/src/prefect/agent/kubernetes/job_template.yaml
+++ b/src/prefect/agent/kubernetes/job_template.yaml
@@ -3,7 +3,5 @@ kind: Job
 spec:
   template:
     spec:
-      restartPolicy: Never
       containers:
         - name: flow
-          command: ["/bin/sh", "-c"]


### PR DESCRIPTION
- Drops `command` from default k8s job template. We now pass in the
  `prefect execute flow-run` command as a list (rather than a string),
  making it compose better with existing entrypoints.
- Drops `restartPolicy` from default template, setting it
  programmatically instead (default is `Never`).

Prefect now makes no assumptions about the default template, the user
can fill it in how they see fit. This makes it easier for the user to
customize a k8s deployment.

Fixes #3787.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)