### PR TITLE
Add agent labels to k8s flow runs

### DIFF
--- a/changes/pr3954.yaml
+++ b/changes/pr3954.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Propogate agent labels info to k8s flow runs, to match other agent behavior - [#3954](https://github.com/PrefectHQ/prefect/pull/3954)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -653,6 +653,7 @@ class KubernetesAgent(Agent):
             env.update(run_config.env)
         env.update(
             {
+                "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
                 "PREFECT__CLOUD__API": config.cloud.api,
                 "PREFECT__CLOUD__AUTH_TOKEN": config.cloud.agent.auth_token,
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1302,6 +1302,7 @@ class TestK8sAgentRunConfig:
         env_list = job["spec"]["template"]["spec"]["containers"][0]["env"]
         env = {item["name"]: item["value"] for item in env_list}
         assert env == {
+            "PREFECT__CLOUD__AGENT__LABELS": "[]",
             "PREFECT__CLOUD__API": prefect.config.cloud.api,
             "PREFECT__CLOUD__AUTH_TOKEN": prefect.config.cloud.agent.auth_token,
             "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",


### PR DESCRIPTION
Other agents propagate their labels to their flow runs via the
`PREFECT__CLOUD__AGENT__LABELS` environment variable, but the k8s agent
had dropped that in the run-config refactor. We re-add that environment
variable here.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)