### PR TITLE
Add option to disable the deletion of finished jobs in the Kubernetes agent

### DIFF
--- a/changes/pr4351.yaml
+++ b/changes/pr4351.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add option to disable the deletion of finished Prefect jobs in the Kubernetes agent - [#4351](https://github.com/PrefectHQ/prefect/pull/4351)"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -274,6 +274,13 @@ def kubernetes():
     "values can be provided as a comma-separated list "
     "(e.g. `--image-pull-secrets VAL1,VAL2`)",
 )
+@click.option(
+    "--disable-job-deletion",
+    "delete_finished_jobs",
+    help="Turn off automatic deletion of finished jobs in the namespace.",
+    is_flag=True,
+    default=True,
+)
 def start(image_pull_secrets=None, **kwargs):
     """Start a Kubernetes agent"""
     from prefect.agent.kubernetes import KubernetesAgent

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -279,7 +279,7 @@ def kubernetes():
     "delete_finished_jobs",
     help="Turn off automatic deletion of finished jobs in the namespace.",
     is_flag=True,
-    default=True,
+    default=True,  # Defaults to `True` because setting this flag sets `delete_finished_jobs` to `False`
 )
 def start(image_pull_secrets=None, **kwargs):
     """Start a Kubernetes agent"""

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -921,6 +921,43 @@ def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api):
     assert batch_client.delete_namespaced_job.called
 
 
+def test_k8s_agent_manage_jobs_does_not_delete_if_disabled(monkeypatch, cloud_api):
+    job_mock = MagicMock()
+    job_mock.metadata.labels = {
+        "prefect.io/identifier": "id",
+        "prefect.io/flow_run_id": "fr",
+    }
+    job_mock.metadata.name = "my_job"
+    job_mock.status.failed = True
+    job_mock.status.succeeded = True
+    batch_client = MagicMock()
+    list_job = MagicMock()
+    list_job.metadata._continue = 0
+    list_job.items = [job_mock]
+    batch_client.list_namespaced_job.return_value = list_job
+    batch_client.delete_namespaced_job.return_value = None
+    monkeypatch.setattr(
+        "kubernetes.client.BatchV1Api", MagicMock(return_value=batch_client)
+    )
+
+    pod = MagicMock()
+    pod.metadata.name = "pod_name"
+    pod.status.phase = "Success"
+
+    core_client = MagicMock()
+    list_pods = MagicMock()
+    list_pods.items = [pod]
+    core_client.list_namespaced_pod.return_value = list_pods
+    monkeypatch.setattr(
+        "kubernetes.client.CoreV1Api", MagicMock(return_value=core_client)
+    )
+
+    agent = KubernetesAgent(delete_finished_jobs=False)
+    agent.manage_jobs()
+
+    assert not batch_client.delete_namespaced_job.called
+
+
 def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api):
     gql_return = MagicMock(
         return_value=MagicMock(

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -77,6 +77,7 @@ def test_help(cmd):
             (
                 "--namespace TESTNAMESPACE --job-template testtemplate.yaml",
                 "--service-account-name TESTACCT --image-pull-secrets VAL1,VAL2",
+                "--disable-job-deletion",
             ),
             (
                 {
@@ -87,6 +88,7 @@ def test_help(cmd):
                     "service_account_name": "TESTACCT",
                     "image_pull_secrets": ["VAL1", "VAL2"],
                 },
+                {"delete_finished_job": False},
             ),
         ),
         (


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Sometimes non-deterministic failures can happen in a flow that are hard to track down (e.g. memory issues) when running on k8s. When investigating these incidents it would be nice if k8s held onto the resources so one could dig deeper into them before they are deleted. The k8s agent's resource management is currently a bit greedy and it would be nice to disable the cleanup step when necessary. That way in testing/debugging scenarios an Agent can be spun up, perform normally, but one would get to interact with the resources before manually deleting them.



## Changes
This adds a new flag to the Kubernetes agent `delete_finished_jobs` that when set to `False` will explicitly disable the job deletion. It can also be set via the `DELETE_FINISHED_JOBS` environment variable or the `--disable-job-deletion` flag when started via the CLI.


## Importance
Would make certain testing/debugging scenarios nicer.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)