### PR TITLE
add credentials to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,14 @@ docs/api/latest
 docs/changelog.md
 docs/deploy/dist
 docs/.vuepress/public/prefect-coverage
+
+
+# credentials and key material
+config
+credentials
+credentials.csv
+*.env
+*.pem
+*.pub
+*.rdp
+*_rsa


### PR DESCRIPTION
## Summary

This PR proposes adding some rules to .gitignore to prevent sensitive information like passwords and access keys from being checked into source control.

## Changes

I've added common extensions for key material, plus the specific files that the AWS CLI docs encourage people to create: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html.

## Importance

This PR will make it harder for contributors to accidentally expose sensitive information by checking it into source control. I think it's unlikely that such changes would make it past pull request review, but even showing up in a PR diff is still problematic.

## Checklist

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

## Notes for Reviewers

I didn't add a changelog entry since this is just administrative stuff for this repo and won't impact users.

Thanks for your time and consideration.