### PR TITLE
Fix ordering of kubectl apply arguments

### DIFF
--- a/docs/orchestration/agents/kubernetes.md
+++ b/docs/orchestration/agents/kubernetes.md
@@ -177,7 +177,7 @@ The generated manifest can be piped to `kubectl apply`, or manually edited to
 further customize the deployment.
 
 ```bash
-prefect agent kubernetes install -t MY_TOKEN | kubectl apply -f --namespace=my-namespace -
+prefect agent kubernetes install -t MY_TOKEN | kubectl apply --namespace=my-namespace -f -
 ```
 
 Once created, you should be able to see the agent deployment running in your


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

TL;DR: The `-f` argument in `kubectl apply` has to be beside the `-` argument, without it you get an error that looks like:

```
$ prefect agent kubernetes install -t "<TOKEN>" --rbac -n "<namespace>" | kubectl create -f --namespace="<namespace>" -
error: Unexpected args: [-]
See 'kubectl create -h' for help and examples
```

## Changes
<!-- What does this PR change? -->

Updates `docs/orchestration/agents/kubernetes.md` to show the correct ordering of arguments


## Importance
<!-- Why is this PR important? -->

Currently the Prefect provided instructions on applying the Prefect Agent configuration to Kubernetes clusters is broken.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate) N/A
- [X] adds a change file in the `changes/` directory (if appropriate) N/A
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate) N/A

