### PR TITLE
Module storage

### DIFF
--- a/changes/pr4073.yaml
+++ b/changes/pr4073.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add new `Module` storage class, for referencing flows importable from a Python module - [#4073](https://github.com/PrefectHQ/prefect/pull/4073)"

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -58,6 +58,24 @@ Flows configured with `Local` storage also default to using a `LocalResult` for
 persisting any task results in the same filesystem.
 :::
 
+## Module
+
+[Module Storage](/api/latest/storage.md#module) is useful for flows that are
+importable from a Python module. If you package your flows as part of a Python
+module, you can use `Module` storage to reference and load them at execution
+time (provided the module is installed and importable in the execution
+environment).
+
+```python
+from prefect import Flow
+from prefect.storage import Local
+
+flow = Flow("module example", storage=Module("mymodule.flows"))
+
+# Tip: you can use `__name__` to automatically reference the current module.
+flow = Flow("module example", storage=Module(__name__))
+```
+
 ## AWS S3
 
 [S3 Storage](/api/latest/storage.md#s3) is a storage option that

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -68,7 +68,7 @@ environment).
 
 ```python
 from prefect import Flow
-from prefect.storage import Local
+from prefect.storage import Module
 
 flow = Flow("module example", storage=Module("mymodule.flows"))
 

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -233,7 +233,7 @@ classes = ["RunConfig", "UniversalRun", "LocalRun", "DockerRun", "KubernetesRun"
 [pages.storage]
 title = "Storage"
 module = "prefect.storage"
-classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket", "CodeCommit"]
+classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket", "CodeCommit", "Module"]
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -233,7 +233,7 @@ classes = ["RunConfig", "UniversalRun", "LocalRun", "DockerRun", "KubernetesRun"
 [pages.storage]
 title = "Storage"
 module = "prefect.storage"
-classes = ["Storage", "Docker", "Local", "S3", "GCS", "Azure", "GitHub", "Webhook", "GitLab", "Bitbucket", "CodeCommit", "Module"]
+classes = {"Storage" = ["add_flow", "build"], "Azure" = [], "Bitbucket" = [], "CodeCommit" = [], "Docker" = [], "GCS" = [], "GitHub" = [], "GitLab" = [], "Local" = [], "Module" = [], "S3" = [], "Webhook" = []}
 
 [pages.tasks.control_flow]
 title = "Control Flow Tasks"

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -3,16 +3,17 @@ from typing import Any
 from marshmallow import fields, post_load
 
 from prefect.storage import (
-    GCS,
-    S3,
     Azure,
-    Docker,
-    Local,
-    Storage,
-    GitHub,
-    GitLab,
     Bitbucket,
     CodeCommit,
+    Docker,
+    GCS,
+    GitHub,
+    GitLab,
+    Local,
+    Module,
+    S3,
+    Storage,
     Webhook,
 )
 from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
@@ -145,6 +146,13 @@ class WebhookSchema(BaseStorageSchema):
     stored_as_script = fields.Bool(allow_none=True)
 
 
+class ModuleSchema(BaseStorageSchema):
+    class Meta:
+        object_class = Module
+
+    module = fields.String(allow_none=False)
+
+
 class StorageSchema(OneOfSchema):
     """
     Field that chooses between several nested schemas
@@ -153,14 +161,15 @@ class StorageSchema(OneOfSchema):
     # map class name to schema
     type_schemas = {
         "Azure": AzureSchema,
-        "Docker": DockerSchema,
-        "GCS": GCSSchema,
-        "Local": LocalSchema,
-        "Storage": BaseStorageSchema,
-        "S3": S3Schema,
-        "GitHub": GitHubSchema,
-        "GitLab": GitLabSchema,
         "Bitbucket": BitbucketSchema,
         "CodeCommit": CodeCommitSchema,
+        "Docker": DockerSchema,
+        "GCS": GCSSchema,
+        "GitHub": GitHubSchema,
+        "GitLab": GitLabSchema,
+        "Local": LocalSchema,
+        "Module": ModuleSchema,
+        "S3": S3Schema,
+        "Storage": BaseStorageSchema,
         "Webhook": WebhookSchema,
     }

--- a/src/prefect/storage/__init__.py
+++ b/src/prefect/storage/__init__.py
@@ -25,17 +25,18 @@ from warnings import warn
 
 import prefect
 from prefect import config
-from .base import Storage
-from .docker import Docker
-from .local import Local
-from .azure import Azure
-from .gcs import GCS
-from .s3 import S3
-from .github import GitHub
-from .gitlab import GitLab
-from .bitbucket import Bitbucket
-from .codecommit import CodeCommit
-from .webhook import Webhook
+from prefect.storage.base import Storage
+from prefect.storage.azure import Azure
+from prefect.storage.bitbucket import Bitbucket
+from prefect.storage.codecommit import CodeCommit
+from prefect.storage.docker import Docker
+from prefect.storage.gcs import GCS
+from prefect.storage.github import GitHub
+from prefect.storage.gitlab import GitLab
+from prefect.storage.local import Local
+from prefect.storage.module import Module
+from prefect.storage.s3 import S3
+from prefect.storage.webhook import Webhook
 
 
 def get_default_storage_class() -> type:

--- a/src/prefect/storage/__init__.py
+++ b/src/prefect/storage/__init__.py
@@ -1,24 +1,7 @@
 """
-The Prefect Storage interface encapsulates logic for storing, serializing and even running Flows.
-Each storage unit is able to store _multiple_ flows (possibly with the constraint of name uniqueness
-within a given unit), and exposes the following methods and attributes:
-
-- a `flows` attribute that is a dictionary of flow name  -> location
-- an `add_flow(flow: Flow) -> str` method for adding flows to Storage, and that will return the intended
-location of the given flow in the Storage unit (note flow uploading/saving does not happen until `build`)
-- the `__contains__(self, obj) -> bool` special method for determining whether the Storage contains a
-given Flow
-- one of `get_flow(flow_name: str)` for retrieving a way of interfacing with either `flow.run` or a
-`FlowRunner` for the flow
-- a `build() -> Storage` method for "building" the storage. In storage options where flows are stored in
-an external service (such as S3 and the filesystem) the flows are uploaded/saved during this step
-- a `serialize() -> dict` method for serializing the relevant information about this Storage for later
-re-use.
-
-The default flow storage mechanism is based on pickling the flow object using `cloudpickle` and the
-saving that pickle to a location. Flows can optionally also be stored as a script using the
-`stored_as_script` boolean kwarg. For more information visit the
-[file-based storage idiom](/core/idioms/file-based.html).
+The Prefect Storage interface encapsulates logic for storing flows. Each
+storage unit is able to store _multiple_ flows (with the constraint of name
+uniqueness within a given unit).
 """
 
 from warnings import warn

--- a/src/prefect/storage/base.py
+++ b/src/prefect/storage/base.py
@@ -122,7 +122,6 @@ class Storage(metaclass=ABCMeta):
             return False
         return obj in self.flows
 
-    @abstractmethod
     def build(self) -> "Storage":
         """
         Build the Storage object.
@@ -131,7 +130,9 @@ class Storage(metaclass=ABCMeta):
             - Storage: a Storage object that contains information about how and where
                 each flow is stored
         """
-        raise NotImplementedError()
+        self.run_basic_healthchecks()
+
+        return self
 
     def serialize(self) -> dict:
         """

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -140,20 +140,6 @@ class Bitbucket(Storage):
         self._flows[flow.name] = flow
         return self.path  # type: ignore
 
-    def build(self) -> "Storage":
-        """
-        Build the Bitbucket storage object and run basic healthchecks. Due to this object
-        supporting file based storage no files are committed to the repository during
-        this step. Instead, all files should be committed independently.
-
-        Returns:
-            - Storage: a Bitbucket object that contains information about how and where
-                each flow is stored
-        """
-        self.run_basic_healthchecks()
-
-        return self
-
     def _get_bitbucket_client(self) -> "atlassian.Bitbucket":
         try:
             from atlassian import Bitbucket

--- a/src/prefect/storage/codecommit.py
+++ b/src/prefect/storage/codecommit.py
@@ -112,20 +112,6 @@ class CodeCommit(Storage):
         self._flows[flow.name] = flow
         return self.path  # type: ignore
 
-    def build(self) -> "Storage":
-        """
-        Build the CodeCommit storage object and run basic healthchecks. Due to this object
-        supporting file based storage no files are committed to the repository during
-        this step. Instead, all files should be committed independently.
-
-        Returns:
-            - Storage: a CodeCommit object that contains information about how and where
-                each flow is stored
-        """
-        self.run_basic_healthchecks()
-
-        return self
-
     @property
     def _boto3_client(self):  # type: ignore
         from prefect.utilities.aws import get_boto_client

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -149,20 +149,6 @@ class GitHub(Storage):
         self._flows[flow.name] = flow
         return self.path  # type: ignore
 
-    def build(self) -> "Storage":
-        """
-        Build the GitHub storage object and run basic healthchecks. Due to this object
-        supporting file based storage no files are committed to the repository during
-        this step. Instead, all files should be committed independently.
-
-        Returns:
-            - Storage: a GitHub object that contains information about how and where
-                each flow is stored
-        """
-        self.run_basic_healthchecks()
-
-        return self
-
     def _get_github_client(self) -> "Github":
         from github import Github
 

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -130,20 +130,6 @@ class GitLab(Storage):
         self._flows[flow.name] = flow
         return self.path  # type: ignore
 
-    def build(self) -> "Storage":
-        """
-        Build the GitLab storage object and run basic healthchecks. Due to this object
-        supporting file based storage no files are committed to the repository during
-        this step. Instead, all files should be committed independently.
-
-        Returns:
-            - Storage: a GitLab object that contains information about how and where
-                each flow is stored
-        """
-        self.run_basic_healthchecks()
-
-        return self
-
     def _get_gitlab_client(self) -> "Gitlab":
         from gitlab import Gitlab
 

--- a/src/prefect/storage/local.py
+++ b/src/prefect/storage/local.py
@@ -99,7 +99,9 @@ class Local(Storage):
                     return flow_from_bytes_pickle(f.read())
         # otherwise the path is given in the module format
         else:
-            return extract_flow_from_module(module_str=flow_location)
+            return extract_flow_from_module(
+                module_str=flow_location, flow_name=flow_name
+            )
 
     def add_flow(self, flow: "Flow") -> str:
         """

--- a/src/prefect/storage/local.py
+++ b/src/prefect/storage/local.py
@@ -145,14 +145,3 @@ class Local(Storage):
         self.flows[flow.name] = flow_location
         self._flows[flow.name] = flow
         return flow_location
-
-    def build(self) -> "Storage":
-        """
-        Build the Storage object.
-
-        Returns:
-            - Storage: a Storage object that contains information about how and where
-                each flow is stored
-        """
-        self.run_basic_healthchecks()
-        return self

--- a/src/prefect/storage/module.py
+++ b/src/prefect/storage/module.py
@@ -1,0 +1,85 @@
+from typing import Any, TYPE_CHECKING
+
+from prefect.storage.base import Storage
+from prefect.utilities.storage import extract_flow_from_module
+
+if TYPE_CHECKING:
+    from prefect import Flow
+
+
+class Module(Storage):
+    """
+    A Prefect Storage class for referencing flows that can be imported from a
+    python module.
+
+    Args:
+        - module (str): The module to import the flow from.
+        - **kwargs (Any, optional): any additional `Storage` options.
+
+    Example:
+
+    Suppose you have a python module `myproject.flows` that contains all your
+    Prefect flows. If this module is installed and available in your execution
+    environment you can use `Module` storage to reference and load the flows.
+
+    ```python
+    from prefect import Flow
+    from prefect.storage import Module
+
+    flow = Flow("module storage example")
+    flow.storage = Module("myproject.flows")
+
+    # Tip: you can use `__name__` to automatically reference the current module
+    flow.storage = Module(__name__)
+    ```
+    """
+
+    def __init__(self, module: str, **kwargs: Any) -> None:
+        self.module = module
+        super().__init__(**kwargs)
+
+    def get_flow(self, flow_name: str) -> "Flow":
+        """
+        Given a flow name within this Storage object, load and return the Flow.
+
+        Args:
+            - flow_name (str): the name of the flow to return.
+
+        Returns:
+            - Flow: the requested flow
+        """
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        return extract_flow_from_module(module_str=self.module, flow_name=flow_name)
+
+    def add_flow(self, flow: "Flow") -> str:
+        """
+        Add a new flow to this storage object.
+
+        Args:
+            - flow (Flow): the Prefect Flow to add.
+
+        Returns:
+            - str: the location of the newly added flow in this Storage object
+        """
+        if flow.name in self:
+            raise ValueError(
+                'Name conflict: Flow with the name "{}" is already present in this storage.'.format(
+                    flow.name
+                )
+            )
+
+        self.flows[flow.name] = self.module
+        self._flows[flow.name] = flow
+        return self.module
+
+    def build(self) -> "Module":
+        """
+        Build the Storage object.
+
+        Returns:
+            - Storage: a Storage object that contains information about how and where
+                each flow is stored.
+        """
+        self.run_basic_healthchecks()
+        return self

--- a/src/prefect/storage/module.py
+++ b/src/prefect/storage/module.py
@@ -72,14 +72,3 @@ class Module(Storage):
         self.flows[flow.name] = self.module
         self._flows[flow.name] = flow
         return self.module
-
-    def build(self) -> "Module":
-        """
-        Build the Storage object.
-
-        Returns:
-            - Storage: a Storage object that contains information about how and where
-                each flow is stored.
-        """
-        self.run_basic_healthchecks()
-        return self

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -439,3 +439,9 @@ def test_bitbucket_full_serialize(access_token_secret):
     assert serialized["ref"] == "develop"
     assert serialized["secrets"] == ["token"]
     assert serialized["access_token_secret"] == access_token_secret
+
+
+def test_module_serialize():
+    module = storage.Module("test")
+    serialized = module.serialize()
+    assert serialized["module"] == "test"

--- a/tests/storage/test_module.py
+++ b/tests/storage/test_module.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+import pytest
+
+from prefect import Flow
+from prefect.storage import Module
+
+
+@pytest.fixture
+def mymodule(monkeypatch):
+    mod_name = "mymodule"
+    module = types.ModuleType(mod_name)
+    monkeypatch.setitem(sys.modules, mod_name, module)
+    return module
+
+
+class TestModule:
+    def test_init(self):
+        storage = Module("mymodule")
+        assert storage.module == "mymodule"
+
+    def test_add_flow(self):
+        flow = Flow("test")
+
+        storage = Module("mymodule")
+        assert flow.name not in storage
+
+        storage.add_flow(flow)
+        assert flow.name in storage
+
+        with pytest.raises(ValueError, match="Name conflict"):
+            storage.add_flow(flow)
+
+    def test_get_flow(self, mymodule):
+        flow = Flow("test")
+        mymodule.flow = flow
+
+        storage = Module("mymodule")
+        storage.add_flow(flow)
+
+        flow2 = storage.get_flow(flow.name)
+        assert flow2 is flow
+
+    def test_get_flow_name_mismatch(self, mymodule):
+        flow = Flow("test")
+        mymodule.flow = Flow("other name")
+
+        storage = Module("mymodule")
+        storage.add_flow(flow)
+
+        with pytest.raises(ValueError, match="Failed to find flow"):
+            storage.get_flow(flow.name)


### PR DESCRIPTION
Adds a new `Module` storage class, for referencing flows importable from an installed python module. This was previously doable as part of `Local` storage (but kind of hidden). We move it out to its own storage class to better surface this feature, and because it works fine whether run locally or not (e.g. works in a docker container, an ECS task, etc...).

Also does some general storage cleanups.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)