### PR TITLE
Better error for passing Tasks to `StartFlowRun` parameters

### DIFF
--- a/changes/pr4008.yaml
+++ b/changes/pr4008.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Better error message when passing parameters to `StartFlowRun` constructor - [#4008](https://github.com/PrefectHQ/prefect/pull/4008)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -52,6 +52,18 @@ class StartFlowRun(Task):
     ):
         self.flow_name = flow_name
         self.project_name = project_name
+        # Check that users haven't passed tasks to `parameters`
+        if parameters is not None:
+            for v in parameters.values():
+                if isinstance(v, Task):
+                    raise TypeError(
+                        "An instance of `Task` was passed to the `StartFlowRun` constructor via the "
+                        "`parameters` kwarg. You'll want to pass these parameters when calling the "
+                        "task instead. For example:\n\n"
+                        "  start_flow_run = StartFlowRun(...)  # static (non-Task) args go here\n"
+                        "  res = start_flow_run(parameters=...)  # dynamic (Task) args go here\n\n"
+                        "see https://docs.prefect.io/core/concepts/flows.html#apis for more info."
+                    )
         self.parameters = parameters
         self.run_config = run_config
         self.new_flow_context = new_flow_context

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -65,6 +65,12 @@ class TestStartFlowRunCloud:
         assert task.run_name == "test-run"
         assert task.scheduled_start_time == now
 
+    def test_init_errors_if_tasks_passed_to_parameters(self, cloud_api):
+        with pytest.raises(TypeError, match="An instance of `Task` was passed"):
+            StartFlowRun(
+                name="testing", parameters={"a": 1, "b": prefect.Parameter("b")}
+            )
+
     @pytest.mark.parametrize("idempotency_key", [None, "my-key"])
     @pytest.mark.parametrize("task_run_id", [None, "test-id"])
     def test_flow_run_task_submit_args(


### PR DESCRIPTION
Some users have been confused when passing `Parameter` instances through
`parameters` in the constructor of `StartFlowRun` (these should instead
be passed to `StartFlowRun.__call__`). We raise a better error at flow
construction now.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)