### PR TITLE
Better error message when failing to find flow in file

### DIFF
--- a/changes/pr4182.yaml
+++ b/changes/pr4182.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Better error message when flow not found in file - [#4182](https://github.com/PrefectHQ/prefect/pull/4182)"

--- a/tests/utilities/test_storage.py
+++ b/tests/utilities/test_storage.py
@@ -49,55 +49,71 @@ def test_get_flow_image_raises_on_missing_info():
         get_flow_image(flow=flow)
 
 
-def test_extract_flow_from_file(tmpdir):
-    contents = """from prefect import Flow\nf=Flow('test-flow')"""
+class TestExtractFlowFromFile:
+    @pytest.fixture
+    def flow_path(self, tmpdir):
+        contents = """from prefect import Flow\nf=Flow('flow-1')\nf2=Flow('flow-2')"""
 
-    full_path = os.path.join(tmpdir, "flow.py")
+        full_path = os.path.join(tmpdir, "flow.py")
 
-    with open(full_path, "w") as f:
-        f.write(contents)
+        with open(full_path, "w") as f:
+            f.write(contents)
 
-    flow = extract_flow_from_file(file_path=full_path)
-    assert flow.run().is_successful()
+        return full_path
 
-    flow = extract_flow_from_file(file_contents=contents)
-    assert flow.run().is_successful()
+    def test_extract_flow_from_file_path(self, flow_path):
+        flow = extract_flow_from_file(file_path=flow_path)
+        assert flow.name == "flow-1"
+        assert flow.run().is_successful()
 
-    flow = extract_flow_from_file(file_path=full_path, flow_name="test-flow")
-    assert flow.run().is_successful()
+        flow = extract_flow_from_file(file_path=flow_path, flow_name="flow-1")
+        assert flow.name == "flow-1"
 
-    with pytest.raises(ValueError):
-        extract_flow_from_file(file_path=full_path, flow_name="not-real")
+        flow = extract_flow_from_file(file_path=flow_path, flow_name="flow-2")
+        assert flow.name == "flow-2"
 
-    with pytest.raises(ValueError):
-        extract_flow_from_file(file_path=full_path, file_contents=contents)
+    def test_extract_flow_from_file_contents(self, flow_path):
+        with open(flow_path, "r") as f:
+            contents = f.read()
 
-    with pytest.raises(ValueError):
-        extract_flow_from_file()
+        flow = extract_flow_from_file(file_contents=contents)
+        assert flow.name == "flow-1"
+        assert flow.run().is_successful()
 
+        flow = extract_flow_from_file(file_contents=contents, flow_name="flow-1")
+        assert flow.name == "flow-1"
 
-def test_extract_flow_from_file_raises_on_run_register(tmpdir):
-    contents = """from prefect import Flow\nf=Flow('test-flow')\nf.run()"""
+        flow = extract_flow_from_file(file_contents=contents, flow_name="flow-2")
+        assert flow.name == "flow-2"
 
-    full_path = os.path.join(tmpdir, "flow.py")
+    def test_extract_flow_from_file_errors(self, flow_path):
+        with pytest.raises(ValueError, match="but not both"):
+            extract_flow_from_file(file_path="", file_contents="")
 
-    with open(full_path, "w") as f:
-        f.write(contents)
+        with pytest.raises(ValueError, match="Provide either"):
+            extract_flow_from_file()
 
-    with prefect.context({"loading_flow": True}):
-        with pytest.warns(Warning):
-            extract_flow_from_file(file_path=full_path)
+        expected = (
+            "Flow 'not-real' not found in file. Found flows:\n- 'flow-1'\n- 'flow-2'"
+        )
+        with pytest.raises(ValueError, match=expected):
+            extract_flow_from_file(file_path=flow_path, flow_name="not-real")
 
-    contents = """from prefect import Flow\nf=Flow('test-flow')\nf.register()"""
+        with pytest.raises(ValueError, match="No flows found in file."):
+            extract_flow_from_file(file_contents="")
 
-    full_path = os.path.join(tmpdir, "flow.py")
+    @pytest.mark.parametrize("method", ["run", "register"])
+    def test_extract_flow_from_file_raises_on_run_register(self, tmpdir, method):
+        contents = f"from prefect import Flow\nf=Flow('test-flow')\nf.{method}()"
 
-    with open(full_path, "w") as f:
-        f.write(contents)
+        full_path = os.path.join(tmpdir, "flow.py")
 
-    with prefect.context({"loading_flow": True}):
-        with pytest.warns(Warning):
-            extract_flow_from_file(file_path=full_path)
+        with open(full_path, "w") as f:
+            f.write(contents)
+
+        with prefect.context({"loading_flow": True}):
+            with pytest.warns(Warning):
+                extract_flow_from_file(file_path=full_path)
 
 
 @pytest.fixture


### PR DESCRIPTION
When loading a flow from a source file, if the file doesn't contain the
expected flow we now raise a better error message.