### PR TITLE
Docker healthchecks for prefect server

### DIFF
--- a/changes/4041_docker_healthcheck.yaml
+++ b/changes/4041_docker_healthcheck.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add healthchecks to prefect server - [#4041](https://github.com/PrefectHQ/prefect/pull/4041)"
+
+contributor:
+  - "[Peter Roelants](https://github.com/peterroelants)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -103,9 +103,7 @@ services:
       - prefect-server
     # Test GraphQL Apollo endpoint as health-check
     healthcheck:
-      test: |
-        curl --fail --silent "http://apollo:4200/graphql" -H 'Content-Type: application/json' \
-          --data-binary '{"query":"query{hello}"}' &>/dev/null || echo "failed"
+      test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" || exit 1
       interval: 5s
       timeout: 2s
       retries: 18
@@ -126,6 +124,11 @@ services:
       PREFECT_SERVER__APOLLO_URL: ${APOLLO_URL:-http://localhost:4200/graphql}
     networks:
       - prefect-server
+    healthcheck:
+      test: curl --fail --silent -I "http://ui:8080/" &> /dev/null || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 5
     restart: always
     depends_on:
       apollo:

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -68,6 +68,12 @@ services:
       PREFECT_CORE_VERSION: ${PREFECT_CORE_VERSION:-"UNKNOWN"}
     networks:
       - prefect-server
+    healthcheck:
+      test: curl --fail --silent "http://graphql:4201/health" &> /dev/null || exit 1
+      interval: 5s
+      timeout: 2s
+      retries: 18
+      start_period: 1s
     restart: always
     depends_on:
       hasura:
@@ -84,7 +90,8 @@ services:
       - prefect-server
     restart: "always"
     depends_on:
-      - graphql
+      graphql:
+        condition: service_healthy
 
   # Apollo: the main endpoint for interacting with the server
   apollo:
@@ -103,14 +110,15 @@ services:
       - prefect-server
     # Test GraphQL Apollo endpoint as health-check
     healthcheck:
-      test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" || exit 1
+      test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" &> /dev/null || exit 1
       interval: 5s
       timeout: 2s
       retries: 18
       start_period: 1s
     restart: always
     depends_on:
-      - graphql
+      graphql:
+        condition: service_healthy
 
   # UI: the user interface that provides a visual dashboard for mutating and querying metadata
   # The UI is a standalone web interface and only communicates with the Apollo GraphQL API via
@@ -125,14 +133,14 @@ services:
     networks:
       - prefect-server
     healthcheck:
-      test: curl --fail --silent -I "http://ui:8080/" &> /dev/null || exit 1
+      test: curl --fail --silent --head "http://ui:8080/" &> /dev/null || exit 1
       interval: 30s
       timeout: 5s
       retries: 5
     restart: always
     depends_on:
       apollo:
-        condition: service_healthy
+        condition: service_started
 
 networks:
   prefect-server:

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -22,10 +22,10 @@ services:
     # Use `pg_isready` to check the connection status of the PostgreSQL server
     healthcheck:
       test: pg_isready -q -d $${POSTGRES_DB} -U $${POSTGRES_USER} || exit 1
-      interval: 5s
+      interval: 1s
       timeout: 2s
-      retries: 18
-      start_period: 1s
+      retries: 60
+      start_period: 2s
     restart: always
 
   # Hasura: the GraphQL API that layers on top of Postgres for querying metadata
@@ -45,9 +45,9 @@ services:
     # /healthz endpoints returns OK when not unhealthy
     healthcheck:
       test: wget -O - http://hasura:$${HASURA_GRAPHQL_SERVER_PORT}/healthz &>/dev/null || exit 1
-      interval: 5s
+      interval: 1s
       timeout: 2s
-      retries: 18
+      retries: 60
       start_period: 1s
     restart: always
     depends_on:
@@ -70,9 +70,9 @@ services:
       - prefect-server
     healthcheck:
       test: curl --fail --silent "http://graphql:4201/health" &> /dev/null || exit 1
-      interval: 5s
+      interval: 1s
       timeout: 2s
-      retries: 18
+      retries: 60
       start_period: 1s
     restart: always
     depends_on:
@@ -111,13 +111,15 @@ services:
     # Test GraphQL Apollo endpoint as health-check
     healthcheck:
       test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" &> /dev/null || exit 1
-      interval: 5s
+      interval: 1s
       timeout: 2s
-      retries: 18
+      retries: 60
       start_period: 1s
     restart: always
     depends_on:
       graphql:
+        condition: service_healthy
+      hasura:
         condition: service_healthy
 
   # UI: the user interface that provides a visual dashboard for mutating and querying metadata
@@ -136,7 +138,7 @@ services:
       test: curl --fail --silent --head "http://ui:8080/" &> /dev/null || exit 1
       interval: 30s
       timeout: 5s
-      retries: 5
+      retries: 3
     restart: always
     depends_on:
       apollo:

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.7"
 
 services:
+  # PostgreSQL: the database persistence layer where metadata is stored
   postgres:
     image: "postgres:11"
     ports:
@@ -13,12 +14,21 @@ services:
       - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
     networks:
       - prefect-server
-    restart: "always"
     command:
       - "postgres"
       # explicitly set max connections
       - "-c"
       - "max_connections=150"
+    # Use `pg_isready` to check the connection status of the PostgreSQL server
+    healthcheck:
+      test: pg_isready -q -d $${POSTGRES_DB} -U $${POSTGRES_USER} || exit 1
+      interval: 5s
+      timeout: 2s
+      retries: 18
+      start_period: 1s
+    restart: always
+
+  # Hasura: the GraphQL API that layers on top of Postgres for querying metadata
   hasura:
     image: "hasura/graphql-engine:v1.3.0"
     ports:
@@ -32,9 +42,19 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: "warn"
     networks:
       - prefect-server
-    restart: "always"
+    # /healthz endpoints returns OK when not unhealthy
+    healthcheck:
+      test: wget -O - http://hasura:$${HASURA_GRAPHQL_SERVER_PORT}/healthz &>/dev/null || exit 1
+      interval: 5s
+      timeout: 2s
+      retries: 18
+      start_period: 1s
+    restart: always
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+
+  # GraphQL: the server's business logic that exposes GraphQL mutations
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
@@ -48,9 +68,12 @@ services:
       PREFECT_CORE_VERSION: ${PREFECT_CORE_VERSION:-"UNKNOWN"}
     networks:
       - prefect-server
-    restart: "always"
+    restart: always
     depends_on:
-      - hasura
+      hasura:
+        condition: service_healthy
+
+  # Towel: runs utilities that are responsible for server maintenance
   towel:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     command: "python src/prefect_server/services/towel/__main__.py"
@@ -62,6 +85,8 @@ services:
     restart: "always"
     depends_on:
       - graphql
+
+  # Apollo: the main endpoint for interacting with the server
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
@@ -76,9 +101,22 @@ services:
       GRAPHQL_SERVICE_PORT: 4201
     networks:
       - prefect-server
-    restart: "always"
+    # Test GraphQL Apollo endpoint as health-check
+    healthcheck:
+      test: |
+        curl --fail --silent "http://apollo:4200/graphql" -H 'Content-Type: application/json' \
+          --data-binary '{"query":"query{hello}"}' &>/dev/null || echo "failed"
+      interval: 5s
+      timeout: 2s
+      retries: 18
+      start_period: 1s
+    restart: always
     depends_on:
       - graphql
+
+  # UI: the user interface that provides a visual dashboard for mutating and querying metadata
+  # The UI is a standalone web interface and only communicates with the Apollo GraphQL API via
+  #  the host from which it is accessed.
   ui:
     image: "prefecthq/ui:${PREFECT_UI_TAG:-latest}"
     ports:
@@ -88,9 +126,10 @@ services:
       PREFECT_SERVER__APOLLO_URL: ${APOLLO_URL:-http://localhost:4200/graphql}
     networks:
       - prefect-server
-    restart: "always"
+    restart: always
     depends_on:
-      - apollo
+      apollo:
+        condition: service_healthy
 
 networks:
   prefect-server:


### PR DESCRIPTION
## Summary
Add [healthchecks](https://github.com/compose-spec/compose-spec/blob/master/spec.md#healthcheck) to docker-compose of Prefect server.

## Changes
Add healthchecks to the following services:
- postgres (Based on [`pg_isready` utility](https://www.postgresql.org/docs/9.4/app-pg-isready.html) )
- hasura (Based on [`/healthz` endpoint](https://hasura.io/docs/1.0/graphql/core/api-reference/health.html) )
- apollo (Based on apollo graphql endpoint)

Startup dependent services only when dependencies are healthy.

## Importance
- Monitor the health of the different server components.
- Force restart of unhealthy server components.
- Ability for downstream services to wait on server components.

For example: I have a deployment where I'm spinning up the prefect server along with any agents. I can have the agents in Docker containers wait for apollo to be up before registering themselves.




## Checklist
This PR:

- [N/A] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [N/A] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)