### PR TITLE
Cleanup docker-compose for `prefect server start`

### DIFF
--- a/changes/pr4396.yaml
+++ b/changes/pr4396.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Lower required docker-compose version and add note to docs - [#4396](https://github.com/PrefectHQ/prefect/pull/4396)"

--- a/changes/pr4396.yaml
+++ b/changes/pr4396.yaml
@@ -1,3 +1,4 @@
 
 enhancement:
   - "Lower required docker-compose version and add note to docs - [#4396](https://github.com/PrefectHQ/prefect/pull/4396)"
+  - "Increase healthcheck intervals for Prefect Server - [#4396](https://github.com/PrefectHQ/prefect/pull/4396)"

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -1,8 +1,9 @@
 # Deploying to a single node
 
-Prefect Server can be deployed on a single node using a
-[docker-compose](https://docs.docker.com/compose/) setup. One way to accomplish this is to use the
-builtin command in the Prefect CLI. Note that this requires both `docker-compose` and `docker` to be installed.
+Prefect Server can be deployed on a single node using [docker-compose](https://docs.docker.com/compose/). 
+
+The easiest way accomplish this is to use the built-in command in the Prefect CLI.
+Note that this requires both `docker-compose >= 1.18.0` and `docker` to be installed.
 
 ```bash
 prefect server start
@@ -11,6 +12,15 @@ prefect server start
 Note that this command may take a bit to complete, as the various docker images are pulled. Once running,
 you should see some "Prefect Server" ASCII art along with the logs output from each service, and the UI should be available at
 [http://localhost:8080](http://localhost:8080).
+
+::: tip Installing Docker
+We recommend installing [Docker Desktop](https://www.docker.com/products/docker-desktop) following their instructions then installing docker-compose with `pip install docker-compose`.
+:::
+
+
+:: tip Just show me the config
+`prefect server start` templates a basic docker-compose file to conform to the options you pass. Sometimes, you just want to generate this file then manage running it yourself (or make further customizations). We provide a `prefect server config` command that takes all the same settings as `prefect server start` and prints the file to stdout. Try piping it to a file `prefect server config > docker-compose.yaml`.
+::
 
 ## UI configuration
 

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -18,9 +18,9 @@ We recommend installing [Docker Desktop](https://www.docker.com/products/docker-
 :::
 
 
-:: tip Just show me the config
+::: tip Just show me the config
 `prefect server start` templates a basic docker-compose file to conform to the options you pass. Sometimes, you just want to generate this file then manage running it yourself (or make further customizations). We provide a `prefect server config` command that takes all the same settings as `prefect server start` and prints the file to stdout. Try piping it to a file `prefect server config > docker-compose.yaml`.
-::
+:::
 
 ## UI configuration
 

--- a/docs/orchestration/server/overview.md
+++ b/docs/orchestration/server/overview.md
@@ -34,18 +34,16 @@ repository.
 ## Deploying Prefect Server
 
 Prefect Server is designed to be deployed inside user infrastructure, and should be runnable in a wide
-variety of deployment backends. Currently the core team only officially supports a single-node
-deployment, but there are plans to expand to other deployment models (e.g. Kubernetes) in the near future. If you're
-interested in supporting such efforts, please [feel free to reach out](mailto:hello@prefect.io).
+variety of deployment backends. 
 
-In the meantime, please read our guide to [Single-Node Deployment](/orchestration/Server/deploy-local.html).
+For deployment instructions, read our guide to [Single-Node Deployment](/orchestration/Server/deploy-local.html) or, if you have a Kubernetes cluste you'd prefer to use, see the [Helm chart README](https://github.com/PrefectHQ/server/tree/master/helm/prefect-server).
 
 ::: warning Migrating off of Prefect Server <= 0.12.6
 The initial release of Prefect Server with Prefect Core 0.12.6 is no longer supported. Due to the large number of features and changes in the new [Server codebase](https://github.com/PrefectHQ/server) there is unfortunately no route to migrating your run and state history to a new Server installation.
 :::
 
 ::: warning Docker and Docker Compose required
-Because of [the diverse collection of services required](architecture.html) to run the full backend, Prefect Server ships as a docker-compose file that allows each of these services to run inside a custom configured Docker image within an appropriately configured Docker network.  This allows users to get up and running with a single CLI command.
+Because of [the diverse collection of services required](architecture.html) to run the full backend, Prefect Server ships as a docker-compose file that allows each of these services to run inside a custom configured Docker image within an appropriately configured Docker network.  This allows users to get up and running with a single CLI command. docker-compose is not included in our Python requirements file as it is not necessary for general use of Prefect. We require a minimum docker-compose version of `1.18.0`.
 :::
 
 ## Prefect Server vs. Prefect Cloud - which should I choose?

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     # Use `pg_isready` to check the connection status of the PostgreSQL server
     healthcheck:
       test: pg_isready -q -d $${POSTGRES_DB} -U $${POSTGRES_USER} || exit 1
-      interval: 1s
+      interval: 10s
       timeout: 2s
       retries: 60
       start_period: 2s
@@ -49,7 +49,7 @@ services:
     # /healthz endpoints returns OK when not unhealthy
     healthcheck:
       test: wget -O - http://hasura:$${HASURA_GRAPHQL_SERVER_PORT}/healthz &>/dev/null || exit 1
-      interval: 1s
+      interval: 10s
       timeout: 2s
       retries: 60
       start_period: 1s
@@ -73,7 +73,7 @@ services:
       - prefect-server
     healthcheck:
       test: curl --fail --silent "http://graphql:4201/health" &> /dev/null || exit 1
-      interval: 1s
+      interval: 10s
       timeout: 2s
       retries: 60
       start_period: 1s
@@ -112,7 +112,7 @@ services:
     # Test GraphQL Apollo endpoint as health-check
     healthcheck:
       test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" &> /dev/null || exit 1
-      interval: 1s
+      interval: 10s
       timeout: 2s
       retries: 60
       start_period: 1s

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.5"
 # - healthcheck                   2.1
 
 services:
-  # PostgreSQL: the database persistence layer where metadata is stored
+  # PostgreSQL: the backing database which stores flow metadata
   postgres:
     image: "postgres:11"
     ports:
@@ -23,7 +23,6 @@ services:
       # explicitly set max connections
       - "-c"
       - "max_connections=150"
-    # Use `pg_isready` to check the connection status of the PostgreSQL server
     healthcheck:
       test: pg_isready -q -d $${POSTGRES_DB} -U $${POSTGRES_USER} || exit 1
       interval: 10s
@@ -32,7 +31,7 @@ services:
       start_period: 2s
     restart: always
 
-  # Hasura: the GraphQL API that layers on top of Postgres for querying metadata
+  # Hasura: automatically generates a GraphQL schema from Postgres, provides most of the 'query' API
   hasura:
     image: "hasura/graphql-engine:v1.3.3"
     ports:
@@ -46,7 +45,6 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: "warn"
     networks:
       - prefect-server
-    # /healthz endpoints returns OK when not unhealthy
     healthcheck:
       test: wget -O - http://hasura:$${HASURA_GRAPHQL_SERVER_PORT}/healthz &>/dev/null || exit 1
       interval: 10s
@@ -57,7 +55,7 @@ services:
     depends_on:
       - postgres
 
-  # GraphQL: the server's business logic that exposes GraphQL mutations
+  # GraphQL: provides most of the 'mutation' GraphQL API
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
@@ -81,7 +79,7 @@ services:
     depends_on:
       - hasura
 
-  # Towel: runs utilities that are responsible for server maintenance
+  # Towel: runs a collection of simple services
   towel:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     command: "python src/prefect_server/services/towel/__main__.py"
@@ -94,7 +92,7 @@ services:
     depends_on:
       - graphql
 
-  # Apollo: the main endpoint for interacting with the server
+  # Apollo: combines the hasura and graphql schemas into a unified schema, the primary API entrypoint
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
@@ -109,7 +107,6 @@ services:
       GRAPHQL_SERVICE_PORT: 4201
     networks:
       - prefect-server
-    # Test GraphQL Apollo endpoint as health-check
     healthcheck:
       test: curl --fail --silent "http://apollo:4200/.well-known/apollo/server-health" &> /dev/null || exit 1
       interval: 10s
@@ -123,7 +120,7 @@ services:
 
   # UI: the user interface that provides a visual dashboard for mutating and querying metadata
   # The UI is a standalone web interface and only communicates with the Apollo GraphQL API via
-  #  the host from which it is accessed.
+  #  the host from which it is accessed (i.e. the user's browser) .
   ui:
     image: "prefecthq/ui:${PREFECT_UI_TAG:-latest}"
     ports:

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -51,8 +51,7 @@ services:
       start_period: 1s
     restart: always
     depends_on:
-      postgres:
-        condition: service_healthy
+      - postgres
 
   # GraphQL: the server's business logic that exposes GraphQL mutations
   graphql:
@@ -76,8 +75,7 @@ services:
       start_period: 1s
     restart: always
     depends_on:
-      hasura:
-        condition: service_healthy
+      - hasura
 
   # Towel: runs utilities that are responsible for server maintenance
   towel:
@@ -90,8 +88,7 @@ services:
       - prefect-server
     restart: "always"
     depends_on:
-      graphql:
-        condition: service_healthy
+      - graphql
 
   # Apollo: the main endpoint for interacting with the server
   apollo:
@@ -117,10 +114,8 @@ services:
       start_period: 1s
     restart: always
     depends_on:
-      graphql:
-        condition: service_healthy
-      hasura:
-        condition: service_healthy
+      - graphql
+      - hasura
 
   # UI: the user interface that provides a visual dashboard for mutating and querying metadata
   # The UI is a standalone web interface and only communicates with the Apollo GraphQL API via
@@ -141,8 +136,7 @@ services:
       retries: 3
     restart: always
     depends_on:
-      apollo:
-        condition: service_started
+      - apollo
 
 networks:
   prefect-server:

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -1,4 +1,8 @@
-version: "2.1"
+version: "3.5"
+# Features driving version requirement
+# - networks.name                 3.5
+# - healthcheck.start_period      2.3
+# - healthcheck                   2.1
 
 services:
   # PostgreSQL: the database persistence layer where metadata is stored

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "2.1"
 
 services:
   # PostgreSQL: the database persistence layer where metadata is stored

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - prefect-server
     healthcheck:
       test: curl --fail --silent "http://graphql:4201/health" &> /dev/null || exit 1
-      interval: 10s
+      interval: 20s
       timeout: 2s
       retries: 60
       start_period: 1s


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Lowers the required docker-compose version to 1.18.0 and cleans up some of the work done in #4041 


## Changes
<!-- What does this PR change? -->

- Lowers version of the compose-file from 3.7 to 3.5
- Drops `condition` from healthchecks (not recommended, support dropped in newer compose versions)
- Cleans up comments in compose file
- Adds minimum docker-compose version to docs
- Adds helm chart link to docs for using server
- Increases healthcheck intervals to reduce load from healthchecks

## Importance
<!-- Why is this PR important? -->

- Helps direct users to the best way to get docker running
- Both clarifies and expands the supported docker-compose versions

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~