### PR TITLE
Add `tini` to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ LABEL org.label-schema.vcs-ref=${GIT_SHA}
 LABEL org.label-schema.build-date=${BUILD_DATE}
 
 RUN apt update && \
-    apt install -y gcc git && \
+    apt install -y gcc git tini && \
     mkdir /root/.prefect/ && \
     pip install "pip==20.2.4" && \
     pip install --no-cache-dir git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[${EXTRAS}] && \
     apt remove -y git && \
     apt clean && apt autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["tini", "-g", "--"]

--- a/changes/pr3839.yaml
+++ b/changes/pr3839.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add `tini` to the official Prefect docker images - [#3839](https://github.com/PrefectHQ/prefect/pull/3839)"

--- a/docs/orchestration/agents/local.md
+++ b/docs/orchestration/agents/local.md
@@ -18,7 +18,9 @@ installed](/core/getting_started/installation.md).
 If running the local agent inside a Docker container, we recommend you also use
 an init process like [`tini`](https://github.com/krallin/tini). Running without
 an init process may result in lingering zombie processes accumulating in your
-container.
+container. If you're using the [official Prefect docker
+images](/core/getting_started/installation.md#docker) then this is already
+handled for you.
 :::
 
 ## Flow Configuration


### PR DESCRIPTION
Without an init process like `tini`, long running Prefect jobs can
sometimes end up creating lots of zombie processes. Adding an init
process to reap these fixes this. This is a problem in containerized
instances only, non-containerized systems already have an init process
running and aren't affected.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)