### PR TITLE
Fix duplicate provided kwargs in aws utility

### DIFF
--- a/changes/pr3857.yaml
+++ b/changes/pr3857.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix AWS boto3 utility passing duplicate kwargs to client initialization - [#3857](https://github.com/PrefectHQ/prefect/pull/3857)"

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -39,25 +39,25 @@ def get_boto_client(
         aws_secret_access_key = ctx_credentials.get("SECRET_ACCESS_KEY")
         aws_session_token = ctx_credentials.get("SESSION_TOKEN")
 
+    kwargs_access_key_id = kwargs.pop("aws_access_key_id", None)
+    kwargs_secret_access_key = kwargs.pop("aws_secret_access_key", None)
+    kwargs_session_token = kwargs.pop("aws_session_token", None)
+
     if use_session:
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing  # noqa
         session = boto3.session.Session()
         return session.client(
             resource,
-            aws_access_key_id=aws_access_key or kwargs.pop("aws_access_key_id", None),
-            aws_secret_access_key=aws_secret_access_key
-            or kwargs.pop("aws_secret_access_key", None),
-            aws_session_token=aws_session_token
-            or kwargs.pop("aws_session_token", None),
+            aws_access_key_id=aws_access_key or kwargs_access_key_id,
+            aws_secret_access_key=aws_secret_access_key or kwargs_secret_access_key,
+            aws_session_token=aws_session_token or kwargs_session_token,
             **kwargs
         )
     else:
         return boto3.client(
             resource,
-            aws_access_key_id=aws_access_key or kwargs.pop("aws_access_key_id", None),
-            aws_secret_access_key=aws_secret_access_key
-            or kwargs.pop("aws_secret_access_key", None),
-            aws_session_token=aws_session_token
-            or kwargs.pop("aws_session_token", None),
+            aws_access_key_id=aws_access_key or kwargs_access_key_id,
+            aws_secret_access_key=aws_secret_access_key or kwargs_secret_access_key,
+            aws_session_token=aws_session_token or kwargs_session_token,
             **kwargs
         )

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -89,3 +89,21 @@ class TestGetBotoClient:
             "aws_secret_access_key": "secret",
             "aws_session_token": "session",
         }
+
+    def test_credentials_does_not_duplicate_kwargs(self, monkeypatch):
+        client = MagicMock()
+        boto3 = MagicMock(client=client)
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        get_boto_client(
+            resource="not a real resource",
+            credentials={"ACCESS_KEY": "true_key", "SECRET_ACCESS_KEY": "true_secret"},
+            aws_access_key_id="id",
+            aws_secret_access_key="secret",
+            aws_session_token="session",
+        )
+        kwargs = client.call_args[1]
+        assert kwargs == {
+            "aws_access_key_id": "true_key",
+            "aws_secret_access_key": "true_secret",
+            "aws_session_token": "session",
+        }


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Using the AWS utility to get a boto3 client like this

```python
get_boto_client(
    resource="not a real resource",
    credentials={"ACCESS_KEY": "true_key", "SECRET_ACCESS_KEY": "true_secret"},
    aws_access_key_id="id",
    aws_secret_access_key="secret",
    aws_session_token="session",
)
```

will currently fail due to the kwargs `.pop` not being called because it is only popped if no other credentials have been provided. Thus it was causing the issue where the variables to initialze the client could be passed in twice, leading to an error.

```
  File "/......./prefect/utilities/aws.py", line 55, in get_boto_client
    return boto3.client(
TypeError: boto3.client() got multiple values for keyword argument 'aws_access_key_id'
```

Issue originally raised in slack thread [here](https://prefect-community.slack.com/archives/C014Z8DPDSR/p1608143444327500)

## Changes
Pops the values off of the kwargs regardless of the existence of other values.



## Importance
Fix the aws utility for certain use cases!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)