### PR TITLE
Allow Docker Agent to connect container to multiple Docker networks

### DIFF
--- a/changes/3986_docker_networks.yaml
+++ b/changes/3986_docker_networks.yaml
@@ -3,3 +3,6 @@ enhancement:
 
 contributor:
   - "[Peter Roelants](https://github.com/peterroelants)"
+
+deprecation:
+  - "Docker agent `network` kwarg deprecated in favor of `networks`"

--- a/changes/3986_docker_networks.yaml
+++ b/changes/3986_docker_networks.yaml
@@ -5,4 +5,4 @@ contributor:
   - "[Peter Roelants](https://github.com/peterroelants)"
 
 deprecation:
-  - "Docker agent `network` kwarg deprecated in favor of `networks`"
+  - "Docker agent `network` kwarg deprecated in favor of `networks` - [#3986](https://github.com/PrefectHQ/prefect/issues/3986)"

--- a/changes/3986_docker_networks.yaml
+++ b/changes/3986_docker_networks.yaml
@@ -1,0 +1,8 @@
+enhancement:
+  - "Support multiple docker networks with Docker Agent - [#3986](https://github.com/PrefectHQ/prefect/issues/3986)"
+
+breaking:
+  - "Docker agent CLI `--network` parameter gets assigned to `networks` argument"
+
+contributor:
+  - "[Peter Roelants](https://github.com/peterroelants)"

--- a/changes/3986_docker_networks.yaml
+++ b/changes/3986_docker_networks.yaml
@@ -1,8 +1,5 @@
 enhancement:
   - "Support multiple docker networks with Docker Agent - [#3986](https://github.com/PrefectHQ/prefect/issues/3986)"
 
-breaking:
-  - "Docker agent CLI `--network` parameter gets assigned to `networks` argument"
-
 contributor:
   - "[Peter Roelants](https://github.com/peterroelants)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -673,7 +673,7 @@ class Agent:
             version=flow_run.version,
             state=Failed(message=str(exc)),
         )
-        self.logger.error("Error while deploying flow: {}".format(repr(exc)))
+        self.logger.error("Error while deploying flow: {}".format(repr(exc)), exc_info=exc)
 
     def _get_run_config(
         self, flow_run: GraphQLResult, run_config_cls: Type[RunConfig]

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -673,7 +673,7 @@ class Agent:
             version=flow_run.version,
             state=Failed(message=str(exc)),
         )
-        self.logger.error("Error while deploying flow: {}".format(repr(exc)), exc_info=exc)
+        self.logger.error("Error while deploying flow", exc_info=exc)
 
     def _get_run_config(
         self, flow_run: GraphQLResult, run_config_cls: Type[RunConfig]

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -5,6 +5,7 @@ import re
 import sys
 from sys import platform
 from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
+import warnings
 
 from prefect import config, context
 from prefect.agent import Agent
@@ -74,6 +75,8 @@ class DockerAgent(Agent):
         - volumes (List[str], optional): a list of Docker volume mounts to be attached to any
             and all created containers.
         - network (str, optional): Add containers to an existing docker network
+            (deprecated in favor of `networks`).
+        - networks (List[str], optional): Add containers to existing Docker networks.
         - docker_interface (bool, optional): Toggle whether or not a `docker0` interface is
             present on this machine.  Defaults to `True`. **Note**: This is mostly relevant for
             some Docker-in-Docker setups that users may be running their agent with.
@@ -95,6 +98,7 @@ class DockerAgent(Agent):
         volumes: List[str] = None,
         show_flow_logs: bool = False,
         network: str = None,
+        networks: List[str] = None,
         docker_interface: bool = True,
         reg_allow_list: List[str] = None,
     ) -> None:
@@ -130,9 +134,22 @@ class DockerAgent(Agent):
             self.host_spec,
         ) = self._parse_volume_spec(volumes or [])
 
-        # Add containers to a docker network
+        # Add containers to the given Docker networks
+        if networks and network:
+            raise ValueError(
+                "Only provide either `network` or `networks` argument, not both!"
+            )
+        if network:
+            warnings.warn(
+                "DockerAgent `network` argument is deprecated and will be removed from Prefect. "
+                "Use `networks` instead.",
+                UserWarning,
+            )
+        # TODO: Only keep `self.networks` when `network` parameter gets removed.
         self.network = network
-        self.logger.debug("Docker network set to {}".format(self.network))
+        self.logger.debug(f"Docker network set to {self.network}")
+        self.networks = networks
+        self.logger.debug(f"Docker networks set to {self.networks}")
 
         self.docker_interface = docker_interface
         self.logger.debug(
@@ -156,11 +173,10 @@ class DockerAgent(Agent):
                 "Issue connecting to the Docker daemon. Make sure it is running."
             )
             raise exc
-
         self.logger.debug(f"Base URL: {self.base_url}")
         self.logger.debug(f"No pull: {self.no_pull}")
         self.logger.debug(f"Volumes: {volumes}")
-        self.logger.debug(f"Network: {self.network}")
+        self.logger.debug(f"Networks: {self.networks}")
         self.logger.debug(f"Docker interface: {self.docker_interface}")
 
     def _get_docker_client(self) -> "docker.APIClient":
@@ -399,17 +415,25 @@ class DockerAgent(Agent):
             host_config.update(extra_hosts={"host.docker.internal": docker_internal_ip})
 
         networking_config = None
+        # At the time of creation, you can only connect a container to a single network,
+        # however you can create more connections after creation.
+        # Connect first network in the creation step. If no network is connected here the container
+        # is connected to the default `bridge` network.
+        # The rest of the networks are connected after creation.
+        if self.networks:
+            networking_config = self.docker_client.create_networking_config(
+                {self.networks[0]: self.docker_client.create_endpoint_config()}
+            )
+        # Try fallback on old, deprecated, behaviour.
         if self.network:
             networking_config = self.docker_client.create_networking_config(
                 {self.network: self.docker_client.create_endpoint_config()}
             )
-
         labels = {
             "io.prefect.flow-name": flow_run.flow.name,
             "io.prefect.flow-id": flow_run.flow.id,
             "io.prefect.flow-run-id": flow_run.id,
         }
-
         container = self.docker_client.create_container(
             image,
             command=get_flow_run_command(flow_run),
@@ -419,11 +443,18 @@ class DockerAgent(Agent):
             networking_config=networking_config,
             labels=labels,
         )
-
+        # Connect the rest of the networks
+        if self.networks:
+            for network in self.networks[1:]:
+                self.docker_client.connect_container_to_network(
+                    container=container, net_id=network
+                )
         # Start the container
         self.logger.debug(
             "Starting Docker container with ID {}".format(container.get("Id"))
         )
+        if self.networks:
+            self.logger.debug(f"Adding container to docker networks: {self.networks}")
         if self.network:
             self.logger.debug(
                 "Adding container to docker network: {}".format(self.network)

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -433,19 +433,15 @@ class DockerAgent(Agent):
             "io.prefect.flow-id": flow_run.flow.id,
             "io.prefect.flow-run-id": flow_run.id,
         }
-        try:
-            container = self.docker_client.create_container(
-                image,
-                command=get_flow_run_command(flow_run),
-                environment=env_vars,
-                volumes=container_mount_paths,
-                host_config=self.docker_client.create_host_config(**host_config),
-                networking_config=networking_config,
-                labels=labels,
-            )
-        except Exception as exc:
-            self.logger.exception(exc)
-            raise exc
+        container = self.docker_client.create_container(
+            image,
+            command=get_flow_run_command(flow_run),
+            environment=env_vars,
+            volumes=container_mount_paths,
+            host_config=self.docker_client.create_host_config(**host_config),
+            networking_config=networking_config,
+            labels=labels,
+        )
         # Connect the rest of the networks
         if self.networks:
             for network in self.networks[1:]:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -216,7 +216,13 @@ def docker():
 )
 @click.option(
     "--network",
-    help="Add containers to an existing docker network",
+    "networks",
+    multiple=True,
+    help=(
+        "Add containers to existing Docker networks. "
+        "Can be provided multiple times to pass multiple networks "
+        "(e.g. `--network network1 --network network2`)"
+    ),
 )
 @click.option(
     "--no-docker-interface",
@@ -518,7 +524,8 @@ _agents = {
 )
 @click.option(
     "--network",
-    help="Add containers to an existing docker network",
+    multiple=True,
+    help="Add containers to existing Docker networks.",
     hidden=True,
 )
 @click.option(
@@ -608,7 +615,9 @@ def start(
         --volume            TEXT    Host paths for Docker bind mount volumes attached to
                                     each Flow runtime container. Multiple values supported.
                                         e.g. `--volume /some/path`
-        --network           TEXT    Add containers to an existing docker network
+        --network           TEXT    Add containers to existing Docker networks.
+                                    Multiple values supported.
+                                        e.g. `--network network1 --network network2`
         --no-docker-interface       Disable the check of a Docker interface on this machine.
                                     Note: This is mostly relevant for some Docker-in-Docker
                                     setups that users may be running their agent with.
@@ -691,7 +700,7 @@ def start(
                 no_pull=no_pull,
                 show_flow_logs=show_flow_logs,
                 volumes=list(volume),
-                network=network,
+                networks=tuple(network),
                 docker_interface=not no_docker_interface,
             ).start()
         elif agent_option == "fargate":

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -58,12 +58,13 @@ def test_help(cmd):
             "prefect.agent.docker.DockerAgent",
             (
                 "--base-url testurl --no-pull --show-flow-logs --volume volume1 "
-                "--volume volume2 --network testnetwork --no-docker-interface"
+                "--volume volume2 --network testnetwork1 --network testnetwork2 "
+                "--no-docker-interface"
             ),
             {
                 "base_url": "testurl",
                 "volumes": ["volume1", "volume2"],
-                "network": "testnetwork",
+                "networks": ("testnetwork1", "testnetwork2"),
                 "no_pull": True,
                 "show_flow_logs": True,
                 "docker_interface": False,


### PR DESCRIPTION
## Summary
Allow Docker Agent to connect to multiple Docker networks (https://github.com/PrefectHQ/prefect/issues/3986).


## Changes
- `prefect agent docker start` allows connecting to multiple networks, e.g. `--network network1 --network network2`.
- `prefect agent docker start --network <network-name>` assigns `<network-name>` to `networks` argument instead of `network`.
- `DockerAgent` has new `networks` argument, the `network` argument is set to deprecated.


## Importance
A Docker container started by a Docker Agent might want to connect to multiple docker networks (e.g. in my use case a Kafka network, a database network, and the prefect network). This was previously not possible, this PR makes this possible.


## Checklist
This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)