### PR TITLE
Move creation of markdown artifact in RunGreatExpectationsValidation up so it is created even when validation fails

### DIFF
--- a/changes/pr3829.yaml
+++ b/changes/pr3829.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Produce artifact for RunGreatExpectationsValidation even if validation fails - [#1234](https://github.com/PrefectHQ/prefect/pull/1234)"
+
+contributor:
+  - "[Christian Werner](https://github.com/cwerner)"

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -247,9 +247,6 @@ class RunGreatExpectationsValidation(Task):
             run_id={"run_name": run_name or prefect.context.get("task_slug")},
         )
 
-        if results.success is False:
-            raise signals.FAIL(result=results)
-
         # Generate artifact markdown
         if not disable_markdown_artifact:
             run_info_at_end = True
@@ -270,6 +267,9 @@ class RunGreatExpectationsValidation(Task):
             )
 
             create_markdown(markdown_artifact)
+
+        if results.success is False:
+            raise signals.FAIL(result=results)
 
         return results
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Hi. I wanted to receive artifact reports for my GreatExpectations validation even if the validation fails. 

## Changes
Solution is to simply move the creation of markdown artifact in RunGreatExpectationsValidation up so it is created even when success check fails and thus returns with state FAIL.

## Importance
Creates the artifact even if validation fails (which I think is important).

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [ x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)