### PR TITLE
patch S3Result to use a global client

### DIFF
--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 S3_CLIENT = None
 
+
 class S3Result(Result):
     """
     Result that is written to and retrieved from an AWS S3 Bucket.
@@ -46,6 +47,7 @@ class S3Result(Result):
         Initializes an S3 Client.
         """
         from prefect.utilities.aws import get_boto_client
+
         global S3_CLIENT
         if S3_CLIENT:
             self.client = S3_CLIENT

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -7,6 +7,7 @@ from prefect.engine.result import Result
 if TYPE_CHECKING:
     import boto3
 
+S3_CLIENT = None
 
 class S3Result(Result):
     """
@@ -45,13 +46,17 @@ class S3Result(Result):
         Initializes an S3 Client.
         """
         from prefect.utilities.aws import get_boto_client
-
-        # use a new boto session when initializing in case we are in a new thread see
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
-        s3_client = get_boto_client(
-            "s3", credentials=None, use_session=True, **self.boto3_kwargs
-        )
-        self.client = s3_client
+        global S3_CLIENT
+        if S3_CLIENT:
+            self.client = S3_CLIENT
+        else:
+            # use a new boto session when initializing in case we are in a new thread see
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing
+            s3_client = get_boto_client(
+                "s3", credentials=None, use_session=True, **self.boto3_kwargs
+            )
+            self.client = s3_client
+            S3_CLIENT = s3_client
 
     @property
     def client(self) -> "boto3.client":


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Patch the S3Result to initialize the boto client once. Resolves #4085 



## Changes
<!-- What does this PR change? -->
S3Result causes a memory leak in DaskExecutor. Instead of creating a client with every S3Result, create a global client and reuse it.



## Importance
<!-- Why is this PR important? -->
If many tasks are cached, a Dask worker will eventually run out of memory and the job will stall. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)