### PR TITLE
Add note on add_default_labels to Storage docs

### DIFF
--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -50,7 +50,11 @@ After registration, the flow will be stored at
 :::tip Automatic Labels
 Flows registered with this storage option will automatically be labeled with
 the hostname of the machine from which it was registered; this prevents agents
-not running on the same machine from attempting to run this flow.
+not running on the same machine from attempting to run this flow. This behavior
+can be overridden by passing `add_default_labels = False` to the constructor:
+```python
+flow = Flow("local-flow", storage=Local(add_default_labels = False))
+```
 :::
 
 :::tip Flow Results

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -51,10 +51,9 @@ After registration, the flow will be stored at
 Flows registered with this storage option will automatically be labeled with
 the hostname of the machine from which it was registered; this prevents agents
 not running on the same machine from attempting to run this flow. This behavior
-can be overridden by passing `add_default_labels = False` to the constructor:
+can be overridden by passing `add_default_labels=False` to the object:
 ```python
-flow = Flow("local-flow", storage=Local(add_default_labels = False))
-```
+flow = Flow("local-flow", storage=Local(add_default_labels=False))
 :::
 
 :::tip Flow Results


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Add a note to the Storage docs mentioning how to override the `LocalStorage` default of adding the hostname as a label. I've seen questions about this multiple times in the Slack channel, most recently today ( https://prefect-community.slack.com/archives/CL09KU1K7/p1612442778238000 )

## Changes
Just adding this sentence and example to the "Automatic Labels" tip:

```
This behavior can be overridden by passing `add_default_labels = False` to the constructor:
\```python
flow = Flow("local-flow", storage=Local(add_default_labels = False))
\```
```

## Importance
Hopefully saving people the time and effort of asking and answering this question again in Slack :)


## Checklist

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~