### PR TITLE
Pass reference states to terminal handler

### DIFF
--- a/changes/pr4409.yaml
+++ b/changes/pr4409.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Pass reference tasks states instead of task states to terminal_state_handler - [#4409](https://github.com/PrefectHQ/prefect/pull/4409)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -146,9 +146,9 @@ class Flow:
             your prefect configuration file.
         -  terminal_state_handler (Callable, optional): A state handler that can be used to
             inspect or modify the final state of the flow run. Expects a callable with signature
-            `handler(flow: Flow, state: State, task_states: Dict[Task, State]) -> Optional[State]`,
+            `handler(flow: Flow, state: State, reference_task_states: Set[State]) -> Optional[State]`,
             where `flow` is the current Flow, `state` is the current state of the Flow run, and
-            `task_states` is a mapping from task -> state for all tasks in the flow. It should
+            `reference_task_states` is set of states for all reference tasks in the flow. It should
             return either a new state for the flow run, or `None` (in which case the existing
             state will be used).
     """

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -169,7 +169,7 @@ class Flow:
         validate: bool = None,
         result: Optional[Result] = None,
         terminal_state_handler: Optional[
-            Callable[["Flow", State, Dict[Task, State]], Optional[State]]
+            Callable[["Flow", State, Set[State]], Optional[State]]
         ] = None,
     ):
         self._cache = {}  # type: dict

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -718,9 +718,7 @@ class FlowRunner(Runner):
             state = Success(message="No reference tasks failed.", result=return_states)
 
         if self.flow.terminal_state_handler:
-            new_state = self.flow.terminal_state_handler(
-                self.flow, state, return_states
-            )
+            new_state = self.flow.terminal_state_handler(self.flow, state, key_states)
             if new_state is not None:
                 return new_state
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR allows the flow runner to pass a set of reference task states instead of all task states.




## Changes
<!-- What does this PR change? -->




## Importance
When running against Cloud or Server, `task_states` is not populated. Until we implement some sort of deferred task result retrieval in place, passing reference task states seems reasonable.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)