### PR TITLE
Respect global context in flow runner

### DIFF
--- a/changes/pr4287.yaml
+++ b/changes/pr4287.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug where sometimes the global `prefect.context` wouldn't be respected during a flow run - [#4287](https://github.com/PrefectHQ/prefect/pull/4287)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -224,10 +224,13 @@ class FlowRunner(Runner):
         self.logger.info("Beginning Flow run for '{}'".format(self.flow.name))
 
         # make copies to avoid modifying user inputs
-        task_states = dict(task_states or {})
-        context = dict(context or {})
-        task_contexts = dict(task_contexts or {})
         parameters = dict(parameters or {})
+        task_states = dict(task_states or {})
+        task_contexts = dict(task_contexts or {})
+        # Default to global context, with provided context as override
+        run_context = dict(prefect.context)
+        run_context.update(context or {})
+
         if executor is None:
             # Use the executor on the flow, if configured
             executor = getattr(self.flow, "executor", None)
@@ -237,15 +240,15 @@ class FlowRunner(Runner):
         self.logger.debug("Using executor type %s", type(executor).__name__)
 
         try:
-            state, task_states, context, task_contexts = self.initialize_run(
+            state, task_states, run_context, task_contexts = self.initialize_run(
                 state=state,
                 task_states=task_states,
-                context=context,
+                context=run_context,
                 task_contexts=task_contexts,
                 parameters=parameters,
             )
 
-            with prefect.context(context):
+            with prefect.context(run_context):
                 state = self.check_flow_is_pending_or_running(state)
                 state = self.check_flow_reached_start_time(state)
                 state = self.set_flow_to_running(state)
@@ -266,7 +269,7 @@ class FlowRunner(Runner):
             self.logger.exception(
                 "Unexpected error while running flow: {}".format(repr(exc))
             )
-            if prefect.context.get("raise_on_exception"):
+            if run_context.get("raise_on_exception"):
                 raise exc
             new_state = Failed(
                 message="Unexpected error while running flow: {}".format(repr(exc)),

--- a/tests/engine/test_flow_runner.py
+++ b/tests/engine/test_flow_runner.py
@@ -1323,18 +1323,28 @@ class TestContext:
         output = res.result[return_ctx_key].result
         assert isinstance(output, datetime.datetime)
 
-    def test_user_provided_context_is_prioritized(self):
+    @pytest.mark.parametrize(
+        "outer_context, inner_context, sol",
+        [
+            ({"date": "outer"}, {"date": "inner"}, "inner"),
+            ({"date": "outer"}, {}, "outer"),
+        ],
+    )
+    def test_user_provided_context_is_prioritized(
+        self, outer_context, inner_context, sol
+    ):
         @prefect.task
         def return_ctx_key():
             return prefect.context.get("date")
 
         f = Flow(name="test", tasks=[return_ctx_key])
-        res = f.run(context={"date": "42"})
+        with prefect.context(**outer_context):
+            res = f.run(context=inner_context)
 
         assert res.is_successful()
 
         output = res.result[return_ctx_key].result
-        assert output == "42"
+        assert output == sol
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When adding default fields to context during a flow run, several check
if there's an existing value and only override if it doesn't already
exist (e.g. `"date"`). However, this would only work if the context was
passed explicitly to `.run(context=context)`, rather than being part of
the implicit global context (since that wasn't added until the very
end). This PR fixes that bug.

Fixes #4276.

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)