### PR TITLE
Add column names to PostgresFetch

### DIFF
--- a/changes/pr4414.yaml
+++ b/changes/pr4414.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Adds column name fetching to PostgresFetch task - [#4414](https://github.com/PrefectHQ/prefect/pull/4414)"
+
+contributor:
+  - "[Gabriel Montañola](https://github.com/gmontanola)"

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -264,7 +264,7 @@ class PostgresFetch(Task):
                 placeholder is query string
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - password (str): password used to authenticate; should be provided from a `Secret` task
-            - col_names (bool, optional): set to True to add column names to fetched records, defaults to False
+            - col_names (bool, optional): set to True to add column names to records, defaults to False
 
         Returns:
             - records (tuple or list of tuples): records from provided query

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -249,6 +249,7 @@ class PostgresFetch(Task):
         data: tuple = None,
         commit: bool = False,
         password: str = None,
+        col_names: bool = False,
     ):
         """
         Task run method. Executes a query against Postgres database and fetches results.
@@ -263,6 +264,7 @@ class PostgresFetch(Task):
                 placeholder is query string
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - password (str): password used to authenticate; should be provided from a `Secret` task
+            - col_names (bool, optional): set to True to add column names to fetched records, defaults to False
 
         Returns:
             - records (tuple or list of tuples): records from provided query
@@ -305,6 +307,13 @@ class PostgresFetch(Task):
 
                 if commit:
                     conn.commit()
+
+                if col_names:
+                    names_list = [
+                        col_description[0] for col_description in cursor.description
+                    ]
+                    header = [tuple(col_name for col_name in names_list)]
+                    records = header + records
 
             return records
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
There are plenty of ways of doing this: 
* We could add other cursors like the MySQL task does and get column names through the results (DictCursor and NamedTupleCursor store field name values).
* Doing an extra query in order to fetch those values

I tried to keep it simple and use the `cursor` object that we've already have. I**f this change is out of scope** for the task, I think we should add different cursors support so the user can handle this without the need of extra querying,

## Changes
<!-- What does this PR change? -->
It adds a boolean flag to the `PostgresFetch` task.
If it's set to `True` the task fetches column names through the already created cursor and merge it with the result set.

Defaults to `False` to avoid breaking anything already built with the current behavior.



## Importance
<!-- Why is this PR important? -->
It's a pretty common need when fetching data. Without this we need to make an extra query to fetch column names from `information_schema.columns` and merge it with your actual data.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)
