### PR TITLE
feat(email_task): sending attachments with emails

### DIFF
--- a/changes/pr4457.yaml
+++ b/changes/pr4457.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Enable sending attachments with emails in the EmailTask - [#4457](https://github.com/PrefectHQ/prefect/pull/4457)"
+
+contributor:
+  - "[Thomas Heyenbrock](https://github.com/thomasheyenbrock)"

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -83,6 +83,7 @@ class EmailTask(Task):
         "msg_plain",
         "email_to_cc",
         "email_to_bcc",
+        "attachments",
     )
     def run(
         self,
@@ -96,7 +97,7 @@ class EmailTask(Task):
         msg_plain: str = None,
         email_to_cc: str = None,
         email_to_bcc: str = None,
-        attachments: List[str] = [],
+        attachments: List[str] = None,
     ) -> None:
         """
         Run method which sends an email.

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -1,7 +1,11 @@
+import os
 import ssl
 import smtplib
-from email.message import EmailMessage
-from typing import Any, cast
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any, cast, List
 
 from prefect import Task
 from prefect.client import Secret
@@ -34,6 +38,8 @@ class EmailTask(Task):
             can also be provided at runtime
         - email_to_bcc (str, optional): additional email address to send the message to as bcc;
             can also be provided at runtime
+        - attachments (List[str], optional): names of files that should be sent as attachment; can
+            also be provided at runtime
         - **kwargs (Any, optional): additional keyword arguments to pass to the base Task
             initialization
     """
@@ -50,6 +56,7 @@ class EmailTask(Task):
         msg_plain: str = None,
         email_to_cc: str = None,
         email_to_bcc: str = None,
+        attachments: List[str] = [],
         **kwargs: Any,
     ):
         self.subject = subject
@@ -62,6 +69,7 @@ class EmailTask(Task):
         self.msg_plain = msg_plain
         self.email_to_cc = email_to_cc
         self.email_to_bcc = email_to_bcc
+        self.attachments = attachments
         super().__init__(**kwargs)
 
     @defaults_from_attrs(
@@ -88,6 +96,7 @@ class EmailTask(Task):
         msg_plain: str = None,
         email_to_cc: str = None,
         email_to_bcc: str = None,
+        attachments: List[str] = [],
     ) -> None:
         """
         Run method which sends an email.
@@ -113,6 +122,8 @@ class EmailTask(Task):
                 defaults to the one provided at initialization
             - email_to_bcc (str, optional): additional email address to send the message to as bcc;
                 defaults to the one provided at initialization
+            - attachments (List[str], optional): names of files that should be sent as attachment;
+                defaults to the one provided at initialization
 
         Returns:
             - None
@@ -121,7 +132,7 @@ class EmailTask(Task):
         username = cast(str, Secret("EMAIL_USERNAME").get())
         password = cast(str, Secret("EMAIL_PASSWORD").get())
 
-        message = EmailMessage()
+        message = MIMEMultipart()
         message["Subject"] = subject
         message["From"] = email_from
         message["To"] = email_to
@@ -130,14 +141,25 @@ class EmailTask(Task):
         if email_to_bcc:
             message["Bcc"] = email_to_bcc
 
-        # https://docs.python.org/3/library/email.examples.html
-        # If present, first set the plain content of the email. After which the html version is
-        # added. This converts the message into a multipart/alternative container, with the
-        # original text message as the first part and the new html message as the second part.
+        # First add the message in plain text, then the HTML version. Email clients try to render
+        # the last part first
         if msg_plain:
-            message.set_content(msg_plain, subtype="plain")
+            message.attach(MIMEText(msg_plain, "plain"))
         if msg:
-            message.add_alternative(msg, subtype="html")
+            message.attach(MIMEText(msg, "html"))
+
+        for filepath in attachments:
+            with open(filepath, "rb") as attachment:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(attachment.read())
+
+            encoders.encode_base64(part)
+            filename = os.path.basename(filepath)
+            part.add_header(
+                "Content-Disposition",
+                f"attachment; filename= {filename}",
+            )
+            message.attach(part)
 
         context = ssl.create_default_context()
         if smtp_type == "SSL":

--- a/src/prefect/tasks/notifications/email_task.py
+++ b/src/prefect/tasks/notifications/email_task.py
@@ -56,7 +56,7 @@ class EmailTask(Task):
         msg_plain: str = None,
         email_to_cc: str = None,
         email_to_bcc: str = None,
-        attachments: List[str] = [],
+        attachments: List[str] = None,
         **kwargs: Any,
     ):
         self.subject = subject
@@ -69,7 +69,7 @@ class EmailTask(Task):
         self.msg_plain = msg_plain
         self.email_to_cc = email_to_cc
         self.email_to_bcc = email_to_bcc
-        self.attachments = attachments
+        self.attachments = attachments or []
         super().__init__(**kwargs)
 
     @defaults_from_attrs(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR adds a new option to the `EmailTask`, allowing to send attachments with the email.


## Changes
<!-- What does this PR change? -->

The email task now always creates a multipart-message. The user of the task can optionally pass a list of files that should be sent as attachment with the email. The files are looked up in the local filesystem and attached to the multipart-message.


## Importance
<!-- Why is this PR important? -->

Sending attachments with emails is a very common thing to do. A concrete use-case would be to extract and transform some data and then send the resulting data (as csv, Excel, etc.) via email.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)