### PR TITLE
Better secret error message

### DIFF
--- a/changes/pr4003.yaml
+++ b/changes/pr4003.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Improve error message when Secrets are missing with Server - [#4003](https://github.com/PrefectHQ/prefect/pull/4003)"

--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -136,6 +136,10 @@ class Secret:
         try:
             value = secrets[self.name]
         except KeyError:
+            if prefect.config.backend != "cloud":
+                raise ValueError(
+                    'Local Secret "{}" was not found.'.format(self.name)
+                ) from None
             if prefect.context.config.cloud.use_local_secrets is False:
                 try:
                     result = self.client.graphql(

--- a/tests/client/test_secrets.py
+++ b/tests/client/test_secrets.py
@@ -25,6 +25,14 @@ def test_secret_raises_if_doesnt_exist():
             secret.get()
 
 
+def test_secret_raises_informative_error_for_server():
+    secret = Secret(name="test")
+    with set_temporary_config({"cloud.use_local_secrets": False, "backend": "server"}):
+        with pytest.raises(ValueError) as exc:
+            secret.get()
+    assert str(exc.value) == 'Local Secret "test" was not found.'
+
+
 def test_secret_value_pulled_from_context():
     secret = Secret(name="test")
     with set_temporary_config({"cloud.use_local_secrets": True}):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
From a user question in Slack, I noticed that when running against Server we were still querying the API for secrets despite secrets not being a part of the Server API.  The traceback was huge and possibly misleading for users.  This PR simplifies the error message.

## Changes
<!-- What does this PR change? -->
Raise more straightforward error message when a secret is missing when running against Server / locally.



## Importance
<!-- Why is this PR important? -->
Better UX.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)