### PR TITLE
Add 429 as a retry status code on the client

### DIFF
--- a/changes/pr3959.yaml
+++ b/changes/pr3959.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Retry on additional status codes - [#3959](https://github.com/PrefectHQ/prefect/pull/3959)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -341,11 +341,11 @@ class Client:
             start_time = time.time()
 
         if method == "GET":
-            response = session.get(url, headers=headers, params=params, timeout=30)
+            response = session.get(url, headers=headers, params=params, timeout=15)
         elif method == "POST":
-            response = session.post(url, headers=headers, json=params, timeout=30)
+            response = session.post(url, headers=headers, json=params, timeout=15)
         elif method == "DELETE":
-            response = session.delete(url, headers=headers, timeout=30)
+            response = session.delete(url, headers=headers, timeout=15)
         else:
             raise ValueError("Invalid method: {}".format(method))
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -438,7 +438,7 @@ class Client:
         retries = requests.packages.urllib3.util.retry.Retry(
             total=retry_total,
             backoff_factor=1,
-            status_forcelist=[500, 502, 503, 504],
+            status_forcelist=[429, 500, 502, 503, 504],
             method_whitelist=["DELETE", "GET", "POST"],
         )
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
In anticipation of some possible API changes, best to have this in place.


## Changes
<!-- What does this PR change? -->
Adds 429 as a retry status code in the client.



## Importance
<!-- Why is this PR important? -->
Future proofing.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)