### PR TITLE
Document auto-labelling behavior.

### DIFF
--- a/changes/pr3947.yaml
+++ b/changes/pr3947.yaml
@@ -1,2 +1,2 @@
 fix:
-  - "Document the auto-labelling behavior for Flow Runs of local Flows."
+  - "Document the auto-labelling behavior for Flow Runs of local Flows, and other stuff."

--- a/changes/pr3947.yaml
+++ b/changes/pr3947.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Document the auto-labelling behavior for Flow Runs of local Flows."

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -58,6 +58,21 @@ register a flow with no labels it will only be picked up by Agents which also
 do not have labels specified.
 :::
 
+:::tip Automatic Labels
+If your Flow is configured for [Local Storage](storage.md#local), which is the
+default, then flow runs generated from it will automatically be given a label
+matching the hostname of the machine where the flow run was created. This behavior can be disabled
+by adding the following to your `config.toml`:
+
+    [flows.defaults]
+        [flows.defaults.storage]
+
+        add_default_labels = false
+
+However, doing this does not enable you to use Local Storage with any agent
+besides the [local agent](/orchestration/agents/local.md).
+:::
+
 ## Types
 
 Prefect has a number of different `RunConfig` implementations - we'll briefly

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -70,7 +70,8 @@ by adding the following to your `config.toml`:
         add_default_labels = false
 
 However, doing this does not enable you to use Local Storage with any agent
-besides the [local agent](/orchestration/agents/local.md).
+besides the [local agent](/orchestration/agents/local.md), which expects
+the hostname label to be there by default.
 :::
 
 ## Types

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -147,6 +147,11 @@ which means both upload (build) and download (local agent) times need to have
 the proper Google Application Credentials configuration.
 :::
 
+:::tip Extra dependency
+You need to install `google` PIP extra (`pip install prefect[google]`) to use
+GCS Storage.
+:::
+
 ## GitHub
 
 [GitHub Storage](/api/latest/storage.md#github) is a storage


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Document the esoteric auto-labelling behavior that happens
when you create a flow run for a Local Storage flow.


## Changes
<!-- What does this PR change? -->

Documentation only.


## Importance
<!-- Why is this PR important? -->

After first setting up Prefect, I found that the agent I set up was just ignoring the flows I created. Someone in Slack was having the same problem, and it had to do with mismatching labels. The person in Slack did not understand why his flow run had a label.

Based on the view from the CLI, I expected my flow run to have no labels, but when I looked at it through the Web interface, my flow run also inexplicably had a label. The presence of this label is not explained by the documentation.

Then I discovered that other people were *so* surprised by this behavior, that an issue got filed asking for a flag to disable it. 

This behavior seems to be an endless source of surprise and confusion.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [N/A] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [N/A] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)