### PR TITLE
Support local directory imports in flow scripts from CLI

### DIFF
--- a/changes/pr4332.yaml
+++ b/changes/pr4332.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Support imports from local directory when registering/building flows via CLI - [#4332](https://github.com/PrefectHQ/prefect/pull/4332)"

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -1,11 +1,12 @@
 import functools
+import hashlib
 import importlib
 import json
 import multiprocessing
 import os
+import runpy
 import sys
 import time
-import hashlib
 import traceback
 from collections import Counter, defaultdict
 from typing import Union, NamedTuple, List, Dict, Iterator, Tuple
@@ -113,17 +114,20 @@ def expand_paths(paths: List[str]) -> List[str]:
 
 def load_flows_from_script(path: str) -> "List[prefect.Flow]":
     """Given a file path, load all flows found in the file"""
-    with open(path, "rb") as fil:
-        contents = fil.read()
-
-    namespace = {}
+    # Temporarily add the flow's local directory to `sys.path` so that local
+    # imports work. This ensures that `sys.path` is the same as it would be if
+    # the flow script was run directly (i.e. `python path/to/flow.py`).
+    orig_sys_path = sys.path.copy()
+    sys.path.insert(0, os.path.dirname(os.path.abspath(path)))
     try:
         with prefect.context({"loading_flow": True, "local_script_path": path}):
-            exec(contents, namespace)
+            namespace = runpy.run_path(path, run_name="<flow>")
     except Exception as exc:
         click.secho(f"Error loading {path!r}:", fg="red")
         log_exception(exc, 2)
         raise TerminalError
+    finally:
+        sys.path[:] = orig_sys_path
 
     flows = [f for f in namespace.values() if isinstance(f, prefect.Flow)]
     if flows:

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -276,13 +276,19 @@ class TestRegister:
             """
             from prefect import Flow
             from prefect.storage import S3
+            from my_prefect_helper_file import helper
             f1 = Flow("f1")
             f1.storage = S3("my-bucket", key="my-key", stored_as_script=True)
             f2 = Flow("f2")
+
+            assert __file__.endswith("test.py")
+            assert __name__ != "__main__"
             """
         )
         with open(path, "w") as f:
             f.write(source)
+
+        tmpdir.join("my_prefect_helper_file.py").write("def helper():\n    pass")
 
         flows = {f.name: f for f in load_flows_from_script(path)}
         assert len(flows) == 2


### PR DESCRIPTION
When using `prefect register`/`prefect build` we now support flows that
import files from other files in the same directory. Note that this does
_not_ ensure that these flows will run successfully (as the presence of
these "helper scripts" would have to be ensured by the storage/runtime
environment). All this does is ensure that running `prefect register
--path path/to/flow.py` has the same `sys.path` as `python
path/to/flow.py` would have.

We also move to using `runpy` to properly setup some other metadata
values in the script's namespace (e.g. `__file__`).

Reported on slack: https://prefect-community.slack.com/archives/CL09KU1K7/p1617276925312300?thread_ts=1617160663.217800&cid=CL09KU1K7

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)