### PR TITLE
Add `prefect server config` command to output a compose file

### DIFF
--- a/changes/pr4176.yaml
+++ b/changes/pr4176.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "Add command `prefect server config` to output configured docker-compose yaml - [#4176](https://github.com/PrefectHQ/prefect/pull/4176)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -71,7 +71,7 @@ commands = ["flow"]
 [pages.cli.server]
 title = "server"
 module = "prefect.cli.server"
-commands = ["start", "create_tenant", "stop", "config"]
+commands = ["start", "create_tenant", "stop", "config_cmd"]
 
 [pages.schedules.schedules]
 title = "Schedules"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -71,7 +71,7 @@ commands = ["flow"]
 [pages.cli.server]
 title = "server"
 module = "prefect.cli.server"
-commands = ["start", "create_tenant"]
+commands = ["start", "create_tenant", "stop", "config"]
 
 [pages.schedules.schedules]
 title = "Schedules"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -3,6 +3,7 @@ import click
 from prefect import config
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.serialization import from_qualified_name
+from prefect.utilities.cli import add_options
 
 COMMON_START_OPTIONS = [
     click.option(
@@ -82,17 +83,6 @@ COMMON_INSTALL_OPTIONS = [
         help="Environment variables to set on each submitted flow run.",
     ),
 ]
-
-
-def add_options(options):
-    """A decorator for adding a list of options to a click command"""
-
-    def decorator(func):
-        for opt in reversed(options):
-            func = opt(func)
-        return func
-
-    return decorator
 
 
 def start_agent(agent_cls, token, api, label, env, log_level, **kwargs):

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -210,15 +210,15 @@ def setup_compose_file(
 
 
 def setup_compose_env(
-    version,
-    ui_version,
-    no_upgrade,
-    postgres_port,
-    hasura_port,
-    graphql_port,
-    ui_port,
-    server_port,
-    volume_path,
+    version=None,
+    ui_version=None,
+    no_upgrade=None,
+    postgres_port=None,
+    hasura_port=None,
+    graphql_port=None,
+    ui_port=None,
+    server_port=None,
+    volume_path=None,
 ):
     # Pull current version information
     base_version = prefect.__version__.split("+")
@@ -292,14 +292,15 @@ def setup_compose_env(
             "environment variable value (={env['PREFECT_SERVER_DB_CMD']}) will be "
             "ignored."
         )
-    else:
-        # Allow a more complex database command to be passed via env
-        env.setdefault(
-            "PREFECT_SERVER_DB_CMD",
-            "prefect-server database upgrade -y"
-            if not no_upgrade
-            else "echo 'DATABASE MIGRATIONS SKIPPED'",
-        )
+        env.pop("PREFECT_SERVER_DB_CMD")
+
+    # Allow a more complex database command to be passed via env
+    env.setdefault(
+        "PREFECT_SERVER_DB_CMD",
+        "prefect-server database upgrade -y"
+        if not no_upgrade
+        else "echo 'DATABASE MIGRATIONS SKIPPED'",
+    )
 
     env.update(**PREFECT_ENV, **APOLLO_ENV, **POSTGRES_ENV, **UI_ENV, **HASURA_ENV)
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import subprocess
 import tempfile
-import warnings
 import time
+import warnings
 from pathlib import Path
 
 import click

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -150,14 +150,17 @@ COMMON_SERVER_OPTIONS = [
 
 
 def setup_compose_file(
-    no_ui,
-    no_postgres_port,
-    no_hasura_port,
-    no_graphql_port,
-    no_ui_port,
-    no_server_port,
-    use_volume,
+    no_ui=False,
+    no_postgres_port=False,
+    no_hasura_port=False,
+    no_graphql_port=False,
+    no_ui_port=False,
+    no_server_port=False,
+    use_volume=True,
 ) -> str:
+    # Defaults should be set in the `click` command option, these defaults are to
+    # simplify testing
+
     base_compose_path = Path(__file__).parents[0].joinpath("docker-compose.yml")
 
     temp_dir = tempfile.gettempdir()
@@ -220,6 +223,9 @@ def setup_compose_env(
     server_port=None,
     volume_path=None,
 ):
+    # Defaults should be set in the `click` command option, these should _not_ be `None`
+    # at runtime.
+
     # Pull current version information
     base_version = prefect.__version__.split("+")
     if len(base_version) > 1:

--- a/src/prefect/utilities/cli.py
+++ b/src/prefect/utilities/cli.py
@@ -1,15 +1,15 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Callable
 
 if TYPE_CHECKING:
     from click import Option
 
 
-def add_options(options: List["Option"]):
+def add_options(options: List["Option"]) -> Callable:
     """A decorator for adding a list of options to a click command"""
 
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
         for opt in reversed(options):
-            func = opt(func)
+            func = opt(func)  # type: ignore
         return func
 
     return decorator

--- a/src/prefect/utilities/cli.py
+++ b/src/prefect/utilities/cli.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from click import Option
+
+
+def add_options(options: List["Option"]):
+    """A decorator for adding a list of options to a click command"""
+
+    def decorator(func):
+        for opt in reversed(options):
+            func = opt(func)
+        return func
+
+    return decorator

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -25,8 +25,9 @@ else:
 # Provide 3.6/3.7 `call` with `.args` and `.kwargs`
 
 
-def Call(call):
+def Call(call):  # type: ignore
     # Takes a `unittest.mock.call` and adds args/kwargs properties
+    # We cannot enforce type-checks here because unittest.mock._Call is private
 
     if sys.version_info < (3, 8):
         # Properties were added in 3.8

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -4,6 +4,7 @@ only be used internally.
 """
 
 import sys
+from unittest.mock import call as _Call
 
 
 # Provide `nullcontext`
@@ -21,3 +22,17 @@ if sys.version_info < (3, 7):
 else:
 
     from contextlib import nullcontext  # noqa: F401
+
+
+# Provide 3.8+ `call` with `.args` and `.kwargs`
+
+
+def Call(call: _Call) -> _Call:
+
+    if sys.version_info < (3, 8):
+        # Properties were added in 3.8
+
+        call.args = call.call_args[0]
+        call.kwargs = call.call_args[1]
+
+    return call

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -20,18 +20,3 @@ if sys.version_info < (3, 7):
 else:
 
     from contextlib import nullcontext  # noqa: F401
-
-
-# Provide 3.6/3.7 `call` with `.args` and `.kwargs`
-
-
-def Call(call):  # type: ignore
-    # Takes a `unittest.mock.call` and adds args/kwargs properties
-    # We cannot enforce type-checks here because unittest.mock._Call is private
-
-    if sys.version_info < (3, 8):
-        # Properties were added in 3.8
-        call.args = call[1]
-        call.kwargs = call[2]
-
-    return call

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -4,8 +4,6 @@ only be used internally.
 """
 
 import sys
-from unittest.mock import call as _Call
-
 
 # Provide `nullcontext`
 
@@ -24,15 +22,15 @@ else:
     from contextlib import nullcontext  # noqa: F401
 
 
-# Provide 3.8+ `call` with `.args` and `.kwargs`
+# Provide 3.6/3.7 `call` with `.args` and `.kwargs`
 
 
-def Call(call: _Call) -> _Call:
+def Call(call):
+    # Takes a `unittest.mock.call` and adds args/kwargs properties
 
     if sys.version_info < (3, 8):
         # Properties were added in 3.8
-
-        call.args = call.call_args[0]
-        call.kwargs = call.call_args[1]
+        call.args = call[1]
+        call.kwargs = call[2]
 
     return call

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -1,11 +1,165 @@
-from unittest.mock import MagicMock
+import os
+from unittest.mock import MagicMock, call
+from typing import List
 
 from click.testing import CliRunner
 import pytest
+import yaml
 
 import prefect
-from prefect.cli.server import server, make_env
+from prefect.cli.server import server, setup_compose_env, setup_compose_file
 from prefect.utilities.configuration import set_temporary_config
+
+
+@pytest.fixture()
+def mock_subprocess(monkeypatch):
+    """
+    Mock the various ways of creating a subprocess for `prefect server start` tests
+
+    Interrupts the `time.sleep()` call after `docker-compose up` finishes so that the
+    tests exit the loop.
+    """
+    mock = MagicMock()
+
+    monkeypatch.setattr("subprocess.Popen", mock)
+    # We will mock `check_call` and `check_output` as well so they don't depend on
+    # proper objects being returned from `Popen`
+    monkeypatch.setattr("subprocess.check_call", mock)
+    monkeypatch.setattr("subprocess.check_output", mock)
+
+    # Mock the sleep to raise an interrupt to prevent it from hanging after `up`
+    monkeypatch.setattr("time.sleep", MagicMock(side_effect=KeyboardInterrupt()))
+
+    return mock
+
+
+def assert_command_not_called(mock: MagicMock, command: List[str]) -> None:
+    """
+    Assert a mocked `subprocess` was not called with the given command
+    """
+    for call in mock.mock_calls:
+        if call.args:
+            assert call.args[0] != command
+
+
+def get_command_call(mock: MagicMock, command: List[str]) -> call:
+    """
+    Get a mock `call` by command from the a mocked `subprocess` creation
+    """
+    for call in mock.mock_calls:
+        if call.args and call.args[0] == command:
+            return call
+
+    call_commands = [call.args[0] for call in mock.mock_calls if call.args]
+    raise ValueError(f"{command} was not found in {call_commands}")
+
+
+# Test utilities -----------------------------------------------------------------------
+
+
+class TestSetupComposeEnv:
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("0.10.3", "core-0.10.3"),
+            ("0.13.3", "core-0.13.3"),
+            ("0.10.3+114.g35bc7ba4", "master"),
+            ("0.10.2+999.gr34343.dirty", "master"),
+        ],
+    )
+    def test_server_start_image_versions(
+        self, monkeypatch, version, expected, macos_platform
+    ):
+        monkeypatch.setattr(prefect, "__version__", version)
+        assert setup_compose_env()["PREFECT_SERVER_TAG"] == expected
+
+    def test_warns_on_version_conflict(self):
+        os.environ["PREFECT_SERVER_TAG"] = "FOO"
+        with pytest.warns(
+            UserWarning,
+            match="The version has been set in the environment .* and the CLI",
+        ):
+            env = setup_compose_env(version="BAR")
+
+        assert env["PREFECT_SERVER_TAG"] == "BAR"
+
+    def test_warns_on_ui_version_conflict(self):
+        os.environ["PREFECT_UI_TAG"] = "FOO"
+        with pytest.warns(
+            UserWarning,
+            match="The UI version has been set in the environment .* and the CLI",
+        ):
+            env = setup_compose_env(ui_version="BAR")
+
+        assert env["PREFECT_UI_TAG"] == "BAR"
+
+    def test_warns_on_db_command_conflict(self):
+        os.environ["PREFECT_SERVER_DB_CMD"] = "FOO"
+        with pytest.warns(
+            UserWarning,
+            match="The database startup command has been set in the environment .* CLI",
+        ):
+            env = setup_compose_env(no_upgrade=True)
+
+        assert env["PREFECT_SERVER_DB_CMD"] == "echo 'DATABASE MIGRATIONS SKIPPED'"
+
+    def test_allows_db_command_override(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_SERVER_DB_CMD", "FOO")
+        env = setup_compose_env(no_upgrade=False)
+        assert env["PREFECT_SERVER_DB_CMD"] == "FOO"
+
+    def test_fills_env_with_values_from_config_and_args(self, monkeypatch):
+        monkeypatch.delenv("PREFECT_SERVER_DB_CMD")  # Ensure this is not set
+        with set_temporary_config(
+            {
+                "server.database.connection_url": "localhost/foo",
+                "server.database.name": "D",
+                "server.database.password": "E",
+                "server.database.username": "F",
+                "server.graphql.path": "/G",
+                "server.telemetry.enabled": False,
+            }
+        ):
+            env = setup_compose_env(
+                version="A",
+                ui_version="B",
+                no_upgrade=False,
+                postgres_port=1,
+                hasura_port=2,
+                graphql_port=3,
+                ui_port=4,
+                server_port=5,
+                volume_path="C",
+            )
+
+        expected = {
+            "APOLLO_HOST_PORT": "5",
+            "APOLLO_URL": "http://localhost:4200/graphql",
+            "DB_CONNECTION_URL": "postgres/foo",
+            "GRAPHQL_HOST_PORT": "3",
+            "HASURA_API_URL": "http://hasura:2/v1alpha1/graphql",
+            "HASURA_HOST_PORT": "2",
+            "HASURA_WS_URL": "ws://hasura:2/v1alpha1/graphql",
+            "POSTGRES_DATA_PATH": "C",
+            "POSTGRES_DB": "D",
+            "POSTGRES_HOST_PORT": "1",
+            "POSTGRES_PASSWORD": "E",
+            "POSTGRES_USER": "F",
+            "PREFECT_API_HEALTH_URL": "http://graphql:3/health",
+            "PREFECT_API_URL": f"http://graphql:3/G",
+            "PREFECT_CORE_VERSION": prefect.__version__,
+            "PREFECT_SERVER_DB_CMD": "prefect-server database upgrade -y",
+            "PREFECT_SERVER_TAG": "A",
+            "PREFECT_UI_TAG": "B",
+            "UI_HOST_PORT": "4",
+            "PREFECT_SERVER__TELEMETRY__ENABLED": "false",
+        }
+
+        for key, expected_value in expected.items():
+            assert env[key] == expected_value
+
+
+# Test commands ------------------------------------------------------------------------
 
 
 def test_server_init():
@@ -22,244 +176,148 @@ def test_server_help():
     assert "Commands for interacting with the Prefect Core server" in result.output
 
 
-def test_make_env():
-    env = make_env()
-    assert env
-
-
-def test_make_env_config_vars():
-    with set_temporary_config(
-        {
-            "server.database.connection_url": "localhost",
-            "server.graphql.host_port": "1",
-            "server.ui.host_port": "2",
-            "server.hasura.port": "3",
-            "server.graphql.port": "4",
-            "server.graphql.path": "/path",
-            "server.host_port": "5",
-            "server.database.host_port": "6",
-            "server.database.username": "username",
-            "server.database.password": "password",
-            "server.database.name": "db",
-            "server.hasura.host_port": "7",
-            "server.database.volume_path": "test/path",
-        }
+class TestPrefectServerStart:
+    def test_server_start_setup_and_teardown(
+        self, monkeypatch, macos_platform, mock_subprocess
     ):
-        env = make_env()
+        # Pull current version information to test default values
+        base_version = prefect.__version__.split("+")
+        if len(base_version) > 1:
+            default_tag = "master"
+        else:
+            default_tag = f"core-{base_version[0]}"
 
-        assert env["DB_CONNECTION_URL"] == "postgres"
-        assert env["GRAPHQL_HOST_PORT"] == "1"
-        assert env["UI_HOST_PORT"] == "2"
-        assert env["HASURA_API_URL"] == "http://hasura:3/v1alpha1/graphql"
-        assert env["HASURA_WS_URL"] == "ws://hasura:3/v1alpha1/graphql"
-        assert env["PREFECT_API_URL"] == "http://graphql:4/path"
-        assert env["PREFECT_API_HEALTH_URL"] == "http://graphql:4/health"
+        expected_env = setup_compose_env(
+            version=default_tag,
+            ui_version=default_tag,
+            ui_port=prefect.config.server.ui.host_port,
+            hasura_port=prefect.config.server.hasura.host_port,
+            graphql_port=prefect.config.server.graphql.host_port,
+            postgres_port=prefect.config.server.database.host_port,
+            server_port=prefect.config.server.host_port,
+            no_upgrade=False,
+            volume_path=prefect.config.server.database.volume_path,
+        )
+
+        CliRunner().invoke(server, ["start"])
+
+        pull = get_command_call(mock_subprocess, ["docker-compose", "pull"])
+        up = get_command_call(mock_subprocess, ["docker-compose", "up"])
+        down = get_command_call(mock_subprocess, ["docker-compose", "down"])
+
+        # Ensure that cwd, env were passed and used consistently
+        cwd = pull.kwargs.get("cwd")
+        env = pull.kwargs.get("env")
+
+        assert env is not None
+        assert cwd is not None
+
+        assert up.kwargs.get("cwd") == cwd
+        assert up.kwargs.get("env") == env
+        assert down.kwargs.get("cwd") == cwd
+        assert down.kwargs.get("env") == env
+
+        # Check the environment matches expected defaults
+        assert env == expected_env
+
+        # Ensure the docker-compose.yml exists at the tmpdir
+        assert os.path.exists(os.path.join(cwd, "docker-compose.yml"))
+
+    def test_server_start_skip_pull(self, monkeypatch, macos_platform, mock_subprocess):
+        CliRunner().invoke(
+            server,
+            ["start", "--skip-pull"],
+        )
+        assert_command_not_called(mock_subprocess, ["docker-compose", "pull"])
+        assert get_command_call(mock_subprocess, ["docker-compose", "up"])
+
+    def test_server_start_no_upgrade(
+        self, monkeypatch, macos_platform, mock_subprocess
+    ):
+        CliRunner().invoke(
+            server,
+            ["start", "--no-upgrade"],
+        )
+        up = get_command_call(mock_subprocess, ["docker-compose", "up"])
+        env = up.kwargs.get("env")
+        assert env["PREFECT_SERVER_DB_CMD"] == "echo 'DATABASE MIGRATIONS SKIPPED'"
+
+    def test_server_start_port_options(
+        self, monkeypatch, macos_platform, mock_subprocess
+    ):
+        CliRunner().invoke(
+            server,
+            [
+                "start",
+                "--postgres-port",
+                "1",
+                "--hasura-port",
+                "2",
+                "--graphql-port",
+                "3",
+                "--ui-port",
+                "4",
+                "--server-port",
+                "5",
+            ],
+        )
+        up = get_command_call(mock_subprocess, ["docker-compose", "up"])
+        env = up.kwargs.get("env")
+        assert env["POSTGRES_HOST_PORT"] == "1"
+        assert env["HASURA_HOST_PORT"] == "2"
+        assert env["GRAPHQL_HOST_PORT"] == "3"
+        assert env["UI_HOST_PORT"] == "4"
         assert env["APOLLO_HOST_PORT"] == "5"
-        assert env["POSTGRES_HOST_PORT"] == "6"
-        assert env["POSTGRES_USER"] == "username"
-        assert env["POSTGRES_PASSWORD"] == "password"
-        assert env["POSTGRES_DB"] == "db"
-        assert env["HASURA_HOST_PORT"] == "7"
-        assert env["POSTGRES_DATA_PATH"] == "test/path"
 
+    def test_server_start_detach(self, monkeypatch, macos_platform, mock_subprocess):
 
-def test_server_start(monkeypatch, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
+        CliRunner().invoke(
+            server,
+            ["start", "--detach"],
+        )
+        assert get_command_call(mock_subprocess, ["docker-compose", "up", "--detach"])
 
-    runner = CliRunner()
-    result = runner.invoke(server, ["start", "--detach"])
-    assert result.exit_code == 1
+    def test_server_start_disable_port_mapping(
+        self, monkeypatch, macos_platform, mock_subprocess
+    ):
+        CliRunner().invoke(
+            server,
+            [
+                "start",
+                "--no-postgres-port",
+                "--no-hasura-port",
+                "--no-graphql-port",
+                "--no-ui-port",
+                "--no-server-port",
+            ],
+        )
+        up = get_command_call(mock_subprocess, ["docker-compose", "up"])
+        tmpdir = up.kwargs["cwd"]
 
-    assert check_call.called
-    assert popen.called
-    assert check_output.called
+        with open(os.path.join(tmpdir, "docker-compose.yml"), "r") as file:
+            compose_yml = yaml.safe_load(file)
 
-    assert check_call.call_args[0][0] == ["docker-compose", "pull"]
-    assert check_call.call_args[1].get("cwd")
-    assert check_call.call_args[1].get("env")
+        assert "ports" not in compose_yml["services"]["postgres"]
+        assert "ports" not in compose_yml["services"]["hasura"]
+        assert "ports" not in compose_yml["services"]["graphql"]
+        assert "ports" not in compose_yml["services"]["ui"]
+        assert "ports" not in compose_yml["services"]["apollo"]
+        assert "volumes" not in compose_yml["services"]["postgres"]
 
-    assert popen.call_args[0][0] == ["docker-compose", "up", "--detach"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
+    def test_server_start_no_ui_service(
+        self, monkeypatch, macos_platform, mock_subprocess
+    ):
+        CliRunner().invoke(
+            server,
+            ["start", "--no-ui"],
+        )
+        up = get_command_call(mock_subprocess, ["docker-compose", "up"])
+        tmpdir = up.kwargs["cwd"]
 
-    assert check_output.call_args[0][0] == ["docker-compose", "down"]
-    assert check_output.call_args[1].get("cwd")
-    assert check_output.call_args[1].get("env")
+        with open(os.path.join(tmpdir, "docker-compose.yml"), "r") as file:
+            compose_yml = yaml.safe_load(file)
 
-
-@pytest.mark.parametrize(
-    "version",
-    [
-        ("0.10.3", "core-0.10.3"),
-        ("0.13.3", "core-0.13.3"),
-        ("0.10.3+114.g35bc7ba4", "master"),
-        ("0.10.2+999.gr34343.dirty", "master"),
-    ],
-)
-def test_server_start_image_versions(monkeypatch, version, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-    monkeypatch.setattr(prefect, "__version__", version[0])
-
-    runner = CliRunner()
-    result = runner.invoke(server, ["start"])
-    assert result.exit_code == 1
-
-    assert check_call.called
-    assert popen.called
-    assert check_output.called
-
-    assert popen.call_args[0][0] == ["docker-compose", "up"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
-    assert popen.call_args[1]["env"].get("PREFECT_SERVER_TAG") == version[1]
-
-
-def test_server_start_options_and_flags(monkeypatch, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        server,
-        ["start", "--version", "version", "--skip-pull", "--no-upgrade", "--no-ui"],
-    )
-    assert result.exit_code == 1
-
-    assert not check_call.called
-    assert popen.called
-    assert check_output.called
-
-    assert popen.call_args[0][0] == ["docker-compose", "up"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
-    assert popen.call_args[1]["env"].get("PREFECT_SERVER_TAG") == "version"
-    assert (
-        popen.call_args[1]["env"].get("PREFECT_SERVER_DB_CMD")
-        == "echo 'DATABASE MIGRATIONS SKIPPED'"
-    )
-
-    assert check_output.call_args[0][0] == ["docker-compose", "down"]
-    assert check_output.call_args[1].get("cwd")
-    assert check_output.call_args[1].get("env")
-
-
-def test_server_start_port_options(monkeypatch, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        server,
-        [
-            "start",
-            "--postgres-port",
-            "1",
-            "--hasura-port",
-            "2",
-            "--graphql-port",
-            "3",
-            "--ui-port",
-            "4",
-            "--server-port",
-            "5",
-        ],
-    )
-    assert result.exit_code == 1
-
-    assert check_call.called
-    assert popen.called
-    assert check_output.called
-
-    assert popen.call_args[0][0] == ["docker-compose", "up"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
-    assert popen.call_args[1]["env"].get("POSTGRES_HOST_PORT") == "1"
-    assert popen.call_args[1]["env"].get("HASURA_HOST_PORT") == "2"
-    assert popen.call_args[1]["env"].get("GRAPHQL_HOST_PORT") == "3"
-    assert popen.call_args[1]["env"].get("UI_HOST_PORT") == "4"
-    assert popen.call_args[1]["env"].get("APOLLO_HOST_PORT") == "5"
-
-
-def test_server_start_disable_port_mapping(monkeypatch, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        server,
-        [
-            "start",
-            "--no-postgres-port",
-            "--no-hasura-port",
-            "--no-graphql-port",
-            "--no-ui-port",
-            "--no-server-port",
-        ],
-    )
-    assert result.exit_code == 1
-
-    assert check_call.called
-    assert popen.called
-    assert check_output.called
-
-    assert check_call.call_args[0][0] == ["docker-compose", "pull"]
-    assert check_call.call_args[1].get("cwd")
-    assert check_call.call_args[1].get("env")
-
-    assert popen.call_args[0][0] == ["docker-compose", "up"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
-
-    assert check_output.call_args[0][0] == ["docker-compose", "down"]
-    assert check_output.call_args[1].get("cwd")
-    assert check_output.call_args[1].get("env")
-
-
-def test_server_start_volume_options(monkeypatch, macos_platform):
-    check_call = MagicMock()
-    popen = MagicMock(side_effect=KeyboardInterrupt())
-    check_output = MagicMock()
-    monkeypatch.setattr("subprocess.Popen", popen)
-    monkeypatch.setattr("subprocess.check_call", check_call)
-    monkeypatch.setattr("subprocess.check_output", check_output)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        server,
-        ["start", "--use-volume", "--volume-path", "test/path"],
-    )
-    assert result.exit_code == 1
-
-    assert check_call.called
-    assert popen.called
-    assert check_output.called
-
-    assert popen.call_args[0][0] == ["docker-compose", "up"]
-    assert popen.call_args[1].get("cwd")
-    assert popen.call_args[1].get("env")
-    assert popen.call_args[1]["env"].get("POSTGRES_DATA_PATH") == "test/path"
+        assert "ui" not in compose_yml["services"]
 
 
 def test_create_tenant(monkeypatch, cloud_api):
@@ -267,8 +325,7 @@ def test_create_tenant(monkeypatch, cloud_api):
         "prefect.client.Client.create_tenant", MagicMock(return_value="my_id")
     )
 
-    runner = CliRunner()
-    result = runner.invoke(
+    result = CliRunner().invoke(
         server,
         ["create-tenant", "-n", "name", "-s", "slug"],
     )
@@ -283,6 +340,5 @@ def test_stop_server(monkeypatch):
         return_value={"Containers": {"id": {"test": "val"}}}
     )
     monkeypatch.setattr("docker.APIClient", client)
-    runner = CliRunner()
-    result = runner.invoke(server, ["stop"])
+    result = CliRunner().invoke(server, ["stop"])
     assert result.exit_code == 0

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -159,6 +159,69 @@ class TestSetupComposeEnv:
             assert env[key] == expected_value
 
 
+class TestSetupComposeFile:
+    @pytest.mark.parametrize(
+        "service", ["postgres", "hasura", "graphql", "ui", "server"]
+    )
+    def test_disable_port_mapping(self, service):
+        compose_file = setup_compose_file(**{f"no_{service}_port": True})
+
+        with open(compose_file) as file:
+            compose_yml = yaml.safe_load(file)
+
+        default_compose_file = setup_compose_file()
+        with open(default_compose_file) as file:
+            default_compose_yml = yaml.safe_load(file)
+
+        if service == "server":
+            service = "apollo"
+
+        # Ensure ports is not set
+        assert "ports" not in compose_yml["services"][service]
+
+        # Ensure nothing else has changed
+        default_compose_yml["services"][service].pop("ports")
+        assert compose_yml == default_compose_yml
+
+    def test_disable_ui_service(
+        self,
+    ):
+        compose_file = setup_compose_file(no_ui=True)
+
+        with open(compose_file) as file:
+            compose_yml = yaml.safe_load(file)
+
+        default_compose_file = setup_compose_file()
+        with open(default_compose_file) as file:
+            default_compose_yml = yaml.safe_load(file)
+
+        # Ensure ui is not set
+        assert "ui" not in compose_yml["services"]
+
+        # Ensure nothing else has changed
+        default_compose_yml["services"].pop("ui")
+        assert compose_yml == default_compose_yml
+
+    def test_disable_postgres_volumes(
+        self,
+    ):
+        compose_file = setup_compose_file(use_volume=False)
+
+        with open(compose_file) as file:
+            compose_yml = yaml.safe_load(file)
+
+        default_compose_file = setup_compose_file()
+        with open(default_compose_file) as file:
+            default_compose_yml = yaml.safe_load(file)
+
+        # Ensure ui is not set
+        assert "volumes" not in compose_yml["services"]["postgres"]
+
+        # Ensure nothing else has changed
+        default_compose_yml["services"]["postgres"].pop("volumes")
+        assert compose_yml == default_compose_yml
+
+
 # Test commands ------------------------------------------------------------------------
 
 

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -391,7 +391,7 @@ class TestPrefectServerStart:
 
 
 class TestPrefectServerConfig:
-    def test_server_config_setup(self):
+    def test_server_config_setup(self, mock_subprocess):
         # Pull current version information to test default values
         base_version = prefect.__version__.split("+")
         if len(base_version) > 1:

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -240,9 +240,7 @@ def test_server_help():
 
 
 class TestPrefectServerStart:
-    def test_server_start_setup_and_teardown(
-        self, monkeypatch, macos_platform, mock_subprocess
-    ):
+    def test_server_start_setup_and_teardown(self, macos_platform, mock_subprocess):
         # Pull current version information to test default values
         base_version = prefect.__version__.split("+")
         if len(base_version) > 1:
@@ -286,7 +284,7 @@ class TestPrefectServerStart:
         # Ensure the docker-compose.yml exists at the tmpdir
         assert os.path.exists(os.path.join(cwd, "docker-compose.yml"))
 
-    def test_server_start_skip_pull(self, monkeypatch, macos_platform, mock_subprocess):
+    def test_server_start_skip_pull(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             ["start", "--skip-pull"],
@@ -294,9 +292,7 @@ class TestPrefectServerStart:
         assert_command_not_called(mock_subprocess, ["docker-compose", "pull"])
         assert get_command_call(mock_subprocess, ["docker-compose", "up"])
 
-    def test_server_start_no_upgrade(
-        self, monkeypatch, macos_platform, mock_subprocess
-    ):
+    def test_server_start_no_upgrade(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             ["start", "--no-upgrade"],
@@ -305,9 +301,7 @@ class TestPrefectServerStart:
         env = up.kwargs.get("env")
         assert env["PREFECT_SERVER_DB_CMD"] == "echo 'DATABASE MIGRATIONS SKIPPED'"
 
-    def test_server_start_port_options(
-        self, monkeypatch, macos_platform, mock_subprocess
-    ):
+    def test_server_start_port_options(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             [
@@ -332,17 +326,14 @@ class TestPrefectServerStart:
         assert env["UI_HOST_PORT"] == "4"
         assert env["APOLLO_HOST_PORT"] == "5"
 
-    def test_server_start_detach(self, monkeypatch, macos_platform, mock_subprocess):
-
+    def test_server_start_detach(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             ["start", "--detach"],
         )
         assert get_command_call(mock_subprocess, ["docker-compose", "up", "--detach"])
 
-    def test_server_start_disable_port_mapping(
-        self, monkeypatch, macos_platform, mock_subprocess
-    ):
+    def test_server_start_disable_port_mapping(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             [
@@ -367,9 +358,7 @@ class TestPrefectServerStart:
         assert "ports" not in compose_yml["services"]["apollo"]
         assert "volumes" not in compose_yml["services"]["postgres"]
 
-    def test_server_start_no_ui_service(
-        self, monkeypatch, macos_platform, mock_subprocess
-    ):
+    def test_server_start_no_ui_service(self, macos_platform, mock_subprocess):
         CliRunner().invoke(
             server,
             ["start", "--no-ui"],

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -9,6 +9,7 @@ import yaml
 import prefect
 from prefect.cli.server import server, setup_compose_env, setup_compose_file
 from prefect.utilities.configuration import set_temporary_config
+from prefect.utilities.compatibility import Call
 
 
 @pytest.fixture()
@@ -37,20 +38,21 @@ def assert_command_not_called(mock: MagicMock, command: List[str]) -> None:
     """
     Assert a mocked `subprocess` was not called with the given command
     """
-    for call in mock.mock_calls:
-        if call.args:
-            assert call.args[0] != command
+    for call_ in mock.mock_calls:
+        call_ = call(call_)
+        if call_.args:
+            assert call_.args[0] != command
 
 
 def get_command_call(mock: MagicMock, command: List[str]) -> call:
     """
     Get a mock `call` by command from the a mocked `subprocess` creation
     """
-    for call in mock.mock_calls:
+    for call in map(Call, mock.mock_calls):
         if call.args and call.args[0] == command:
             return call
 
-    call_commands = [call.args[0] for call in mock.mock_calls if call.args]
+    call_commands = [call.args[0] for call in map(Call, mock.mock_calls) if call.args]
     raise ValueError(f"{command} was not found in {call_commands}")
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Instead of starting the server, provide the configured file for a user to spin it up themselves.

`prefect server config` writes a configure docker-compose yaml to standard output using `docker-compose config` to resolve environment variables. It takes all the same (non pull/start) options as `prefect server start`

## Changes
<!-- What does this PR change? -->

- Adds `config` to `prefect server` CLI
- Refactors docker-compose file and environment generation
- Warns on collisions between the current environment and CLI commands

## Importance
<!-- Why is this PR important? -->

Closes https://github.com/PrefectHQ/prefect/issues/4151


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)