### PR TITLE
Add threaded local dask executor to timeout tests

### DIFF
--- a/changes/pr4217.yaml
+++ b/changes/pr4217.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Add test coverage for threaded `LocalDaskExecutor` timeouts - [#4217](https://github.com/PrefectHQ/prefect/pull/4217)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,12 @@ def mproc_local():
     yield LocalDaskExecutor(scheduler="processes")
 
 
+@pytest.fixture()
+def threaded_local():
+    "Multithreaded executor using local dask (not distributed cluster)"
+    yield LocalDaskExecutor(scheduler="threads")
+
+
 @pytest.fixture(scope="session")
 def mproc():
     "Multi-processing executor using dask distributed"
@@ -89,7 +95,7 @@ def mproc():
 
 
 @pytest.fixture()
-def _switch(mthread, local, sync, mproc, mproc_local):
+def _switch(mthread, local, sync, mproc, mproc_local, threaded_local):
     """
     A construct needed so we can parametrize the executor fixture.
 
@@ -97,7 +103,12 @@ def _switch(mthread, local, sync, mproc, mproc_local):
     in slightly different ways.
     """
     execs = dict(
-        mthread=mthread, local=local, sync=sync, mproc=mproc, mproc_local=mproc_local
+        mthread=mthread,
+        local=local,
+        sync=sync,
+        mproc=mproc,
+        mproc_local=mproc_local,
+        threaded_local=threaded_local,
     )
     return lambda e: execs[e]
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -3056,7 +3056,9 @@ class TestSaveLoad:
     reason="Windows doesn't support any timeout logic",
 )
 @pytest.mark.parametrize(
-    "executor", ["local", "sync", "mthread", "mproc_local", "mproc"], indirect=True
+    "executor",
+    ["local", "sync", "mthread", "mproc_local", "mproc", "threaded_local"],
+    indirect=True,
 )
 def test_timeout_actually_stops_execution(
     executor,

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -832,7 +832,9 @@ def test_flow_runner_properly_provides_context_to_task_runners(executor):
     assert res.result[tt].result[0] == "test-map"
 
 
-@pytest.mark.parametrize("executor", ["local", "mthread", "sync"], indirect=True)
+@pytest.mark.parametrize(
+    "executor", ["local", "mthread", "sync", "mproc", "threaded_local"], indirect=True
+)
 def test_flow_runner_handles_timeouts(executor):
     sleeper = SlowTask(timeout=1)
 
@@ -843,18 +845,6 @@ def test_flow_runner_handles_timeouts(executor):
     assert state.is_failed()
     assert isinstance(state.result[res], TimedOut)
     assert "timed out" in state.result[res].message
-    assert isinstance(state.result[res].result, TaskTimeoutError)
-
-
-def test_flow_runner_handles_timeout_error_with_mproc(mproc):
-    sleeper = SlowTask(timeout=1)
-
-    with Flow(name="test") as flow:
-        res = sleeper(2)
-
-    state = FlowRunner(flow=flow).run(return_tasks=[res], executor=mproc)
-    assert state.is_failed()
-    assert isinstance(state.result[res], TimedOut)
     assert isinstance(state.result[res].result, TaskTimeoutError)
 
 
@@ -1338,7 +1328,7 @@ class TestContext:
 
 
 @pytest.mark.parametrize(
-    "executor", ["local", "sync", "mproc", "mthread"], indirect=True
+    "executor", ["local", "sync", "mproc", "mthread", "threaded_local"], indirect=True
 )
 def test_task_logs_survive_if_timeout_is_used(caplog, executor):
     @prefect.task(timeout=2)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Originally created in an attempt to replicate a user's issue on Linux. The issue could not reproduced but additional executor coverage is nice and we've been seeing a lot of use of `LocalDaskExecutor` with timeouts lately.

## Changes

- Adds `threaded_local` executor fixture
- Uses executor fixture in relevant timeout tests

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)