### PR TITLE
Support `EXTRA_PIP_PACKAGES` in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ RUN apt update && \
     apt clean && apt autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["tini", "-g", "--"]
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["tini", "-g", "--", "entrypoint.sh"]

--- a/changes/pr4013.yaml
+++ b/changes/pr4013.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add support for `EXTRA_PIP_PACKAGES` environment variable in `prefecthq/prefect` images, simplifying installation of dependencies during development - [#4013](https://github.com/PrefectHQ/prefect/pull/4013)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+if [ ! -z "$EXTRA_PIP_PACKAGES" ]; then
+  echo "+pip install $EXTRA_PIP_PACKAGES"
+  pip install $EXTRA_PIP_PACKAGES
+fi
+if [ -z "$*" ]; then
+  echo "\
+            _____  _____  ______ ______ ______ _____ _______
+           |  __ \|  __ \|  ____|  ____|  ____/ ____|__   __|
+           | |__) | |__) | |__  | |__  | |__ | |       | |
+           |  ___/|  _  /|  __| |  __| |  __|| |       | |
+           | |    | | \ \| |____| |    | |___| |____   | |
+           |_|    |_|  \_\______|_|    |______\_____|  |_|
+
+Thanks for using Prefect!!!
+
+This is the official docker image for Prefect Core, intended for executing
+Prefect Flows. For more information, please see the docs:
+https://docs.prefect.io/core/getting_started/installation.html#docker
+"
+  exec bash --login
+else
+  exec "$@"
+fi


### PR DESCRIPTION
This adds support for a `EXTRA_PIP_PACKAGES` environment variable in our
official `prefect` docker images. This takes a space delimited list of
packages to pass to `pip install` on image startup, allowing for easier
runtime installation of extra packages. For production deployments users
should still build images with their required dependencies, but for
development this can make things a bit easier. The official dask images
also support this, so there's some precedence here.

Also extends our default entrypoint to drop the user into a shell if no
CMD is specified (with a header explaining what the image is). We've had
a few users confused with what the prefect image was for (mostly
assuming it would start prefect server automatically), so hopefully this
helps remove this confusion.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)