### PR TITLE
Pin dask upper version limits

### DIFF
--- a/changes/pr4350.yaml
+++ b/changes/pr4350.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Pin dask upper package versions - [#4350](https://github.com/PrefectHQ/prefect/pull/4350)"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click >= 7.0
 cloudpickle >=1.3.0
 croniter >= 0.3.24, <1.0
-dask >= 2.17.0
-distributed >= 2.17.0
+dask >= 2.17.0, <2021.04.0
+distributed >= 2.17.0, <2021.04.0
 docker >=3.4.1
 importlib_resources >= 3.0.0; python_version < '3.7'
 marshmallow >= 3.0.0b19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 click >= 7.0
 cloudpickle >=1.3.0
 croniter >= 0.3.24, <1.0
-dask >= 2.17.0, <2021.04.0
-distributed >= 2.17.0, <2021.04.0
+dask >= 2.17.0; python_version > '3.6'
+dask >= 2.17.0, <2021.04.0; python_version < '3.7'
+distributed >= 2.17.0; python_version > '3.6'
+distributed >= 2.17.0, <2021.04.0; python_version < '3.7'
 docker >=3.4.1
 importlib_resources >= 3.0.0; python_version < '3.7'
 marshmallow >= 3.0.0b19


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Dask dropped support for Python 3.6 in their latest release. This PR pins upper `dask` and `distributed` versions to allow requirements to build in Python3.6 environments.




## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)