### PR TITLE
Raise error when invalid data type is uploaded with GCSUpload

### DIFF
--- a/changes/pr3978.yaml
+++ b/changes/pr3978.yaml
@@ -1,0 +1,5 @@
+fix:
+- "GCSUpload tasks now explicitely fail when ran on non-supported types - [#3978](https://github.com/PrefectHQ/prefect/pull/3978)"
+
+contributor:
+- [Loïc Macherel](https://github.com/LoicEm)

--- a/changes/pr3978.yaml
+++ b/changes/pr3978.yaml
@@ -1,5 +1,5 @@
 fix:
-- "GCSUpload tasks now explicitely fail when ran on non-supported types - [#3978](https://github.com/PrefectHQ/prefect/pull/3978)"
+- "GCSUpload task now explicitely fails when ran on non-supported types - [#3978](https://github.com/PrefectHQ/prefect/pull/3978)"
 
 contributor:
-- [Loïc Macherel](https://github.com/LoicEm)
+- "[Loïc Macherel](https://github.com/LoicEm)"

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -22,7 +22,7 @@ class GCSBaseTask(Task):
         chunk_size: int = 104857600,  # 1024 * 1024 B * 100 = 100 MB
         encryption_key_secret: str = None,
         request_timeout: Union[float, Tuple[float, float]] = 60,
-        **kwargs
+        **kwargs,
     ):
         self.bucket = bucket
         self.blob = blob
@@ -112,7 +112,7 @@ class GCSDownload(GCSBaseTask):
         chunk_size: int = None,
         encryption_key_secret: str = None,
         request_timeout: Union[float, Tuple[float, float]] = 60,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             bucket=bucket,
@@ -121,7 +121,7 @@ class GCSDownload(GCSBaseTask):
             chunk_size=chunk_size,
             encryption_key_secret=encryption_key_secret,
             request_timeout=request_timeout,
-            **kwargs
+            **kwargs,
         )
 
     @defaults_from_attrs(
@@ -232,7 +232,7 @@ class GCSUpload(GCSBaseTask):
         create_bucket: bool = False,
         encryption_key_secret: str = None,
         request_timeout: Union[float, Tuple[float, float]] = 60,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             bucket=bucket,
@@ -242,7 +242,7 @@ class GCSUpload(GCSBaseTask):
             create_bucket=create_bucket,
             encryption_key_secret=encryption_key_secret,
             request_timeout=request_timeout,
-            **kwargs
+            **kwargs,
         )
 
     @defaults_from_attrs(
@@ -300,6 +300,7 @@ class GCSUpload(GCSBaseTask):
                 Can also be passed as a tuple (connect_timeout, read_timeout).
 
         Raises:
+            - ValueError: if data is neither string nor bytes.
             - google.cloud.exception.NotFound: if `create_bucket=False` and the bucket name is
                 not found
 
@@ -335,6 +336,8 @@ class GCSUpload(GCSBaseTask):
             if content_encoding:
                 gcs_blob.content_encoding = content_encoding
             gcs_blob.upload_from_file(io.BytesIO(data), timeout=request_timeout)
+        else:
+            raise ValueError(f"data must be str or bytes: got {type(data)} instead")
         return gcs_blob.name
 
 
@@ -373,7 +376,7 @@ class GCSCopy(GCSBaseTask):
         dest_blob: str = None,
         project: str = None,
         request_timeout: Union[float, Tuple[float, float]] = 60,
-        **kwargs
+        **kwargs,
     ):
         self.source_bucket = source_bucket
         self.source_blob = source_blob

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -300,7 +300,7 @@ class GCSUpload(GCSBaseTask):
                 Can also be passed as a tuple (connect_timeout, read_timeout).
 
         Raises:
-            - ValueError: if data is neither string nor bytes.
+            - TypeError: if data is neither string nor bytes.
             - google.cloud.exception.NotFound: if `create_bucket=False` and the bucket name is
                 not found
 
@@ -337,7 +337,7 @@ class GCSUpload(GCSBaseTask):
                 gcs_blob.content_encoding = content_encoding
             gcs_blob.upload_from_file(io.BytesIO(data), timeout=request_timeout)
         else:
-            raise ValueError(f"data must be str or bytes: got {type(data)} instead")
+            raise TypeError(f"data must be str or bytes: got {type(data)} instead")
         return gcs_blob.name
 
 

--- a/tests/tasks/gcp/test_gcs_upload_download.py
+++ b/tests/tasks/gcp/test_gcs_upload_download.py
@@ -140,6 +140,6 @@ class TestRuntimeValidation:
         monkeypatch.setattr("prefect.tasks.gcp.storage.get_storage_client", client)
 
         with pytest.raises(
-            ValueError, match="data must be str or bytes: got .* instead"
+            TypeError, match="data must be str or bytes: got .* instead"
         ):
             task.run([1, 2, 3])

--- a/tests/tasks/gcp/test_gcs_upload_download.py
+++ b/tests/tasks/gcp/test_gcs_upload_download.py
@@ -139,5 +139,5 @@ class TestRuntimeValidation:
         )
         monkeypatch.setattr("prefect.tasks.gcp.storage.get_storage_client", client)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="data must be str or bytes: got .* instead"):
             task.run([1, 2, 3])

--- a/tests/tasks/gcp/test_gcs_upload_download.py
+++ b/tests/tasks/gcp/test_gcs_upload_download.py
@@ -139,5 +139,7 @@ class TestRuntimeValidation:
         )
         monkeypatch.setattr("prefect.tasks.gcp.storage.get_storage_client", client)
 
-        with pytest.raises(ValueError, match="data must be str or bytes: got .* instead"):
+        with pytest.raises(
+            ValueError, match="data must be str or bytes: got .* instead"
+        ):
             task.run([1, 2, 3])

--- a/tests/tasks/gcp/test_gcs_upload_download.py
+++ b/tests/tasks/gcp/test_gcs_upload_download.py
@@ -126,3 +126,18 @@ class TestBlob:
         task.run(blob="run-time", credentials={})
 
         assert blob.call_args[0] == ("run-time",)
+
+
+class TestRuntimeValidation:
+    def test_invalid_data_type_raises_error(self, monkeypatch):
+        task = GCSUpload(bucket="test", blob="blobber")
+
+        blob = MagicMock()
+        client = MagicMock()
+        client.return_value = MagicMock(
+            get_bucket=MagicMock(return_value=MagicMock(blob=blob))
+        )
+        monkeypatch.setattr("prefect.tasks.gcp.storage.get_storage_client", client)
+
+        with pytest.raises(ValueError):
+            task.run([1, 2, 3])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Added a case when data uploaded is neither string nor bytes in `prefect.tasks.gcp.storage.GCSUpload`, raising an explicit `ValuError` in that case.

Solving issue #3974 


## Changes
<!-- What does this PR change? -->

Create an `else` case when determining the data type in `prefect.tasks.gcp.storage.GCSUpload`, raising a `ValueError` if type is neither string nor bytes.

Created an associated test in `tests/tasks/gcp/storage/test_gcs_upload_and_download.py`: I have created a `TestRunTimeValidation` object with this test a single function, took the naming from `test_gcs_copy.py` in the same folder.


## Importance
<!-- Why is this PR important? -->

GCSUpload is at the moment failing silently when data uploaded is neither string nor bytes.
With this PR it will explicitely fail.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)