### PR TITLE
Add base_url parameter for Github storage

### DIFF
--- a/changes/pr4194.yaml
+++ b/changes/pr4194.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Github: accept base_url - [#4194](https://github.com/PrefectHQ/prefect/pull/4194)"
+
+contributor:
+  - "[Yogi Patel](https://github.com/ypatel-whitepages)"

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -98,6 +98,7 @@ class GitHubSchema(BaseStorageSchema):
     ref = fields.String(allow_none=True)
     path = fields.String(allow_none=False)
     access_token_secret = fields.String(allow_none=True)
+    base_url = fields.String(allow_none=True)
 
 
 class GitLabSchema(BaseStorageSchema):

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -39,6 +39,8 @@ class GitHub(Storage):
         - access_token_secret (str, optional): The name of a Prefect secret
             that contains a GitHub access token to use when loading flows from
             this storage.
+        - base_url(str, optional): the Github REST api url for the repo. If not specified,
+            https://api.github.com is used.
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
@@ -48,12 +50,14 @@ class GitHub(Storage):
         path: str,
         ref: str = None,
         access_token_secret: str = None,
+        base_url = None,
         **kwargs: Any,
     ) -> None:
         self.repo = repo
         self.path = path
         self.ref = ref
         self.access_token_secret = access_token_secret
+        self.base_url = base_url
 
         super().__init__(**kwargs)
 
@@ -161,4 +165,7 @@ class GitHub(Storage):
             if access_token is None:
                 access_token = os.getenv("GITHUB_ACCESS_TOKEN")
 
-        return Github(access_token)
+        if self.base_url:
+            return Github(login_or_token=access_token, base_url=self.base_url)
+        else:
+            return Github(access_token)

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -50,7 +50,7 @@ class GitHub(Storage):
         path: str,
         ref: str = None,
         access_token_secret: str = None,
-        base_url = None,
+        base_url=None,
         **kwargs: Any,
     ) -> None:
         self.repo = repo

--- a/src/prefect/storage/github.py
+++ b/src/prefect/storage/github.py
@@ -50,7 +50,7 @@ class GitHub(Storage):
         path: str,
         ref: str = None,
         access_token_secret: str = None,
-        base_url=None,
+        base_url: str = None,
         **kwargs: Any,
     ) -> None:
         self.repo = repo

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -358,9 +358,10 @@ def test_webhook_full_serialize():
 
 @pytest.mark.parametrize("ref", [None, "testref"])
 @pytest.mark.parametrize("access_token_secret", [None, "secret"])
-def test_github_serialize(ref, access_token_secret):
+@pytest.mark.parametrize("base_url", [None, "https://some-url"])
+def test_github_serialize(ref, access_token_secret, base_url):
     github = storage.GitHub(
-        repo="test/repo", path="flow.py", access_token_secret=access_token_secret
+        repo="test/repo", path="flow.py", access_token_secret=access_token_secret, base_url=base_url
     )
     if ref is not None:
         github.ref = ref
@@ -371,6 +372,7 @@ def test_github_serialize(ref, access_token_secret):
     assert serialized["ref"] == ref
     assert serialized["secrets"] == []
     assert serialized["access_token_secret"] == access_token_secret
+    assert serialized["base_url"] == base_url
 
 
 def test_gitlab_empty_serialize():

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -361,7 +361,10 @@ def test_webhook_full_serialize():
 @pytest.mark.parametrize("base_url", [None, "https://some-url"])
 def test_github_serialize(ref, access_token_secret, base_url):
     github = storage.GitHub(
-        repo="test/repo", path="flow.py", access_token_secret=access_token_secret, base_url=base_url
+        repo="test/repo",
+        path="flow.py",
+        access_token_secret=access_token_secret,
+        base_url=base_url,
     )
     if ref is not None:
         github.ref = ref

--- a/tests/storage/test_github_storage.py
+++ b/tests/storage/test_github_storage.py
@@ -29,7 +29,11 @@ def test_create_github_storage():
 
 def test_create_github_storage_init_args():
     storage = GitHub(
-        repo="test/repo", path="flow.py", ref="my_branch", base_url="https://some-url", secrets=["auth"]
+        repo="test/repo",
+        path="flow.py",
+        ref="my_branch",
+        base_url="https://some-url",
+        secrets=["auth"],
     )
     assert storage
     assert storage.flows == dict()
@@ -77,11 +81,16 @@ def test_github_base_url(monkeypatch):
     orig_github = github.Github
     mock_github = MagicMock(wraps=github.Github)
     monkeypatch.setattr("github.Github", mock_github)
-    storage = GitHub(repo="test/repo", path="flow.py", access_token_secret="TEST", base_url="https://some-url")
+    storage = GitHub(
+        repo="test/repo",
+        path="flow.py",
+        access_token_secret="TEST",
+        base_url="https://some-url",
+    )
     with context(secrets={"TEST": "TEST-VAL"}):
         client = storage._get_github_client()
     assert isinstance(client, orig_github)
-    assert mock_github.call_args[1]['base_url'] == "https://some-url"
+    assert mock_github.call_args[1]["base_url"] == "https://some-url"
 
 
 def test_add_flow_to_github_storage():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Adds support for custom Github domains in Github storage



## Changes
<!-- What does this PR change? -->
Adds the base_url parameter in in Github storage for the pygithub library, that adds support for custom Github REST api endpoints



## Importance
<!-- Why is this PR important? -->
Adds support for custom Github domain in Github storage.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)