### PR TITLE
Improve logs from s3 storage

### DIFF
--- a/changes/pr3995.yaml
+++ b/changes/pr3995.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "S3 storage now logs `ETag`, `LastModified` timestamp, and `VersionId` (if present) when loading a flow - [#3995](https://github.com/PrefectHQ/prefect/pull/3995)"

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -1,4 +1,5 @@
 import io
+from contextlib import closing
 from typing import TYPE_CHECKING, Any, Dict
 
 import pendulum
@@ -78,26 +79,25 @@ class S3(Storage):
         """
         if flow_name not in self.flows:
             raise ValueError("Flow is not contained in this Storage")
-        flow_location = self.flows[flow_name]
+        key = self.flows[flow_name]
 
-        stream = io.BytesIO()
-
-        self.logger.info("Downloading {} from {}".format(flow_location, self.bucket))
-
-        # Download stream from S3
-        from botocore.exceptions import ClientError
+        self.logger.info(f"Downloading flow from s3://{self.bucket}/{key}")
 
         try:
-            self._boto3_client.download_fileobj(
-                Bucket=self.bucket, Key=flow_location, Fileobj=stream
-            )
-        except ClientError as err:
+            obj = self._boto3_client.get_object(Bucket=self.bucket, Key=key)
+            body = obj["Body"]
+            with closing(body):
+                output = body.read()
+        except Exception as err:
             self.logger.error("Error downloading Flow from S3: {}".format(err))
-            raise err
+            raise
 
-        # prepare data and return
-        stream.seek(0)
-        output = stream.read()
+        self.logger.info(
+            "Flow successfully downloaded. ETag: %s, LastModified: %s, VersionId: %s",
+            obj["ETag"],
+            obj["LastModified"].isoformat(),
+            obj.get("VersionId"),
+        )
 
         if self.stored_as_script:
             return extract_flow_from_file(file_contents=output, flow_name=flow_name)  # type: ignore

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -1,16 +1,26 @@
 import io
+import datetime
+import textwrap
 from unittest.mock import MagicMock
 
 import pytest
 
 from prefect import context, Flow
 from prefect.storage import S3
-from prefect.utilities.storage import flow_from_bytes_pickle
+from prefect.utilities.storage import flow_from_bytes_pickle, flow_to_bytes_pickle
 
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
 
 from botocore.exceptions import ClientError
+
+
+@pytest.fixture
+def s3_client(monkeypatch):
+    client = MagicMock()
+    get_boto_client = MagicMock(return_value=client)
+    monkeypatch.setattr("prefect.utilities.aws.get_boto_client", get_boto_client)
+    return client
 
 
 def test_create_s3_storage():
@@ -78,136 +88,44 @@ def test_boto3_client_property(monkeypatch):
     )
 
 
-def test_add_flow_to_S3(bucket="bucket"):
+def test_add_flow_to_S3():
     storage = S3(bucket="bucket")
 
     f = Flow("test")
     assert f.name not in storage
-    assert storage.add_flow(f)
+    key = storage.add_flow(f)
+    assert storage.flows[f.name] == key
     assert f.name in storage
 
 
-def test_add_multiple_flows_to_S3(bucket="bucket"):
+def test_add_multiple_flows_to_S3():
     storage = S3(bucket="bucket")
 
-    f = Flow("test")
-    g = Flow("testg")
-    assert f.name not in storage
-    assert storage.add_flow(f)
-    assert storage.add_flow(g)
-    assert f.name in storage
-    assert g.name in storage
+    flows = [Flow("f"), Flow("g")]
+    keys = [storage.add_flow(f) for f in flows]
+    for flow, key in zip(flows, keys):
+        assert storage.flows[flow.name] == key
+        assert flow.name in storage
 
 
-def test_upload_flow_to_s3(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(bucket="bucket")
+@pytest.mark.parametrize("key", ["mykey", None])
+def test_upload_flow_to_s3(s3_client, key):
+    storage = S3(bucket="bucket", key=key)
 
     f = Flow("test")
-    assert f.name not in storage
-    assert storage.add_flow(f)
-    assert storage.build()
-    assert boto3.upload_fileobj.called
-    assert f.name in storage
 
+    key_used = storage.add_flow(f)
+    if key is not None:
+        assert key_used == key
 
-def test_build_no_upload_if_file_and_no_script(monkeypatch):
-    storage = S3(bucket="bucket", stored_as_script=True)
+    assert storage.build() is storage
 
-    with pytest.raises(ValueError):
-        storage.build()
+    assert s3_client.upload_fileobj.called
 
-    storage = S3(bucket="bucket", stored_as_script=True, key="flow.py")
-    assert storage == storage.build()
+    assert s3_client.upload_fileobj.call_args[1]["Bucket"] == "bucket"
+    assert s3_client.upload_fileobj.call_args[1]["Key"] == key_used
 
-
-def test_build_script_upload(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(
-        bucket="bucket", stored_as_script=True, local_script_path="local.py", key="key"
-    )
-
-    f = Flow("test")
-    assert f.name not in storage
-    assert storage.add_flow(f)
-    assert storage.build()
-    assert f.name in storage
-
-    assert boto3.upload_file.called
-    assert boto3.upload_file.call_args[0] == ("local.py", "bucket", "key")
-
-    boto3.upload_file.side_effect = ClientError({}, None)
-
-    with pytest.raises(ClientError):
-        storage.build()
-
-
-def test_upload_flow_to_s3_client_error(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    boto3.upload_fileobj.side_effect = ClientError({}, None)
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(bucket="bucket")
-
-    f = Flow("test")
-    assert f.name not in storage
-    assert storage.add_flow(f)
-
-    with pytest.raises(ClientError):
-        storage.build()
-    assert boto3.upload_fileobj.called
-
-
-def test_upload_flow_to_s3_bucket_key(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(bucket="bucket", key="key")
-
-    f = Flow("test")
-    assert storage.add_flow(f)
-    assert storage.build()
-
-    assert boto3.upload_fileobj.call_args[1]["Bucket"] == "bucket"
-    assert boto3.upload_fileobj.call_args[1]["Key"] == "key"
-
-
-def test_upload_multiple_flows_to_s3_bucket_key(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(bucket="bucket")
-
-    f1 = Flow("test1")
-    f2 = Flow("test2")
-    assert storage.add_flow(f1)
-    assert storage.add_flow(f2)
-    assert storage.build()
-
-    assert boto3.upload_fileobj.call_args[1]["Bucket"] == "bucket"
-
-
-def test_upload_flow_to_s3_flow_byte_stream(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    storage = S3(bucket="bucket")
-
-    f = Flow("test")
-    assert storage.add_flow(f)
-    assert storage.build()
-
-    flow_as_bytes = boto3.upload_fileobj.call_args[0][0]
+    flow_as_bytes = s3_client.upload_fileobj.call_args[0][0]
     assert isinstance(flow_as_bytes, io.BytesIO)
 
     new_flow = flow_from_bytes_pickle(flow_as_bytes.read())
@@ -217,25 +135,64 @@ def test_upload_flow_to_s3_flow_byte_stream(monkeypatch):
     assert state.is_successful()
 
 
-def test_upload_flow_to_s3_key_format(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(upload_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
+def test_build_no_upload_if_file_and_no_script(s3_client):
+    storage = S3(bucket="bucket", stored_as_script=True)
+
+    with pytest.raises(ValueError):
+        storage.build()
+
+    storage = S3(bucket="bucket", stored_as_script=True, key="flow.py")
+    storage.build()
+    assert not s3_client.upload_fileobj.called
+
+
+def test_build_script_upload(s3_client):
+    storage = S3(
+        bucket="bucket", stored_as_script=True, local_script_path="local.py", key="key"
+    )
+
+    f = Flow("test")
+    storage.add_flow(f)
+    assert f.name in storage
+
+    storage.build()
+    assert s3_client.upload_file.called
+    assert s3_client.upload_file.call_args[0] == ("local.py", "bucket", "key")
+
+    s3_client.upload_file.side_effect = ClientError({}, None)
+
+    with pytest.raises(ClientError):
+        storage.build()
+
+
+def test_upload_flow_to_s3_client_error(s3_client):
+    s3_client.upload_fileobj.side_effect = ClientError({}, None)
 
     storage = S3(bucket="bucket")
 
     f = Flow("test")
+    assert f.name not in storage
     assert storage.add_flow(f)
+
+    with pytest.raises(ClientError):
+        storage.build()
+    assert s3_client.upload_fileobj.called
+
+
+def test_upload_multiple_flows_to_s3_bucket(s3_client):
+    storage = S3(bucket="bucket")
+
+    f1 = Flow("test1")
+    f2 = Flow("test2")
+    assert storage.add_flow(f1)
+    assert storage.add_flow(f2)
     assert storage.build()
 
-    assert boto3.upload_fileobj.call_args[1]["Bucket"] == "bucket"
-    key = boto3.upload_fileobj.call_args[1]["Key"].split("/")
-
-    assert key[0] == "test"
-    assert key[1]
+    assert s3_client.upload_fileobj.call_count == 2
+    assert s3_client.upload_fileobj.call_args[1]["Bucket"] == "bucket"
 
 
-def test_add_flow_to_s3_already_added(monkeypatch):
+def test_add_flow_to_s3_already_added():
     storage = S3(bucket="bucket")
 
     f = Flow("test")
@@ -247,133 +204,133 @@ def test_add_flow_to_s3_already_added(monkeypatch):
         storage.add_flow(f)
 
 
-def test_get_flow_s3(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
+@pytest.mark.parametrize("key", ["mykey", None])
+def test_get_flow_s3_pickle(s3_client, key):
     f = Flow("test")
+    storage = S3(bucket="bucket", key=key)
+    key_used = storage.add_flow(f)
 
-    monkeypatch.setattr("cloudpickle.loads", MagicMock(return_value=f))
+    data = flow_to_bytes_pickle(f)
 
-    storage = S3(bucket="bucket")
-
-    assert f.name not in storage
-    storage.add_flow(f)
+    s3_client.get_object.return_value = {
+        "ETag": "my-etag",
+        "LastModified": datetime.datetime.now(),
+        "Body": io.BytesIO(data),
+    }
 
     f2 = storage.get_flow(f.name)
+
+    assert s3_client.get_object.called
+    assert s3_client.get_object.call_args[1]["Bucket"] == "bucket"
+    assert s3_client.get_object.call_args[1]["Key"] == key_used
+
     assert f2.name == f.name
-    assert boto3.download_fileobj.called
-    assert f.name in storage
+    state = f2.run()
+    assert state.is_successful()
 
 
-def test_get_flow_s3_client_error(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    boto3.download_fileobj.side_effect = ClientError({}, None)
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
+@pytest.mark.parametrize("key", ["mykey", None])
+def test_get_flow_s3_script(s3_client, key):
+    f = Flow("test")
+    storage = S3(bucket="bucket", key=key, stored_as_script=True)
+    key_used = storage.add_flow(f)
+
+    data = textwrap.dedent(
+        """
+        from prefect import Flow
+        flow = Flow("test")
+        """
+    ).encode("utf-8")
+
+    s3_client.get_object.return_value = {
+        "ETag": "my-etag",
+        "LastModified": datetime.datetime.now(),
+        "Body": io.BytesIO(data),
+    }
+
+    f2 = storage.get_flow(f.name)
+
+    assert s3_client.get_object.called
+    assert s3_client.get_object.call_args[1]["Bucket"] == "bucket"
+    assert s3_client.get_object.call_args[1]["Key"] == key_used
+
+    assert f2.name == f.name
+    state = f2.run()
+    assert state.is_successful()
+
+
+@pytest.mark.parametrize("version_id", ["my-version-id", None])
+def test_get_flow_s3_logs(s3_client, caplog, version_id):
+    f = Flow("test")
+    storage = S3(bucket="mybucket")
+    key_used = storage.add_flow(f)
+
+    data = flow_to_bytes_pickle(f)
+
+    etag = "my-etag"
+    t = datetime.datetime.now()
+
+    s3_client.get_object.return_value = {
+        "ETag": etag,
+        "LastModified": t,
+        "Body": io.BytesIO(data),
+    }
+    if version_id:
+        s3_client.get_object.return_value["VersionId"] = version_id
+
+    storage.get_flow(f.name)
+    logs = [l.getMessage() for l in caplog.records]
+    assert f"s3://mybucket/{key_used}" in logs[0]
+    assert (
+        f"ETag: {etag}, LastModified: {t.isoformat()}, VersionId: {version_id}"
+        in logs[1]
+    )
+
+
+def test_get_flow_s3_client_error(s3_client):
+    s3_client.get_object.side_effect = ClientError({}, None)
 
     f = Flow("test")
 
     storage = S3(bucket="bucket")
-
-    assert f.name not in storage
     storage.add_flow(f)
 
     with pytest.raises(ClientError):
         storage.get_flow(f.name)
 
-    assert boto3.download_fileobj.called
 
+def test_get_flow_s3_download_error(s3_client):
+    class BadReader:
+        def __init__(self):
+            self.closed = False
 
-def test_get_flow_s3_bucket_key(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
+        def read(self):
+            raise ValueError("Oh no!")
+
+        def close(self):
+            self.closed = True
+
+    reader = BadReader()
+
+    s3_client.get_object.return_value = {
+        "ETag": "my-etag",
+        "LastModified": datetime.datetime.now(),
+        "Body": reader,
+    }
 
     f = Flow("test")
-
-    monkeypatch.setattr("cloudpickle.loads", MagicMock(return_value=f))
-
-    storage = S3(bucket="bucket", key="key")
-
-    assert f.name not in storage
+    storage = S3(bucket="bucket")
     storage.add_flow(f)
 
-    assert storage.get_flow(f.name)
-    assert boto3.download_fileobj.call_args[1]["Bucket"] == "bucket"
-    assert boto3.download_fileobj.call_args[1]["Key"] == "key"
+    with pytest.raises(ValueError, match="Oh no!"):
+        storage.get_flow(f.name)
+
+    assert reader.closed
 
 
-def test_get_flow_s3_not_in_storage(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
+def test_get_flow_s3_not_in_storage():
     f = Flow("test")
-
-    monkeypatch.setattr("cloudpickle.loads", MagicMock(return_value=f))
-
     storage = S3(bucket="bucket", key="test")
-
-    assert f.name not in storage
 
     with pytest.raises(ValueError):
         storage.get_flow(f.name)
-
-
-def test_get_flow_s3_runs(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    f = Flow("test")
-
-    monkeypatch.setattr("cloudpickle.loads", MagicMock(return_value=f))
-
-    storage = S3(bucket="bucket")
-
-    assert f.name not in storage
-    storage.add_flow(f)
-
-    new_flow = storage.get_flow(f.name)
-    assert boto3.download_fileobj.called
-    assert f.name in storage
-
-    assert isinstance(new_flow, Flow)
-    assert new_flow.name == "test"
-    assert len(new_flow.tasks) == 0
-
-    state = new_flow.run()
-    assert state.is_successful()
-
-
-def test_get_flow_as_file_s3_runs(monkeypatch):
-    client = MagicMock()
-    boto3 = MagicMock(download_fileobj=MagicMock(return_value=client))
-    monkeypatch.setattr("prefect.storage.S3._boto3_client", boto3)
-
-    f = Flow("test")
-
-    extract_flow_from_file = MagicMock(return_value=f)
-    monkeypatch.setattr(
-        "prefect.storage.s3.extract_flow_from_file",
-        extract_flow_from_file,
-    )
-
-    storage = S3(bucket="bucket", stored_as_script=True)
-
-    assert f.name not in storage
-    storage.add_flow(f)
-
-    new_flow = storage.get_flow(f.name)
-    assert boto3.download_fileobj.called
-    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
-    assert f.name in storage
-
-    assert isinstance(new_flow, Flow)
-    assert new_flow.name == "test"
-    assert len(new_flow.tasks) == 0
-
-    state = new_flow.run()
-    assert state.is_successful()


### PR DESCRIPTION
We now log the `ETag`, `LastModified` timestamp, and `VersionId` (if
present) for flows downloaded from S3 storage. This makes it easier to
track what version of a flow is run.

Also cleans up the S3 storage tests to make better use of fixtures, and
remove duplicate tests.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)