### PR TITLE
Fix bug in `prefect.context`

### DIFF
--- a/changes/pr3924.yaml
+++ b/changes/pr3924.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug in `prefect.context` contextmanager that resulted in context fields reverting to their initially configured values - [#3924](https://github.com/PrefectHQ/prefect/pull/3924)"

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -82,10 +82,14 @@ class Context(DotDict, threading.local):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        if "context" in config:
-            self.update(config.context)
-        self["config"] = merge_dicts(config, self.get("config", {}))  # order matters
+        init = {}
+        # Initialize with config context
+        init.update(config.get("context", {}))
+        # Overwrite with explicit args
+        init.update(dict(*args, **kwargs))
+        # Merge in config (with explicit args overwriting)
+        init["config"] = merge_dicts(config, init.get("config", {}))
+        super().__init__(init)
 
     def __getstate__(self) -> None:
         """
@@ -111,7 +115,8 @@ class Context(DotDict, threading.local):
             with prefect.context(dict(a=1, b=2), c=3):
                 print(prefect.context.a) # 1
         """
-        previous_context = self.copy()
+        # Avoid creating new `Context` object, copy as `dict` instead.
+        previous_context = self.__dict__.copy()
         try:
             new_context = dict(*args, **kwargs)
             if "config" in new_context:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -120,11 +120,13 @@ def test_modify_context_by_calling_update_inside_contextmanager():
 
 def test_context_loads_values_from_config(monkeypatch):
     subsection = Config(password="1234")
-    config = Config(context=Config(subsection=subsection, my_key="my_value"))
+    config = Config(context=Config(subsection=subsection, key1="val1", key2="val2"))
     monkeypatch.setattr(prefect.utilities.context, "config", config)
-    fresh_context = Context()
+
+    fresh_context = Context(key2="new")
     assert "subsection" in fresh_context
-    assert fresh_context.my_key == "my_value"
+    assert fresh_context.key1 == "val1"
+    assert fresh_context.key2 == "new"  # overridden by constructor
     assert fresh_context.subsection == subsection
 
 
@@ -135,6 +137,28 @@ def test_context_loads_secrets_from_config(monkeypatch):
     fresh_context = Context()
     assert "secrets" in fresh_context
     assert fresh_context.secrets == secrets_dict
+
+
+def test_context_contextmanager_prioritizes_new_keys_even_on_context_exit(monkeypatch):
+    """Previously exiting a context block would reload from the config,
+
+    overwriting any explicitly set values in a nested context. This was due to
+    the `Context` constructor being implicitly called when stashing the old
+    context, and the constructor prioritizing `config.context` over explicit
+    values."""
+    config = Config(context=Config(my_key="fizz"))
+    monkeypatch.setattr(prefect.utilities.context, "config", config)
+
+    context = Context()
+    assert context.my_key == "fizz"
+
+    with context(my_key="buzz"):
+        assert context.my_key == "buzz"
+        with context({"config": {"logging": {"log_to_cloud": "FOO"}}}):
+            assert context.config.logging.log_to_cloud == "FOO"
+            assert context.my_key == "buzz"
+        assert context.my_key == "buzz"
+    assert context.my_key == "fizz"
 
 
 def test_context_contextmanager_prioritizes_new_config_keys():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -141,7 +141,6 @@ def test_context_loads_secrets_from_config(monkeypatch):
 
 def test_context_contextmanager_prioritizes_new_keys_even_on_context_exit(monkeypatch):
     """Previously exiting a context block would reload from the config,
-
     overwriting any explicitly set values in a nested context. This was due to
     the `Context` constructor being implicitly called when stashing the old
     context, and the constructor prioritizing `config.context` over explicit


### PR DESCRIPTION
This fixes a bug in the contextmanager for `prefect.context` where
exiting the context would overwrite any values set in
`prefect.config.context` with their original config values (ignoring any
explicit values passed in at runtime). This was due to two things:

- The `Context` constructor being implicitly called when stashing a
  temporary context away in the `contextmanager`. This is fixed by
  avoiding creating temporary `Context` objects (which is also more
  efficient).
- Values set on `prefect.config.context` being prioritized over values
  explicitly set when creating `prefect.context`. This logic ordering is
  fixed in the constructor.

New tests are added that would have caught this bug.

Fixes #3828.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)