### PR TITLE
Fixup read_bytes_from_path on s3

### DIFF
--- a/changes/pr3885.yaml
+++ b/changes/pr3885.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `read_bytes_from_path` to work properly with S3 - [#3885](https://github.com/PrefectHQ/prefect/pull/3885)"

--- a/src/prefect/utilities/filesystems.py
+++ b/src/prefect/utilities/filesystems.py
@@ -77,7 +77,9 @@ def read_bytes_from_path(path: str) -> bytes:
 
         client = get_boto_client(resource="s3")
         stream = io.BytesIO()
-        client.download_fileobj(Bucket=parsed.netloc, Key=parsed.path, Fileobj=stream)
+        client.download_fileobj(
+            Bucket=parsed.netloc, Key=parsed.path.lstrip("/"), Fileobj=stream
+        )
         return stream.getvalue()
     else:
         raise ValueError(f"Unsupported file scheme {path}")

--- a/tests/utilities/test_filesystems.py
+++ b/tests/utilities/test_filesystems.py
@@ -74,5 +74,5 @@ class Test_read_bytes_from_path:
         )
         res = read_bytes_from_path("s3://mybucket/path/to/thing.yaml")
         assert client.download_fileobj.call_args[1]["Bucket"] == "mybucket"
-        assert client.download_fileobj.call_args[1]["Key"] == "/path/to/thing.yaml"
+        assert client.download_fileobj.call_args[1]["Key"] == "path/to/thing.yaml"
         assert isinstance(res, bytes)


### PR DESCRIPTION
Previously this would erroneously pass in the file key with a leading `/`, leading to api errors. I could have sworn we QA'd this against a real deployment months ago and it worked, but apparently not. I've tested this against a real S3 bucket and can confirm things are working appropriately.

Fixes #3876.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)