### PR TITLE
Docs issue: Fix option for generating a RUNNER scope token

### DIFF
--- a/docs/orchestration/concepts/tokens.md
+++ b/docs/orchestration/concepts/tokens.md
@@ -35,7 +35,7 @@ After you click create you will be prompted with the token which you can copy an
 To create a token with the CLI run the `create-token` command with the desired token name and scope. For more information on how to use the CLI go [here](cli.html).
 
 ```
-$ prefect auth create-token -n my-runner-token -r RUNNER
+$ prefect auth create-token -n my-runner-token -s RUNNER
 ```
 
 ### GraphQL


### PR DESCRIPTION
## Summary

The [Tokens doc](https://docs.prefect.io/orchestration/concepts/tokens.html#cli) illustrates that the way we generate a RUNNER token with the CLI is to add a `-r` option, but now it's `-s` option (I guess `s` stands for **scope**?).

## Changes

Change the option for generating RUNNER scope token from `-r` to `-s`, so the command becomes:

```bash
$ prefect auth create-token -n my-runner-token -s RUNNER
```

## Importance

The command can be executed successfully now.

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)