### PR TITLE
Deprecate the Fargate Agent

### DIFF
--- a/changes/pr3812.yaml
+++ b/changes/pr3812.yaml
@@ -1,0 +1,2 @@
+deprecation:
+  - "Deprecate the Fargate Agent in favor of the ECS Agent - [#3812](https://github.com/PrefectHQ/prefect/pull/3812)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ env =
     PREFECT__USER_CONFIG_PATH=""
     PREFECT__BACKEND="cloud"
 usedevelop = True
+filterwarnings =
+    ignore:`Environment` based flow configuration is deprecated:UserWarning
 
 [isort]
 skip = __init__.py,/engine/executors/dask.py

--- a/src/prefect/agent/fargate/agent.py
+++ b/src/prefect/agent/fargate/agent.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import warnings
 from ast import literal_eval
 from typing import Iterable
 import uuid
@@ -15,9 +16,14 @@ from prefect.utilities.graphql import GraphQLResult
 
 class FargateAgent(Agent):
     """
-    Agent which deploys flow runs as tasks using Fargate. This agent can run anywhere as
-    long as the proper access configuration variables are set.  Information on using the
-    Fargate Agent can be found at https://docs.prefect.io/orchestration/agents/fargate.html
+    Agent which deploys flow runs as tasks using Fargate.
+
+    DEPRECATED: The Fargate agent is deprecated, please transition to using the
+    ECS agent instead.
+
+    This agent can run anywhere as long as the proper access configuration
+    variables are set.  Information on using the Fargate Agent can be found at
+    https://docs.prefect.io/orchestration/agents/fargate.html
 
     All `kwargs` are accepted that one would normally pass to boto3 for `register_task_definition`
     and `run_task`. For information on the kwargs supported visit the following links:
@@ -130,6 +136,11 @@ class FargateAgent(Agent):
             agent_address=agent_address,
             no_cloud_logs=no_cloud_logs,
         )
+
+        if not kwargs.pop("_called_from_cli", False):
+            warnings.warn(
+                "`FargateAgent` is deprecated, please transition to using `ECSAgent` instead"
+            )
 
         from boto3 import client as boto3_client
         from boto3 import resource as boto3_resource

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -323,9 +323,20 @@ def install(label, env, **kwargs):
 #################
 
 
+def warn_fargate_deprecated():
+    click.secho(
+        "Warning: The Fargate agent is deprecated, please transition to using the ECS agent instead",
+        fg="yellow",
+        err=True,
+    )
+
+
 @agent.group()
 def fargate():
-    """Manage Prefect Fargate agents."""
+    """Manage Prefect Fargate agents (DEPRECATED).
+
+    The Fargate agent is deprecated, please transition to using the ECS agent instead.
+    """
 
 
 @fargate.command(
@@ -334,14 +345,19 @@ def fargate():
 @add_options(COMMON_START_OPTIONS)
 @click.pass_context
 def start(ctx, **kwargs):
-    """Start a Fargate agent"""
+    """Start a Fargate agent (DEPRECATED)
+
+    The Fargate agent is deprecated, please transition to using the ECS agent instead.
+    """
     from prefect.agent.fargate import FargateAgent
+
+    warn_fargate_deprecated()
 
     for item in ctx.args:
         k, v = item.replace("--", "").split("=", 2)
         kwargs[k] = v
 
-    start_agent(FargateAgent, **kwargs)
+    start_agent(FargateAgent, _called_from_cli=True, **kwargs)
 
 
 #############
@@ -633,12 +649,15 @@ def start(
             )
             return
 
-        click.secho(
-            f"Warning: `prefect agent start {agent_option}` is deprecated, use "
-            f"`prefect agent {agent_option} start` instead",
-            fg="yellow",
-            err=True,
-        )
+        if agent_option == "fargate":
+            warn_fargate_deprecated()
+        else:
+            click.secho(
+                f"Warning: `prefect agent start {agent_option}` is deprecated, use "
+                f"`prefect agent {agent_option} start` instead",
+                fg="yellow",
+                err=True,
+            )
 
         env_vars = dict()
         for env_var in env:
@@ -686,6 +705,7 @@ def start(
                 max_polls=max_polls,
                 no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
+                _called_from_cli=True,
                 **kwargs,
             ).start()
         elif agent_option == "kubernetes":

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -10,6 +10,7 @@ from prefect.utilities.graphql import GraphQLResult
 
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
+pytestmark = pytest.mark.filterwarnings("ignore:`FargateAgent` is deprecated")
 
 from botocore.exceptions import ClientError
 

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -166,7 +166,12 @@ def test_agent_start(
 
     result = CliRunner().invoke(agent, command)
     if deprecated:
-        assert f"Warning: `prefect agent start {name}` is deprecated" in result.output
+        if name == "fargate":
+            assert f"Warning: The Fargate agent is deprecated" in result.output
+        else:
+            assert (
+                f"Warning: `prefect agent start {name}` is deprecated" in result.output
+            )
 
     kwargs = agent_cls.call_args[1]
     for k, v in expected_kwargs.items():

--- a/tests/environments/execution/__init__.py
+++ b/tests/environments/execution/__init__.py
@@ -5,5 +5,3 @@ pytest.importorskip("botocore")
 pytest.importorskip("dask_kubernetes")
 pytest.importorskip("kubernetes")
 pytest.importorskip("yaml")
-
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")

--- a/tests/environments/execution/test_base_environment.py
+++ b/tests/environments/execution/test_base_environment.py
@@ -11,8 +11,6 @@ from prefect.storage import Docker, Local, Storage
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
-
 
 def test_create_environment():
     environment = Environment()

--- a/tests/environments/execution/test_dask_cloud_provider.py
+++ b/tests/environments/execution/test_dask_cloud_provider.py
@@ -13,8 +13,6 @@ from prefect.environments.execution import DaskCloudProviderEnvironment
 
 from dask_cloudprovider.aws import FargateCluster
 
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
-
 
 def test_create_environment():
     environment = DaskCloudProviderEnvironment(Cluster)

--- a/tests/environments/execution/test_dask_k8s_environment.py
+++ b/tests/environments/execution/test_dask_k8s_environment.py
@@ -13,9 +13,6 @@ from prefect.storage import Docker, Local
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
 
-
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
-
 base_flow = prefect.Flow("test", storage=Docker())
 
 

--- a/tests/environments/execution/test_fargate_task_environment.py
+++ b/tests/environments/execution/test_fargate_task_environment.py
@@ -11,9 +11,6 @@ from prefect.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
 
 
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
-
-
 def test_create_fargate_task_environment():
     environment = FargateTaskEnvironment()
     assert environment.executor is not None

--- a/tests/environments/execution/test_k8s_job_environment.py
+++ b/tests/environments/execution/test_k8s_job_environment.py
@@ -15,9 +15,6 @@ from prefect.storage import Docker
 from prefect.utilities.configuration import set_temporary_config
 
 
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
-
-
 @pytest.fixture
 def default_command_args() -> List[str]:
     return [

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -1,5 +1,4 @@
 from unittest.mock import MagicMock
-import pytest
 
 import prefect
 from prefect import Flow
@@ -7,9 +6,6 @@ from prefect.executors import LocalDaskExecutor
 from prefect.environments.execution import LocalEnvironment
 from prefect.storage import Docker, Local
 from prefect.utilities.configuration import set_temporary_config
-
-
-pytestmark = pytest.mark.filterwarnings("ignore:`Environment` based flow configuration")
 
 
 class DummyStorage(Local):


### PR DESCRIPTION
Adds a deprecation warning to programmatic use of `FargateAgent`, and a
warning message to CLI usage of `prefect agent fargate start`/`prefect
agent start fargate`. Docs have been updated as well.

Also changes how we silence expected warnings in tests to be more
thorough.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)