### PR TITLE
A couple ECS fixups for fargate

### DIFF
--- a/changes/pr4325.yaml
+++ b/changes/pr4325.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Improve ECS agent error messages, and fix bug that prevented using ECS agent on Fargate with ECR - [#4325](https://github.com/PrefectHQ/prefect/pull/4325)"


### PR DESCRIPTION
- Always set `requiresCompatibilities` in the task definition. This
  isn't strictly required, but without it ECS won't provide good error
  messages when a task definition is invalid.
- Set `executionRoleArn` on the task definition as well as at runtime.
  Fargate requires an execution role ARN be set on the task definition
  for any task that uses ECR, even if the execution role ARN would be
  provided at runtime. We still provide it at runtime to support users
  who provide their own pre-registered task definition and may want to
  override the setting at runtime.

Fixes #4243.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)