### PR TITLE
Add option to provide flow ID when calling run flow CLI command

### DIFF
--- a/changes/pr4021.yaml
+++ b/changes/pr4021.yaml
@@ -1,0 +1,3 @@
+enhancement:
+  - "Add option to provide flow ID to `run flow` CLI command - [#4021](https://github.com/PrefectHQ/prefect/pull/4021)"
+  - "Flow name and project are no longer required options when calling `run flow` CLI command - [#4021](https://github.com/PrefectHQ/prefect/pull/4021)"

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -94,9 +94,9 @@ def flow(
 
     \b
     Options:
-        --name, -n                  TEXT        The name of a flow to run [required]
-        --project, -p               TEXT        The name of a project that contains
-                                                the flow [required]
+        --id, -i                    TEXT        The ID of a flow to run
+        --name, -n                  TEXT        The name of a flow to run
+        --project, -p               TEXT        The name of a project that contains the flow
         --version, -v               INTEGER     A flow version to run
         --parameters-file, -pf      FILE PATH   A filepath of a JSON file containing
                                                 parameters
@@ -115,6 +115,10 @@ def flow(
                                                 link
 
     \b
+    Either `id` or both `name` and `project` must be provided to run a flow. If all three
+    are provided then `id` will be used when calling the mutation.
+
+    \b
     If both `--parameters-file` and `--parameters-string` are provided then the values
     passed in through the string will override the values provided from the file.
 
@@ -131,7 +135,8 @@ def flow(
     """
     if not id and not (name and project):
         click.secho(
-            "A flow ID or some combination of flow name and project must be provided.", fg="red"
+            "A flow ID or some combination of flow name and project must be provided.",
+            fg="red",
         )
         return
 

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -115,8 +115,7 @@ def flow(
                                                 link
 
     \b
-    Either `id` or both `name` and `project` must be provided to run a flow. If all three
-    are provided then `id` will be used when calling the mutation.
+    Either `id` or both `name` and `project` must be provided to run a flow.
 
     \b
     If both `--parameters-file` and `--parameters-string` are provided then the values
@@ -136,6 +135,13 @@ def flow(
     if not id and not (name and project):
         click.secho(
             "A flow ID or some combination of flow name and project must be provided.",
+            fg="red",
+        )
+        return
+
+    if id and (name or project):
+        click.secho(
+            "Both a flow ID and a name/project combination cannot be provided.",
             fg="red",
         )
         return

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -512,3 +512,23 @@ def test_run_flow_no_id_or_name_and_project():
         "A flow ID or some combination of flow name and project must be provided"
         in result.output
     )
+
+
+def test_run_flow_no_id_or_name_and_project():
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        [
+            "flow",
+            "--id",
+            "id",
+            "--name",
+            "flow",
+            "--project",
+            "project",
+        ],
+    )
+    assert (
+        "Both a flow ID and a name/project combination cannot be provided"
+        in result.output
+    )

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -468,3 +468,47 @@ def test_run_flow_flow_run_id_no_link(monkeypatch, cloud_api):
     )
     assert result.exit_code == 0
     assert "Flow Run ID" in result.output
+
+
+def test_run_flow_using_id(monkeypatch, cloud_api):
+    post = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(return_value=dict(data=dict(flow=[{"id": "flow"}])))
+        )
+    )
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+
+    create_flow_run_mock = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.client.Client.create_flow_run", create_flow_run_mock)
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        [
+            "flow",
+            "--id",
+            "id",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Flow Run" in result.output
+    assert create_flow_run_mock.called
+
+
+def test_run_flow_no_id_or_name_and_project():
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        [
+            "flow",
+        ],
+    )
+    assert (
+        "A flow ID or some combination of flow name and project must be provided"
+        in result.output
+    )


### PR DESCRIPTION
This PR adds the option to provide a flow ID to the `prefect run flow` CLI command.