### PR TITLE
Better error messages on failure to load flow

### DIFF
--- a/changes/pr3940.yaml
+++ b/changes/pr3940.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Better errors/warnings when flow fails to load in execution environment - [#3940](https://github.com/PrefectHQ/prefect/pull/3940)"

--- a/src/prefect/storage/_healthcheck.py
+++ b/src/prefect/storage/_healthcheck.py
@@ -39,6 +39,7 @@ def cloudpickle_deserialization_check(flow_file_paths: list):
     for flow_file in flow_file_paths:
         with open(flow_file, encoding="utf-8") as f:
             try:
+                # Match implementation in prefect.utilities.storage.flow_from_bytes_pickle
                 flow_bytes = binascii.a2b_base64(json.loads(f.read())["flow"])
                 flows.append(cloudpickle.loads(flow_bytes))
             except ModuleNotFoundError:

--- a/src/prefect/storage/_healthcheck.py
+++ b/src/prefect/storage/_healthcheck.py
@@ -5,7 +5,9 @@ deployment issues early on.
 """
 
 import ast
+import binascii
 import importlib
+import json
 import sys
 import warnings
 
@@ -35,9 +37,10 @@ def system_check(python_version: str):
 def cloudpickle_deserialization_check(flow_file_paths: list):
     flows = []
     for flow_file in flow_file_paths:
-        with open(flow_file, "rb") as f:
+        with open(flow_file, encoding="utf-8") as f:
             try:
-                flows.append(cloudpickle.load(f))
+                flow_bytes = binascii.a2b_base64(json.loads(f.read())["flow"])
+                flows.append(cloudpickle.loads(flow_bytes))
             except ModuleNotFoundError:
                 warnings.warn(
                     "Flow uses module which is not importable. Refer to documentation "

--- a/src/prefect/storage/azure.py
+++ b/src/prefect/storage/azure.py
@@ -1,13 +1,16 @@
 import os
 from typing import TYPE_CHECKING, Any, Dict
 
-import cloudpickle
 import pendulum
 from slugify import slugify
 
 from prefect.engine.results import AzureResult
 from prefect.storage import Storage
-from prefect.utilities.storage import extract_flow_from_file
+from prefect.utilities.storage import (
+    extract_flow_from_file,
+    flow_to_bytes_pickle,
+    flow_from_bytes_pickle,
+)
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow
@@ -93,7 +96,7 @@ class Azure(Storage):
         if self.stored_as_script:
             return extract_flow_from_file(file_contents=content)  # type: ignore
 
-        return cloudpickle.loads(content)
+        return flow_from_bytes_pickle(content)
 
     def add_flow(self, flow: "Flow") -> str:
         """
@@ -152,7 +155,7 @@ class Azure(Storage):
             return self
 
         for flow_name, flow in self._flows.items():
-            data = cloudpickle.dumps(flow)
+            data = flow_to_bytes_pickle(flow)
 
             client = self._azure_block_blob_service.get_blob_client(
                 container=self.container, blob=self.flows[flow_name]

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict
 
-import cloudpickle
 import pendulum
 from slugify import slugify
 
@@ -8,7 +7,11 @@ import prefect
 from prefect.engine.results import GCSResult
 from prefect.storage import Storage
 from prefect.utilities.exceptions import StorageError
-from prefect.utilities.storage import extract_flow_from_file
+from prefect.utilities.storage import (
+    extract_flow_from_file,
+    flow_from_bytes_pickle,
+    flow_to_bytes_pickle,
+)
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow
@@ -109,7 +112,7 @@ class GCS(Storage):
         if self.stored_as_script:
             return extract_flow_from_file(file_contents=content)
 
-        return cloudpickle.loads(content)
+        return flow_from_bytes_pickle(content)
 
     def add_flow(self, flow: "Flow") -> str:
         """
@@ -183,7 +186,7 @@ class GCS(Storage):
             return self
 
         for flow_name, flow in self._flows.items():
-            content = cloudpickle.dumps(flow)
+            content = flow_to_bytes_pickle(flow)
 
             bucket = self._gcs_client.get_bucket(self.bucket)
 

--- a/src/prefect/storage/local.py
+++ b/src/prefect/storage/local.py
@@ -2,14 +2,18 @@ import os
 import socket
 from typing import TYPE_CHECKING, Any, Dict, List
 
-import cloudpickle
 import pendulum
 from slugify import slugify
 
 import prefect
 from prefect.engine.results import LocalResult
 from prefect.storage import Storage
-from prefect.utilities.storage import extract_flow_from_file, extract_flow_from_module
+from prefect.utilities.storage import (
+    extract_flow_from_file,
+    extract_flow_from_module,
+    flow_from_bytes_pickle,
+    flow_to_bytes_pickle,
+)
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow
@@ -102,7 +106,7 @@ class Local(Storage):
                     return extract_flow_from_file(file_path=flow_location)
                 else:
                     with open(flow_location, "rb") as f:
-                        return cloudpickle.load(f)
+                        return flow_from_bytes_pickle(f.read())
             # otherwise the path is given in the module format
             else:
                 return extract_flow_from_module(module_str=flow_location)
@@ -147,7 +151,7 @@ class Local(Storage):
                 )
             os.makedirs(os.path.dirname(flow_location), exist_ok=True)
             with open(flow_location, "wb") as f:
-                cloudpickle.dump(flow, f)
+                f.write(flow_to_bytes_pickle(flow))
 
         self.flows[flow.name] = flow_location
         self._flows[flow.name] = flow

--- a/src/prefect/storage/webhook.py
+++ b/src/prefect/storage/webhook.py
@@ -1,4 +1,3 @@
-import cloudpickle
 import os
 import string
 import warnings
@@ -13,7 +12,11 @@ from requests.packages.urllib3.util.retry import Retry
 
 from prefect.client import Secret
 from prefect.storage import Storage
-from prefect.utilities.storage import extract_flow_from_file
+from prefect.utilities.storage import (
+    extract_flow_from_file,
+    flow_from_bytes_pickle,
+    flow_to_bytes_pickle,
+)
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow
@@ -260,7 +263,7 @@ class Webhook(Storage):
             flow_script_content = response.content.decode("utf-8")
             return extract_flow_from_file(file_contents=flow_script_content)  # type: ignore
 
-        return cloudpickle.loads(response.content)
+        return flow_from_bytes_pickle(response.content)
 
     def add_flow(self, flow: "Flow") -> str:
         """
@@ -347,7 +350,7 @@ class Webhook(Storage):
         for flow_name, flow in self._flows.items():
             self.logger.info("Uploading flow '{}'".format(flow_name))
 
-            data = cloudpickle.dumps(flow)
+            data = flow_to_bytes_pickle(flow)
             if self.stored_as_script:
 
                 # these checks are here in build() instead of the constructor

--- a/src/prefect/utilities/storage.py
+++ b/src/prefect/utilities/storage.py
@@ -201,7 +201,7 @@ def flow_from_bytes_pickle(data: bytes) -> "Flow":
         flow = cloudpickle.loads(flow_bytes)
     except Exception as exc:
         parts = ["An error occurred while unpickling the flow:", f"  {exc!r}"]
-        # Check for mismatched versions to provide a better warning if possible
+        # Check for mismatched versions to provide a better error if possible
         mismatches = []
         for name, v1 in sorted(reg_versions.items()):
             if name in run_versions:

--- a/tests/storage/test_docker_healthcheck.py
+++ b/tests/storage/test_docker_healthcheck.py
@@ -3,13 +3,13 @@ import os
 import sys
 import tempfile
 
-import cloudpickle
 import pytest
 
 from prefect import Flow, Task, task
 from prefect.engine.results import LocalResult
 from prefect.environments import Environment
 from prefect.storage import _healthcheck as healthchecks
+from prefect.utilities.storage import flow_to_bytes_pickle
 
 
 pytestmark = pytest.mark.skipif(
@@ -18,18 +18,15 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestSerialization:
-    def test_cloudpickle_deserialization_check_raises_on_bad_imports(self):
-        bad_bytes = b"\x80\x04\x95\x18\x00\x00\x00\x00\x00\x00\x00\x8c\x0bfoo_machine\x94\x8c\x04func\x94\x93\x94."
-        with tempfile.NamedTemporaryFile() as f:
-            f.write(bad_bytes)
-            f.seek(0)
-            with pytest.raises(ImportError, match="foo_machine"):
-                objs = healthchecks.cloudpickle_deserialization_check(
-                    ["{}".format(f.name)]
-                )
+    def test_cloudpickle_deserialization_check_raises_on_bad_imports(self, tmpdir):
+        path = str(tmpdir.join("test.prefect"))
+        with open(path, "wb") as f:
+            f.write(b'{"flow": "gASVGAAAAAAAAACMC2Zvb19tYWNoaW5llIwEZnVuY5STlC4=\\n"}')
+        with pytest.raises(ImportError, match="foo_machine"):
+            healthchecks.cloudpickle_deserialization_check([path])
 
     def test_cloudpickle_deserialization_check_passes_and_returns_objs(self):
-        good_bytes = cloudpickle.dumps(Flow("empty"))
+        good_bytes = flow_to_bytes_pickle(Flow("empty"))
         with tempfile.NamedTemporaryFile() as f:
             f.write(good_bytes)
             f.seek(0)
@@ -43,8 +40,8 @@ class TestSerialization:
         assert flow.tasks == set()
 
     def test_cloudpickle_deserialization_check_passes_and_returns_multiple_objs(self):
-        flow_one = cloudpickle.dumps(Flow("one"))
-        flow_two = cloudpickle.dumps(Flow("two"))
+        flow_one = flow_to_bytes_pickle(Flow("one"))
+        flow_two = flow_to_bytes_pickle(Flow("two"))
         with tempfile.TemporaryDirectory() as tmpdir:
             file_one = os.path.join(tmpdir, "one.flow")
             with open(file_one, "wb") as f:

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -6,6 +6,7 @@ import pytest
 
 from prefect import context, Flow
 from prefect.storage import S3
+from prefect.utilities.storage import flow_from_bytes_pickle
 
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
@@ -210,7 +211,7 @@ def test_upload_flow_to_s3_flow_byte_stream(monkeypatch):
     flow_as_bytes = boto3.upload_fileobj.call_args[0][0]
     assert isinstance(flow_as_bytes, io.BytesIO)
 
-    new_flow = cloudpickle.loads(flow_as_bytes.read())
+    new_flow = flow_from_bytes_pickle(flow_as_bytes.read())
     assert new_flow.name == "test"
 
     state = new_flow.run()

--- a/tests/utilities/test_storage.py
+++ b/tests/utilities/test_storage.py
@@ -1,16 +1,19 @@
 import os
-import tempfile
 
 import pytest
+import cloudpickle
 
 import prefect
-from prefect import Flow
+from prefect import Flow, Task
 from prefect.environments import LocalEnvironment
 from prefect.storage import Docker, Local
+from prefect.utilities.exceptions import StorageError
 from prefect.utilities.storage import (
     get_flow_image,
     extract_flow_from_file,
     extract_flow_from_module,
+    flow_to_bytes_pickle,
+    flow_from_bytes_pickle,
 )
 
 
@@ -41,7 +44,7 @@ def test_get_flow_image_raises_on_missing_info():
         storage=Local(),
     )
     with pytest.raises(ValueError):
-        image = get_flow_image(flow=flow)
+        get_flow_image(flow=flow)
 
 
 def test_extract_flow_from_file(tmpdir):
@@ -158,3 +161,64 @@ def test_extract_flow_from_module():
         extract_flow_from_module(
             f"{module_name}:test_extract_flow_from_module.invalid_callable"
         )
+
+
+class RaiseOnLoad(Task):
+    def __init__(self, exc):
+        super().__init__()
+        self.exc = exc
+
+    @staticmethod
+    def _raise(exc):
+        raise exc
+
+    def __reduce__(self):
+        return (self._raise, (self.exc,))
+
+
+class TestFlowToFromBytesPickle:
+    def test_serialize_deserialize(self):
+        s = flow_to_bytes_pickle(Flow("test"))
+        assert isinstance(s, bytes)
+        flow = flow_from_bytes_pickle(s)
+        assert isinstance(flow, Flow)
+        assert flow.name == "test"
+
+    def test_flow_from_bytes_loads_raw_pickle(self):
+        """Older versions of prefect serialized flows as straight pickle bytes.
+        This checks that we can still deserialize these payloads"""
+        s = cloudpickle.dumps(Flow("test"))
+        flow = flow_from_bytes_pickle(s)
+        assert isinstance(flow, Flow)
+        assert flow.name == "test"
+
+    def test_flow_from_bytes_warns_prefect_version_mismatch(self, monkeypatch):
+        s = flow_to_bytes_pickle(Flow("test"))
+        monkeypatch.setattr(prefect, "__version__", "0.1.0")
+        with pytest.warns(UserWarning, match="This flow was built using Prefect"):
+            flow = flow_from_bytes_pickle(s)
+        assert isinstance(flow, Flow)
+        assert flow.name == "test"
+
+    @pytest.mark.parametrize("version_mismatch", [False, True])
+    @pytest.mark.parametrize("import_error", [False, True])
+    def test_flow_from_bytes_error(self, monkeypatch, version_mismatch, import_error):
+        exc = ImportError("mymodule") if import_error else ValueError("Oh no!")
+        flow = Flow("test", tasks=[RaiseOnLoad(exc)])
+        s = flow_to_bytes_pickle(flow)
+
+        if version_mismatch:
+            monkeypatch.setattr(prefect, "__version__", "0.0.1")
+            monkeypatch.setattr(cloudpickle, "__version__", "0.0.2")
+
+        with pytest.raises(
+            StorageError, match="An error occurred while unpickling"
+        ) as exc:
+            flow_from_bytes_pickle(s)
+
+        msg = "mymodule" if import_error else "Oh no!"
+        assert msg in str(exc.value)
+
+        # Extra components only present if relevant
+        assert ("missing Python module" in str(exc.value)) == import_error
+        assert ("version mismatches" in str(exc.value)) == version_mismatch


### PR DESCRIPTION
Currently flows are stored using `cloudpickle` by default. While
flexible, the error messages produced on failure can be opaque
(especially for new users). Since `pickle` makes the internal
datastructures part of the public api, changes in core library versions
can lead to subtle errors - it's hard for us to provide better error
messages without knowing these version differences exist.

This commit changes the storage representation to include extra metadata
(currently only version info), which allows for generating better error
messages. We currently encode the versions for things likely to lead to
pickling errors:

- `prefect`
- `python`
- `cloudpickle`

If the flow fails to load, version differences between the build and
execution environments are checked and added to the error message to
provide better information to the user. Additionally, if an
`ImportError` is raised we note that they may need to install additional
dependencies.

If the flow successfully loads, we also check that the build and
execution versions of `prefect` match, and warn if they don't.
Differences in prefect version can lead to subtle bugs (due to the
pickled representation of a class changing), but things *may* work
anyway. A warning provides a nudge to the user to keep their
dependencies aligned, but doesn't break things unnecessarily.

We also pin to pickle protocol 4, which is supported by all versions of
Python prefect supports. Previously we'd use cloudpickle's default,
which would default to version 5 on Python 3.8, causing flows to
fail to load on 3.7.

Fixes #3457.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)