### PR TITLE
Basic redis result storage - code complete but no tests

### DIFF
--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -1,0 +1,96 @@
+import os
+from typing import Any
+from prefect.engine.result import Result
+import prefect
+
+
+class RedisResult(Result):
+    """
+    Hook for storing and retrieving constant Python objects in redis.
+
+    connection_string: Redis URI used for Redis.from_url
+        default to REDIS_STORAGE_CONNECTION_STRING
+    ttl_seconds: key time to live in seconds if the result is to expire
+
+    Args:
+        - **kwargs (Any, optional): any additional `Result` initialization options
+    """
+    def __init__(
+        self,
+        connection_string: str = None,
+        ttl_seconds: int = None,
+        **kwargs: Any
+    ) -> None:
+        self.connection_string = connection_string or os.getenv(
+            "REDIS_STORAGE_CONNECTION_STRING"
+        )
+        self.ttl_seconds = ttl_seconds
+        super().__init__(**kwargs)
+
+    def initialize_redis_client(self) -> None:
+        import redis
+
+        self._redis_client = redis.Redis.from_url(self.connection_string)
+        try:
+            self._redis_client.ping()
+        except (ConnectionError, redis.InvalidResponse) as ee:
+            raise Exception(f"redis .. details .. {ee}")
+
+    @property
+    def redis_client(self) -> "redis.client.Redis": # noqa Not imported yet
+        if not hasattr(self, "_redis_client"):
+            self.initialize_redis_client()
+        return self._redis_client
+
+    @redis_client.setter
+    def redis_client(self, val: Any) -> None:
+        self._redis_client = val
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        if "_redis_client" in state:
+            del state["_redis_client"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+    def read(self, location: str) -> Result:
+        """
+        Will return the underlying value regardless of the argument passed.
+
+        Args:
+            - location (str): Redis key
+        """
+        new = self.copy()
+        new.location = location
+        content = self.redis_client.get(new.location)
+        new.value = new.serializer.deserialize(content)
+        return new
+
+    def write(self, value_: Any, **kwargs: Any) -> Result:
+        """
+        Will return the repr of the underlying value, purely for convenience.
+
+        Args:
+            - value_ (Any): value to be stored
+            - **kwargs (optional): unused, for interface compatibility
+        """
+        new = self.format(**kwargs)
+        new.value = value_
+        binary_data = new.serializer.serialize(new.value)
+        self.redis_client.set(new.location, binary_data, ex=self.ttl_seconds)
+        return new
+
+    def exists(self, location: str, **kwargs: Any) -> bool:
+        """
+        As all Python objects are valid constants, always returns `True`.
+
+        Args:
+             - location (str): The redis key.
+             - **kwargs (Any): string format arguments for `location`
+
+        Returns:
+            - bool: True, confirming the constant exists.
+        """
+        return self.redis_client.exists(location)

--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -18,13 +18,15 @@ class RedisResult(Result):
     Args:
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
-
     def __init__(
         self, connection_string: str = None, ttl_seconds: int = None, **kwargs: Any
     ) -> None:
         self.connection_string = connection_string or os.getenv(
             "REDIS_STORAGE_CONNECTION_STRING"
         )
+        if not self.connection_string:
+            raise Exception("RedisResult expects to be passed connection_string "
+                            "or present in the environment from REDIS_STORAGE_CONNECTION_STRING")
         self.ttl_seconds = ttl_seconds
         super().__init__(**kwargs)
 

--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -57,7 +57,7 @@ class RedisResult(Result):
 
     def read(self, location: str) -> Result:
         """
-        Will return the underlying value regardless of the argument passed.
+        Read from reids and deserialize the value at location
 
         Args:
             - location (str): Redis key
@@ -70,7 +70,7 @@ class RedisResult(Result):
 
     def write(self, value_: Any, **kwargs: Any) -> Result:
         """
-        Will return the repr of the underlying value, purely for convenience.
+        Write the value into location
 
         Args:
             - value_ (Any): value to be stored
@@ -84,8 +84,7 @@ class RedisResult(Result):
 
     def exists(self, location: str, **kwargs: Any) -> bool:
         """
-        As all Python objects are valid constants, always returns `True`.
-
+        Check existence of a key in redis.
         Args:
              - location (str): The redis key.
              - **kwargs (Any): string format arguments for `location`

--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -1,7 +1,10 @@
 import os
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from prefect.engine.result import Result
-import prefect
+
+
+if TYPE_CHECKING:
+    import redis
 
 
 class RedisResult(Result):
@@ -35,7 +38,7 @@ class RedisResult(Result):
             raise Exception(f"redis .. details .. {ee}")
 
     @property
-    def redis_client(self) -> "redis.client.Redis":  # noqa Not imported yet
+    def redis_client(self) -> "redis.client.Redis":
         if not hasattr(self, "_redis_client"):
             self.initialize_redis_client()
         return self._redis_client
@@ -90,4 +93,4 @@ class RedisResult(Result):
         Returns:
             - bool: True, confirming the constant exists.
         """
-        return self.redis_client.exists(location)
+        return self.redis_client.exists(location) != 0

--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -15,11 +15,9 @@ class RedisResult(Result):
     Args:
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
+
     def __init__(
-        self,
-        connection_string: str = None,
-        ttl_seconds: int = None,
-        **kwargs: Any
+        self, connection_string: str = None, ttl_seconds: int = None, **kwargs: Any
     ) -> None:
         self.connection_string = connection_string or os.getenv(
             "REDIS_STORAGE_CONNECTION_STRING"
@@ -37,7 +35,7 @@ class RedisResult(Result):
             raise Exception(f"redis .. details .. {ee}")
 
     @property
-    def redis_client(self) -> "redis.client.Redis": # noqa Not imported yet
+    def redis_client(self) -> "redis.client.Redis":  # noqa Not imported yet
         if not hasattr(self, "_redis_client"):
             self.initialize_redis_client()
         return self._redis_client

--- a/src/prefect/engine/results/redis_result.py
+++ b/src/prefect/engine/results/redis_result.py
@@ -19,12 +19,12 @@ class RedisResult(Result):
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
     def __init__(
-        self, connection_string: str = None, ttl_seconds: int = None, **kwargs: Any
+        self, connection_string: str = "", ttl_seconds: int = None, **kwargs: Any
     ) -> None:
         self.connection_string = connection_string or os.getenv(
-            "REDIS_STORAGE_CONNECTION_STRING"
+            "REDIS_STORAGE_CONNECTION_STRING", ""
         )
-        if not self.connection_string:
+        if self.connection_string == "":
             raise Exception("RedisResult expects to be passed connection_string "
                             "or present in the environment from REDIS_STORAGE_CONNECTION_STRING")
         self.ttl_seconds = ttl_seconds
@@ -33,7 +33,7 @@ class RedisResult(Result):
     def initialize_redis_client(self) -> None:
         import redis
 
-        self._redis_client = redis.Redis.from_url(self.connection_string)
+        self._redis_client = redis.Redis.from_url(url=self.connection_string)
         try:
             self._redis_client.ping()
         except (ConnectionError, redis.InvalidResponse) as ee:
@@ -60,7 +60,7 @@ class RedisResult(Result):
 
     def read(self, location: str) -> Result:
         """
-        Read from reids and deserialize the value at location
+        Read from Redis and deserialize the value at location
 
         Args:
             - location (str): Redis key


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Add a redis Result type to store prefect results in redis.
Incomplete PR. I'll update the rest below when I get to it, or if people are actually interested in this I'll do it sooner.
Using this in our lab environment.

## Changes
Adds RedisResult type.

## Importance
If you use docker storage there is no easy local storage option. This adds it.
In my use case I want to be able to re-run short but complex tasks.
If the data is lost and I have to restart the whole task that is not a huge problem.

<!-- Why is this PR important? -->


## Interim Changes
RedisResult() takes:
  -  connection_string: Redis URI used for Redis.from_url default to REDIS_STORAGE_CONNECTION_STRING
   -  ttl_seconds: key time to live in seconds if the result is to expire

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->
Not for review yet.

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)