### PR TITLE
Add error handling to timeouts that fail during result pickling or passing

### DIFF
--- a/changes/pr4384.yaml
+++ b/changes/pr4384.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Add error handling to timeouts that fail during result pickling or passing - [#4384](https://github.com/PrefectHQ/prefect/pull/4384)"

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -174,11 +174,42 @@ def multiprocessing_safe_run_and_retrieve(
         with prefect.context(context):
             logger.debug(f"{name}: Executing...")
             return_val = fn(*args, **kwargs)
+            logger.debug(f"{name}: Execution successful.")
     except Exception as exc:
         return_val = exc
+        logger.debug(
+            f"{name}: Encountered a {type(exc).__name__}, "
+            f"returning details as a result..."
+        )
+
+    try:
+        pickled_val = cloudpickle.dumps(return_val)
+    except Exception as exc:
+        base_msg = (
+            f"Failed to pickle result of type {type(return_val).__name__!r} with "
+            f'exception: "{type(exc).__name__}: {str(exc)}".'
+        )
+        logger.error(f"{name}: {base_msg}")
+        pickled_val = cloudpickle.dumps(
+            RuntimeError(
+                f"{base_msg} This timeout handler requires your function return "
+                f"value to be serializable with `cloudpickle`. "
+                "If you must return a unserializable value, consider switching your "
+                "executor to use processes instead of threads to use a different "
+                "timeout handler."
+            )
+        )
 
     logger.debug(f"{name}: Passing result back to main process...")
-    queue.put(cloudpickle.dumps(return_val))
+
+    try:
+        queue.put(pickled_val)
+    except Exception:
+        logger.error(
+            f"{name}: Failed to put result in queue to main process!",
+            exc_info=True,
+        )
+        raise
 
 
 def run_with_multiprocess_timeout(

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -185,20 +185,13 @@ def multiprocessing_safe_run_and_retrieve(
     try:
         pickled_val = cloudpickle.dumps(return_val)
     except Exception as exc:
-        base_msg = (
+        err_msg = (
             f"Failed to pickle result of type {type(return_val).__name__!r} with "
-            f'exception: "{type(exc).__name__}: {str(exc)}".'
+            f'exception: "{type(exc).__name__}: {str(exc)}". This timeout handler "'
+            "requires your function return value to be serializable with `cloudpickle`."
         )
-        logger.error(f"{name}: {base_msg}")
-        pickled_val = cloudpickle.dumps(
-            RuntimeError(
-                f"{base_msg} This timeout handler requires your function return "
-                f"value to be serializable with `cloudpickle`. "
-                "If you must return a unserializable value, consider switching your "
-                "executor to use processes instead of threads to use a different "
-                "timeout handler."
-            )
-        )
+        logger.error(f"{name}: {err_msg}")
+        pickled_val = cloudpickle.dumps(RuntimeError(err_msg))
 
     logger.debug(f"{name}: Passing result back to main process...")
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -177,7 +177,7 @@ def multiprocessing_safe_run_and_retrieve(
             logger.debug(f"{name}: Execution successful.")
     except Exception as exc:
         return_val = exc
-        logger.debug(
+        logger.error(
             f"{name}: Encountered a {type(exc).__name__}, "
             f"returning details as a result..."
         )

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -226,7 +226,10 @@ def test_run_with_multiprocess_timeout_handles_unpicklable_return_values():
         run_with_multiprocess_timeout(fn, timeout=12)
 
     # We include the original exception
-    assert "TypeError: cannot pickle '_thread.lock' object" in str(exc_info.value)
+    assert "TypeError: cannot pickle '_thread.lock' object" in str(
+        exc_info.value
+        # Python 3.6/7 have a different error message
+    ) or "TypeError: can't pickle _thread.lock objects" in str(exc_info.value)
 
 
 @pytest.mark.skipif(

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -3,7 +3,9 @@ import multiprocessing
 import sys
 import threading
 import time
+from unittest.mock import MagicMock
 
+import cloudpickle
 import pytest
 
 import prefect
@@ -11,6 +13,7 @@ from prefect.utilities.exceptions import TaskTimeoutError
 from prefect.utilities.executors import (
     run_with_thread_timeout,
     run_with_multiprocess_timeout,
+    multiprocessing_safe_run_and_retrieve,
     tail_recursive,
     RecursiveCall,
 )
@@ -192,6 +195,60 @@ def test_run_with_multiprocess_timeout_preserves_logging(capfd):
     stdout = capfd.readouterr().out
     assert "Beginning Flow run" in stdout
     assert "Flow run SUCCESS" in stdout
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
+def test_run_with_multiprocess_timeout_handles_none_return_values():
+    def fn():
+        return None
+
+    result = run_with_multiprocess_timeout(fn, timeout=10)
+
+    assert result is None
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
+def test_run_with_multiprocess_timeout_handles_unpicklable_return_values():
+    def fn():
+        import threading
+
+        # An unpickleable type
+        return threading.Lock()
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to pickle result of type 'lock'",
+    ) as exc_info:
+        run_with_multiprocess_timeout(fn, timeout=12)
+
+    # We include the original exception
+    assert "TypeError: cannot pickle '_thread.lock' object" in str(exc_info.value)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't support any timeout logic"
+)
+def test_multiprocessing_safe_run_and_retrieve_logs_queue_errors(caplog):
+    # We cannot mock queue.put
+    def fn():
+        pass
+
+    mock_queue = MagicMock(put=MagicMock(side_effect=Exception("Test")))
+
+    request = cloudpickle.dumps({"fn": fn})
+
+    with pytest.raises(
+        Exception,
+        match="Test",
+    ):
+        multiprocessing_safe_run_and_retrieve(mock_queue, request)
+
+    assert "Failed to put result in queue to main process!" in caplog.text
+    assert "Exception: Test" in caplog.text
 
 
 def test_recursion_go_case():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

A couple error cases in the `run_with_multiprocess_timeout` typically used by the `TaskRunner` when running a threaded dask scheduler were not captured and logged which could lead to opaque failures of the timeout handler. This PR adds logging and error capturing to try to improve introspection during failure cases.


## Changes
<!-- What does this PR change? -->

- Pickling errors are captured, logged, and returned so the user gets a clear description of result requirements while using this timeout handler. Previously, this would result in a `TimeoutError` because the queue would be empty.
- `Queue.put` errors are logged and re-raised. They cannot be returned to the main process because the queue is how we pass exceptions up. Logging with a traceback is our best way to improve this edge-case right now.


## Importance
<!-- Why is this PR important? -->

Several users have encountered unknowable errors while using the timeout handler lately


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)