### PR TITLE
Handle empty container statuses when reporting failed pods in Kubernetes agent

### DIFF
--- a/changes/pr3941.yaml
+++ b/changes/pr3941.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Kubernetes Agent attempting to report container info for failed pods when no container statuses are found- [#3941](https://github.com/PrefectHQ/prefect/pull/3941)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -264,7 +264,7 @@ class KubernetesAgent(Agent):
                             pod_status_logs = [f"Pod {pod.metadata.name} failed."]
                             if not pod.status.container_statuses:
                                 pod_status_logs.append(
-                                    f"\tNo container statuses found for pod"
+                                    "\tNo container statuses found for pod"
                                 )
                             else:
                                 for status in pod.status.container_statuses:

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -262,36 +262,39 @@ class KubernetesAgent(Agent):
                             # Format pod failure error message
                             failed_pods.append(pod.metadata.name)
                             pod_status_logs = [f"Pod {pod.metadata.name} failed."]
-                            for status in pod.status.container_statuses:
-                                state = (
-                                    "running"
-                                    if status.state.running
-                                    else "waiting"
-                                    if status.state.waiting
-                                    else "terminated"
-                                    if status.state.terminated
-                                    else "Not Found"
-                                )
-                                pod_status_logs.append(
-                                    f"\tContainer '{status.name}' state: {state}"
-                                )
-
-                                if status.state.terminated:
-                                    pod_status_logs.append(
-                                        f"\t\tExit Code:: {status.state.terminated.exit_code}"
+                            if not pod.status.container_statuses:
+                                pod_status_logs.append(f"\tNo container statuses found for pod")
+                            else:
+                                for status in pod.status.container_statuses:
+                                    state = (
+                                        "running"
+                                        if status.state.running
+                                        else "waiting"
+                                        if status.state.waiting
+                                        else "terminated"
+                                        if status.state.terminated
+                                        else "Not Found"
                                     )
-                                    if status.state.terminated.message:
+                                    pod_status_logs.append(
+                                        f"\tContainer '{status.name}' state: {state}"
+                                    )
+
+                                    if status.state.terminated:
                                         pod_status_logs.append(
-                                            f"\t\tMessage: {status.state.terminated.message}"
+                                            f"\t\tExit Code:: {status.state.terminated.exit_code}"
                                         )
-                                    if status.state.terminated.reason:
-                                        pod_status_logs.append(
-                                            f"\t\tReason: {status.state.terminated.reason}"
-                                        )
-                                    if status.state.terminated.signal:
-                                        pod_status_logs.append(
-                                            f"\t\tSignal: {status.state.terminated.signal}"
-                                        )
+                                        if status.state.terminated.message:
+                                            pod_status_logs.append(
+                                                f"\t\tMessage: {status.state.terminated.message}"
+                                            )
+                                        if status.state.terminated.reason:
+                                            pod_status_logs.append(
+                                                f"\t\tReason: {status.state.terminated.reason}"
+                                            )
+                                        if status.state.terminated.signal:
+                                            pod_status_logs.append(
+                                                f"\t\tSignal: {status.state.terminated.signal}"
+                                            )
 
                             # Send pod failure information to flow run logs
                             self.client.write_run_logs(

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -263,7 +263,9 @@ class KubernetesAgent(Agent):
                             failed_pods.append(pod.metadata.name)
                             pod_status_logs = [f"Pod {pod.metadata.name} failed."]
                             if not pod.status.container_statuses:
-                                pod_status_logs.append(f"\tNo container statuses found for pod")
+                                pod_status_logs.append(
+                                    f"\tNo container statuses found for pod"
+                                )
                             else:
                                 for status in pod.status.container_statuses:
                                     state = (

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -981,6 +981,60 @@ def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     assert core_client.list_namespaced_pod.called
 
 
+def test_k8s_agent_manage_jobs_reports_empty_status(monkeypatch, cloud_api):
+    gql_return = MagicMock(
+        return_value=MagicMock(
+            data=MagicMock(
+                set_flow_run_state=None,
+                write_run_logs=None,
+                get_flow_run_state=prefect.engine.state.Success(),
+            )
+        )
+    )
+    client = MagicMock()
+    client.return_value.graphql = gql_return
+    monkeypatch.setattr("prefect.agent.agent.Client", client)
+
+    job_mock = MagicMock()
+    job_mock.metadata.labels = {
+        "prefect.io/identifier": "id",
+        "prefect.io/flow_run_id": "fr",
+    }
+    job_mock.metadata.name = "my_job"
+    job_mock.status.failed = True
+    job_mock.status.succeeded = False
+    batch_client = MagicMock()
+    list_job = MagicMock()
+    list_job.metadata._continue = 0
+    list_job.items = [job_mock]
+    batch_client.list_namespaced_job.return_value = list_job
+    monkeypatch.setattr(
+        "kubernetes.client.BatchV1Api", MagicMock(return_value=batch_client)
+    )
+
+    pod = MagicMock()
+    pod.metadata.name = "pod_name"
+    pod.status.phase = "Failed"
+    pod.status.container_statuses = None
+
+    pod2 = MagicMock()
+    pod2.metadata.name = "pod_name"
+    pod2.status.phase = "Success"
+
+    core_client = MagicMock()
+    list_pods = MagicMock()
+    list_pods.items = [pod, pod2]
+    core_client.list_namespaced_pod.return_value = list_pods
+    monkeypatch.setattr(
+        "kubernetes.client.CoreV1Api", MagicMock(return_value=core_client)
+    )
+
+    agent = KubernetesAgent()
+    agent.manage_jobs()
+
+    assert core_client.list_namespaced_pod.called
+
+
 def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api):
     gql_return = MagicMock(
         return_value=MagicMock(data=MagicMock(set_flow_run_state=None))


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Sometimes certain scenarios could lead to a failed pod being reported by the Kubernetes agent but it is unable to retrieve any container statuses. This would lead to an error like this:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/prefect/agent/kubernetes/agent.py", line 357, in heartbeat
    self.manage_jobs()
  File "/usr/local/lib/python3.7/site-packages/prefect/agent/kubernetes/agent.py", line 265, in manage_jobs
    for status in pod.status.container_statuses:
TypeError: 'NoneType' object is not iterable
```



## Changes
Avoids attempting to use container statuses if none are found when reporting failed pods.



## Importance
Error handling




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
cc @TylerWanner 