### PR TITLE
Support GCS versions < 1.31.0

### DIFF
--- a/changes/issue3870.yaml
+++ b/changes/issue3870.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Add support for `google-cloud-storage` < 1.31.0 - [#3875](https://github.com/PrefectHQ/prefect/pull/3875)"

--- a/src/prefect/engine/results/gcs_result.py
+++ b/src/prefect/engine/results/gcs_result.py
@@ -94,7 +94,13 @@ class GCSResult(Result):
 
         try:
             self.logger.debug("Starting to download result from {}...".format(location))
-            serialized_value = self.gcs_bucket.blob(location).download_as_bytes()
+            blob = self.gcs_bucket.blob(location)
+            # Support GCS < 1.31
+            serialized_value = (
+                blob.download_as_bytes()
+                if hasattr(blob, "download_as_bytes")
+                else blob.download_as_string()
+            )
             try:
                 new.value = new.serializer.deserialize(serialized_value)
             except EOFError:

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -99,7 +99,12 @@ class GCS(Storage):
                     flow_location, self.bucket
                 )
             )
-        content = blob.download_as_string()
+        # Support GCS < 1.31
+        content = (
+            blob.download_as_bytes()
+            if hasattr(blob, "download_as_bytes")
+            else blob.download_as_string()
+        )
 
         if self.stored_as_script:
             return extract_flow_from_file(file_contents=content)

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -168,14 +168,18 @@ class GCSDownload(GCSBaseTask):
         )
 
         # identify blob name
-        gcs_blob = self._get_blob(
+        blob = self._get_blob(
             bucket,
             blob,
             encryption_key=encryption_key,
             encryption_key_secret=encryption_key_secret,
         )
-        data = gcs_blob.download_as_string(timeout=request_timeout)
-        return data
+        # Support GCS < 1.31
+        return (
+            blob.download_as_bytes(timeout=request_timeout)
+            if hasattr(blob, "download_as_bytes")
+            else blob.download_as_string(timeout=request_timeout)
+        )
 
 
 class GCSUpload(GCSBaseTask):

--- a/src/prefect/utilities/filesystems.py
+++ b/src/prefect/utilities/filesystems.py
@@ -66,7 +66,12 @@ def read_bytes_from_path(path: str) -> bytes:
         blob = bucket.get_blob(parsed.path.lstrip("/"))
         if blob is None:
             raise ValueError(f"Job template doesn't exist at {path}")
-        return blob.download_as_bytes()
+        # Support GCS < 1.31
+        return (
+            blob.download_as_bytes()
+            if hasattr(blob, "download_as_bytes")
+            else blob.download_as_string()
+        )
     elif parsed.scheme == "s3":
         from prefect.utilities.aws import get_boto_client
 

--- a/tests/storage/test_gcs_storage.py
+++ b/tests/storage/test_gcs_storage.py
@@ -92,7 +92,7 @@ class TestGCSStorage:
         f = Flow("awesome-flow")
         flow_content = cloudpickle.dumps(f)
 
-        blob_mock = MagicMock(download_as_string=MagicMock(return_value=flow_content))
+        blob_mock = MagicMock(download_as_bytes=MagicMock(return_value=flow_content))
         bucket_mock = MagicMock(get_blob=MagicMock(return_value=blob_mock))
         google_client.return_value.get_bucket = MagicMock(return_value=bucket_mock)
 
@@ -107,13 +107,13 @@ class TestGCSStorage:
 
         assert fetched_flow.name == f.name
         bucket_mock.get_blob.assert_called_with("a-place")
-        assert blob_mock.download_as_string.call_count == 1
+        assert blob_mock.download_as_bytes.call_count == 1
 
     def test_get_flow_from_gcs_as_file(self, google_client):
         f = Flow("awesome-flow")
         flow_content = """from prefect import Flow\nf=Flow('awesome-flow')"""
 
-        blob_mock = MagicMock(download_as_string=MagicMock(return_value=flow_content))
+        blob_mock = MagicMock(download_as_bytes=MagicMock(return_value=flow_content))
         bucket_mock = MagicMock(get_blob=MagicMock(return_value=blob_mock))
         google_client.return_value.get_bucket = MagicMock(return_value=bucket_mock)
 
@@ -124,7 +124,7 @@ class TestGCSStorage:
 
         assert fetched_flow.name == f.name
         bucket_mock.get_blob.assert_called_with("a-place")
-        assert blob_mock.download_as_string.call_count == 1
+        assert blob_mock.download_as_bytes.call_count == 1
 
     def test_build_no_upload_if_file_and_no_local_script_path(self, google_client):
         storage = GCS(bucket="awesome-bucket", stored_as_script=True)


### PR DESCRIPTION
Use `download_as_string` if `download_as_bytes` isn't available.

Fixes #3870.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)