### PR TITLE
Fix Agent registration possibly skipping on server connection issues

### DIFF
--- a/changes/issue3972.yaml
+++ b/changes/issue3972.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix Agent registration possibly skipping on server connection issues - [#3972](https://github.com/PrefectHQ/prefect/issues/3972)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -220,16 +220,8 @@ class Agent:
         if config.backend == "cloud":
             self._verify_token(self.client.get_auth_token())
 
-        try:
-            self.client.attach_headers({"X-PREFECT-AGENT-ID": self._register_agent()})
-        except Exception as exc:
-            if config.backend == "cloud":
-                raise exc
-            else:
-                self.logger.warning(
-                    f"Unable to register agent to {self.client.api_server}. "
-                    f"Make sure the server is running on the latest version."
-                )
+        # Register agent with backend API
+        self.client.attach_headers({"X-PREFECT-AGENT-ID": self._register_agent()})
 
         try:
             self.setup()


### PR DESCRIPTION
On start Agents register themselves with the backend API. An exception handling step was added in to support the case where _old_ versions of the server did not contain the routes for agent registration. This had the potential to skip agent registration on new versions where the server was not yet started. Process being this: agent starts, can't register, keeps trying to connect to server, server starts up, agent begins and is in an unregistered state. Now that agent registration has existed for quite a few releases, this check can be removed.

Closes #3972 