### PR TITLE
Improve message when task slugs are missing

### DIFF
--- a/changes/pr4259.yaml
+++ b/changes/pr4259.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Improve error message when a loaded flow doesn't match the version stored in Prefect Cloud/Server - [#4259](https://github.com/PrefectHQ/prefect/pull/4259)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -69,6 +69,7 @@ class FlowRunInfoResult(NamedTuple):
     scheduled_start_time: datetime.datetime
     state: "prefect.engine.state.State"
     task_runs: List[TaskRunInfoResult]
+    storage: Dict[str, Any]
 
 
 class Client:
@@ -1141,7 +1142,7 @@ class Client:
                         "version": True,
                         "serialized_state": True,
                     },
-                    "flow": {"project": {"name": True, "id": True}},
+                    "flow": {"project": {"name": True, "id": True}, "storage": True},
                 }
             }
         }
@@ -1174,6 +1175,7 @@ class Client:
                 {} if result.parameters is None else result.parameters.to_dict()
             ),
             context=({} if result.context is None else result.context.to_dict()),
+            storage=result.storage,
         )
 
     def update_flow_run_heartbeat(self, flow_run_id: str) -> None:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -69,7 +69,6 @@ class FlowRunInfoResult(NamedTuple):
     scheduled_start_time: datetime.datetime
     state: "prefect.engine.state.State"
     task_runs: List[TaskRunInfoResult]
-    storage: Dict[str, Any]
 
 
 class Client:
@@ -1142,7 +1141,7 @@ class Client:
                         "version": True,
                         "serialized_state": True,
                     },
-                    "flow": {"project": {"name": True, "id": True}, "storage": True},
+                    "flow": {"project": {"name": True, "id": True}},
                 }
             }
         }
@@ -1175,7 +1174,6 @@ class Client:
                 {} if result.parameters is None else result.parameters.to_dict()
             ),
             context=({} if result.context is None else result.context.to_dict()),
-            storage=result.storage,
         )
 
     def update_flow_run_heartbeat(self, flow_run_id: str) -> None:

--- a/src/prefect/engine/cloud/flow_runner.py
+++ b/src/prefect/engine/cloud/flow_runner.py
@@ -397,23 +397,15 @@ class CloudFlowRunner(FlowRunner):
             try:
                 task = tasks[task_run.task_slug]
             except KeyError as exc:
-                msg = (
-                    f"Task slug {task_run.task_slug} not found in the current Flow; "
-                    "this is usually caused by a mismatch between the serialized flow "
-                    "metadata stored by the Prefect API and the flow loaded from "
-                    f"storage. Did you change the flow without re-registering it?"
-                )
-
-                # Storage with paths indicate that the user may need to update the code
-                # there e.g. GitHub storage
-                storage_has_path = flow_run_info.storage.get("path")
-                if storage_has_path:
-                    msg += (
-                        " Did you register your flow without pushing it to your "
-                        "storage location?"
-                    )
-
-                raise KeyError(msg) from exc
+                raise KeyError(
+                    f"Task slug {task_run.task_slug} is not found in the current Flow. "
+                    "This is usually caused by a mismatch between the flow version "
+                    "stored in the Prefect backend and the flow that was loaded from "
+                    "storage.\n"
+                    "- Did you change the flow without re-registering it?\n"
+                    "- Did you register the flow without updating it in your storage "
+                    "location (if applicable)?"
+                ) from exc
 
             task_states.setdefault(task, task_run.state)
             task_contexts.setdefault(task, {}).update(

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -1012,7 +1012,7 @@ def test_slug_mismatch_raises_informative_error(monkeypatch):
     ## assert informative message; can't use `match` because the real exception is one layer depeer than the ENDRUN
     assert "KeyError" in repr(state.result)
     assert "not found" in repr(state.result)
-    assert "changing the Flow" in repr(state.result)
+    assert "mismatch between the flow version" in repr(state.result)
 
 
 def test_can_queue_successfully_and_run(monkeypatch):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Improves the error message for the case where serialized flow task slugs cannot be found in the flow loaded from storage.

## Changes
<!-- What does this PR change? -->

- Adds `storage` to `FlowRunInfoResult`
- Adds a special note if a "path" is attached to the storage
- Clarifies general message for task slug mismatches

## Importance
<!-- Why is this PR important? -->

Improves likelihood that a user can self-resolve this exception

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)