### PR TITLE
Add init to apollo/graphql deployment to reap healthcheck zombies

### DIFF
--- a/changes/pr4142.yaml
+++ b/changes/pr4142.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Add init to apollo/graphql deployment to reap healthcheck zombies - [#4142](https://github.com/PrefectHQ/prefect/pull/4142)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -57,6 +57,7 @@ services:
   # GraphQL: the server's business logic that exposes GraphQL mutations
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
+    init: true
     ports:
       - "${GRAPHQL_HOST_PORT:-4201}:4201"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
@@ -96,6 +97,7 @@ services:
   # Apollo: the main endpoint for interacting with the server
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
+    init: true
     ports:
       - "${APOLLO_HOST_PORT:-4200}:4200"
     command: bash -c "./post-start.sh && npm run serve"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Reaps the zombies introduced by #4041 

Alternative to https://github.com/PrefectHQ/server/pull/191 which installs tini into the server images.

Per the [tini docs](https://github.com/krallin/tini#using-tini)
> NOTE: If you are using Docker 1.13 or greater, Tini is included in Docker itself. This includes all versions of Docker CE. To enable Tini, just pass the --init flag to docker run.

Simply adding the `init` flag should solve this without modifying `Server` images.

## Changes
<!-- What does this PR change? -->

- Adds `init: true` to apollo/graphql images

## Importance
<!-- Why is this PR important? -->

Fixes https://github.com/PrefectHQ/prefect/issues/4114

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~