### PR TITLE
Speed up flow validation logic

### DIFF
--- a/changes/pr4347.yaml
+++ b/changes/pr4347.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Speed up flow validation logic - [#4347](https://github.com/PrefectHQ/prefect/pull/4347)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -881,8 +881,8 @@ class Flow:
             tasks = set(root_tasks)
             seen = set()  # type: Set[Task]
 
-            # compute the downstream edges dict once, cache validation is expensive
-            # for large flows
+            # compute the downstream edges dict once, this method uses
+            # @cached but validation is expensive for large flows
             downstream_edges = self.all_downstream_edges()
 
             # while the set of tasks is different from the seen tasks...
@@ -900,8 +900,8 @@ class Flow:
         remaining_tasks = list(tasks)
         sorted_tasks = []
 
-        # compute the upstream edges dict once, cache validation is expensive
-        # for large flows
+        # compute the upstream edges dict once, this method uses
+        # @cached but validation is expensive for large flows
         upstream_edges = self.all_upstream_edges()
 
         while remaining_tasks:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Speed up `flow.validate()` call. For a Flow with 1,000 tasks and 10,000 edges, `flow.validate()` call time drops from ~32 seconds to ~5 seconds. 


## Changes

This PR stores calls to `Flow.all_upstream_edges` and `Flow.all_downstream_edges` as a variable when sorting flow tasks, and moves minor logic into `Flow._sorted_tasks` instead of relying other Flow methods.

By doing so, we avoid repeated cache validation calls which check that all tasks, edges, and reference tasks on the flow model remain the same as prior calls. https://github.com/PrefectHQ/prefect/blob/master/src/prefect/core/flow.py#L67

These validation calls become very expensive as flow size increases.


I also played around with the idea of some object level property to ignore cache validation, but it seemed like there were too many edge cases to managing that property.

## Importance
Flows are validated as part of the registration process. `flow.validate()` is VERY slow, for large flow objects at the moment.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)