### PR TITLE
Use boto3 session in S3Upload and S3Download tasks

### DIFF
--- a/changes/pr3925.yaml
+++ b/changes/pr3925.yaml
@@ -1,5 +1,0 @@
-task:
-  - "Added `use_session` argument to `S3Upload` and `S3Download` tasks, to enable thread-safe execution - [#3925](https://github.com/PrefectHQ/prefect/pull/3925)"
-
-contributor:
-  - "[Gregory Roche](https://github.com/gregoryroche)"

--- a/changes/pr3925.yaml
+++ b/changes/pr3925.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Added `use_session` argument to `S3Upload` and `S3Download` tasks, to enable thread-safe execution - [#3925](https://github.com/PrefectHQ/prefect/pull/3925)"
+
+contributor:
+  - "[Gregory Roche](https://github.com/gregoryroche)"

--- a/changes/pr3981.yaml
+++ b/changes/pr3981.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Added `use_session` argument to `S3Upload` and `S3Download` tasks, to enable thread-safe execution - [#3981](https://github.com/PrefectHQ/prefect/pull/3981)"
+
+contributor:
+  - "[Gregory Roche](https://github.com/gregoryroche)"

--- a/changes/pr3981.yaml
+++ b/changes/pr3981.yaml
@@ -1,5 +1,5 @@
 task:
-  - "Added `use_session` argument to `S3Upload` and `S3Download` tasks, to enable thread-safe execution - [#3981](https://github.com/PrefectHQ/prefect/pull/3981)"
+  - "Use boto3 session in `S3Upload` and `S3Download` tasks, to ensure thread-safe execution - [#3981](https://github.com/PrefectHQ/prefect/pull/3981)"
 
 contributor:
   - "[Gregory Roche](https://github.com/gregoryroche)"

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -43,6 +43,7 @@ class S3Download(Task):
         credentials: str = None,
         bucket: str = None,
         compression: str = None,
+        use_session: bool = False,
     ):
         """
         Task run method.
@@ -57,6 +58,9 @@ class S3Download(Task):
             - bucket (str, optional): the name of the S3 Bucket to download from
             - compression (str, optional): specifies a file format for decompression, decompressing
                 data upon download. Currently supports `'gzip'`.
+            - use_session (bool, optional): specifies whether the `boto3` client should
+                be loaded as a session. Defaults to `False`. Using a session requires
+                more overhead to create the client, but ensures that it is thread-safe.
 
         Returns:
             - str: the contents of this Key / Bucket, as a string
@@ -64,7 +68,9 @@ class S3Download(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
+        s3_client = get_boto_client(
+            "s3", credentials=credentials, use_session=use_session, **self.boto_kwargs
+        )
 
         stream = io.BytesIO()
 
@@ -121,6 +127,7 @@ class S3Upload(Task):
         credentials: dict = None,
         bucket: str = None,
         compression: str = None,
+        use_session: bool = False,
     ):
         """
         Task run method.
@@ -137,6 +144,9 @@ class S3Upload(Task):
             - bucket (str, optional): the name of the S3 Bucket to upload to
             - compression (str, optional): specifies a file format for compression,
                 compressing data before upload. Currently supports `'gzip'`.
+            - use_session (bool, optional): specifies whether the `boto3` client should
+                be loaded as a session. Defaults to `False`. Using a session requires
+                more overhead to create the client, but ensures that it is thread-safe.
 
         Returns:
             - str: the name of the Key the data payload was uploaded to
@@ -144,7 +154,9 @@ class S3Upload(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
+        s3_client = get_boto_client(
+            "s3", credentials=credentials, use_session=use_session, **self.boto_kwargs
+        )
 
         # compress data if compression is specified
         if compression:

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -43,7 +43,6 @@ class S3Download(Task):
         credentials: str = None,
         bucket: str = None,
         compression: str = None,
-        use_session: bool = False,
     ):
         """
         Task run method.
@@ -58,9 +57,6 @@ class S3Download(Task):
             - bucket (str, optional): the name of the S3 Bucket to download from
             - compression (str, optional): specifies a file format for decompression, decompressing
                 data upon download. Currently supports `'gzip'`.
-            - use_session (bool, optional): specifies whether the `boto3` client should
-                be loaded as a session. Defaults to `False`. Using a session requires
-                more overhead to create the client, but ensures that it is thread-safe.
 
         Returns:
             - str: the contents of this Key / Bucket, as a string
@@ -69,7 +65,7 @@ class S3Download(Task):
             raise ValueError("A bucket name must be provided.")
 
         s3_client = get_boto_client(
-            "s3", credentials=credentials, use_session=use_session, **self.boto_kwargs
+            "s3", credentials=credentials, use_session=True, **self.boto_kwargs
         )
 
         stream = io.BytesIO()
@@ -127,7 +123,6 @@ class S3Upload(Task):
         credentials: dict = None,
         bucket: str = None,
         compression: str = None,
-        use_session: bool = False,
     ):
         """
         Task run method.
@@ -144,9 +139,6 @@ class S3Upload(Task):
             - bucket (str, optional): the name of the S3 Bucket to upload to
             - compression (str, optional): specifies a file format for compression,
                 compressing data before upload. Currently supports `'gzip'`.
-            - use_session (bool, optional): specifies whether the `boto3` client should
-                be loaded as a session. Defaults to `False`. Using a session requires
-                more overhead to create the client, but ensures that it is thread-safe.
 
         Returns:
             - str: the name of the Key the data payload was uploaded to
@@ -155,7 +147,7 @@ class S3Upload(Task):
             raise ValueError("A bucket name must be provided.")
 
         s3_client = get_boto_client(
-            "s3", credentials=credentials, use_session=use_session, **self.boto_kwargs
+            "s3", credentials=credentials, use_session=True, **self.boto_kwargs
         )
 
         # compress data if compression is specified

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -47,6 +47,51 @@ class TestS3Download:
         with pytest.raises(ValueError, match="gz_fake"):
             task.run("key", compression="gz_fake")
 
+    def test_use_session_true_creates_session_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Download(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(key="foo", use_session=True)
+        assert "session.Session" in boto3.mock_calls[0]
+
+    def test_use_session_false_creates_sessionless_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Download(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(key="foo", use_session=False)
+        assert "session.Session" not in boto3.mock_calls[0]
+
+    def test_use_session_omitted_creates_sessionless_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Download(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(key="foo")
+        assert "session.Session" not in boto3.mock_calls[0]
+
 
 class TestS3Upload:
     def test_initialization(self):
@@ -97,6 +142,51 @@ class TestS3Upload:
 
         with pytest.raises(ValueError, match="gz_fake"):
             task.run(b"data", compression="gz_fake")
+
+    def test_use_session_true_creates_session_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Upload(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(data="foo", use_session=True)
+        assert "session.Session" in boto3.mock_calls[0]
+
+    def test_use_session_false_creates_sessionless_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Upload(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(data="foo", use_session=False)
+        assert "session.Session" not in boto3.mock_calls[0]
+
+    def test_use_session_omitted_creates_sessionless_client(self, monkeypatch):
+        """ Test fix for issue #3925 """
+        task = S3Upload(bucket="test")
+        client = MagicMock()
+        boto3 = MagicMock(client=MagicMock(return_value=client))
+        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+        with set_temporary_config({"cloud.use_local_secrets": True}):
+            with prefect.context(
+                secrets=dict(
+                    AWS_CREDENTIALS={"ACCESS_KEY": "42", "SECRET_ACCESS_KEY": "99"}
+                )
+            ):
+                task.run(data="foo")
+        assert "session.Session" not in boto3.mock_calls[0]
 
 
 class TestS3List:


### PR DESCRIPTION
## Summary
Create a boto3 session during `tasks.aws.S3Upload` and `tasks.aws.S3Download` to ensure the task is executed in a thread-safe way. Provides a workaround for #3925.


## Changes
~~The only change is the addition of one argument to the `run()` method for each of the two tasks, with the value of this argument being passed to `get_boto_client()`. The default value is `False`, which makes the task use the exact same behaviour from before this PR to avoid backwards compatibility issues. If `True`, a boto3 session is created before the boto3 client is created, requiring slightly more overhead but ensuring thread-safe execution.~~

After discussion with code owners, updated the logic so that the only change is to always pass `use_session = True` to `get_boto_client()`.


## Importance
This PR makes the `S3Upload` and `S3Download` tasks more robust when used in flows with parallel execution.


## Checklist

This PR:
- [✔] adds new tests (if appropriate)
- [✔] adds a change file in the `changes/` directory (if appropriate)
- [✔] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

(note: this is my first ever pull request, and my first ever commit to a public repo, apologies in advance for any mistakes or weirdness)