### PR TITLE
Pass S3 client option from storage to result

### DIFF
--- a/changes/pr4195.yaml
+++ b/changes/pr4195.yaml
@@ -1,5 +1,5 @@
 fix:
-  - "Ensure the S3 storage properly initialize the S3Result with client_option"
+  - "Forward `client_options` to `S3Result` from `S3` storage - [#4195](https://github.com/PrefectHQ/prefect/pull/4195"
 
 
 contributor:

--- a/changes/pr4195.yaml
+++ b/changes/pr4195.yaml
@@ -1,0 +1,6 @@
+fix:
+  - "Ensure the S3 storage properly initialize the S3Result with client_option"
+
+
+contributor:
+  - "[David Zucker](https://github.com/davzucky)"

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -58,7 +58,7 @@ class S3(Storage):
 
         self.client_options = client_options
 
-        result = S3Result(bucket=bucket)
+        result = S3Result(bucket=bucket, boto3_kwargs=client_options)
         super().__init__(
             result=result,
             stored_as_script=stored_as_script,

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -95,6 +95,32 @@ def test_boto3_client_property(monkeypatch):
     )
 
 
+def test_s3_storage_init_properly_result_with_boto3_args(monkeypatch):
+    client = MagicMock()
+    boto3 = MagicMock(client=MagicMock(return_value=client))
+    monkeypatch.setattr("boto3.client", boto3)
+
+    storage = S3(
+        bucket="bucket",
+        client_options={"endpoint_url": "http://some-endpoint", "use_ssl": False},
+    )
+
+    credentials = dict(
+        ACCESS_KEY="id", SECRET_ACCESS_KEY="secret", SESSION_TOKEN="session"
+    )
+    with context(secrets=dict(AWS_CREDENTIALS=credentials)):
+        result_path = storage.result.write("test")
+    assert result_path
+    boto3.assert_called_with(
+        "s3",
+        aws_access_key_id="id",
+        aws_secret_access_key="secret",
+        aws_session_token="session",
+        region_name=None,
+        endpoint_url="http://some-endpoint",
+        use_ssl=False,
+    )
+
 def test_add_flow_to_S3():
     storage = S3(bucket="bucket")
 

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -121,6 +121,7 @@ def test_s3_storage_init_properly_result_with_boto3_args(monkeypatch):
         use_ssl=False,
     )
 
+
 def test_add_flow_to_S3():
     storage = S3(bucket="bucket")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
The initialization of storage.s3 initialize as well the S3Result property for S3. however the client_options dict is not passed to the result boto3_kwargs. 

## Changes
<!-- What does this PR change? -->
Pass the property to the S3Result as below
```
result = S3Result(bucket=bucket, boto3_kwargs=client_options)
```

## Importance
<!-- Why is this PR important? -->
This is important to ensure the storage and the result are initialized with the same param when calling S3



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)