### PR TITLE
Fix `ShellTask` on win32

### DIFF
--- a/changes/pr4397.yaml
+++ b/changes/pr4397.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Allow the `ShellTask` to be used on win32 - [#4397](https://github.com/PrefectHQ/prefect/pull/4397)"

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import logging
+import sys
 from subprocess import PIPE, STDOUT, Popen
 from typing import Any, List, Union, Optional
 

--- a/src/prefect/tasks/shell.py
+++ b/src/prefect/tasks/shell.py
@@ -126,11 +126,17 @@ class ShellTask(prefect.Task):
         with tempfile.NamedTemporaryFile(prefix="prefect-") as tmp:
             if helper_script:
                 tmp.write(helper_script.encode())
-                tmp.write("\n".encode())
+                tmp.write(os.linesep.encode())
             tmp.write(command.encode())
             tmp.flush()
             with Popen(
-                [self.shell, tmp.name], stdout=PIPE, stderr=STDOUT, env=current_env
+                [self.shell, tmp.name],
+                stdout=PIPE,
+                stderr=STDOUT,
+                env=current_env,
+                # Windows does not use the PATH during subprocess creation
+                # by default so we will use `shell` mode to do so
+                shell=sys.platform == "win32",
             ) as sub_process:
                 line = None
                 lines = []

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -231,7 +231,7 @@ def test_shell_task_handles_multiline_commands():
             cat $file
         done
         """.format(
-            tempdir
+            tempdir.replace("\\", "\\\\")
         )
         with open(tempdir + "/testfile.txt", "w") as f:
             f.write("this is a test")

--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -10,10 +10,6 @@ from prefect import Flow
 from prefect.tasks.shell import ShellTask
 from prefect.utilities.debug import raise_on_exception
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="ShellTask currently not supported on Windows"
-)
-
 
 def test_shell_initializes_and_runs_basic_cmd():
     with Flow(name="test") as f:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The `ShellTask` does not work on win32 because it does not look for executables in the path by default. This sets `Popen(..., shell=True)` when using win32 which inspects the path for the given executable.

You still need `bash` installed and on your `PATH` for this to work by default. Other shells should work without issue as well, but `cmd.exe` does not seem to support running a script.

## Importance
<!-- Why is this PR important? -->

Closes #1984 https://github.com/PrefectHQ/prefect/issues/4393

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)