### PR TITLE
Don't forward nout in mapped tasks

### DIFF
--- a/changes/pr4206.yaml
+++ b/changes/pr4206.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Don't forward `nout` to mapped tasks - [#4206](https://github.com/PrefectHQ/prefect/pull/4206)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -711,7 +711,9 @@ class Task(metaclass=TaskMetaclass):
                         t=type(arg), preview=repr(arg)[:10]
                     )
                 )
-        new = self.copy(**(task_args or {}))
+        task_args = task_args.copy() if task_args else {}
+        task_args.setdefault("nout", None)
+        new = self.copy(**task_args)
         return new.bind(
             *args, mapped=True, upstream_tasks=upstream_tasks, flow=flow, **kwargs
         )

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -717,6 +717,15 @@ class TestTaskNout:
         assert res.result[a].result == 2
         assert res.result[b].result == 0
 
+    def test_nout_not_set_on_mapped_tasks(self):
+        @task(nout=2)
+        def test(a):
+            return a + 1, a - 1
+
+        with Flow("test"):
+            with pytest.raises(TypeError, match="Task is not iterable"):
+                a, b = test.map(range(10))
+
 
 @pytest.mark.skip("Result handlers not yet deprecated")
 def test_cache_options_show_deprecation():


### PR DESCRIPTION
Previously setting `nout` on a task would forward the `nout` to both
normal task call outputs (which we want) and mapped task outputs (which
we don't). This led some users to assume that calling `task.map` would
result in a tuple of lists of results, when the actual output is a list
of tuples.

This PR fixes this to stop propagating the `nout` field on `task.map`
calls, so the improper usage will error instead of implicitly passing.