### PR TITLE
A few changes to GitHub storage

### DIFF
--- a/changes/pr3998.yaml
+++ b/changes/pr3998.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "`GitHub` storage now logs the commit sha used when loading a flow - [#3998](https://github.com/PrefectHQ/prefect/pull/3998)"
+  - "`GitHub` storage now loads from a repo's default branch, allowing default branch names other than 'master' - [#3998](https://github.com/PrefectHQ/prefect/pull/3998)"

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -126,8 +126,8 @@ class GitHubSchema(ObjectSchema):
         object_class = GitHub
 
     repo = fields.String(allow_none=False)
-    ref = fields.String(allow_none=False)
-    path = fields.String(allow_none=True)
+    ref = fields.String(allow_none=True)
+    path = fields.String(allow_none=False)
     flows = fields.Dict(key=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
 

--- a/tests/storage/test_base_storage.py
+++ b/tests/storage/test_base_storage.py
@@ -55,7 +55,7 @@ def inst(sub) -> Storage:
         ("CodeCommit", ("repo",)),
         ("Docker", ()),
         ("GCS", ("bucket",)),
-        ("GitHub", ("repo",)),
+        ("GitHub", ("repo", "path")),
         ("GitLab", ("repo",)),
         ("Local", ()),
         ("S3", ("bucket",)),

--- a/tests/storage/test_github_storage.py
+++ b/tests/storage/test_github_storage.py
@@ -5,11 +5,11 @@ import pytest
 from prefect import context, Flow
 from prefect.storage import GitHub
 
-pytest.importorskip("github")
+github = pytest.importorskip("github")
 
 
 def test_create_github_storage():
-    storage = GitHub(repo="test/repo")
+    storage = GitHub(repo="test/repo", path="flow.py")
     assert storage
     assert storage.logger
 
@@ -40,7 +40,7 @@ def test_github_client_property(monkeypatch):
     github = MagicMock()
     monkeypatch.setattr("prefect.utilities.git.Github", github)
 
-    storage = GitHub(repo="test/repo")
+    storage = GitHub(repo="test/repo", path="flow.py")
 
     credentials = "ACCESS_TOKEN"
     with context(secrets=dict(GITHUB_ACCESS_TOKEN=credentials)):
@@ -70,22 +70,82 @@ def test_add_flow_to_github_already_added():
         storage.add_flow(f)
 
 
-def test_get_flow_github(monkeypatch):
-    f = Flow("test")
-
-    github = MagicMock()
-    monkeypatch.setattr("prefect.utilities.git.Github", github)
-
-    extract_flow_from_file = MagicMock(return_value=f)
-    monkeypatch.setattr(
-        "prefect.storage.github.extract_flow_from_file", extract_flow_from_file
+@pytest.fixture
+def github_client(monkeypatch):
+    client = MagicMock(spec=github.Github)
+    monkeypatch.setattr("prefect.utilities.git.Github", MagicMock(return_value=client))
+    repo = client.get_repo.return_value
+    repo.default_branch = "main"
+    repo.get_commit.return_value.sha = "mycommitsha"
+    repo.get_contents.return_value.decoded_content = (
+        b"from prefect import Flow\nflow=Flow('extra')\nflow=Flow('test')"
     )
+    return client
 
-    storage = GitHub(repo="test/repo", path="flow", ref="my_branch")
 
-    assert f.name not in storage
-    storage.add_flow(f)
+@pytest.mark.parametrize("ref", [None, "myref"])
+def test_get_flow(github_client, ref, caplog):
+    storage = GitHub(repo="test/repo", path="flow.py", ref=ref)
+    storage.add_flow(Flow("test"))
 
-    new_flow = storage.get_flow(f.name)
-    assert extract_flow_from_file.call_args[1]["flow_name"] == f.name
-    assert new_flow.run()
+    f = storage.get_flow("test")
+    assert github_client.get_repo.call_args[0][0] == "test/repo"
+    repo = github_client.get_repo.return_value
+
+    assert repo.get_commit.call_args[0][0] == ref or "main"
+    assert repo.get_contents.call_args[0][0] == "flow.py"
+    assert repo.get_contents.call_args[1]["ref"] == "mycommitsha"
+
+    assert f.name == "test"
+    state = f.run()
+    assert state.is_successful()
+
+    msg = "Downloading flow from GitHub storage - repo: 'test/repo', path: 'flow.py'"
+    if ref is not None:
+        msg += f", ref: {ref!r}"
+    assert msg in caplog.text
+    assert "Flow successfully downloaded. Using commit: mycommitsha" in caplog.text
+
+
+def test_get_flow_missing_repo(github_client, caplog):
+    github_client.get_repo.side_effect = github.UnknownObjectException(404, {})
+
+    storage = GitHub(repo="test/repo", path="flow.py")
+    storage.add_flow(Flow("test"))
+
+    with pytest.raises(github.UnknownObjectException):
+        storage.get_flow("test")
+
+    assert "Repo 'test/repo' not found." in caplog.text
+
+
+@pytest.mark.parametrize("ref", [None, "myref"])
+def test_get_flow_missing_ref(github_client, ref, caplog):
+    repo = github_client.get_repo.return_value
+    repo.get_commit.side_effect = github.UnknownObjectException(404, {})
+
+    storage = GitHub(repo="test/repo", path="flow.py", ref=ref)
+    storage.add_flow(Flow("test"))
+
+    ref = ref or "main"
+
+    with pytest.raises(github.UnknownObjectException):
+        storage.get_flow("test")
+
+    assert f"Ref {ref!r} not found in repo 'test/repo'" in caplog.text
+
+
+@pytest.mark.parametrize("ref", [None, "myref"])
+def test_get_flow_missing_file(github_client, ref, caplog):
+    repo = github_client.get_repo.return_value
+    repo.get_contents.side_effect = github.UnknownObjectException(404, {})
+
+    storage = GitHub(repo="test/repo", path="flow.py", ref=ref)
+    storage.add_flow(Flow("test"))
+
+    ref = ref or "main"
+
+    with pytest.raises(github.UnknownObjectException):
+        storage.get_flow("test")
+
+    assert f"File 'flow.py' not found in repo 'test/repo', ref {ref!r}" in caplog.text


### PR DESCRIPTION
- Default `ref` is now `None` (instead of `"master"`). This defaults to
  using the default branch for the repo, allowing for alternate default
  branch names than `"master"`.
- Makes `path` a required parameter for `GitHub` storage. This was
  always implicitly required (things would break if it was missing), but
  the code and serializers still allowed for it.
- Adds improved log messages when failing to load a flow from `GitHub`
  storage
- Adds more information to the github storage logs, including the commit
  sha for the code that's loaded in all cases. This makes it easier to
  determine the exact source used when running a flow.
- Improved test coverage


This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)