### PR TITLE
Move `Client` methods to `prefect.backend` modules

### DIFF
--- a/changes/pr4439.yaml
+++ b/changes/pr4439.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Move `Client` methods to `prefect.backend` modules - [#4439](https://github.com/PrefectHQ/prefect/pull/4439)"

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -33,6 +33,7 @@ class FlowView:
         self,
         flow_id: str,
         flow: "prefect.Flow",
+        flow_group_id: str,
         settings: dict,
         run_config: dict,
         serialized_flow: dict,
@@ -44,6 +45,7 @@ class FlowView:
     ):
         self.flow_id = flow_id
         self.flow = flow
+        self.flow_group_id = flow_group_id
         self.settings = settings
         self.run_config = run_config
         self.serialized_flow = serialized_flow
@@ -256,6 +258,7 @@ class FlowView:
                     "project": {"name"},
                     "core_version": True,
                     "storage": True,
+                    "flow_group_id": True,
                 }
             }
         }

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -94,7 +94,7 @@ def register(
         }
     }
 
-    project = self.graphql(query_project).data.project  # type: ignore
+    project = client.graphql(query_project).data.project  # type: ignore
 
     if not project:
         raise ValueError(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

This draft outlines an example change that will be expanded to include all of the backend methods currently included in the `Client` class. This requires (but will not be included in) #4434.

## Summary
<!-- A sentence summarizing the PR -->

Currently, the `Client` contains all functions for interacting with the backend. Following the introduction of a dedicated backend module, it makes sense to move methods from within the client into properly scoped locations. This will make the `Client` a lot easier to reason about as it will have the singular task of managing an authenticated session with a Prefect backend (ie Cloud).

All methods requiring a `Client` will create one themselves. There will be required work to share sessions across clients so this is not unperformant and to determine if we need to allow every method to receive a custom `Client` instance.

## Changes
<!-- What does this PR change? -->

- Relocations
    - `Client.register` -> `prefect.backend.flow.register` 
- `prefect.backend.flow.register`
    - returns a `FlowView` instead of just a `flow_id`
    - drops support for displaying the url of the registered flow


## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)