### PR TITLE
POC - Infer Github storage values from git

### DIFF
--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -43,22 +43,19 @@ class GitHub(Storage):
         self.flows = dict()  # type: Dict[str, str]
         self._flows = dict()  # type: Dict[str, "Flow"]
 
-        # Given a path that exists, we'll look at git for info
-        if os.path.exists(path) and (not repo or not path):
-            inferred_repo, inferred_path = self._infer_git_info(path)
-        else:
-            inferred_repo = None
-            inferred_path = None
+        # Given a path that exists and no repo, we'll try to infer it
+        if path and os.path.exists(path) and not repo:
+            repo, path = self._infer_git_info(path)
 
-        self.repo = repo or inferred_repo
-        self.path = path or inferred_path
+        self.repo = repo
+        self.path = path
         self.ref = ref
 
         if not self.repo:
-            raise ValueError("`repo` was not provided and could not be detected.")
+            raise ValueError("`repo` was not provided or failed to be inferred.")
 
         if not self.path:
-            raise ValueError("`path` was not provided and could not be detected.")
+            raise ValueError("`path` was not provided or failed to be inferred.")
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

This is proof of concept and requires more helpful error messages, documentation updates, and tests.

## Summary
<!-- A sentence summarizing the PR -->

Adds inference to GitHub storage so the user does not need to provide a `repo` and `path` when they are using source control to write their flow.


## Changes
<!-- What does this PR change? -->

`repo` is now an optional argument to `GitHub`. If it is not provided, but a `path` is, and that `path` exists on the file system, we can infer that we were passed `__file__` and run `git` commands to infer the repo of that file and the path of the file within the repo to set default values.

Note: We could also update `ref` which I think is quite useful to do when developing but since it *has* a default value this would require more changes to the interface.

## Importance
<!-- Why is this PR important? -->

Simplifies usage of Github storage to

```python
flow.storage = GitHub(path=__file__)
```

rather than repeating the information that we already know e.g. the name of the file that the code is in

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)