### PR TITLE
Fixed bug from Flow.copy() not copying the slugs dictionary

### DIFF
--- a/changes/pr4435.yaml
+++ b/changes/pr4435.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fixed bug from Flow.copy() not copying the slugs dictionary - [#4435](https://github.com/PrefectHQ/prefect/pull/4435)"
+
+contributor:
+  - "[Ben Fogelson](https://github.com/benfogelson)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -247,6 +247,7 @@ class Flow:
         new.constants = self.constants.copy()
         new.tasks = self.tasks.copy()
         new.edges = self.edges.copy()
+        new.slugs = self.slugs.copy()
         new.set_reference_tasks(self._reference_tasks)
         return new
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -622,6 +622,14 @@ def test_copy():
     assert len(f2.tasks) == len(f.tasks) - 2
     assert len(f2.edges) == len(f.edges) - 1
     assert f.reference_tasks() == f2.reference_tasks() == set([t1])
+    assert id(f.slugs) != id(f2.slugs)
+
+
+def test_copy_copies_slugs():
+    f = Flow("test")
+    f2 = f.copy()
+    f.add_task(Parameter("p"))
+    f2.add_task(Parameter("p"))
 
 
 def test_infer_root_tasks():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes https://github.com/PrefectHQ/prefect/issues/4437, which caused a flow and its copies to refer to the same `slugs` dictionary.



## Changes
Copies the `slugs` dictionary as part of calling `Flow.copy()`.




## Importance
Not copying the `slugs` dictionary means that the dictionary can be modified by adding tasks to either the original flow or its copy, leading to `slugs` that are not in sync with the tasks in the flow.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)