### PR TITLE
Fix docker-compose with custom graphql host port

### DIFF
--- a/changes/pr3933.yaml
+++ b/changes/pr3933.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `prefect server start` failure when given a custom graphql host port - [#3933](https://github.com/PrefectHQ/prefect/pull/3933)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       PREFECT_API_HEALTH_URL: ${PREFECT_API_HEALTH_URL:-http://graphql:4201/health}
       PREFECT_SERVER__TELEMETRY__ENABLED: ${PREFECT_SERVER__TELEMETRY__ENABLED:-true}
       GRAPHQL_SERVICE_HOST: http://graphql
-      GRAPHQL_SERVICE_PORT: ${GRAPHQL_HOST_PORT:-4201}
+      GRAPHQL_SERVICE_PORT: 4201
     networks:
       - prefect-server
     restart: "always"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When `prefect server start` is given a custom graphql host port `--graphql-port 4303`, the apollo service hangs forever because the health check fails. This is because the docker-compose file sets `GRAPHQL_SERVICE_PORT` to `GRAPHQL_HOST_PORT` when it should be just be the hardcoded internal port of `4201` 

## Changes
<!-- What does this PR change? -->

- Hardcodes `GRAPHQL_SERVICE_PORT` to `4201` in `docker-compose.yaml`


## Importance
<!-- Why is this PR important? -->

Fixes bug where the apollo service hangs when the graphql host port is changed.

See also https://github.com/PrefectHQ/server/pull/172

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~