### PR TITLE
Add bitbucket cloud

### DIFF
--- a/changes/issue4318.yaml
+++ b/changes/issue4318.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Added support for Bitbucket cloud into Bitbucket storage class [#4318](https://github.com/PrefectHQ/prefect/issues/4318)"
+
+contributor:
+  - "[Jonathan Wright](https://github.com/wrightjonathan)"

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -118,10 +118,13 @@ class BitbucketSchema(BaseStorageSchema):
 
     project = fields.String(allow_none=False)
     repo = fields.String(allow_none=False)
+    workspace = fields.String(allow_none=True)
     host = fields.String(allow_none=True)
     path = fields.String(allow_none=True)
     ref = fields.String(allow_none=True)
     access_token_secret = fields.String(allow_none=True)
+    cloud_username_secret = fields.String(allow_none=True)
+    cloud_app_password_secret = fields.String(allow_none=True)
 
 
 class CodeCommitSchema(BaseStorageSchema):

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -145,7 +145,9 @@ class Bitbucket(Storage):
                     ref = tag_hashes[ref]
 
             if not re.match(SHA1_REGEX, ref):
-                raise ValueError("ref not found in this Storage")
+                raise ValueError(
+                    "ref {ref!r} not found in '{self.workspace}/{self.repo}'"
+                )
 
             contents_url = (
                 f"repositories/{self.workspace}/{self.repo}/src/{ref}/{flow_location}"

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -145,9 +145,7 @@ class Bitbucket(Storage):
             contents_url = (
                 f"repositories/{self.workspace}/{self.repo}/src/{ref}/{flow_location}"
             )
-            self.logger.info(
-                f"Downloading flow from Bitbucket cloud - {contents_url}"
-            )
+            self.logger.info(f"Downloading flow from Bitbucket cloud - {contents_url}")
             contents = client.get(contents_url)
 
         except RequestsHTTPError as err:

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -278,19 +278,16 @@ class Bitbucket(Storage):
                 "Unable to import atlassian, please ensure you have installed the bitbucket extra"
             ) from exc
 
-        if self.cloud_username_secret is not None:
-            # If cloud username secret specified, load it
-            cloud_username = Secret(self.cloud_username_secret).get()
-        else:
-            if cloud_username is None:
-                cloud_username = os.getenv("BITBUCKET_CLOUD_USERNAME")
-
-        if self.cloud_app_password_secret is not None:
-            # If cloud app password secret specified, load it
-            cloud_app_password = Secret(self.cloud_app_password_secret).get()
-        else:
-            if cloud_app_password is None:
-                cloud_app_password = os.getenv("BITBUCKET_CLOUD_APP_PASSWORD")
+        cloud_username = (
+            Secret(self.cloud_username_secret).get()
+            if self.cloud_username_secret is not None
+            else os.getenv("BITBUCKET_CLOUD_USERNAME")
+        )
+        cloud_app_password = (
+            Secret(self.cloud_app_password_secret).get()
+            if self.cloud_app_password_secret is not None
+            else os.getenv("BITBUCKET_CLOUD_APP_PASSWORD")
+        )
 
         # Bitbucket clould api is rate limited, retry at this frequency
         # 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -82,6 +82,11 @@ class Bitbucket(Storage):
         self.cloud_username_secret = cloud_username_secret
         self.cloud_app_password_secret = cloud_app_password_secret
 
+        if self.workspace and self.access_token_secret:
+            raise ValueError(
+                "Wrong secret variable set. Workspace variable implies Bitbucket Cloud but an access token for Bitbucket Server was provided."
+            )
+
         super().__init__(**kwargs)
 
     def get_flow(self, flow_name: str) -> "Flow":

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -51,11 +51,11 @@ class Bitbucket(Storage):
         - access_token_secret (str, optional): the name of a Prefect secret
             that contains a Bitbucket access token to use when loading flows from
             this storage. Bitbucket Server only
-        - cloud_username_secret (str, optional): the name of a Prefect secret that contains a Bitbucket
-            username to use when loading flows from this storage. Bitbucket Cloud only.
-        - cloud_app_password_secret (str, optional): the name of a Prefect secret that contains a Bitbucket
-            app password, from the account associated with the `cloud_username_secret`, to use when loading
-            flows from this storage. Bitbucket Cloud only.
+        - cloud_username_secret (str, optional): the name of a Prefect secret that contains a
+            Bitbucket username to use when loading flows from this storage. Bitbucket Cloud only.
+        - cloud_app_password_secret (str, optional): the name of a Prefect secret that contains a
+            Bitbucket app password, from the account associated with the `cloud_username_secret`,
+            to use when loading flows from this storage. Bitbucket Cloud only.
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
@@ -156,7 +156,8 @@ class Bitbucket(Storage):
                 raise
             else:
                 self.logger.error(
-                    f"Error retrieving contents at {flow_location} in {self.workspace}/{self.project}/{self.repo}@{ref}. "
+                    "Error retrieving contents at "
+                    f"{flow_location} in {self.workspace}/{self.project}/{self.repo}@{ref}. "
                     "Please check arguments passed to Bitbucket storage and verify project exists."
                 )
                 raise

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -94,8 +94,8 @@ class Bitbucket(Storage):
 
         if self.workspace and self.access_token_secret:
             raise ValueError(
-                "Wrong secret variable set. "
-                "Workspace variable implies Bitbucket Cloud but an access token for Bitbucket Server was provided."
+                "Wrong secret variable set. Workspace variable implies Bitbucket Cloud "
+                "but an access token for Bitbucket Server was provided."
             )
 
         super().__init__(**kwargs)

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -1,8 +1,10 @@
 import os
+import re
 from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError
 
 import requests
+from requests.exceptions import HTTPError as RequestsHTTPError
 
 import prefect
 from prefect.client import Secret
@@ -17,7 +19,7 @@ if TYPE_CHECKING:
 class Bitbucket(Storage):
     """
     Bitbucket storage class. This class represents the Storage interface for Flows stored
-    in `.py` files in a Bitbucket repository. This is for Bitbucket Server only.
+    in `.py` files in a Bitbucket repository. This is for Bitbucket Server or Bitbucket Cloud.
 
     This class represents a mapping of flow name to file paths contained in the git repo,
     meaning that all flow files should be pushed independently. A typical workflow using
@@ -38,16 +40,22 @@ class Bitbucket(Storage):
     - Call `prefect register -f flow.py` to register this flow with Bitbucket storage.
 
     Args:
-        - project (str): Project that the repository will be in.  Not equivalent to a GitHub project;
+        - project (str): project that the repository will be in.  Not equivalent to a GitHub project;
             required value for all Bitbucket repositories.
         - repo (str): the repository name, with complete taxonomy.
-        - host (str, optional): If using Bitbucket server, the server host. If not specified, defaults
-            to Bitbucket cloud.
+        - workspace (str, optional): the workspace name. Bitbucket cloud only.
+        - host (str, optional): the server host. Bitbucket server only.
         - path (str, optional): a path pointing to a flow file in the repo
-        - ref (str, optional): a commit SHA-1 value or branch name
-        - access_token_secret (str, optional): The name of a Prefect secret
+        - ref (str, optional): a commit SHA-1 value or branch name or tag. If not specified,
+            defaults to master branch for the repo.
+        - access_token_secret (str, optional): the name of a Prefect secret
             that contains a Bitbucket access token to use when loading flows from
-            this storage.
+            this storage. Bitbucket Server only
+        - cloud_username_secret (str, optional): the name of a Prefect secret that contains a Bitbucket
+            username to use when loading flows from this storage. Bitbucket Cloud only.
+        - cloud_app_password_secret (str, optional): the name of a Prefect secret that contains a Bitbucket
+            app password, from the account associated with the `cloud_username_secret`, to use when loading
+            flows from this storage. Bitbucket Cloud only.
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 
@@ -55,18 +63,24 @@ class Bitbucket(Storage):
         self,
         project: str,
         repo: str,
+        workspace: str = None,
         host: str = None,
         path: str = None,
         ref: str = None,
         access_token_secret: str = None,
+        cloud_username_secret: str = None,
+        cloud_app_password_secret: str = None,
         **kwargs: Any,
     ) -> None:
         self.project = project
         self.repo = repo
+        self.workspace = workspace
         self.host = host
         self.path = path
         self.ref = ref
         self.access_token_secret = access_token_secret
+        self.cloud_username_secret = cloud_username_secret
+        self.cloud_app_password_secret = cloud_app_password_secret
 
         super().__init__(**kwargs)
 
@@ -80,6 +94,14 @@ class Bitbucket(Storage):
         Returns:
             - Flow: the requested flow
         """
+
+        return (
+            self._get_flow_cloud(flow_name)
+            if self.workspace
+            else self._get_flow_server(flow_name)
+        )
+
+    def _get_flow_cloud(self, flow_name: str) -> "Flow":
         if flow_name not in self.flows:
             raise ValueError("Flow is not contained in this Storage")
         flow_location = self.flows[flow_name]
@@ -87,7 +109,71 @@ class Bitbucket(Storage):
         # Use ref attribute if present, defaulting to "master"
         ref = self.ref or "master"
 
-        client = self._get_bitbucket_client()
+        client = self._get_bitbucket_cloud_client()
+
+        try:
+
+            # Fetch SHA-1 of all branches if ref is not alread a SHA-1 hash
+            SHA1_REGEX = r"^[0-9a-f]{40}$"
+            if not re.match(SHA1_REGEX, ref):
+                branches = client.get(
+                    f"repositories/{self.workspace}/{self.repo}/refs/branches"
+                )
+                branch_hashes = {
+                    branch["name"]: branch["target"]["hash"]
+                    for branch in branches["values"]
+                }
+
+                if ref in branch_hashes:
+                    ref = branch_hashes[ref]
+
+            # Fetch SHA-1 of all tags if ref is not alread a SHA-1 hash
+            if not re.match(SHA1_REGEX, ref):
+                tags = client.get(
+                    f"repositories/{self.workspace}/{self.repo}/refs/tags"
+                )
+                tag_hashes = {
+                    tag["name"]: tag["target"]["hash"] for tag in tags["values"]
+                }
+
+                if ref in tag_hashes:
+                    ref = tag_hashes[ref]
+
+            if not re.match(SHA1_REGEX, ref):
+                raise ValueError("ref not found in this Storage")
+
+            contents_url = (
+                f"repositories/{self.workspace}/{self.repo}/src/{ref}/{flow_location}"
+            )
+            self.logger.info(
+                f"Downloading flow from Bitbucket cloud - {contents_url}"
+            )
+            contents = client.get(contents_url)
+
+        except RequestsHTTPError as err:
+            if err.response.status_code == 403:
+                self.logger.error(
+                    "Access denied to repository. Please check credentials."
+                )
+                raise
+            else:
+                self.logger.error(
+                    f"Error retrieving contents at {flow_location} in {self.workspace}/{self.project}/{self.repo}@{ref}. "
+                    "Please check arguments passed to Bitbucket storage and verify project exists."
+                )
+                raise
+
+        return extract_flow_from_file(file_contents=contents, flow_name=flow_name)
+
+    def _get_flow_server(self, flow_name: str) -> "Flow":
+        if flow_name not in self.flows:
+            raise ValueError("Flow is not contained in this Storage")
+        flow_location = self.flows[flow_name]
+
+        # Use ref attribute if present, defaulting to "master"
+        ref = self.ref or "master"
+
+        client = self._get_bitbucket_server_client()
 
         try:
             contents = client.get_content_of_file(
@@ -140,7 +226,7 @@ class Bitbucket(Storage):
         self._flows[flow.name] = flow
         return self.path  # type: ignore
 
-    def _get_bitbucket_client(self) -> "atlassian.Bitbucket":
+    def _get_bitbucket_server_client(self) -> "atlassian.Bitbucket":
         try:
             from atlassian import Bitbucket
         except ImportError as exc:
@@ -167,3 +253,56 @@ class Bitbucket(Storage):
         else:
             session.headers["Authorization"] = "Bearer " + access_token
         return Bitbucket(host, session=session)
+
+    def _get_bitbucket_cloud_client(self) -> "atlassian.Bitbucket":
+        try:
+            from atlassian.bitbucket.cloud import Cloud
+        except ImportError as exc:
+            raise ImportError(
+                "Unable to import atlassian, please ensure you have installed the bitbucket extra"
+            ) from exc
+
+        if self.cloud_username_secret is not None:
+            # If cloud username secret specified, load it
+            cloud_username = Secret(self.cloud_username_secret).get()
+        else:
+            # Otherwise, fallback to loading from local secret or environment variable
+            cloud_username = prefect.context.get("secrets", {}).get(
+                "BITBUCKET_CLOUD_USERNAME"
+            )
+            if cloud_username is None:
+                cloud_username = os.getenv("BITBUCKET_CLOUD_USERNAME")
+
+        if self.cloud_app_password_secret is not None:
+            # If cloud app password secret specified, load it
+            cloud_app_password = Secret(self.cloud_app_password_secret).get()
+        else:
+            # Otherwise, fallback to loading from local secret or environment variable
+            cloud_app_password = prefect.context.get("secrets", {}).get(
+                "BITBUCKET_CLOUD_APP_PASSWORD"
+            )
+            if cloud_app_password is None:
+                cloud_app_password = os.getenv("BITBUCKET_CLOUD_APP_PASSWORD")
+
+        # Bitbucket clould api is rate limited, retry at this frequency
+        # 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128
+        import http
+        from requests.adapters import HTTPAdapter
+        from requests.packages.urllib3.util.retry import Retry
+
+        retry_strategy = Retry(
+            total=10,
+            backoff_factor=0.5,
+            status_forcelist=[429],
+            method_whitelist=["HEAD", "GET", "OPTIONS"],
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        session = requests.Session()
+        session.mount("https://", adapter)
+
+        return Cloud(
+            username=cloud_username,
+            password=cloud_app_password,
+            cloud=True,
+            session=session,
+        )

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -94,7 +94,8 @@ class Bitbucket(Storage):
 
         if self.workspace and self.access_token_secret:
             raise ValueError(
-                "Wrong secret variable set. Workspace variable implies Bitbucket Cloud but an access token for Bitbucket Server was provided."
+                "Wrong secret variable set. "
+                "Workspace variable implies Bitbucket Cloud but an access token for Bitbucket Server was provided."
             )
 
         super().__init__(**kwargs)

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -95,7 +95,11 @@ class Bitbucket(Storage):
             - Flow: the requested flow
         """
 
-        return self._get_flow_cloud(flow_name) if self.workspace else self._get_flow_server(flow_name)
+        return (
+            self._get_flow_cloud(flow_name)
+            if self.workspace
+            else self._get_flow_server(flow_name)
+        )
 
     def _get_flow_cloud(self, flow_name: str) -> "Flow":
         if flow_name not in self.flows:
@@ -112,9 +116,12 @@ class Bitbucket(Storage):
             # Fetch SHA-1 of all branches if ref is not alread a SHA-1 hash
             SHA1_REGEX = r"^[0-9a-f]{40}$"
             if not re.match(SHA1_REGEX, ref):
-                branches = client.get(f"repositories/{self.workspace}/{self.repo}/refs/branches")
+                branches = client.get(
+                    f"repositories/{self.workspace}/{self.repo}/refs/branches"
+                )
                 branch_hashes = {
-                    branch["name"]: branch["target"]["hash"] for branch in branches["values"]
+                    branch["name"]: branch["target"]["hash"]
+                    for branch in branches["values"]
                 }
 
                 if ref in branch_hashes:
@@ -122,8 +129,12 @@ class Bitbucket(Storage):
 
             # Fetch SHA-1 of all tags if ref is not alread a SHA-1 hash
             if not re.match(SHA1_REGEX, ref):
-                tags = client.get(f"repositories/{self.workspace}/{self.repo}/refs/tags")
-                tag_hashes = {tag["name"]: tag["target"]["hash"] for tag in tags["values"]}
+                tags = client.get(
+                    f"repositories/{self.workspace}/{self.repo}/refs/tags"
+                )
+                tag_hashes = {
+                    tag["name"]: tag["target"]["hash"] for tag in tags["values"]
+                }
 
                 if ref in tag_hashes:
                     ref = tag_hashes[ref]
@@ -131,13 +142,17 @@ class Bitbucket(Storage):
             if not re.match(SHA1_REGEX, ref):
                 raise ValueError("ref not found in this Storage")
 
-            contents_url = f"repositories/{self.workspace}/{self.repo}/src/{ref}/{flow_location}"
+            contents_url = (
+                f"repositories/{self.workspace}/{self.repo}/src/{ref}/{flow_location}"
+            )
             self.logger.info(f"Downloading flow from Bitbucket cloud - {contents_url}")
             contents = client.get(contents_url)
 
         except RequestsHTTPError as err:
             if err.response.status_code == 403:
-                self.logger.error("Access denied to repository. Please check credentials.")
+                self.logger.error(
+                    "Access denied to repository. Please check credentials."
+                )
                 raise
             else:
                 self.logger.error(
@@ -167,7 +182,9 @@ class Bitbucket(Storage):
             )
         except HTTPError as err:
             if err.code == 401:
-                self.logger.error("Access denied to repository. Please check credentials.")
+                self.logger.error(
+                    "Access denied to repository. Please check credentials."
+                )
                 raise
             elif err.code == 404:
                 self.logger.error(
@@ -220,7 +237,9 @@ class Bitbucket(Storage):
             access_token = Secret(self.access_token_secret).get()
         else:
             # Otherwise, fallback to loading from local secret or environment variable
-            access_token = prefect.context.get("secrets", {}).get("BITBUCKET_ACCESS_TOKEN")
+            access_token = prefect.context.get("secrets", {}).get(
+                "BITBUCKET_ACCESS_TOKEN"
+            )
             if access_token is None:
                 access_token = os.getenv("BITBUCKET_ACCESS_TOKEN")
 
@@ -246,7 +265,9 @@ class Bitbucket(Storage):
             cloud_username = Secret(self.cloud_username_secret).get()
         else:
             # Otherwise, fallback to loading from local secret or environment variable
-            cloud_username = prefect.context.get("secrets", {}).get("BITBUCKET_CLOUD_USERNAME")
+            cloud_username = prefect.context.get("secrets", {}).get(
+                "BITBUCKET_CLOUD_USERNAME"
+            )
             if cloud_username is None:
                 cloud_username = os.getenv("BITBUCKET_CLOUD_USERNAME")
 
@@ -255,7 +276,9 @@ class Bitbucket(Storage):
             cloud_app_password = Secret(self.cloud_app_password_secret).get()
         else:
             # Otherwise, fallback to loading from local secret or environment variable
-            cloud_app_password = prefect.context.get("secrets", {}).get("BITBUCKET_CLOUD_APP_PASSWORD")
+            cloud_app_password = prefect.context.get("secrets", {}).get(
+                "BITBUCKET_CLOUD_APP_PASSWORD"
+            )
             if cloud_app_password is None:
                 cloud_app_password = os.getenv("BITBUCKET_CLOUD_APP_PASSWORD")
 

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -282,10 +282,6 @@ class Bitbucket(Storage):
             # If cloud username secret specified, load it
             cloud_username = Secret(self.cloud_username_secret).get()
         else:
-            # Otherwise, fallback to loading from local secret or environment variable
-            cloud_username = prefect.context.get("secrets", {}).get(
-                "BITBUCKET_CLOUD_USERNAME"
-            )
             if cloud_username is None:
                 cloud_username = os.getenv("BITBUCKET_CLOUD_USERNAME")
 
@@ -293,10 +289,6 @@ class Bitbucket(Storage):
             # If cloud app password secret specified, load it
             cloud_app_password = Secret(self.cloud_app_password_secret).get()
         else:
-            # Otherwise, fallback to loading from local secret or environment variable
-            cloud_app_password = prefect.context.get("secrets", {}).get(
-                "BITBUCKET_CLOUD_APP_PASSWORD"
-            )
             if cloud_app_password is None:
                 cloud_app_password = os.getenv("BITBUCKET_CLOUD_APP_PASSWORD")
 

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -94,8 +94,9 @@ class Bitbucket(Storage):
 
         if self.workspace and self.access_token_secret:
             raise ValueError(
-                "Wrong secret variable set. Workspace variable implies Bitbucket Cloud "
-                "but an access token for Bitbucket Server was provided."
+                "`access_token_secret` and `workspace` are both set. Setting `workspace` "
+                "is only for use with Bitbucket Cloud which uses `cloud_username_secret` "
+                "and `cloud_app_password_secret` to provide authentication."
             )
 
         super().__init__(**kwargs)

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -101,12 +101,12 @@ class Bitbucket(Storage):
         """
 
         return (
-            self._get_flow_cloud(flow_name)
+            self._get_flow_from_bitbucket_cloud(flow_name)
             if self.workspace
-            else self._get_flow_server(flow_name)
+            else self._get_flow_from_bitbucket_server(flow_name)
         )
 
-    def _get_flow_cloud(self, flow_name: str) -> "Flow":
+    def _get_flow_from_bitbucket_cloud(self, flow_name: str) -> "Flow":
         if flow_name not in self.flows:
             raise ValueError("Flow is not contained in this Storage")
         flow_location = self.flows[flow_name]
@@ -169,7 +169,7 @@ class Bitbucket(Storage):
 
         return extract_flow_from_file(file_contents=contents, flow_name=flow_name)
 
-    def _get_flow_server(self, flow_name: str) -> "Flow":
+    def _get_flow_from_bitbucket_server(self, flow_name: str) -> "Flow":
         if flow_name not in self.flows:
             raise ValueError("Flow is not contained in this Storage")
         flow_location = self.flows[flow_name]

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -156,18 +156,18 @@ class Bitbucket(Storage):
             contents = client.get(contents_url)
 
         except RequestsHTTPError as err:
+
             if err.response.status_code == 403:
-                self.logger.error(
-                    "Access denied to repository. Please check credentials."
-                )
-                raise
+                err_msg = "Access denied to repository. Please check credentials."
             else:
-                self.logger.error(
+                err_msg = (
                     "Error retrieving contents at "
                     f"{flow_location} in {self.workspace}/{self.project}/{self.repo}@{ref}. "
-                    "Please check arguments passed to Bitbucket storage and verify project exists."
+                    "Please check arguments passed to Bitbucket storage."
                 )
-                raise
+
+            self.logger.error(err_msg)
+            raise RuntimeError(err_msg) from err
 
         return extract_flow_from_file(file_contents=contents, flow_name=flow_name)
 

--- a/tests/serialization/test_storage.py
+++ b/tests/serialization/test_storage.py
@@ -446,6 +446,20 @@ def test_bitbucket_full_serialize(access_token_secret):
     assert serialized["access_token_secret"] == access_token_secret
 
 
+def test_bitbucket_incorrect_secret():
+    with pytest.raises(ValueError):
+        storage.Bitbucket(
+            project="PROJECT",
+            repo="test-repo",
+            workspace="test-workspace",
+            path="test-flow.py",
+            host="http://localhost:7990",
+            ref="develop",
+            secrets=["token"],
+            access_token_secret="secret",
+        )
+
+
 def test_module_serialize():
     module = storage.Module("test")
     serialized = module.serialize()


### PR DESCRIPTION
## Summary
Added support for Bitbucket cloud into Bitbucket storage class

## Changes
Added three class variables to Bitbucket class (workspace, cloud_username_secret, cloud_app_password_secret). When constructed with a workspace the class will switch to using the bitbucket cloud client; without it the behaviour for bitbucket server remains unchanged.

The retry adapter is not required and could be removed. Our Bitbucket cloud API gets a lot of requests and the limit is 5000 per hour.

## Importance
A lot of people and businesses will be using Bitbucket cloud and not hosting their own bitbucket servers. 

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)