### PR TITLE
Fix BigQuery: logging errors if exception is thrown during load_table_from_uri

### DIFF
--- a/changes/pr4419.yaml
+++ b/changes/pr4419.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "BigQuery: logging errors if exception is thrown during load_table_from_uri - [#4419](https://github.com/PrefectHQ/prefect/pull/4419)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"


### PR DESCRIPTION
…_from_uri

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes logging of error when exception is thrown during BigQuery load_table_from_uri. Currently another exception is thrown due invalid handling.


## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)