### PR TITLE
Better support multiple flows per file in Storage

### DIFF
--- a/changes/pr3969.yaml
+++ b/changes/pr3969.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix support for storing multiple flows in a single script in storage - [#3969](https://github.com/PrefectHQ/prefect/pull/3969)"

--- a/src/prefect/cli/execute.py
+++ b/src/prefect/cli/execute.py
@@ -64,7 +64,7 @@ def flow_run():
             secrets[secret] = PrefectSecret(name=secret).run()
 
         with prefect.context(secrets=secrets, loading_flow=True):
-            flow = storage.get_flow(storage.flows[flow_data.name])
+            flow = storage.get_flow(flow_data.name)
 
         with prefect.context(secrets=secrets):
             if flow_data.run_config is not None:

--- a/src/prefect/environments/execution/base.py
+++ b/src/prefect/environments/execution/base.py
@@ -169,7 +169,7 @@ def load_and_run_flow() -> None:
             secrets[secret] = prefect.tasks.secrets.PrefectSecret(name=secret).run()
 
         with prefect.context(secrets=secrets):
-            flow = storage.get_flow(storage.flows[flow_data.name])
+            flow = storage.get_flow(flow_data.name)
             flow.environment.run(flow)
     except Exception as exc:
         logger.exception("Unexpected error raised during flow run: {}".format(exc))

--- a/src/prefect/storage/__init__.py
+++ b/src/prefect/storage/__init__.py
@@ -8,7 +8,7 @@ within a given unit), and exposes the following methods and attributes:
 location of the given flow in the Storage unit (note flow uploading/saving does not happen until `build`)
 - the `__contains__(self, obj) -> bool` special method for determining whether the Storage contains a
 given Flow
-- one of `get_flow(flow_location: str)` for retrieving a way of interfacing with either `flow.run` or a
+- one of `get_flow(flow_name: str)` for retrieving a way of interfacing with either `flow.run` or a
 `FlowRunner` for the flow
 - a `build() -> Storage` method for "building" the storage. In storage options where flows are stored in
 an external service (such as S3 and the filesystem) the flows are uploaded/saved during this step

--- a/src/prefect/storage/base.py
+++ b/src/prefect/storage/base.py
@@ -88,12 +88,12 @@ class Storage(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def get_flow(self, flow_location: str) -> "prefect.core.flow.Flow":
+    def get_flow(self, flow_name: str) -> "prefect.core.flow.Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage
+            - flow_name (str): the name of the flow to return.
 
         Returns:
             - Flow: the requested flow

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -61,35 +61,22 @@ class Bitbucket(Storage):
 
         super().__init__(**kwargs)
 
-    def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
-        If the Flow is not found an error will be logged and `None` will be returned.
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path on a repository where a Flow file has been committed. Will use `path` if not
-                provided.
-            - ref (str, optional): a commit SHA-1 value or branch name. Defaults to 'master' if
-                not specified
+            - flow_name (str): the name of the flow to return.
 
         Returns:
-            - Flow: the requested Flow; Atlassian API retrieves raw, decoded files.
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
-            - HTTPError: if flow is unable to access the Bitbucket repository
+            - Flow: the requested flow
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
-        # Use ref argument if exists, else use attribute, else default to 'master'
-        ref = ref if ref else (self.ref if self.ref else "master")
+        # Use ref attribute if present, defaulting to "master"
+        ref = self.ref or "master"
 
         try:
             contents = self._bitbucket_client.get_content_of_file(
@@ -116,7 +103,7 @@ class Bitbucket(Storage):
                 )
                 raise
 
-        return extract_flow_from_file(file_contents=contents)
+        return extract_flow_from_file(file_contents=contents, flow_name=flow_name)
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/codecommit.py
+++ b/src/prefect/storage/codecommit.py
@@ -55,30 +55,19 @@ class CodeCommit(Storage):
 
         super().__init__(**kwargs)
 
-    def get_flow(self, flow_location: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
-        If the Flow is not found an error will be logged and `None` will be returned.
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path on a repository where a Flow file has been committed. Will use `path` if not
-                provided.
+            - flow_name (str): the name of the flow to return.
 
         Returns:
-            - Flow: the requested Flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
-            - UnknownObjectException: if the flow file is unable to be retrieved
+            - Flow: the requested flow
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         client = self._boto3_client
 
@@ -97,7 +86,9 @@ class CodeCommit(Storage):
             )
             raise exc
 
-        return extract_flow_from_file(file_contents=decoded_contents)
+        return extract_flow_from_file(
+            file_contents=decoded_contents, flow_name=flow_name
+        )
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -285,31 +285,22 @@ class Docker(Storage):
         self._flows[flow.name] = flow  # needed prior to build
         return flow_path
 
-    def get_flow(self, flow_location: str = None) -> "prefect.core.flow.Flow":
+    def get_flow(self, flow_name: str) -> "prefect.core.flow.Flow":
         """
-        Given a file path within this Docker container, returns the underlying Flow.
-        Note that this method should only be run _within_ the container itself.
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str, optional): the file path of a flow within this container. Will use
-                `path` if not provided.
+            - flow_name (str): the name of the flow to return.
 
         Returns:
             - Flow: the requested flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         if self.stored_as_script:
-            return extract_flow_from_file(file_path=flow_location)
+            return extract_flow_from_file(file_path=flow_location, flow_name=flow_name)
 
         with open(flow_location, "rb") as f:
             return flow_from_bytes_pickle(f.read())

--- a/src/prefect/storage/gcs.py
+++ b/src/prefect/storage/gcs.py
@@ -66,27 +66,19 @@ class GCS(Storage):
         result = GCSResult(bucket=bucket)
         super().__init__(result=result, stored_as_script=stored_as_script, **kwargs)
 
-    def get_flow(self, flow_location: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage; in this case,
-                a file path where a Flow has been serialized to. Will use `key` if not provided.
+            - flow_name (str): the name of the flow to return.
 
         Returns:
             - Flow: the requested flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.key:
-            flow_location = self.key
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         bucket = self._gcs_client.get_bucket(self.bucket)
 
@@ -107,7 +99,7 @@ class GCS(Storage):
         )
 
         if self.stored_as_script:
-            return extract_flow_from_file(file_contents=content)
+            return extract_flow_from_file(file_contents=content, flow_name=flow_name)
 
         return flow_from_bytes_pickle(content)
 

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -46,39 +46,26 @@ class GitHub(Storage):
 
         super().__init__(**kwargs)
 
-    def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
-        If the Flow is not found an error will be logged and `None` will be returned.
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path on a repository where a Flow file has been committed. Will use `path` if not
-                provided.
-            - ref (str, optional): a commit SHA-1 value or branch name. Defaults to 'master' if not
-                specified
+            - flow_name (str): the name of the flow to return.
 
         Returns:
-            - Flow: the requested Flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
-            - UnknownObjectException: if the flow file is unable to be retrieved
+            - Flow: the requested flow
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         from github import UnknownObjectException
 
         repo = self._github_client.get_repo(self.repo)
 
         try:
-            contents = repo.get_contents(flow_location, ref=ref or self.ref)
+            contents = repo.get_contents(flow_location, ref=self.ref)
             decoded_contents = contents.decoded_content
         except UnknownObjectException as exc:
             self.logger.error(
@@ -88,7 +75,9 @@ class GitHub(Storage):
             )
             raise exc
 
-        return extract_flow_from_file(file_contents=decoded_contents)
+        return extract_flow_from_file(
+            file_contents=decoded_contents, flow_name=flow_name
+        )
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -55,35 +55,21 @@ class GitLab(Storage):
 
         super().__init__(**kwargs)
 
-    def get_flow(self, flow_location: str = None, ref: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
-        If the Flow is not found an error will be logged and `None` will be returned.
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str): the location of a flow within this Storage; in this case,
-                a file path on a repository where a Flow file has been committed. Will use `path` if not
-                provided.
-            - ref (str, optional): a commit SHA-1 value or branch name. Defaults to 'master' if
-                not specified
+            - flow_name (str): the name of the flow to return.
 
         Returns:
-            - Flow: the requested Flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
-            - UnknownObjectException: if the flow file is unable to be retrieved
+            - Flow: the requested flow
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
-        # Use ref argument if exists, else use attribute, else default to 'master'
-        ref = ref if ref else (self.ref if self.ref else "master")
+        ref = self.ref or "master"
 
         from gitlab.exceptions import GitlabAuthenticationError, GitlabGetError
 
@@ -102,7 +88,9 @@ class GitLab(Storage):
             )
             raise
 
-        return extract_flow_from_file(file_contents=contents.decode())
+        return extract_flow_from_file(
+            file_contents=contents.decode(), flow_name=flow_name
+        )
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/local.py
+++ b/src/prefect/storage/local.py
@@ -76,43 +76,32 @@ class Local(Storage):
         else:
             return []
 
-    def get_flow(self, flow_location: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object, returns the underlying Flow (if possible).
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage; in this case,
-                a file path or python path where a Flow has been serialized to. Will use `path`
-                if not provided.
+            - flow_name (str): the name of the flow to return.
 
         Returns:
             - Flow: the requested flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.path:
-            flow_location = self.path
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         # check if the path given is a file path
-        try:
-            if os.path.isfile(flow_location):
-                if self.stored_as_script:
-                    return extract_flow_from_file(file_path=flow_location)
-                else:
-                    with open(flow_location, "rb") as f:
-                        return flow_from_bytes_pickle(f.read())
-            # otherwise the path is given in the module format
+        if os.path.isfile(flow_location):
+            if self.stored_as_script:
+                return extract_flow_from_file(
+                    file_path=flow_location, flow_name=flow_name
+                )
             else:
-                return extract_flow_from_module(module_str=flow_location)
-        except Exception:
-            self.logger.exception(f"Failed to load Flow from {flow_location}")
-            raise
+                with open(flow_location, "rb") as f:
+                    return flow_from_bytes_pickle(f.read())
+        # otherwise the path is given in the module format
+        else:
+            return extract_flow_from_module(module_str=flow_location)
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -66,29 +66,19 @@ class S3(Storage):
             **kwargs,
         )
 
-    def get_flow(self, flow_location: str = None) -> "Flow":
+    def get_flow(self, flow_name: str) -> "Flow":
         """
-        Given a flow_location within this Storage object or S3, returns the underlying Flow
-        (if possible).
+        Given a flow name within this Storage object, load and return the Flow.
 
         Args:
-            - flow_location (str, optional): the location of a flow within this Storage; in this case
-                an S3 object key where a Flow has been serialized to. Will use `key` if not provided.
+            - flow_name (str): the name of the flow to return.
 
         Returns:
-            - Flow: the requested Flow
-
-        Raises:
-            - ValueError: if the flow is not contained in this storage
-            - botocore.ClientError: if there is an issue downloading the Flow from S3
+            - Flow: the requested flow
         """
-        if flow_location:
-            if flow_location not in self.flows.values():
-                raise ValueError("Flow is not contained in this Storage")
-        elif self.key:
-            flow_location = self.key
-        else:
-            raise ValueError("No flow location provided")
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
 
         stream = io.BytesIO()
 
@@ -110,7 +100,7 @@ class S3(Storage):
         output = stream.read()
 
         if self.stored_as_script:
-            return extract_flow_from_file(file_contents=output)  # type: ignore
+            return extract_flow_from_file(file_contents=output, flow_name=flow_name)  # type: ignore
 
         return flow_from_bytes_pickle(output)
 

--- a/tests/environments/execution/test_local_environment.py
+++ b/tests/environments/execution/test_local_environment.py
@@ -13,8 +13,8 @@ class DummyStorage(Local):
         self.flows[flow.name] = flow
         return flow.name
 
-    def get_flow(self, location):
-        return self.flows[location]
+    def get_flow(self, flow_name):
+        return self.flows[flow_name]
 
 
 def test_create_environment():

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -234,12 +234,12 @@ def test_local_empty_serialize():
 def test_local_roundtrip():
     with tempfile.TemporaryDirectory() as tmpdir:
         s = storage.Local(directory=tmpdir, secrets=["AUTH"])
-        flow_loc = s.add_flow(prefect.Flow("test"))
+        s.add_flow(prefect.Flow("test"))
         serialized = LocalSchema().dump(s)
         deserialized = LocalSchema().load(serialized)
 
         assert "test" in deserialized
-        runner = deserialized.get_flow(flow_loc)
+        runner = deserialized.get_flow("test")
 
     assert runner.run().is_successful()
     assert deserialized.secrets == ["AUTH"]

--- a/tests/storage/test_bitbucket_storage.py
+++ b/tests/storage/test_bitbucket_storage.py
@@ -86,21 +86,16 @@ def test_get_flow_bitbucket(monkeypatch):
     bitbucket = MagicMock()
     monkeypatch.setattr("prefect.utilities.git.Bitbucket", bitbucket)
 
+    extract_flow_from_file = MagicMock(return_value=f)
     monkeypatch.setattr(
-        "prefect.storage.bitbucket.extract_flow_from_file",
-        MagicMock(return_value=f),
+        "prefect.storage.bitbucket.extract_flow_from_file", extract_flow_from_file
     )
-
-    with pytest.raises(ValueError) as ex:
-        storage = Bitbucket(project="PROJECT", repo="test-repo")
-        storage.get_flow()
-
-    assert "No flow location provided" in str(ex.value)
 
     storage = Bitbucket(project="PROJECT", repo="test-repo", path="test-flow.py")
 
     assert f.name not in storage
-    flow_location = storage.add_flow(f)
+    storage.add_flow(f)
 
-    new_flow = storage.get_flow(flow_location)
+    new_flow = storage.get_flow(f.name)
+    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
     assert new_flow.run()

--- a/tests/storage/test_codecommit_storage.py
+++ b/tests/storage/test_codecommit_storage.py
@@ -112,19 +112,17 @@ def test_get_flow_codecommit(monkeypatch):
 
     f = Flow("test")
 
+    extract_flow_from_file = MagicMock(return_value=f)
     monkeypatch.setattr(
-        "prefect.storage.github.extract_flow_from_file",
-        MagicMock(return_value=f),
+        "prefect.storage.codecommit.extract_flow_from_file",
+        extract_flow_from_file,
     )
-
-    with pytest.raises(ValueError):
-        storage = CodeCommit(repo="test/repo")
-        storage.get_flow()
 
     storage = CodeCommit(repo="test/repo", path="flow", commit="master")
 
     assert f.name not in storage
-    flow_location = storage.add_flow(f)
+    storage.add_flow(f)
 
-    new_flow = storage.get_flow(flow_location)
+    new_flow = storage.get_flow(f.name)
+    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
     assert new_flow.run()

--- a/tests/storage/test_docker_storage.py
+++ b/tests/storage/test_docker_storage.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import json
 import tempfile
@@ -210,7 +209,7 @@ def test_docker_storage_allows_for_user_provided_config_locations():
 
 def test_files_not_absolute_path():
     with pytest.raises(ValueError):
-        storage = Docker(files={"test": "test"})
+        Docker(files={"test": "test"})
 
 
 def test_build_base_image(monkeypatch):
@@ -870,32 +869,20 @@ def test_docker_storage_name_registry_url_none():
     assert storage.name == "test2:test3"
 
 
-def test_docker_storage_get_flow_method():
-    with tempfile.TemporaryDirectory() as directory:
-        storage = Docker(base_image="python:3.6", prefect_directory=directory)
+def test_docker_storage_get_flow_method(tmpdir):
+    flow_dir = str(tmpdir.mkdir("flows"))
 
-        with pytest.raises(ValueError):
-            storage.get_flow()
+    flow = Flow("test")
+    flow_path = os.path.join(flow_dir, "test.prefect")
+    with open(flow_path, "wb") as f:
+        cloudpickle.dump(flow, f)
 
-        @prefect.task
-        def add_to_dict():
-            with open(os.path.join(directory, "output"), "w") as tmp:
-                tmp.write("success")
+    storage = Docker(base_image="python:3.6", prefect_directory=str(tmpdir))
+    storage.add_flow(flow)
 
-        flow_dir = os.path.join(directory, "flows")
-        os.makedirs(flow_dir, exist_ok=True)
-
-        with open(os.path.join(flow_dir, "test.prefect"), "w+") as env:
-            flow = Flow("test", tasks=[add_to_dict])
-            flow_path = os.path.join(flow_dir, "test.prefect")
-            with open(flow_path, "wb") as f:
-                cloudpickle.dump(flow, f)
-            out = storage.add_flow(flow)
-
-        f = storage.get_flow(out)
-        assert isinstance(f, Flow)
-        assert f.name == "test"
-        assert len(f.tasks) == 1
+    f = storage.get_flow(flow.name)
+    assert isinstance(f, Flow)
+    assert f.name == "test"
 
 
 def test_add_similar_flows_fails():

--- a/tests/storage/test_github_storage.py
+++ b/tests/storage/test_github_storage.py
@@ -76,19 +76,16 @@ def test_get_flow_github(monkeypatch):
     github = MagicMock()
     monkeypatch.setattr("prefect.utilities.git.Github", github)
 
+    extract_flow_from_file = MagicMock(return_value=f)
     monkeypatch.setattr(
-        "prefect.storage.github.extract_flow_from_file",
-        MagicMock(return_value=f),
+        "prefect.storage.github.extract_flow_from_file", extract_flow_from_file
     )
 
-    with pytest.raises(ValueError):
-        storage = GitHub(repo="test/repo")
-        storage.get_flow()
-
-    storage = GitHub(repo="test/repo", path="flow")
+    storage = GitHub(repo="test/repo", path="flow", ref="my_branch")
 
     assert f.name not in storage
-    flow_location = storage.add_flow(f)
+    storage.add_flow(f)
 
-    new_flow = storage.get_flow(flow_location, ref="my_branch")
+    new_flow = storage.get_flow(f.name)
+    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
     assert new_flow.run()

--- a/tests/storage/test_gitlab_storage.py
+++ b/tests/storage/test_gitlab_storage.py
@@ -81,21 +81,17 @@ def test_get_flow_gitlab(monkeypatch):
     gitlab = MagicMock()
     monkeypatch.setattr("prefect.utilities.git.Gitlab", gitlab)
 
+    extract_flow_from_file = MagicMock(return_value=f)
     monkeypatch.setattr(
         "prefect.storage.gitlab.extract_flow_from_file",
-        MagicMock(return_value=f),
+        extract_flow_from_file,
     )
-
-    with pytest.raises(ValueError) as ex:
-        storage = GitLab(repo="test/repo")
-        storage.get_flow()
-
-    assert "No flow location provided" in str(ex.value)
 
     storage = GitLab(repo="test/repo", path="flow.py")
 
     assert f.name not in storage
-    flow_location = storage.add_flow(f)
+    storage.add_flow(f)
 
-    new_flow = storage.get_flow(flow_location)
+    new_flow = storage.get_flow(f.name)
+    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
     assert new_flow.run()

--- a/tests/storage/test_webhook_storage.py
+++ b/tests/storage/test_webhook_storage.py
@@ -143,7 +143,7 @@ def test_webhook_build_works_with_no_arguments(sample_flow):
     res = webhook.build()
     assert isinstance(res, Webhook)
 
-    res = webhook.get_flow()
+    res = webhook.get_flow(sample_flow.name)
     assert isinstance(res, Flow)
 
 
@@ -221,7 +221,7 @@ def test_webhook_raises_error_on_get_flow_failure(sample_flow):
     webhook.build()
 
     with pytest.raises(HTTPError, match="test-error-message"):
-        webhook.get_flow()
+        webhook.get_flow(sample_flow.name)
 
 
 def test_render_dict_gets_env_variables(monkeypatch):
@@ -360,7 +360,7 @@ def test_webhook_works_with_file_storage(sample_flow, tmpdir):
     res = webhook.build()
     assert isinstance(res, Webhook)
 
-    res = webhook.get_flow()
+    res = webhook.get_flow(sample_flow.name)
     assert isinstance(res, Flow)
     assert res.name == "test-flow"
 


### PR DESCRIPTION
We previously added support for storing multiple flows in a single
script file, but in practice that would fail since which flow was
retrieved was non-deterministic (the first flow found would be used).
This fixes this to always load and return the correct flow.

To accomplish this (and clean up some storage internals), the signature
for the `get_flow` method has been changed to accept the *flow name*
rather than the *flow location*. A location may host more than one flow,
but a flow name is always unique within a `Storage` object. Since the
`get_flow` method isn't user facing this change should be fine.

Fixes #3961.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)