### PR TITLE
Fetch flow parameters by calling parameters()

### DIFF
--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -18,9 +18,7 @@ from prefect.utilities.serialization import (
 
 def get_parameters(obj: prefect.Flow, context: dict) -> List:
     if isinstance(obj, prefect.Flow):
-        params = {
-            p for p in obj.tasks if isinstance(p, prefect.core.parameter.Parameter)
-        }
+        params = obj.parameters()
     else:
         params = utils.get_value(obj, "parameters")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Call `parameters()` to fetch flow parameters.

## Changes
<!-- What does this PR change? -->


## Importance
<!-- Why is this PR important? -->


It's better to call `parameters()` to fetch parameters of a flow, so user can inherit Flow class and rewrite parameters method.

For me, my flow contains a huge number of parameters, since Parameter is a Task, it takes 20s ~ 30s to run these tasks to fetch parameters.
So I create a new Parameter class (just a namedtuple) and a subclass of Flow, rewrite the `parameters` method, a subclass of FunctionTask to fetch parameters directly from `context['parameters']`.
It works fine, except I can't register to the server, because the flow serialize with `get_parameters` and it fetch parameters without calling `parameters()`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)