### PR TITLE
Support setting `image` in agent-side templates

### DIFF
--- a/changes/pr4270.yaml
+++ b/changes/pr4270.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Support setting default `image` in `--job-template`/`--task-definition` in Kubernetes/ECS agents - [#4270](https://github.com/PrefectHQ/prefect/pull/4270)"

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -387,7 +387,9 @@ class ECSAgent(Agent):
             containers.append(container)
 
         # Set flow image
-        container["image"] = image = get_flow_image(flow_run)
+        container["image"] = image = get_flow_image(
+            flow_run, default=container.get("image")
+        )
 
         # Add `PREFECT__CONTEXT__IMAGE` environment variable
         env = {"PREFECT__CONTEXT__IMAGE": image}

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -651,7 +651,9 @@ class KubernetesAgent(Agent):
         container = containers[0]
 
         # Set container image
-        container["image"] = image = get_flow_image(flow_run)
+        container["image"] = image = get_flow_image(
+            flow_run, default=container.get("image")
+        )
 
         # Set flow run command
         container["args"] = get_flow_run_command(flow_run).split()

--- a/src/prefect/utilities/agent.py
+++ b/src/prefect/utilities/agent.py
@@ -3,12 +3,15 @@ from distutils.version import LooseVersion
 from prefect.utilities.graphql import GraphQLResult
 
 
-def get_flow_image(flow_run: GraphQLResult) -> str:
+def get_flow_image(flow_run: GraphQLResult, default: str = None) -> str:
     """
     Retrieve the image to use for this flow run deployment.
 
     Args:
         - flow_run (GraphQLResult): A GraphQLResult flow run object
+        - default (str, optional): A default image to use. If not specified,
+            The `prefecthq/prefect` image corresponding with the flow's prefect
+            version will be used.
 
     Returns:
         - str: a full image name to use for this flow run
@@ -29,13 +32,19 @@ def get_flow_image(flow_run: GraphQLResult) -> str:
     # Not having an environment implies run-config based flow, even if
     # run_config is None.
     if has_run_config or not has_environment:
+        # Precedence:
+        # - Image on docker storage
+        # - Image on run_config
+        # - Provided default
+        # - `prefecthq/prefect` for flow's core version
         if isinstance(storage, Docker):
             return storage.name
-        elif has_run_config:
+        if has_run_config:
             run_config = RunConfigSchema().load(flow_run.run_config)
             if getattr(run_config, "image", None) is not None:
                 return run_config.image
-        # No image found on run-config, and no environment present. Use default.
+        if default is not None:
+            return default
         # core_version should always be present, but just in case
         version = flow_run.flow.get("core_version") or "latest"
         cleaned_version = version.split("+")[0]

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -335,9 +335,20 @@ class TestGenerateTaskDefinition:
                 "test/name:tag",
             ),
             (ECSRun(image="myimage"), Local(), "myimage"),
+            (
+                ECSRun(
+                    task_definition={
+                        "containerDefinitions": [
+                            {"name": "flow", "image": "on-template"}
+                        ]
+                    }
+                ),
+                Local(),
+                "on-template",
+            ),
             (ECSRun(), Local(), "prefecthq/prefect:0.13.0"),
         ],
-        ids=["on-storage", "on-run_config", "default"],
+        ids=["on-storage", "on-run_config", "on-template", "default"],
     )
     def test_generate_task_definition_image(self, run_config, storage, expected):
         taskdef = self.generate_task_definition(run_config, storage)

--- a/tests/utilities/test_agent.py
+++ b/tests/utilities/test_agent.py
@@ -84,7 +84,8 @@ def test_get_flow_image_run_config_docker_storage(run_config):
 
 @pytest.mark.parametrize("run_config", [KubernetesRun(), LocalRun(), None])
 @pytest.mark.parametrize("version", ["0.13.0", "0.10.0+182.g385a32514.dirty", None])
-def test_get_flow_image_run_config_default_value_from_core_version(run_config, version):
+@pytest.mark.parametrize("default", [None, "default-value"])
+def test_get_flow_image_run_config_default(run_config, version, default):
     flow_run = GraphQLResult(
         {
             "flow": GraphQLResult(
@@ -98,9 +99,14 @@ def test_get_flow_image_run_config_default_value_from_core_version(run_config, v
             "id": "id",
         }
     )
-    image = get_flow_image(flow_run)
-    expected_version = version.split("+")[0] if version else "latest"
-    assert image == f"prefecthq/prefect:{expected_version}"
+    if default is None:
+        expected_version = version.split("+")[0] if version else "latest"
+        expected = f"prefecthq/prefect:{expected_version}"
+    else:
+        expected = default
+
+    image = get_flow_image(flow_run, default=default)
+    assert image == expected
 
 
 def test_get_flow_image_run_config_image_on_RunConfig():


### PR DESCRIPTION
Previously we always overrode the `image` used at runtime for the K8s
and ECS agents, which prevented setting a default image to use on the
agent. This PR fixes that, allowing agent side defaults to be set
(through `--job-template` on the k8s agent and `--task-definition` on
the ECS agent).

Fixes #4269 , fixes #4128.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)