### PR TITLE
Add ability to stream ShellTask logs with custom log level

### DIFF
--- a/changes/pr4322.yaml
+++ b/changes/pr4322.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add ability to stream ShellTask logs with level INFO - [#4322](https://github.com/PrefectHQ/prefect/pull/4322)"
+
+contributor:
+  - "[Sean Talia](https://github.com/TaliaSRTR)"

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -34,6 +34,9 @@ class ShellTask(prefect.Task):
         - stream_output (bool, optional): specifies whether this task should log
             the output as it occurs. If enabled, `log_stderr` will be ignored as the
             output will have already been logged. defaults to `False`
+        - log_stream_as_info (bool, optional): boolean specifying whether the
+            streamed output should be logged using `INFO` as its log level. Will be
+            ignored if `stream_output` has not been set to `True`; defaults to `False`.
         - **kwargs: additional keyword arguments to pass to the Task constructor
 
     Example:
@@ -60,6 +63,7 @@ class ShellTask(prefect.Task):
         return_all: bool = False,
         log_stderr: bool = False,
         stream_output: bool = False,
+        log_stream_as_info: bool = False,
         **kwargs: Any
     ):
         self.command = command
@@ -69,6 +73,7 @@ class ShellTask(prefect.Task):
         self.return_all = return_all
         self.log_stderr = log_stderr
         self.stream_output = stream_output
+        self.log_stream_as_info = log_stream_as_info
         super().__init__(**kwargs)
 
     @defaults_from_attrs("command", "env", "helper_script")
@@ -124,7 +129,10 @@ class ShellTask(prefect.Task):
                         lines.append(line)
 
                     if self.stream_output:
-                        self.logger.debug(line)
+                        if self.log_stream_as_info:
+                            self.logger.info(line)
+                        else:
+                            self.logger.debug(line)
 
                 sub_process.wait()
                 if sub_process.returncode:

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -34,9 +34,11 @@ class ShellTask(prefect.Task):
              output unless `return_all` is `True`
         - stream_output (Union[bool, int, str], optional): specifies whether this task should log
             the output as it occurs, and at what logging level. If `True` is passed,
-            the default logging level used is `INFO`; otherwise, any integer that's
-            passed will be treated as the log level. If enabled, `log_stderr` will
-            be ignored as the output will have already been logged. defaults to `False`
+            the logging level defaults to `INFO`; otherwise, any integer or string
+            value that's passed will be treated as the log level, provided
+            the `logging` library can successfully interpret it. If enabled,
+            `log_stderr` will be ignored as the output will have already been
+            logged. defaults to `False`
         - **kwargs: additional keyword arguments to pass to the Task constructor
 
     Example:
@@ -53,7 +55,8 @@ class ShellTask(prefect.Task):
         out = f.run()
         ```
     Raises:
-        - TypeError: if `stream_output`
+        - TypeError: if `stream_output` is passed in as a string, but cannot
+          successfully be converted to a numeric value by logging.getLevelName()
     """
 
     def __init__(

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -135,6 +135,7 @@ def test_shell_respects_stream_output(caplog, stream_output):
     stdout_in_log = "foo" in caplog.messages and "bar" in caplog.messages
     assert stdout_in_log == stream_output
 
+
 def test_shell_log_stream_as_info(caplog):
     with Flow(name="test") as f:
         ShellTask(stream_output=True, log_stream_as_info=True)(
@@ -143,7 +144,8 @@ def test_shell_log_stream_as_info(caplog):
     f.run()
 
     log_messages = [(r.levelname, r.message) for r in caplog.records]
-    assert ('INFO', 'foo') in log_messages and ('INFO', 'bar') in log_messages
+    assert ("INFO", "foo") in log_messages and ("INFO", "bar") in log_messages
+
 
 def test_shell_logs_stream_as_debug(caplog):
     with Flow(name="test") as f:
@@ -153,7 +155,8 @@ def test_shell_logs_stream_as_debug(caplog):
     f.run()
 
     log_messages = [(r.levelname, r.message) for r in caplog.records]
-    assert ('DEBUG', 'foo') in log_messages and ('DEBUG', 'bar') in log_messages
+    assert ("DEBUG", "foo") in log_messages and ("DEBUG", "bar") in log_messages
+
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     caplog.set_level(level=logging.ERROR, logger="prefect.ShellTask")

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -163,6 +163,26 @@ def test_shell_logs_stream_as_debug(caplog):
     assert ("DEBUG", "foo") in log_messages and ("DEBUG", "bar") in log_messages
 
 
+def test_shell_log_stream_type_error_on_invalid_log_level_string(caplog):
+    with pytest.raises(TypeError):
+        with raise_on_exception():
+            with Flow(name="test") as f:
+                ShellTask(stream_output="FOO")
+
+
+@pytest.mark.parametrize("stream_output", ["INFO", "DEBUG"])
+def test_shell_log_stream_as_info_string_input(caplog, stream_output):
+    with Flow(name="test") as f:
+        ShellTask(stream_output=stream_output)(command="echo foo && echo bar")
+    f.run()
+
+    log_messages = [(r.levelname, r.message) for r in caplog.records]
+    assert (stream_output, "foo") in log_messages and (
+        stream_output,
+        "bar",
+    ) in log_messages
+
+
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     caplog.set_level(level=logging.ERROR, logger="prefect.ShellTask")
     with Flow(name="test") as f:

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -135,6 +135,25 @@ def test_shell_respects_stream_output(caplog, stream_output):
     stdout_in_log = "foo" in caplog.messages and "bar" in caplog.messages
     assert stdout_in_log == stream_output
 
+def test_shell_log_stream_as_info(caplog):
+    with Flow(name="test") as f:
+        ShellTask(stream_output=True, log_stream_as_info=True)(
+            command="echo foo && echo bar",
+        )
+    f.run()
+
+    log_messages = [(r.levelname, r.message) for r in caplog.records]
+    assert ('INFO', 'foo') in log_messages and ('INFO', 'bar') in log_messages
+
+def test_shell_logs_stream_as_debug(caplog):
+    with Flow(name="test") as f:
+        ShellTask(stream_output=True)(
+            command="echo foo && echo bar",
+        )
+    f.run()
+
+    log_messages = [(r.levelname, r.message) for r in caplog.records]
+    assert ('DEBUG', 'foo') in log_messages and ('DEBUG', 'bar') in log_messages
 
 def test_shell_logs_stderr_on_non_zero_exit(caplog):
     caplog.set_level(level=logging.ERROR, logger="prefect.ShellTask")

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -136,11 +136,18 @@ def test_shell_respects_stream_output(caplog, stream_output):
     assert stdout_in_log == stream_output
 
 
+def test_shell_log_stream_default(caplog):
+    with Flow(name="test") as f:
+        ShellTask(stream_output=True)(command="echo foo && echo bar")
+    f.run()
+
+    log_messages = [(r.levelname, r.message) for r in caplog.records]
+    assert ("INFO", "foo") in log_messages and ("INFO", "bar") in log_messages
+
+
 def test_shell_log_stream_as_info(caplog):
     with Flow(name="test") as f:
-        ShellTask(stream_output=True, log_stream_as_info=True)(
-            command="echo foo && echo bar",
-        )
+        ShellTask(stream_output=logging.INFO)(command="echo foo && echo bar")
     f.run()
 
     log_messages = [(r.levelname, r.message) for r in caplog.records]
@@ -149,9 +156,7 @@ def test_shell_log_stream_as_info(caplog):
 
 def test_shell_logs_stream_as_debug(caplog):
     with Flow(name="test") as f:
-        ShellTask(stream_output=True)(
-            command="echo foo && echo bar",
-        )
+        ShellTask(stream_output=logging.DEBUG)(command="echo foo && echo bar")
     f.run()
 
     log_messages = [(r.levelname, r.message) for r in caplog.records]


### PR DESCRIPTION
There are certain circumstances under which we'd like to be able to stream the output of a `ShellTask` (or its child classes) without having to set the global logging level to `DEBUG`; for example, the process launched by `ShellTask` sometimes streams valuable output that a user might like to capture and stream using the base Prefect logger. Currently, this is not possible. This change gives the user more control in that they can change the log level from one `ShellTask` to the next within a given flow.

Fixes #3865.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Add ability to stream ShellTask logs with custom log level



## Changes
<!-- What does this PR change? -->
- Changes the default behavior of `ShellTask.stream_output`, which will default to using a log level of `INFO` when enabled.
- Changes the type of `ShellTask.stream_output` to be a `Union[bool, int, str]`. This will allow a user to pass in a log level (either as an int like `logging.INFO` or as a string like `"INFO"`) as an argument to the `ShellTask` constructor, thereby letting them decide how they want Prefect to log the underlying Shell process' output from one task to the next, without adjusting the global log level.



## Importance
<!-- Why is this PR important? -->
There are certain Shell tasks (the immediate use case here was for the `DbtShellTask`) where it would be helpful to have the task's output _always_ streamed to the Prefect output log; not just when the logging level is set to `DEBUG`. `dbt`, for example, logs a lot of useful information to STDOUT during normal execution of the `dbt run` or `dbt test` commands. None of this output is forwarded to the Prefect logs if you're not running in `DEBUG` mode.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)