### PR TITLE
Improve indexed task naming

### DIFF
--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -953,7 +953,7 @@ class Task(metaclass=TaskMetaclass):
             - Task
         """
         return prefect.tasks.core.operators.GetItem(
-            checkpoint=self.checkpoint, name=f"{self.name}[{key}]", result=self.result
+            checkpoint=self.checkpoint, name=f"{self.name}[{key!r}]", result=self.result
         ).bind(self, key)
 
     def __or__(self, other: object) -> object:

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -953,7 +953,7 @@ class Task(metaclass=TaskMetaclass):
             - Task
         """
         return prefect.tasks.core.operators.GetItem(
-            checkpoint=self.checkpoint, result=self.result
+            checkpoint=self.checkpoint, name=f"{self.name}[{key}]", result=self.result
         ).bind(self, key)
 
     def __or__(self, other: object) -> object:

--- a/tests/core/test_task_operators.py
+++ b/tests/core/test_task_operators.py
@@ -85,6 +85,15 @@ class TestMagicInteractionMethods:
         assert isinstance(y.result, LocalResult)
         assert y.result.dir.endswith("home")
 
+    def test_getitem_name(self):
+        with Flow(name="test") as f:
+            x = Parameter("x")[0]
+            assert x.name == "x[0]"
+            y = Parameter("y")["a"]
+            assert y.name == "y['a']"
+            z = Parameter("z")[Parameter("a")]
+            assert z.name == "z[<Parameter: a>]"
+
     # -----------------------------------------
     # or / pipe / |
 


### PR DESCRIPTION
## Summary
<!-- A sentence summarizing the PR -->

Use the parent task name + key for the `GetItem` task returned by indexing.

First pass at fixing #3789 with just task + key naming (didn't try `NamedTuple`)

## Changes
<!-- What does this PR change? -->


## Importance
<!-- Why is this PR important? -->

`GetItem` tasks are noisy and hard to follow in the UI schematic, this makes them a bit easier to work with.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
