### PR TITLE
Storage doc fixups

### DIFF
--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -44,7 +44,8 @@ from prefect.storage import Local
 flow = Flow("local-flow", storage=Local())
 ```
 
-After registration, the flow will be stored at `~/.prefect/flows/local-flow.prefect`.
+After registration, the flow will be stored at
+`~/.prefect/flows/<slugified-flow-name>/<slugified-current-timestamp>`.
 
 :::tip Automatic Labels
 Flows registered with this storage option will automatically be labeled with
@@ -70,7 +71,7 @@ flow = Flow("s3-flow", storage=S3(bucket="<my-bucket>"))
 ```
 
 After registration, the flow will be stored in the specified bucket under
-`s3-flow/<slugified-current-timestamp>`.
+`<slugified-flow-name>/<slugified-current-timestamp>`.
 
 :::tip Flow Results
 Flows configured with `S3` storage also default to using a `S3Result` for
@@ -103,7 +104,7 @@ flow = Flow(
 ```
 
 After registration, the flow will be stored in the container under
-`azure-flow/<slugified-current-timestamp>`.
+`<slugified-flow-name>/<slugified-current-timestamp>`.
 
 :::tip Flow Results
 Flows configured with `Azure` storage also default to using an `AzureResult` for
@@ -132,7 +133,7 @@ flow = Flow("gcs-flow", storage=GCS(bucket="<my-bucket>"))
 ```
 
 After registration the flow will be stored in the specified bucket under
-`gcs-flow/<slugified-current-timestamp>`.
+`<slugified-flow-name>/<slugified-current-timestamp>`.
 
 :::tip Flow Results
 Flows configured with `GCS` storage also default to using a `GCSResult` for
@@ -283,13 +284,13 @@ from prefect import Flow
 from prefect.storage import Docker
 
 flow = Flow(
-    "gcs-flow",
+    "docker-flow",
     storage=Docker(registry_url="<my-registry.io>", image_name="my_flow")
 )
 ```
 
 After registration, the flow's image will be stored in the container registry
-under `my-registry.io/my_flow:<slugified-current-timestamp>`. Note that each
+under `my-registry.io/<slugified-flow-name>:<slugified-current-timestamp>`. Note that each
 type of container registry uses a different format for image naming (e.g.
 DockerHub vs GCR).
 

--- a/src/prefect/storage/azure.py
+++ b/src/prefect/storage/azure.py
@@ -25,9 +25,6 @@ class Azure(Storage):
     when stored in Azure. If this key is not provided the Flow upload name will take the form
     `slugified-flow-name/slugified-current-timestamp`.
 
-    **Note**: Flows registered with this Storage option will automatically be
-     labeled with `azure-flow-storage`.
-
     Args:
         - container (str): the name of the Azure Blob Container to store the Flow
         - connection_string (str, optional): an Azure connection string for communicating with

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -29,9 +29,6 @@ class GCS(Storage):
     when stored in GCS. If this key is not provided the Flow upload name will take the form
     `slugified-flow-name/slugified-current-timestamp`.
 
-    **Note**: Flows registered with this Storage option will automatically be
-     labeled with `gcs-flow-storage`.
-
     Args:
         - bucket (str, optional): the name of the GCS Bucket to store the Flow
         - key (str, optional): a unique key to use for uploading this Flow to GCS. This

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -26,9 +26,6 @@ class S3(Storage):
     when stored in S3. If this key is not provided the Flow upload name will take the form
     `slugified-flow-name/slugified-current-timestamp`.
 
-     **Note**: Flows registered with this Storage option will automatically be
-     labeled with `s3-flow-storage`.
-
     Args:
         - bucket (str): the name of the S3 Bucket to store Flows
         - key (str, optional): a unique key to use for uploading a Flow to S3. This

--- a/src/prefect/storage/webhook.py
+++ b/src/prefect/storage/webhook.py
@@ -104,9 +104,6 @@ class Webhook(Storage):
     strings which will be filled in dynamically from environment variables
     or Prefect secrets.
 
-     **Note**: Flows registered with this Storage option will automatically be
-     labeled with `webhook-flow-storage`.
-
     Args:
         - build_request_kwargs (dict): Dictionary of keyword arguments to the
             function from `requests` used to store the flow. Do not supply


### PR DESCRIPTION
- Remove lingering notes about default storage labels
- Clarify descriptions of where flows are stored by default for each backend.


Fixes #3948.