### PR TITLE
Properly pass labels to register call in CLI command

### DIFF
--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -85,9 +85,4 @@ def flow(file, name, project, label):
     with prefect.context({"loading_flow": True, "local_script_path": file_path}):
         flow = extract_flow_from_file(file_path=file_path, flow_name=name)
 
-    if getattr(flow, "run_config", None) is not None:
-        flow.run_config.labels.update(label)
-    else:
-        flow.environment.labels.update(label)
-
-    flow.register(project_name=project)
+    flow.register(project_name=project, labels=label)

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -28,7 +28,7 @@ def test_register_flow_help():
 
 
 @pytest.mark.parametrize("labels", [[], ["b", "c"]])
-@pytest.mark.parametrize("kind", ["run_config", "environment"])
+@pytest.mark.parametrize("kind", ["run_config", "environment", "neither"])
 def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
     client = MagicMock()
     monkeypatch.setattr("prefect.Client", MagicMock(return_value=client))
@@ -41,13 +41,19 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
             "f = Flow('test-flow', environment=LocalEnvironment(labels=['a']),\n"
             "   storage=Local(add_default_labels=False))"
         )
-    else:
+    elif kind == "run_config":
         contents = (
             "from prefect import Flow\n"
             "from prefect.run_configs import KubernetesRun\n"
             "from prefect.storage import Local\n"
             "f = Flow('test-flow', run_config=KubernetesRun(labels=['a']),\n"
             "   storage=Local(add_default_labels=False))"
+        )
+    else:
+        contents = (
+            "from prefect import Flow\n"
+            "from prefect.storage import Local\n"
+            "f = Flow('test-flow', storage=Local(add_default_labels=False))"
         )
 
     full_path = str(tmpdir.join("flow.py"))
@@ -67,7 +73,9 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
     flow = client.register.call_args[1]["flow"]
     if kind == "run_config":
         assert flow.run_config.labels == {"a", *labels}
-    else:
+    elif kind == "environment":
         assert flow.environment.labels == {"a", *labels}
+    else:
+        assert flow.run_config.labels == {*labels}
 
     assert result.exit_code == 0


### PR DESCRIPTION
Updates the `prefect register flow` command to pass labels to the register call. Currently calling w/o any run config or environment would error because the UniversalRun isn't added until later. Simply passing in the labels this way fixes that and achieves the same behavior as before. (also updates a test)

No changes entry necessary since this was brought about due to a change in master