### PR TITLE
Drop default resource limits on k8s agent

### DIFF
--- a/changes/pr4077.yaml
+++ b/changes/pr4077.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Drop resource limits from manifest generated using `prefect agent kubernetes install` - [#4077](https://github.com/PrefectHQ/prefect/pull/4077)"

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -49,10 +49,6 @@ spec:
               value: "cloud"
             - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
               value: "http://:8080"
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
           livenessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
These were extremely low, and there's not a good reason to have them
(IMO). If a user wants to ensure the agent doesn't exceed a limit they
can add one themself (or add a request), but we shouldn't assume any by
default.

Fixes #3942.