### PR TITLE
Return flow run information in `StartFlowRun`

### DIFF
--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -82,6 +82,7 @@ class StartFlowRun(Task):
         "new_flow_context",
         "run_name",
         "scheduled_start_time",
+        "wait",
     )
     def run(
         self,
@@ -93,6 +94,7 @@ class StartFlowRun(Task):
         run_name: str = None,
         idempotency_key: str = None,
         scheduled_start_time: datetime.datetime = None,
+        wait: bool = None,
     ) -> str:
         """
         Run method for the task; responsible for scheduling the specified flow run.
@@ -116,6 +118,9 @@ class StartFlowRun(Task):
                 if this task is retried. If not provided, defaults to the active `task_run_id`.
             - scheduled_start_time (datetime, optional): the time to schedule the execution
                 for; if not provided, defaults to now
+            - wait (bool, optional): whether to wait the triggered flow run's state; if True, this
+                task will wait until the flow run is complete, and then reflect the corresponding
+                state as the state of this task.  Defaults to `False`.
 
         Returns:
             - str: the ID of the newly-scheduled flow run
@@ -190,7 +195,7 @@ class StartFlowRun(Task):
         run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
         create_link(urlparse(run_link).path)
 
-        if not self.wait:
+        if not wait:
             return flow_run_id
 
         while True:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR is a draft of returning flow run information from successful `StartFlowRun` tasks on success when `wait=True`. Previously, it would return the object `SUCCESS('<flow-run-id> finished in state <Success: "All reference tasks succeeded.">')` with no additional result / information. The `flow_run_id` cannot be retrieved without some arbitrary string parsing and this return value was undocumented. 

To prevent breaking compatibility we could try to return a `SUCCESS` state with the `result` attached as an attribute but it seems like the `Task/FlowRunner` unrolls success states into their `result` attribute if it exists.

## Changes
<!-- What does this PR change? -->

- `StartFlowRun` return type is documented with `wait` toggle
- `StartFlowRun` returns `prefect.client.client.FlowRunInfoResult`

Also a few usability fixes
- Change some logs to info
- Adds logs for subflow state changes
- Adds logs clarifying `wait` behavior
- Allows `wait` to be passed to `.run(...)`


## Importance
<!-- Why is this PR important? -->

Improves usability of `StartFlowRun` and prepares for more robust result passing.

## Future work

`FlowRunInfoResult` contains `TaskRunInfoResult` for each task in the flow which contains the task states which will hold `Result` references that can be used to retrieve persisted task results. Upgrading the `FlowRunInfoResult` from a `NamedTuple` to a class that supports `__getattr__` like task indexing may allow us to create subflow data passing patterns.

## Example

```python
from prefect import Flow, task
from prefect.client import Client
from prefect.tasks.prefect.flow_run import StartFlowRun


# Define a very simple child flow -----------------------------------------


@task(log_stdout=True)
def say_hello():
    print("Hello")
    return "Hello"


with Flow("hello-flow") as hello_flow:
    say_hello()

# Register the flow to the API
hello_flow.register("default", idempotency_key="ONLY_REGISTER_ONCE")

# A local agent will need to be started for this flow to run
run_hello_flow = StartFlowRun(flow_name="hello-flow", project_name="default")


# Define our orchestrator flow --------------------------------------------


@task(log_stdout=True)
def do_something_with_run_id(flow_run_id):
    client = Client()
    flow_info = client.get_flow_run_info(flow_run_id)
    # Here we'll have to manually wait if we want the final flow result...
    # Otherwise the flow will likely just be in a Scheduled state
    print(flow_info)


@task(log_stdout=True)
def do_something_with_run_result(flow_result):
    # Here we have the 'terminal' information about the flow if it succeeded
    # If it failed, this task will have automatically failed as its upstream
    # task will have been marked as a failure. We could change this task's
    # triggers to _always_ process the result of the flow
    for task_run in flow_result.task_runs:
        print(f"Subflow task {task_run.task_slug!r} has final state {task_run.state}")


with Flow("orchestrator") as flow:
    # A subflow that we do not wait for finish
    hello_run_id = run_hello_flow(wait=False)
    do_something_with_run_id(hello_run_id)

    # Another subflow that we wait for finish
    hello_info = run_hello_flow(wait=True, run_name="hello-with-wait")
    do_something_with_run_result(hello_info)


# Test --------------------------------------------------------------------

if __name__ == "__main__":
    # We'll run this flow locally without the agent for ease of testing
    flow.run()
```

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)