### PR TITLE
Dynamically load compression libraries for serializers

### DIFF
--- a/changes/pr4150.yaml
+++ b/changes/pr4150.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Dynamically import compression libraries for `CompressedSerializer` - [#4150](https://github.com/PrefectHQ/prefect/pull/4150)"

--- a/src/prefect/engine/serializers.py
+++ b/src/prefect/engine/serializers.py
@@ -261,8 +261,10 @@ class CompressedSerializer(Serializer):
 
     Args:
         - serializer (Serializer): the serializer that this serializer wraps
-        - format (str): name of the selected pre-defined compression format (bz2, gzip,
-            lzma, or zlib)
+        - format (str): name of the compression format library. Typically one of the
+            python standard compression libraries: bz2, gzip, lzma, or zlib. Attempts
+            to import the given format's  module and retrieves the compress/decompress
+            functions.
         - compress (Callable[..., bytes]): the custom compression function
         - decompress (Callable[..., bytes]): the custom decompression function
         - compress_kwargs (Dict[str, Any]): keyword arguments to be passed to the
@@ -345,11 +347,12 @@ class CompressedSerializer(Serializer):
         """
         Attempt to pull a compression format from a library. Typically one of
             "lzma", "gzip", "zlib", "bz2"
+
         Args:
-            compression_format:
+            compression_format: The format to load
 
         Returns:
-
+            A tuple of functions for compression and decompression
         """
         common_libs = {"lzma", "gzip", "zlib", "bz2"}
 

--- a/src/prefect/engine/serializers.py
+++ b/src/prefect/engine/serializers.py
@@ -346,10 +346,10 @@ class CompressedSerializer(Serializer):
     ) -> Tuple[Callable[..., bytes], Callable[..., bytes]]:
         """
         Attempt to pull a compression format from a library. Typically one of
-            "lzma", "gzip", "zlib", "bz2"
+        "lzma", "gzip", "zlib", "bz2"
 
         Args:
-            compression_format: The format to load
+            compression_format: The compression format/library to load
 
         Returns:
             A tuple of functions for compression and decompression

--- a/src/prefect/engine/serializers.py
+++ b/src/prefect/engine/serializers.py
@@ -368,7 +368,7 @@ class CompressedSerializer(Serializer):
             ) from exc
 
         try:
-            funcs = (module.compress, module.decompress)
+            funcs = (module.compress, module.decompress)  # type: ignore
         except AttributeError as exc:
             raise ValueError(
                 f"Given compression format {compression_format!r} module does not have "

--- a/src/prefect/engine/serializers.py
+++ b/src/prefect/engine/serializers.py
@@ -349,7 +349,7 @@ class CompressedSerializer(Serializer):
         "lzma", "gzip", "zlib", "bz2"
 
         Args:
-            compression_format: The compression format/library to load
+            - compression_format: The compression format/library to load
 
         Returns:
             A tuple of functions for compression and decompression

--- a/tests/engine/test_serializers.py
+++ b/tests/engine/test_serializers.py
@@ -127,7 +127,7 @@ class TestPandasSerializer:
 
 class TestCompressedSerializer:
     @pytest.mark.parametrize("format", ["bz2", "gzip", "lzma", "zlib"])
-    def test_constructor_accepts_known_formats(self, format) -> None:
+    def test_constructor_accepts_standard_formats(self, format) -> None:
         serializer = PickleSerializer()
         module = pytest.importorskip(format)
         assert CompressedSerializer(

--- a/tests/engine/test_serializers.py
+++ b/tests/engine/test_serializers.py
@@ -217,6 +217,7 @@ def test_equality():
 
 
 def test_compressed_serializer_equality() -> None:
+    gzip = pytest.importorskip("gzip")
     assert CompressedSerializer(
         PickleSerializer(), format="bz2"
     ) == CompressedSerializer(PickleSerializer(), format="bz2")

--- a/tests/engine/test_serializers.py
+++ b/tests/engine/test_serializers.py
@@ -1,9 +1,5 @@
 import base64
-import bz2
-import gzip
 import json
-import lzma
-import zlib
 
 import cloudpickle
 import pendulum
@@ -130,18 +126,26 @@ class TestPandasSerializer:
 
 
 class TestCompressedSerializer:
-    def test_constructor_accepts_known_formats(self) -> None:
+    @pytest.mark.parametrize("format", ["bz2", "gzip", "lzma", "zlib"])
+    def test_constructor_accepts_known_formats(self, format) -> None:
         serializer = PickleSerializer()
-        for module in (bz2, gzip, lzma, zlib):
-            assert CompressedSerializer(
-                serializer, format=module.__name__
-            ) == CompressedSerializer(
-                serializer, compress=module.compress, decompress=module.decompress
-            )
+        module = pytest.importorskip(format)
+        assert CompressedSerializer(
+            serializer, format=module.__name__
+        ) == CompressedSerializer(
+            serializer, compress=module.compress, decompress=module.decompress
+        )
 
-    def test_constructor_rejects_unknown_formats(self) -> None:
-        with pytest.raises(ValueError):
+    def test_constructor_rejects_missing_format_libs(self) -> None:
+        with pytest.raises(ImportError, match="'foo' is not installed"):
             CompressedSerializer(PickleSerializer(), format="foo")
+
+    def test_constructor_rejects_format_libs_without_compression(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="'prefect' module does not have 'compress' and 'decompress'",
+        ):
+            CompressedSerializer(PickleSerializer(), format="prefect")
 
     def test_constructor_requires_format_or_functions(self) -> None:
         with pytest.raises(ValueError):
@@ -152,8 +156,8 @@ class TestCompressedSerializer:
             CompressedSerializer(
                 PickleSerializer(),
                 format="gzip",
-                compress=gzip.compress,
-                decompress=gzip.decompress,
+                compress=lambda: True,
+                decompress=lambda: True,
             )
 
     def test_serialize_returns_bytes(self) -> None:
@@ -174,6 +178,7 @@ class TestCompressedSerializer:
         assert deserialized == value
 
     def test_deserialize_with_functions_returns_objects(self) -> None:
+        lzma = pytest.importorskip("lzma")
         value = ["abc", 123, pendulum.now()]
         serializer = CompressedSerializer(
             PickleSerializer(),
@@ -187,6 +192,7 @@ class TestCompressedSerializer:
         assert deserialized == value
 
     def test_pickle_serialize_returns_compressed_cloudpickle(self) -> None:
+        zlib = pytest.importorskip("zlib")
         value = ["abc", 123, pendulum.now()]
         serialized = CompressedSerializer(PickleSerializer(), format="zlib").serialize(
             value
@@ -195,6 +201,7 @@ class TestCompressedSerializer:
         assert deserialized == value
 
     def test_pickle_deserialize_raises_meaningful_errors(self) -> None:
+        zlib = pytest.importorskip("zlib")
         # when pickle deserialization involving decompression fails, show the original
         # error, not the backwards-compatible error
         with pytest.raises(cloudpickle.pickle.UnpicklingError, match="stack underflow"):


### PR DESCRIPTION
Not all users have them installed and it breaks the import of core if they are imported at the top level.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If a user does not have a compression library required by the new `CompressedSerializer` (#4063) then `prefect` cannot be imported without exceptions. To resolve this, we 

## Changes
<!-- What does this PR change? -->

Instead of importing all the libraries at module load, we import the library requested for compression as needed.

## Importance
<!-- Why is this PR important? -->

This reduces assumptions about the user's python environment.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)