### PR TITLE
clear _stopped threading.Event for reuse

### DIFF
--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -82,6 +82,7 @@ class LogManager:
             self._write_logs()
             self.thread = None
             self.client = None
+            self._stopped.clear()
 
     def _write_logs_loop(self) -> None:
         """Runs in a background thread, uploads logs periodically in a loop"""


### PR DESCRIPTION
The original code does not cause the error if the logger manager only start once

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
clear the `threading.Event` instance `_stopped`  for possible reuse.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)