### PR TITLE
Per flow run run config

### DIFF
--- a/changes/pr3903.yaml
+++ b/changes/pr3903.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Support for specifying `run_config` for an individual flow run - [#3903](https://github.com/PrefectHQ/prefect/pull/3903)"
+
+task:
+  - "Add support for specifying a `run_config` in `StartFlowRun` - [#3903](https://github.com/PrefectHQ/prefect/pull/3903)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -586,11 +586,11 @@ class Agent:
                     "serialized_state": True,
                     "parameters": True,
                     "scheduled_start_time": True,
+                    "run_config": True,
                     "flow": {
                         "id",
                         "name",
                         "environment",
-                        "run_config",
                         "storage",
                         "version",
                         "core_version",
@@ -698,8 +698,8 @@ class Agent:
                 environment-based flow.
         """
         # If the flow is using a run_config, load it
-        if getattr(flow_run.flow, "run_config", None) is not None:
-            run_config = RunConfigSchema().load(flow_run.flow.run_config)
+        if getattr(flow_run, "run_config", None) is not None:
+            run_config = RunConfigSchema().load(flow_run.run_config)
             if isinstance(run_config, UniversalRun):
                 # Convert to agent-specific run-config
                 return run_config_cls(labels=run_config.labels)

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -8,6 +8,7 @@ from prefect import context, Task
 from prefect.artifacts import create_link
 from prefect.client import Client
 from prefect.engine.signals import signal_from_state
+from prefect.run_configs import RunConfig
 from prefect.utilities.graphql import EnumValue, with_args
 from prefect.utilities.tasks import defaults_from_attrs
 
@@ -25,6 +26,8 @@ class StartFlowRun(Task):
             running with Prefect Core's server as the backend, this should not be provided.
         - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
             this value may also be provided at run time
+        - run_config (RunConfig, optional): a run-config to use for this flow
+            run, overriding any existing flow settings.
         - wait (bool, optional): whether to wait the triggered flow run's state; if True, this
             task will wait until the flow run is complete, and then reflect the corresponding
             state as the state of this task.  Defaults to `False`.
@@ -40,6 +43,7 @@ class StartFlowRun(Task):
         flow_name: str = None,
         project_name: str = None,
         parameters: dict = None,
+        run_config: RunConfig = None,
         wait: bool = False,
         new_flow_context: dict = None,
         run_name: str = None,
@@ -49,6 +53,7 @@ class StartFlowRun(Task):
         self.flow_name = flow_name
         self.project_name = project_name
         self.parameters = parameters
+        self.run_config = run_config
         self.new_flow_context = new_flow_context
         self.run_name = run_name
         self.wait = wait
@@ -61,6 +66,7 @@ class StartFlowRun(Task):
         "flow_name",
         "project_name",
         "parameters",
+        "run_config",
         "new_flow_context",
         "run_name",
         "scheduled_start_time",
@@ -70,6 +76,7 @@ class StartFlowRun(Task):
         flow_name: str = None,
         project_name: str = None,
         parameters: dict = None,
+        run_config: RunConfig = None,
         new_flow_context: dict = None,
         run_name: str = None,
         idempotency_key: str = None,
@@ -87,6 +94,8 @@ class StartFlowRun(Task):
             - parameters (dict, optional): the parameters to pass to the flow run being
                 scheduled; if not provided, this method will use the parameters provided at
                 initialization
+            - run_config (RunConfig, optional): a run-config to use for this flow
+                run, overriding any existing flow settings.
             - new_flow_context (dict, optional): the optional run context for the new flow run
             - run_name (str, optional): name to be set for the flow run
             - idempotency_key (str, optional): a unique idempotency key for scheduling the
@@ -156,6 +165,7 @@ class StartFlowRun(Task):
         flow_run_id = client.create_flow_run(
             flow_id=flow_id,
             parameters=parameters,
+            run_config=run_config,
             idempotency_key=idempotency_key,
             context=new_flow_context,
             run_name=run_name,

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -22,7 +22,7 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
     from prefect.serialization.run_config import RunConfigSchema
     from prefect.serialization.environment import EnvironmentSchema
 
-    has_run_config = getattr(flow_run.flow, "run_config", None) is not None
+    has_run_config = getattr(flow_run, "run_config", None) is not None
     has_environment = getattr(flow_run.flow, "environment", None) is not None
 
     storage = StorageSchema().load(flow_run.flow.storage)
@@ -32,7 +32,7 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
         if isinstance(storage, Docker):
             return storage.name
         elif has_run_config:
-            run_config = RunConfigSchema().load(flow_run.flow.run_config)
+            run_config = RunConfigSchema().load(flow_run.run_config)
             if getattr(run_config, "image", None) is not None:
                 return run_config.image
         # No image found on run-config, and no environment present. Use default.

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -171,7 +171,8 @@ def test_populate_env_vars_from_run_config(api):
             {
                 "id": "id",
                 "name": "name",
-                "flow": {"id": "foo", "run_config": run.serialize()},
+                "flow": {"id": "foo"},
+                "run_config": run.serialize(),
             }
         ),
         "test-image",
@@ -289,10 +290,10 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
                         "id": "foo",
                         "name": "flow-name",
                         "storage": storage.serialize(),
-                        "run_config": run.serialize() if run else None,
                         "core_version": "0.13.11",
                     }
                 ),
+                "run_config": run.serialize() if run else None,
                 "id": "id",
                 "name": "name",
             }
@@ -319,12 +320,12 @@ def test_docker_agent_deploy_flow_unsupported_run_config(api):
                     "flow": GraphQLResult(
                         {
                             "storage": Local().serialize(),
-                            "run_config": LocalRun().serialize(),
                             "id": "foo",
                             "name": "flow-name",
                             "core_version": "0.13.0",
                         }
                     ),
+                    "run_config": LocalRun().serialize(),
                     "id": "id",
                     "name": "name",
                     "version": "version",

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -275,13 +275,13 @@ class TestGenerateTaskDefinition:
                 "flow": GraphQLResult(
                     {
                         "storage": storage.serialize(),
-                        "run_config": run_config.serialize(),
                         "id": "flow-id",
                         "version": 1,
                         "name": "Test Flow",
                         "core_version": "0.13.0",
                     }
                 ),
+                "run_config": run_config.serialize(),
                 "id": "flow-run-id",
             }
         )
@@ -426,13 +426,13 @@ class TestGetRunTaskKwargs:
                 "flow": GraphQLResult(
                     {
                         "storage": Local().serialize(),
-                        "run_config": run_config.serialize(),
                         "id": "flow-id",
                         "version": 1,
                         "name": "Test Flow",
                         "core_version": "0.13.0",
                     }
                 ),
+                "run_config": run_config.serialize(),
                 "id": "flow-run-id",
             }
         )
@@ -558,13 +558,13 @@ class TestDeployFlow:
                 "flow": GraphQLResult(
                     {
                         "storage": Local().serialize(),
-                        "run_config": run_config.serialize() if run_config else None,
                         "id": "flow-id",
                         "version": 1,
                         "name": "Test Flow",
                         "core_version": "0.13.0",
                     }
                 ),
+                "run_config": run_config.serialize() if run_config else None,
                 "id": "flow-run-id",
             }
         )

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1098,11 +1098,11 @@ class TestK8sAgentRunConfig:
                 "flow": GraphQLResult(
                     {
                         "storage": storage.serialize(),
-                        "run_config": None if config is None else config.serialize(),
                         "id": "new_id",
                         "core_version": core_version,
                     }
                 ),
+                "run_config": None if config is None else config.serialize(),
                 "id": "id",
             }
         )

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -197,7 +197,8 @@ def test_populate_env_vars_from_run_config(tmpdir):
             {
                 "id": "id",
                 "name": "name",
-                "flow": {"id": "foo", "run_config": run.serialize()},
+                "flow": {"id": "foo"},
+                "run_config": run.serialize(),
             }
         ),
         run,
@@ -320,10 +321,10 @@ def test_local_agent_deploy_unsupported_run_config(monkeypatch):
                     "id": "id",
                     "flow": {
                         "storage": Local().serialize(),
-                        "run_config": KubernetesRun().serialize(),
                         "id": "foo",
                         "core_version": "0.13.0",
                     },
+                    "run_config": KubernetesRun().serialize(),
                 },
             )
         )
@@ -345,10 +346,10 @@ def test_local_agent_deploy_null_or_univeral_run_config(monkeypatch, run_config)
                 "id": "id",
                 "flow": {
                     "storage": Local().serialize(),
-                    "run_config": run_config.serialize() if run_config else None,
                     "id": "foo",
                     "core_version": "0.13.0",
                 },
+                "run_config": run_config.serialize() if run_config else None,
             },
         )
     )
@@ -373,10 +374,10 @@ def test_local_agent_deploy_run_config_working_dir(monkeypatch, working_dir, tmp
                 "id": "id",
                 "flow": {
                     "storage": Local().serialize(),
-                    "run_config": LocalRun(working_dir=working_dir).serialize(),
                     "id": "foo",
                     "core_version": "0.13.0",
                 },
+                "run_config": LocalRun(working_dir=working_dir).serialize(),
             },
         )
     )
@@ -401,10 +402,10 @@ def test_local_agent_deploy_run_config_missing_working_dir(monkeypatch, tmpdir):
                     "id": "id",
                     "flow": {
                         "storage": Local().serialize(),
-                        "run_config": LocalRun(working_dir=working_dir).serialize(),
                         "id": "foo",
                         "core_version": "0.13.0",
                     },
+                    "run_config": LocalRun(working_dir=working_dir).serialize(),
                 },
             )
         )

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import MagicMock
 
 import prefect
+from prefect.run_configs import UniversalRun
 from prefect.tasks.prefect.flow_run import StartFlowRun
 
 
@@ -40,6 +41,7 @@ def test_deprecated_old_name():
 class TestStartFlowRunCloud:
     def test_initialization(self, cloud_api):
         now = pendulum.now()
+        run_config = UniversalRun()
 
         # verify that the task is initialized as expected
         task = StartFlowRun(
@@ -49,6 +51,7 @@ class TestStartFlowRunCloud:
             flow_name="Test Flow",
             new_flow_context={"foo": "bar"},
             parameters={"test": "ing"},
+            run_config=run_config,
             run_name="test-run",
             scheduled_start_time=now,
         )
@@ -58,6 +61,7 @@ class TestStartFlowRunCloud:
         assert task.flow_name == "Test Flow"
         assert task.new_flow_context == {"foo": "bar"}
         assert task.parameters == {"test": "ing"}
+        assert task.run_config == run_config
         assert task.run_name == "test-run"
         assert task.scheduled_start_time == now
 
@@ -66,11 +70,14 @@ class TestStartFlowRunCloud:
     def test_flow_run_task_submit_args(
         self, client, cloud_api, idempotency_key, task_run_id
     ):
+        run_config = UniversalRun()
+
         # verify that create_flow_run was called
         task = StartFlowRun(
             project_name="Test Project",
             flow_name="Test Flow",
             parameters={"test": "ing"},
+            run_config=run_config,
             run_name="test-run",
         )
         # verify that run returns the new flow run ID
@@ -85,6 +92,7 @@ class TestStartFlowRunCloud:
         assert client.create_flow_run.call_args[1] == dict(
             flow_id="abc123",
             parameters={"test": "ing"},
+            run_config=run_config,
             idempotency_key=idempotency_key or task_run_id,
             context=None,
             run_name="test-run",
@@ -110,6 +118,7 @@ class TestStartFlowRunCloud:
             context=None,
             run_name=None,
             scheduled_start_time=in_one_hour,
+            run_config=None,
         )
 
     def test_flow_run_task_without_flow_name(self, cloud_api):
@@ -191,6 +200,7 @@ class TestStartFlowRunServer:
             context=None,
             run_name="test-run",
             scheduled_start_time=None,
+            run_config=None,
         )
 
     def test_flow_run_task_without_flow_name(self, server_api):

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -71,10 +71,10 @@ def test_get_flow_image_run_config_docker_storage(run_config):
                     "storage": Docker(
                         registry_url="test", image_name="name", image_tag="tag"
                     ).serialize(),
-                    "run_config": run_config.serialize() if run_config else None,
                     "id": "id",
                 }
             ),
+            "run_config": run_config.serialize() if run_config else None,
             "id": "id",
         }
     )
@@ -91,10 +91,10 @@ def test_get_flow_image_run_config_default_value_from_core_version(run_config, v
                 {
                     "core_version": version,
                     "storage": Local().serialize(),
-                    "run_config": run_config.serialize() if run_config else None,
                     "id": "id",
                 }
             ),
+            "run_config": run_config.serialize() if run_config else None,
             "id": "id",
         }
     )
@@ -109,10 +109,10 @@ def test_get_flow_image_run_config_image_on_RunConfig():
             "flow": GraphQLResult(
                 {
                     "storage": Local().serialize(),
-                    "run_config": KubernetesRun(image="myfancyimage").serialize(),
                     "id": "id",
                 }
             ),
+            "run_config": KubernetesRun(image="myfancyimage").serialize(),
             "id": "id",
         }
     )


### PR DESCRIPTION
This adds support for per-flow-run `run_config`. This shouldn't be merged until upstream support is finished (server PR is https://github.com/PrefectHQ/server/pull/166).

From a core interface perspective, there's only 2 user-facing changes

- Addition of `run_config` parameter in `Client.create_flow_run`
- Addition of `run_config` parameter in `StartFlowRun` task

Part of #3858.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)