### PR TITLE
Remove default creation of `flow.environment`

### DIFF
--- a/changes/pr3806.yaml
+++ b/changes/pr3806.yaml
@@ -1,0 +1,2 @@
+breaking:
+  - "Flows now use `RunConfig` based deployments by default - legacy `Environment` based deployments are now opt-in only - [#3806](https://github.com/PrefectHQ/prefect/pull/3806)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -119,8 +119,8 @@ class Flow:
         - executor (prefect.executors.Executor, optional): The executor that the flow
            should use. If `None`, the default executor configured in the runtime environment
            will be used.
-        - environment (prefect.environments.Environment, optional): The environment
-           that the flow should be run in. If `None`, a `LocalEnvironment` will be created.
+        - environment (prefect.environments.Environment, optional, DEPRECATED): The environment
+           that the flow should be run in.
         - run_config (prefect.run_configs.RunConfig, optional): The runtime
            configuration to use when deploying this flow.
         - storage (prefect.storage.Storage, optional): The unit of storage
@@ -175,7 +175,7 @@ class Flow:
         self.logger = logging.get_logger(self.name)
         self.schedule = schedule
         self.executor = executor
-        self.environment = environment or prefect.environments.LocalEnvironment()
+        self.environment = environment
         self.run_config = run_config
         self.storage = storage
         if result_handler:
@@ -1569,8 +1569,10 @@ class Flow:
         with set_temporary_config(temp_config):
             if self.run_config is not None:
                 labels = list(self.run_config.labels or ())
-            else:
+            elif self.environment is not None:
                 labels = list(self.environment.labels or ())
+            else:
+                labels = []
             agent = prefect.agent.local.LocalAgent(
                 labels=labels, show_flow_logs=show_flow_logs
             )

--- a/src/prefect/utilities/diagnostics.py
+++ b/src/prefect/utilities/diagnostics.py
@@ -121,35 +121,48 @@ def flow_information(flow: "prefect.Flow") -> dict:
         return True
 
     # Check presence of environment attributes
-    environment = dict()  # type: ignore
     if flow.environment:
         environment = {
             "type": type(flow.environment).__name__,
+            **_replace_values(flow.environment.__dict__),
         }
-        environment.update(_replace_values(flow.environment.__dict__))
+    else:
+        environment = False  # type: ignore
+
+    # Check presence of run_config attributes
+    if flow.run_config:
+        run_config = {
+            "type": type(flow.run_config).__name__,
+            **_replace_values(flow.run_config.__dict__),
+        }
+    else:
+        run_config = False  # type: ignore
 
     # Check presence of storage attributes
-    storage = dict()  # type: ignore
     if flow.storage:
         storage = {
             "type": type(flow.storage).__name__,
+            **_replace_values(flow.storage.__dict__),
         }
-        storage.update(_replace_values(flow.storage.__dict__))
+    else:
+        storage = False  # type: ignore
 
     # Check presence of a result handler
-    result = dict()  # type: ignore
     if flow.result:
         result = {"type": type(flow.result).__name__}
+    else:
+        result = False  # type: ignore
 
     # Check presence of a schedule
-    schedule = dict()  # type: ignore
     if flow.schedule:
-        schedule = {"type": type(flow.schedule).__name__}
-        schedule.update(flow.schedule.__dict__)
+        schedule = {"type": type(flow.schedule).__name__, **flow.schedule.__dict__}
+    else:
+        schedule = False  # type: ignore
 
     return dict(
         flow_information=dict(
             environment=environment,
+            run_config=run_config,
             storage=storage,
             result=result,
             schedule=schedule,

--- a/src/prefect/utilities/storage.py
+++ b/src/prefect/utilities/storage.py
@@ -25,7 +25,11 @@ def get_flow_image(flow: "Flow") -> str:
             present in environment metadata
     """
     environment = flow.environment
-    if hasattr(environment, "metadata") and environment.metadata.get("image"):
+    if (
+        environment is not None
+        and hasattr(environment, "metadata")
+        and environment.metadata.get("image")
+    ):
         return environment.metadata.get("image", "")
     else:
         storage = flow.storage

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -492,6 +492,7 @@ def test_client_register_docker_image_name(patch_post, compressed, monkeypatch, 
     flow = prefect.Flow(
         name="test",
         storage=prefect.storage.Docker(image_name="test_image"),
+        environment=LocalEnvironment(),
     )
     flow.result = flow.storage.result
 
@@ -548,7 +549,11 @@ def test_client_register_default_all_extras_image(
         }
     ):
         client = Client()
-    flow = prefect.Flow(name="test", storage=prefect.storage.Local(tmpdir))
+    flow = prefect.Flow(
+        name="test",
+        storage=prefect.storage.Local(tmpdir),
+        environment=LocalEnvironment(),
+    )
     flow.result = flow.storage.result
 
     client.register(

--- a/tests/utilities/test_diagnostics.py
+++ b/tests/utilities/test_diagnostics.py
@@ -131,18 +131,12 @@ def test_flow_information():
     assert flow_information
 
     # Type information
-    assert flow_information["environment"]["type"] == "LocalEnvironment"
+    assert flow_information["environment"] is False
+    assert flow_information["run_config"] is False
     assert flow_information["storage"]["type"] == "Local"
     assert flow_information["result"]["type"] == "PrefectResult"
     assert flow_information["schedule"]["type"] == "Schedule"
     assert flow_information["task_count"] == 2
-
-    # Kwargs presence check
-    assert flow_information["environment"]["executor"] is True
-    assert flow_information["environment"]["labels"] is False
-    assert flow_information["environment"]["on_start"] is False
-    assert flow_information["environment"]["on_exit"] is False
-    assert flow_information["environment"]["logger"] is True
 
 
 def test_diagnostic_info_with_flow_no_secrets(monkeypatch):
@@ -167,6 +161,7 @@ def test_diagnostic_info_with_flow_no_secrets(monkeypatch):
             "test",
             tasks=[t1, t2],
             storage=prefect.storage.Local(),
+            run_config=prefect.run_configs.LocalRun(),
             schedule=prefect.schedules.Schedule(clocks=[]),
             result=prefect.engine.results.PrefectResult(),
         )
@@ -189,18 +184,15 @@ def test_diagnostic_info_with_flow_no_secrets(monkeypatch):
         assert flow_information
 
         # Type information
-        assert flow_information["environment"]["type"] == "LocalEnvironment"
         assert flow_information["storage"]["type"] == "Local"
         assert flow_information["result"]["type"] == "PrefectResult"
         assert flow_information["schedule"]["type"] == "Schedule"
         assert flow_information["task_count"] == 2
 
-        # Kwargs presence check
-        assert flow_information["environment"]["executor"] is True
-        assert flow_information["environment"]["labels"] is False
-        assert flow_information["environment"]["on_start"] is False
-        assert flow_information["environment"]["on_exit"] is False
-        assert flow_information["environment"]["logger"] is True
+        assert flow_information["run_config"]["type"] == "LocalRun"
+        assert flow_information["run_config"]["env"] is False
+        assert flow_information["run_config"]["labels"] is False
+        assert flow_information["run_config"]["working_dir"] is False
 
         assert system_info["prefect_version"] == prefect.__version__
         assert system_info["platform"] == platform.platform()


### PR DESCRIPTION
Previously all flows had a `flow.environment` field created by default.
This has now been removed - use of the legacy `Environment` based
configuration is now opt-in only. Users who weren't setting
`flow.environment` explicitly before should transition automatically to
using the new `flow.run_config` based configuration without any changes
on their part.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)