### PR TITLE
Allow terminal flow state handler override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Released on March 24, 2021.
 - Improve error message when a loaded flow doesn't match the version stored in Prefect Cloud/Server - [#4259](https://github.com/PrefectHQ/prefect/pull/4259)
 - Support setting flow run labels from cli - [#4266](https://github.com/PrefectHQ/prefect/pull/4266)
 - Support setting default `image` in `--job-template`/`--task-definition` in Kubernetes/ECS agents - [#4270](https://github.com/PrefectHQ/prefect/pull/4270)
+- Allow the terminal flow state handler to be overridden  - [#4198](https://github.com/PrefectHQ/prefect/issues/4198)
 
 ### Task Library
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -143,6 +143,7 @@ class Flow:
             the flow (e.g., presence of cycles and illegal keys) after adding the edges passed
             in the `edges` argument. Defaults to the value of `eager_edge_validation` in
             your prefect configuration file.
+        -  terminal_state_handler (Callable, optional): A state handler that mutates the final state of the flow, with signature `state_handler(state: State) -> State`
     """
 
     def __init__(
@@ -160,6 +161,7 @@ class Flow:
         on_failure: Callable = None,
         validate: bool = None,
         result: Optional[Result] = None,
+        terminal_state_handler: Optional[Callable] = None,
     ):
         self._cache = {}  # type: dict
 
@@ -174,6 +176,7 @@ class Flow:
         self.run_config = run_config
         self.storage = storage
         self.result = result
+        self.terminal_state_handler = terminal_state_handler
 
         self.tasks = set()  # type: Set[Task]
         self.edges = set()  # type: Set[Edge]

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -143,7 +143,8 @@ class Flow:
             the flow (e.g., presence of cycles and illegal keys) after adding the edges passed
             in the `edges` argument. Defaults to the value of `eager_edge_validation` in
             your prefect configuration file.
-        -  terminal_state_handler (Callable, optional): A state handler that mutates the final state of the flow, with signature `state_handler(state: State) -> State`
+        -  terminal_state_handler (Callable, optional): A state handler that mutates the final state
+            of the flow, with signature `state_handler(state: State) -> State`
     """
 
     def __init__(

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -696,7 +696,7 @@ class FlowRunner(Runner):
             self.logger.info("Flow run SUCCESS: no reference tasks failed")
             state = Success(message="No reference tasks failed.", result=return_states)
 
-        if getattr(self.flow, "terminal_state_handler", None):
+        if self.flow.terminal_state_handler:
             return self.flow.terminal_state_handler(state)
 
         return state

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -696,6 +696,9 @@ class FlowRunner(Runner):
             self.logger.info("Flow run SUCCESS: no reference tasks failed")
             state = Success(message="No reference tasks failed.", result=return_states)
 
+        if getattr(self.flow, "terminal_state_handler", None):
+            return self.flow.terminal_state_handler(state)
+
         return state
 
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -3252,3 +3252,16 @@ class TestSlugGeneration:
             flow.add_task(a2)
 
         assert flow.slugs == {a1: "a-1", a2: "a-2"}
+
+
+def test_terminal_state_handler_determines_final_state():
+    def fake_terminal_state_handler(state: State) -> State:
+        state.message = "Custom message here"
+        return state
+
+    with Flow("test", terminal_state_handler=fake_terminal_state_handler) as flow:
+        fake_task = Task("fake")
+        flow.add_task(fake_task)
+
+    assert flow.terminal_state_handler == fake_terminal_state_handler
+    assert flow.run().message == "Custom message here"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Introduces a new `terminal_state_handler` to `Flow` objects. If present, the state handler mutates the final Flow state in `FlowRunner.determine_final_state`.




## Changes

- Adds `terminal_state_handler` property and logic
- Adds relevant tests




## Importance
Resolves [#4198](https://github.com/PrefectHQ/prefect/issues/4198).




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)