### PR TITLE
Fix issue with fixed-duration paused states not resuming properly

### DIFF
--- a/changes/issue4031.yaml
+++ b/changes/issue4031.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix issue with fixed duration Paused states not resuming properly - [#4031](https://github.com/PrefectHQ/prefect/issues/4031)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -25,6 +25,7 @@ from prefect.engine.state import (
     Failed,
     Looped,
     Mapped,
+    Paused,
     Pending,
     Resume,
     Retrying,
@@ -141,7 +142,11 @@ class TaskRunner(Runner):
         else:
             run_count = state.context.get("task_run_count", 1)
 
-        if isinstance(state, Resume):
+        if (
+            isinstance(state, Resume)
+            or isinstance(state, Paused)
+            and state.start_time <= pendulum.now("utc")
+        ):
             context.update(resume=True)
 
         if "_loop_count" in state.context:

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -142,11 +142,13 @@ class TaskRunner(Runner):
         else:
             run_count = state.context.get("task_run_count", 1)
 
-        if (
-            isinstance(state, Resume)
-            or isinstance(state, Paused)
-            and state.start_time <= pendulum.now("utc")
-        ):
+        # detect if currently Paused with a recent start_time
+        should_resume = (
+            isinstance(state, Paused)
+            and state.start_time
+            and state.start_time <= pendulum.now("utc")  # type: ignore
+        )
+        if isinstance(state, Resume) or should_resume:
             context.update(resume=True)
 
         if "_loop_count" in state.context:

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -429,6 +429,23 @@ class TestInitializeRun:
             result = TaskRunner(Task()).initialize_run(state=Resume(), context=ctx)
             assert result.context.resume is True
 
+    def test_task_runner_puts_resume_in_context_if_paused_start_time_elapsed(self):
+        with prefect.context() as ctx:
+            assert "resume" not in ctx
+            result = TaskRunner(Task()).initialize_run(
+                state=Paused(start_time=pendulum.now("utc")), context=ctx
+            )
+            assert result.context.resume is True
+
+    def test_task_runner_ignores_resume_in_context_if_paused_start_time_in_future(self):
+        with prefect.context() as ctx:
+            assert "resume" not in ctx
+            result = TaskRunner(Task()).initialize_run(
+                state=Paused(start_time=pendulum.now("utc").add(seconds=10)),
+                context=ctx,
+            )
+            assert "resume" not in ctx
+
     def test_task_runner_puts_checkpointing_in_context(self):
         with prefect.context() as ctx:
             assert "checkpointing" not in ctx


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
The most prominent use case for pausing a task run is using a `manual_only` trigger, which results in a task run in a `Paused` state that waits for someone to manually place it back into a `Resume` state.  However, the [`pause_task` utility](https://docs.prefect.io/api/latest/utilities/tasks.html#functions) and the `Paused` state itself allow for users to specify a start time for the task run to automatically resume.  This means that the task run never transitions through a `Resume` state, which is how we normally detect whether to skip paused signals. 

This PR adjusts our task run initialization logic to account for `Paused` states with current start times so that they can be properly resumed.


## Changes
<!-- What does this PR change? -->
Places `resume=True` into context if the current task run state is `Paused` and if the specified start time is in the past.


## Importance
<!-- Why is this PR important? -->
Closes #4031 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)