### PR TITLE
Add warning if mixing `environment` and `executor` config

### DIFF
--- a/changes/pr3808.yaml
+++ b/changes/pr3808.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add warning on flow registration if `flow.executor` is set but the flow is using the legacy `flow.environment` configuration system - [#3808](https://github.com/PrefectHQ/prefect/pull/3808)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1637,6 +1637,22 @@ class Flow:
             )
             return None
 
+        if (
+            self.environment is not None
+            and self.run_config is None
+            and self.executor is not None
+        ):
+            warnings.warn(
+                "This flow is using the deprecated `flow.environment` based configuration, "
+                "but has `flow.executor` set.\n\n"
+                "This executor will be *not* be used at runtime.\n\n"
+                "Please transition to the `flow.run_config` based system instead to "
+                "make use of setting `flow.executor`. "
+                "See https://docs.prefect.io/orchestration/flow_config/overview.html "
+                "for more information.",
+                stacklevel=2,
+            )
+
         if self.storage is None:
             self.storage = get_default_storage_class()(**kwargs)
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2796,6 +2796,15 @@ class TestFlowRegister:
             exc.value
         )
 
+    def test_flow_register_warns_if_mixing_environment_and_executor(self, monkeypatch):
+        monkeypatch.setattr("prefect.Client", MagicMock())
+        flow = Flow(
+            name="test", environment=LocalEnvironment(), executor=LocalExecutor()
+        )
+
+        with pytest.warns(UserWarning, match="This flow is using the deprecated"):
+            flow.register("testing", build=False)
+
 
 def test_bad_flow_runner_code_still_returns_state_obj():
     class BadFlowRunner(prefect.engine.flow_runner.FlowRunner):


### PR DESCRIPTION
Adds a warning when registering a flow that is using the legacy
`flow.environment` based configuration but also sets a `flow.executor`
(which will thus be ignored at runtime).

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)