### PR TITLE
Warn if user shadows attributes in Task class

### DIFF
--- a/changes/pr4011.yaml
+++ b/changes/pr4011.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add warning if user-defined class shadows an attribute used by the base class - [#4011](https://github.com/PrefectHQ/prefect/pull/4011)"

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -743,7 +743,7 @@ def test_passing_task_to_task_constructor_raises_helpful_warning():
             self.b = b
             super().__init__(**kwargs)
 
-    with Flow("test") as flow:
+    with Flow("test"):
         a = Task()()
         with pytest.warns(
             UserWarning, match="A Task was passed as an argument to MyTask"
@@ -752,3 +752,15 @@ def test_passing_task_to_task_constructor_raises_helpful_warning():
         # Warning doesn't stop normal operation
         assert t.a == 1
         assert t.b == a
+
+
+def test_task_init_uses_reserved_attribute_raises_helpful_warning():
+    class MyTask(Task):
+        def __init__(self, **kwargs):
+            self.a = 1
+            self.target = "oh no!"
+            super().__init__(**kwargs)
+
+    with Flow("test"):
+        with pytest.warns(UserWarning, match="`MyTask` sets a `target` attribute"):
+            MyTask()


### PR DESCRIPTION
This adds a warning for user defined tasks if they accidentally shadow
an attribute used by the default `Task.__init__`. We do this with
attributes instead of parameters, since users may want to override the
defaults for Task parameters for their specific subclass.

For example:

```python
from prefect import Task

class MyTask(Task):
    def __init__(self, **kwargs):
        self.target = "oops"
        super().__init__(**kwargs)

MyTask()
```

raises the following warning:

```
/Users/jcristharif/Code/prefect/src/prefect/core/task.py:331:
UserWarning: `MyTask` sets a `target` attribute, which will be
overwritten by `prefect.Task`. Please rename this attribute to avoid
this issue.
 ```

Fixes #3950.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)