### PR TITLE
Rerun secret tasks on flow restart

### DIFF
--- a/changes/pr3977.yaml
+++ b/changes/pr3977.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Rerun secret tasks on flow-run restart - [#3977](https://github.com/PrefectHQ/prefect/pull/3977)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -427,8 +427,8 @@ class FlowRunner(Runner):
                 ):
                     task_states[task] = task_state = Success(result=task.value)
 
-                # Always restart completed resource setup/cleanup tasks unless
-                # they were explicitly cached.
+                # Always restart completed resource setup/cleanup tasks and
+                # secret tasks unless they were explicitly cached.
                 # TODO: we only need to rerun these tasks if any pending
                 # downstream tasks depend on them.
                 if (
@@ -437,6 +437,7 @@ class FlowRunner(Runner):
                         (
                             prefect.tasks.core.resource_manager.ResourceSetupTask,
                             prefect.tasks.core.resource_manager.ResourceCleanupTask,
+                            prefect.tasks.secrets.SecretBase,
                         ),
                     )
                     and task_state is not None


### PR DESCRIPTION
When restarting a flow, we now always rerun secret tasks, since they're
never cached.

Fixes #3926.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)