### PR TITLE
Load run config from backend on execute

### DIFF
--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -39,7 +39,7 @@ def flow_run():
     query = {
         "query": {
             with_args("flow_run", {"where": {"id": {"_eq": flow_run_id}}}): {
-                "flow": {"name": True, "storage": True},
+                "flow": {"name": True, "storage": True, "run_config": True},
                 "version": True,
             }
         }
@@ -65,6 +65,12 @@ def flow_run():
 
         with prefect.context(secrets=secrets, loading_flow=True):
             flow = storage.get_flow(storage.flows[flow_data.name])
+
+        # Load run config from backend if not present on flow object
+        if flow.run_config is None and flow_data.run_config:
+            flow.run_config = prefect.serialization.run_config.RunConfigSchema().load(
+                flow_data.run_config
+            )
 
         with prefect.context(secrets=secrets):
             if getattr(flow, "run_config", None) is not None:

--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -66,12 +66,6 @@ def flow_run():
         with prefect.context(secrets=secrets, loading_flow=True):
             flow = storage.get_flow(storage.flows[flow_data.name])
 
-        # Load run config from backend if not present on flow object
-        if flow.run_config is None and flow_data.run_config:
-            flow.run_config = prefect.serialization.run_config.RunConfigSchema().load(
-                flow_data.run_config
-            )
-
         with prefect.context(secrets=secrets):
             if flow_data.run_config is not None:
                 runner_cls = get_default_flow_runner_class()

--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -73,7 +73,7 @@ def flow_run():
             )
 
         with prefect.context(secrets=secrets):
-            if getattr(flow, "run_config", None) is not None:
+            if flow_data.run_config is not None:
                 runner_cls = get_default_flow_runner_class()
                 runner_cls(flow=flow).run()
             else:


### PR DESCRIPTION
In the case where there is no run config on a flow object and the flow is stored using file-based storage then the execute command will previously error. This is due to the fact that the run config needs to be loaded off of the backend metadata (just like storage is) in order to retrieve the `UniversalRun` default.

No changes entry necessary since this was brought about due to a change in master