### PR TITLE
:key: - Allow the usage of a profile_name on get_boto_client

### DIFF
--- a/changes/pr3916.yaml
+++ b/changes/pr3916.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Allow the usage of a profile_name on get_boto_client - [#3916](https://github.com/PrefectHQ/prefect/pull/3916)"
+
+contributor:
+  - "[Albert Franzi](https://github.com/afranzi)"

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -4,11 +4,15 @@ Utility functions for interacting with AWS.
 import prefect
 
 import boto3
-from typing import Any
+from typing import Any, Optional
 
 
 def get_boto_client(
-    resource: str, credentials: dict = None, use_session: bool = False, **kwargs: Any
+        resource: str,
+        credentials: Optional[dict] = None,
+        use_session: Optional[bool] = False,
+        profile_name: Optional[str] = None,
+        **kwargs: Any
 ) -> "boto3.client":
     """
     Utility function for loading boto3 client objects from a given set of credentials.
@@ -20,14 +24,15 @@ def get_boto_client(
             Client using ambient environment settings
         - use_session (bool, optional): a boolean specifying whether to load
             this client using a session or not; defaults to `False`
+        - profile_name (str, optional): The name of a profile to use.
         - **kwargs (Any, optional): additional keyword arguments to pass to boto3
 
     Returns:
         - Client: an initialized and authenticated boto3 Client
     """
-    aws_access_key = None
-    aws_secret_access_key = None
-    aws_session_token = None
+
+    if profile_name and not use_session:
+        raise ValueError("profile_name can only be used with the boto3.session. Please set use_session=True")
 
     if credentials:
         aws_access_key = credentials["ACCESS_KEY"]
@@ -43,21 +48,31 @@ def get_boto_client(
     kwargs_secret_access_key = kwargs.pop("aws_secret_access_key", None)
     kwargs_session_token = kwargs.pop("aws_session_token", None)
 
+    aws_access_key = aws_access_key or kwargs_access_key_id
+    aws_secret_access_key = aws_secret_access_key or kwargs_secret_access_key
+    aws_session_token = aws_session_token or kwargs_session_token
+
     if use_session:
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing  # noqa
-        session = boto3.session.Session()
+        region_name = kwargs.pop('region_name', None)
+        botocore_session = kwargs.pop('botocore_session', None)
+        session = boto3.session.Session(
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            profile_name=profile_name,
+            region_name=region_name,
+            botocore_session=botocore_session
+        )
         return session.client(
             resource,
-            aws_access_key_id=aws_access_key or kwargs_access_key_id,
-            aws_secret_access_key=aws_secret_access_key or kwargs_secret_access_key,
-            aws_session_token=aws_session_token or kwargs_session_token,
             **kwargs
         )
     else:
         return boto3.client(
             resource,
-            aws_access_key_id=aws_access_key or kwargs_access_key_id,
-            aws_secret_access_key=aws_secret_access_key or kwargs_secret_access_key,
-            aws_session_token=aws_session_token or kwargs_session_token,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             **kwargs
         )

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -59,14 +59,17 @@ def get_boto_client(
         region_name = kwargs.pop("region_name", None)
         botocore_session = kwargs.pop("botocore_session", None)
         session = boto3.session.Session(
-            aws_access_key_id=aws_access_key,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
             profile_name=profile_name,
             region_name=region_name,
             botocore_session=botocore_session,
         )
-        return session.client(resource, **kwargs)
+        return session.client(
+            resource,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            **kwargs
+        )
     else:
         return boto3.client(
             resource,

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -8,11 +8,11 @@ from typing import Any, Optional
 
 
 def get_boto_client(
-        resource: str,
-        credentials: Optional[dict] = None,
-        use_session: Optional[bool] = False,
-        profile_name: Optional[str] = None,
-        **kwargs: Any
+    resource: str,
+    credentials: Optional[dict] = None,
+    use_session: Optional[bool] = False,
+    profile_name: Optional[str] = None,
+    **kwargs: Any
 ) -> "boto3.client":
     """
     Utility function for loading boto3 client objects from a given set of credentials.
@@ -32,7 +32,9 @@ def get_boto_client(
     """
 
     if profile_name and not use_session:
-        raise ValueError("profile_name can only be used with the boto3.session. Please set use_session=True")
+        raise ValueError(
+            "profile_name can only be used with the boto3.session. Please set use_session=True"
+        )
 
     if credentials:
         aws_access_key = credentials["ACCESS_KEY"]
@@ -54,20 +56,17 @@ def get_boto_client(
 
     if use_session:
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing  # noqa
-        region_name = kwargs.pop('region_name', None)
-        botocore_session = kwargs.pop('botocore_session', None)
+        region_name = kwargs.pop("region_name", None)
+        botocore_session = kwargs.pop("botocore_session", None)
         session = boto3.session.Session(
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
             profile_name=profile_name,
             region_name=region_name,
-            botocore_session=botocore_session
+            botocore_session=botocore_session,
         )
-        return session.client(
-            resource,
-            **kwargs
-        )
+        return session.client(resource, **kwargs)
     else:
         return boto3.client(
             resource,

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -121,13 +121,16 @@ class TestGetBotoClient:
         )
         session_kwargs = session.call_args[1]
         assert session_kwargs == {
-            "aws_access_key_id": None,
-            "aws_secret_access_key": None,
-            "aws_session_token": None,
             "botocore_session": None,
             "profile_name": "TestProfile",
             "region_name": None,
         }
 
-        kwargs = client.method_calls[0][1]
-        assert kwargs == ("not a real resource",)
+        args = client.method_calls[0][1]
+        assert args == ("not a real resource",)
+        kwargs = client.method_calls[0][2]
+        assert kwargs == {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+        }

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -113,20 +113,20 @@ class TestGetBotoClient:
         session = MagicMock(return_value=client)
         boto3 = MagicMock(session=MagicMock(Session=session))
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        monkeypatch.setattr("prefect.utilities.aws.boto3.session.Session.client", client)
+        monkeypatch.setattr(
+            "prefect.utilities.aws.boto3.session.Session.client", client
+        )
         get_boto_client(
-            resource="not a real resource",
-            use_session=True,
-            profile_name="TestProfile"
+            resource="not a real resource", use_session=True, profile_name="TestProfile"
         )
         session_kwargs = session.call_args[1]
         assert session_kwargs == {
-            'aws_access_key_id': None,
-            'aws_secret_access_key': None,
-            'aws_session_token': None,
-            'botocore_session': None,
-            'profile_name': 'TestProfile',
-            'region_name': None
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+            "botocore_session": None,
+            "profile_name": "TestProfile",
+            "region_name": None,
         }
 
         kwargs = client.method_calls[0][1]

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -107,3 +107,27 @@ class TestGetBotoClient:
             "aws_secret_access_key": "true_secret",
             "aws_session_token": "session",
         }
+
+    def test_session_with_profile_name(self, monkeypatch):
+        client = MagicMock()
+        session = MagicMock(return_value=client)
+        boto3 = MagicMock(session=MagicMock(Session=session))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        monkeypatch.setattr("prefect.utilities.aws.boto3.session.Session.client", client)
+        get_boto_client(
+            resource="not a real resource",
+            use_session=True,
+            profile_name="TestProfile"
+        )
+        session_kwargs = session.call_args[1]
+        assert session_kwargs == {
+            'aws_access_key_id': None,
+            'aws_secret_access_key': None,
+            'aws_session_token': None,
+            'botocore_session': None,
+            'profile_name': 'TestProfile',
+            'region_name': None
+        }
+
+        kwargs = client.method_calls[0][1]
+        assert kwargs == ("not a real resource",)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Allow the usage of `profile_name` on the `get_boto_client` method.


## Changes
This PR aims to allow users to define a `profile_name` to be used on the boto3 sessions.

The `profile_name` could be used to access different secrets or AWS resources based on profiles.

```python
AWSSecretsManager(
        secret='prefect/dummy',
        boto_kwargs={
            'use_session': True,
            'profile_name': 'MyAwsProfile',
            'region_name': 'us-east-1'
        }
    )
```

## Importance
The current code doesn't allow to specify profile names when working with AWS. This could allow using different profiles on different flows.

## Checklist
This PR:
- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)