### PR TITLE
A few additions to the storage docs

### DIFF
--- a/docs/core/idioms/idioms.md
+++ b/docs/core/idioms/idioms.md
@@ -10,6 +10,6 @@
 - [Testing Prefect flows and tasks](testing-flows.html)
 - [Using Result targets for efficient caching](targets.html)
 - [Configuring notifications](notifications.html)
-- [Using file based flow storage](file-based.html)
+- [Using script based flow storage](script-based.html)
 - [Pause for Approval](pause-for-approval.html)
 - [Naming task runs based on inputs](task-run-names.html)

--- a/docs/core/idioms/script-based.md
+++ b/docs/core/idioms/script-based.md
@@ -1,18 +1,19 @@
-# Using file based flow storage
+# Using script based flow storage
 
-As of Prefect version `0.12.5` all storage options support storing flows as files. This means that flow
-code can change in between (or even during) runs without needing to be reregistered. As long as the
-structure of the flow itself does not change, only the task content, then a Prefect API backend will be
-able to execute the flow. This is a useful storage mechanism especially for testing, debugging, CI/CD
-processes, and more!
+As of Prefect version `0.12.5` all storage options support storing flows as
+source files instead of pickled objects. This means that flow code can change
+in between (or even during) runs without needing to be reregistered. As long as
+the structure of the flow itself does not change, only the task content, then a
+Prefect API backend will be able to execute the flow. This is a useful storage
+mechanism especially for testing, debugging, CI/CD processes, and more!
 
-### Enable file storage
+### Enable script storage
 
-GitHub storage only supports files however the other storage options (Local, Docker, S3, etc.) store
-flows both as pickles and files. To switch to using file storage and enable the workflow above set
-`stored_as_script=True` on the storage object.
+Some storage classes (e.g. `GitHub`, `GitLab`, `Bitbucket`, ...) only support
+script based storage. All other classes require you to opt-in by passing
+`stored_as_script=True` to the storage class constructor.
 
-### Example file based workflow
+### Example script based workflow
 
 ::: warning GitHub dependency
 This idiom requires that `git` is installed as well as Prefect's `github` extra dependencies:
@@ -49,7 +50,7 @@ def get_data():
 def print_data(data):
     print(data)
 
-with Flow("file-based-flow") as flow:
+with Flow("example") as flow:
     data = get_data()
     print_data(data)
 
@@ -124,7 +125,7 @@ flow.storage = Bitbucket(
 ```
 :::
 
-### File based Docker storage
+### Script based Docker storage
 
 ```python
 flow.storage = Docker(
@@ -139,7 +140,7 @@ Docker storage build step:
 
 - `path`: the path that the file is stored in the Docker image
 - `files`: a dictionary of local file source to path destination in image
-- `stored_as_script`: boolean enabling file based storage
+- `stored_as_script`: boolean enabling script based storage
 
 If your Docker storage is using an image that already has your flow files added into it then you only
 need to specify the following:
@@ -151,9 +152,9 @@ flow.storage = Docker(
 )
 ```
 
-### File based cloud storage
+### Script based cloud storage
 
-File based storage of flows is also supported for flows stored in S3 and GCS buckets. The following
+Script based storage of flows is also supported for flows stored in S3 and GCS buckets. The following
 snippet shows S3 and GCS storage options where a flow is stored as a script and the `key` points to the
 specific file path in the bucket.
 

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -13,8 +13,8 @@ As of Prefect version `0.9.0` every storage option except for `Docker` and `GitH
 
 Version `0.12.0` introduces a new way to store flows using the various cloud storage options (S3, GCS, Azure) and then in turn run them using Agents which orchestrate containerized environments. For more information see [below](/orchestration/execution/storage_options.html#non-docker-storage-for-containerized-environments).
 
-Version `0.12.5` introduces file-based storage for all storage options. For more information see the
-[Using file based flow storage idiom](/core/idioms/file-based.html).
+Version `0.12.5` introduces script-based storage for all storage options. For more information see the
+[Using script based flow storage idiom](/core/idioms/script-based.html).
 
 ## Local
 
@@ -114,7 +114,7 @@ GCS Storage uses Google Cloud credentials the same way as the standard [google.c
 
 [GitHub Storage](/api/latest/storage.html#github) is a storage option that uploads flows to a GitHub repository as `.py` files.
 
-For a detailed look on how to use GitHub storage visit the [Using file based storage](/core/idioms/file-based.html) idiom.
+For a detailed look on how to use GitHub storage visit the [Using script based storage](/core/idioms/script-based.html) idiom.
 
 :::tip GitHub Credentials
 GitHub storage uses a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for authenticating with repositories.
@@ -124,7 +124,7 @@ GitHub storage uses a [personal access token](https://help.github.com/en/github/
 
 [GitLab Storage](/api/latest/storage.html#github) is a storage option that uploads flows to a GitLab repository as `.py` files.
 
-Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to GitLab as well.
+Much of the GitHub example in the [script based storage](/core/idioms/script-based.html) documentation applies to GitLab as well.
 
 :::tip GitLab Credentials
 GitLab storage uses a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for authenticating with repositories.
@@ -138,7 +138,7 @@ GitLab server users can point the `host` argument to their personal GitLab insta
 
 [Bitbucket Storage](/api/latest/storage.html#github) is a storage option that uploads flows to a Bitbucket repository as `.py` files.
 
-Much of the GitHub example in the [file based storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
+Much of the GitHub example in the [script based storage](/core/idioms/script-based.html) documentation applies to Bitbucket as well.
 
 :::tip Bitbucket Credentials
 Bitbucket storage uses a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) for authenticating with repositories.

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -71,7 +71,7 @@ This has a few nice properties:
   range of Prefect/Python/dependency versions.
 
 The downside is you may have to do a bit more configuration to tell prefect
-where your script is located (since it can't always automatically inferred).
+where your script is located (since it can't always be automatically inferred).
 
 Some storage classes (e.g. `GitHub`, `Bitbucket`, `GitLab`, ...) only support
 script-based flow storage. Other classes (e.g. `Local`, `S3`, `GCS`, ...)

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -1,8 +1,8 @@
 # Storage
 
-`Storage` objects define where a Flow should be stored. Examples include things
-like `Local` storage (which uses the local filesystem) or `S3` (which stores
-flows remotely on AWS S3). Flows themselves are never stored directly in
+`Storage` objects define where a Flow's definition is stored. Examples include
+things like `Local` storage (which uses the local filesystem) or `S3` (which
+stores flows remotely on AWS S3). Flows themselves are never stored directly in
 Prefect's backend; only a reference to the storage location is persisted. This
 helps keep your flow's code secure, as the Prefect servers never have direct
 access.
@@ -26,11 +26,89 @@ with Flow("example") as flow:
 flow.storage = Local()
 ```
 
+## Pickle vs Script Based Storage
+
+Prefect Storage classes support two ways of storing a flow's definition:
+
+### Pickle based storage
+
+Pickle based flow storage uses the `cloudpickle` library to "pickle"
+(serialize) the `Flow` object. At runtime the flow is unpickled and can then be
+executed.
+
+This means that the flow's definition is effectively "frozen" at registration
+time. Anything executed at the top-level of the script will only execute at
+flow *registration* time, not at flow *execution* time.
+
+```python
+from prefect import Flow
+
+# Top-level functionality (like this print statement) runs only at flow
+# *registration* time, it will not run during each flow run. If you want
+# something to run as part of a flow, you must write it as a task.
+print("This print only runs at flow registration time")
+
+with Flow("example") as flow:
+    pass
+```
+
+### Script based storage
+
+Script based flow storage uses the Python script that created the flow as the
+flow definition. Each time the flow is run, the script will be run to recreate
+the `Flow` object.
+
+This has a few nice properties:
+
+- Script based flows allow you to make small edits to the source of your flow
+  without re-registration. Changing the flow's structure (e.g. adding new tasks
+  or edges) or the flow's metadata (e.g. updating the run config) will require
+  re-registration, but editing the definitions for individual tasks is fine.
+
+- Pickle based flows are prone to breakage if the internals of Prefect or a
+  dependent library changes (even if the public-facing API remains the same).
+  Using a script based flow storage your flow is likely to work across a larger
+  range of Prefect/Python/dependency versions.
+
+The downside is you may have to do a bit more configuration to tell prefect
+where your script is located (since it can't always automatically inferred).
+
+Some storage classes (e.g. `GitHub`, `Bitbucket`, `GitLab`, ...) only support
+script-based flow storage. Other classes (e.g. `Local`, `S3`, `GCS`, ...)
+support both - pickle is used by default, but you can opt in to script-based
+storage by passing `stored_as_script=True`. See the [script based storage
+idiom](/core/idioms/script-based.html) for more information.
+
+## Choosing a Storage Class
+
+Prefect's storage mechanism is flexible, supporting many different backends and
+deployment strategies. However, such flexibility can be daunting for both new
+and experienced users. Below we provide a few general recommendations for
+deciding what Storage mechanism is right for you.
+
+- If you're deploying flows locally using a [local
+  agent](/orchestration/agents/local.md), you likely want to use the default
+  [Local](#local) storage class. It requires no external resources, and is
+  quick to configure.
+
+- If you store your flows in a code repository you may want to use the
+  corresponding storage class (e.g. [GitHub](#github), [Bitbucket](#bitbucket),
+  [GitLab](#gitlab), ...).  During a flow run your flow source will be pulled
+  from the repo (optionally from a specific commit/branch) before execution.
+
+- If you're making use of cloud storage within your flows, you may want to
+  store your flow source in the same location. Storage classes like
+  [S3](#aws-s3), [GCS](#google-cloud-storage), and [Azure](#azure-blob-storage)
+  make it possible to specify a single location for hosting both your flow
+  source and results from that flow.
+
+## Storage Types
+
 Prefect has a number of different `Storage` implementations - we'll briefly
 cover each below. See [the API documentation](/api/latest/storage.md) for more
 information.
 
-## Local
+### Local
 
 [Local Storage](/api/latest/storage.md#local) is the default
 `Storage` option for all flows. Flows using local storage are stored as files
@@ -54,6 +132,7 @@ not running on the same machine from attempting to run this flow. This behavior
 can be overridden by passing `add_default_labels=False` to the object:
 ```python
 flow = Flow("local-flow", storage=Local(add_default_labels=False))
+```
 :::
 
 :::tip Flow Results
@@ -61,7 +140,7 @@ Flows configured with `Local` storage also default to using a `LocalResult` for
 persisting any task results in the same filesystem.
 :::
 
-## Module
+### Module
 
 [Module Storage](/api/latest/storage.md#module) is useful for flows that are
 importable from a Python module. If you package your flows as part of a Python
@@ -79,7 +158,7 @@ flow = Flow("module example", storage=Module("mymodule.flows"))
 flow = Flow("module example", storage=Module(__name__))
 ```
 
-## AWS S3
+### AWS S3
 
 [S3 Storage](/api/latest/storage.md#s3) is a storage option that
 uploads flows to an AWS S3 bucket.
@@ -106,7 +185,7 @@ which means both upload (build) and download (local agent) times need to have
 proper AWS credential configuration.
 :::
 
-## Azure Blob Storage
+### Azure Blob Storage
 
 [Azure Storage](/api/latest/storage.md#azure) is a storage
 option that uploads flows to an Azure Blob container.
@@ -141,7 +220,7 @@ environment variable `AZURE_STORAGE_CONNECTION_STRING` if it is not passed to
 the class directly.
 :::
 
-## Google Cloud Storage
+### Google Cloud Storage
 
 [GCS Storage](/api/latest/storage.md#gcs) is a storage option
 that uploads flows to a Google Cloud Storage bucket.
@@ -169,7 +248,7 @@ which means both upload (build) and download (local agent) times need to have
 the proper Google Application Credentials configuration.
 :::
 
-## GitHub
+### GitHub
 
 [GitHub Storage](/api/latest/storage.md#github) is a storage
 option for referencing flows stored in a GitHub repository as `.py` files.
@@ -188,8 +267,8 @@ flow = Flow(
 )
 ```
 
-For a detailed look on how to use GitHub storage visit the [Using file based
-storage](/core/idioms/file-based.md) idiom.
+For a detailed look on how to use GitHub storage visit the [Using script based
+storage](/core/idioms/script-based.md) idiom.
 
 :::tip GitHub Credentials
 GitHub storage uses a [personal access
@@ -197,7 +276,7 @@ token](https://help.github.com/en/github/authenticating-to-github/creating-a-per
 for authenticating with repositories.
 :::
 
-## GitLab
+### GitLab
 
 [GitLab Storage](/api/latest/storage.md#gitlab) is a storage
 option for referencing flows stored in a GitLab repository as `.py` files.
@@ -216,8 +295,8 @@ flow = Flow(
 )
 ```
 
-Much of the GitHub example in the [file based
-storage](/core/idioms/file-based.md) documentation applies to GitLab as well.
+Much of the GitHub example in the [script based
+storage](/core/idioms/script-based.md) documentation applies to GitLab as well.
 
 :::tip GitLab Credentials
 GitLab storage uses a [personal access
@@ -230,7 +309,7 @@ GitLab server users can point the `host` argument to their personal GitLab
 instance.
 :::
 
-## Bitbucket
+### Bitbucket
 
 [Bitbucket Storage](/api/latest/storage.html#github) is a
 storage option that uploads flows to a Bitbucket repository as `.py` files.
@@ -250,8 +329,8 @@ flow = Flow(
 )
 ```
 
-Much of the GitHub example in the [file based
-storage](/core/idioms/file-based.html) documentation applies to Bitbucket as well.
+Much of the GitHub example in the [script based
+storage](/core/idioms/script-based.html) documentation applies to Bitbucket as well.
 
 :::tip Bitbucket Credentials
 Bitbucket storage uses a [personal access
@@ -265,7 +344,7 @@ must be associated with a Project. Bitbucket storage requires a `project` argume
 pointing to the correct project name.
 :::
 
-## CodeCommit
+### CodeCommit
 
 [CodeCommit Storage](/api/latest/storage.html#codecommit) is a
 storage option that uploads flows to a CodeCommit repository as `.py` files.
@@ -291,14 +370,13 @@ which means both upload (build) and download (local agent) times need to
 have proper AWS credential configuration.
 :::
 
-## Docker
+### Docker
 
-[Docker Storage](/api/latest/storage.md#docker) is a storage
-option that puts flows inside of a Docker image and pushes them to a container
-registry. This method of Storage has deployment compatability with the [Docker
-Agent](/orchestration/agents/docker.md), [Kubernetes
-Agent](/orchestration/agents/kubernetes.md), and [Fargate
-Agent](/orchestration/agents/fargate.md).
+[Docker Storage](/api/latest/storage.md#docker) is a storage option that puts
+flows inside of a Docker image and pushes them to a container registry. As
+such, it will not work with flows deployed via a [local
+agent](/orchestration/agents/local.md), since docker images aren't supported
+there.
 
 ```python
 from prefect import Flow
@@ -330,7 +408,7 @@ Additionally make sure whichever platform Agent deploys the container also has
 permissions to pull from that same registry.
 :::
 
-## Webhook
+### Webhook
 
 [Webhook Storage](/api/latest/storage.md#webhook) is a storage
 option that stores and retrieves flows with HTTP requests. This type of storage

--- a/docs/orchestration/tutorial/overview.md
+++ b/docs/orchestration/tutorial/overview.md
@@ -17,7 +17,7 @@ Welcome to the Prefect Deployment Tutorial! This tutorial will cover:
 - Using a [Prefect Agent](/orchestration/agents/overview.md) to run that Flow
 
 If you haven't yet, you might want to go through the [Prefect Core
-Tutorial](http://localhost:8080/core/tutorial/01-etl-before-prefect.html),
+Tutorial](/core/tutorial/01-etl-before-prefect.html),
 which covers in greater detail how to write Prefect Flows.
 
 ## Install Prefect


### PR DESCRIPTION
Expands the storage docs a bit:

- Standardizes use of `script based` flow storage, instead of `file based`. The kwarg is named `stored_as_script`, and not all backends refer to things as "files", so I think this makes more sense.

- Adds section to storage docs clarifying the difference between pickle and script based flow storage, and why you might pick one or the other.

- Adds section to the docs on choosing a storage class.

- A few small typo fixers.