### PR TITLE
POC - Flow builder function

### DIFF
--- a/src/prefect/utilities/flows.py
+++ b/src/prefect/utilities/flows.py
@@ -1,0 +1,157 @@
+import inspect
+import sys
+from functools import wraps
+from typing import Callable, Union, Dict, Any
+
+from toolz import curry
+
+import prefect
+
+# A reusable type definition for flows or a function that creates a flow
+ResolvesToFlow = Union[prefect.Flow, Callable[[], prefect.Flow]]
+
+
+@curry
+def flow_builder(
+    fn: Callable[..., None],
+    run_kwargs: dict = None,
+    register_kwargs: dict = None,
+    **flow_kwargs,
+) -> Callable[..., prefect.Flow]:
+    """
+    Wraps a function with a Prefect Flow context and calls `run_or_register` so the
+    flow file can be run as a script. The function *must* take `flow` as the first
+    argument. The flow name defaults to the name of the function with '_' replaced with
+    '-'.
+
+    Args:
+        fn: The callable to wrap
+        run_kwargs: A dict of kwargs to pass to `run_or_register` for script run calls
+        register_kwargs: A dict of kwargs to pass to `run_or_register` for script
+            register calls
+        **flow_kwargs: Additional kwargs as passed to the `Flow` initializer
+
+    Returns:
+        A wrapped function with the flow context.
+
+    Examples:
+
+        Tasks called from within the function are added to the flow
+        ```python
+        from prefect import task
+        from prefect.utilities.flows import flow_builder
+
+        @task(log_stdout=True)
+        def foo():
+            print("Foobar!")
+
+        @flow_builder
+        def my_flow(flow):
+            foo()
+        ```
+
+        Flow initializer arguments can be passed
+        ```python
+        import prefect
+        from prefect import task
+        from prefect.utilities.flows import flow_builder
+
+        def say_name():
+            prefect.context.logger.info(f"Hi, my name is {prefect.context.flow_id!r}")
+
+        @flow_builder(name="my-custom-name")
+        def my_flow(flow):
+            say_name()
+        ```
+
+        Run and register arguments can be passed as well for when called as a script
+        ```python
+        from prefect.utilities.flows import flow_builder
+        from prefect.executors import DaskExecutor
+
+        @flow_builder(
+            register_kwargs=dict(project_name="default"),
+            run_kwargs=dict(executor=DaskExecutor()),
+        )
+        def my_flow(flow):
+            pass
+        ```
+    """
+
+    @wraps(fn)
+    def fn_with_flow_ctx(*args, **kwargs) -> prefect.Flow:
+        flow_kwargs.setdefault("name", fn.__name__.replace("_", "-"))
+        with prefect.Flow(**flow_kwargs) as flow:
+            fn(flow, *args, **kwargs)
+        return flow
+
+    run_or_register(
+        fn_with_flow_ctx,
+        run_kwargs=run_kwargs,
+        register_kwargs=register_kwargs,
+        __frames__=3,
+    )
+
+    return fn_with_flow_ctx
+
+
+def resolve_flow(flow: ResolvesToFlow) -> prefect.Flow:
+    """
+    Resolves a callable into a flow type and enforces that it is a flow instance
+    """
+    resolved = flow() if callable(flow) else flow
+
+    if not isinstance(resolved, prefect.Flow):
+        raise TypeError(
+            f"{flow} resolved to type {type(resolved)!r}, expected 'Flow' or subclass"
+        )
+
+    return resolved
+
+
+def run_or_register(
+    flow: ResolvesToFlow,
+    run_kwargs: Dict[str, Any] = None,
+    register_kwargs: Dict[str, Any] = None,
+    __frames__: int = 1,
+) -> None:
+    """
+    If the caller of this function was run as a script, the flow is either run or
+    registered according to first script argument if provided, defaults to running the
+    flow.
+
+    Args:
+        flow: The flow to run/register/track
+        run_kwargs: kwargs to pass to flow.run()
+        register_kwargs: kwargs to pass to flow.register()
+        __frames__: The number of stack frames to go up when checking the __name__
+            Exposed for the `flow_builder` decorator
+    """
+    run_kwargs = run_kwargs or {}
+    register_kwargs = register_kwargs or {}
+
+    # A bit of magic to get __name__ from the caller so they don't have to pass it
+    frame = inspect.stack()[__frames__].frame
+    caller__name__ = frame.f_globals.get("__name__")
+
+    # Check if the caller of this was called as a script in which case we will
+    # run or register the flow as called for in the config
+    if caller__name__ != "__main__":
+        return
+
+    # Check the first argument
+    if len(sys.argv) > 1:
+        mode = sys.argv[1].lower()
+    else:
+        mode = "run"  # default to running locally
+
+    if mode == "run":
+        # Run the flow
+        resolve_flow(flow).run(**run_kwargs)
+
+    elif mode == "register":
+        # Register the flow
+        resolve_flow(flow).register(**register_kwargs)
+
+    else:
+        raise ValueError(f"Unexpected mode {mode!r} please use 'run' or 'register'")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->
Note: Holding off on tests and documentation until discussion

## Summary
<!-- A sentence summarizing the PR -->

I'd like to improve the flow development experience in a project format which benefits from some additional utilities.

This introduces a `flow_builder` decorator for functions that will initialize a flow named after the wrapped function and enter the context.

Tasks called from within the function are added to the flow
```python
from prefect import task
from prefect.utilities.flows import flow_builder

@task(log_stdout=True)
def foo():
    print("Foobar!")

@flow_builder
def my_flow(flow):
    foo()
```

Flow initializer arguments can be passed
```python
import prefect
from prefect import task
from prefect.utilities.flows import flow_builder

def say_name():
    prefect.context.logger.info(f"Hi, my name is {prefect.context.flow_id!r}")

@flow_builder(name="my-custom-name")
def my_flow(flow):
    say_name()
```

It also introduces a `run_or_register` utility which takes the place of 

```python
if __name__ == "__main__":
     flow.run(...)
     flow.register(...)
```

where users frequently have to comment out one of the calls. This allows you to do

```python
run_or_register(flow, run_kwargs=dict(for_example=True))
```
then

`python my-flow-file.py <run/register>` to run or register it. 

It also supports callables that produce flows so flows can be functional e.g.

```python
def my_flow() -> Flow:
    with Flow("test") as flow:
        pass

run_or_register(my_flow)
```

The `flow_builder` decorator calls this automatically so it doesn't need to be included in every file and args can be passed to it still, e.g.

```python
from prefect.utilities.flows import flow_builder
from prefect.executors import DaskExecutor

@flow_builder(
    register_kwargs=dict(project_name="default"),
    run_kwargs=dict(executor=DaskExecutor()),
)
def my_flow(flow):
    pass
```

Flow builder functions can be imported and treated normally as well, this doesn't make use of `run/register_kwargs` though -- it may be nice to have these defaults be stored in the `Flow` object?
```
from my_project import fn_that_uses_flow_builder

flow = fn_that_uses_flow_builder()
flow.register()
```

## Changes
<!-- What does this PR change? -->

- Adds new `flows` utilities


## Importance
<!-- Why is this PR important? -->

- Defining flows in functions keeps module import times fast
- Improves flow development experience without introducing new CLI
- Provides a future pathway to tracking flows
- Reduces user confusion around Python `__main__` usage


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)