### PR TITLE
Use custom `date` in context to determine dependent context vars

### DIFF
--- a/changes/pr4295.yaml
+++ b/changes/pr4295.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Use custom `date` in context to determine dependent context vars [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"

--- a/changes/pr4295.yaml
+++ b/changes/pr4295.yaml
@@ -1,2 +1,3 @@
 enhancement:
-  - "Use custom `date` in context to determine dependent context vars [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"
+  - "When manually set, `prefect.context.date` will be used to determine dependent values - [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"
+  - "`prefect.context.date` will be converted to a `DateTime` object if given a parsable string - [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"

--- a/changes/pr4295.yaml
+++ b/changes/pr4295.yaml
@@ -1,3 +1,3 @@
 enhancement:
   - "When manually set, `prefect.context.date` will be used to determine dependent values - [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"
-  - "`prefect.context.date` will be converted to a `DateTime` object if given a parsable string - [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"
+  - "`prefect.context.date` will be cast to a `DateTime` object if given a parsable string - [#4295](https://github.com/PrefectHQ/prefect/pull/4295)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -155,8 +155,26 @@ class FlowRunner(Runner):
         context.update(flow_name=self.flow.name)
         context.setdefault("scheduled_start_time", pendulum.now("utc"))
 
+        # Determine the current time, allowing our formatted dates in the context
+        # to rely on a manually set value
+        now = context.get("date")
+        if isinstance(now, str):
+            # Attempt to parse into a `DateTime` object
+            try:
+                now = pendulum.parse(now)
+            except:
+                pass
+        if not isinstance(now, pendulum.DateTime):
+            if now is not None:
+                self.logger.warning(
+                    "`date` was set in the context manually but could not be parsed "
+                    "into a pendulum `DateTime` object. Additional context variables "
+                    "that rely on the current date i.e `today` and `tomorrow` will be "
+                    "based on the current time instead of the `date` context variable."
+                )
+            now = pendulum.now()
+
         # add various formatted dates to context
-        now = pendulum.now("utc")
         dates = {
             "date": now,
             "today": now.strftime("%Y-%m-%d"),

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -172,7 +172,7 @@ class FlowRunner(Runner):
                     "that rely on the current date i.e `today` and `tomorrow` will be "
                     "based on the current time instead of the `date` context variable."
                 )
-            now = pendulum.now()
+            now = pendulum.now("utc")
 
         # add various formatted dates to context
         dates = {

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -159,9 +159,12 @@ class FlowRunner(Runner):
         # to rely on a manually set value
         now = context.get("date")
         if isinstance(now, str):
-            # Attempt to parse into a `DateTime` object
+            # Attempt to parse into a `DateTime` object since it will often be passed
+            # as a serialized string from the UI we'll override the context on a
+            # successful parse so the type is consistent for users
             try:
                 now = pendulum.parse(now)
+                context["date"] = now
             except Exception:
                 pass
         if not isinstance(now, pendulum.DateTime):

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -162,7 +162,7 @@ class FlowRunner(Runner):
             # Attempt to parse into a `DateTime` object
             try:
                 now = pendulum.parse(now)
-            except:
+            except Exception:
                 pass
         if not isinstance(now, pendulum.DateTime):
             if now is not None:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Previously, if you overrode `date` in the context for a flow, the dependent variables such as `tomorrow` and `today` would still be based on `pendulum.now()` making it hard for a user to do a simple override and see expected context changes. This will attempt to parse `date` if set to determine the "now" `DateTime` to be used to set the dependent variables. If unparsable, a warning will be displayed.

## Changes
<!-- What does this PR change? -->

Dependent variables are automatically updated if `date` is set and is parsable as a `DateTime`.


## Importance
<!-- Why is this PR important? -->

Improves usability for testing / backfilled schedules.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~