### PR TITLE
Fix `DatabricksRunNow` task attribute override behavior

### DIFF
--- a/changes/pr4309.yaml
+++ b/changes/pr4309.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix `DatabricksRunNow` task attribute override behavior - [#4309](https://github.com/PrefectHQ/prefect/pull/4309)"
+
+contributor:
+  - "[Greg Lu](https://github.com/greglu)"

--- a/src/prefect/tasks/databricks/databricks_submitjob.py
+++ b/src/prefect/tasks/databricks/databricks_submitjob.py
@@ -663,25 +663,26 @@ class DatabricksRunNow(Task):
         ), "`databricks_conn_secret` must be supplied as a valid dictionary."
         self.databricks_conn_secret = databricks_conn_secret
 
-        if json:
-            self.json = json
-
         # Initialize Databricks Connections
         hook = self.get_hook()
 
-        if self.job_id is not None:
-            self.json["job_id"] = self.job_id
-        if self.notebook_params is not None:
-            self.json["notebook_params"] = self.notebook_params
-        if self.python_params is not None:
-            self.json["python_params"] = self.python_params
-        if self.spark_submit_params is not None:
-            self.json["spark_submit_params"] = self.spark_submit_params
-        if self.jar_params is not None:
-            self.json["jar_params"] = self.jar_params
+        run_now_json = json or {}
+
+        if job_id is not None:
+            run_now_json["job_id"] = job_id
+        if notebook_params is not None:
+            merged = run_now_json.setdefault("notebook_params", {})
+            merged.update(notebook_params)
+            run_now_json["notebook_params"] = merged
+        if python_params is not None:
+            run_now_json["python_params"] = python_params
+        if spark_submit_params is not None:
+            run_now_json["spark_submit_params"] = spark_submit_params
+        if jar_params is not None:
+            run_now_json["jar_params"] = jar_params
 
         # Validate the dictionary to a valid JSON object
-        self.json = _deep_string_coerce(self.json)
+        self.json = _deep_string_coerce(run_now_json)
 
         # Submit the job
         self.run_id = hook.run_now(self.json)

--- a/tests/tasks/databricks/test_databricks.py
+++ b/tests/tasks/databricks/test_databricks.py
@@ -2,9 +2,44 @@ import pytest
 
 from prefect.tasks.databricks import DatabricksSubmitRun
 from prefect.tasks.databricks import DatabricksRunNow
+from prefect.tasks.databricks.databricks_hook import DatabricksHook
 
 
-@pytest.fixture(scope="session")
+class DatabricksHookTestOverride(DatabricksHook):
+    """
+    Overrides `DatabricksHook` to avoid making actual API calls
+    and return mocked responses instead
+
+    Args:
+        - mocked_response (dict): JSON response of API call
+    """
+
+    def __init__(self, mocked_response={}, **kwargs) -> None:
+        self.mocked_response = mocked_response
+        super().__init__(self, **kwargs)
+
+    def _do_api_call(self, endpoint_info, json):
+        return self.mocked_response
+
+
+class DatabricksRunNowTestOverride(DatabricksRunNow):
+    """
+    Overrides `DatabricksRunNow` to allow mocked API responses
+    to be returned using `DatabricksHookTestOverride`
+
+    Args:
+        - mocked_response (dict): JSON response of API call
+    """
+
+    def __init__(self, mocked_response, **kwargs) -> None:
+        self.mocked_response = mocked_response
+        super().__init__(**kwargs)
+
+    def get_hook(self):
+        return DatabricksHookTestOverride(self.mocked_response)
+
+
+@pytest.fixture
 def job_config():
 
     config = {
@@ -23,7 +58,7 @@ def job_config():
     return config
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def notebook_job_config():
 
     config = {
@@ -35,6 +70,52 @@ def notebook_job_config():
     }
 
     return config
+
+
+@pytest.fixture
+def notebook_job_config_full():
+
+    config = {
+        "job_id": 1,
+        "notebook_params": {
+            "dry-run": "true",
+            "oldest-time-to-consider": "1457570074236",
+        },
+        "python_params": ["python-param1", "python-param2"],
+        "spark_submit_params": ["spark-param1", "spark-param2"],
+        "jar_params": ["jar-param1", "jar-param2"],
+    }
+
+    return config
+
+
+@pytest.fixture
+def databricks_api_response_success():
+
+    response = {
+        "run_id": "test-run-id",
+        "run_page_url": "https://run_page_url",
+        "state": {
+            "life_cycle_state": "TERMINATED",
+            "result_state": "SUCCESS",
+            "state_message": "Completed",
+        },
+    }
+
+    return response
+
+
+@pytest.fixture
+def task_template(databricks_api_response_success, notebook_job_config_full):
+
+    return DatabricksRunNowTestOverride(
+        mocked_response=databricks_api_response_success,
+        databricks_conn_secret={
+            "host": "https://cloud.databricks.com",
+            "token": "databricks-token",
+        },
+        json=notebook_job_config_full,
+    )
 
 
 def test_raises_if_invalid_host_submitrun(job_config):
@@ -61,3 +142,64 @@ def test_raises_if_invalid_host_runnow(notebook_job_config):
             databricks_conn_secret={"host": "", "token": ""}, json=notebook_job_config
         )
         task.run()
+
+
+class TestDatabricksRunNowAttributeOverrides:
+    """Test various expected attribute override behavior with `DatabricksRunNow.run`"""
+
+    def test_without_overrides(self, task_template):
+        task_template.run()
+
+        run_now_json = task_template.json
+        assert run_now_json.get("job_id") == "1"
+        assert run_now_json.get("notebook_params", {}).get("dry-run") == "true"
+        assert (
+            run_now_json.get("notebook_params", {}).get("oldest-time-to-consider")
+            == "1457570074236"
+        )
+        assert run_now_json.get("python_params") == ["python-param1", "python-param2"]
+        assert run_now_json.get("spark_submit_params") == [
+            "spark-param1",
+            "spark-param2",
+        ]
+        assert run_now_json.get("jar_params") == ["jar-param1", "jar-param2"]
+
+    def test_with_job_id_override(self, task_template):
+        task_template.run(job_id="42")
+        assert task_template.json.get("job_id") == "42"
+
+    def test_with_notebook_params_override(self, task_template):
+        task_template.run(notebook_params={"dry-run": "false"})
+
+        run_now_json = task_template.json
+        assert run_now_json.get("notebook_params", {}).get("dry-run") == "false"
+        assert (
+            run_now_json.get("notebook_params", {}).get("oldest-time-to-consider")
+            == "1457570074236"
+        )
+
+    def test_with_python_params_override(self, task_template):
+        task_template.run(python_params=["python-param3"])
+        assert task_template.json.get("python_params") == ["python-param3"]
+
+    def test_with_spark_submit_params_override(self, task_template):
+        task_template.run(spark_submit_params=["spark-param3"])
+        assert task_template.json.get("spark_submit_params") == ["spark-param3"]
+
+    def test_with_jar_params_override(self, task_template):
+        task_template.run(jar_params=["jar-param3"])
+        assert task_template.json.get("jar_params") == ["jar-param3"]
+
+    def test_with_json_override(self, task_template):
+        task_template.run(
+            json={"job_id": "123"},
+            notebook_params={"notebookparam1": "notebookvalue1"},
+        )
+
+        run_now_json = task_template.json
+        assert len(run_now_json) == 2
+        assert run_now_json.get("job_id") == "123"
+        assert (
+            run_now_json.get("notebook_params", {}).get("notebookparam1")
+            == "notebookvalue1"
+        )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`DatabricksRunNow.run` was not properly overriding task attributes, which resulted in unexpected job json objects being generated for the Databricks API calls.

## Changes
<!-- What does this PR change? -->

* Fixes task attribute override behavior when calling `DatabricksRunNow.run`.
* Improves `test_databricks.py` to allow mocked responses from Databricks API.
* Implement tests for `DatabricksRunNow.run` and generated job json object for Databricks API calls.

## Importance
<!-- Why is this PR important? -->

Using the `DatabricksRunNow` task resulted in some unexpected behavior when attempting to override task attributes during `DatabricksRunNow.run`. The issues are best demonstrated with this simple test (which currently fails):

```python
def test_run_with_attribute_overrides():
    task_template = DatabricksRunNow(
        databricks_conn_secret={
            "host": "https://cloud.databricks.com",
            "token": "databricks-token",
        },
        json={
            "job_id": 1,
            "notebook_params": {
                "dry-run": "false"
            }
        },
    )

    task_template.run(job_id="42", notebook_params={"dry-run": "true"})

    print(task_template.json)
    # {'job_id': '1', 'notebook_params': {'dry-run': 'false'}}

    assert task_template.json.get("job_id") == "42"
    assert task_template.json.get("notebook_params", {}).get("dry-run") == "true"
```

Aside from these 2 attributes, the same issues also occurred with all other task attributes.

Test coverage was also sparse and there was no ability to actually test the results of `DatabricksRunNow.run` calls without triggering outgoing API requests. By subclassing and overriding specific methods, the task and run method behavior can be better tested now.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)