### PR TITLE
Test and bugfix for variadic keyword-only task signature

### DIFF
--- a/changes/pr4235.yaml
+++ b/changes/pr4235.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix task signature with variadic kwargs - [#4235](https://github.com/PrefectHQ/prefect/pull/4235)"
+
+contributor:
+  - "[Ben Fogelson](https://github.com/benfogelson)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -565,12 +565,18 @@ class Task(metaclass=TaskMetaclass):
             parameters_by_kind = defaultdict(list)
             for parameter in parameters:
                 parameters_by_kind[parameter.kind].append(parameter)
-            parameters_by_kind[inspect.Parameter.KEYWORD_ONLY].extend(EXTRA_CALL_PARAMETERS)
-            
+            parameters_by_kind[inspect.Parameter.KEYWORD_ONLY].extend(
+                EXTRA_CALL_PARAMETERS
+            )
+
             ordered_parameters = []
-            ordered_kinds = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                             inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.KEYWORD_ONLY,
-                             inspect.Parameter.VAR_KEYWORD)
+            ordered_kinds = (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.VAR_KEYWORD,
+            )
             for kind in ordered_kinds:
                 ordered_parameters.extend(parameters_by_kind[kind])
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -266,7 +266,6 @@ class TestCreateTask:
         class_sig = inspect.signature(Test)
         assert "name" in class_sig.parameters
 
-
     def test_create_task_with_and_without_cache_for(self):
         t1 = Task()
         assert t1.cache_validator is never_use

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -247,7 +247,7 @@ class TestCreateTask:
 
     def test_task_signature_generation(self):
         class Test(Task):
-            def run(self, x: int, y: bool, z: int = 1):
+            def run(self, x: int, y: bool, z: int = 1, **kwargs):
                 pass
 
         t = Test()
@@ -265,6 +265,7 @@ class TestCreateTask:
         # doesn't override class signature
         class_sig = inspect.signature(Test)
         assert "name" in class_sig.parameters
+
 
     def test_create_task_with_and_without_cache_for(self):
         t1 = Task()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR fixes a bug (https://github.com/PrefectHQ/prefect/issues/4234) where task signatures could not be generated for subclasses of `Task` where `.run` includes `**kwargs`.



## Changes
This PR changes `prefect.core.Task.__signature__` to fix the bug by correctly accounting for parameter kind and order when modifying the task instance's call signature.




## Importance
`task` is a core piece of prefect's functionality, and fixing this bug is necessary for it to work as documented.




## Checklist

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)