### PR TITLE
Always load latest task run info prior to running task

### DIFF
--- a/changes/pr4296.yaml
+++ b/changes/pr4296.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Always load task run info prior to running a task - [#4296](https://github.com/PrefectHQ/prefect/pull/4296)"

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -152,8 +152,8 @@ class CloudTaskRunner(TaskRunner):
         # load task run info
         try:
             task_run_info = self.client.get_task_run_info(
-                flow_run_id=context.get("flow_run_id"),
-                task_id=context.get("task_id"),
+                flow_run_id=context.get("flow_run_id", ""),
+                task_id=context.get("task_id", ""),
                 map_index=context.get("map_index"),
             )
 

--- a/src/prefect/engine/cloud/task_runner.py
+++ b/src/prefect/engine/cloud/task_runner.py
@@ -378,18 +378,6 @@ class CloudTaskRunner(TaskRunner):
                 self.client.update_task_run_heartbeat(
                     task_run_id=prefect.context.get("task_run_id")
                 )
-                # mapped children will retrieve their latest info inside
-                # initialize_run(), but we can load up-to-date versions
-                # for all other task runs here
-                if prefect.context.get("map_index") in [-1, None]:
-                    task_run_info = self.client.get_task_run_info(
-                        flow_run_id=prefect.context.get("flow_run_id"),
-                        task_id=prefect.context.get("task_id"),
-                        map_index=prefect.context.get("map_index"),
-                    )
-
-                    # if state was provided, keep it; otherwise use the one from db
-                    context.update(task_run_version=task_run_info.version)  # type: ignore
 
                 end_state = super().run(
                     state=end_state,

--- a/tests/engine/cloud/test_cloud_flow_runner.py
+++ b/tests/engine/cloud/test_cloud_flow_runner.py
@@ -471,6 +471,9 @@ def test_cloud_task_runners_submitted_to_remote_machines_respect_original_config
                 task_runs=[MagicMock(task_slug="log_stuff-1", id="TESTME")],
             )
 
+        def get_task_run_info(self, *args, **kwargs):
+            return MagicMock(id="TESTME")
+
     monkeypatch.setattr("prefect.engine.flow_runner.run_task", my_run_task)
     monkeypatch.setattr("prefect.client.Client", Client)
     monkeypatch.setattr("prefect.engine.cloud.task_runner.Client", Client)

--- a/tests/engine/cloud/test_cloud_flows.py
+++ b/tests/engine/cloud/test_cloud_flows.py
@@ -9,12 +9,11 @@ import pytest
 import prefect
 from prefect.client.client import (
     Client,
-    ProjectInfo,
     FlowRunInfoResult,
+    ProjectInfo,
     TaskRunInfoResult,
 )
 from prefect.engine.cloud import CloudFlowRunner, CloudTaskRunner
-from prefect.executors import LocalExecutor
 from prefect.engine.result import Result
 from prefect.engine.results import LocalResult, PrefectResult
 from prefect.engine.state import (
@@ -29,6 +28,7 @@ from prefect.engine.state import (
     TimedOut,
     TriggerFailed,
 )
+from prefect.executors import LocalExecutor
 from prefect.utilities.configuration import set_temporary_config
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
@@ -172,6 +172,9 @@ class MockedCloudClient(MagicMock):
         """
         self.call_count["get_task_run_info"] += 1
 
+        if map_index is None:
+            map_index = -1
+
         task_run = next(
             (
                 t
@@ -262,7 +265,7 @@ class QueueingMockCloudClient(MockedCloudClient):
 
 
 @pytest.mark.parametrize("executor", ["local", "sync"], indirect=True)
-def test_simple_two_task_flow2(monkeypatch, executor):
+def test_simple_two_task_flow_2(monkeypatch, executor):
     flow_run_id = str(uuid.uuid4())
     task_run_id_1 = str(uuid.uuid4())
     task_run_id_2 = str(uuid.uuid4())
@@ -276,10 +279,14 @@ def test_simple_two_task_flow2(monkeypatch, executor):
         flow_runs=[FlowRun(id=flow_run_id)],
         task_runs=[
             TaskRun(
-                id=task_run_id_1, task_slug=flow.slugs[t1], flow_run_id=flow_run_id
+                id=task_run_id_1,
+                task_slug=flow.slugs[t1],
+                flow_run_id=flow_run_id,
             ),
             TaskRun(
-                id=task_run_id_2, task_slug=flow.slugs[t2], flow_run_id=flow_run_id
+                id=task_run_id_2,
+                task_slug=flow.slugs[t2],
+                flow_run_id=flow_run_id,
             ),
         ],
         monkeypatch=monkeypatch,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Generally, we pre-load task run information when the flow run starts. The only time we load task run information when the task itself starts is for dynamic tasks. However, in certain fast-moving situations, the flow may actually begin running before all task-level detail is available. This PR modifies the task run info logic to ALWAYS load when the task run starts.

With this in place, we could further improve performance by completely eliminating the initial batch task run load, but I'm not including that here.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)