### PR TITLE
Fix `StartFlowRun` idempotency_key

### DIFF
--- a/changes/pr3892.yaml
+++ b/changes/pr3892.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Change default `idempotency_key` in `StartFlowRun` to use `task_run_id` instead of `flow_run_id` - [#3892](https://github.com/PrefectHQ/prefect/pull/3892)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -30,10 +30,6 @@ class StartFlowRun(Task):
             state as the state of this task.  Defaults to `False`.
         - new_flow_context (dict, optional): the optional run context for the new flow run
         - run_name (str, optional): name to be set for the flow run
-        - idempotency_key (str, optional): a unique idempotency key for scheduling the
-            flow run. Duplicate flow runs with the same idempotency key will only create
-            a single flow run. This is useful for ensuring that only one run is created
-            if this task is retried. If not provided, defaults to the active `task_run_id`.
         - scheduled_start_time (datetime, optional): the time to schedule the execution
             for; if not provided, defaults to now
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
@@ -47,7 +43,6 @@ class StartFlowRun(Task):
         wait: bool = False,
         new_flow_context: dict = None,
         run_name: str = None,
-        idempotency_key: str = None,
         scheduled_start_time: datetime.datetime = None,
         **kwargs: Any,
     ):
@@ -56,7 +51,6 @@ class StartFlowRun(Task):
         self.parameters = parameters
         self.new_flow_context = new_flow_context
         self.run_name = run_name
-        self.idempotency_key = idempotency_key
         self.wait = wait
         self.scheduled_start_time = scheduled_start_time
         if flow_name:
@@ -69,7 +63,6 @@ class StartFlowRun(Task):
         "parameters",
         "new_flow_context",
         "run_name",
-        "idempotency_key",
         "scheduled_start_time",
     )
     def run(

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -25,11 +25,15 @@ class StartFlowRun(Task):
             running with Prefect Core's server as the backend, this should not be provided.
         - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
             this value may also be provided at run time
-        - new_flow_context (dict, optional): the optional run context for the new flow run
-        - run_name (str, optional): name to be set for the flow run
         - wait (bool, optional): whether to wait the triggered flow run's state; if True, this
             task will wait until the flow run is complete, and then reflect the corresponding
             state as the state of this task.  Defaults to `False`.
+        - new_flow_context (dict, optional): the optional run context for the new flow run
+        - run_name (str, optional): name to be set for the flow run
+        - idempotency_key (str, optional): a unique idempotency key for scheduling the
+            flow run. Duplicate flow runs with the same idempotency key will only create
+            a single flow run. This is useful for ensuring that only one run is created
+            if this task is retried. If not provided, defaults to the active `task_run_id`.
         - scheduled_start_time (datetime, optional): the time to schedule the execution
             for; if not provided, defaults to now
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
@@ -43,6 +47,7 @@ class StartFlowRun(Task):
         wait: bool = False,
         new_flow_context: dict = None,
         run_name: str = None,
+        idempotency_key: str = None,
         scheduled_start_time: datetime.datetime = None,
         **kwargs: Any,
     ):
@@ -51,6 +56,7 @@ class StartFlowRun(Task):
         self.parameters = parameters
         self.new_flow_context = new_flow_context
         self.run_name = run_name
+        self.idempotency_key = idempotency_key
         self.wait = wait
         self.scheduled_start_time = scheduled_start_time
         if flow_name:
@@ -63,6 +69,7 @@ class StartFlowRun(Task):
         "parameters",
         "new_flow_context",
         "run_name",
+        "idempotency_key",
         "scheduled_start_time",
     )
     def run(
@@ -70,9 +77,9 @@ class StartFlowRun(Task):
         flow_name: str = None,
         project_name: str = None,
         parameters: dict = None,
-        idempotency_key: str = None,
         new_flow_context: dict = None,
         run_name: str = None,
+        idempotency_key: str = None,
         scheduled_start_time: datetime.datetime = None,
     ) -> str:
         """
@@ -87,11 +94,12 @@ class StartFlowRun(Task):
             - parameters (dict, optional): the parameters to pass to the flow run being
                 scheduled; if not provided, this method will use the parameters provided at
                 initialization
-            - idempotency_key (str, optional): an optional idempotency key for scheduling the
-                flow run; if provided, ensures that only one run is created if this task is retried
-                or rerun with the same inputs.  If not provided, the current flow run ID will be used.
             - new_flow_context (dict, optional): the optional run context for the new flow run
             - run_name (str, optional): name to be set for the flow run
+            - idempotency_key (str, optional): a unique idempotency key for scheduling the
+                flow run. Duplicate flow runs with the same idempotency key will only create
+                a single flow run. This is useful for ensuring that only one run is created
+                if this task is retried. If not provided, defaults to the active `task_run_id`.
             - scheduled_start_time (datetime, optional): the time to schedule the execution
                 for; if not provided, defaults to now
 
@@ -147,20 +155,15 @@ class StartFlowRun(Task):
         # grab the ID for the most recent version
         flow_id = flow[0].id
 
-        idem_key = None
-        if context.get("flow_run_id"):
-            map_index = context.get("map_index")
-            default = context.get("flow_run_id") + (
-                f"-{map_index}" if map_index else ""
-            )
-            idem_key = idempotency_key or default
+        if idempotency_key is None:
+            idempotency_key = context.get("task_run_id", None)
 
         # providing an idempotency key ensures that retries for this task
         # will not create additional flow runs
         flow_run_id = client.create_flow_run(
             flow_id=flow_id,
             parameters=parameters,
-            idempotency_key=idem_key or idempotency_key,
+            idempotency_key=idempotency_key,
             context=new_flow_context,
             run_name=run_name,
             scheduled_start_time=scheduled_start_time,

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -72,11 +72,10 @@ class TestStartFlowRunCloud:
             flow_name="Test Flow",
             parameters={"test": "ing"},
             run_name="test-run",
-            idempotency_key=idempotency_key,
         )
         # verify that run returns the new flow run ID
         with prefect.context(task_run_id=task_run_id):
-            assert task.run() == "xyz890"
+            assert task.run(idempotency_key=idempotency_key) == "xyz890"
         # verify the GraphQL query was called with the correct arguments
         query_args = list(client.graphql.call_args_list[0][0][0]["query"].keys())[0]
         assert "Test Project" in query_args


### PR DESCRIPTION
- Adds `idempotency_key` as a kwarg to `StartFlowRun` constructor for
  parity with its use in `run`.
- Changes the default `idempotency_key` to use `task_run_id` instead of
  `flow_run_id`. The previous default would lead to only a single flow
  run being created if multiple `StartFlowRun` tasks were created for
  the same flow without relying on mapping.


This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)