### PR TITLE
Support agent --env with equals in value

### DIFF
--- a/changes/pr4160.yaml
+++ b/changes/pr4160.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Support passing environment variables containing `=` through agent CLI `--env` flag - [#4160](https://github.com/PrefectHQ/prefect/pull/4160)"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -97,7 +97,7 @@ def add_options(options):
 
 def start_agent(agent_cls, token, api, label, env, log_level, **kwargs):
     labels = sorted(set(label))
-    env_vars = dict(e.split("=", 2) for e in env)
+    env_vars = dict(e.split("=", 1) for e in env)
 
     tmp_config = {
         "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
@@ -177,7 +177,7 @@ def install(label, env, import_paths, **kwargs):
 
     conf = LocalAgent.generate_supervisor_conf(
         labels=sorted(set(label)),
-        env_vars=dict(e.split("=", 2) for e in env),
+        env_vars=dict(e.split("=", 1) for e in env),
         import_paths=list(import_paths),
         **kwargs,
     )
@@ -313,7 +313,7 @@ def install(label, env, **kwargs):
     from prefect.agent.kubernetes import KubernetesAgent
 
     deployment = KubernetesAgent.generate_deployment_yaml(
-        labels=sorted(set(label)), env_vars=dict(e.split("=", 2) for e in env), **kwargs
+        labels=sorted(set(label)), env_vars=dict(e.split("=", 1) for e in env), **kwargs
     )
     click.echo(deployment)
 
@@ -354,7 +354,7 @@ def start(ctx, **kwargs):
     warn_fargate_deprecated()
 
     for item in ctx.args:
-        k, v = item.replace("--", "").split("=", 2)
+        k, v = item.replace("--", "").split("=", 1)
         kwargs[k] = v
 
     start_agent(FargateAgent, _called_from_cli=True, **kwargs)
@@ -637,7 +637,7 @@ def start(
     kwargs = dict()
     for item in ctx.args:
         item = item.replace("--", "")
-        kwargs.update([item.split("=")])
+        kwargs.update([item.split("=", 1)])
 
     tmp_config = {
         "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
@@ -668,7 +668,7 @@ def start(
 
         env_vars = dict()
         for env_var in env:
-            k, v = env_var.split("=")
+            k, v = env_var.split("=", 1)
             env_vars[k] = v
 
         labels = sorted(set(label))
@@ -921,7 +921,7 @@ def install(
 
     env_vars = dict()
     for env_var in env:
-        k, v = env_var.split("=")
+        k, v = env_var.split("=", 1)
         env_vars[k] = v
 
     labels = sorted(set(label))

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -139,7 +139,7 @@ def test_agent_start(
         (
             "--token TEST-TOKEN --api TEST-API --agent-config-id TEST-AGENT-CONFIG-ID "
             "--name TEST-NAME -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
-            "--max-polls 10 --agent-address 127.0.0.1:8080"
+            "-e KEY3=VALUE=WITH=EQUALS --max-polls 10 --agent-address 127.0.0.1:8080"
         ).split()
     )
     if deprecated:
@@ -161,7 +161,7 @@ def test_agent_start(
         "agent_config_id": "TEST-AGENT-CONFIG-ID",
         "name": "TEST-NAME",
         "labels": ["label1", "label2"],
-        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
+        "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2", "KEY3": "VALUE=WITH=EQUALS"},
         "max_polls": 10,
         "agent_address": "127.0.0.1:8080",
         "no_cloud_logs": False,


### PR DESCRIPTION
Fixes a bug in the agent cli code, where environment variables passed to
`--env` couldn't have `=` in the values.

Fixes #4138.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)