### PR TITLE
Ensure agent health-check thread has an active event loop

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -291,6 +291,14 @@ class Agent:
             )
 
             def run() -> None:
+                # Ensure there's an active event loop in this thread
+                import asyncio
+
+                try:
+                    asyncio.get_event_loop()
+                except RuntimeError:
+                    asyncio.set_event_loop(asyncio.new_event_loop())
+
                 self.logger.debug(
                     f"Agent API server listening on port {self.agent_address}"
                 )


### PR DESCRIPTION
This was broken in 0.14.7. Previously we had accidentally relied
distributed implicitly setting a global `AnyThreadEventLoop` policy on
import, but in 0.14.7 we dropped all unnecessary imports (so this
implicit global change didn't happen). Our tests still passed though,
since `distributed` is imported as part of the test suite.

This bug caused all health checks to fail in the agent, since the event
loop wouldn't properly start. I don't have a good test for this (global
state makes testing tricky), but have verified locally that this fixes
the issue.