### PR TITLE
Display a more helpful error when flow context cannot be inferred

### DIFF
--- a/changes/pr4374.yaml
+++ b/changes/pr4374.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Display the relevant task when flow context cannot be inferred - [#4374](https://github.com/PrefectHQ/prefect/pull/4374)"

--- a/changes/pr4374.yaml
+++ b/changes/pr4374.yaml
@@ -1,3 +1,3 @@
 
 enhancement:
-  - "Display the relevant task when flow context cannot be inferred - [#4374](https://github.com/PrefectHQ/prefect/pull/4374)"
+  - "Display a more helpful error when calling a task outside a flow context - [#4374](https://github.com/PrefectHQ/prefect/pull/4374)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -671,10 +671,18 @@ class Task(metaclass=TaskMetaclass):
 
         flow = flow or prefect.context.get("flow", None)
         if not flow:
+            # Determine the task name to display which is either the function task name
+            # or the initialized class where we can't know the name of the variable
+            task_name = (
+                self.name
+                if isinstance(self, prefect.tasks.core.function.FunctionTask)
+                else f"{type(self).__name__}(...)"
+            )
             raise ValueError(
                 f"Could not infer an active Flow context while creating edge to {self}."
                 " This often means you called a task outside a `with Flow(...)` block. "
-                "Did you mean to call `this_task.run(...)`?"
+                "If you're trying to run this task outside of a Flow context, you "
+                f"need to call `{task_name}.run(...)`"
             )
 
         self.set_dependencies(

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -671,7 +671,9 @@ class Task(metaclass=TaskMetaclass):
 
         flow = flow or prefect.context.get("flow", None)
         if not flow:
-            raise ValueError("Could not infer an active Flow context.")
+            raise ValueError(
+                f"Could not infer an active Flow context while creating edge to {self}."
+            )
 
         self.set_dependencies(
             flow=flow,

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -673,6 +673,8 @@ class Task(metaclass=TaskMetaclass):
         if not flow:
             raise ValueError(
                 f"Could not infer an active Flow context while creating edge to {self}."
+                " This often means you called a task outside a `with Flow(...)` block. "
+                "Did you mean to call `this_task.run(...)`?"
             )
 
         self.set_dependencies(

--- a/tests/utilities/test_tasks.py
+++ b/tests/utilities/test_tasks.py
@@ -33,7 +33,10 @@ class TestTaskDecorator:
         def fn(x):
             return x
 
-        with pytest.raises(ValueError, match="Could not infer an active Flow context"):
+        with pytest.raises(
+            ValueError,
+            match=f"Could not infer an active Flow context while creating edge to {fn}",
+        ):
             fn(1)
 
     def test_task_decorator_with_no_args_must_be_called_inside_flow_context(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Flow context cannot be inferred if a task is called outside of the `with Flow()` block. This PR aims to help users quickly determine which task in a large script is causing this error.

e.g.

```
>>> from prefect import Flow, task
>>> @task
... def foo():
...    pass
... 
>>> foo()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/Caskroom/miniconda/base/envs/prefect-core/lib/python3.8/site-packages/prefect/core/task.py", line 621, in __call__
    new.bind(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/prefect-core/lib/python3.8/site-packages/prefect/core/task.py", line 674, in bind
    raise ValueError(
ValueError: Could not infer an active Flow context while creating edge to <Task: foo>. This often means you called a task outside a `with Flow(...)` block. Did you mean to call `this_task.run(...)`?
```

## Changes
<!-- What does this PR change? -->

- Identifies the task that is called when flow context cannot be inferred

## Importance
<!-- Why is this PR important? -->

- Improves ability to quickly determine the task where this error occurs 
Prompted by https://prefect-community.slack.com/archives/CL09KU1K7/p1617891432223300

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)