### PR TITLE
Support setting flow run labels from cli

### DIFF
--- a/changes/pr4266.yaml
+++ b/changes/pr4266.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - Support setting flow run labels from cli - [#4266](https://github.com/PrefectHQ/prefect/pull/4266)
+
+contributor:
+  - "[Jacob Hayes](https://github.com/JacobHayes)"

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -74,6 +74,13 @@ def run():
     hidden=True,
 )
 @click.option(
+    "--label",
+    "labels",
+    help="A list of labels to apply to the flow run",
+    hidden=True,
+    multiple=True,
+)
+@click.option(
     "--logs", "-l", is_flag=True, help="Live logs of the flow run.", hidden=True
 )
 @click.option(
@@ -93,6 +100,7 @@ def flow(
     run_name,
     context,
     watch,
+    labels,
     logs,
     no_url,
 ):
@@ -117,6 +125,8 @@ def flow(
                                                 to include the full payload within single quotes)
         --watch, -w                             Watch current state of the flow run, stream
                                                 output to stdout
+        --label                     TEXT        Set labels on the flow run; use multiple times to set
+                                                multiple labels.
         --logs, -l                              Get logs of the flow run, stream output to
                                                 stdout
         --no-url                                Only output the flow run id instead of a
@@ -214,6 +224,7 @@ def flow(
         flow_id=flow_id,
         version_group_id=version_group_id,
         context=context,
+        labels=labels,
         parameters={**file_params, **string_params},
         run_name=run_name,
     )

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -496,6 +496,42 @@ def test_run_flow_using_id(monkeypatch, cloud_api):
     assert create_flow_run_mock.called
 
 
+def test_run_flow_labels(monkeypatch, cloud_api):
+    post = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(return_value=dict(data=dict(flow=[{"id": "flow"}])))
+        )
+    )
+    session = MagicMock()
+    session.return_value.post = post
+    monkeypatch.setattr("requests.Session", session)
+
+    create_flow_run_mock = MagicMock(return_value="id")
+    monkeypatch.setattr("prefect.client.Client.create_flow_run", create_flow_run_mock)
+    monkeypatch.setattr(
+        "prefect.client.Client.get_default_tenant_slug", MagicMock(return_value="tslug")
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        [
+            "flow",
+            "--name",
+            "flow",
+            "--project",
+            "project",
+            "--label",
+            "label1",
+            "--label",
+            "label2",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Flow Run" in result.output
+    assert create_flow_run_mock.called
+
+
 def test_run_flow_using_version_group_id(monkeypatch, cloud_api):
     post = MagicMock(
         return_value=MagicMock(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Support setting flow run labels from cli

[Slack context](https://prefect-community.slack.com/archives/CL09KU1K7/p1616010761095000)




## Changes

Adds a `--label` flag to `prefect run flow`.




## Importance

Allows labels to be set via the CLI or in code wrapping the CLI in order to tail logs.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
