### PR TITLE
Fix compatibility with PyGithub >= 1.55

### DIFF
--- a/changes/pr4440.yaml
+++ b/changes/pr4440.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix compatibility with PyGithub >= 1.55 - [#4440](https://github.com/PrefectHQ/prefect/pull/4440)"

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -77,7 +77,7 @@ def clear_context_cache():
 
 
 class TestCreateFlow:
-    """ Test various Flow constructors """
+    """Test various Flow constructors"""
 
     def test_create_flow_with_no_args(self):
         # name is required

--- a/tests/storage/test_github_storage.py
+++ b/tests/storage/test_github_storage.py
@@ -139,7 +139,9 @@ def test_get_flow(github_client, ref, caplog):
 
 
 def test_get_flow_missing_repo(github_client, caplog):
-    github_client.get_repo.side_effect = github.UnknownObjectException(404, {})
+    github_client.get_repo.side_effect = github.UnknownObjectException(
+        status=404, data={}, headers={}
+    )
 
     storage = GitHub(repo="test/repo", path="flow.py")
     storage.add_flow(Flow("test"))
@@ -153,7 +155,9 @@ def test_get_flow_missing_repo(github_client, caplog):
 @pytest.mark.parametrize("ref", [None, "myref"])
 def test_get_flow_missing_ref(github_client, ref, caplog):
     repo = github_client.get_repo.return_value
-    repo.get_commit.side_effect = github.UnknownObjectException(404, {})
+    repo.get_commit.side_effect = github.UnknownObjectException(
+        status=404, data={}, headers={}
+    )
 
     storage = GitHub(repo="test/repo", path="flow.py", ref=ref)
     storage.add_flow(Flow("test"))
@@ -169,7 +173,9 @@ def test_get_flow_missing_ref(github_client, ref, caplog):
 @pytest.mark.parametrize("ref", [None, "myref"])
 def test_get_flow_missing_file(github_client, ref, caplog):
     repo = github_client.get_repo.return_value
-    repo.get_contents.side_effect = github.UnknownObjectException(404, {})
+    repo.get_contents.side_effect = github.UnknownObjectException(
+        status=404, data={}, headers={}
+    )
 
     storage = GitHub(repo="test/repo", path="flow.py", ref=ref)
     storage.add_flow(Flow("test"))

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -66,7 +66,7 @@ class TestS3Download:
             task.run("key", compression="gz_fake")
 
     def test_boto3_client_is_created_with_session(self, mocked_boto_client):
-        """ Tests the fix for #3925 """
+        """Tests the fix for #3925"""
         task = S3Download("test")
         task.run("key")
         assert (
@@ -114,7 +114,7 @@ class TestS3Upload:
             task.run(b"data", compression="gz_fake")
 
     def test_boto3_client_is_created_with_session(self, mocked_boto_client):
-        """ Tests the fix for #3925 """
+        """Tests the fix for #3925"""
         task = S3Upload("test")
         task.run("key")
         assert (


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

We construct some `GithubExceptions` in tests which have been changed in the newest PyGithub release to require `headers` to be passed per https://github.com/PyGithub/PyGithub/pull/1887


## Changes
<!-- What does this PR change? -->

Passes fake `headers` to the test exceptions

## Importance
<!-- Why is this PR important? -->

Tests will not pass in CI using the newest PyGithub


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~