### PR TITLE
add task_definition_add_uuid as an agent option for ecs

### DIFF
--- a/changes/pr4380.yaml
+++ b/changes/pr4380.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Adds ability to append UUID to task definition name (aka family) for the ECS agent preventing per family rate limiting on RegisterTaskDefinition api. [#4380](https://github.com/PrefectHQ/prefect/pull/4380)"
+
+contributor:
+  - "[Joe McDonald](https://github.com/joe1981al)"

--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -188,6 +188,17 @@ prefect agent ecs start --execution-role-arn my-execution-role-arn
 Flows can override this agent default by passing the `execution_role_arn` option to
 their respective [ECSRun](/orchestration/flow_config/run_configs.md#ecsrun) `run_config`.
 
+### Task Definition Add UUID
+
+The ECS agent when generating a task definition name (aka family) will default to using
+the pattern of `prefect-<flow_name>` which can lead to rate limiting if submit several
+flow runs in a short period.  This rate limit is per family, to bypass this set the 
+`--task-definition-add-uuid` option to true.
+
+```bash
+prefect agent ecs start --task-definition-add-uuid true
+```
+
 ### Custom Task Definition Template
 
 For deeper customization of the Tasks created by the agent, you may want to

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -398,6 +398,13 @@ def ecs():
     "run_task_kwargs_path",
     help="Path to a yaml file containing extra kwargs to pass to `run_task`",
 )
+@click.option(
+    "--task_definition_add_uuid",
+    help=(
+        "Set true to allow for a unique id to be appended to task definition "
+        "name (aka family).  This helps prevent rate limiting."
+    ),
+)
 def start(**kwargs):
     """Start an ECS agent"""
     from prefect.agent.ecs import ECSAgent

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -399,7 +399,7 @@ def ecs():
     help="Path to a yaml file containing extra kwargs to pass to `run_task`",
 )
 @click.option(
-    "--task_definition_add_uuid",
+    "--task-definition-add-uuid",
     help=(
         "Set true to allow for a unique id to be appended to task definition "
         "name (aka family).  This helps prevent rate limiting."


### PR DESCRIPTION
## Summary
Adds ability to append UUID to task definition for ECS Agent

## Changes
updates to ECS agent and agent CLI command

## Importance
AWS has a rate limit on RegisterTaskDefinition endpoint that is extremely low for the same task definition name (aka family). The error occurred when 10 runs of the same flow were scheduled and 3 agents starting trying to run the flows, 6 of the 10 failed with the message below.  

> An error occurred (ClientException) when calling the RegisterTaskDefinition operation: Too many concurrent attempts to create a new revision of the specified family.

## Checklist
This PR:

- [X] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)