### PR TITLE
Make `setup` method optional for resource managers

### DIFF
--- a/changes/pr3869.yaml
+++ b/changes/pr3869.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Make `setup` method optional for `resource_manager` tasks - [#3869](https://github.com/PrefectHQ/prefect/pull/3869)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -401,10 +401,13 @@ class Flow:
 
     @cache
     def _default_reference_tasks(self) -> Set[Task]:
-        from prefect.tasks.core.resource_manager import ResourceCleanupTask
+        from prefect.tasks.core.resource_manager import (
+            ResourceInitTask,
+            ResourceCleanupTask,
+        )
 
-        # Select all tasks that aren't ResourceCleanupTasks and have no
-        # downstream dependencies that aren't ResourceCleanupTasks
+        # Select all tasks that aren't a ResourceInitTask/ResourceCleanupTask
+        # and have no downstream dependencies that aren't ResourceCleanupTasks
         #
         # Note: this feels a bit gross, since it special cases a certain
         # subclass inside the flow runner. If this behavior expands to other
@@ -413,7 +416,7 @@ class Flow:
         return {
             t
             for t in self.tasks
-            if not isinstance(t, ResourceCleanupTask)
+            if not isinstance(t, (ResourceInitTask, ResourceCleanupTask))
             and not any(
                 t
                 for t in self.downstream_tasks(t)

--- a/tests/tasks/core/test_resource_manager.py
+++ b/tests/tasks/core/test_resource_manager.py
@@ -186,6 +186,56 @@ def test_resource_manager_generated_flow_structure(api):
     }
 
 
+def test_resource_manager_generated_flow_structure_no_setup():
+    @resource_manager
+    class MyResource:
+        def __init__(self, a):
+            self.a = a
+
+        def cleanup(self, val):
+            pass
+
+    with Flow("test") as flow:
+        a = inc(1)
+        context = MyResource(a)
+        with context as resource:
+            b = add(resource, a)
+            c = inc(b)
+            d = inc(2)
+            e = inc(d)
+            f = inc(3)
+        g = inc(f)
+
+    # task kwargs successfully forwarded to tasks
+    assert context.init_task.name == "MyResource"
+    assert context.setup_task is None
+    assert resource is None
+    assert context.cleanup_task.name == "MyResource.cleanup"
+    assert not context.cleanup_task.skip_on_upstream_skip
+
+    # Reference tasks setup properly
+    assert flow.reference_tasks() == {c, e, g}
+
+    # Check that:
+    # - Tasks with no downstream dependency in the resource context have
+    #   the cleanup task set as a downstream dependency
+    # - All other tasks only have explicit dependencies
+    assert flow.upstream_tasks(a) == set()
+    assert flow.upstream_tasks(context.init_task) == {a}
+    assert flow.upstream_tasks(b) == {a}
+    assert flow.upstream_tasks(c) == {b}
+    assert flow.upstream_tasks(d) == set()
+    assert flow.upstream_tasks(e) == {d}
+    assert flow.upstream_tasks(f) == set()
+    assert flow.upstream_tasks(g) == {f}
+    assert flow.upstream_tasks(context.cleanup_task) == {
+        context.init_task,
+        c,
+        e,
+        f,
+    }
+
+
 def test_resource_manager_execution_success():
     on_setup = MagicMock(return_value=100)
     on_cleanup = MagicMock()
@@ -201,6 +251,29 @@ def test_resource_manager_execution_success():
     state = flow.run()
     assert on_setup.called
     assert on_cleanup.call_args == ((100,), {})
+    assert state.is_successful()
+    for r in state.result.values():
+        assert r.is_successful()
+
+
+def test_resource_manager_execution_success_no_setup():
+    @resource_manager
+    class MyResource:
+        def __init__(self, on_cleanup):
+            self.on_cleanup = on_cleanup
+
+        def cleanup(self, val):
+            self.on_cleanup(val)
+
+    on_cleanup = MagicMock()
+
+    with Flow("test") as flow:
+        context = MyResource(on_cleanup)
+        with context:
+            inc(inc(1))
+
+    state = flow.run()
+    assert on_cleanup.call_args == ((None,), {})
     assert state.is_successful()
     for r in state.result.values():
         assert r.is_successful()


### PR DESCRIPTION
This makes the `setup` method optional for resource managers, allowing
creation of resource managers that only run a cleanup action on exit
from a block. This produces a slightly nicer graph in these cases, since
the `setup` task isn't needed.

Fixes #3841.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)