### PR TITLE
A few ECS agent cleanups

### DIFF
--- a/changes/pr4211.yaml
+++ b/changes/pr4211.yaml
@@ -1,2 +1,3 @@
 fix:
-  - "Move `command` and `environment` configuration for ECS tasks to runtime in the ECS agent - [#4211](https://github.com/PrefectHQ/prefect/pull/4211)"
+  - "Move `command`, `environment`, `cpu`, `memory`, `execution_role_arn`, and `task_role_arn` configuration for ECS tasks from definition time to run time in the ECS agent - [#4211](https://github.com/PrefectHQ/prefect/pull/4211)"
+  - "Register (and deregister) a new task definition for every flow run in ECS agent - [#4211](https://github.com/PrefectHQ/prefect/pull/4211)"

--- a/changes/pr4211.yaml
+++ b/changes/pr4211.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Move `command` and `environment` configuration for ECS tasks to runtime in the ECS agent - [#4211](https://github.com/PrefectHQ/prefect/pull/4211)"

--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -133,18 +133,17 @@ their respective [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run
 
 ### Execution Role ARN
 
-The following policy is the AmazonECSTaskExecutionPolicy. The execution-role-arn 
-can be used to pull the image from ECR or enable logs in CloudWatch. More information for creating this role
-can be found [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html). 
-You can configure a default execution role for tasks started by the agent using the `--execution-role-arn` option:
+ECS tasks use [execution
+roles](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
+to grant permissions to the ECS infrastructure to make AWS API calls on your
+behalf. If actions taken to *start* your task require external AWS services
+(e.g. pulling an image from ECR), you'll need to configure an execution role.
+Permissions used by your code once your task starts are granted via [task
+roles](#task-role-arn) instead (see above).
 
-```bash
-prefect agent ecs start --execution-role-arn my-execution-role-arn
-```
-
-Flows can override this agent default by passing the `execution_role_arn` option to
-their respective [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run_config`.
-
+ECS provides a builtin policy `AmazonECSTaskExecutionPolicy` that provides
+common settings.  This supports pulling images from ECR and enables using
+CloudWatch logs. The full policy is below:
 
 ```json
 {
@@ -165,6 +164,21 @@ their respective [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run
     ]
 }
 ```
+
+Usually AWS will automatically create an IAM role with this policy named
+`ecsTaskExecutionRole` (if not, you may need to create one yourself, see [the
+AWS docs for more
+info](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)).
+
+You can configure a default execution role for tasks started by the agent using
+the `--execution-role-arn` option:
+
+```bash
+prefect agent ecs start --execution-role-arn my-execution-role-arn
+```
+
+Flows can override this agent default by passing the `execution_role_arn` option to
+their respective [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run_config`.
 
 ### Custom Task Definition Template
 

--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -139,7 +139,10 @@ configured per-flow (on the
 [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run_config`), or on
 the Agent as a default for flows that don't provide their own template.
 
-Any option available to
+The flow will be executed in a container named `flow` - if a container named
+`flow` isn't part of the task definition template Prefect will add a new
+container with that name (this allows adding sidecar containers without
+requiring the user to define a `flow` container as well). Any option available to
 [`register_task_definition`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition)
 may be specified here. For reference, the default template packaged with
 Prefect can be found

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -303,6 +303,13 @@ class ECSAgent(Agent):
                 flow_run.flow.id,
             )
         else:
+            from prefect.serialization.storage import StorageSchema
+            from prefect.storage import Docker
+
+            if isinstance(StorageSchema().load(flow_run.flow.storage), Docker):
+                raise ValueError(
+                    "Cannot provide `task_definition_arn` when using `Docker` storage"
+                )
             taskdef_arn = run_config.task_definition_arn
             new_taskdef_arn = False
             self.logger.debug(

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -135,6 +135,12 @@ ecs.html#ECS.Client.run_task
                 "Can only provide one of `task_definition`, `task_definition_path`, "
                 "or `task_definition_arn`"
             )
+        if task_definition_arn is not None and image is not None:
+            raise ValueError(
+                "Cannot provide both `task_definition_arn` and `image`, since an ECS "
+                "task's `image` can only be configured as part of the task definition"
+            )
+
         if task_definition_path is not None:
             parsed = parse_path(task_definition_path)
             if parsed.scheme == "file":

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -23,10 +23,13 @@ class ECSRun(RunConfig):
 
     Args:
         - task_definition (dict, optional): An in-memory task definition spec
-            to use. See the [ECS.Client.register_task_definition][1] docs for
-            more information on task definitions. Note that this definition
-            will be stored directly in Prefect Cloud/Server - use
-            `task_definition_path` instead if you wish to avoid this.
+            to use. The flow will be executed in a container named `flow` - if
+            a container named `flow` isn't part of the task definition, Prefect
+            will add a new container with that name.  See the
+            [ECS.Client.register_task_definition][1] docs for more information
+            on task definitions. Note that this definition will be stored
+            directly in Prefect Cloud/Server - use `task_definition_path`
+            instead if you wish to avoid this.
         - task_definition_path (str, optional): Path to a task definition spec
             to use. If a local path (no file scheme, or a `file`/`local`
             scheme), the task definition will be loaded on initialization and
@@ -36,7 +39,8 @@ class ECSRun(RunConfig):
             `agent` (for paths local to the runtime agent)).
         - task_definition_arn (str, optional): A pre-registered task definition
             ARN to use (either `family`, `family:version`, or a full task
-            definition ARN).
+            definition ARN). This task definition must include a container
+            named `flow` (which will be used to run the flow).
         - image (str, optional): The image to use for this task. If not
             provided, will be either inferred from the flow's storage (if using
             `Docker` storage), or use the default configured on the agent.

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -343,45 +343,6 @@ class TestGenerateTaskDefinition:
         taskdef = self.generate_task_definition(run_config, storage)
         assert taskdef["containerDefinitions"][0]["image"] == expected
 
-    def test_generate_task_definition_resources(self):
-        taskdef = self.generate_task_definition(ECSRun(cpu="2048", memory="4096"))
-        assert taskdef["cpu"] == "2048"
-        assert taskdef["memory"] == "4096"
-
-    @pytest.mark.parametrize(
-        "on_run_config, on_agent, expected",
-        [
-            (None, None, None),
-            ("task-role-1", None, "task-role-1"),
-            (None, "task-role-2", "task-role-2"),
-            ("task-role-1", "task-role-2", "task-role-1"),
-        ],
-    )
-    def test_generate_task_definition_task_role_arn(
-        self, on_run_config, on_agent, expected
-    ):
-        taskdef = self.generate_task_definition(
-            ECSRun(task_role_arn=on_run_config), task_role_arn=on_agent
-        )
-        assert taskdef.get("taskRoleArn") == expected
-
-    @pytest.mark.parametrize(
-        "on_run_config, on_agent, expected",
-        [
-            (None, None, None),
-            ("execution-role-1", None, "execution-role-1"),
-            (None, "execution-role-2", "execution-role-2"),
-            ("execution-role-1", "execution-role-2", "execution-role-1"),
-        ],
-    )
-    def test_generate_task_definition_execution_role_arn(
-        self, on_run_config, on_agent, expected
-    ):
-        taskdef = self.generate_task_definition(
-            ECSRun(execution_role_arn=on_run_config), execution_role_arn=on_agent
-        )
-        assert taskdef.get("executionRoleArn") == expected
-
     def test_generate_task_definition_environment(self):
         run_config = ECSRun(
             image="test-image",
@@ -485,6 +446,43 @@ class TestGetRunTaskKwargs:
             "-c",
             "prefect execute flow-run",
         ]
+
+    def test_get_run_task_kwargs_resources(self):
+        kwargs = self.get_run_task_kwargs(ECSRun(cpu="2048", memory="4096"))
+        assert kwargs["overrides"]["cpu"] == "2048"
+        assert kwargs["overrides"]["memory"] == "4096"
+
+    @pytest.mark.parametrize(
+        "on_run_config, on_agent, expected",
+        [
+            (None, None, None),
+            ("task-role-1", None, "task-role-1"),
+            (None, "task-role-2", "task-role-2"),
+            ("task-role-1", "task-role-2", "task-role-1"),
+        ],
+    )
+    def test_get_task_run_kwargs_task_role_arn(self, on_run_config, on_agent, expected):
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(task_role_arn=on_run_config), task_role_arn=on_agent
+        )
+        assert kwargs["overrides"].get("taskRoleArn") == expected
+
+    @pytest.mark.parametrize(
+        "on_run_config, on_agent, expected",
+        [
+            (None, None, None),
+            ("execution-role-1", None, "execution-role-1"),
+            (None, "execution-role-2", "execution-role-2"),
+            ("execution-role-1", "execution-role-2", "execution-role-1"),
+        ],
+    )
+    def test_get_task_run_kwargs_execution_role_arn(
+        self, on_run_config, on_agent, expected
+    ):
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(execution_role_arn=on_run_config), execution_role_arn=on_agent
+        )
+        assert kwargs["overrides"].get("executionRoleArn") == expected
 
     def test_get_run_task_kwargs_environment(self, tmpdir, backend):
         path = str(tmpdir.join("kwargs.yaml"))

--- a/tests/run_configs/test_ecs.py
+++ b/tests/run_configs/test_ecs.py
@@ -106,6 +106,10 @@ def test_task_definition_arn():
     assert config.task_definition is None
     assert config.task_definition_path is None
 
+    # Can't mix `image` and `task_definition_arn`
+    with pytest.raises(ValueError, match="task_definition_arn"):
+        ECSRun(task_definition_arn="my-task-definition", image="my-image")
+
 
 def test_task_definition():
     task_definition = {


### PR DESCRIPTION
- Move `command` and `environment` for the `flow` container to be set at ECS task run time rather than as part of the task definition. This makes it simpler to provide a `task_definition_arn`, as prefect can set more of the required parameters for you.
- Improve our docs a bit on what's required for a custom task definition.