### PR TITLE
Check for AWS_RETRY_MODE variable before setting default in `ECSAgent`

### DIFF
--- a/changes/pr4417.yaml
+++ b/changes/pr4417.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Check for AWS_RETRY_MODE variable before setting default in `ECSAgent` - [#4417](https://github.com/PrefectHQ/prefect/pull/4417)"

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -180,7 +180,7 @@ class ECSAgent(Agent):
         # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
         # for more info.
         boto_config = Config(**botocore_config or {})
-        if not boto_config.retries:
+        if not boto_config.retries and not os.environ.get("AWS_RETRY_MODE"):
             boto_config.retries = {"mode": "standard"}
 
         self.boto_kwargs = dict(

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -135,7 +135,7 @@ class TestMergeRunTaskKwargs:
         }
 
 
-def test_boto_kwargs():
+def test_boto_kwargs(monkeypatch):
     # Defaults to loaded from environment
     agent = ECSAgent()
     keys = [
@@ -159,6 +159,11 @@ def test_boto_kwargs():
         "mode": "adaptive",
         "max_attempts": 2,
     }
+
+    # Does not set 'standard' if env variable is set
+    monkeypatch.setenv("AWS_RETRY_MODE", "adaptive")
+    agent = ECSAgent()
+    assert agent.boto_kwargs["config"].get("retries", {}).get("mode") is None
 
 
 def test_agent_defaults(default_task_definition):

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -163,7 +163,7 @@ def test_boto_kwargs(monkeypatch):
     # Does not set 'standard' if env variable is set
     monkeypatch.setenv("AWS_RETRY_MODE", "adaptive")
     agent = ECSAgent()
-    assert agent.boto_kwargs["config"].get("retries", {}).get("mode") is None
+    assert (agent.boto_kwargs["config"].retries or {}).get("mode") is None
 
 
 def test_agent_defaults(default_task_definition):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The `botocore.Config` object does not load pre-existing settings so if a user tries to override this setting via environment variable, we will override them (which is not the intended behavior). Passing the variables via CLI is tricky because botocore expects a bunch of different types (ie we can't just take a (str, str) tuple of key value settings for to pass to `botocore_config`). This is the only setting we set a default for so this is an acceptable workaround for now. Users with more complex use-cases can start their agent via a custom python script rather than using the CLI. Note that this will likely not respect settings in an aws config file.


## Changes
<!-- What does this PR change? -->

- Do not force the retry mode to be 'standard' if it is set already via environment variable


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)