### PR TITLE
Speedup flushing of cloud logs on shutdown

### DIFF
--- a/changes/pr4334.yaml
+++ b/changes/pr4334.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Speedup flushing of logs to cloud/server on flow run shutdown, avoiding lost logs on platforms that SIGKILL the process after a short period - [#4334](https://github.com/PrefectHQ/prefect/pull/4334)"


### PR DESCRIPTION
When writing logs to prefect cloud, we batch uploads into batches by a
time period (defaults to 5 seconds). On shutdown, the intent was to
break out of this write-then-sleep loop and write all the remaining logs
before closing.  Unfortunately this accidentally relied on the shutdown
signal interrupting the sleeping thread, leading to a slower shutdown
process on some platforms. When running on dask, the worker process must
shutdown in 3 seconds before a kill signal is sent, and since 3 < 5,
some logs could be lost. We now use a `threading.Event` instead of
sleeping, ensuring that the write-then-sleep loop breaks early on
shutdown and all logs are written.

Issue reported on slack here: https://prefect-community.slack.com/archives/CL09KU1K7/p1616957545069800