### PR TITLE
Reduce number of boto3 clients created

### DIFF
--- a/changes/pr4115.yaml
+++ b/changes/pr4115.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Reduce the number of boto3 clients created across Prefect when interacting with AWS services - [#4115](https://github.com/PrefectHQ/prefect/pull/4115)"
+
+deprecations:
+  - "Deprecate the `use_session` argument in all AWS-related components - [#4115](https://github.com/PrefectHQ/prefect/pull/4115)"

--- a/changes/pr4115.yaml
+++ b/changes/pr4115.yaml
@@ -1,5 +1,5 @@
 fix:
   - "Reduce the number of boto3 clients created across Prefect when interacting with AWS services - [#4115](https://github.com/PrefectHQ/prefect/pull/4115)"
 
-deprecations:
+deprecation:
   - "Deprecate the `use_session` argument in all AWS-related components - [#4115](https://github.com/PrefectHQ/prefect/pull/4115)"

--- a/src/prefect/storage/codecommit.py
+++ b/src/prefect/storage/codecommit.py
@@ -117,6 +117,4 @@ class CodeCommit(Storage):
         from prefect.utilities.aws import get_boto_client
 
         kwargs = self.client_options or {}
-        return get_boto_client(
-            resource="codecommit", credentials=None, use_session=False, **kwargs
-        )
+        return get_boto_client(resource="codecommit", credentials=None, **kwargs)

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -209,6 +209,4 @@ class S3(Storage):
         from prefect.utilities.aws import get_boto_client
 
         kwargs = self.client_options or {}
-        return get_boto_client(
-            resource="s3", credentials=None, use_session=False, **kwargs
-        )
+        return get_boto_client(resource="s3", credentials=None, **kwargs)

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -64,9 +64,7 @@ class S3Download(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client(
-            "s3", credentials=credentials, use_session=True, **self.boto_kwargs
-        )
+        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
 
         stream = io.BytesIO()
 
@@ -146,9 +144,7 @@ class S3Upload(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client(
-            "s3", credentials=credentials, use_session=True, **self.boto_kwargs
-        )
+        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
 
         # compress data if compression is specified
         if compression:

--- a/src/prefect/utilities/aws.py
+++ b/src/prefect/utilities/aws.py
@@ -1,19 +1,32 @@
 """
 Utility functions for interacting with AWS.
 """
+import threading
+import warnings
+import weakref
+
 import prefect
 
 import boto3
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, MutableMapping
+
+if TYPE_CHECKING:
+    import botocore.client
+
+
+_CACHE = (
+    weakref.WeakValueDictionary()
+)  # type: MutableMapping[tuple, botocore.client.BaseClient]
+_LOCK = threading.Lock()
 
 
 def get_boto_client(
     resource: str,
     credentials: Optional[dict] = None,
-    use_session: Optional[bool] = False,
+    region_name: Optional[str] = None,
     profile_name: Optional[str] = None,
     **kwargs: Any
-) -> "boto3.client":
+) -> "botocore.client.BaseClient":
     """
     Utility function for loading boto3 client objects from a given set of credentials.
 
@@ -22,19 +35,22 @@ def get_boto_client(
         - credentials (dict, optional): a dictionary of AWS credentials used to
             initialize the Client; if not provided, will attempt to load the
             Client using ambient environment settings
-        - use_session (bool, optional): a boolean specifying whether to load
-            this client using a session or not; defaults to `False`
-        - profile_name (str, optional): The name of a profile to use.
+        - region_name (str, optional): The aws region name to use, defaults to your
+            global configured default.
+        - profile_name (str, optional): The name of a boto3 profile to use.
         - **kwargs (Any, optional): additional keyword arguments to pass to boto3
 
     Returns:
         - Client: an initialized and authenticated boto3 Client
     """
 
-    if profile_name and not use_session:
-        raise ValueError(
-            "profile_name can only be used with the boto3.session. Please set use_session=True"
+    if kwargs.pop("use_session", None) is not None:
+        warnings.warn(
+            "The `use_session` kwarg has been deprecated, prefect now infers "
+            "whether a new boto session should be used automatically."
         )
+
+    botocore_session = kwargs.pop("botocore_session", None)
 
     if credentials:
         aws_access_key = credentials["ACCESS_KEY"]
@@ -54,27 +70,55 @@ def get_boto_client(
     aws_secret_access_key = aws_secret_access_key or kwargs_secret_access_key
     aws_session_token = aws_session_token or kwargs_session_token
 
-    if use_session:
-        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?#multithreading-multiprocessing  # noqa
-        region_name = kwargs.pop("region_name", None)
+    # Boto3 clients _are_ threadsafe, but the creation of a client or a session
+    # isn't thread safe. Creating a client has a small cost (~5-10 ms), while a
+    # session has a larger cost (50-120 ms). Creating a new session also
+    # renegotiates auth - apparently AWS can throttle these requests if there
+    # are too many of them, so we really want to minimize session creation if
+    # we can.
+    #
+    # We keep a weakref cache of clients around to minimize recreation, and use
+    # a global lock to synchronize access to this cache. Unfortunately a client
+    # doesn't keep a ref around to its backing session, so we can't (easily)
+    # keep a cache of sessions around. Most users should use only a single
+    # session per process though, and boto3 already supports that with a global
+    # shared session. In practice this is much more efficient than creating a
+    # new AWS session for every request, and still maintains thread safety.
+    with _LOCK:
         botocore_session = kwargs.pop("botocore_session", None)
-        session = boto3.session.Session(
-            profile_name=profile_name,
+        cache_key = (
+            profile_name,
+            region_name,
+            id(botocore_session),
+            resource,
+            aws_access_key,
+            aws_secret_access_key,
+            aws_session_token,
+        )
+
+        # If no extra kwargs and client already created, use the cached client
+        if not kwargs and cache_key in _CACHE:
+            return _CACHE[cache_key]
+
+        if profile_name or botocore_session:
+            session = boto3.session.Session(
+                profile_name=profile_name,
+                region_name=region_name,
+                botocore_session=botocore_session,
+            )
+        else:
+            session = boto3
+
+        client = session.client(
+            resource,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             region_name=region_name,
-            botocore_session=botocore_session,
+            **kwargs,
         )
-        return session.client(
-            resource,
-            aws_access_key_id=aws_access_key,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
-            **kwargs
-        )
-    else:
-        return boto3.client(
-            resource,
-            aws_access_key_id=aws_access_key,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
-            **kwargs
-        )
+        # Cache the client if no extra kwargs
+        if not kwargs:
+            _CACHE[cache_key] = client
+
+    return client

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -18,12 +18,12 @@ from prefect.run_configs import ECSRun, LocalRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.filesystems import read_bytes_from_path
 from prefect.utilities.graphql import GraphQLResult
-from prefect.utilities.aws import _CACHE
+from prefect.utilities.aws import _CLIENT_CACHE
 
 
 @pytest.fixture(autouse=True)
 def clear_boto3_cache():
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()
 
 
 @pytest.fixture

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -4,6 +4,9 @@ import box
 import pytest
 import yaml
 
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+
 import prefect
 from prefect.agent.ecs.agent import (
     merge_run_task_kwargs,
@@ -15,9 +18,12 @@ from prefect.run_configs import ECSRun, LocalRun, UniversalRun
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.filesystems import read_bytes_from_path
 from prefect.utilities.graphql import GraphQLResult
+from prefect.utilities.aws import _CACHE
 
-pytest.importorskip("boto3")
-pytest.importorskip("botocore")
+
+@pytest.fixture(autouse=True)
+def clear_boto3_cache():
+    _CACHE.clear()
 
 
 @pytest.fixture

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -2,18 +2,24 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+pytestmark = pytest.mark.filterwarnings("ignore:`FargateAgent` is deprecated")
+
+from botocore.exceptions import ClientError
+
 import prefect
 from prefect.agent.fargate import FargateAgent
 from prefect.environments import LocalEnvironment
 from prefect.storage import Docker, Local
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
+from prefect.utilities.aws import _CACHE
 
-pytest.importorskip("boto3")
-pytest.importorskip("botocore")
-pytestmark = pytest.mark.filterwarnings("ignore:`FargateAgent` is deprecated")
 
-from botocore.exceptions import ClientError
+@pytest.fixture(autouse=True)
+def clear_boto3_cache():
+    _CACHE.clear()
 
 
 def test_fargate_agent_init(monkeypatch, cloud_api):

--- a/tests/agent/test_fargate_agent.py
+++ b/tests/agent/test_fargate_agent.py
@@ -14,12 +14,12 @@ from prefect.environments import LocalEnvironment
 from prefect.storage import Docker, Local
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.graphql import GraphQLResult
-from prefect.utilities.aws import _CACHE
+from prefect.utilities.aws import _CLIENT_CACHE
 
 
 @pytest.fixture(autouse=True)
 def clear_boto3_cache():
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()
 
 
 def test_fargate_agent_init(monkeypatch, cloud_api):

--- a/tests/engine/results/test_s3_result.py
+++ b/tests/engine/results/test_s3_result.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest
@@ -11,104 +11,88 @@ pytest.importorskip("boto3")
 pytest.importorskip("botocore")
 
 
+@pytest.fixture
+def mock_boto3(monkeypatch):
+    from prefect.utilities.aws import _CACHE
+
+    _CACHE.clear()
+
+    boto3 = MagicMock()
+    monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+    secrets = dict(
+        AWS_CREDENTIALS=dict(
+            ACCESS_KEY="access_key", SECRET_ACCESS_KEY="secret_access_key"
+        )
+    )
+    with set_temporary_config({"cloud.use_local_secrets": True}), prefect.context(
+        secrets=secrets
+    ):
+        yield boto3
+
+
 class TestS3Result:
-    @pytest.fixture
-    def session(self, monkeypatch):
-        import boto3
-
-        session = MagicMock()
-        boto = MagicMock(session=session)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto)
-        yield session
-
-    def test_s3_client_init_uses_secrets(self, session):
+    def test_s3_client_init_uses_secrets(self, mock_boto3):
         result = S3Result(bucket="bob")
         assert result.bucket == "bob"
-        assert session.Session().client.called is False
+        assert mock_boto3.client.called is False
 
-        with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
-        ):
-            with set_temporary_config({"cloud.use_local_secrets": True}):
-                result.initialize_client()
-        assert session.Session().client.call_args[1] == {
-            "aws_access_key_id": 1,
+        assert result.client is not None
+
+        assert mock_boto3.client.call_args[1] == {
+            "aws_access_key_id": "access_key",
             "aws_session_token": None,
-            "aws_secret_access_key": 42,
+            "aws_secret_access_key": "secret_access_key",
+            "region_name": None,
         }
 
-    def test_s3_writes_to_blob_with_rendered_filename(self, session):
+    def test_forwards_boto3_kwargs(self, mock_boto3):
+        result = S3Result(bucket="mybucket", boto3_kwargs={"region_name": "a-region"})
+        assert result.client is not None
+
+        assert mock_boto3.client.call_args[1] == {
+            "aws_access_key_id": "access_key",
+            "aws_session_token": None,
+            "aws_secret_access_key": "secret_access_key",
+            "region_name": "a-region",
+        }
+
+    def test_s3_writes_to_blob_with_rendered_filename(self, mock_boto3):
         result = S3Result(bucket="foo", location="{thing}/here.txt")
 
-        with prefect.context(
-            secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42)),
-            thing="yes!",
-        ) as ctx:
-            with set_temporary_config({"cloud.use_local_secrets": True}):
-                new_result = result.write("so-much-data", **ctx)
+        with prefect.context(thing="yes!"):
+            new_result = result.write("so-much-data", **prefect.context)
 
-        used_uri = session.Session().client.return_value.upload_fileobj.call_args[1][
-            "Key"
-        ]
+        used_uri = mock_boto3.client.return_value.upload_fileobj.call_args[1]["Key"]
 
         assert used_uri == new_result.location
         assert new_result.location.startswith("yes!/here.txt")
 
-    def test_s3_result_is_pickleable(self, monkeypatch):
-        class client:
-            def __init__(self, *args, **kwargs):
-                pass
-
+    def test_s3_result_is_pickleable(self, mock_boto3):
+        class NoPickle:
             def __getstate__(self):
                 raise ValueError("I cannot be pickled.")
 
-        import boto3
+        mock_boto3.client.return_value = NoPickle()
 
-        with patch.dict("sys.modules", {"boto3": MagicMock()}):
-            boto3.session.Session().client = client
+        result = S3Result(bucket="foo")
+        assert result.client is not None
 
-            with prefect.context(
-                secrets=dict(AWS_CREDENTIALS=dict(ACCESS_KEY=1, SECRET_ACCESS_KEY=42))
-            ):
-                with set_temporary_config({"cloud.use_local_secrets": True}):
-                    result = S3Result(bucket="foo")
-            res = cloudpickle.loads(cloudpickle.dumps(result))
-            assert isinstance(res, S3Result)
+        res = cloudpickle.loads(cloudpickle.dumps(result))
+        assert isinstance(res, S3Result)
 
-    def test_s3_result_does_not_exist(self, session):
+    def test_s3_result_does_not_exist(self, mock_boto3):
         import botocore
 
         exc = botocore.exceptions.ClientError(
             {"Error": {"Code": "NoSuchKey"}}, "list_objects"
         )
+        mock_boto3.client.return_value.get_object.side_effect = exc
 
-        class _client:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def get_object(self, *args, **kwargs):
-                raise exc
-
-        session.Session().client = _client
         result = S3Result(bucket="bob", location="stuff")
         result = result.format()
         assert result.exists("stuff") is False
 
-    def test_s3_result_exists(self, session):
-        import botocore
-
-        exc = botocore.exceptions.ClientError(
-            {"Error": {"Code": "NoSuchKey"}}, "list_objects"
-        )
-
-        class _client:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def get_object(self, *args, **kwargs):
-                return MagicMock()
-
-        session.Session().client = _client
+    def test_s3_result_exists(self, mock_boto3):
         result = S3Result(bucket="bob", location="stuff")
         result = result.format()
         assert result.exists("stuff") is True

--- a/tests/engine/results/test_s3_result.py
+++ b/tests/engine/results/test_s3_result.py
@@ -13,9 +13,9 @@ pytest.importorskip("botocore")
 
 @pytest.fixture
 def mock_boto3(monkeypatch):
-    from prefect.utilities.aws import _CACHE
+    from prefect.utilities.aws import _CLIENT_CACHE
 
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()
 
     boto3 = MagicMock()
     monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)

--- a/tests/storage/test_codecommit_storage.py
+++ b/tests/storage/test_codecommit_storage.py
@@ -2,11 +2,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from prefect import context, Flow
-from prefect.storage import CodeCommit
-
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
+
+from prefect import context, Flow
+from prefect.storage import CodeCommit
+from prefect.utilities.aws import _CACHE
+
+
+@pytest.fixture(autouse=True)
+def clear_boto3_cache():
+    _CACHE.clear()
 
 
 def test_create_codecommit_storage():
@@ -77,6 +83,7 @@ def test_codecommit_client_property(monkeypatch):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="session",
+        region_name=None,
         endpoint_url="http://some-endpoint",
         use_ssl=False,
     )

--- a/tests/storage/test_codecommit_storage.py
+++ b/tests/storage/test_codecommit_storage.py
@@ -7,12 +7,12 @@ pytest.importorskip("botocore")
 
 from prefect import context, Flow
 from prefect.storage import CodeCommit
-from prefect.utilities.aws import _CACHE
+from prefect.utilities.aws import _CLIENT_CACHE
 
 
 @pytest.fixture(autouse=True)
 def clear_boto3_cache():
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()
 
 
 def test_create_codecommit_storage():

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -5,14 +5,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from prefect import context, Flow
-from prefect.storage import S3
-from prefect.utilities.storage import flow_from_bytes_pickle, flow_to_bytes_pickle
-
 pytest.importorskip("boto3")
 pytest.importorskip("botocore")
 
+from prefect import context, Flow
+from prefect.storage import S3
+from prefect.utilities.storage import flow_from_bytes_pickle, flow_to_bytes_pickle
+from prefect.utilities.aws import _CACHE
+
 from botocore.exceptions import ClientError
+
+
+@pytest.fixture(autouse=True)
+def clear_boto3_cache():
+    _CACHE.clear()
 
 
 @pytest.fixture
@@ -83,6 +89,7 @@ def test_boto3_client_property(monkeypatch):
         aws_access_key_id="id",
         aws_secret_access_key="secret",
         aws_session_token="session",
+        region_name=None,
         endpoint_url="http://some-endpoint",
         use_ssl=False,
     )

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -11,14 +11,14 @@ pytest.importorskip("botocore")
 from prefect import context, Flow
 from prefect.storage import S3
 from prefect.utilities.storage import flow_from_bytes_pickle, flow_to_bytes_pickle
-from prefect.utilities.aws import _CACHE
+from prefect.utilities.aws import _CLIENT_CACHE
 
 from botocore.exceptions import ClientError
 
 
 @pytest.fixture(autouse=True)
 def clear_boto3_cache():
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()
 
 
 @pytest.fixture

--- a/tests/tasks/aws/__init__.py
+++ b/tests/tasks/aws/__init__.py
@@ -1,3 +1,0 @@
-import pytest
-
-pytest.importorskip("boto3")

--- a/tests/tasks/aws/conftest.py
+++ b/tests/tasks/aws/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from prefect.utilities.aws import _CACHE
+
+
+@pytest.fixture(autouse=True)
+def clear_client_cache():
+    _CACHE.clear()

--- a/tests/tasks/aws/conftest.py
+++ b/tests/tasks/aws/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("boto3")
+
 from prefect.utilities.aws import _CACHE
 
 

--- a/tests/tasks/aws/conftest.py
+++ b/tests/tasks/aws/conftest.py
@@ -3,6 +3,6 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clear_client_cache():
-    from prefect.utilities.aws import _CACHE
+    from prefect.utilities.aws import _CLIENT_CACHE
 
-    _CACHE.clear()
+    _CLIENT_CACHE.clear()

--- a/tests/tasks/aws/conftest.py
+++ b/tests/tasks/aws/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 
-pytest.importorskip("boto3")
-
-from prefect.utilities.aws import _CACHE
-
 
 @pytest.fixture(autouse=True)
 def clear_client_cache():
+    from prefect.utilities.aws import _CACHE
+
     _CACHE.clear()

--- a/tests/tasks/aws/test_batch.py
+++ b/tests/tasks/aws/test_batch.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import MagicMock
 
+pytest.importorskip("boto3")
+
 from prefect.engine.signals import FAIL
 from prefect.tasks.aws import BatchSubmit
 

--- a/tests/tasks/aws/test_client_waiter.py
+++ b/tests/tasks/aws/test_client_waiter.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("boto3")
+
 from unittest.mock import MagicMock
 
 from botocore.waiter import WaiterModel

--- a/tests/tasks/aws/test_lambda.py
+++ b/tests/tasks/aws/test_lambda.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+
 import prefect
 from prefect.tasks.aws import LambdaCreate, LambdaDelete, LambdaInvoke, LambdaList
 from prefect.utilities.configuration import set_temporary_config

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+
 import prefect
 from prefect.tasks.aws import S3Download, S3Upload, S3List
 from prefect.utilities.configuration import set_temporary_config

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+
 import prefect
 from prefect.tasks.aws import AWSSecretsManager
 from prefect.utilities.configuration import set_temporary_config

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("boto3")
+
 import prefect
 from prefect.tasks.aws import StepActivate
 from prefect.utilities.configuration import set_temporary_config

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -5,7 +5,7 @@ import pytest
 pytest.importorskip("boto3")
 
 import prefect
-from prefect.utilities.aws import get_boto_client, _CACHE as CACHE
+from prefect.utilities.aws import get_boto_client, _CLIENT_CACHE as CACHE
 from prefect.utilities.configuration import set_temporary_config
 
 

--- a/tests/utilities/test_aws.py
+++ b/tests/utilities/test_aws.py
@@ -5,15 +5,24 @@ import pytest
 pytest.importorskip("boto3")
 
 import prefect
-from prefect.utilities.aws import get_boto_client
+from prefect.utilities.aws import get_boto_client, _CACHE as CACHE
 from prefect.utilities.configuration import set_temporary_config
 
 
+@pytest.fixture(autouse=True)
+def clear_boto3_cache():
+    CACHE.clear()
+
+
+@pytest.fixture
+def mock_boto3(monkeypatch):
+    boto3 = MagicMock()
+    monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+    return boto3
+
+
 class TestGetBotoClient:
-    def test_uses_context_secrets(self, monkeypatch):
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+    def test_uses_context_secrets(self, mock_boto3):
         with set_temporary_config({"cloud.use_local_secrets": True}):
             with prefect.context(
                 secrets=dict(
@@ -24,19 +33,17 @@ class TestGetBotoClient:
                     }
                 )
             ):
-                get_boto_client(resource="not a real resource")
-        kwargs = client.call_args[1]
+                get_boto_client(resource="myresource")
+        kwargs = mock_boto3.client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "42",
             "aws_secret_access_key": "99",
             "aws_session_token": "1",
+            "region_name": None,
         }
 
-    def test_prefers_passed_credentials_over_secrets(self, monkeypatch):
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        desired_credentials = {
+    def test_prefers_passed_credentials_over_secrets(self, mock_boto3):
+        credentials = {
             "ACCESS_KEY": "pick",
             "SECRET_ACCESS_KEY": "these",
             "SESSION_TOKEN": "please",
@@ -51,86 +58,104 @@ class TestGetBotoClient:
                     }
                 )
             ):
-                get_boto_client(
-                    resource="not a real resource", credentials=desired_credentials
-                )
-        kwargs = client.call_args[1]
+                get_boto_client(resource="myresource", credentials=credentials)
+        kwargs = mock_boto3.client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "pick",
             "aws_secret_access_key": "these",
             "aws_session_token": "please",
+            "region_name": None,
         }
 
-    def test_creds_default_to_environment(self, monkeypatch):
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        get_boto_client(resource="not a real resource")
-        kwargs = client.call_args[1]
+    def test_creds_default_to_environment(self, mock_boto3):
+        get_boto_client(resource="myresource")
+        kwargs = mock_boto3.client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": None,
             "aws_secret_access_key": None,
             "aws_session_token": None,
+            "region_name": None,
         }
 
-    def test_credentials_provided_in_kwargs(self, monkeypatch):
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+    def test_credentials_provided_in_kwargs(self, mock_boto3):
         get_boto_client(
-            resource="not a real resource",
+            resource="myresource",
             aws_access_key_id="id",
             aws_secret_access_key="secret",
             aws_session_token="session",
         )
-        kwargs = client.call_args[1]
+        kwargs = mock_boto3.client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "id",
             "aws_secret_access_key": "secret",
             "aws_session_token": "session",
+            "region_name": None,
         }
 
-    def test_credentials_does_not_duplicate_kwargs(self, monkeypatch):
-        client = MagicMock()
-        boto3 = MagicMock(client=client)
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
+    def test_credentials_does_not_duplicate_kwargs(self, mock_boto3):
         get_boto_client(
-            resource="not a real resource",
+            resource="myresource",
             credentials={"ACCESS_KEY": "true_key", "SECRET_ACCESS_KEY": "true_secret"},
             aws_access_key_id="id",
             aws_secret_access_key="secret",
             aws_session_token="session",
         )
-        kwargs = client.call_args[1]
+        kwargs = mock_boto3.client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": "true_key",
             "aws_secret_access_key": "true_secret",
             "aws_session_token": "session",
+            "region_name": None,
         }
 
-    def test_session_with_profile_name(self, monkeypatch):
-        client = MagicMock()
-        session = MagicMock(return_value=client)
-        boto3 = MagicMock(session=MagicMock(Session=session))
-        monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        monkeypatch.setattr(
-            "prefect.utilities.aws.boto3.session.Session.client", client
-        )
-        get_boto_client(
-            resource="not a real resource", use_session=True, profile_name="TestProfile"
-        )
-        session_kwargs = session.call_args[1]
+    def test_session_used_if_profile_name_provided(self, mock_boto3):
+        get_boto_client(resource="myresource", profile_name="TestProfile")
+        session_kwargs = mock_boto3.session.Session.call_args[1]
         assert session_kwargs == {
             "botocore_session": None,
             "profile_name": "TestProfile",
             "region_name": None,
         }
+        client = mock_boto3.session.Session.return_value.client
 
-        args = client.method_calls[0][1]
-        assert args == ("not a real resource",)
-        kwargs = client.method_calls[0][2]
+        args = client.call_args[0]
+        assert args == ("myresource",)
+        kwargs = client.call_args[1]
         assert kwargs == {
             "aws_access_key_id": None,
             "aws_secret_access_key": None,
             "aws_session_token": None,
+            "region_name": None,
         }
+
+    def test_client_cache(self, mock_boto3):
+        class Client:
+            pass
+
+        mock_boto3.client.side_effect = lambda *a, **kw: Client()
+
+        c1 = get_boto_client("myresource")
+        assert len(CACHE) == 1
+
+        # Cached if same parameters used
+        c2 = get_boto_client("myresource")
+        assert c2 is c1
+
+        # Different parameters lead to unique client
+        c3 = get_boto_client("myresource", region_name="a new region")
+        assert c3 is not c1
+
+        assert len(CACHE) == 2
+
+        del c1, c2, c3
+        assert len(CACHE) == 0
+
+    def test_client_cache_not_used_extra_kwargs(self, mock_boto3):
+        """If extra kwargs are passed to boto3, we skip the cache since we
+        don't know how to interpret them"""
+        mock_boto3.client.side_effect = lambda *args, **kws: MagicMock()
+
+        c1 = get_boto_client("myresource", extra_kwarg="stuff")
+        c2 = get_boto_client("myresource", extra_kwarg="stuff")
+        assert len(CACHE) == 0
+        assert c1 is not c2


### PR DESCRIPTION
Prefect relies on `boto3` for aws integration. Previously we were relying on creating a new session for parallel requests to avoid thread-safety issues - this worked, but was expensive (creating a new session is an order of magnitude slower). This was compounded by some faulty logic in the `S3Result` code that looked like it was supposed to result in shared boto3 clients, but in practice didn't.

Turns out boto3 clients are thread safe to use, the thread-safety issues only apply to instantiation (or if you're using the higher-level `boto3.resource` clients). We now use a single lock around boto3 client creation, and have a shared weakref cache of clients, allowing use across threads. This results in significantly fewer boto3 clients being created (possibly only one session per process), reducing memory usage and speeding up aws operations.

Fixes #4085, supersedes #4104.
