### PR TITLE
Add new task KubernetesSecret

### DIFF
--- a/changes/pr4307.yaml
+++ b/changes/pr4307.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+task:
+  - "Add new task KubernetesSecret - [#4307](https://github.com/PrefectHQ/prefect/pull/4307)"
+
+contributor:
+  - "[David Zucker](https://github.com/davzucky)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -322,6 +322,7 @@ classes = [
         "PatchNamespacedService",
         "ReadNamespacedService",
         "ReplaceNamespacedService",
+        "KubernetesSecret",
         ]
 
 [pages.tasks.dbt]

--- a/src/prefect/tasks/kubernetes/__init__.py
+++ b/src/prefect/tasks/kubernetes/__init__.py
@@ -33,6 +33,7 @@ try:
         ReplaceNamespacedPod,
         ReadNamespacedPodLogs,
     )
+    from prefect.tasks.kubernetes.secrets import KubernetesSecret
     from prefect.tasks.kubernetes.service import (
         CreateNamespacedService,
         DeleteNamespacedService,

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -69,8 +69,6 @@ class KubernetesSecret(SecretBase):
         "namespace",
         "kube_kwargs",
         "kubernetes_api_key_secret",
-        "cast_function",
-        "raise_if_missing",
     )
     def run(
         self,
@@ -79,8 +77,6 @@ class KubernetesSecret(SecretBase):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
-        cast_function: Callable[[Any], Any] = None,
-        raise_if_missing: bool = False,
     ):
         """
         Returns the value of an kubenetes secret after applying an optional `cast` function.
@@ -94,11 +90,6 @@ class KubernetesSecret(SecretBase):
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
                 which stored your Kubernetes API Key; this Secret must be a string and in
                 BearerToken format
-            - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
-                value to coerce it to a type.
-            - raise_if_missing (bool): if True, an error will be raised if the env var is not found.
-        Returns:
-            - Any: the (optionally type-cast) value of the Kubenetes secret
 
         Raises:
             - ValueError: if `raise_is_missing` is `True` and the kubernetes secret was not found.
@@ -120,7 +111,7 @@ class KubernetesSecret(SecretBase):
         ).data
 
         if secret_key not in secret_data:
-            if raise_if_missing:
+            if self.raise_if_missing:
                 raise ValueError(f"Cannot find the key {secret_key} in {secret_name} ")
             else:
                 return None
@@ -128,5 +119,7 @@ class KubernetesSecret(SecretBase):
         decoded_secret = base64.b64decode(secret_data[secret_key]).decode("utf8")
 
         return (
-            decoded_secret if cast_function is None else cast_function(decoded_secret)
+            decoded_secret
+            if self.cast_function is None
+            else self.cast_function(decoded_secret)
         )

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -81,7 +81,7 @@ class KubernetesSecret(SecretBase):
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
         cast_function: Callable[[Any], Any] = None,
         raise_if_missing: bool = False,
-    ) -> Any:
+    ):
         """
         Returns the value of an kubenetes secret after applying an optional `cast` function.
 

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -12,11 +12,11 @@ from prefect.utilities.kubernetes import get_kubernetes_client
 class KubernetesSecret(SecretBase):
     """
     Task for loading a Prefect secret from a kubernetes secret.
-    
+
     This task will read a secret from kubernetes, returning the decoded value
     associated with `secret_key`. All initialization arguments can optionally
     be provided or overwritten at runtime.
-    
+
     Note that depending on cluster configuration, you may need to ensure you
     have the proper RBAC permissions to read the secret.
 

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -14,8 +14,8 @@ class KubernetesSecret(SecretBase):
     Task for creating a Prefect secret from the kubernetes secret.
 
     This task will read the secret object from kubernetes and extract the value of the secret_key
-    and decode it. The kubernetes secret can be created by sealedsecret or vault and read here. 
-    
+    and decode it. The kubernetes secret can be created by sealedsecret or vault and read here.
+
     Note that you need to ensure that you have the right RBAC from your cluster admin to read the secret
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
@@ -38,7 +38,7 @@ class KubernetesSecret(SecretBase):
             BearerToken format
         - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
             value to coerce it to a type.
-        - raise_if_missing (bool): if True, an error will be raised if the env var is not found.            
+        - raise_if_missing (bool): if True, an error will be raised if the env var is not found.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task
             constructor
     """
@@ -96,7 +96,7 @@ class KubernetesSecret(SecretBase):
                 BearerToken format
             - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
                 value to coerce it to a type.
-            - raise_if_missing (bool): if True, an error will be raised if the env var is not found.            
+            - raise_if_missing (bool): if True, an error will be raised if the env var is not found.
             - **kwargs (dict, optional): additional keyword arguments to pass to the Task
                 constructor
 

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -1,7 +1,7 @@
 import base64
 
-from typing import Any, cast, Callable, Optional
-
+from typing import Any,  Callable, Optional
+from typing import cast as typing_cast
 from kubernetes import client
 
 from prefect.tasks.secrets.base import SecretBase
@@ -38,7 +38,7 @@ class KubernetesSecret(SecretBase):
         - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
             which stored your Kubernetes API Key; this Secret must be a string and in
             BearerToken format
-        - cast_function (Callable[[Any], Any], optional): If provided, this will
+        - cast (Callable[[Any], Any], optional): If provided, this will
             be called on the secret to transform it before returning. An example
             use might be passing in `json.loads` to load values from stored JSON.
         - raise_if_missing (bool): if True, an error will be raised if the secret is not found.
@@ -53,7 +53,7 @@ class KubernetesSecret(SecretBase):
         namespace: str = "default",
         kube_kwargs: dict = None,
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
-        cast_function: Callable[[Any], Any] = None,
+        cast: Callable[[Any], Any] = None,
         raise_if_missing: bool = False,
         **kwargs: Any,
     ):
@@ -62,7 +62,7 @@ class KubernetesSecret(SecretBase):
         self.namespace = namespace
         self.kube_kwargs = kube_kwargs or {}
         self.kubernetes_api_key_secret = kubernetes_api_key_secret
-        self.cast_function = cast_function
+        self.cast = cast
         self.raise_if_missing = raise_if_missing
         super().__init__(**kwargs)
 
@@ -105,7 +105,7 @@ class KubernetesSecret(SecretBase):
         if not secret_key:
             raise ValueError("The key of the secret must be provided.")
 
-        api_client = cast(
+        api_client = typing_cast(
             client.CoreV1Api,
             get_kubernetes_client("secret", kubernetes_api_key_secret),
         )
@@ -124,6 +124,6 @@ class KubernetesSecret(SecretBase):
 
         return (
             decoded_secret
-            if self.cast_function is None
-            else self.cast_function(decoded_secret)
+            if self.cast is None
+            else self.cast(decoded_secret)
         )

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -1,0 +1,135 @@
+import base64
+
+from typing import Any, cast, Callable, Optional
+
+from kubernetes import client
+
+from prefect.tasks.secrets.base import SecretBase
+from prefect.utilities.tasks import defaults_from_attrs
+from prefect.utilities.kubernetes import get_kubernetes_client
+
+
+class KubernetesSecret(SecretBase):
+    """
+    Task for creating a Prefect secret from the kubernetes secret.
+
+    This task will read the secret object from kubernetes and extract the value of the secret_key
+    and decode it. The kubernetes secret can be created by sealedsecret or vault and read here. 
+    
+    Note that you need to ensure that you have the right RBAC from your cluster admin to read the secret
+    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+
+    1. Attempt to use a Prefect Secret that contains a Kubernetes API Key. If
+    `kubernetes_api_key_secret` = `None` then it will attempt the next two connection
+    methods. By default the value is `KUBERNETES_API_KEY` so providing `None` acts as
+    an override for the remote connection.
+    2. Attempt in-cluster connection (will only work when running on a Pod in a cluster)
+    3. Attempt out-of-cluster connection using the default location for a kube config file
+
+
+    Args:
+        - secret_name (string, optional): The name of the kubernetes secret object
+        - secret_key (string, optional): The key to look for in the kubernetes data
+        - namespace (str, optional): The Kubernetes namespace to read the secret from
+        - kube_kwargs (dict, optional): Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`)
+        - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
+            which stored your Kubernetes API Key; this Secret must be a string and in
+            BearerToken format
+        - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
+            value to coerce it to a type.
+        - raise_if_missing (bool): if True, an error will be raised if the env var is not found.            
+        - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+            constructor
+    """
+
+    def __init__(
+        self,
+        secret_name: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        namespace: str = "default",
+        kube_kwargs: dict = None,
+        kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        cast_function: Callable[[Any], Any] = None,
+        raise_if_missing: bool = False,
+        **kwargs: Any,
+    ):
+        self.secret_name = secret_name
+        self.secret_key = secret_key
+        self.namespace = namespace
+        self.kube_kwargs = kube_kwargs or {}
+        self.kubernetes_api_key_secret = kubernetes_api_key_secret
+        self.cast_function = cast_function
+        self.raise_if_missing = raise_if_missing
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs(
+        "secret_name",
+        "secret_key",
+        "namespace",
+        "kube_kwargs",
+        "kubernetes_api_key_secret",
+        "cast_function",
+        "raise_if_missing",
+    )
+    def run(
+        self,
+        secret_name: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        namespace: str = "default",
+        kube_kwargs: dict = None,
+        kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
+        cast_function: Callable[[Any], Any] = None,
+        raise_if_missing: bool = False,
+    ) -> None:
+        """
+        Returns the value of an kubenetes secret after applying an optional `cast` function.
+
+        Args:
+            - secret_name (string, optional): The name of the kubernetes secret object
+            - secret_key (string, optional): The key to look for in the kubernetes data
+            - namespace (str, optional): The Kubernetes namespace to read the secret from
+            - kube_kwargs (dict, optional): Optional extra keyword arguments to pass to the
+                Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`)
+            - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
+                which stored your Kubernetes API Key; this Secret must be a string and in
+                BearerToken format
+            - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
+                value to coerce it to a type.
+            - raise_if_missing (bool): if True, an error will be raised if the env var is not found.            
+            - **kwargs (dict, optional): additional keyword arguments to pass to the Task
+                constructor
+
+        Returns:
+            - Any: the (optionally type-cast) value of the Kubenetes secret
+
+        Raises:
+            - ValueError: if `raise_is_missing` is `True` and the kubernetes secret was not found.
+                The value of secret_name and secret_key are mandatory as well
+        """
+        if not secret_name:
+            raise ValueError("The name of a Kubernetes secret must be provided.")
+
+        if not secret_key:
+            raise ValueError("The key of the secret must be provided.")
+
+        api_client = cast(
+            client.CoreV1Api,
+            get_kubernetes_client("secret", kubernetes_api_key_secret),
+        )
+
+        secret_data = api_client.read_namespaced_secret(
+            name=secret_name, namespace=namespace
+        ).data
+
+        if secret_key not in secret_data:
+            if raise_if_missing:
+                raise ValueError(f"Cannot find the key {secret_key} in {secret_name} ")
+            else:
+                return None
+
+        decoded_secret = base64.b64decode(secret_data[secret_key]).decode("utf8")
+
+        return (
+            decoded_secret if cast_function is None else cast_function(decoded_secret)
+        )

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -11,13 +11,14 @@ from prefect.utilities.kubernetes import get_kubernetes_client
 
 class KubernetesSecret(SecretBase):
     """
-    Task for creating a Prefect secret from the kubernetes secret.
-
-    This task will read the secret object from kubernetes and extract the value of the secret_key
-    and decode it. The kubernetes secret can be created by sealedsecret or vault and read here.
-
-    Note that you need to ensure that you have the right RBAC from your cluster admin to read the secret
-    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+    Task for loading a Prefect secret from a kubernetes secret.
+    
+    This task will read a secret from kubernetes, returning the decoded value
+    associated with `secret_key`. All initialization arguments can optionally
+    be provided or overwritten at runtime.
+    
+    Note that depending on cluster configuration, you may need to ensure you
+    have the proper RBAC permissions to read the secret.
 
     1. Attempt to use a Prefect Secret that contains a Kubernetes API Key. If
     `kubernetes_api_key_secret` = `None` then it will attempt the next two connection
@@ -30,15 +31,17 @@ class KubernetesSecret(SecretBase):
     Args:
         - secret_name (string, optional): The name of the kubernetes secret object
         - secret_key (string, optional): The key to look for in the kubernetes data
-        - namespace (str, optional): The Kubernetes namespace to read the secret from
+        - namespace (str, optional): The Kubernetes namespace to read the secret from,
+            defaults to the `default` namespace.
         - kube_kwargs (dict, optional): Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`)
         - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret
             which stored your Kubernetes API Key; this Secret must be a string and in
             BearerToken format
-        - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
-            value to coerce it to a type.
-        - raise_if_missing (bool): if True, an error will be raised if the env var is not found.
+        - cast_function (Callable[[Any], Any], optional): If provided, this will
+            be called on the secret to transform it before returning. An example
+            use might be passing in `json.loads` to load values from stored JSON.
+        - raise_if_missing (bool): if True, an error will be raised if the secret is not found.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task
             constructor
     """
@@ -84,7 +87,8 @@ class KubernetesSecret(SecretBase):
         Args:
             - secret_name (string, optional): The name of the kubernetes secret object
             - secret_key (string, optional): The key to look for in the kubernetes data
-            - namespace (str, optional): The Kubernetes namespace to read the secret from
+            - namespace (str, optional): The Kubernetes namespace to read the secret from,
+                defaults to the `default` namespace.
             - kube_kwargs (dict, optional): Optional extra keyword arguments to pass to the
                 Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`)
             - kubernetes_api_key_secret (str, optional): the name of the Prefect Secret

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -81,7 +81,7 @@ class KubernetesSecret(SecretBase):
         kubernetes_api_key_secret: str = "KUBERNETES_API_KEY",
         cast_function: Callable[[Any], Any] = None,
         raise_if_missing: bool = False,
-    ) -> None:
+    ) -> Any:
         """
         Returns the value of an kubenetes secret after applying an optional `cast` function.
 
@@ -97,9 +97,6 @@ class KubernetesSecret(SecretBase):
             - cast_function (Callable[[Any], Any]): A function that will be called on the Parameter
                 value to coerce it to a type.
             - raise_if_missing (bool): if True, an error will be raised if the env var is not found.
-            - **kwargs (dict, optional): additional keyword arguments to pass to the Task
-                constructor
-
         Returns:
             - Any: the (optionally type-cast) value of the Kubenetes secret
 

--- a/src/prefect/tasks/kubernetes/secrets.py
+++ b/src/prefect/tasks/kubernetes/secrets.py
@@ -1,6 +1,6 @@
 import base64
 
-from typing import Any,  Callable, Optional
+from typing import Any, Callable, Optional
 from typing import cast as typing_cast
 from kubernetes import client
 
@@ -122,8 +122,4 @@ class KubernetesSecret(SecretBase):
 
         decoded_secret = base64.b64decode(secret_data[secret_key]).decode("utf8")
 
-        return (
-            decoded_secret
-            if self.cast is None
-            else self.cast(decoded_secret)
-        )
+        return decoded_secret if self.cast is None else self.cast(decoded_secret)

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -14,6 +14,7 @@ K8S_CLIENTS = {
     "pod": client.CoreV1Api,
     "service": client.CoreV1Api,
     "deployment": client.AppsV1Api,
+    "secret": client.CoreV1Api,
 }
 
 

--- a/tests/tasks/kubernetes/test_secrets.py
+++ b/tests/tasks/kubernetes/test_secrets.py
@@ -12,7 +12,7 @@ def kube_secret():
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
             yield
-            
+
 
 @pytest.fixture
 def client_read_namespaced_secret(monkeypatch):

--- a/tests/tasks/kubernetes/test_secrets.py
+++ b/tests/tasks/kubernetes/test_secrets.py
@@ -85,7 +85,7 @@ class TestKubernetesSecretTask:
         self, kube_secret, client_read_namespaced_secret
     ):
         task = KubernetesSecret(
-            secret_name="secret-name", secret_key="some_mumber", cast_function=int
+            secret_name="secret-name", secret_key="some_mumber", cast=int
         )
 
         secret_value = task.run()

--- a/tests/tasks/kubernetes/test_secrets.py
+++ b/tests/tasks/kubernetes/test_secrets.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import prefect
+from prefect.tasks.kubernetes import KubernetesSecret
+from prefect.utilities.configuration import set_temporary_config
+
+
+@pytest.fixture
+def kube_secret():
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):
+            yield
+            
+
+@pytest.fixture
+def client_read_namespaced_secret(monkeypatch):
+    class SecretResult:
+        def __init__(self):
+            self.data = {"valide_secret": "cHJlZmVjdA==", "some_mumber": "MTIzNA=="}
+
+    secret = MagicMock(return_value=SecretResult())
+    # secret = MagicMock()
+    monkeypatch.setattr("kubernetes.client.CoreV1Api.read_namespaced_secret", secret)
+    client = MagicMock()
+    monkeypatch.setattr(
+        "prefect.tasks.kubernetes.service.get_kubernetes_client",
+        MagicMock(return_value=client),
+    )
+    return secret
+
+
+class TestKubernetesSecretTask:
+    def test_empty_initialization(self):
+        task = KubernetesSecret()
+        assert task.secret_name == None
+        assert task.secret_key == None
+        assert task.namespace == "default"
+        assert task.kube_kwargs == {}
+        assert task.kubernetes_api_key_secret == "KUBERNETES_API_KEY"
+
+    def test_filled_initialization(self):
+        task = KubernetesSecret(
+            secret_name="test_secret",
+            secret_key="mysecret",
+            namespace="test",
+            kube_kwargs={"test": "test"},
+            kubernetes_api_key_secret="test",
+        )
+        assert task.secret_name == "test_secret"
+        assert task.secret_key == "mysecret"
+        assert task.namespace == "test"
+        assert task.kube_kwargs == {"test": "test"}
+        assert task.kubernetes_api_key_secret == "test"
+
+    def test_empty_secret_name_raises_error(self):
+        task = KubernetesSecret()
+        with pytest.raises(ValueError):
+            task.run()
+
+    def test_empty_secret_key_raises_error(self):
+        task = KubernetesSecret()
+        with pytest.raises(ValueError):
+            task.run()
+
+    def test_params_are_passed_to_read_namespaced_secret(
+        self, kube_secret, client_read_namespaced_secret
+    ):
+        task = KubernetesSecret(secret_name="secret-name", secret_key="valide_secret")
+
+        task.run()
+        assert client_read_namespaced_secret.call_args.kwargs["name"] == "secret-name"
+        assert client_read_namespaced_secret.call_args.kwargs["namespace"] == "default"
+
+    def test_secret_is_decoded_to_string(
+        self, kube_secret, client_read_namespaced_secret
+    ):
+        task = KubernetesSecret(secret_name="secret-name", secret_key="valide_secret")
+
+        secret_value = task.run()
+        assert secret_value == "prefect"
+
+    def test_secret_is_decoded_and_cast_to_int(
+        self, kube_secret, client_read_namespaced_secret
+    ):
+        task = KubernetesSecret(
+            secret_name="secret-name", secret_key="some_mumber", cast_function=int
+        )
+
+        secret_value = task.run()
+        assert secret_value == 1234
+
+    def test_secret_thow_value_error_if_secret_not_found_and_raise_flag_enabled(
+        self, kube_secret, client_read_namespaced_secret
+    ):
+        task = KubernetesSecret(
+            secret_name="secret-name",
+            secret_key="key_that_doesnt_exist",
+            raise_if_missing=True,
+        )
+
+        with pytest.raises(ValueError):
+            task.run()
+
+    def test_secret_return_None_if_secret_key_not_found(
+        self, kube_secret, client_read_namespaced_secret
+    ):
+        task = KubernetesSecret(
+            secret_name="secret-name",
+            secret_key="key_that_doesnt_exist",
+            raise_if_missing=False,
+        )
+
+        secret_value = task.run()
+        assert secret_value == None


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This is a new task that allows us to extract Kubernetes Secret and transform it into a Prefect secret.
The idea is to have another secret store from the one which already exists. Prefect, env var or AWSvault.



## Changes
This PR adds a new task KubernetesSecret that inherit from SecretBase

## Importance
This PR allows users who are using Prefect Server to centralize all their secret on a Kubernetes Secret object

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)