### PR TITLE
Fixup imagePullSecrets/serviceAccountName in k8s agent

### DIFF
--- a/changes/pr3884.yaml
+++ b/changes/pr3884.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix use of `imagePullSecrets`/`serviceAccountName` in k8s agent - [#3884](https://github.com/PrefectHQ/prefect/pull/3884)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -586,7 +586,7 @@ class KubernetesAgent(Agent):
         job["metadata"]["name"] = job_name
         job["metadata"]["labels"].update(**k8s_labels)
         job["spec"]["template"]["metadata"]["labels"].update(**k8s_labels)
-        pod_template = job["spec"]["template"]
+        pod_spec = job["spec"]["template"]["spec"]
 
         # Configure `service_account_name` if specified
         if run_config.service_account_name is not None:
@@ -594,7 +594,7 @@ class KubernetesAgent(Agent):
             service_account_name = (
                 run_config.service_account_name
             )  # type: Optional[str]
-        elif "serviceAccountName" in pod_template and (
+        elif "serviceAccountName" in pod_spec and (
             run_config.job_template or run_config.job_template_path
         ):
             # On run-config job-template, no override
@@ -603,7 +603,7 @@ class KubernetesAgent(Agent):
             # Use agent value, if provided
             service_account_name = self.service_account_name
         if service_account_name is not None:
-            pod_template["serviceAccountName"] = service_account_name
+            pod_spec["serviceAccountName"] = service_account_name
 
         # Configure `image_pull_secrets` if specified
         if run_config.image_pull_secrets is not None:
@@ -611,7 +611,7 @@ class KubernetesAgent(Agent):
             image_pull_secrets = (
                 run_config.image_pull_secrets
             )  # type: Optional[Iterable[str]]
-        elif "imagePullSecrets" in pod_template and (
+        elif "imagePullSecrets" in pod_spec and (
             run_config.job_template or run_config.job_template_path
         ):
             # On run-config job template, no override
@@ -620,7 +620,7 @@ class KubernetesAgent(Agent):
             # Use agent, if provided
             image_pull_secrets = self.image_pull_secrets
         if image_pull_secrets is not None:
-            pod_template["imagePullSecrets"] = [{"name": s} for s in image_pull_secrets]
+            pod_spec["imagePullSecrets"] = [{"name": s} for s in image_pull_secrets]
 
         # Default restartPolicy to Never
         _get_or_create(job, "spec.template.spec.restartPolicy", "Never")

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1279,14 +1279,16 @@ class TestK8sAgentRunConfig:
     def test_generate_job_spec_service_account_name(self, tmpdir):
         template_path = str(tmpdir.join("job.yaml"))
         template = self.read_default_template()
-        template["spec"]["template"]["serviceAccountName"] = "on-agent-template"
+        template["spec"]["template"]["spec"]["serviceAccountName"] = "on-agent-template"
         with open(template_path, "w") as f:
             yaml.safe_dump(template, f)
 
         self.agent.service_account_name = "on-agent"
         self.agent.job_template_path = template_path
 
-        template["spec"]["template"]["serviceAccountName"] = "on-run-config-template"
+        template["spec"]["template"]["spec"][
+            "serviceAccountName"
+        ] = "on-run-config-template"
 
         run_config = KubernetesRun(
             job_template=template, service_account_name="on-run-config"
@@ -1295,36 +1297,41 @@ class TestK8sAgentRunConfig:
         # Check precedence order:
         # 1. Explicit on run-config"
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] == "on-run-config"
+        assert job["spec"]["template"]["spec"]["serviceAccountName"] == "on-run-config"
 
         # 2. In job template on run-config
         run_config.service_account_name = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] == "on-run-config-template"
+        assert (
+            job["spec"]["template"]["spec"]["serviceAccountName"]
+            == "on-run-config-template"
+        )
         # None in run-config job template is still used
-        run_config.job_template["spec"]["template"]["serviceAccountName"] = None
+        run_config.job_template["spec"]["template"]["spec"]["serviceAccountName"] = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] is None
+        assert job["spec"]["template"]["spec"]["serviceAccountName"] is None
 
         # 3. Explicit on agent
         # Not present in job template
-        run_config.job_template["spec"]["template"].pop("serviceAccountName")
+        run_config.job_template["spec"]["template"]["spec"].pop("serviceAccountName")
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] == "on-agent"
+        assert job["spec"]["template"]["spec"]["serviceAccountName"] == "on-agent"
         # No job template present
         run_config.job_template = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] == "on-agent"
+        assert job["spec"]["template"]["spec"]["serviceAccountName"] == "on-agent"
 
         # 4. In job template on agent
         self.agent.service_account_name = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["serviceAccountName"] == "on-agent-template"
+        assert (
+            job["spec"]["template"]["spec"]["serviceAccountName"] == "on-agent-template"
+        )
 
     def test_generate_job_spec_image_pull_secrets(self, tmpdir):
         template_path = str(tmpdir.join("job.yaml"))
         template = self.read_default_template()
-        template["spec"]["template"]["imagePullSecrets"] = [
+        template["spec"]["template"]["spec"]["imagePullSecrets"] = [
             {"name": "on-agent-template"}
         ]
         with open(template_path, "w") as f:
@@ -1333,7 +1340,7 @@ class TestK8sAgentRunConfig:
         self.agent.image_pull_secrets = ["on-agent"]
         self.agent.job_template_path = template_path
 
-        template["spec"]["template"]["imagePullSecrets"] = [
+        template["spec"]["template"]["spec"]["imagePullSecrets"] = [
             {"name": "on-run-config-template"}
         ]
 
@@ -1344,34 +1351,38 @@ class TestK8sAgentRunConfig:
         # Check precedence order:
         # 1. Explicit on run-config"
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] == [
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
             {"name": "on-run-config"}
         ]
 
         # 2. In job template on run-config
         run_config.image_pull_secrets = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] == [
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
             {"name": "on-run-config-template"}
         ]
         # None in run-config job template is still used
-        run_config.job_template["spec"]["template"]["imagePullSecrets"] = None
+        run_config.job_template["spec"]["template"]["spec"]["imagePullSecrets"] = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] is None
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] is None
 
         # 3. Explicit on agent
         # Not present in job template
-        run_config.job_template["spec"]["template"].pop("imagePullSecrets")
+        run_config.job_template["spec"]["template"]["spec"].pop("imagePullSecrets")
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] == [{"name": "on-agent"}]
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
+            {"name": "on-agent"}
+        ]
         # No job template present
         run_config.job_template = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] == [{"name": "on-agent"}]
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
+            {"name": "on-agent"}
+        ]
 
         # 4. In job template on agent
         self.agent.image_pull_secrets = None
         job = self.agent.generate_job_spec(self.build_flow_run(run_config))
-        assert job["spec"]["template"]["imagePullSecrets"] == [
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
             {"name": "on-agent-template"}
         ]


### PR DESCRIPTION
Previously these were inserted at the wrong level in the k8s agent.
Updates code and tests appropriately.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)