### PR TITLE
Fix task decorator chaining by using inspect.unwrap instead of __wrap…

### DIFF
--- a/changes/pr4053.yaml
+++ b/changes/pr4053.yaml
@@ -1,0 +1,5 @@
+fix:
+  - Fix task decorator chaining by using inspect.unwrap instead of __wrap__ - [#4053](https://github.com/PrefectHQ/prefect/pull/4053)
+contributor:
+  - "[Alex P.](https://github.com/alexifm)" 
+  - "[Marwan S.](https://github.com/marwan116)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -48,7 +48,7 @@ class NoDefault(enum.Enum):
 
 
 def _validate_run_signature(run: Callable) -> None:
-    func = getattr(run, "__wrapped__", run)
+    func = inspect.unwrap(run)
     try:
         run_sig = inspect.getfullargspec(func)
     except TypeError as exc:

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import functools
 from datetime import timedelta
 from typing import Any, Tuple
 
@@ -131,63 +130,10 @@ class TestCreateTask:
         with pytest.raises(TypeError):
             Task(state_handlers=lambda *a: 1)
 
-    def test_class_instantiation_allows_for_decorator_chaining(self):
-        def simple_dec(func):
-            @functools.wraps(func)
-            def wrapped(*args, **kwargs):
-                return func(*args, **kwargs)
-
-            return wrapped
-
-        @task
-        @simple_dec
-        def run(x):
-            pass
-
-        class A(Task):
-            @simple_dec
-            def run(self, x):
-                pass
-
-        @task
-        @simple_dec
-        @simple_dec
-        def run(x):
-            pass
-
-        class A(Task):
-            @simple_dec
-            @simple_dec
-            def run(self, x):
-                pass
-
     def test_class_instantiation_rejects_varargs(self):
         with pytest.raises(ValueError):
 
             class VarArgsTask(Task):
-                def run(self, x, *y):
-                    pass
-
-    def test_class_instantiation_rejects_varargs_with_chained_decorator(self):
-        def simple_dec(func):
-            @functools.wraps(func)
-            def wrapped(*args, **kwargs):
-                return func(*args, **kwargs)
-
-            return wrapped
-
-        with pytest.raises(ValueError):
-
-            class VarArgsTask(Task):
-                @simple_dec
-                def run(self, x, *y):
-                    pass
-
-        with pytest.raises(ValueError):
-
-            class VarArgsTask(Task):
-                @simple_dec
-                @simple_dec
                 def run(self, x, *y):
                     pass
 

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -1,3 +1,4 @@
+import functools
 import pytest
 
 from prefect import Flow, Task, case, Parameter, resource_manager
@@ -85,6 +86,59 @@ class TestTaskDecorator:
 
             @tasks.task
             def fn(upstream_tasks):
+                pass
+
+    def test_task_decorator_allows_for_decorator_chaining(self):
+        def simple_dec(func):
+            @functools.wraps(func)
+            def wrapped(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapped
+
+        @tasks.task
+        @simple_dec
+        def run(x):
+            pass
+
+        class A(Task):
+            @simple_dec
+            def run(self, x):
+                pass
+
+        @tasks.task
+        @simple_dec
+        @simple_dec
+        def run(x):
+            pass
+
+        class A(Task):
+            @simple_dec
+            @simple_dec
+            def run(self, x):
+                pass
+
+    def test_task_decorator_rejects_varargs_with_chained_decorator(self):
+        def simple_dec(func):
+            @functools.wraps(func)
+            def wrapped(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapped
+
+        with pytest.raises(ValueError):
+
+            @tasks.task
+            @simple_dec
+            def run(self, x, *y):
+                pass
+
+        with pytest.raises(ValueError):
+
+            @tasks.task
+            @simple_dec
+            @simple_dec
+            def run(self, x, *y):
                 pass
 
 


### PR DESCRIPTION
…ped__

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

We came across a bug when chaining more than one decorator with the prefect task decorator basically the method `_validate_run_signature` tries to unwrap the function provided to get to the underlying function but it does so by accessing `__wrapped__` instead of using something like `inspect.unwrap` that would traverse the `__wrapped__ ` chain …

so a simple decorator like this:
```
def simple_dec(func):
    @functools.wraps(func)
    def wrapped(*args, **kwargs):
        return func(*args, **kwargs)
    return wrapped
```
would work fine when chained with a task decorator - i.e.
```
@task
@simple_dec
def test(a: int, b:int) -> int:
    return a + b
```
but chaining the simple decorator more than once would fail -i.e.
```
@task
@simple_dec
@simple_dec
def test(a: int, b:int) -> int:
    return a + b
```
with the following error
```
Traceback (most recent call last):
  File "./_tmp/r.py", line 16, in <module>
    def test(a: int, b: int) -> int:
  File "/Users/marwansarieddine/.pyenv/versions/3.8.5/envs/pyinfima/lib/python3.8/site-packages/prefect/utilities/tasks.py", line 408, in task
    return prefect.tasks.core.function.FunctionTask(fn=fn, **task_init_kwargs)
  File "/Users/marwansarieddine/.pyenv/versions/3.8.5/envs/pyinfima/lib/python3.8/site-packages/prefect/core/task.py", line 158, in init
    old_init(self, *args, **kwargs)
  File "/Users/marwansarieddine/.pyenv/versions/3.8.5/envs/pyinfima/lib/python3.8/site-packages/prefect/tasks/core/function.py", line 60, in __init__
    prefect.core.task._validate_run_signature(fn)  # type: ignore
  File "/Users/marwansarieddine/.pyenv/versions/3.8.5/envs/pyinfima/lib/python3.8/site-packages/prefect/core/task.py", line 66, in _validate_run_signature
    raise ValueError(
ValueError: Tasks with variable positional arguments (*args) are not supported, because all Prefect arguments are stored as keywords. As a workaround, consider modifying the run() method to accept **kwargs and feeding the values to *args.
 ```
    



## Changes
<!-- What does this PR change? -->
A simple change is proposed to use `inspect.unwrap` instead of trying to access `__wrapped__`



## Importance
<!-- Why is this PR important? -->
This would allow further flexibility in composing prefect tasks by chaining decorators, or using complex decorators that have calls to other decorators.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)