### PR TITLE
Add external postgres support

### DIFF
--- a/changes/pr4424.yaml
+++ b/changes/pr4424.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow external Postgres with `prefect server start` command - [#4424](https://github.com/PrefectHQ/prefect/pull/4424)"

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -68,16 +68,24 @@ see the documentation on [prefect server migrations](https://github.com/PrefectH
 
 ### External Postgres instance
 
-If you want Prefect Server to use an external Postgres instance, configure the database url in `~/.prefect/config.toml` on whatever machine you're running Prefect Server:
+You can also configure Prefect Server to use an external Postgres instance.
+
+The simplest way to specify an external Postgres instance is passing in a command line argument:
+
+```bash
+prefect server start --postgres-url postgres://<username>:<password>@hostname:<port>/<dbname>
+```
+
+You can also configure the database url in `~/.prefect/config.toml` on whatever machine you're running Prefect Server:
 
 ```
 [server.database]
 connection_url = "postgres://<username>:<password>@hostname:<port>/<dbname>"
 ```
 
-This connection url will be passed directly to Hasura. For more information and troubleshooting, see the [docs](https://hasura.io/docs/latest/graphql/core/deployment/deployment-guides/docker.html#database-url).
+And then run `prefect server start --external-postgres`. 
 
-After setting the connection url, run `prefect server start --external-postgres`.
+Using either method, the connection url will be passed directly to Hasura. For more information and troubleshooting, see the [docs](https://hasura.io/docs/latest/graphql/core/deployment/deployment-guides/docker.html#database-url).
 
 Please note [a set of alembic migrations](https://github.com/PrefectHQ/server/tree/master/services/postgres/alembic/versions) are automatically applied against
 the external database on start.

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -66,6 +66,22 @@ Every time you run the `prefect server start` command [a set of alembic migratio
 applied against the database to ensure the schema is consistent. To run the migrations directly please
 see the documentation on [prefect server migrations](https://github.com/PrefectHQ/server#running-the-system).
 
+### External Postgres instance
+
+If you want Prefect Server to use an external Postgres instance, configure the database url in `~/.prefect/config.toml` on whatever machine you're running Prefect Server:
+
+```
+[server.database]
+connection_url = "postgres://<username>:<password>@hostname:<port>/<dbname>"
+```
+
+This connection url will be passed directly to Hasura. For more information and troubleshooting, see the [docs](https://hasura.io/docs/latest/graphql/core/deployment/deployment-guides/docker.html#database-url).
+
+After setting the connection url, run `prefect server start --external-postgres`.
+
+Please note [a set of alembic migrations](https://github.com/PrefectHQ/server/tree/master/services/postgres/alembic/versions) are automatically applied against
+the external database on start.
+
 ## How to upgrade your server instance
 
 When new versions of the server are released you will want to upgrade in order to stay on top of fixes,

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -250,7 +250,7 @@ def setup_compose_env(
     db_connection_url = config.server.database.connection_url
     if not external_postgres:
         # replace localhost with postgres to use docker-compose dns
-        db_connection_url.replace("localhost", "postgres")
+        db_connection_url = db_connection_url.replace("localhost", "postgres")
 
     PREFECT_ENV = dict(
         DB_CONNECTION_URL=db_connection_url,

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -392,6 +392,25 @@ def config_cmd(
         --volume-path       TEXT    A path to use for the Postgres volume, defaults to
                                     '~/.prefect/pg_data'. Not valid for external Postgres.
     """
+
+    if external_postgres:
+        if no_postgres_port:
+            warnings.warn(
+                "Using external Postgres instance, `--no-postgres-port` flag will be ignored."
+            )
+        if postgres_port != config.server.database.host_port:
+            warnings.warn(
+                "Using external Postgres instance, `--postgres-port` flag will be ignored."
+            )
+        if use_volume:
+            warnings.warn(
+                "Using external Postgres instance, `--use-volume` flag will be ignored."
+            )
+        if volume_path != config.server.database.volume_path:
+            warnings.warn(
+                "Using external Postgres instance, `--volume-path` flag will be ignored."
+            )
+
     compose_path = setup_compose_file(
         no_ui=no_ui,
         external_postgres=external_postgres,
@@ -499,6 +518,24 @@ def start(
         --detach, -d                Detached mode. Runs Server containers in the background
         --skip-pull                 Flag to skip pulling new images (if available)
     """
+
+    if external_postgres:
+        if no_postgres_port:
+            warnings.warn(
+                "Using external Postgres instance, `--no-postgres-port` flag will be ignored."
+            )
+        if postgres_port != config.server.database.host_port:
+            warnings.warn(
+                "Using external Postgres instance, `--postgres-port` flag will be ignored."
+            )
+        if use_volume:
+            warnings.warn(
+                "Using external Postgres instance, `--use-volume` flag will be ignored."
+            )
+        if volume_path != config.server.database.volume_path:
+            warnings.warn(
+                "Using external Postgres instance, `--volume-path` flag will be ignored."
+            )
 
     compose_path = setup_compose_file(
         no_ui=no_ui,

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -109,7 +109,9 @@ class TestSetupComposeEnv:
         assert env["PREFECT_SERVER_DB_CMD"] == "FOO"
 
     def test_fills_env_with_values_from_config_and_args(self, monkeypatch):
-        monkeypatch.delenv("PREFECT_SERVER_DB_CMD")  # Ensure this is not set
+        monkeypatch.delenv(
+            "PREFECT_SERVER_DB_CMD", raising=False
+        )  # Ensure this is not set
         with set_temporary_config(
             {
                 "server.database.connection_url": "localhost/foo",
@@ -159,6 +161,9 @@ class TestSetupComposeEnv:
             assert env[key] == expected_value
 
     def test_setup_env_for_external_postgres(self, monkeypatch):
+        monkeypatch.delenv(
+            "PREFECT_SERVER_DB_CMD", raising=False
+        )  # Ensure this is not set
         with set_temporary_config(
             {
                 "server.database.connection_url": "localhost/foo",
@@ -504,6 +509,7 @@ class TestPrefectServerConfig:
         cmd = ["config"]
         if with_flags:
             cmd += [
+                "--external-postgres",
                 "--no-postgres-port",
                 "--no-hasura-port",
                 "--no-graphql-port",
@@ -516,6 +522,7 @@ class TestPrefectServerConfig:
 
         mock.assert_called_once_with(
             no_ui=with_flags,
+            external_postgres=with_flags,
             no_postgres_port=with_flags,
             no_hasura_port=with_flags,
             no_graphql_port=with_flags,

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -160,7 +160,17 @@ class TestSetupComposeEnv:
         for key, expected_value in expected.items():
             assert env[key] == expected_value
 
-    def test_setup_env_for_external_postgres(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "external_postgres, postgres_url, expected_postgres_url",
+        [
+            (True, None, "localhost/foo"),
+            (False, "localhost/bar", "localhost/bar"),
+            (True, "localhost/bar", "localhost/bar"),
+        ],
+    )
+    def test_setup_env_for_external_postgres(
+        self, monkeypatch, external_postgres, postgres_url, expected_postgres_url
+    ):
         monkeypatch.delenv(
             "PREFECT_SERVER_DB_CMD", raising=False
         )  # Ensure this is not set
@@ -175,7 +185,8 @@ class TestSetupComposeEnv:
                 version="A",
                 ui_version="B",
                 no_upgrade=False,
-                external_postgres=True,
+                external_postgres=external_postgres,
+                postgres_url=postgres_url,
                 hasura_port=2,
                 graphql_port=3,
                 ui_port=4,
@@ -186,7 +197,7 @@ class TestSetupComposeEnv:
         expected = {
             "APOLLO_HOST_PORT": "5",
             "APOLLO_URL": "http://localhost:4200/graphql",
-            "DB_CONNECTION_URL": "localhost/foo",
+            "DB_CONNECTION_URL": expected_postgres_url,
             "GRAPHQL_HOST_PORT": "3",
             "HASURA_API_URL": "http://hasura:2/v1alpha1/graphql",
             "HASURA_HOST_PORT": "2",


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR adds support for external Postgres databases with `prefect server start`.




## Changes
- Adds a new flag `--external-postgres`, which if True removes `postgres` from the docker compose file
- Adds a new flat `--postgres-url`, which takes in a connection string and removes `postgres` from the docker compose file

If this flag is passed, Hasura will use `config.server.database.connection_url` to connect to Postgres.

Example usage
In `.prefect/config.toml`
```
[server.database]
connection_url = "postgres://<username>:<password>@hostname:<port>/<dbname> "
```
From the command line
`prefect server start --external-postgres`

OR just from the command line
`prefect server start --postgres-url postgres://<username>:<password>@hostname:<port>/<dbname>`



## Importance
Addresses https://github.com/PrefectHQ/prefect/issues/3891




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)