### PR TITLE
Add safe-to-evict annotation to k8s job

### DIFF
--- a/changes/pr4346.yaml
+++ b/changes/pr4346.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Add safe-to-evict annotation to k8s job - [#4643](https://github.com/PrefectHQ/prefect/pull/4346)"
+
+contributor:
+  - "[Xinyi2016](https://github.com/xinyi2016)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -74,7 +74,7 @@ class KubernetesAgent(Agent):
         - volumes (list, optional): A list of volumes to make available to be mounted when a
             job is run. The volumes in the list should be specified as nested dicts.
             i.e `[{"name": "my-vol", "csi": {"driver": "secrets-store.csi.k8s.io"}}]`
-        - safe_to_evict (bool, optional): Allow Cluster Autoscaler to remove the nodes where jobs
+        - safe_to_evict (str, optional): Allow Cluster Autoscaler to remove the nodes where jobs
             are running on.
     """
 
@@ -93,7 +93,7 @@ class KubernetesAgent(Agent):
         no_cloud_logs: bool = False,
         volume_mounts: List[dict] = None,
         volumes: List[dict] = None,
-        safe_to_evict: bool = None,
+        safe_to_evict: str = None,
     ) -> None:
         super().__init__(
             agent_config_id=agent_config_id,
@@ -753,7 +753,7 @@ class KubernetesAgent(Agent):
         cpu_limit: str = None,
         image_pull_policy: str = None,
         service_account_name: str = None,
-        safe_to_evict: bool = None,
+        safe_to_evict: str = None,
         labels: Iterable[str] = None,
         env_vars: dict = None,
         backend: str = None,
@@ -781,7 +781,7 @@ class KubernetesAgent(Agent):
                 Job defaults to `IfNotPresent`.
             - service_account_name (str, optional): Name of a service account to use for
                 Prefect init job. Job defaults to using `default` service account.
-            - safe_to_evict (bool, optional): Allow Cluster Autoscaler to remove the nodes
+            - safe_to_evict (str, optional): Allow Cluster Autoscaler to remove the nodes
                 where jobs are running on.
             - labels (List[str], optional): a list of labels, which are arbitrary string
                 identifiers used by Prefect Agents when polling for work

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: ""
             - name: SERVICE_ACCOUNT_NAME
               value: ""
+            - name: SAFE_TO_EVICT
+              value: True
             - name: PREFECT__BACKEND
               value: "cloud"
             - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS

--- a/src/prefect/agent/kubernetes/deployment.yaml
+++ b/src/prefect/agent/kubernetes/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: SERVICE_ACCOUNT_NAME
               value: ""
             - name: SAFE_TO_EVICT
-              value: True
+              value: "true"
             - name: PREFECT__BACKEND
               value: "cloud"
             - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS

--- a/src/prefect/agent/kubernetes/job_spec.yaml
+++ b/src/prefect/agent/kubernetes/job_spec.yaml
@@ -7,6 +7,8 @@ spec:
   template:
     metadata:
       labels: {}
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
         - name: flow

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -274,6 +274,11 @@ def kubernetes():
     "values can be provided as a comma-separated list "
     "(e.g. `--image-pull-secrets VAL1,VAL2`)",
 )
+@click.option(
+    "--safe-to-evict",
+    "safe_to_evict",
+    help="Allow Cluster Autoscaler to remove the nodes where jobs are running on.",
+)
 def start(image_pull_secrets=None, **kwargs):
     """Start a Kubernetes agent"""
     from prefect.agent.kubernetes import KubernetesAgent
@@ -304,6 +309,11 @@ def start(image_pull_secrets=None, **kwargs):
     "--service-account-name", help="Name of Service Account for Prefect init job"
 )
 @click.option("--backend", "-b", help="Prefect backend to use for this agent.")
+@click.option(
+    "--safe-to-evict",
+    "safe_to_evict",
+    help="Allow Cluster Autoscaler to remove the nodes where jobs are running on.",
+)
 def install(label, env, **kwargs):
     """Generate a supervisord.conf file for a Local agent"""
     from prefect.agent.kubernetes import KubernetesAgent

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -546,6 +546,11 @@ _agents = {
     type=int,
     hidden=True,
 )
+@click.option(
+    "--safe-to-evict",
+    "safe_to_evict",
+    help="Allow Cluster Autoscaler to remove the nodes where jobs are running on.",
+)
 @click.pass_context
 def start(
     ctx,
@@ -572,6 +577,7 @@ def start(
     hostname_label,
     storage_labels,
     docker_client_timeout,
+    safe_to_evict,
 ):
     """
     Start an agent.
@@ -641,6 +647,8 @@ def start(
         --namespace     TEXT    A Kubernetes namespace to create Prefect jobs in
                                 Defaults to env var `NAMESPACE` or `default`
         --job-template  TEXT    Path to a job template to use instead of the default.
+        --safe-to-evict  TEXT   Allow Cluster AutoScaler to remove nodes where Prefect
+                                jobs are running on.
 
     \b
     Fargate Agent Options:
@@ -741,6 +749,7 @@ def start(
                 max_polls=max_polls,
                 no_cloud_logs=no_cloud_logs,
                 agent_address=agent_address,
+                safe_to_evict=safe_to_evict,
             ).start()
         else:
             from_qualified_name(retrieved_agent)(
@@ -846,6 +855,11 @@ def start(
     help="Prefect backend to use for this agent.",
     hidden=True,
 )
+@click.option(
+    "--safe-to-evict",
+    "safe_to_evict",
+    help="Allow Cluster Autoscaler to remove the nodes where jobs are running on.",
+)
 def install(
     name,
     token,
@@ -865,6 +879,7 @@ def install(
     import_path,
     show_flow_logs,
     backend,
+    safe_to_evict,
 ):
     """
     Install an agent. Outputs configuration text which can be used to install on various
@@ -902,8 +917,10 @@ def install(
         --cpu-limit                 TEXT    Limit CPU for Prefect init job
         --image-pull-policy         TEXT    imagePullPolicy for Prefect init job
         --service-account-name      TEXT    Name of Service Account for Prefect init job
-        --backend                   TEST    Prefect backend to use for this agent
+        --backend                   TEXT    Prefect backend to use for this agent
                                             Defaults to the backend currently set in config.
+        --safe-to-evict             TEXT    Allow Cluster AutoScaler to remove nodes where
+                                            Prefect jobs are running on.
 
     \b
     Local Agent:
@@ -957,6 +974,7 @@ def install(
             labels=labels,
             env_vars=env_vars,
             backend=backend,
+            safe_to_evict=safe_to_evict,
         )
         click.echo(deployment)
     elif name == "local":

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -35,7 +35,7 @@ class KubernetesRun(RunConfig):
         - image_pull_secrets (list, optional): A list of image pull secrets to
             use for this job. If present, overrides any image pull secrets
             configured on the agent or in the job template.
-        - safe_to_evict (bool, optional): Allow Cluster Autoscaler to remove the
+        - safe_to_evict (str, optional): Allow Cluster Autoscaler to remove the
             nodes where jobs are running on.
         - labels (Iterable[str], optional): an iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
@@ -82,7 +82,7 @@ class KubernetesRun(RunConfig):
         memory_request: str = None,
         service_account_name: str = None,
         image_pull_secrets: Iterable[str] = None,
-        safe_to_evict: bool = None,
+        safe_to_evict: str = None,
         labels: Iterable[str] = None,
     ) -> None:
         super().__init__(labels=labels)

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -35,6 +35,8 @@ class KubernetesRun(RunConfig):
         - image_pull_secrets (list, optional): A list of image pull secrets to
             use for this job. If present, overrides any image pull secrets
             configured on the agent or in the job template.
+        - safe_to_evict (bool, optional): Allow Cluster Autoscaler to remove the
+            nodes where jobs are running on.
         - labels (Iterable[str], optional): an iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
             for selecting valid flow runs when polling for work
@@ -80,6 +82,7 @@ class KubernetesRun(RunConfig):
         memory_request: str = None,
         service_account_name: str = None,
         image_pull_secrets: Iterable[str] = None,
+        safe_to_evict: bool = None,
         labels: Iterable[str] = None,
     ) -> None:
         super().__init__(labels=labels)
@@ -108,6 +111,9 @@ class KubernetesRun(RunConfig):
         if image_pull_secrets is not None:
             image_pull_secrets = list(image_pull_secrets)
 
+        if safe_to_evict is not None:
+            safe_to_evict = str(safe_to_evict).lower()
+
         self.job_template_path = job_template_path
         self.job_template = job_template
         self.image = image
@@ -118,3 +124,4 @@ class KubernetesRun(RunConfig):
         self.memory_request = memory_request
         self.service_account_name = service_account_name
         self.image_pull_secrets = image_pull_secrets
+        self.safe_to_evict = safe_to_evict

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -32,7 +32,7 @@ class KubernetesRunSchema(RunConfigSchemaBase):
     memory_request = fields.String(allow_none=True)
     service_account_name = fields.String(allow_none=True)
     image_pull_secrets = fields.List(fields.String(), allow_none=True)
-    safe_to_evict = fields.Bool(allow_none=True)
+    safe_to_evict = fields.String(allow_none=True)
 
 
 class ECSRunSchema(RunConfigSchemaBase):

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -32,6 +32,7 @@ class KubernetesRunSchema(RunConfigSchemaBase):
     memory_request = fields.String(allow_none=True)
     service_account_name = fields.String(allow_none=True)
     image_pull_secrets = fields.List(fields.String(), allow_none=True)
+    safe_to_evict = fields.Bool(allow_none=True)
 
 
 class ECSRunSchema(RunConfigSchemaBase):

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -254,7 +254,8 @@ def test_agent_kubernetes_install(monkeypatch, deprecated):
             "--latest --image-pull-secrets secret-test --mem-request mem_req "
             "--mem-limit mem_lim --cpu-request cpu_req --cpu-limit cpu_lim "
             "--image-pull-policy custom_policy --service-account-name svc_name "
-            "-b backend-test"
+            "-b backend-test "
+            "--safe-to-evict false"
         ).split()
     )
 
@@ -274,6 +275,7 @@ def test_agent_kubernetes_install(monkeypatch, deprecated):
         "image_pull_policy": "custom_policy",
         "service_account_name": "svc_name",
         "backend": "backend-test",
+        "safe_to_evict": "false",
     }
 
     generate = MagicMock(wraps=KubernetesAgent.generate_deployment_yaml)

--- a/tests/run_configs/test_kubernetes.py
+++ b/tests/run_configs/test_kubernetes.py
@@ -19,6 +19,7 @@ def test_no_args():
     assert config.service_account_name is None
     assert config.image_pull_secrets is None
     assert config.labels == set()
+    assert config.safe_to_evict is None
 
 
 def test_labels():
@@ -100,3 +101,8 @@ def test_service_account_name_and_image_pull_secrets():
     # Ensure falsey-lists aren't converted to `None`.
     config = KubernetesRun(image_pull_secrets=[])
     assert config.image_pull_secrets == []
+
+
+def test_safe_to_evict():
+    config = KubernetesRun(safe_to_evict=False)
+    assert config.safe_to_evict == "false"

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -33,6 +33,7 @@ def test_serialize_universal_run(config):
             memory_request="2G",
             service_account_name="my-account",
             image_pull_secrets=["secret-1", "secret-2"],
+            safe_to_evict=False,
             labels=["a", "b"],
         ),
         KubernetesRun(
@@ -59,6 +60,7 @@ def test_serialize_kubernetes_run(config):
         "memory_request",
         "service_account_name",
         "image_pull_secrets",
+        "safe_to_evict",
     ]
     for field in fields:
         assert getattr(config, field) == getattr(config2, field)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Closes #3058 


## Changes
<!-- What does this PR change? -->

Added `--safe-to-evict` CLI argument and `safe_to_evict` to Kubernetes agent. When the agent spawns the Pod, it checks for that variable to add that annotation to the job manifest.


## Importance
<!-- Why is this PR important? -->

The Kubernetes Cluster Autoscaler will evaluate the utilization of each Node in the cluster to determine if it can scale down the number of Nodes. When a node is removed from service, Pods running on that node are relocated and restarted on another Node. This results in:
- Prefect will encounter `No heartbeat detected from the remote task`; marking the run as "Failed".
- The initial Pod was relocated by the Cluster AutoScaler and the newly started Pod is actually reporting logs to Prefect Cloud.
- Because no heartbeat was detected from that original Pod, the Lazarus process will attempt to reschedule the Flow Run. but the Flow Run was already restarted by K8, it's just in a different Pod now.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)