### PR TITLE
Add support to CLI for pre-building flows

### DIFF
--- a/changes/pr4282.yaml
+++ b/changes/pr4282.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "New `prefect build` CLI command for building flows. Artifacts produced by this command can then be used by `prefect register` to register flows without requiring the source. - [#4282](https://github.com/PrefectHQ/prefect/pull/4282)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -60,8 +60,13 @@ commands = ["flows", "tasks", "projects", "flow_runs", "logs"]
 
 [pages.cli.register]
 title = "register"
-module = "prefect.cli.register"
+module = "prefect.cli.build_register"
 commands = ["register"]
+
+[pages.cli.build]
+title = "build"
+module = "prefect.cli.build_register"
+commands = ["build"]
 
 [pages.cli.run]
 title = "run"

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -16,7 +16,7 @@ from .get import get as _get
 from .run import run as _run
 from .server import server as _server
 from .heartbeat import heartbeat as _heartbeat
-from .register import register as _register, build as _build
+from .build_register import register as _register, build as _build
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -16,7 +16,7 @@ from .get import get as _get
 from .run import run as _run
 from .server import server as _server
 from .heartbeat import heartbeat as _heartbeat
-from .register import register as _register
+from .register import register as _register, build as _build
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -72,6 +72,7 @@ cli.add_command(_run)
 cli.add_command(_server)
 cli.add_command(_heartbeat)
 cli.add_command(_register)
+cli.add_command(_build)
 
 
 # Miscellaneous Commands

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -613,6 +613,10 @@ REGISTER_EPILOG = """
 
 \b    $ prefect register --project my-project -m "myproject.flows"
 
+\b  Register all pre-built flows from a remote JSON file.
+
+\b    $ prefect register --project my-project --json https://some-url/flows.json
+
 \b  Watch a directory of flows for changes, and re-register flows upon change.
 
 \b    $ prefect register --project my-project -p myflows/ --watch
@@ -651,7 +655,8 @@ REGISTER_EPILOG = """
     "json_paths",
     help=(
         "A path or URL to a json file containing the flow(s) to register. "
-        "May be passed multiple times to specify multiple paths to register."
+        "May be passed multiple times to specify multiple paths to register. "
+        "Note that this path may be a remote url (e.g. https://some-url/flows.json)."
     ),
     multiple=True,
 )
@@ -750,7 +755,24 @@ def register(ctx, project, paths, modules, json_paths, names, labels, force, wat
         register_internal(project, paths, modules, json_paths, names, labels, force)
 
 
-@click.command()
+BUILD_EPILOG = """
+\bExamples:
+
+\b  Build all flows found in a directory.
+
+\b    $ prefect build -p myflows/
+
+\b  Build a flow named "example" found in `flow.py`.
+
+\b    $ prefect build -p flow.py -n "example"
+
+\b  Build all flows found in a module named `myproject.flows`.
+
+\b    $ prefect build -m "myproject.flows"
+"""
+
+
+@click.command(epilog=BUILD_EPILOG)
 @click.option(
     "--path",
     "-p",
@@ -808,7 +830,12 @@ def register(ctx, project, paths, modules, json_paths, names, labels, force, wat
 )
 @handle_terminal_error
 def build(paths, modules, names, labels, output, update):
-    """Build one or more flows."""
+    """Build one or more flows.
+
+    This command builds all specified flows and writes their metadata to a JSON
+    file. These flows can then be registered without building later by passing
+    the `--json` flag to `prefect register`.
+    """
     succeeded = 0
     errored = 0
 

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -635,7 +635,7 @@ REGISTER_EPILOG = """
     "paths",
     help=(
         "A path to a file or a directory containing the flow(s) to register. "
-        "May be passed multiple times to specify multiple paths to register."
+        "May be passed multiple times to specify multiple paths."
     ),
     multiple=True,
 )
@@ -645,7 +645,7 @@ REGISTER_EPILOG = """
     "modules",
     help=(
         "A python module name containing the flow(s) to register. May be "
-        "passed multiple times to specify multiple modules to register."
+        "passed multiple times to specify multiple modules."
     ),
     multiple=True,
 )
@@ -654,8 +654,8 @@ REGISTER_EPILOG = """
     "-j",
     "json_paths",
     help=(
-        "A path or URL to a json file containing the flow(s) to register. "
-        "May be passed multiple times to specify multiple paths to register. "
+        "A path or URL to a JSON file created by `prefect build` containing the flow(s) "
+        "to register. May be passed multiple times to specify multiple paths. "
         "Note that this path may be a remote url (e.g. https://some-url/flows.json)."
     ),
     multiple=True,
@@ -667,8 +667,8 @@ REGISTER_EPILOG = """
     help=(
         "The name of a flow to register from the specified paths/modules. If "
         "provided, only flows with a matching name will be registered. May be "
-        "passed multiple times to specify multiple flows to register. If not "
-        "provided, all flows found on all paths/modules will be registered."
+        "passed multiple times to specify multiple flows. If not provided, all "
+        "flows found on all paths/modules will be registered."
     ),
     multiple=True,
 )
@@ -779,7 +779,7 @@ BUILD_EPILOG = """
     "paths",
     help=(
         "A path to a file or a directory containing the flow(s) to build. "
-        "May be passed multiple times to specify multiple paths to build."
+        "May be passed multiple times to specify multiple paths."
     ),
     multiple=True,
 )
@@ -789,7 +789,7 @@ BUILD_EPILOG = """
     "modules",
     help=(
         "A python module name containing the flow(s) to build. May be "
-        "passed multiple times to specify multiple modules to build."
+        "passed multiple times to specify multiple modules."
     ),
     multiple=True,
 )
@@ -800,8 +800,8 @@ BUILD_EPILOG = """
     help=(
         "The name of a flow to build from the specified paths/modules. If "
         "provided, only flows with a matching name will be built. May be "
-        "passed multiple times to specify multiple flows to build. If not "
-        "provided, all flows found on all paths/modules will be built."
+        "passed multiple times to specify multiple flows. If not provided, "
+        "all flows found on all paths/modules will be built."
     ),
     multiple=True,
 )
@@ -819,7 +819,7 @@ BUILD_EPILOG = """
     "--output",
     "-o",
     default="flows.json",
-    help="The output path. Defaults to `flows.json`",
+    help="The output path. Defaults to `flows.json`.",
 )
 @click.option(
     "--update",

--- a/src/prefect/utilities/filesystems.py
+++ b/src/prefect/utilities/filesystems.py
@@ -58,6 +58,10 @@ def read_bytes_from_path(path: str) -> bytes:
     if not parsed.scheme or parsed.scheme in ("file", "agent"):
         with open(parsed.path, "rb") as f:
             return f.read()
+    elif parsed.scheme in {"https", "http"}:
+        import requests
+
+        return requests.get(path).content
     elif parsed.scheme == "gcs":
         from prefect.utilities.gcp import get_storage_client
 

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 
 from prefect import Flow
 from prefect.cli import cli
-from prefect.cli.register import (
+from prefect.cli.build_register import (
     TerminalError,
     watch_for_changes,
     load_flows_from_script,
@@ -208,7 +208,7 @@ class TestWatchForChanges:
 def mock_get_project_id(monkeypatch):
     get_project_id = MagicMock()
     get_project_id.return_value = "my-project-id"
-    monkeypatch.setattr("prefect.cli.register.get_project_id", get_project_id)
+    monkeypatch.setattr("prefect.cli.build_register.get_project_id", get_project_id)
     return get_project_id
 
 
@@ -355,14 +355,15 @@ class TestRegister:
         ]
         data = json.dumps({"version": 1, "flows": flows}).encode("utf-8")
         monkeypatch.setattr(
-            "prefect.cli.register.read_bytes_from_path", MagicMock(return_value=data)
+            "prefect.cli.build_register.read_bytes_from_path",
+            MagicMock(return_value=data),
         )
         res = load_flows_from_json("https://some/url/flows.json")
         assert res == flows
 
     def test_load_flows_from_json_fail_read(self, monkeypatch, capsys):
         monkeypatch.setattr(
-            "prefect.cli.register.read_bytes_from_path",
+            "prefect.cli.build_register.read_bytes_from_path",
             MagicMock(side_effect=ValueError("oh no!")),
         )
         with pytest.raises(TerminalError):
@@ -374,7 +375,7 @@ class TestRegister:
 
     def test_load_flows_from_json_schema_error(self, monkeypatch):
         monkeypatch.setattr(
-            "prefect.cli.register.read_bytes_from_path",
+            "prefect.cli.build_register.read_bytes_from_path",
             MagicMock(return_value=json.dumps({"bad": "file"})),
         )
         with pytest.raises(
@@ -384,7 +385,7 @@ class TestRegister:
 
     def test_load_flows_from_json_unsupported_version(self, monkeypatch, capsys):
         monkeypatch.setattr(
-            "prefect.cli.register.read_bytes_from_path",
+            "prefect.cli.build_register.read_bytes_from_path",
             MagicMock(return_value=json.dumps({"version": 2, "flows": []})),
         )
         with pytest.raises(TerminalError, match="is version 2, only version 1"):
@@ -422,7 +423,8 @@ class TestRegister:
             ("old-id-8", 2, False),
         ]
         monkeypatch.setattr(
-            "prefect.cli.register.register_serialized_flow", register_serialized_flow
+            "prefect.cli.build_register.register_serialized_flow",
+            register_serialized_flow,
         )
 
         storage1 = MyModule("testing")
@@ -540,7 +542,8 @@ class TestRegister:
             ("old-id-2", 2, False),
         ]
         monkeypatch.setattr(
-            "prefect.cli.register.register_serialized_flow", register_serialized_flow
+            "prefect.cli.build_register.register_serialized_flow",
+            register_serialized_flow,
         )
 
         cmd = ["register", "--project", "testing", "--path", path, "-l", "a", "-l", "b"]

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -11,7 +11,7 @@ from prefect.cli import cli
 from prefect.cli.register import (
     TerminalError,
     watch_for_changes,
-    load_flows_from_path,
+    load_flows_from_script,
     load_flows_from_module,
     build_and_register,
 )
@@ -200,7 +200,7 @@ class TestWatchForChanges:
 
 
 class TestRegister:
-    def test_load_flows_from_path(self, tmpdir):
+    def test_load_flows_from_script(self, tmpdir):
         path = str(tmpdir.join("test.py"))
         source = textwrap.dedent(
             """
@@ -214,7 +214,7 @@ class TestRegister:
         with open(path, "w") as f:
             f.write(source)
 
-        flows = {f.name: f for f in load_flows_from_path(path)}
+        flows = {f.name: f for f in load_flows_from_script(path)}
         assert len(flows) == 2
         assert isinstance(flows["f1"].storage, S3)
         assert flows["f1"].storage.local_script_path == path
@@ -222,13 +222,13 @@ class TestRegister:
         assert flows["f2"].storage.path == path
         assert flows["f2"].storage.stored_as_script
 
-    def test_load_flows_from_path_error(self, tmpdir, capsys):
+    def test_load_flows_from_script_error(self, tmpdir, capsys):
         path = str(tmpdir.join("test.py"))
         with open(path, "w") as f:
             f.write("raise ValueError('oh no!')")
 
         with pytest.raises(TerminalError):
-            load_flows_from_path(path)
+            load_flows_from_script(path)
 
         out, _ = capsys.readouterr()
         assert "oh no!" in out

--- a/tests/utilities/test_filesystems.py
+++ b/tests/utilities/test_filesystems.py
@@ -52,6 +52,19 @@ class Test_read_bytes_from_path:
         res = read_bytes_from_path(path_arg)
         assert res == b"hello"
 
+    @pytest.mark.parametrize("scheme", ["http", "https"])
+    def test_read_http_file(self, monkeypatch, scheme):
+        pytest.importorskip("requests")
+
+        url = f"{scheme}://some/file.json"
+
+        requests_get = MagicMock(return_value=MagicMock(content=b"testing"))
+        monkeypatch.setattr("requests.get", requests_get)
+
+        res = read_bytes_from_path(url)
+        assert requests_get.call_args[0] == (url,)
+        assert res == b"testing"
+
     def test_read_gcs(self, monkeypatch):
         pytest.importorskip("prefect.utilities.gcp")
         client = MagicMock()


### PR DESCRIPTION
This PR:

- Adds a new `prefect build` CLI command for building flows and creating/updating a `.json` file containing their representations.
- Adds a `--json` flag to `prefect register` for registering flows from a `.json` file. Note that this file may be local, or hosted elsewhere (currently only `https`/`http`, `s3`, and `gcs` are supported).

Combined, these let users build flows once and host the `json` results somewhere for later registration into one or more projects.

For example, you might build your flows as part of CI (and host the output `flows.json` file on github pages as part of your docs). Users can then register flows from your repo as:

```
$ prefect register --json https://username.github.io/your-project/flows.json --project their-project-name
```

With pre-built flows, the client doesn't need access to the source or dependencies, making registration very lightweight.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)