### PR TITLE
Print link to flow run in StartFlowRun

### DIFF
--- a/changes/pr4458.yaml
+++ b/changes/pr4458.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Print link to flow run in StartFlowRun - [#4458](https://github.com/PrefectHQ/prefect/pull/4458)"
+
+contributor:
+  - "[Brett Naul](https://github.com/bnaul)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -184,11 +184,11 @@ class StartFlowRun(Task):
             scheduled_start_time=scheduled_start_time,
         )
 
-        self.logger.debug(f"Flow Run {flow_run_id} created.")
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
         create_link(urlparse(run_link).path)
+        self.logger.info(f"Flow Run: {run_link}")
 
         if not self.wait:
             return flow_run_id

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -184,7 +184,6 @@ class StartFlowRun(Task):
             scheduled_start_time=scheduled_start_time,
         )
 
-
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
         create_link(urlparse(run_link).path)

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -184,6 +184,8 @@ class StartFlowRun(Task):
             scheduled_start_time=scheduled_start_time,
         )
 
+        self.logger.debug(f"Flow Run {flow_run_id} created.")
+
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
         create_link(urlparse(run_link).path)


### PR DESCRIPTION
The link artifact produced by StartFlowRun is very handy for navigating from parent to child flow, but a log message (like what `prefect run flow` produces) would still be nice: you can see it right away when following the logs from the command line, and when the parent task is running outside cloud there's no artifact at all. cc @madkinsz @cicdw