### PR TITLE
fix: make slug_counters use partial instead of lambda

### DIFF
--- a/changes/pr4209.yaml
+++ b/changes/pr4209.yaml
@@ -1,0 +1,5 @@
+task:
+  - "fix: make slug_counters use partial instead of lambda ` - [#4209](https://github.com/PrefectHQ/prefect/pull/4209)"
+
+contributor:
+  - "[Marwan S.](https://github.com/marwan116)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -178,7 +178,7 @@ class Flow:
         self.tasks = set()  # type: Set[Task]
         self.edges = set()  # type: Set[Edge]
         self._slug_counters = collections.defaultdict(
-            functools.partial(itertools.count, firstval=1)
+            cast(Callable, functools.partial(itertools.count, firstval=1))
         )  # type: Dict[str, Iterator[int]]
         self.slugs = {}  # type: Dict[Task, str]
         self.constants = collections.defaultdict(

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -178,7 +178,7 @@ class Flow:
         self.tasks = set()  # type: Set[Task]
         self.edges = set()  # type: Set[Edge]
         self._slug_counters = collections.defaultdict(
-            cast(Callable, functools.partial(itertools.count, firstval=1))
+            cast(Callable, functools.partial(itertools.count, 1))
         )  # type: Dict[str, Iterator[int]]
         self.slugs = {}  # type: Dict[Task, str]
         self.constants = collections.defaultdict(

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -178,7 +178,7 @@ class Flow:
         self.tasks = set()  # type: Set[Task]
         self.edges = set()  # type: Set[Edge]
         self._slug_counters = collections.defaultdict(
-            lambda: itertools.count(1)
+            functools.partial(itertools.count, firstval=1)
         )  # type: Dict[str, Iterator[int]]
         self.slugs = {}  # type: Dict[Task, str]
         self.constants = collections.defaultdict(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
A simple fix swapping a lambda function by partial. This will help keep the Flow more pickle-friendly.



## Changes
<!-- What does this PR change? -->
Setting of `_slug_counters` using `partial` instead of `lambda`



## Importance
<!-- Why is this PR important? -->
This is a simple fix, but will help users that rely on using `pickle` and `prefect.Flow` 
