### PR TITLE
Fix cycle creation in apply_map

### DIFF
--- a/changes/pr3920.yaml
+++ b/changes/pr3920.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix edge case in `apply_map` that resulted in cycles in the `Flow` graph - [#3920](https://github.com/PrefectHQ/prefect/pull/3920)"

--- a/src/prefect/utilities/tasks.py
+++ b/src/prefect/utilities/tasks.py
@@ -106,6 +106,7 @@ def apply_map(func: Callable, *args: Any, flow: "Flow" = None, **kwargs: Any) ->
         arg_info[a2] = (is_mapped, is_constant)
         if not is_constant:
             flow.add_task(a2)  # type: ignore
+            flow2.add_task(a2)  # type: ignore
         if is_mapped and is_constant:
             id_to_const[id(a2.value)] = a2  # type: ignore
         return a2


### PR DESCRIPTION
Fixes accidental cycle creation in `apply_map` in cases where a `case`
statement is mapped over a task that isn't used elsewhere in the
sub-flow beforehand. This was due to the args to `apply_map` not being
added to the subflow before the mapped function is called, causing the
logic in the `case` statement to automatically add erroneous edges to
these tasks.

Fixes #3890.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)