### PR TITLE
Support running without prefect on path

### DIFF
--- a/changes/pr3918.yaml
+++ b/changes/pr3918.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Support executing Prefect agents/flows without having the `prefect` CLI on path - [#3918](https://github.com/PrefectHQ/prefect/pull/3918)"

--- a/src/prefect/__main__.py
+++ b/src/prefect/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -157,7 +157,7 @@ class LocalAgent(Agent):
         # show flow logs, these log entries will continue to stream to the users terminal
         # until these child processes exit, even if the agent has already exited.
         p = Popen(
-            ["prefect", "execute", "flow-run"],
+            [sys.executable, "-m", "prefect", "execute", "flow-run"],
             stdout=stdout,
             stderr=STDOUT,
             env=env,

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import sys
 import threading
 from time import sleep as time_sleep
 from typing import Any, Callable, Dict, Iterable, Optional, Iterator
@@ -73,7 +74,15 @@ class CloudFlowRunner(FlowRunner):
             # use empty string for testing purposes
             flow_run_id = prefect.context.get("flow_run_id", "")  # type: str
             self.client.update_flow_run_heartbeat(flow_run_id)
-            self.heartbeat_cmd = ["prefect", "heartbeat", "flow-run", "-i", flow_run_id]
+            self.heartbeat_cmd = [
+                sys.executable,
+                "-m",
+                "prefect",
+                "heartbeat",
+                "flow-run",
+                "-i",
+                flow_run_id,
+            ]
 
             query = {
                 "query": {

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -447,7 +447,7 @@ def test_local_agent_heartbeat(monkeypatch, returncode, show_flow_logs, logs):
     popen = MockPopen()
     # expect a process to be called with the following command (with specified behavior)
     popen.set_command(
-        f"{sys.executable} -m prefect execute flow-run",
+        [sys.executable, "-m", "prefect", "execute", "flow-run"],
         stdout=b"awesome output!",
         stderr=b"blerg, eRroR!",
         returncode=returncode,

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -446,7 +447,7 @@ def test_local_agent_heartbeat(monkeypatch, returncode, show_flow_logs, logs):
     popen = MockPopen()
     # expect a process to be called with the following command (with specified behavior)
     popen.set_command(
-        "prefect execute flow-run",
+        f"{sys.executable} -m prefect execute flow-run",
         stdout=b"awesome output!",
         stderr=b"blerg, eRroR!",
         returncode=returncode,

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import sys
 import time
 import threading
 from datetime import timedelta
@@ -413,7 +414,15 @@ def test_flow_runner_heartbeat_sets_command(monkeypatch, setting_available):
         res = runner._heartbeat()
 
     assert res is True
-    assert runner.heartbeat_cmd == ["prefect", "heartbeat", "flow-run", "-i", "foo"]
+    assert runner.heartbeat_cmd == [
+        sys.executable,
+        "-m",
+        "prefect",
+        "heartbeat",
+        "flow-run",
+        "-i",
+        "foo",
+    ]
 
 
 def test_flow_runner_does_not_have_heartbeat_if_disabled(monkeypatch):


### PR DESCRIPTION
Updates all `prefect ...` commands run by the agents/flow runners to
execute using a full python executable path. This lets prefect run
without having the `prefect` CLI on path.

Also makes `prefect` an executable module, so users can do
`path/to/python -m prefect ...` instead of `prefect ...` and things
should just work.

Fixes #3779.