### PR TITLE
Assorted docs cleanups

### DIFF
--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -64,7 +64,7 @@ mutation($flow: JSON!) {
 
 Every registered flow is part of a version group and has a version group id and a flow group id. 
 
-Version group ids are deprecated but maintained for backwards compatibility. The version group id can be provided when [registering a flow](/api/latest/core/flow.html#flow-2). If no version group id is provided at registration, the platform checks if any other flows in the same project have the same name as the new flow. If so, the new flow is assigned to the same version group as the other flow.  Version group ids can be used when creating a flow run and, if provided, the unique unarchived version in this version group will be run; this input is useful as a stable API for running a regularly updated flow.
+The version group id can be provided when [registering a flow](/api/latest/core/flow.html#flow-2). If no version group id is provided at registration, the platform checks if any other flows in the same project have the same name as the new flow. If so, the new flow is assigned to the same version group as the other flow.  Version group ids can be used when creating a flow run and, if provided, the unique unarchived version in this version group will be run; this input is useful as a stable API for running a regularly updated flow.
 
 The flow group id is a UUID and is not currently editable.  The flow group id can be used when setting [flow group settings](/orchestration/ui/flow.html#flow-group-settings) such as default parameters and labels.
 

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -31,10 +31,14 @@ flow.storage.build()
 
 The flow is now available under `~/.prefect/flows/local-flow.prefect`.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with the hostname of the machine from which it was registered; this prevents agents not running on the same machine from attempting to run this flow.
+::: tip Automatic Labels
+Flows registered with this storage option will automatically be labeled with
+the hostname of the machine from which it was registered; this prevents agents
+not running on the same machine from attempting to run this flow.
+:::
 
-Additionally, in more recent releases of Core your flow will default to using a `LocalResult` for persisting any task results in the same file location.
+::: tip Flow Results
+In more recent releases of Core your flow will default to using a `LocalResult` for persisting any task results in the same file location.
 :::
 
 ## Azure Blob Storage
@@ -52,10 +56,8 @@ flow.storage.build()
 
 The flow is now available in the container under `azure-flow/slugified-current-timestamp`.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"azure-flow-storage"`; this prevents agents not explicitly authenticated with your Azure deployment from attempting to run this flow.
-
-Additionally, in more recent releases of Core your flow will default to using a `AzureResult` for persisting any task results in the same Azure container.
+::: tip Flow Results
+In more recent releases of Core your flow will default to using a `AzureResult` for persisting any task results in the same Azure container.
 :::
 
 :::tip Azure Credentials
@@ -77,10 +79,8 @@ flow.storage.build()
 
 The flow is now available in the bucket under `s3-flow/slugified-current-timestamp`.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"s3-flow-storage"`; this helps prevent agents not explicitly authenticated with your AWS deployment from attempting to run this flow.
-
-Additionally, in more recent releases of Core your flow will default to using a `S3Result` for persisting any task results in the same S3 bucket.
+::: tip Flow Results
+In more recent releases of Core your flow will default to using a `S3Result` for persisting any task results in the same S3 bucket.
 :::
 
 :::tip AWS Credentials
@@ -102,10 +102,8 @@ flow.storage.build()
 
 The flow is now available in the bucket under `gcs-flow/slugified-current-timestamp`.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"gcs-flow-storage"`; this helps prevents agents not explicitly authenticated with your GCS project from attempting to run this flow.
-
-Additionally, in more recent releases of Core your flow will default to using a `GCSResult` for persisting any task results in the same GCS location.
+::: tip Flow Results
+In more recent releases of Core your flow will default to using a `GCSResult` for persisting any task results in the same GCS location.
 :::
 
 :::tip Google Cloud Credentials
@@ -118,10 +116,6 @@ GCS Storage uses Google Cloud credentials the same way as the standard [google.c
 
 For a detailed look on how to use GitHub storage visit the [Using file based storage](/core/idioms/file-based.html) idiom.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"github-flow-storage"`; this helps prevents agents not explicitly authenticated with your GitHub repo from attempting to run this flow.
-:::
-
 :::tip GitHub Credentials
 GitHub storage uses a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for authenticating with repositories.
 :::
@@ -131,10 +125,6 @@ GitHub storage uses a [personal access token](https://help.github.com/en/github/
 [GitLab Storage](/api/latest/storage.html#github) is a storage option that uploads flows to a GitLab repository as `.py` files.
 
 Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to GitLab as well.
-
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"gitlab-flow-storage"`; this helps prevents agents not explicitly authenticated with your GitLab repo from attempting to run this flow.
-:::
 
 :::tip GitLab Credentials
 GitLab storage uses a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for authenticating with repositories.
@@ -150,10 +140,6 @@ GitLab server users can point the `host` argument to their personal GitLab insta
 
 Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"bitbucket-flow-storage"`; this helps prevents agents not explicitly authenticated with your Bitbucket repo from attempting to run this flow.
-:::
-
 :::tip Bitbucket Credentials
 Bitbucket storage uses a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) for authenticating with repositories.
 :::
@@ -168,10 +154,6 @@ Unlike GitHub or GitLab, Bitbucket organizes repositories in Projects and each r
 ## CodeCommit
 
 [CodeCommit Storage](/api/latest/storage.html#codecommit) is a storage option that uploads flows to a CodeCommit repository as `.py` files.
-
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"codecommit-flow-storage"`; this helps prevent agents not explicitly authenticated with your AWS deployment from attempting to run this flow.
-:::
 
 :::tip AWS Credentials
 S3 Storage uses AWS credentials the same way as [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) which means both upload (build) and download (local agent) times need to have proper AWS credential configuration.
@@ -246,10 +228,6 @@ flow.storage.build()
 
 Template strings in `${}` are used to reference sensitive information. Given `${SOME_TOKEN}`, this storage object will first look in environment variable `SOME_TOKEN` and then fall back to [Prefect secrets](/core/concepts/secrets.html) `SOME_TOKEN`. Because this resolution is at runtime, this storage option never has your sensitive information stored in it and that sensitive information is never sent to Prefect Cloud.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with `"webhook-flow-storage"`. Add that label to an agent to tell Prefect Cloud that that agent should run flows with `Webhook` storage.
-:::
-
 ### Non-Docker Storage for Containerized Environments
 
 Prefect allows for flows to be stored in cloud storage services and executed in containerized environments. This has the added benefit of rapidly deploying new versions of flows without having to rebuild images each time. To enable this functionality add an image name to the flow's Environment metadata.
@@ -269,8 +247,6 @@ flow.environment = LocalEnvironment(metadata={"image": "repo/name:tag"})
 ```
 
 This example flow can now be run using an agent that orchestrates containerized environments. When the flow is run the image set in the environment's metadata will be used and inside that container the flow will be retrieved from the storage object (which is S3 in this example).
-
-Make sure that the agent's labels match the desired labels for the flow storage objects. For example, if you are using `prefect.storage.s3` to store flows, the agent should get label `s3-flow-storage`. See the `"Sensible Defaults"` tips in the previous sections for more details.
 
 ```bash
 # starting a kubernetes agent that will pull flows stored in S3

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -46,13 +46,15 @@ flow = Flow("local-flow", storage=Local())
 
 After registration, the flow will be stored at `~/.prefect/flows/local-flow.prefect`.
 
-:::tip Sensible Defaults
+:::tip Automatic Labels
 Flows registered with this storage option will automatically be labeled with
 the hostname of the machine from which it was registered; this prevents agents
 not running on the same machine from attempting to run this flow.
+:::
 
-Additionally, your flow will default to using a `LocalResult` for persisting
-any task results in the same file location.
+:::tip Flow Results
+Flows configured with `Local` storage also default to using a `LocalResult` for
+persisting any task results in the same filesystem.
 :::
 
 ## AWS S3
@@ -70,13 +72,9 @@ flow = Flow("s3-flow", storage=S3(bucket="<my-bucket>"))
 After registration, the flow will be stored in the specified bucket under
 `s3-flow/<slugified-current-timestamp>`.
 
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"s3-flow-storage"`; this helps prevent agents not explicitly authenticated
-with your AWS deployment from attempting to run this flow.
-
-Additionally your flow will default to using a `S3Result` for persisting any
-task results in the same S3 bucket.
+:::tip Flow Results
+Flows configured with `S3` storage also default to using a `S3Result` for
+persisting any task results in the same S3 bucket.
 :::
 
 :::tip AWS Credentials
@@ -107,13 +105,9 @@ flow = Flow(
 After registration, the flow will be stored in the container under
 `azure-flow/<slugified-current-timestamp>`.
 
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"azure-flow-storage"`; this prevents agents not explicitly authenticated with
-your Azure deployment from attempting to run this flow.
-
-Additionally your flow will default to using a `AzureResult` for persisting any
-task results in the same Azure container.
+:::tip Flow Results
+Flows configured with `Azure` storage also default to using an `AzureResult` for
+persisting any task results to the same container in Azure Blob storage.
 :::
 
 :::tip Azure Credentials
@@ -140,13 +134,9 @@ flow = Flow("gcs-flow", storage=GCS(bucket="<my-bucket>"))
 After registration the flow will be stored in the specified bucket under
 `gcs-flow/<slugified-current-timestamp>`.
 
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"gcs-flow-storage"`; this helps prevents agents not explicitly authenticated
-with your GCS project from attempting to run this flow.
-
-Additionally, your flow will default to using a `GCSResult` for persisting any
-task results in the same GCS location.
+:::tip Flow Results
+Flows configured with `GCS` storage also default to using a `GCSResult` for
+persisting any task results in the same GCS location.
 :::
 
 :::tip Google Cloud Credentials
@@ -179,12 +169,6 @@ flow = Flow(
 For a detailed look on how to use GitHub storage visit the [Using file based
 storage](/core/idioms/file-based.md) idiom.
 
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"github-flow-storage"`; this helps prevents agents not explicitly
-authenticated with your GitHub repo from attempting to run this flow.
-:::
-
 :::tip GitHub Credentials
 GitHub storage uses a [personal access
 token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
@@ -212,12 +196,6 @@ flow = Flow(
 
 Much of the GitHub example in the [file based
 storage](/core/idioms/file-based.md) documentation applies to GitLab as well.
-
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"gitlab-flow-storage"`; this helps prevents agents not explicitly
-authenticated with your GitLab repo from attempting to run this flow.
-:::
 
 :::tip GitLab Credentials
 GitLab storage uses a [personal access
@@ -253,12 +231,6 @@ flow = Flow(
 Much of the GitHub example in the [file based
 storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
 
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"bitbucket-flow-storage"`; this helps prevents agents not explicitly
-authenticated with your Bitbucket repo from attempting to run this flow.
-:::
-
 :::tip Bitbucket Credentials
 Bitbucket storage uses a [personal access
 token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
@@ -289,12 +261,6 @@ flow = Flow(
     )
 )
 ```
-
-::: tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"codecommit-flow-storage"`; this helps prevent agents not explicitly
-authenticated with your AWS deployment from attempting to run this flow.
-:::
 
 :::tip AWS Credentials
 S3 Storage uses AWS credentials the same way as
@@ -396,9 +362,3 @@ Template strings in `${}` are used to reference sensitive information. Given
 secrets](/core/concepts/secrets.md) `SOME_TOKEN`. Because this resolution is
 at runtime, this storage option never has your sensitive information stored in
 it and that sensitive information is never sent to Prefect Cloud.
-
-:::tip Sensible Defaults
-Flows registered with this storage option will automatically be labeled with
-`"webhook-flow-storage"`. Add that label to an agent to tell Prefect Cloud that
-that agent should run flows with `Webhook` storage.
-:::

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -62,7 +62,7 @@ When new versions of the server are released you will want to upgrade in order t
 enhancements, and new features. When running the server in containers using Docker compose an upgrade
 should be as simple as stopping the instance, installing the most recent version of prefect, and then
 starting the server again. Note that you'll want to be using a [persistent
-volume](/orchestration/server/deploy.html#database-persistence-and-migrations) for Postgres to ensure
+volume](/orchestration/server/deploy-local.md#database-persistence-and-migrations) for Postgres to ensure
 that your metadata is not lost between restarts.
 
 Due to the current implementation of the single node deployment for server this will result in a small


### PR DESCRIPTION
- Remove docs on automatic storage labels, these are no longer relevant
- Remove note on `version_group_id` being deprecated
- Fix link in server docs