### PR TITLE
Fix incorrect unused task tracking

### DIFF
--- a/changes/pr4368.yaml
+++ b/changes/pr4368.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix incorrect unused task tracking - [#4368](https://github.com/PrefectHQ/prefect/pull/4368)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -173,7 +173,11 @@ class TaskMetaclass(type):
         computed to avoid circular import issues.
         """
         if not hasattr(Task, "_cached_reserved_attributes"):
-            Task._cached_reserved_attributes = tuple(sorted(Task().__dict__))  # type: ignore
+            # Create a base task instance to determine which attributes are reserved
+            # we need to disable the unused_task_tracker for this duration or it will
+            # track this task
+            with prefect.context(_unused_task_tracker=set()):
+                Task._cached_reserved_attributes = tuple(sorted(Task().__dict__))  # type: ignore
         return Task._cached_reserved_attributes  # type: ignore
 
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -552,8 +552,7 @@ class Task(metaclass=TaskMetaclass):
         # as it has been "interacted" with and don't want spurious
         # warnings
         if "_unused_task_tracker" in prefect.context:
-            if self in prefect.context._unused_task_tracker:
-                prefect.context._unused_task_tracker.remove(self)
+            prefect.context._unused_task_tracker.discard(self)
             if not isinstance(new, prefect.tasks.core.constants.Constant):
                 prefect.context._unused_task_tracker.add(new)
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -790,6 +790,29 @@ def test_warning_not_raised_for_constant_tasks_as_inputs():
     assert len(record) == 0
 
 
+def test_warning_not_raised_with_called_task_subclass_in_context():
+    # Covers fix in commit e5c75adb38915485997965fcb3a4110e7a7728b2
+
+    class AddOne(Task):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def run(self, x):
+            return x + 1
+
+    with pytest.warns(None) as record:
+        with Flow(name="test") as f:
+            add_one = AddOne()
+            tt = add_one(10)
+
+    # confirm tasks were added
+    assert len(f.tasks) == 1
+    assert f.constants[tt]["x"] == 10
+
+    # no warnings
+    assert len(record) == 0
+
+
 def test_warning_raised_if_tasks_are_copied_but_not_added_to_flow():
     x = Parameter("x")
     with pytest.warns(UserWarning, match="Tasks were created but not added"):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When a task subclass is declared in the `with Flow..` context we instantiate a `Task()` object to check the reserved attributes. Unfortunately, this adds a `Task` to the `unused_task_tracker` set that will never be removed which will give users false warnings that they have task objects in their flow that are not called.


## Changes
<!-- What does this PR change? -->

- Disable the unused task tracker during reserved attribute retrieval


## Importance
<!-- Why is this PR important? -->

Fixes incorrect warning


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)