### PR TITLE
Minor CLI enhancements

### DIFF
--- a/changes/pr4061.yaml
+++ b/changes/pr4061.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - "Add `--detect-changes` to `prefect register flow` CLI command that avoids bumping flow version if flow has not changed - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"
+  - "Add `--skip-if-exists` to `prefect create project` CLI command that safely skips if the project has already been created - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"

--- a/changes/pr4061.yaml
+++ b/changes/pr4061.yaml
@@ -1,3 +1,3 @@
-enhancements:
+enhancement:
   - "Add `--detect-changes` to `prefect register flow` CLI command that avoids bumping flow version if flow has not changed - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"
   - "Add `--skip-if-exists` to `prefect create project` CLI command that safely skips if the project has already been created - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"

--- a/changes/pr4061.yaml
+++ b/changes/pr4061.yaml
@@ -1,3 +1,3 @@
 enhancement:
-  - "Add `--detect-changes` to `prefect register flow` CLI command that avoids bumping flow version if flow has not changed - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"
+  - "Add `--skip-if-flow-metadata-unchanged` to `prefect register flow` CLI command that avoids bumping flow version if flow metadata has not changed - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"
   - "Add `--skip-if-exists` to `prefect create project` CLI command that safely skips if the project has already been created - [#4061](https://github.com/PrefectHQ/prefect/pull/4061)"

--- a/src/prefect/cli/create.py
+++ b/src/prefect/cli/create.py
@@ -2,6 +2,7 @@ import click
 
 from prefect.client import Client
 from prefect.utilities.exceptions import ClientError
+from prefect.utilities.graphql import with_args
 
 
 @click.group(hidden=True)
@@ -31,7 +32,13 @@ def create():
 @create.command(hidden=True)
 @click.argument("name", required=True)
 @click.option("--description", "-d", help="Project description to create", hidden=True)
-def project(name, description):
+@click.option(
+    "--skip-if-exists",
+    is_flag=True,
+    help="Skip creation if project already exists",
+    hidden=True,
+)
+def project(name, description, skip_if_exists):
     """
     Create projects with the Prefect API that organize flows. Does nothing if
     the project already exists.
@@ -43,8 +50,23 @@ def project(name, description):
     \b
     Options:
         --description, -d   TEXT    A project description
+        --skip-if-exists            Optionally skip creation call if project already exists
 
     """
+    if skip_if_exists:
+        result = Client().graphql(
+            query={
+                "query": {
+                    with_args("project", {"where": {"name": {"_eq": name}}}): {
+                        "id": True
+                    }
+                }
+            }
+        )
+        if result.data.project:
+            click.secho("{} already exists".format(name), fg="green")
+            return
+
     try:
         Client().create_project(project_name=name, project_description=description)
     except ClientError as exc:

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -62,12 +62,12 @@ def register():
     multiple=True,
 )
 @click.option(
-    "--detect-changes",
+    "--skip-if-flow-metadata-unchanged",
     is_flag=True,
-    help="Detect changes to the flow on registration",
+    help="Skips registration if flow metadata is unchanged",
     hidden=True,
 )
-def flow(file, name, project, label, detect_changes):
+def flow(file, name, project, label, skip_if_flow_metadata_unchanged):
     """
     Register a flow from a file. This call will pull a Flow object out of a `.py` file
     and call `flow.register` on it.
@@ -80,9 +80,11 @@ def flow(file, name, project, label, detect_changes):
         --project, -p   TEXT    The name of a Prefect project to register this flow
         --label, -l     TEXT    A label to set on the flow, extending any existing labels.
                                 Multiple labels are supported, eg. `-l label1 -l label2`.
-        --detect-changes        If toggled, passes a serialized hash of the flow to the register
-                                function's idempotency key. This allows you to avoid bumping the
-                                registered flow's version if the flow has not changed.
+
+        --skip-if-flow-metadata-unchanged       If toggled, passes a serialized hash of the flow to the
+                                                register function's idempotency key. This allows you to
+                                                avoid bumping the registered flow's version if the flow
+                                                metadata (structure) has not changed.
 
     \b
     Examples:
@@ -93,6 +95,8 @@ def flow(file, name, project, label, detect_changes):
     with prefect.context({"loading_flow": True, "local_script_path": file_path}):
         flow = extract_flow_from_file(file_path=file_path, flow_name=name)
 
-    idempotency_key = flow.serialized_hash() if detect_changes else None
+    idempotency_key = (
+        flow.serialized_hash() if skip_if_flow_metadata_unchanged else None
+    )
 
     flow.register(project_name=project, labels=label, idempotency_key=idempotency_key)

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -81,10 +81,8 @@ def flow(file, name, project, label, skip_if_flow_metadata_unchanged):
         --label, -l     TEXT    A label to set on the flow, extending any existing labels.
                                 Multiple labels are supported, eg. `-l label1 -l label2`.
 
-        --skip-if-flow-metadata-unchanged       If toggled, passes a serialized hash of the flow to the
-                                                register function's idempotency key. This allows you to
-                                                avoid bumping the registered flow's version if the flow
-                                                metadata (structure) has not changed.
+        --skip-if-flow-metadata-unchanged       If set, the flow will only be re-registered if its
+                                                metadata or structure has changed.
 
     \b
     Examples:

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -42,7 +42,7 @@ def register():
     "--name",
     "-n",
     required=False,
-    help="The `flow.name` to pull out of the file provided.",
+    help="The `flow.name` to pull out of the file provided",
     hidden=True,
     default=None,
 )
@@ -50,7 +50,7 @@ def register():
     "--project",
     "-p",
     required=False,
-    help="The name of a Prefect project to register this flow.",
+    help="The name of a Prefect project to register this flow",
     hidden=True,
     default=None,
 )
@@ -61,7 +61,12 @@ def register():
     hidden=True,
     multiple=True,
 )
-@click.option("--detect-changes", is_flag=True, help="Detect changes to the flow")
+@click.option(
+    "--detect-changes",
+    is_flag=True,
+    help="Detect changes to the flow on registration",
+    hidden=True,
+)
 def flow(file, name, project, label, detect_changes):
     """
     Register a flow from a file. This call will pull a Flow object out of a `.py` file

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -68,3 +68,14 @@ def test_create_project_that_already_exists(patch_posts):
     result = runner.invoke(create, ["project", "test"])
     assert result.exit_code == 0
     assert "test created" in result.output
+
+
+def test_skip_if_exists(patch_post, cloud_api):
+    patch_post(dict(data=dict(project=[dict(id="id")])))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create, ["project", "test", "-d", "description", "--skip-if-exists"]
+    )
+    assert result.exit_code == 0
+    assert "test already exists" in result.output

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -68,7 +68,7 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
         "test-flow",
         "--project",
         "project",
-        "--detect-changes",
+        "--skip-if-flow-metadata-unchanged",
     ]
     for l in labels:
         args.extend(["-l", l])

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -60,7 +60,16 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
     with open(full_path, "w") as f:
         f.write(contents)
 
-    args = ["flow", "--file", full_path, "--name", "test-flow", "--project", "project"]
+    args = [
+        "flow",
+        "--file",
+        full_path,
+        "--name",
+        "test-flow",
+        "--project",
+        "project",
+        "--detect-changes",
+    ]
     for l in labels:
         args.extend(["-l", l])
 
@@ -68,6 +77,7 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
     result = runner.invoke(register, args)
     assert client.register.called
     assert client.register.call_args[1]["project_name"] == "project"
+    assert client.register.call_args[1]["idempotency_key"] is not None
 
     # Check additional labels are set if specified
     flow = client.register.call_args[1]["flow"]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR adds two new options to the CLI:
- `--detect-changes` when calling `prefect register flow` that uses the flow's serialized hash as the idempotency key when registering (allowing the flow version to not be bumped if the flow has not changed)
- `--skip-if-exists` when calling `prefect create project` to safely query for the project by name and skip if it has already been created

cc @cicdw 



## Importance
This comes out of a direct request from some users that would make their CI/CD flow building and registration process smoother!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)