### PR TITLE
Modified resource manager to allow success and failure cleanup

### DIFF
--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -407,6 +407,8 @@ class Flow:
         from prefect.tasks.core.resource_manager import (
             ResourceInitTask,
             ResourceCleanupTask,
+            ResourceSuccessCleanupTask,
+            ResourceFailureCleanupTask,
         )
 
         # Select all tasks that aren't a ResourceInitTask/ResourceCleanupTask
@@ -419,11 +421,26 @@ class Flow:
         return {
             t
             for t in self.tasks
-            if not isinstance(t, (ResourceInitTask, ResourceCleanupTask))
+            if not isinstance(
+                t,
+                (
+                    ResourceInitTask,
+                    ResourceCleanupTask,
+                    ResourceSuccessCleanupTask,
+                    ResourceFailureCleanupTask,
+                ),
+            )
             and not any(
                 t
                 for t in self.downstream_tasks(t)
-                if not isinstance(t, ResourceCleanupTask)
+                if not isinstance(
+                    t,
+                    (
+                        ResourceCleanupTask,
+                        ResourceSuccessCleanupTask,
+                        ResourceFailureCleanupTask,
+                    ),
+                )
             )
         }
 


### PR DESCRIPTION
## Summary
This PR modifies the resource manager so that the user can supply `success_cleanup()` and `failure_cleanup()` functions in addition to `cleanup()`. When present, `success_cleanup()` is executed before `cleanup()` if all tasks in the resource manager context succeeded, and `failure_cleanup()` is executed if at least on task in the context failed.




## Changes
Changes `resource_manager.py` by adding `ResourceSuccessCleanupTask` and `ResourceFailureCleanupTask`, adds custom triggers for each class type, modifies `ResourceContext.__exit__` to set downstream tasks with the new conditional cleanup tasks, and `ResourceManager` and `resource_manager` to support these cleanup tasks.




## Importance
Resource managers are important, because they allow many tasks to make use of a shared resource while ensuring that that resource is only cleaned up after all tasks that need it have finished. It is commonly the case that different cleanup steps need to be performed depending on the outcome of tasks that depend on the resource. For example, the resource could be a database transaction, which we want to commit or rollback depending on the success or failure of the queries that are part of that transaction.




## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)