### PR TITLE
Fixing Snowflake Query Task

### DIFF
--- a/changes/pr4298.yaml
+++ b/changes/pr4298.yaml
@@ -1,0 +1,3 @@
+task:
+  - "Ensures Snowflake Query Task output is serializable [#3744]
+  (https://github.com/PrefectHQ/prefect/issues/3744)"

--- a/src/prefect/tasks/snowflake/snowflake.py
+++ b/src/prefect/tasks/snowflake/snowflake.py
@@ -106,8 +106,7 @@ class SnowflakeQuery(Task):
         try:
             with conn:
                 with conn.cursor() as cursor:
-                    executed = cursor.execute(query, params=data)
-
+                    executed = cursor.execute(query, params=data).fetchall()
             conn.close()
             return executed
 

--- a/tests/tasks/snowflake/test_snowflake.py
+++ b/tests/tasks/snowflake/test_snowflake.py
@@ -49,7 +49,8 @@ class TestSnowflakeQuery:
     def test_execute_fetchall(self, monkeypatch):
         """
         Tests that the SnowflakeQuery Task calls the fetchall method on the
-        cursor. This is to prevent future code edits from returning the cursor.
+        cursor. This is to prevent future code edits from returning the cursor
+        object because that cursors are not pickleable.
         """
         snowflake_module_connect_method = MagicMock()
         connection = MagicMock(spec=sf.SnowflakeConnection)

--- a/tests/tasks/snowflake/test_snowflake.py
+++ b/tests/tasks/snowflake/test_snowflake.py
@@ -48,7 +48,7 @@ class TestSnowflakeQuery:
 
     def test_execute_fetchall(self, monkeypatch):
         """
-        Tests that the SnowflakeQuery Task calls the fetchall method on the 
+        Tests that the SnowflakeQuery Task calls the fetchall method on the
         cursor. This is to prevent future code edits from returning the cursor.
         """
         snowflake_module_connect_method = MagicMock()

--- a/tests/tasks/snowflake/test_snowflake.py
+++ b/tests/tasks/snowflake/test_snowflake.py
@@ -47,6 +47,10 @@ class TestSnowflakeQuery:
             task.run(query="SELECT * FROM foo")
 
     def test_execute_fetchall(self, monkeypatch):
+        """
+        Tests that the SnowflakeQuery Task calls the fetchall method on the 
+        cursor. This is to prevent future code edits from returning the cursor.
+        """
         snowflake_module_connect_method = MagicMock()
         connection = MagicMock(spec=sf.SnowflakeConnection)
         cursor = MagicMock(spec=sf.DictCursor)


### PR DESCRIPTION
## Summary

This is to fix this [issue](https://github.com/PrefectHQ/prefect/issues/3744) about Snowflake output not being pickleable. This is because the original code just returned the cursor.

I spun up a free trial for Snowflake and tested this change with the default databases. I then used `cloudpickle` to make sure results are serializable. This is hard to reflect in the unit tests.

## Changes

I added the `fetchall` call, and then I added a new unit test that ensures the Task has the `fetchall` call.


## Checklist
This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)