### PR TITLE
Prefect Secret support for Exasol tasks

### DIFF
--- a/changes/pr4436.yaml
+++ b/changes/pr4436.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Allow Exasol Tasks to handle Prefect Secrets directly - [#4436](https://github.com/PrefectHQ/prefect/pull/4436)"
+
+contributor:
+  - "[Timo S.](https://github.com/sti0)"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Prefect Secret support for Exasol tasks



## Changes
<!-- What does this PR change? -->
- Prefect Secret support for Exasol Tasks
- Pass the name of a Prefect Secret for dsn string, user or password. ** To discuss**: should we make it possible to pass the secrets even at runtime?
- Removes deprecated constructor parameters user and password ([deprecated since 0.14.13](https://github.com/PrefectHQ/prefect/pull/4268#pullrequestreview-615513989))
- Unittests
- `ExasolExecute` doesn't return the `ExaConnection` object anymore, because it's not serializable. **To discuss**: we could maybe return the executed statement or the execution time??


## Importance
<!-- Why is this PR important? -->
 As it's best pratice to use Prefect Secret it should be supported directly. It makes it easier for use because it's not neccessary to introduce Prefect Secret tasks to the flow.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)