### PR TITLE
Add deprecation warning to environments

### DIFF
--- a/changes/pr3811.yaml
+++ b/changes/pr3811.yaml
@@ -1,0 +1,2 @@
+deprecation:
+  - "Deprecates all `Environment` classes - users should transition to setting `flow.run_config` instead of `flow.environment` - [#3811](https://github.com/PrefectHQ/prefect/pull/3811)"

--- a/src/prefect/environments/execution/__init__.py
+++ b/src/prefect/environments/execution/__init__.py
@@ -1,8 +1,9 @@
 """
 Execution environments encapsulate the logic for where your Flow should execute in Prefect Cloud.
 
-Currently, we recommend all users deploy their Flow using the `LocalEnvironment` configured with the
-appropriate choice of executor.
+DEPRECATED: Environment based configuration is deprecated, please transition to
+configuring `flow.run_config` instead of `flow.environment`. See
+https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
 """
 from prefect.environments.execution.base import Environment, load_and_run_flow
 from prefect.environments.execution.dask import DaskKubernetesEnvironment

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -8,6 +8,7 @@ that environment. e.g. the `DaskKubernetesEnvironment` is an environment which
 runs a flow on Kubernetes using the `dask-kubernetes` library.
 """
 
+import warnings
 from typing import Callable, Iterable, TYPE_CHECKING
 
 import prefect
@@ -22,6 +23,10 @@ if TYPE_CHECKING:
 class Environment:
     """
     Base class for Environments.
+
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
 
     An environment is an object that can be instantiated in a way that makes it possible to
     call `environment.setup()` to stand up any required static infrastructure and
@@ -51,6 +56,12 @@ class Environment:
         self.on_exit = on_exit
         self.metadata = metadata or {}
         self.logger = logging.get_logger(type(self).__name__)
+        warnings.warn(
+            "`Environment` based flow configuration is deprecated, please transition to configuring "
+            "`flow.run_config` instead of `flow.environment`. "
+            "See https://docs.prefect.io/orchestration/flow_config/overview.html for more info.",
+            stacklevel=2 if type(self) is Environment else 3,
+        )
 
     def __repr__(self) -> str:
         return "<Environment: {}>".format(type(self).__name__)

--- a/src/prefect/environments/execution/dask/cloud_provider.py
+++ b/src/prefect/environments/execution/dask/cloud_provider.py
@@ -14,7 +14,13 @@ if TYPE_CHECKING:
 class DaskCloudProviderEnvironment(Environment):
     """
     DaskCloudProviderEnvironment creates Dask clusters using the Dask Cloud Provider
-    project. For each flow run, a new Dask cluster will be dynamically created and the
+    project.
+
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
+
+    For each flow run, a new Dask cluster will be dynamically created and the
     flow will run using a `DaskExecutor` with the Dask scheduler address from the newly
     created Dask cluster. You can specify the number of Dask workers manually
     (for example, passing the kwarg `n_workers`) or enable adaptive mode by

--- a/src/prefect/environments/execution/dask/k8s.py
+++ b/src/prefect/environments/execution/dask/k8s.py
@@ -23,6 +23,10 @@ class DaskKubernetesEnvironment(Environment):
     [dask-kubernetes](https://kubernetes.dask.org/en/latest/)) and running the Prefect
     `DaskExecutor` on this cluster.
 
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
+
     When running your flows that are registered with a private container registry, you should
     either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment`
     or directly set the `imagePullSecrets` on your custom worker/scheduler specs.

--- a/src/prefect/environments/execution/fargate/fargate_task.py
+++ b/src/prefect/environments/execution/fargate/fargate_task.py
@@ -32,11 +32,15 @@ _DEFINITION_KWARG_LIST = [
 class FargateTaskEnvironment(Environment, _RunMixin):
     """
     FargateTaskEnvironment is an environment which deploys your flow as a Fargate task.
-    This environment requires AWS credentials and extra boto3 kwargs which
-    are used in the creation and running of the Fargate task.
 
-    When providing a custom container definition spec the first container in the spec must be the
-    container that the flow runner will be executed on.
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
+
+    This environment requires AWS credentials and extra boto3 kwargs which are
+    used in the creation and running of the Fargate task. When providing a
+    custom container definition spec the first container in the spec must be
+    the container that the flow runner will be executed on.
 
     The following environment variables, required for cloud, do not need to be
     included––they are automatically added and populated during execution:

--- a/src/prefect/environments/execution/k8s/job.py
+++ b/src/prefect/environments/execution/k8s/job.py
@@ -18,6 +18,10 @@ class KubernetesJobEnvironment(Environment, _RunMixin):
     KubernetesJobEnvironment is an environment which deploys your flow as a Kubernetes
     job. This environment allows (and requires) a custom job YAML spec to be provided.
 
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
+
     When providing a custom YAML job spec the first container in the spec must be the
     container that the flow runner will be executed on.
 

--- a/src/prefect/environments/execution/local.py
+++ b/src/prefect/environments/execution/local.py
@@ -11,6 +11,10 @@ class LocalEnvironment(Environment, _RunMixin):
     """
     A LocalEnvironment class for executing a flow in the local process.
 
+    DEPRECATED: Environment based configuration is deprecated, please transition to
+    configuring `flow.run_config` instead of `flow.environment`. See
+    https://docs.prefect.io/orchestration/flow_config/overview.html for more info.
+
     Args:
         - executor (Executor, optional): the executor to run the flow with. If not provided, the
             default executor will be used.

--- a/tests/environments/execution/__init__.py
+++ b/tests/environments/execution/__init__.py
@@ -5,3 +5,5 @@ pytest.importorskip("botocore")
 pytest.importorskip("dask_kubernetes")
 pytest.importorskip("kubernetes")
 pytest.importorskip("yaml")
+
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")

--- a/tests/environments/execution/test_base_environment.py
+++ b/tests/environments/execution/test_base_environment.py
@@ -11,6 +11,8 @@ from prefect.storage import Docker, Local, Storage
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
+
 
 def test_create_environment():
     environment = Environment()

--- a/tests/environments/execution/test_dask_cloud_provider.py
+++ b/tests/environments/execution/test_dask_cloud_provider.py
@@ -13,6 +13,8 @@ from prefect.environments.execution import DaskCloudProviderEnvironment
 
 from dask_cloudprovider.aws import FargateCluster
 
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
+
 
 def test_create_environment():
     environment = DaskCloudProviderEnvironment(Cluster)

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -14,6 +14,8 @@ from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
 
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
+
 base_flow = prefect.Flow("test", storage=Docker())
 
 

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -11,6 +11,9 @@ from prefect.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
 
 
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
+
+
 def test_create_fargate_task_environment():
     environment = FargateTaskEnvironment()
     assert environment.executor is not None

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -15,6 +15,9 @@ from prefect.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
 
 
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
+
+
 @pytest.fixture
 def default_command_args() -> List[str]:
     return [

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+import pytest
 
 import prefect
 from prefect import Flow
@@ -6,6 +7,9 @@ from prefect.executors import LocalDaskExecutor
 from prefect.environments.execution import LocalEnvironment
 from prefect.storage import Docker, Local
 from prefect.utilities.configuration import set_temporary_config
+
+
+pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
 
 
 class DummyStorage(Local):


### PR DESCRIPTION
Adds a warning on init to all `Environment` classes, and updates the
docstrings appropriately.


This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)