### PR TITLE
Handle missing flow runs in k8s agent resource management

### DIFF
--- a/changes/pr4006.yaml
+++ b/changes/pr4006.yaml
@@ -1,2 +1,8 @@
 fix:
   - "Handle setting state for missing flow runs in Kubernetes agent resource management - [#4006](https://github.com/PrefectHQ/prefect/pull/4006)"
+
+task:
+  - "Ensure connection secrets can be passed to Databricks tasks at runtime - [#4001](https://github.com/PrefectHQ/prefect/pull/4001)"
+
+contributor:
+  - "[Thomas Baldwin](https://github.com/baldwint)"

--- a/changes/pr4006.yaml
+++ b/changes/pr4006.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Handle setting state for missing flow runs in Kubernetes agent resource management - [#4006](https://github.com/PrefectHQ/prefect/pull/4006)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -199,10 +199,11 @@ class KubernetesAgent(Agent):
                                                     )
                                                 ),
                                             )
-                                        except ClientError:
+                                        except ClientError as exc:
                                             self.logger.error(
                                                 "Error attempting to set flow run state for "
-                                                f"{flow_run_id}"
+                                                f"{flow_run_id}:"
+                                                f"{exc}"
                                             )
 
                                         delete_job = True
@@ -336,9 +337,10 @@ class KubernetesAgent(Agent):
                                         )
                                     ),
                                 )
-                            except ClientError:
+                            except ClientError as exc:
                                 self.logger.error(
-                                    f"Error attempting to set flow run state for {flow_run_id}"
+                                    f"Error attempting to set flow run state for {flow_run_id}:"
+                                    f"{exc}"
                                 )
 
                     # Delete job if it is successful or failed

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -15,6 +15,7 @@ from prefect.agent import Agent
 from prefect.engine.state import Failed
 from prefect.run_configs import KubernetesRun
 from prefect.utilities.agent import get_flow_image, get_flow_run_command
+from prefect.utilities.exceptions import ClientError
 from prefect.utilities.filesystems import read_bytes_from_path
 from prefect.utilities.graphql import GraphQLResult
 
@@ -189,14 +190,20 @@ class KubernetesAgent(Agent):
                                         self.logger.debug(
                                             f"Failing flow run {flow_run_id} due to pod {waiting.reason}"
                                         )
-                                        self.client.set_flow_run_state(
-                                            flow_run_id=flow_run_id,
-                                            state=Failed(
-                                                message="Kubernetes Error: {}".format(
-                                                    container_status.state.waiting.message
-                                                )
-                                            ),
-                                        )
+                                        try:
+                                            self.client.set_flow_run_state(
+                                                flow_run_id=flow_run_id,
+                                                state=Failed(
+                                                    message="Kubernetes Error: {}".format(
+                                                        container_status.state.waiting.message
+                                                    )
+                                                ),
+                                            )
+                                        except ClientError:
+                                            self.logger.error(
+                                                "Error attempting to set flow run state for "
+                                                f"{flow_run_id}"
+                                            )
 
                                         delete_job = True
                                         break
@@ -320,14 +327,19 @@ class KubernetesAgent(Agent):
                             self.logger.debug(
                                 f"Failing flow run {flow_run_id} due to the failed pods {failed_pods}"
                             )
-                            self.client.set_flow_run_state(
-                                flow_run_id=flow_run_id,
-                                state=Failed(
-                                    message="Kubernetes Error: pods {} failed for this job".format(
-                                        failed_pods
-                                    )
-                                ),
-                            )
+                            try:
+                                self.client.set_flow_run_state(
+                                    flow_run_id=flow_run_id,
+                                    state=Failed(
+                                        message="Kubernetes Error: pods {} failed for this job".format(
+                                            failed_pods
+                                        )
+                                    ),
+                                )
+                            except ClientError:
+                                self.logger.error(
+                                    f"Error attempting to set flow run state for {flow_run_id}"
+                                )
 
                     # Delete job if it is successful or failed
                     if delete_job:

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -199,11 +199,11 @@ class KubernetesAgent(Agent):
                                                     )
                                                 ),
                                             )
-                                        except ClientError as exc:
+                                        except ClientError:
                                             self.logger.error(
                                                 "Error attempting to set flow run state for "
-                                                f"{flow_run_id}:"
-                                                f"{exc}"
+                                                f"{flow_run_id}",
+                                                exc_info=True,
                                             )
 
                                         delete_job = True
@@ -337,10 +337,10 @@ class KubernetesAgent(Agent):
                                         )
                                     ),
                                 )
-                            except ClientError as exc:
+                            except ClientError:
                                 self.logger.error(
-                                    f"Error attempting to set flow run state for {flow_run_id}:"
-                                    f"{exc}"
+                                    f"Error attempting to set flow run state for {flow_run_id}",
+                                    exc_info=True,
                                 )
 
                     # Delete job if it is successful or failed

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -202,7 +202,7 @@ class KubernetesAgent(Agent):
                                         except ClientError as exc:
                                             self.logger.error(
                                                 "Error attempting to set flow run state for "
-                                                f"{flow_run_id}:"
+                                                f"{flow_run_id}: "
                                                 f"{exc}"
                                             )
 
@@ -339,7 +339,7 @@ class KubernetesAgent(Agent):
                                 )
                             except ClientError as exc:
                                 self.logger.error(
-                                    f"Error attempting to set flow run state for {flow_run_id}:"
+                                    f"Error attempting to set flow run state for {flow_run_id}: "
                                     f"{exc}"
                                 )
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -199,11 +199,11 @@ class KubernetesAgent(Agent):
                                                     )
                                                 ),
                                             )
-                                        except ClientError:
+                                        except ClientError as exc:
                                             self.logger.error(
                                                 "Error attempting to set flow run state for "
-                                                f"{flow_run_id}",
-                                                exc_info=True,
+                                                f"{flow_run_id}:"
+                                                f"{exc}"
                                             )
 
                                         delete_job = True
@@ -337,10 +337,10 @@ class KubernetesAgent(Agent):
                                         )
                                     ),
                                 )
-                            except ClientError:
+                            except ClientError as exc:
                                 self.logger.error(
-                                    f"Error attempting to set flow run state for {flow_run_id}",
-                                    exc_info=True,
+                                    f"Error attempting to set flow run state for {flow_run_id}:"
+                                    f"{exc}"
                                 )
 
                     # Delete job if it is successful or failed


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
The resource management loop in the Kubernetes agent has the potential to error if it attempts to set the state for a missing flow run. This can happen in the case where a job is started, the user deletes the flow run, then the agent attempts to clean up the job (when the job is in a state where the agent marks the flow run as failed). To avoid this we handle the case where a `ClientError` is raised by the call to the client and the loop continues with its resource management cycle.



## Changes
Handles `ClientError`s when calling the `set_flow_run_state` mutation in the Kubernetes agent resource management loop



## Importance
Avoids a possible edge case



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)