### PR TITLE
Fix Azure result byte decoding

### DIFF
--- a/changes/issue3846.yaml
+++ b/changes/issue3846.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Azure result byte decoding of blob data - [#3846](https://github.com/PrefectHQ/prefect/issues/3846)"

--- a/src/prefect/engine/results/azure_result.py
+++ b/src/prefect/engine/results/azure_result.py
@@ -126,10 +126,10 @@ class AzureResult(Result):
             client = self.service.get_blob_client(
                 container=self.container, blob=location
             )
-            content_string = client.download_blob()
+            content_bytes = client.download_blob().content_as_bytes()
 
             try:
-                new.value = new.serializer.deserialize(content_string)
+                new.value = new.serializer.deserialize(content_bytes)
             except EOFError:
                 new.value = None
             self.logger.debug("Finished downloading result from {}.".format(location))

--- a/tests/engine/results/test_azure_result.py
+++ b/tests/engine/results/test_azure_result.py
@@ -58,7 +58,11 @@ class TestAzureResult:
         assert service.get_blob_client.call_args[1]["container"] == "foo"
 
     def test_azure_reads_and_updates_location(self, monkeypatch):
-        client = MagicMock(download_blob=MagicMock(return_value=b""))
+        client = MagicMock(
+            download_blob=MagicMock(
+                return_value=MagicMock(content_as_bytes=MagicMock(return_value=b""))
+            )
+        )
         service = MagicMock(get_blob_client=MagicMock(return_value=client))
         monkeypatch.setattr(
             "prefect.engine.results.azure_result.AzureResult.service", service


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Closes #3846 



## Changes
Fix the Azure result read function that was not previously decoding blob contents as bytes.



## Importance
Fix functionality



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)