### PR TITLE
Remove references to deprecated resource manager in install agent CLI command

### DIFF
--- a/changes/pr3840.yaml
+++ b/changes/pr3840.yaml
@@ -1,0 +1,2 @@
+breaking:
+  - "Remove option to enable deprecated Kubernetes resource manager in agent install CLI command - [#3840](https://github.com/PrefectHQ/prefect/pull/3840)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -686,7 +686,6 @@ class KubernetesAgent(Agent):
         api: str = None,
         namespace: str = None,
         image_pull_secrets: str = None,
-        resource_manager_enabled: bool = False,
         rbac: bool = False,
         latest: bool = False,
         mem_request: str = None,
@@ -710,8 +709,6 @@ class KubernetesAgent(Agent):
                 to `default`
             - image_pull_secrets (str, optional): The name of an image pull secret to use
                 for Prefect jobs
-            - resource_manager_enabled (bool, optional): Whether to include the resource
-                manager as part of the YAML. Defaults to `False`
             - rbac (bool, optional): Whether to include default RBAC configuration as
                 part of the YAML. Defaults to `False`
             - latest (bool, optional): Whether to use the `latest` Prefect image.
@@ -788,23 +785,6 @@ class KubernetesAgent(Agent):
         deployment["spec"]["template"]["spec"]["containers"][0][
             "image"
         ] = "prefecthq/prefect:{}".format(image_version)
-
-        # Populate resource manager if requested
-        if resource_manager_enabled:
-            resource_manager_env = deployment["spec"]["template"]["spec"]["containers"][
-                1
-            ]["env"]
-
-            resource_manager_env[0]["value"] = token
-            resource_manager_env[1]["value"] = api
-            resource_manager_env[3]["value"] = namespace
-
-            # Use local prefect version for image
-            deployment["spec"]["template"]["spec"]["containers"][1][
-                "image"
-            ] = "prefecthq/prefect:{}".format(image_version)
-        else:
-            del deployment["spec"]["template"]["spec"]["containers"][1]
 
         # Populate image pull secrets if provided
         if image_pull_secrets:

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -60,24 +60,3 @@ spec:
             initialDelaySeconds: 40
             periodSeconds: 40
             failureThreshold: 2
-        - name: resource-manager
-          image: prefecthq/prefect:latest
-          imagePullPolicy: Always
-          command: ["/bin/bash", "-c"]
-          args:
-            [
-              "python -c 'from prefect.agent.kubernetes import ResourceManager; ResourceManager().start()'",
-            ]
-          env:
-            - name: PREFECT__CLOUD__AGENT__AUTH_TOKEN
-              value: ""
-            - name: PREFECT__CLOUD__API
-              value: "https://api.prefect.io"
-            - name: PREFECT__CLOUD__AGENT__RESOURCE_MANAGER__LOOP_INTERVAL
-              value: "60"
-            - name: NAMESPACE
-              value: "default"
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "100m"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -291,12 +291,6 @@ def start(image_pull_secrets=None, **kwargs):
     "-i",
     help="Name of image pull secrets to use for workloads.",
 )
-@click.option(
-    "--resource-manager",
-    "resource_manager_enabled",
-    is_flag=True,
-    help="Enable resource manager.",
-)
 @click.option("--rbac", is_flag=True, help="Enable default RBAC.")
 @click.option("--latest", is_flag=True, help="Use the latest Prefect image.")
 @click.option("--mem-request", help="Requested memory for Prefect init job.")
@@ -752,9 +746,6 @@ def start(
     help="Name of image pull secrets to use for workloads.",
     hidden=True,
 )
-@click.option(
-    "--resource-manager", is_flag=True, help="Enable resource manager.", hidden=True
-)
 @click.option("--rbac", is_flag=True, help="Enable default RBAC.", hidden=True)
 @click.option(
     "--latest", is_flag=True, help="Use the latest Prefect image.", hidden=True
@@ -833,7 +824,6 @@ def install(
     api,
     namespace,
     image_pull_secrets,
-    resource_manager,
     rbac,
     latest,
     mem_request,
@@ -876,7 +866,6 @@ def install(
         --api, -a                   TEXT    A Prefect API URL
         --namespace, -n             TEXT    Agent namespace to launch workloads
         --image-pull-secrets, -i    TEXT    Name of image pull secrets to use for workloads
-        --resource-manager                  Enable resource manager on install
         --rbac                              Enable default RBAC on install
         --latest                            Use the `latest` Prefect image
         --mem-request               TEXT    Requested memory for Prefect init job
@@ -929,7 +918,6 @@ def install(
             api=api,
             namespace=namespace,
             image_pull_secrets=image_pull_secrets,
-            resource_manager_enabled=resource_manager,
             rbac=rbac,
             latest=latest,
             mem_request=mem_request,

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -526,25 +526,17 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, cloud_api):
         token="test_token",
         api="test_api",
         namespace="test_namespace",
-        resource_manager_enabled=True,
         backend="backend-test",
     )
 
     deployment = yaml.safe_load(deployment)
 
     agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
-    resource_manager_env = deployment["spec"]["template"]["spec"]["containers"][1][
-        "env"
-    ]
 
     assert agent_env[0]["value"] == "test_token"
     assert agent_env[1]["value"] == "test_api"
     assert agent_env[2]["value"] == "test_namespace"
     assert agent_env[11]["value"] == "backend-test"
-
-    assert resource_manager_env[0]["value"] == "test_token"
-    assert resource_manager_env[1]["value"] == "test_api"
-    assert resource_manager_env[3]["value"] == "test_namespace"
 
 
 def test_k8s_agent_generate_deployment_yaml_env_vars(monkeypatch, cloud_api):
@@ -610,16 +602,13 @@ def test_k8s_agent_generate_deployment_yaml_local_version(
         token="test_token",
         api="test_api",
         namespace="test_namespace",
-        resource_manager_enabled=True,
     )
 
     deployment = yaml.safe_load(deployment)
 
     agent_yaml = deployment["spec"]["template"]["spec"]["containers"][0]
-    resource_manager_yaml = deployment["spec"]["template"]["spec"]["containers"][1]
 
     assert agent_yaml["image"] == "prefecthq/prefect:{}".format(version[1])
-    assert resource_manager_yaml["image"] == "prefecthq/prefect:{}".format(version[1])
 
 
 def test_k8s_agent_generate_deployment_yaml_latest(monkeypatch, cloud_api):
@@ -634,40 +623,14 @@ def test_k8s_agent_generate_deployment_yaml_latest(monkeypatch, cloud_api):
         token="test_token",
         api="test_api",
         namespace="test_namespace",
-        resource_manager_enabled=True,
         latest=True,
     )
 
     deployment = yaml.safe_load(deployment)
 
     agent_yaml = deployment["spec"]["template"]["spec"]["containers"][0]
-    resource_manager_yaml = deployment["spec"]["template"]["spec"]["containers"][1]
 
     assert agent_yaml["image"] == "prefecthq/prefect:latest"
-    assert resource_manager_yaml["image"] == "prefecthq/prefect:latest"
-
-
-def test_k8s_agent_generate_deployment_yaml_no_resource_manager(monkeypatch, cloud_api):
-    get_jobs = MagicMock(return_value=[])
-    monkeypatch.setattr(
-        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
-        get_jobs,
-    )
-
-    agent = KubernetesAgent()
-    deployment = agent.generate_deployment_yaml(
-        token="test_token", api="test_api", namespace="test_namespace"
-    )
-
-    deployment = yaml.safe_load(deployment)
-
-    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
-
-    assert agent_env[0]["value"] == "test_token"
-    assert agent_env[1]["value"] == "test_api"
-    assert agent_env[2]["value"] == "test_namespace"
-
-    assert len(deployment["spec"]["template"]["spec"]["containers"]) == 1
 
 
 def test_k8s_agent_generate_deployment_yaml_labels(monkeypatch, cloud_api):

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -232,7 +232,7 @@ def test_agent_kubernetes_install(monkeypatch, deprecated):
     command.extend(
         (
             "--token TEST-TOKEN -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
-            "--api TEST_API --namespace TEST_NAMESPACE --resource-manager --rbac "
+            "--api TEST_API --namespace TEST_NAMESPACE --rbac "
             "--latest --image-pull-secrets secret-test --mem-request mem_req "
             "--mem-limit mem_lim --cpu-request cpu_req --cpu-limit cpu_lim "
             "--image-pull-policy custom_policy --service-account-name svc_name "
@@ -246,7 +246,6 @@ def test_agent_kubernetes_install(monkeypatch, deprecated):
         "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
         "api": "TEST_API",
         "namespace": "TEST_NAMESPACE",
-        "resource_manager_enabled": True,
         "rbac": True,
         "latest": True,
         "image_pull_secrets": "secret-test",


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
The Kubernetes resource manager was officially deprecated in `0.13.5` and all of its functionality (plus more) now exists inside the agent process. This PR removes the kwargs for setting the resource manager on the k8s agent install command however it does not fully remove the resource manager code as to not yet break any existing deployments that may be using it.



## Changes
Remove option to enable deprecated resource manager in `prefect agent kubernetes install` command.



## Importance
First step in removing this deprecated code.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)