### PR TITLE
Increase Prefect Client HTTP Request Timeout

### DIFF
--- a/changes/task-increase-client-timeout.yaml
+++ b/changes/task-increase-client-timeout.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Bumps client request timeout from 15s to 60s - [#4118](https://github.com/PrefectHQ/prefect/issues/4118)"
+
+contributor:
+  - "[Andrew Hannigan](https://github.com/AndrewHannigan)"

--- a/changes/task-increase-client-timeout.yaml
+++ b/changes/task-increase-client-timeout.yaml
@@ -1,5 +1,5 @@
-fix:
-  - "Bumps client request timeout from 15s to 60s - [#4118](https://github.com/PrefectHQ/prefect/issues/4118)"
+enhancement:
+  - "Allow `Client` timeout seconds to be configurable through configuration - [#4118](https://github.com/PrefectHQ/prefect/issues/4118)"
 
 contributor:
   - "[Andrew Hannigan](https://github.com/AndrewHannigan)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -341,11 +341,11 @@ class Client:
             start_time = time.time()
 
         if method == "GET":
-            response = session.get(url, headers=headers, params=params, timeout=15)
+            response = session.get(url, headers=headers, params=params, timeout=60)
         elif method == "POST":
-            response = session.post(url, headers=headers, json=params, timeout=15)
+            response = session.post(url, headers=headers, json=params, timeout=60)
         elif method == "DELETE":
-            response = session.delete(url, headers=headers, timeout=15)
+            response = session.delete(url, headers=headers, timeout=60)
         else:
             raise ValueError("Invalid method: {}".format(method))
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -341,14 +341,25 @@ class Client:
             start_time = time.time()
 
         if method == "GET":
-            response = session.get(url, headers=headers, params=params,
-                                timeout=prefect.context.config.cloud.request_timeout)
+            response = session.get(
+                url,
+                headers=headers,
+                params=params,
+                timeout=prefect.context.config.cloud.request_timeout,
+            )
         elif method == "POST":
-            response = session.post(url, headers=headers, json=params,
-                                timeout=prefect.context.config.cloud.request_timeout)
+            response = session.post(
+                url,
+                headers=headers,
+                json=params,
+                timeout=prefect.context.config.cloud.request_timeout,
+            )
         elif method == "DELETE":
-            response = session.delete(url, headers=headers,
-                                timeout=prefect.context.config.cloud.request_timeout)
+            response = session.delete(
+                url,
+                headers=headers,
+                timeout=prefect.context.config.cloud.request_timeout,
+            )
         else:
             raise ValueError("Invalid method: {}".format(method))
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -341,11 +341,14 @@ class Client:
             start_time = time.time()
 
         if method == "GET":
-            response = session.get(url, headers=headers, params=params, timeout=60)
+            response = session.get(url, headers=headers, params=params,
+                                timeout=prefect.context.config.cloud.request_timeout)
         elif method == "POST":
-            response = session.post(url, headers=headers, json=params, timeout=60)
+            response = session.post(url, headers=headers, json=params,
+                                timeout=prefect.context.config.cloud.request_timeout)
         elif method == "DELETE":
-            response = session.delete(url, headers=headers, timeout=60)
+            response = session.delete(url, headers=headers,
+                                timeout=prefect.context.config.cloud.request_timeout)
         else:
             raise ValueError("Invalid method: {}".format(method))
 

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -58,6 +58,7 @@ use_local_secrets = true
 heartbeat_interval = 30.0
 check_cancellation_interval = 15.0
 diagnostics = false
+request_timeout = 30
 
 # rate at which to batch upload logs
 logging_heartbeat = 5

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -58,7 +58,7 @@ use_local_secrets = true
 heartbeat_interval = 30.0
 check_cancellation_interval = 15.0
 diagnostics = false
-request_timeout = 30
+request_timeout = 15
 
 # rate at which to batch upload logs
 logging_heartbeat = 5


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Resolves #4118 



## Changes
Increases prefect client HTTP timeout from 15 seconds to 60 seconds



## Importance
Flow registration is failing for large flows that takes more than 15 seconds to upload



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)