### PR TITLE
Add backend custom server config

### DIFF
--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -573,7 +573,7 @@ functions = ["merge_dicts", "as_nested_dict", "dict_to_flatdict", "flatdict_to_d
 [pages.utilities.configuration]
 title = "Configuration"
 module = "prefect.utilities.configuration"
-functions = ["set_temporary_config"]
+functions = ["set_temporary_config", "set_permanent_user_config"]
 
 [pages.utilities.context]
 title = "Context"

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -17,7 +17,7 @@ from .run import run as _run
 from .server import server as _server
 from .heartbeat import heartbeat as _heartbeat
 from .register import register as _register
-
+from ..utilities.configuration import set_permanent_user_config
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -119,11 +119,29 @@ def diagnostics(include_secret_names):
 @click.argument("api")
 def backend(api):
     """
-    Switch Prefect API backend to either `server` or `cloud`
-    """
-    if api not in ["server", "cloud"]:
-        click.secho("{} is not a valid backend API".format(api), fg="red")
-        return
+    \b
+    Switch Prefect API backend :
+        - `cloud` for using prefect cloud
+        - `server` for using a localhost server
+        - any other string for specifying a custom server host
+            (~/.prefect/config.toml will be updated)
 
-    backend_util.save_backend(api)
-    click.secho("Backend switched to {}".format(api), fg="green")
+    """
+    if api == "cloud":
+        backend_util.save_backend(api)
+        click.secho("Backend switched to {}".format(api), fg="green")
+
+    if api == "server":
+        backend_util.save_backend(api)
+        click.secho("Backend switched to {}".format(api), fg="green")
+
+        # Set back to default localhost
+        fp = set_permanent_user_config({'server': {'host': "localhost"}})
+
+    if api not in ["server", "cloud"]:
+        # Switch backend to server
+        backend_util.save_backend("server")
+
+        # Expect a server hostname
+        fp = set_permanent_user_config({'server': {'host': api}})
+        click.secho(f"User config {fp} updated with server.host = {api}", fg="green")

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -123,7 +123,7 @@ def backend(api):
     Switch Prefect API backend :
         - `cloud` for using prefect cloud
         - `server` for using a localhost server
-        - any other string for specifying a custom server host
+        - any other string for specifying a custom server host, eg. http://my-prefect-server.com
             (~/.prefect/config.toml will be updated)
 
     """
@@ -136,7 +136,7 @@ def backend(api):
         click.secho("Backend switched to {}".format(api), fg="green")
 
         # Set back to default localhost
-        fp = set_permanent_user_config({'server': {'host': "localhost"}})
+        set_permanent_user_config({'server': {'host': "http://localhost"}})
 
     if api not in ["server", "cloud"]:
         # Switch backend to server

--- a/src/prefect/utilities/configuration.py
+++ b/src/prefect/utilities/configuration.py
@@ -57,7 +57,7 @@ def set_permanent_user_config(extra_config: dict, config_path: str = None) -> bo
 
     Example:
         ```python
-        set_permanent_user_config({'server': {'host': 'my-server'}})
+        set_permanent_user_config({'server': {'host': 'http://my-server'}})
         ```
 
     """

--- a/src/prefect/utilities/configuration.py
+++ b/src/prefect/utilities/configuration.py
@@ -52,10 +52,13 @@ def set_permanent_user_config(extra_config: dict, config_path: str = None) -> bo
     Update user config file with a specific dictionary
 
     Args:
-        extra_config:
-        config_path:
+        extra_config (dict): any dict with new key/values to add
+        config_path str: config file path, ~/.prefect/config.toml by default
 
-    Returns:
+    Example:
+        ```python
+        set_permanent_user_config({'server': {'host': 'my-server'}})
+        ```
 
     """
     from prefect.configuration import USER_CONFIG, load_toml, interpolate_env_vars

--- a/src/prefect/utilities/configuration.py
+++ b/src/prefect/utilities/configuration.py
@@ -6,6 +6,8 @@ intended to be used for testing.
 from contextlib import contextmanager
 from typing import Iterator
 
+import toml
+
 import prefect
 from prefect.configuration import Config
 
@@ -43,3 +45,28 @@ def set_temporary_config(temp_config: dict) -> Iterator:
     finally:
         prefect.config.clear()
         prefect.config.update(old_config)
+
+
+def set_permanent_user_config(extra_config: dict, config_path: str = None) -> bool:
+    """
+    Update user config file with a specific dictionary
+
+    Args:
+        extra_config:
+        config_path:
+
+    Returns:
+
+    """
+    from prefect.configuration import USER_CONFIG, load_toml, interpolate_env_vars
+
+    if config_path is None:
+        config_path = interpolate_env_vars(USER_CONFIG)
+
+    user_toml = load_toml(config_path)
+    user_toml.update(extra_config)
+
+    with open(config_path, "w") as fd:
+        toml.dump(user_toml, fd)
+
+    return config_path


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Extend `prefect backend` to setup a custom server host.


## Changes
<!-- What does this PR change? -->

Easiest way to setup custom prefect server host, by using :

```shell
prefect backend http://my-beautiful-prefect-server
```

Will result :

```shell
$ cat ~/.prefect/backend.toml
backend = "server"
 
$ cat ~/.prefect/config.toml
[server]
host = "http://my-beautiful-prefect-server"
```




## Importance
<!-- Why is this PR important? -->

In our test environment, we have two prefect servers:
 - one on my laptop for testing
 - one running on our infra

It's more easy to change the server host through the cli.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)