### PR TITLE
Improve messaging when a flow is skipped during registration

### DIFF
--- a/changes/pr4373.yaml
+++ b/changes/pr4373.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Improve messaging when a flow is skipped during registration - [#4373](https://github.com/PrefectHQ/prefect/pull/4373)"

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -462,7 +462,7 @@ def build_and_register(
                     click.echo(f"  └── Version: {flow_version}")
                     stats["registered"] += 1
                 else:
-                    click.secho(" Skipped", fg="yellow")
+                    click.secho(" Skipped (metadata unchanged)", fg="yellow")
                     stats["skipped"] += 1
     return stats
 
@@ -705,7 +705,11 @@ REGISTER_EPILOG = """
 @click.pass_context
 @handle_terminal_error
 def register(ctx, project, paths, modules, json_paths, names, labels, force, watch):
-    """Register one or more flows into a project."""
+    """Register one or more flows into a project.
+
+    Flows with unchanged metadata will be skipped as registering again will only
+    change the version number.
+    """
     # Since the old command was a subcommand of this, we have to do some
     # mucking to smoothly deprecate it. Can be removed with `prefect register
     # flow` is removed.

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -496,7 +496,7 @@ class TestRegister:
                 "  └── ID: new-id-1\n"
                 "  └── Version: 1\n"
                 "  Building `MyModule` storage...\n"
-                "  Registering 'flow 2'... Skipped\n"
+                "  Registering 'flow 2'... Skipped (metadata unchanged)\n"
                 "  Building `MyModule` storage...\n"
                 "  Registering 'flow 3'... Done\n"
                 "  └── ID: new-id-3\n"
@@ -519,7 +519,7 @@ class TestRegister:
                 "  Registering 'flow 7'... Done\n"
                 "  └── ID: new-id-7\n"
                 "  └── Version: 1\n"
-                "  Registering 'flow 8'... Skipped\n"
+                "  Registering 'flow 8'... Skipped (metadata unchanged)\n"
             ),
         ]
         out, err = capsys.readouterr()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Explains to users who may not understand why their flow is being skipped during `prefect register` that skipping is okay with a couple small display changes.

e.g. https://prefect-community.slack.com/archives/CL09KU1K7/p1617827979177100

## Changes
<!-- What does this PR change? -->

- Adds metadata note to `--help` message
- Adds note after each `Skipped` message

## Importance
<!-- Why is this PR important? -->

- Improves experience for non-power users / people unfamiliar with idempotency keys


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)