### PR TITLE
Fix X-Files SQLiteScript insert code

### DIFF
--- a/docs/core/advanced_tutorials/advanced-mapping.md
+++ b/docs/core/advanced_tutorials/advanced-mapping.md
@@ -316,7 +316,7 @@ from prefect import unmapped
 with flow:
     db = create_db()
     ep_script = create_episode_script.map(episode=dialogue)
-    final = insert_episode.map(ep_script, upstream_tasks=[unmapped(db)])
+    final = insert_episode.map(script=ep_script, upstream_tasks=[unmapped(db)])
 ```
 
 ::: tip task.map()


### PR DESCRIPTION
## Summary

The sample code from the X-Files tutorial raises `OperationalError('unable to open database file')` when attempting to insert the episode scripts into the database using the code from the tutorial:

`final = insert_episode.map(ep_script, upstream_tasks=[unmapped(db)])`

I believe `ep_script` is passed as the first positional argument (`db` to `SQLiteScript` [docs](https://docs.prefect.io/api/latest/tasks/sqlite.html#sqlitescript)) and should have been passed as the `script` kwarg (`.map(script=ep_script, ...`). I've attached a full working example at the bottom

## Changes

Changes one line for the tutorial snippets to work

## Importance

I spent some time really confused why the sample code wasn't working, so this change (however small) would have saved me some head-scratching! 😄 

## Checklist

This PR:

- [x] adds new tests (if appropriate) {N/A}
- [x] adds a change file in the `changes/` directory (if appropriate) {*N/A?*}
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate) {N/A}

## Example

Full traceback when running the tutorial code without `script=`

```sh
>python xfiles_complete.py

...

[2021-02-23 13:39:58-0500] INFO - prefect.TaskRunner | Task 'create_episode_script[0]': Finished task run for task with 
final state: 'Success'
[2021-02-23 13:39:58-0500] INFO - prefect.TaskRunner | Task 'Insert Episode[0]': Starting task run...
[2021-02-23 13:39:58-0500] ERROR - prefect.TaskRunner | Unexpected error: OperationalError('unable to open database file')
Traceback (most recent call last):
  File "C:\Users\king.kyle\Developer\elt\tutorial\.venv\lib\site-packages\prefect\engine\runner.py", line 48, in inner  
    new_state = method(self, state, *args, **kwargs)
  File "C:\Users\king.kyle\Developer\elt\tutorial\.venv\lib\site-packages\prefect\engine\task_runner.py", line 865, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "C:\Users\king.kyle\Developer\elt\tutorial\.venv\lib\site-packages\prefect\utilities\executors.py", line 299, in 
run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "C:\Users\king.kyle\Developer\elt\tutorial\.venv\lib\site-packages\prefect\utilities\tasks.py", line 454, in method
    return run_method(self, *args, **kwargs)
  File "C:\Users\king.kyle\Developer\elt\tutorial\.venv\lib\site-packages\prefect\tasks\database\sqlite.py", line 77, in run
    with closing(sql.connect(db)) as conn:
sqlite3.OperationalError: unable to open database file
[2021-02-23 13:39:58-0500] INFO - prefect.TaskRunner | Task 'Insert Episode[0]': Finished task run for task with final state: 'Failed'
[2021-02-23 13:39:58-0500] INFO - prefect.FlowRunner | Flow run FAILED: some reference tasks failed.
```

Full script stitched together from the tutorial snippets ([advanced_tutorials/advanced-mapping.html](https://docs.prefect.io/core/advanced_tutorials/advanced-mapping.html))

```py
import requests
from bs4 import BeautifulSoup
from prefect import Flow, Parameter, task, unmapped
from prefect.executors import LocalDaskExecutor
from prefect.tasks.database import SQLiteScript


@task(tags=["web"])
def retrieve_url(url):
    """
    Given a URL (string), retrieves html and
    returns the html as a string.
    """

    html = requests.get(url)
    if html.ok:
        return html.text
    else:
        raise ValueError("{} could not be retrieved.".format(url))


@task
def scrape_dialogue(episode_html):
    """
    Given a string of html representing an episode page,
    returns a tuple of (title, [(character, text)]) of the
    dialogue from that episode
    """

    episode = BeautifulSoup(episode_html, 'html.parser')

    title = episode.title.text.rstrip(' *').replace("'", "''")
    convos = episode.find_all('b') or episode.find_all('span', {'class': 'char'})
    dialogue = []
    for item in convos:
        who = item.text.rstrip(': ').rstrip(' *').replace("'", "''")
        what = str(item.next_sibling).rstrip(' *').replace("'", "''")
        dialogue.append((who, what))
    return (title, dialogue)


@task
def create_episode_list(base_url, main_html, bypass):
    """
    Given the main page html, creates a list of episode URLs
    """

    if bypass:
        return [base_url]

    main_page = BeautifulSoup(main_html, 'html.parser')

    episodes = []
    for link in main_page.find_all('a'):
        url = link.get('href')
        if 'transcrp/scrp' in (url or ''):
            episodes.append(base_url + url)

    return episodes


create_db = SQLiteScript(name="Create DB",
                         db="xfiles_db.sqlite",
                         script="CREATE TABLE IF NOT EXISTS XFILES (EPISODE TEXT, CHARACTER TEXT, TEXT TEXT)",
                         tags=["db"])


@task
def create_episode_script(episode):
    title, dialogue = episode
    insert_cmd = "INSERT INTO XFILES (EPISODE, CHARACTER, TEXT) VALUES\n"
    values = ',\n'.join(["('{0}', '{1}', '{2}')".format(title, *row) for row in dialogue]) + ";"
    return insert_cmd + values


insert_episode = SQLiteScript(name="Insert Episode",
                              db="xfiles_db.sqlite",
                              tags=["db"])


def main():
    with Flow("xfiles") as flow:
        url = Parameter("url")
        bypass = Parameter("bypass", default=False, required=False)
        home_page = retrieve_url(url)
        episodes = create_episode_list(url, home_page, bypass=bypass)
        episode = retrieve_url.map(episodes)
        dialogue = scrape_dialogue.map(episode)

        db = create_db()
        ep_script = create_episode_script.map(episode=dialogue)
        # FYI: This is the line of interest
        # final = insert_episode.map(ep_script, upstream_tasks=[unmapped(db)])  # original
        final = insert_episode.map(script=ep_script, upstream_tasks=[unmapped(db)])  # modified

    executor = LocalDaskExecutor()

    # Use the bypass parameter to scrape a single transcript
    state = flow.run(parameters={"url": "http://www.insidethex.co.uk/transcrp/tlg105.htm",
                                 "bypass": True},
                     executor=executor)


if __name__ == "__main__":
    main()
```