### PR TITLE
Improving logging of Jupyter task to capture cell output

### DIFF
--- a/changes/issue4265.yaml
+++ b/changes/issue4265.yaml
@@ -1,0 +1,6 @@
+task:
+  - "Adds logging of cell outputs to Jupyter task - [#4265]
+  (https://github.com/PrefectHQ/prefect/issues/4265)"
+
+contributor:
+  - "[Kevin Kho](https://github.com/kvnkho)"

--- a/src/prefect/tasks/jupyter/jupyter.py
+++ b/src/prefect/tasks/jupyter/jupyter.py
@@ -18,6 +18,8 @@ class ExecuteNotebook(Task):
             Can also be provided post-initialization by calling this task instance
         - parameters (dict, optional): dictionary of parameters to use for the notebook
             Can also be provided at runtime
+        - log_output (bool): whether or not to log notebook cell output to the
+            papermill logger.
         - output_format (str, optional): Notebook output format, should be a valid
             nbconvert Exporter name. 'json' is treated as 'notebook'.
             Valid exporter names: asciidoc, custom, html, latex, markdown,
@@ -33,6 +35,7 @@ class ExecuteNotebook(Task):
         self,
         path: str = None,
         parameters: dict = None,
+        log_output: bool = False,
         output_format: str = "notebook",
         exporter_kwargs: dict = None,
         kernel_name: str = None,
@@ -40,6 +43,7 @@ class ExecuteNotebook(Task):
     ):
         self.path = path
         self.parameters = parameters
+        self.log_output = log_output
         self.output_format = output_format
         self.kernel_name = kernel_name
         self.exporter_kwargs = exporter_kwargs
@@ -68,7 +72,11 @@ class ExecuteNotebook(Task):
             the exporter.
         """
         nb: nbformat.NotebookNode = pm.execute_notebook(
-            path, "-", parameters=parameters, kernel_name=self.kernel_name
+            path,
+            "-",
+            parameters=parameters,
+            kernel_name=self.kernel_name,
+            log_output=self.log_output,
         )
         if output_format == "json":
             output_format = "notebook"

--- a/tests/tasks/jupyter/sample_notebook.ipynb
+++ b/tests/tasks/jupyter/sample_notebook.ipynb
@@ -3,7 +3,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "celtic-panel",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-22T19:42:07.985829Z",
+     "iopub.status.busy": "2021-03-22T19:42:07.985028Z",
+     "iopub.status.idle": "2021-03-22T19:42:07.987056Z",
+     "shell.execute_reply": "2021-03-22T19:42:07.987619Z"
+    },
+    "jupyter": {
+     "source_hidden": true
+    },
+    "papermill": {
+     "duration": 0.021263,
+     "end_time": "2021-03-22T19:42:07.987969",
+     "exception": false,
+     "start_time": "2021-03-22T19:42:07.966706",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -17,7 +34,54 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "conditional-texas",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-22T19:42:08.003263Z",
+     "iopub.status.busy": "2021-03-22T19:42:08.002575Z",
+     "iopub.status.idle": "2021-03-22T19:42:08.004279Z",
+     "shell.execute_reply": "2021-03-22T19:42:08.004860Z"
+    },
+    "papermill": {
+     "duration": 0.010737,
+     "end_time": "2021-03-22T19:42:08.005068",
+     "exception": false,
+     "start_time": "2021-03-22T19:42:07.994331",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "a = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "romance-slovakia",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-22T19:42:08.016671Z",
+     "iopub.status.busy": "2021-03-22T19:42:08.016124Z",
+     "iopub.status.idle": "2021-03-22T19:42:08.018182Z",
+     "shell.execute_reply": "2021-03-22T19:42:08.018569Z"
+    },
+    "jupyter": {
+     "source_hidden": true
+    },
+    "papermill": {
+     "duration": 0.009283,
+     "end_time": "2021-03-22T19:42:08.018737",
+     "exception": false,
+     "start_time": "2021-03-22T19:42:08.009454",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(f\"a*b={a*b}\")"
@@ -26,7 +90,54 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "sublime-bishop",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-22T19:42:08.029408Z",
+     "iopub.status.busy": "2021-03-22T19:42:08.028823Z",
+     "iopub.status.idle": "2021-03-22T19:42:10.045336Z",
+     "shell.execute_reply": "2021-03-22T19:42:10.046043Z"
+    },
+    "papermill": {
+     "duration": 2.023764,
+     "end_time": "2021-03-22T19:42:10.046365",
+     "exception": false,
+     "start_time": "2021-03-22T19:42:08.022601",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "for i in range(1,3):\n",
+    "    print(i)\n",
+    "    time.sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "marked-party",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-22T19:42:10.067742Z",
+     "iopub.status.busy": "2021-03-22T19:42:10.066912Z",
+     "iopub.status.idle": "2021-03-22T19:42:10.068997Z",
+     "shell.execute_reply": "2021-03-22T19:42:10.069439Z"
+    },
+    "jupyter": {
+     "source_hidden": true
+    },
+    "papermill": {
+     "duration": 0.013821,
+     "end_time": "2021-03-22T19:42:10.069622",
+     "exception": false,
+     "start_time": "2021-03-22T19:42:10.055801",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# This cell contains commented Python code"
@@ -49,9 +160,23 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.8"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.043429,
+   "end_time": "2021-03-22T19:42:10.290085",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "tests/tasks/jupyter/sample_notebook.ipynb",
+   "output_path": "tests/tasks/jupyter/sample_notebook.ipynb",
+   "parameters": {
+    "a": 5
+   },
+   "start_time": "2021-03-22T19:42:07.246656",
+   "version": "2.3.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/tests/tasks/jupyter/test_jupyter.py
+++ b/tests/tasks/jupyter/test_jupyter.py
@@ -1,5 +1,7 @@
 import json
+import logging
 
+from prefect import Flow
 from prefect.tasks.jupyter import ExecuteNotebook
 
 
@@ -46,3 +48,17 @@ def test_jupyter_notebook_output():
     output = task.run()
     _ = json.loads(output)  # try loading the JSON string
     assert "a*b=10" in output
+
+
+def test_jupyter_cell_logging(caplog):
+    caplog.set_level(level=logging.INFO, logger="papermill")
+
+    with Flow("Jupyter test") as flow:
+        ExecuteNotebook(
+            "tests/tasks/jupyter/sample_notebook.ipynb",
+            parameters=dict(a=5),
+            output_format="notebook",
+        )()
+
+    flow.run()
+    assert "papermill:execute.py" in caplog.text


### PR DESCRIPTION
## Summary
This is a response to [#4265](https://github.com/PrefectHQ/prefect/issues/4265), which was raised on Slack. The user wanted to capture Jupyter notebook cell outputs in the Prefect logs.

## Changes
There are two things needed to get this to work. One is to pass the `log_output` bool into `papermill`'s execute_notebook function. By default this is False. It needs to be True. For consistency with the previous implementation, I kept the default asFalse, though I feel there might be benefits in making it True.

The second thing is to get the `papermill` logger and change the level to `INFO` or `DEBUG`. By default, it is at `WARN` so it does not log cell outputs. I think we should not do this change on the task side. Instead, Prefect users should use the (extra loggers)[https://docs.prefect.io/core/concepts/logging.html#extra-loggers] part of the TOML config and add the `papermill` logger.

There is an added test to see if the `papermill` logs are being captured. There are some edits to the .ipynb to see more output from the `papermill` logs.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)