### PR TITLE
New flow registration CLI

### DIFF
--- a/changes/pr4256.yaml
+++ b/changes/pr4256.yaml
@@ -1,0 +1,9 @@
+feature:
+  - "Add new improved `prefect register` CLI command. This command supports
+     registering multiple flows at once (through multiple file paths or
+     directories), and also includes a new `--watch` flag for watching files
+     and automatically re-registering upon
+     changes. - [#4256](https://github.com/PrefectHQ/prefect/pull/4256)"
+
+deprecation:
+  - "Deprecate the old `prefect register flow` CLI command in favor of `prefect register` - [#4256](https://github.com/PrefectHQ/prefect/pull/4256)"

--- a/docs/core/idioms/script-based.md
+++ b/docs/core/idioms/script-based.md
@@ -82,9 +82,14 @@ Now that the file exists on the repo the flow needs to be registered with a Pref
 Core's server or Prefect Cloud).
 
 ```bash
-prefect register flow -f flows/my_flow.py -p MyProject
-Result check: OK
-Flow: http://localhost:8080/flow/9f5f7bea-186e-44d1-a746-417239663614
+$ prefect register -p flows/my_flow.py --project MyProject
+Collecting flows...
+Processing 'flows/my_flow.py':
+  Building `GitHub` storage...
+  Registering 'example'... Done
+  └── ID: c0dabf5a-4234-431b-8cc1-dbb6f3d6546d
+  └── Version: 1
+======================== 1 registered ========================
 ```
 
 The flow is ready to run! Every time you need to change the code inside your flow's respective tasks all
@@ -196,8 +201,8 @@ flow.storage = GCS(
 ```
 
 The script location can also be provided when registering the flow through the
-[`register`](/api/latest/cli/register.html) CLI command through the `--file/-f` option:
+[`register`](/api/latest/cli/register.html) CLI command through the `--path/-p` option:
 
 ```bash
-prefect register flow -f my_flow.py -p MyProject
+prefect register -p my_flow.py --project MyProject
 ```

--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -4,12 +4,32 @@ Flows can be registered with the Prefect API for scheduling and execution, as we
 
 ## Registration
 
+### CLI
+
+To register a flow (or flows) with the `prefect` cli, you can use the [prefect
+register](/api/latest/cli/register.md#register) command.
+
+```bash
+$ prefect register --project "my project" --path myflow.py
+```
+
+By default this will register all flows found in `myflow.py`. If you want to
+select a specific flow, you can use the `--name` flag:
+
+```bash
+$ prefect register --project "my project" --path myflow.py --name "my flow's name"
+```
+
+The CLI command supports several additional options, see the
+[docs](/api/latest/cli/register.md#register) for more information.
+
+
 ### Core Client
 
 To register a flow from Prefect Core, use its `register()` method:
 
 ```python
-flow.register(project_name="Hello, World!")
+flow.register(project_name="my project")
 ```
 
 :::warning Projects

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -61,7 +61,7 @@ commands = ["flows", "tasks", "projects", "flow_runs", "logs"]
 [pages.cli.register]
 title = "register"
 module = "prefect.cli.register"
-commands = ["flow"]
+commands = ["register"]
 
 [pages.cli.run]
 title = "run"

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -411,7 +411,28 @@ def watch_for_changes(
         time.sleep(period)
 
 
-@click.group(invoke_without_command=True)
+REGISTER_EPILOG = """
+\bExamples:
+
+\b  Register all flows found in a directory.
+
+\b    $ prefect register --project my-project -p myflows/
+
+\b  Register a flow named "example" found in `flow.py`.
+
+\b    $ prefect register --project my-project -p flow.py -n "example"
+
+\b  Register all flows found in a module named `myproject.flows`.
+
+\b    $ prefect register --project my-project -m "myproject.flows"
+
+\b  Watch a directory of flows for changes, and re-register flows upon change.
+
+\b    $ prefect register --project my-project -p myflows/ --watch
+"""
+
+
+@click.group(invoke_without_command=True, epilog=REGISTER_EPILOG)
 @click.option(
     "--project",
     help="The name of the Prefect project to register this flow in. Required.",
@@ -477,7 +498,7 @@ def watch_for_changes(
 )
 @click.pass_context
 def register(ctx, project, paths, modules, names, labels, force, watch):
-    """Register one or more flows into a project"""
+    """Register one or more flows into a project."""
     # Since the old command was a subcommand of this, we have to do some
     # mucking to smoothly deprecate it. Can be removed with `prefect register
     # flow` is removed.

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -1,34 +1,99 @@
 import os
 
 import click
+from click.exceptions import ClickException
 
 import prefect
 from prefect.utilities.storage import extract_flow_from_file
 
 
-@click.group(hidden=True)
-def register():
-    """
-    Register flows
-
-    \b
-    Usage:
-        $ prefect register [OBJECT]
-
-    \b
-    Arguments:
-        flow    Register flows with a backend API
-
-    \b
-    Examples:
-        $ prefect register flow --file my_flow.py --name My-Flow
-    """
+def register_flows(
+    project, paths=None, modules=None, names=None, labels=None, force=False
+):
+    # TODO
+    pass
 
 
-@register.command(
+@click.group(invoke_without_command=True)
+@click.option(
+    "--project",
+    help="The name of the Prefect project to register this flow in. Required.",
+    default=None,
     hidden=True,
-    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
 )
+@click.option(
+    "--path",
+    "-p",
+    "paths",
+    help=(
+        "A path to a file or a directory containing the flow(s) to register. "
+        "May be passed multiple times to specify multiple paths to register."
+    ),
+    default=None,
+    multiple=True,
+)
+@click.option(
+    "--module",
+    "-m",
+    "modules",
+    help=(
+        "A python module name containing the flow(s) to register. May be "
+        "passed multiple times to specify multiple modules to register."
+    ),
+    default=None,
+    multiple=True,
+)
+@click.option(
+    "--name",
+    "-n",
+    "names",
+    help=(
+        "The name of a flow to register from the specified paths/modules. If "
+        "provided, only flows with a matching name will be registered. May be "
+        "passed multiple times to specify multiple flows to register. If not "
+        "provided, all flows found on all paths/modules will be registered."
+    ),
+    default=None,
+    multiple=True,
+)
+@click.option(
+    "--label",
+    "-l",
+    "labels",
+    help=(
+        "A label to add on all registered flow(s). May be passed multiple "
+        "times to specify multiple labels."
+    ),
+    default=None,
+    multiple=True,
+)
+@click.option(
+    "--force",
+    "-f",
+    help="Force flow registration, even if the flow's metadata is unchanged.",
+    default=False,
+    is_flag=True,
+)
+@click.pass_context
+def register(ctx, project, paths, modules, names, labels, force):
+    """Register one or more flows into a project"""
+    # Since the old command was a subcommand of this, we have to do some
+    # mucking to smoothly deprecate it. Can be removed with `prefect register
+    # flow` is removed.
+    if ctx.invoked_subcommand is not None:
+        if any([project, paths, modules, names, labels, force]):
+            raise ClickException(
+                "Got unexpected extra argument (%s)" % ctx.invoked_subcommand
+            )
+        return
+
+    if project is None:
+        raise ClickException("Missing required option '--project'")
+
+    register_flows(project, paths, modules, names, labels, force)
+
+
+@register.command(hidden=True)
 @click.option(
     "--file",
     "-f",
@@ -58,6 +123,7 @@ def register():
     "--label",
     "-l",
     required=False,
+    help="A label to set on the flow, extending any existing labels.",
     hidden=True,
     multiple=True,
 )
@@ -68,26 +134,15 @@ def register():
     hidden=True,
 )
 def flow(file, name, project, label, skip_if_flow_metadata_unchanged):
-    """
-    Register a flow from a file. This call will pull a Flow object out of a `.py` file
-    and call `flow.register` on it.
-
-    \b
-    Options:
-        --file, -f      TEXT    The path to a local file which contains a flow  [required]
-        --name, -n      TEXT    The `flow.name` to pull out of the file provided. If a name
-                                is not provided then the first flow object found will be registered.
-        --project, -p   TEXT    The name of a Prefect project to register this flow
-        --label, -l     TEXT    A label to set on the flow, extending any existing labels.
-                                Multiple labels are supported, eg. `-l label1 -l label2`.
-
-        --skip-if-flow-metadata-unchanged       If set, the flow will only be re-registered if its
-                                                metadata or structure has changed.
-
-    \b
-    Examples:
-        $ prefect register flow --file my_flow.py --name My-Flow -l label1 -l label2
-    """
+    """Register a flow (DEPRECATED)"""
+    click.secho(
+        (
+            "Warning: `prefect register flow` is deprecated, please transition to "
+            "using `prefect register` instead."
+        ),
+        fg="yellow",
+        err=True,
+    )
     # Don't run extra `run` and `register` functions inside file
     file_path = os.path.abspath(file)
     with prefect.context({"loading_flow": True, "local_script_path": file_path}):

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -1,9 +1,9 @@
 import os
-import inspect
 import importlib
 import multiprocessing
 import sys
 import time
+import traceback
 from typing import NamedTuple
 
 import click
@@ -14,100 +14,186 @@ from prefect.utilities.storage import extract_flow_from_file
 
 
 class Source(NamedTuple):
-    path: str
-    mtime: float
-    module: str = None
+    location: str
+    is_module: bool = False
 
 
-def collect_flows_from_paths(paths):
-    from prefect.storage import Local
+def get_module_paths(modules):
+    out = []
+    for name in modules:
+        try:
+            spec = importlib.util.find_spec(name)
+        except Exception as exc:
+            click.secho(f"Error loading module {name}:", fg="yellow")
+            log_exception(exc, indent=2)
+            return None
+        if spec is None:
+            click.secho(f"No module named {name!r}", fg="yellow")
+            return None
+        else:
+            out.append(spec.origin)
 
+
+def expand_paths(paths):
     paths = list(paths)
-    sources = []
-    flows = {}
+    out = []
     for path in paths:
         path = os.path.abspath(path)
         if not os.path.exists(path):
-            raise ValueError(f"Path {path!r} doesn't exist")
+            click.secho(f"Path {path!r} doesn't exist", fg="yellow")
+            sys.exit(1)
         elif os.path.isdir(path):
             with os.scandir(path) as directory:
-                sources.extend(
-                    Source(e.path, e.stat().st_mtime)
-                    for e in directory
-                    if e.is_file() and e.path.endswith(".py")
+                out.extend(
+                    e.path for e in directory if e.is_file() and e.path.endswith(".py")
                 )
         else:
-            sources.append(Source(path, os.stat(path).st_mtime))
+            out.append(path)
+    return out
 
-    for source in sources:
-        with open(source.path, "rb") as fil:
-            contents = fil.read()
 
-        ns = {}
-        with prefect.context({"loading_flow": True, "local_script_path": source.path}):
+def load_flows_from_path(path):
+    from prefect.storage import Local
+
+    with open(path, "rb") as fil:
+        contents = fil.read()
+
+    ns = {}
+    try:
+        with prefect.context({"loading_flow": True, "local_script_path": path}):
             exec(contents, ns)
+    except Exception as exc:
+        click.secho(f"Error loading {path!r}:", fg="yellow")
+        log_exception(exc, 2)
+        return None
 
-        new_flows = [f for f in ns.values() if isinstance(f, prefect.Flow)]
-        if new_flows:
-            storage = Local(path=source.path, stored_as_script=True)
-            for f in new_flows:
-                if f.storage is None:
-                    f.storage = storage
-        flows[source] = new_flows
-
+    flows = [f for f in ns.values() if isinstance(f, prefect.Flow)]
+    if flows:
+        storage = Local(path=path, stored_as_script=True)
+        for f in flows:
+            if f.storage is None:
+                f.storage = storage
     return flows
 
 
-def collect_flows_from_modules(modules):
+def load_flows_from_module(name):
     from prefect.storage import Module
 
-    flows = {}
-    for name in modules:
+    try:
         with prefect.context({"loading_flow": True}):
             mod = importlib.import_module(name)
-        path = inspect.getsourcefile(mod)
-        mtime = os.stat(path).st_mtime
-        new_flows = [f for f in vars(mod).values() if isinstance(f, prefect.Flow)]
-        if new_flows:
-            storage = Module(name)
-            for f in new_flows:
-                if f.storage is None:
-                    f.storage = storage
-        flows[Source(path, mtime, name)] = new_flows
+    except Exception as exc:
+        if isinstance(exc, ImportError) and repr(name) in str(exc):
+            click.secho(str(exc), fg="yellow")
+        else:
+            click.secho(f"Error loading {name!r}:", fg="yellow")
+            log_exception(exc, 2)
+        return None
+
+    flows = [f for f in vars(mod).values() if isinstance(f, prefect.Flow)]
+    if flows:
+        storage = Module(name)
+        for f in flows:
+            if f.storage is None:
+                f.storage = storage
     return flows
 
 
-def register_flows(
+def collect_flows(paths, modules, in_watch=False):
+    sources = [Source(p, False) for p in paths]
+    sources.extend(Source(m, True) for m in modules)
+
+    out = {}
+    for s in sources:
+        if s.is_module:
+            flows = load_flows_from_module(s.location)
+        else:
+            flows = load_flows_from_path(s.location)
+        if flows is None:
+            if not in_watch:
+                sys.exit(1)
+        else:
+            out[s] = flows
+    return out
+
+
+def log_exception(exc, indent=0):
+    prefix = " " * indent
+    lines = traceback.format_exception(
+        type(exc), exc, getattr(exc, "__traceback__", None)
+    )
+    click.echo("\n".join(prefix + l for l in lines))
+
+
+def add_labels(flows, labels=None):
+    from prefect.run_configs import UniversalRun
+
+    labels = set(labels or ())
+
+    for flow in flows:
+        if flow.run_config is None:
+            if flow.environment is not None:
+                flow.environment.labels.update(labels)
+            else:
+                flow.run_config = UniversalRun(labels=labels)
+        else:
+            flow.run_config.labels.update(labels)
+
+
+def build_storage(flows):
+    for flow in flows:
+        flow.storage.add_flow(flow)
+    built = set()
+    for flow in flows:
+        if flow.storage not in built:
+            click.echo(
+                f"  Building `{type(flow.storage).__name__}` storage...", nl=False
+            )
+            try:
+                flow.storage.build()
+                built.add(flow.storage)
+            except Exception as exc:
+                click.secho(" Error", fg="red")
+                log_exception(exc, indent=4)
+                return False
+            else:
+                click.secho(" Done", fg="green")
+    return True
+
+
+def register_flows(flows, project, force=False):
+    for flow in flows:
+        click.echo(f"  Registering {flow.name!r}...", nl=False)
+        try:
+            flow.register(
+                project_name=project,
+                build=False,
+                no_url=True,
+                idempotency_key=(None if force else flow.serialized_hash()),
+            )
+        except Exception as exc:
+            click.secho(" Error", fg="red")
+            log_exception(exc, indent=4)
+            return False
+        else:
+            click.secho(" Done", fg="green")
+    return True
+
+
+def register_flows_once(
     project,
     paths=None,
     modules=None,
     names=None,
     labels=None,
     force=False,
+    in_watch=False,
 ):
-    from prefect.run_configs import UniversalRun
-
     click.echo("Collecting flows...")
-    source_to_flows = {}
-    if paths:
-        source_to_flows.update(collect_flows_from_paths(paths))
-    if modules:
-        source_to_flows.update(collect_flows_from_modules(modules))
+    source_to_flows = collect_flows(paths, modules, in_watch)
 
-    # Ensure flow names are all unique
-    seen = set()
-    for flows in source_to_flows.values():
-        for flow in flows:
-            if flow.name in seen:
-                click.secho(
-                    f"Error: Multiple flows named {flow.name} found", fg="yellow"
-                )
-                sys.exit(1)
-            seen.add(flow.name)
-
-    names = set(names or ())
+    # Filter flows by name if requested
     if names:
-        # Filter by name
         source_to_flows = {
             source: [f for f in flows if f.name in names]
             for source, flows in source_to_flows.items()
@@ -117,49 +203,31 @@ def register_flows(
         )
         if missing:
             missing_flows = "\n".join(f"- {n}" for n in sorted(missing))
-            click.secho(f"Failed to find the following flows:\n{missing_flows}")
-            sys.exit(1)
-
-    n_flows = sum(map(len, source_to_flows.values()))
-    click.echo(f"Found {n_flows} flows to register")
-
-    for source, flows in source_to_flows.items():
-        if not flows:
-            continue
-
-        click.echo(f"Processing {(source.module or source.path)!r}:")
-
-        for flow in flows:
-            # Add labels and add flow to storage
-            if flow.run_config is None:
-                if flow.environment is not None:
-                    flow.environment.labels.update(labels)
-                else:
-                    flow.run_config = UniversalRun(labels=labels)
-            else:
-                flow.run_config.labels.update(labels)
-
-            flow.storage.add_flow(flow)
-
-        built = set()
-        for flow in flows:
-            if flow.storage not in built:
-                click.echo(
-                    f"  Building `{type(flow.storage).__name__}` storage...", nl=False
-                )
-                flow.storage.build()
-                built.add(flow.storage)
-                click.secho(" Done", fg="green")
-            click.echo(f"  Registering {flow.name!r}...", nl=False)
-            flow.register(
-                project_name=project,
-                build=False,
-                no_url=True,
-                idempotency_key=(None if force else flow.serialized_hash()),
+            click.secho(
+                f"Failed to find the following flows:\n{missing_flows}", fg="yellow"
             )
-            click.secho(" Done", fg="green")
+            if not in_watch:
+                sys.exit(1)
 
-    return list(source_to_flows)
+    # Iterate through each file, building all storage and registering all flows
+    # Log errors as they happen, but only exit once all files have been processed
+    ok = True
+    for source, flows in source_to_flows.items():
+        if flows:
+            click.echo(f"Processing {source.location!r}:")
+
+            add_labels(flows, labels)
+
+            if not build_storage(flows):
+                ok = False
+                continue
+
+            if not register_flows(flows, project, force=True):
+                ok = False
+                continue
+
+    if not in_watch and not ok:
+        sys.exit(1)
 
 
 def register_flows_watch(
@@ -173,58 +241,76 @@ def register_flows_watch(
     paths = list(paths or ())
     modules = list(modules or ())
 
-    with multiprocessing.Pool(1, maxtasksperchild=1) as pool:
-        sources = pool.apply(
-            register_flows,
-            (project,),
-            dict(paths=paths, modules=modules, names=names, labels=labels, force=force),
-        )
-        tracked = [os.path.abspath(p) for p in paths]
-        tracked.extend(s.path for s in sources if s.module)
-        cache = {s.path: s for s in sources}
-        click.echo("")
-        while True:
-            time.sleep(1)
+    for path in paths:
+        if not os.path.exists(path):
+            click.secho(f"Path {path!r} doesn't exist", fg="yellow")
+            sys.exit(1)
 
-            call_paths = []
-            call_mods = []
-            for path in tracked:
+    ctx = multiprocessing.get_context("spawn")
+
+    if modules:
+        # If modules are provided, we need to convert these to paths to watch.
+        # There's no way in Python to do this without possibly importing the
+        # defining module. As such, we run the command in a temporary process
+        # pool.
+        with ctx.Pool(1) as pool:
+            module_paths = pool.apply(get_module_paths, (modules,))
+            if module_paths is None:
+                sys.exit(1)
+    else:
+        module_paths = []
+
+    tracked = paths + module_paths
+    cache = {p: (m, None) for p, m in zip(module_paths, modules)}
+    while True:
+        cache2 = {}
+        for path in tracked:
+            try:
                 try:
                     with os.scandir(path) as directory:
                         for entry in directory:
                             if entry.is_file() and entry.path.endswith(".py"):
-                                source = cache.get(entry.path)
-                                if (
-                                    source is None
-                                    or entry.stat().st_mtime != source.mtime
-                                ):
-                                    call_paths.append(entry.path)
-                except FileNotFoundError:
-                    cache.pop(path, None)
+                                module, old_mtime = cache.get(entry.path, (None, None))
+                                mtime = entry.stat().st_mtime
+                                if mtime != old_mtime:
+                                    cache2[entry.path] = (module, mtime)
                 except NotADirectoryError:
-                    source = cache.get(path)
-                    if source is None:
-                        call_paths.append(path)
-                    elif os.stat(path).st_mtime != source.mtime:
-                        if source.module:
-                            call_mods.append(source.module)
-                        else:
-                            call_paths.append(path)
+                    module, old_mtime = cache.get(path, (None, None))
+                    mtime = os.stat(path).st_mtime
+                    if mtime != old_mtime:
+                        cache2[path] = (module, mtime)
+            except FileNotFoundError:
+                cache.pop(path)
 
-            if call_paths or call_mods:
-                sources = pool.apply(
-                    register_flows,
-                    (project,),
-                    dict(
-                        paths=call_paths,
-                        modules=call_mods,
+        if cache2:
+            change_paths = []
+            change_mods = []
+            for p, (m, _) in cache2.items():
+                if m is None:
+                    change_paths.append(p)
+                else:
+                    change_mods.append(m)
+
+            if change_paths or change_mods:
+                proc = ctx.Process(
+                    target=register_flows_once,
+                    name="prefect-register",
+                    args=(project,),
+                    kwargs=dict(
+                        paths=change_paths,
+                        modules=change_mods,
                         names=names,
                         labels=labels,
                         force=force,
+                        in_watch=True,
                     ),
+                    daemon=True,
                 )
-                cache.update({s.path: s for s in sources})
-                click.echo("")
+                proc.start()
+                proc.join()
+                cache.update(cache2)
+
+        time.sleep(0.5)
 
 
 @click.group(invoke_without_command=True)
@@ -312,8 +398,15 @@ def register(ctx, project, paths, modules, names, labels, force, watch):
     if project is None:
         raise ClickException("Missing required option '--project'")
 
-    func = register_flows_watch if watch else register_flows
-    func(project, paths, modules, names, labels, force)
+    paths = list(paths or ())
+    modules = list(modules or ())
+    names = set(names or ())
+
+    if watch:
+        register_flows_watch(project, paths, modules, names, labels, force)
+    else:
+        paths = expand_paths(paths)
+        register_flows_once(project, paths, modules, names, labels, force)
 
 
 @register.command(hidden=True)
@@ -364,7 +457,6 @@ def flow(file, name, project, label, skip_if_flow_metadata_unchanged):
             "using `prefect register` instead."
         ),
         fg="yellow",
-        err=True,
     )
     # Don't run extra `run` and `register` functions inside file
     file_path = os.path.abspath(file)

--- a/src/prefect/cli/register.py
+++ b/src/prefect/cli/register.py
@@ -71,16 +71,16 @@ def load_flows_from_path(path: str) -> "List[prefect.Flow]":
     with open(path, "rb") as fil:
         contents = fil.read()
 
-    ns = {}
+    namespace = {}
     try:
         with prefect.context({"loading_flow": True, "local_script_path": path}):
-            exec(contents, ns)
+            exec(contents, namespace)
     except Exception as exc:
         click.secho(f"Error loading {path!r}:", fg="red")
         log_exception(exc, 2)
         raise TerminalError
 
-    flows = [f for f in ns.values() if isinstance(f, prefect.Flow)]
+    flows = [f for f in namespace.values() if isinstance(f, prefect.Flow)]
     if flows:
         for f in flows:
             if f.storage is None:

--- a/src/prefect/storage/_healthcheck.py
+++ b/src/prefect/storage/_healthcheck.py
@@ -66,7 +66,7 @@ def import_flow_from_script_check(flow_file_paths: list):
     return flows
 
 
-def result_check(flows: list):
+def result_check(flows: list, quiet=False):
     for flow in flows:
         if flow.result is not None:
             continue
@@ -112,7 +112,8 @@ def result_check(flows: list):
                     f"more details.",
                     stacklevel=2,
                 )
-    print("Result check: OK")
+    if not quiet:
+        print("Result check: OK")
 
 
 def environment_dependency_check(flows: list):

--- a/src/prefect/storage/base.py
+++ b/src/prefect/storage/base.py
@@ -151,4 +151,4 @@ class Storage(metaclass=ABCMeta):
         if not hasattr(self, "_flows"):
             return
 
-        _healthcheck.result_check(self._flows.values())  # type: ignore
+        _healthcheck.result_check(self._flows.values(), quiet=True)  # type: ignore

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -108,9 +108,11 @@ def register_flow_errors_if_pass_options_to_register_group():
 class TestWatchForChanges:
     def test_errors_path_does_not_exist(self, tmpdir):
         missing = str(tmpdir.join("not-real"))
-        with pytest.raises(TerminalError, match=missing):
+        with pytest.raises(TerminalError) as exc:
             for _, _ in watch_for_changes(paths=[missing]):
                 assert False, "Should never get here"
+
+        assert missing in str(exc)
 
     def test_errors_module_does_not_exist(self):
         name = "not_a_real_module_name"
@@ -220,7 +222,7 @@ class TestRegister:
         assert flows["f2"].storage.path == path
         assert flows["f2"].storage.stored_as_script
 
-    def test_load_from_flows_error(self, tmpdir, capsys):
+    def test_load_flows_from_path_error(self, tmpdir, capsys):
         path = str(tmpdir.join("test.py"))
         with open(path, "w") as f:
             f.write("raise ValueError('oh no!')")
@@ -230,7 +232,7 @@ class TestRegister:
 
         out, _ = capsys.readouterr()
         assert "oh no!" in out
-        assert path in out
+        assert repr(path) in out
 
     def test_load_flows_from_module(self, tmpdir, monkeypatch):
         monkeypatch.syspath_prepend(str(tmpdir))
@@ -441,7 +443,7 @@ class TestRegister:
 
         # Bulk of the output is tested elsewhere, only a few smoketests here
         assert "Building `Local` storage..." in result.stdout
-        assert path in result.stdout
+        assert repr(path) in result.stdout
         if len(names) == 2:
             assert (
                 "================== 1 registered, 1 skipped =================="

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -1,12 +1,25 @@
 import os
 import threading
+import textwrap
 from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
 
+from prefect import Flow
 from prefect.cli import cli
-from prefect.cli.register import TerminalError, watch_for_changes
+from prefect.cli.register import (
+    TerminalError,
+    watch_for_changes,
+    load_flows_from_path,
+    load_flows_from_module,
+    build_and_register,
+)
+from prefect.engine.results import LocalResult
+from prefect.environments.execution import LocalEnvironment
+from prefect.run_configs import UniversalRun
+from prefect.storage import S3, Local, Module
+from prefect.utilities.graphql import GraphQLResult
 
 
 def test_register_flow_help():
@@ -78,7 +91,18 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
     else:
         assert flow.run_config.labels == {*labels}
 
+    assert "Warning: `prefect register flow` is deprecated" in result.stdout
     assert result.exit_code == 0
+
+
+def register_flow_errors_if_pass_options_to_register_group():
+    """Since we deprecated a subcommand, we need to manually check that
+    subcommand options are valid"""
+    result = CliRunner().invoke(
+        cli, ["register", "--project", "my-project", "flow", "--file", "some_path.py"]
+    )
+    assert result.exit_code == 1
+    assert "Got unexpected extra argument (flow)" in result.stdout
 
 
 class TestWatchForChanges:
@@ -171,3 +195,319 @@ class TestWatchForChanges:
         mod2.setmtime()
         paths, mods = next(iterator)
         assert set(mods) == {"module1", "module2"}
+
+
+class TestRegister:
+    def test_load_flows_from_path(self, tmpdir):
+        path = str(tmpdir.join("test.py"))
+        source = textwrap.dedent(
+            """
+            from prefect import Flow
+            from prefect.storage import S3
+            f1 = Flow("f1")
+            f1.storage = S3("my-bucket", key="my-key", stored_as_script=True)
+            f2 = Flow("f2")
+            """
+        )
+        with open(path, "w") as f:
+            f.write(source)
+
+        flows = {f.name: f for f in load_flows_from_path(path)}
+        assert len(flows) == 2
+        assert isinstance(flows["f1"].storage, S3)
+        assert flows["f1"].storage.local_script_path == path
+        assert isinstance(flows["f2"].storage, Local)
+        assert flows["f2"].storage.path == path
+        assert flows["f2"].storage.stored_as_script
+
+    def test_load_from_flows_error(self, tmpdir, capsys):
+        path = str(tmpdir.join("test.py"))
+        with open(path, "w") as f:
+            f.write("raise ValueError('oh no!')")
+
+        with pytest.raises(TerminalError):
+            load_flows_from_path(path)
+
+        out, _ = capsys.readouterr()
+        assert "oh no!" in out
+        assert path in out
+
+    def test_load_flows_from_module(self, tmpdir, monkeypatch):
+        monkeypatch.syspath_prepend(str(tmpdir))
+        source = textwrap.dedent(
+            """
+            from prefect import Flow
+            from prefect.storage import Module
+            f1 = Flow("f1")
+            f1.storage = Module("mymodule.submodule")
+            f2 = Flow("f2")
+            """
+        )
+        path = tmpdir.join("mymodule.py")
+        path.write(source)
+
+        flows = {f.name: f for f in load_flows_from_module("mymodule")}
+        assert len(flows) == 2
+        assert isinstance(flows["f1"].storage, Module)
+        assert flows["f1"].storage.module == "mymodule.submodule"
+        assert isinstance(flows["f2"].storage, Module)
+        assert flows["f2"].storage.module == "mymodule"
+
+    def test_load_flows_from_module_not_found_error(self, tmpdir, monkeypatch, capsys):
+        monkeypatch.syspath_prepend(str(tmpdir))
+        tmpdir.join("mymodule1.py").ensure(file=True)
+        tmpdir.join("mymodule2.py").write("raise ValueError('oh no!')")
+
+        with pytest.raises(TerminalError, match="No module named 'mymodule3'"):
+            load_flows_from_module("mymodule3")
+
+        with pytest.raises(TerminalError, match="No module named 'mymodule3'"):
+            load_flows_from_module("mymodule3.submodule")
+
+        with pytest.raises(
+            TerminalError, match="No module named 'mymodule1.submodule'"
+        ):
+            load_flows_from_module("mymodule1.submodule")
+
+        with pytest.raises(TerminalError):
+            load_flows_from_module("mymodule2")
+
+        out, _ = capsys.readouterr()
+        assert "oh no!" in out
+        assert "Error loading 'mymodule2'" in out
+
+    @pytest.mark.parametrize("force", [False, True])
+    def test_build_and_register(self, capsys, monkeypatch, force):
+        """Build and register a few flows:
+        - 1 new flow
+        - 1 updated flow
+        - 1 skipped flow
+        - 1 error during registration
+        - 2 sharing the same storage (which fails to build properly)
+        """
+        build_call_count = 0
+
+        class MyModule(Module):
+            def build(self):
+                nonlocal build_call_count
+                build_call_count += 1
+
+        class BadStorage(Module):
+            def build(self):
+                raise ValueError("whoops!")
+
+        client = MagicMock()
+        client.graphql.side_effect = [
+            GraphQLResult({"data": {"flow": []}}),
+            GraphQLResult({"data": {"flow": [{"id": "old-id-2", "version": 1}]}}),
+            GraphQLResult({"data": {"flow": [{"id": "old-id-3", "version": 2}]}}),
+            GraphQLResult({"data": {"flow": [{"id": "old-id-4", "version": 3}]}}),
+        ]
+        client.register.side_effect = [
+            "new-id-1",
+            "old-id-2",
+            "new-id-3",
+            ValueError("Oh no!"),
+        ]
+
+        storage1 = MyModule("testing")
+        storage1.result = LocalResult()
+        flow1 = Flow("flow 1", storage=storage1, run_config=UniversalRun(labels=["a"]))
+        flow2 = Flow(
+            "flow 2",
+            storage=MyModule("testing"),
+            environment=LocalEnvironment(labels=["a"]),
+        )
+        storage2 = MyModule("testing")
+        flow3 = Flow("flow 3", storage=storage2)
+        flow4 = Flow("flow 4", storage=storage2)
+        storage3 = BadStorage("testing")
+        flow5 = Flow("flow 5", storage=storage3)
+        flow6 = Flow("flow 6", storage=storage3)
+        flows = [flow1, flow2, flow3, flow4, flow5, flow6]
+
+        stats = build_and_register(
+            client, flows, "testing", labels=["b", "c"], force=force
+        )
+
+        # 3 calls (one for each unique `MyModule` storage object)
+        assert build_call_count == 3
+
+        # 4 register calls (6 - 2 that failed to build storage)
+        assert client.register.call_count == 4
+        for flow, (args, kwargs) in zip(flows, client.register.call_args_list):
+            assert not args
+            assert kwargs["flow"] is flow
+            assert kwargs["project_name"] == "testing"
+            assert kwargs["build"] is False
+            assert kwargs["no_url"] is True
+            if force:
+                assert kwargs["idempotency_key"] is None
+            else:
+                assert kwargs["idempotency_key"]
+
+        # Stats are recorded properly
+        assert dict(stats) == {"registered": 2, "skipped": 1, "errored": 3}
+
+        # Flows are properly configured
+        assert flow1.result is storage1.result
+        assert flow1.run_config.labels == {"a", "b", "c"}
+        assert flow2.environment.labels == {"a", "b", "c"}
+        assert isinstance(flow3.run_config, UniversalRun)
+        assert flow3.run_config.labels == {"b", "c"}
+        assert isinstance(flow4.run_config, UniversalRun)
+        assert flow4.run_config.labels == {"b", "c"}
+
+        # The output contains a traceback, which will vary between machines
+        # We only check that the following fixed sections exist in the output
+        parts = [
+            (
+                "  Building `MyModule` storage...\n"
+                "  Registering 'flow 1'... Done\n"
+                "  └── ID: new-id-1\n"
+                "  └── Version: 1\n"
+                "  Building `MyModule` storage...\n"
+                "  Registering 'flow 2'... Skipped\n"
+                "  Building `MyModule` storage...\n"
+                "  Registering 'flow 3'... Done\n"
+                "  └── ID: new-id-3\n"
+                "  └── Version: 3\n"
+                "  Registering 'flow 4'... Error\n"
+                "    Traceback (most recent call last):\n"
+            ),
+            (
+                "    ValueError: Oh no!\n"
+                "\n"
+                "  Building `BadStorage` storage...\n"
+                "    Error building storage:\n"
+                "      Traceback (most recent call last):\n"
+            ),
+            (
+                "      ValueError: whoops!\n"
+                "\n"
+                "  Registering 'flow 5'... Error\n"
+                "  Registering 'flow 6'... Error\n"
+            ),
+        ]
+        out, err = capsys.readouterr()
+        assert not err
+        for part in parts:
+            assert part in out
+
+    @pytest.mark.parametrize("force", [False, True])
+    @pytest.mark.parametrize("names", [[], ["flow 1"]])
+    def test_register_cli(self, tmpdir, monkeypatch, force, names):
+        path = str(tmpdir.join("test.py"))
+        source = textwrap.dedent(
+            """
+            from prefect import Flow
+
+            flow1 = Flow("flow 1")
+            flow2 = Flow("flow 2")
+            """
+        )
+        with open(path, "w") as f:
+            f.write(source)
+
+        client = MagicMock()
+        client.graphql.side_effect = [
+            GraphQLResult({"data": {"flow": []}}),
+            GraphQLResult({"data": {"flow": [{"id": "old-id-2", "version": 1}]}}),
+        ]
+        client.register.side_effect = ["new-id-1", "old-id-2"]
+        monkeypatch.setattr("prefect.Client", MagicMock(return_value=client))
+
+        cmd = ["register", "--project", "testing", "--path", path, "-l", "a", "-l", "b"]
+        if force:
+            cmd.append("--force")
+        for name in names:
+            cmd.extend(["--name", name])
+        result = CliRunner().invoke(cli, cmd)
+
+        assert result.exit_code == 0
+        if not names:
+            names = ["flow 1", "flow 2"]
+
+        assert client.register.call_count == len(names)
+        for args, kwargs in client.register.call_args_list:
+            assert not args
+            assert kwargs["project_name"] == "testing"
+            assert kwargs["flow"].name in names
+            assert kwargs["flow"].run_config.labels == {"a", "b"}
+            if force:
+                assert kwargs["idempotency_key"] is None
+            else:
+                assert kwargs["idempotency_key"]
+
+        # Bulk of the output is tested elsewhere, only a few smoketests here
+        assert "Building `Local` storage..." in result.stdout
+        assert path in result.stdout
+        if len(names) == 2:
+            assert (
+                "================== 1 registered, 1 skipped =================="
+                in result.stdout
+            )
+        else:
+            assert (
+                "======================== 1 registered ========================"
+                in result.stdout
+            )
+
+    def test_register_cli_name_not_found(self, tmpdir):
+        path = str(tmpdir.join("test.py"))
+        source = textwrap.dedent(
+            """
+            from prefect import Flow
+
+            flow1 = Flow("flow 1")
+            flow2 = Flow("flow 2")
+            """
+        )
+        with open(path, "w") as f:
+            f.write(source)
+
+        cmd = [
+            "register",
+            "--project",
+            "testing",
+            "-p",
+            path,
+            "-n",
+            "flow 1",
+            "-n",
+            "flow 3",
+        ]
+        result = CliRunner().invoke(cli, cmd)
+
+        assert result.exit_code == 1
+        assert result.stdout == (
+            "Collecting flows...\n" "Failed to find the following flows:\n" "- flow 3\n"
+        )
+
+    def test_register_cli_path_not_found(self, tmpdir):
+        path = str(tmpdir.join("test.py"))
+        cmd = ["register", "--project", "testing", "-p", path]
+        result = CliRunner().invoke(cli, cmd)
+
+        assert result.exit_code == 1
+        assert result.stdout == f"Path {path!r} doesn't exist\n"
+
+    def test_register_cli_module_not_found(self):
+        cmd = [
+            "register",
+            "--project",
+            "testing",
+            "-m",
+            "a_highly_unlikely_module_name",
+        ]
+        result = CliRunner().invoke(cli, cmd)
+
+        assert result.exit_code == 1
+        assert result.stdout == (
+            "Collecting flows...\n" "No module named 'a_highly_unlikely_module_name'\n"
+        )
+
+    def test_register_cli_no_project_specified(self):
+        result = CliRunner().invoke(cli, ["register", "-p", "some_path"])
+        assert result.exit_code == 1
+        assert result.stdout == "Error: Missing required option '--project'\n"

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -3,26 +3,12 @@ from unittest.mock import MagicMock
 import pytest
 from click.testing import CliRunner
 
-from prefect.cli.register import register
-
-
-def test_register_init():
-    runner = CliRunner()
-    result = runner.invoke(register)
-    assert result.exit_code == 0
-    assert "Register flows" in result.output
-
-
-def test_register_help():
-    runner = CliRunner()
-    result = runner.invoke(register, ["--help"])
-    assert result.exit_code == 0
-    assert "Register flows" in result.output
+from prefect.cli import cli
 
 
 def test_register_flow_help():
     runner = CliRunner()
-    result = runner.invoke(register, ["flow", "--help"])
+    result = runner.invoke(cli, ["register", "flow", "--help"])
     assert result.exit_code == 0
     assert "Register a flow" in result.output
 
@@ -61,6 +47,7 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
         f.write(contents)
 
     args = [
+        "register",
         "flow",
         "--file",
         full_path,
@@ -74,7 +61,7 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
         args.extend(["-l", l])
 
     runner = CliRunner()
-    result = runner.invoke(register, args)
+    result = runner.invoke(cli, args)
     assert client.register.called
     assert client.register.call_args[1]["project_name"] == "project"
     assert client.register.call_args[1]["idempotency_key"] is not None

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -1,9 +1,12 @@
+import os
+import threading
 from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
 
 from prefect.cli import cli
+from prefect.cli.register import TerminalError, watch_for_changes
 
 
 def test_register_flow_help():
@@ -76,3 +79,95 @@ def test_register_flow_call(monkeypatch, tmpdir, kind, labels):
         assert flow.run_config.labels == {*labels}
 
     assert result.exit_code == 0
+
+
+class TestWatchForChanges:
+    def test_errors_path_does_not_exist(self, tmpdir):
+        missing = str(tmpdir.join("not-real"))
+        with pytest.raises(TerminalError, match=missing):
+            for _, _ in watch_for_changes(paths=[missing]):
+                assert False, "Should never get here"
+
+    def test_errors_module_does_not_exist(self):
+        name = "not_a_real_module_name"
+        with pytest.raises(TerminalError, match=name):
+            for _, _ in watch_for_changes(modules=[name]):
+                assert False, "Should never get here"
+
+    def test_watch_paths(self, tmpdir):
+        dir_path = str(tmpdir.join("dir").mkdir())
+        path1 = str(tmpdir.join("test1.py").ensure(file=True))
+        path2 = str(tmpdir.join("test2.py").ensure(file=True))
+        path3 = os.path.join(dir_path, "test3.py")
+        path4 = os.path.join(dir_path, "test4.something")
+
+        iterator = watch_for_changes(paths=[dir_path, path1, path2], period=0.1)
+
+        # Initial iteration hits all known paths
+        paths, mods = next(iterator)
+        assert not mods
+        assert set(paths) == {path1, path2}
+
+        # Later iterations only yield paths that are new or changed
+        def update():
+            with open(path3, "wb"):
+                pass
+            with open(path4, "wb"):
+                pass
+            os.utime(path1)
+
+        timer = threading.Timer(0.15, update)
+        timer.start()
+
+        paths, mods = next(iterator)
+        # path4 isn't included, since only `*.py` files are watched
+        assert set(paths) == {path1, path3}
+
+        # Deleting some original paths causes no errors
+        os.remove(path1)
+        os.remove(path3)
+        timer = threading.Timer(0.15, lambda: os.utime(path2))
+        timer.start()
+
+        paths, mods = next(iterator)
+        assert set(paths) == {path2}
+
+        # If those paths are readded, next iteration picks them up
+        with open(path1, "wb"):
+            pass
+        os.utime(path2)
+        paths, mods = next(iterator)
+        assert set(paths) == {path1, path2}
+
+    def test_watch_modules(self, tmpdir, monkeypatch):
+        mod1 = tmpdir.join("module1.py").ensure(file=True)
+        mod2 = tmpdir.join("module2.py").ensure(file=True)
+        monkeypatch.syspath_prepend(str(tmpdir))
+
+        iterator = watch_for_changes(modules=["module1", "module2"], period=0.1)
+
+        # Initial iteration hits all known modules
+        paths, mods = next(iterator)
+        assert not paths
+        assert set(mods) == {"module1", "module2"}
+
+        # Later iterations only yield modules that are new or changed
+        timer = threading.Timer(0.15, lambda: mod1.setmtime())
+        timer.start()
+
+        paths, mods = next(iterator)
+        assert not paths
+        assert set(mods) == {"module1"}
+
+        # Deleting some original modules causes no errors
+        mod1.remove()
+        timer = threading.Timer(0.15, mod2.setmtime)
+        timer.start()
+        paths, mods = next(iterator)
+        assert set(mods) == {"module2"}
+
+        # If those modules are readded, next iteration picks them up
+        mod1.ensure(file=True)
+        mod2.setmtime()
+        paths, mods = next(iterator)
+        assert set(mods) == {"module1", "module2"}

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -112,7 +112,7 @@ class TestWatchForChanges:
             for _, _ in watch_for_changes(paths=[missing]):
                 assert False, "Should never get here"
 
-        assert missing in str(exc)
+        assert repr(missing) in str(exc.value)
 
     def test_errors_module_does_not_exist(self):
         name = "not_a_real_module_name"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -850,7 +850,7 @@ def test_client_register_flow_id_no_output(
     assert flow_id == "long-id"
 
     captured = capsys.readouterr()
-    assert captured.out == "Result check: OK\n"
+    assert not captured.out
 
 
 def test_set_flow_run_name(patch_posts, cloud_api):


### PR DESCRIPTION
This PR deprecates the previous `prefect register flow` CLI in favor of a new `prefect register` CLI with lots more functionality.

Features:

- Allows registering multiple flows in a single call. Flows can be specified by `--path` (path to a file or directory containing flows) or by `--module` (an importable python module containing flows). Both options can be specified multiple times in a single call for more flexibility.
- A `--name` flag can be used to subselect flows to only register flows with a specific name (or names). If unspecified, all flows found are registered.
- By default, a flow will only be re-registered if it is *structurally different* than the existing version. This means that small edits to the source of tasks won't require re-registration, and the CLI will automatically detect this to avoid needlessly bumping the version. This can be disabled by passing in `--force`.
- A `--watch` flag for watching for changes in a directory/path/module, and re-registering flows on change. This can be used during development to automatically re-register your flows on save (as needed), or as part of a deployment for users who want to watch and auto-update flows from a specific directory (similar to airflow's DAG directory).

These features simplify auto-registering flows from within CI. For example, with github actions you might add the following step to your CI workflow to auto-register all flows in a `flows/` directory on merge.

```yaml
- name: Register Flows
  if: github.ref == 'refs/heads/master'
  run: prefect register flows --project testing --path flows
```

Fixes #4233.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)