### PR TITLE
Make slug generation more robust

### DIFF
--- a/changes/pr4189.yaml
+++ b/changes/pr4189.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Make task slug generation robust to modifying existing task names - [#4189](https://github.com/PrefectHQ/prefect/pull/4189)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import hashlib
 import inspect
+import itertools
 import json
 import os
 import tempfile
@@ -176,7 +177,10 @@ class Flow:
 
         self.tasks = set()  # type: Set[Task]
         self.edges = set()  # type: Set[Edge]
-        self.slugs = dict()  # type: Dict[Task, str]
+        self._slug_counters = collections.defaultdict(
+            lambda: itertools.count(1)
+        )  # type: Dict[str, Iterator[int]]
+        self.slugs = {}  # type: Dict[Task, str]
         self.constants = collections.defaultdict(
             dict
         )  # type: Dict[Task, Dict[str, Any]]
@@ -486,12 +490,14 @@ class Flow:
         Returns:
             - str: the corresponding slug
         """
-        slug_bases = []
-        for t in self.tasks:
-            slug_bases.append(f"{t.name}-" + "-".join(sorted(t.tags)))
-        new_slug = f"{task.name}-" + "-".join(sorted(task.tags))
-        index = slug_bases.count(new_slug)
-        return f"{new_slug}{'' if new_slug.endswith('-') else '-'}{index + 1}"
+        parts = [task.name]
+        parts.extend(sorted(task.tags))
+        prefix = "-".join(parts)
+        while True:
+            ind = next(self._slug_counters[prefix])
+            slug = f"{prefix}-{ind}"
+            if slug not in self.slugs.values():
+                return slug
 
     def add_task(self, task: Task) -> Task:
         """

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -3196,12 +3196,16 @@ def test_run_agent_passes_flow_labels(monkeypatch, kind):
 
 class TestSlugGeneration:
     def test_slugs_are_stable(self):
-        tasks = [Task(name=str(x)) for x in range(10)]
+        tasks = [Task(name="add") for _ in range(5)]
+        tasks.extend(Task(name="mul") for _ in range(5))
         flow_one = Flow("one", tasks=tasks)
         flow_two = Flow("two", tasks=tasks)
 
-        assert set(flow_one.slugs.values()) == set([str(x) + "-1" for x in range(10)])
-        assert flow_one.slugs == flow_two.slugs
+        sol = {f"add-{i}" for i in range(1, 6)}
+        sol.update(f"mul-{i}" for i in range(1, 6))
+
+        assert set(flow_one.slugs.values()) == sol
+        assert set(flow_two.slugs.values()) == sol
 
     def test_slugs_incorporate_tags_and_order(self):
         with Flow("one") as flow_one:
@@ -3224,3 +3228,27 @@ class TestSlugGeneration:
             "a-tag1-1",
             "b-tag1-tag2-1",
         }
+
+    def test_generated_slugs_dont_collide_with_user_provided_slugs(self):
+        with Flow("test") as flow:
+            a3 = Task("a", slug="a-3")
+            flow.add_task(a3)
+            a1 = Task("a")
+            flow.add_task(a1)
+            a2 = Task("a")
+            flow.add_task(a2)
+            a4 = Task("a")
+            flow.add_task(a4)
+
+        assert flow.slugs == {a1: "a-1", a2: "a-2", a3: "a-3", a4: "a-4"}
+
+    def test_slugs_robust_to_task_name_changes(self):
+        "See https://github.com/PrefectHQ/prefect/issues/4185"
+        with Flow("test") as flow:
+            a1 = Task("a")
+            flow.add_task(a1)
+            a1.name = "changed"
+            a2 = Task("a")
+            flow.add_task(a2)
+
+        assert flow.slugs == {a1: "a-1", a2: "a-2"}


### PR DESCRIPTION
Previously generating a slug for a new task was an O(n) operation where
all existing tasks were inspected to determine the next slug to use for
the new task. Besides being mildly expensive, this wasn't robust to
tasks changing name after being added to a flow, leading to duplicate
slugs. We now track auto-generated slugs in a private member on the flow
class, and explicitly handle clashes.

Note that this is still technically O(n) (since we check for a clash in
`slugs.values()`, which is a linear search). But the operation takes
place entirely within the Python C-api, so is generally fast for the
size of `n` we typically deal with.

Fixes #4185.