### PR TITLE
Add `image_pull_policy` option to `KubernetesRun` config

### DIFF
--- a/changes/pr4462.yaml
+++ b/changes/pr4462.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Add an `always_pull_new_image` kwarg to `KubernetesRun` [#4462](https://github.com/PrefectHQ/prefect/pull/4462)"
+  - "Add an `image_pull_policy` kwarg to `KubernetesRun` [#4462](https://github.com/PrefectHQ/prefect/pull/4462)"
 
 contributor:
   - "[Zach Schumacher](https://github.com/zschumacher)"

--- a/changes/pr4462.yaml
+++ b/changes/pr4462.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add an `always_pull_new_image` kwarg to `KubernetesRun` [#4462](https://github.com/PrefectHQ/prefect/pull/4462)"
+
+contributor:
+  - "[Zach Schumacher](https://github.com/zschumacher)"

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -194,7 +194,7 @@ for the Kubernetes job:
 
 
 ```python
-flow.run_config = KubernetesRun(imagePullPolicy="Always")
+flow.run_config = KubernetesRun(image_pull_policy="Always")
 ````
 
 ### ECSRun

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -189,12 +189,12 @@ Use a custom Kubernetes Job spec for this flow, stored in S3:
 flow.run_config = KubernetesRun(job_template_path="s3://bucket/path/to/spec.yaml")
 ```
 
-Always pull the newest image for the job run.  This should be used when using a custom docker image 
-with a tag other than `:latest`.  Doing so will set the kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-to `Always` on the job run.
+Specify an [imagePullPolicy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images) 
+for the Kubernetes job:
+
 
 ```python
-flow.run_config = KubernetesRun(always_pull_latest_image=True)
+flow.run_config = KubernetesRun(imagePullPolicy="Always")
 ````
 
 ### ECSRun

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -189,6 +189,14 @@ Use a custom Kubernetes Job spec for this flow, stored in S3:
 flow.run_config = KubernetesRun(job_template_path="s3://bucket/path/to/spec.yaml")
 ```
 
+Always pull the newest image for the job run.  This should be used when using a custom docker image 
+with a tag other than `:latest`.  Doing so will set the kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+to `Always` on the job run.
+
+```python
+flow.run_config = KubernetesRun(always_pull_latest_image=True)
+````
+
 ### ECSRun
 
 [ECSRun](/api/latest/run_configs.md#ecsrun) configures flow runs

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -665,7 +665,7 @@ class KubernetesAgent(Agent):
         )
 
         # always pull latest docker image for tag if config is set to do so
-        if run_config.always_pull_new_image is True:
+        if run_config.always_pull_new_image:
             container["imagePullPolicy"] = "Always"
 
         # Set flow run command

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -80,21 +80,21 @@ class KubernetesAgent(Agent):
     """
 
     def __init__(
-        self,
-        agent_config_id: str = None,
-        namespace: str = None,
-        service_account_name: str = None,
-        image_pull_secrets: Iterable[str] = None,
-        job_template_path: str = None,
-        name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
-        max_polls: int = None,
-        agent_address: str = None,
-        no_cloud_logs: bool = False,
-        volume_mounts: List[dict] = None,
-        volumes: List[dict] = None,
-        delete_finished_jobs: bool = True,
+            self,
+            agent_config_id: str = None,
+            namespace: str = None,
+            service_account_name: str = None,
+            image_pull_secrets: Iterable[str] = None,
+            job_template_path: str = None,
+            name: str = None,
+            labels: Iterable[str] = None,
+            env_vars: dict = None,
+            max_polls: int = None,
+            agent_address: str = None,
+            no_cloud_logs: bool = False,
+            volume_mounts: List[dict] = None,
+            volumes: List[dict] = None,
+            delete_finished_jobs: bool = True,
     ) -> None:
         super().__init__(
             agent_config_id=agent_config_id,
@@ -122,7 +122,7 @@ class KubernetesAgent(Agent):
         self.volume_mounts = volume_mounts
         self.volumes = volumes
         self.delete_finished_jobs = delete_finished_jobs and (
-            os.getenv("DELETE_FINISHED_JOBS", "True") == "True"
+                os.getenv("DELETE_FINISHED_JOBS", "True") == "True"
         )
 
         from kubernetes import client, config
@@ -191,8 +191,8 @@ class KubernetesAgent(Agent):
                                 for container_status in pod.status.container_statuses:
                                     waiting = container_status.state.waiting
                                     if waiting and (
-                                        waiting.reason == "ErrImagePull"
-                                        or waiting.reason == "ImagePullBackOff"
+                                            waiting.reason == "ErrImagePull"
+                                            or waiting.reason == "ImagePullBackOff"
                                     ):
                                         self.logger.debug(
                                             f"Failing flow run {flow_run_id} due to pod {waiting.reason}"
@@ -227,14 +227,14 @@ class KubernetesAgent(Agent):
                                 )
 
                                 for event in sorted(
-                                    pod_events.items, key=lambda x: x.last_timestamp
+                                        pod_events.items, key=lambda x: x.last_timestamp
                                 ):
                                     # Skip old events
                                     if (
-                                        event.last_timestamp
-                                        < self.job_pod_event_timestamps[job_name][
-                                            pod_name
-                                        ]
+                                            event.last_timestamp
+                                            < self.job_pod_event_timestamps[job_name][
+                                        pod_name
+                                    ]
                                     ):
                                         continue
 
@@ -327,10 +327,10 @@ class KubernetesAgent(Agent):
 
                         # If there are failed pods and the run is not finished, fail the run
                         if (
-                            failed_pods
-                            and not self.client.get_flow_run_state(
-                                flow_run_id
-                            ).is_finished()
+                                failed_pods
+                                and not self.client.get_flow_run_state(
+                            flow_run_id
+                        ).is_finished()
                         ):
                             self.logger.debug(
                                 f"Failing flow run {flow_run_id} due to the failed pods {failed_pods}"
@@ -446,7 +446,7 @@ class KubernetesAgent(Agent):
             return self.generate_job_spec_from_environment(flow_run)
 
     def generate_job_spec_from_environment(
-        self, flow_run: GraphQLResult, image: str = None
+            self, flow_run: GraphQLResult, image: str = None
     ) -> dict:
         """
         Populate a k8s job spec. This spec defines a k8s job that handles
@@ -580,7 +580,7 @@ class KubernetesAgent(Agent):
         return job
 
     def generate_job_spec_from_run_config(
-        self, flow_run: GraphQLResult, run_config: KubernetesRun
+            self, flow_run: GraphQLResult, run_config: KubernetesRun
     ) -> dict:
         """Generate a k8s job spec for a flow run.
 
@@ -623,7 +623,7 @@ class KubernetesAgent(Agent):
                 run_config.service_account_name
             )  # type: Optional[str]
         elif "serviceAccountName" in pod_spec and (
-            run_config.job_template or run_config.job_template_path
+                run_config.job_template or run_config.job_template_path
         ):
             # On run-config job-template, no override
             service_account_name = None
@@ -640,7 +640,7 @@ class KubernetesAgent(Agent):
                 run_config.image_pull_secrets
             )  # type: Optional[Iterable[str]]
         elif "imagePullSecrets" in pod_spec and (
-            run_config.job_template or run_config.job_template_path
+                run_config.job_template or run_config.job_template_path
         ):
             # On run-config job template, no override
             image_pull_secrets = None
@@ -663,6 +663,10 @@ class KubernetesAgent(Agent):
         container["image"] = image = get_flow_image(
             flow_run, default=container.get("image")
         )
+
+        # always pull latest docker image for tag if config is set to do so
+        if run_config.always_pull_new_image is True:
+            container["imagePullPolicy"] = "Always"
 
         # Set flow run command
         container["args"] = get_flow_run_command(flow_run).split()
@@ -715,21 +719,21 @@ class KubernetesAgent(Agent):
 
     @staticmethod
     def generate_deployment_yaml(
-        token: str = None,
-        api: str = None,
-        namespace: str = None,
-        image_pull_secrets: str = None,
-        rbac: bool = False,
-        latest: bool = False,
-        mem_request: str = None,
-        mem_limit: str = None,
-        cpu_request: str = None,
-        cpu_limit: str = None,
-        image_pull_policy: str = None,
-        service_account_name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
-        backend: str = None,
+            token: str = None,
+            api: str = None,
+            namespace: str = None,
+            image_pull_secrets: str = None,
+            rbac: bool = False,
+            latest: bool = False,
+            mem_request: str = None,
+            mem_limit: str = None,
+            cpu_request: str = None,
+            cpu_limit: str = None,
+            image_pull_policy: str = None,
+            service_account_name: str = None,
+            labels: Iterable[str] = None,
+            env_vars: dict = None,
+            backend: str = None,
     ) -> str:
         """
         Generate and output an installable YAML spec for the agent.
@@ -784,7 +788,7 @@ class KubernetesAgent(Agent):
         )
 
         with open(
-            os.path.join(os.path.dirname(__file__), "deployment.yaml"), "r"
+                os.path.join(os.path.dirname(__file__), "deployment.yaml"), "r"
         ) as deployment_file:
             deployment = yaml.safe_load(deployment_file)
 
@@ -831,7 +835,7 @@ class KubernetesAgent(Agent):
         rbac_yaml = []
         if rbac:
             with open(
-                os.path.join(os.path.dirname(__file__), "rbac.yaml"), "r"
+                    os.path.join(os.path.dirname(__file__), "rbac.yaml"), "r"
             ) as rbac_file:
                 rbac_generator = yaml.safe_load_all(rbac_file)
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -80,21 +80,21 @@ class KubernetesAgent(Agent):
     """
 
     def __init__(
-            self,
-            agent_config_id: str = None,
-            namespace: str = None,
-            service_account_name: str = None,
-            image_pull_secrets: Iterable[str] = None,
-            job_template_path: str = None,
-            name: str = None,
-            labels: Iterable[str] = None,
-            env_vars: dict = None,
-            max_polls: int = None,
-            agent_address: str = None,
-            no_cloud_logs: bool = False,
-            volume_mounts: List[dict] = None,
-            volumes: List[dict] = None,
-            delete_finished_jobs: bool = True,
+        self,
+        agent_config_id: str = None,
+        namespace: str = None,
+        service_account_name: str = None,
+        image_pull_secrets: Iterable[str] = None,
+        job_template_path: str = None,
+        name: str = None,
+        labels: Iterable[str] = None,
+        env_vars: dict = None,
+        max_polls: int = None,
+        agent_address: str = None,
+        no_cloud_logs: bool = False,
+        volume_mounts: List[dict] = None,
+        volumes: List[dict] = None,
+        delete_finished_jobs: bool = True,
     ) -> None:
         super().__init__(
             agent_config_id=agent_config_id,
@@ -122,7 +122,7 @@ class KubernetesAgent(Agent):
         self.volume_mounts = volume_mounts
         self.volumes = volumes
         self.delete_finished_jobs = delete_finished_jobs and (
-                os.getenv("DELETE_FINISHED_JOBS", "True") == "True"
+            os.getenv("DELETE_FINISHED_JOBS", "True") == "True"
         )
 
         from kubernetes import client, config
@@ -191,8 +191,8 @@ class KubernetesAgent(Agent):
                                 for container_status in pod.status.container_statuses:
                                     waiting = container_status.state.waiting
                                     if waiting and (
-                                            waiting.reason == "ErrImagePull"
-                                            or waiting.reason == "ImagePullBackOff"
+                                        waiting.reason == "ErrImagePull"
+                                        or waiting.reason == "ImagePullBackOff"
                                     ):
                                         self.logger.debug(
                                             f"Failing flow run {flow_run_id} due to pod {waiting.reason}"
@@ -227,14 +227,14 @@ class KubernetesAgent(Agent):
                                 )
 
                                 for event in sorted(
-                                        pod_events.items, key=lambda x: x.last_timestamp
+                                    pod_events.items, key=lambda x: x.last_timestamp
                                 ):
                                     # Skip old events
                                     if (
-                                            event.last_timestamp
-                                            < self.job_pod_event_timestamps[job_name][
-                                        pod_name
-                                    ]
+                                        event.last_timestamp
+                                        < self.job_pod_event_timestamps[job_name][
+                                            pod_name
+                                        ]
                                     ):
                                         continue
 
@@ -327,10 +327,10 @@ class KubernetesAgent(Agent):
 
                         # If there are failed pods and the run is not finished, fail the run
                         if (
-                                failed_pods
-                                and not self.client.get_flow_run_state(
-                            flow_run_id
-                        ).is_finished()
+                            failed_pods
+                            and not self.client.get_flow_run_state(
+                                flow_run_id
+                            ).is_finished()
                         ):
                             self.logger.debug(
                                 f"Failing flow run {flow_run_id} due to the failed pods {failed_pods}"
@@ -446,7 +446,7 @@ class KubernetesAgent(Agent):
             return self.generate_job_spec_from_environment(flow_run)
 
     def generate_job_spec_from_environment(
-            self, flow_run: GraphQLResult, image: str = None
+        self, flow_run: GraphQLResult, image: str = None
     ) -> dict:
         """
         Populate a k8s job spec. This spec defines a k8s job that handles
@@ -580,7 +580,7 @@ class KubernetesAgent(Agent):
         return job
 
     def generate_job_spec_from_run_config(
-            self, flow_run: GraphQLResult, run_config: KubernetesRun
+        self, flow_run: GraphQLResult, run_config: KubernetesRun
     ) -> dict:
         """Generate a k8s job spec for a flow run.
 
@@ -623,7 +623,7 @@ class KubernetesAgent(Agent):
                 run_config.service_account_name
             )  # type: Optional[str]
         elif "serviceAccountName" in pod_spec and (
-                run_config.job_template or run_config.job_template_path
+            run_config.job_template or run_config.job_template_path
         ):
             # On run-config job-template, no override
             service_account_name = None
@@ -640,7 +640,7 @@ class KubernetesAgent(Agent):
                 run_config.image_pull_secrets
             )  # type: Optional[Iterable[str]]
         elif "imagePullSecrets" in pod_spec and (
-                run_config.job_template or run_config.job_template_path
+            run_config.job_template or run_config.job_template_path
         ):
             # On run-config job template, no override
             image_pull_secrets = None
@@ -719,21 +719,21 @@ class KubernetesAgent(Agent):
 
     @staticmethod
     def generate_deployment_yaml(
-            token: str = None,
-            api: str = None,
-            namespace: str = None,
-            image_pull_secrets: str = None,
-            rbac: bool = False,
-            latest: bool = False,
-            mem_request: str = None,
-            mem_limit: str = None,
-            cpu_request: str = None,
-            cpu_limit: str = None,
-            image_pull_policy: str = None,
-            service_account_name: str = None,
-            labels: Iterable[str] = None,
-            env_vars: dict = None,
-            backend: str = None,
+        token: str = None,
+        api: str = None,
+        namespace: str = None,
+        image_pull_secrets: str = None,
+        rbac: bool = False,
+        latest: bool = False,
+        mem_request: str = None,
+        mem_limit: str = None,
+        cpu_request: str = None,
+        cpu_limit: str = None,
+        image_pull_policy: str = None,
+        service_account_name: str = None,
+        labels: Iterable[str] = None,
+        env_vars: dict = None,
+        backend: str = None,
     ) -> str:
         """
         Generate and output an installable YAML spec for the agent.
@@ -788,7 +788,7 @@ class KubernetesAgent(Agent):
         )
 
         with open(
-                os.path.join(os.path.dirname(__file__), "deployment.yaml"), "r"
+            os.path.join(os.path.dirname(__file__), "deployment.yaml"), "r"
         ) as deployment_file:
             deployment = yaml.safe_load(deployment_file)
 
@@ -835,7 +835,7 @@ class KubernetesAgent(Agent):
         rbac_yaml = []
         if rbac:
             with open(
-                    os.path.join(os.path.dirname(__file__), "rbac.yaml"), "r"
+                os.path.join(os.path.dirname(__file__), "rbac.yaml"), "r"
             ) as rbac_file:
                 rbac_generator = yaml.safe_load_all(rbac_file)
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -664,9 +664,9 @@ class KubernetesAgent(Agent):
             flow_run, default=container.get("image")
         )
 
-        # always pull latest docker image for tag if config is set to do so
-        if run_config.always_pull_new_image:
-            container["imagePullPolicy"] = "Always"
+        # set the the kubernetes imagePullPolicy, if image_pull_policy was specified
+        if run_config.image_pull_policy is not None:
+            container["imagePullPolicy"] = run_config.image_pull_policy
 
         # Set flow run command
         container["args"] = get_flow_run_command(flow_run).split()

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -127,7 +127,8 @@ class KubernetesRun(RunConfig):
             and image_pull_policy not in image_pull_policies
         ):
             raise ValueError(
-                f"Invalid image_pull_policy {image_pull_policy}.  Expected `Always`, `IfNotPresent`, or `Never`"
+                f"Invalid image_pull_policy {image_pull_policy}.  "
+                "Expected `Always`, `IfNotPresent`, or `Never`"
             )
 
         self.job_template_path = job_template_path

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -1,8 +1,9 @@
-import yaml
 from typing import Union, Iterable
 
-from prefect.utilities.filesystems import parse_path
+import yaml
+
 from prefect.run_configs.base import RunConfig
+from prefect.utilities.filesystems import parse_path
 
 
 class KubernetesRun(RunConfig):
@@ -38,6 +39,10 @@ class KubernetesRun(RunConfig):
         - labels (Iterable[str], optional): an iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
             for selecting valid flow runs when polling for work
+        - always_pull_new_image (bool): a boolean flag for telling kubernetes to
+            always pull new images.  This is useful when you are using a tag on
+            and image other than :latest
+            https://kubernetes.io/docs/concepts/containers/images/#updating-images
 
     Examples:
 
@@ -68,19 +73,20 @@ class KubernetesRun(RunConfig):
     """
 
     def __init__(
-        self,
-        *,
-        job_template_path: str = None,
-        job_template: Union[str, dict] = None,
-        image: str = None,
-        env: dict = None,
-        cpu_limit: Union[float, str] = None,
-        cpu_request: Union[float, str] = None,
-        memory_limit: str = None,
-        memory_request: str = None,
-        service_account_name: str = None,
-        image_pull_secrets: Iterable[str] = None,
-        labels: Iterable[str] = None,
+            self,
+            *,
+            job_template_path: str = None,
+            job_template: Union[str, dict] = None,
+            image: str = None,
+            env: dict = None,
+            cpu_limit: Union[float, str] = None,
+            cpu_request: Union[float, str] = None,
+            memory_limit: str = None,
+            memory_request: str = None,
+            service_account_name: str = None,
+            image_pull_secrets: Iterable[str] = None,
+            labels: Iterable[str] = None,
+            always_pull_new_image: bool = False
     ) -> None:
         super().__init__(env=env, labels=labels)
         if job_template_path is not None and job_template is not None:
@@ -117,3 +123,4 @@ class KubernetesRun(RunConfig):
         self.memory_request = memory_request
         self.service_account_name = service_account_name
         self.image_pull_secrets = image_pull_secrets
+        self.always_pull_new_image = always_pull_new_image

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -73,20 +73,20 @@ class KubernetesRun(RunConfig):
     """
 
     def __init__(
-            self,
-            *,
-            job_template_path: str = None,
-            job_template: Union[str, dict] = None,
-            image: str = None,
-            env: dict = None,
-            cpu_limit: Union[float, str] = None,
-            cpu_request: Union[float, str] = None,
-            memory_limit: str = None,
-            memory_request: str = None,
-            service_account_name: str = None,
-            image_pull_secrets: Iterable[str] = None,
-            labels: Iterable[str] = None,
-            always_pull_new_image: bool = False
+        self,
+        *,
+        job_template_path: str = None,
+        job_template: Union[str, dict] = None,
+        image: str = None,
+        env: dict = None,
+        cpu_limit: Union[float, str] = None,
+        cpu_request: Union[float, str] = None,
+        memory_limit: str = None,
+        memory_request: str = None,
+        service_account_name: str = None,
+        image_pull_secrets: Iterable[str] = None,
+        labels: Iterable[str] = None,
+        always_pull_new_image: bool = False
     ) -> None:
         super().__init__(env=env, labels=labels)
         if job_template_path is not None and job_template is not None:

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -128,7 +128,7 @@ class KubernetesRun(RunConfig):
         ):
             raise ValueError(
                 f"Invalid image_pull_policy {image_pull_policy!r}.  "
-                "Expected `Always`, `IfNotPresent`, or `Never`"
+                "Expected 'Always', 'IfNotPresent', or 'Never'"
             )
 
         self.job_template_path = job_template_path

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -127,7 +127,7 @@ class KubernetesRun(RunConfig):
             and image_pull_policy not in image_pull_policies
         ):
             raise ValueError(
-                f"Invalid image_pull_policy {image_pull_policy}.  "
+                f"Invalid image_pull_policy {image_pull_policy!r}.  "
                 "Expected `Always`, `IfNotPresent`, or `Never`"
             )
 

--- a/src/prefect/serialization/__init__.py
+++ b/src/prefect/serialization/__init__.py
@@ -6,3 +6,4 @@ import prefect.serialization.flow
 import prefect.serialization.state
 import prefect.serialization.environment
 import prefect.serialization.storage
+import prefect.serialization.run_config

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -32,6 +32,7 @@ class KubernetesRunSchema(RunConfigSchemaBase):
     memory_request = fields.String(allow_none=True)
     service_account_name = fields.String(allow_none=True)
     image_pull_secrets = fields.List(fields.String(), allow_none=True)
+    always_pull_new_image = fields.String(allow_none=False)
 
 
 class ECSRunSchema(RunConfigSchemaBase):

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -32,7 +32,7 @@ class KubernetesRunSchema(RunConfigSchemaBase):
     memory_request = fields.String(allow_none=True)
     service_account_name = fields.String(allow_none=True)
     image_pull_secrets = fields.List(fields.String(), allow_none=True)
-    always_pull_new_image = fields.String(allow_none=False)
+    image_pull_policy = fields.String(allow_none=True)
 
 
 class ECSRunSchema(RunConfigSchemaBase):

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1262,11 +1262,16 @@ class TestK8sAgentRunConfig:
         template = self.read_default_template()
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
-        flow_run = self.build_flow_run(KubernetesRun(job_template=template, always_pull_new_image=True))
+        flow_run = self.build_flow_run(
+            KubernetesRun(job_template=template, always_pull_new_image=True)
+        )
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
         # test always pull new image kwarg works
-        assert job["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] == "Always"
+        assert (
+            job["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"]
+            == "Always"
+        )
 
     def test_generate_job_spec_uses_job_template_path_provided_in_run_config(
         self, tmpdir, monkeypatch

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1263,7 +1263,7 @@ class TestK8sAgentRunConfig:
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
 
-        flow_run = self.build_flow_run(config)
+        flow_run = self.build_flow_run(KubernetesRun(job_template=template))
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
 

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1243,7 +1243,7 @@ class TestK8sAgentRunConfig:
         )
 
     @pytest.mark.parametrize("run_config", [None, UniversalRun()])
-    def test_generate_job_spec_null_or_univeral_run_config(self, run_config):
+    def test_generate_job_spec_null_or_universal_run_config(self, run_config):
         self.agent.generate_job_spec_from_run_config = MagicMock(
             wraps=self.agent.generate_job_spec_from_run_config
         )
@@ -1262,9 +1262,11 @@ class TestK8sAgentRunConfig:
         template = self.read_default_template()
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
-        flow_run = self.build_flow_run(KubernetesRun(job_template=template))
+        flow_run = self.build_flow_run(KubernetesRun(job_template=template, always_pull_new_image=True))
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
+        # test always pull new image kwarg works
+        assert job["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] == "Always"
 
     def test_generate_job_spec_uses_job_template_path_provided_in_run_config(
         self, tmpdir, monkeypatch

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1262,12 +1262,14 @@ class TestK8sAgentRunConfig:
         template = self.read_default_template()
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
-        flow_run = self.build_flow_run(
-            KubernetesRun(job_template=template, always_pull_new_image=True)
-        )
+        config = KubernetesRun(job_template=template, always_pull_new_image=True)
+
+        flow_run = self.build_flow_run(config)
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
+
         # test always pull new image kwarg works
+        print(type(job))
         assert (
             job["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"]
             == "Always"

--- a/tests/run_configs/test_kubernetes.py
+++ b/tests/run_configs/test_kubernetes.py
@@ -19,6 +19,7 @@ def test_no_args():
     assert config.service_account_name is None
     assert config.image_pull_secrets is None
     assert config.labels == set()
+    assert not config.always_pull_new_image
 
 
 def test_labels():

--- a/tests/run_configs/test_kubernetes.py
+++ b/tests/run_configs/test_kubernetes.py
@@ -19,7 +19,7 @@ def test_no_args():
     assert config.service_account_name is None
     assert config.image_pull_secrets is None
     assert config.labels == set()
-    assert not config.always_pull_new_image
+    assert config.image_pull_policy is None
 
 
 def test_labels():
@@ -101,3 +101,14 @@ def test_service_account_name_and_image_pull_secrets():
     # Ensure falsey-lists aren't converted to `None`.
     config = KubernetesRun(image_pull_secrets=[])
     assert config.image_pull_secrets == []
+
+
+@pytest.mark.parametrize("image_pull_policy", ["Always", "IfNotPresent", "Never"])
+def test_image_pull_policy_valid_value(image_pull_policy):
+    config = KubernetesRun(image_pull_policy=image_pull_policy)
+    assert config.image_pull_policy == image_pull_policy
+
+
+def test_image_pull_policy_invalid_value():
+    with pytest.raises(ValueError):
+        KubernetesRun(image_pull_policy="WrongPolicy")

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -37,6 +37,7 @@ def test_serialize_universal_run(config):
             service_account_name="my-account",
             image_pull_secrets=["secret-1", "secret-2"],
             labels=["a", "b"],
+            image_pull_policy="Always",
         ),
         KubernetesRun(
             job_template={
@@ -63,14 +64,10 @@ def test_serialize_kubernetes_run(config):
         "memory_request",
         "service_account_name",
         "image_pull_secrets",
-        "always_pull_new_image",
+        "image_pull_policy",
     ]
     for field in fields:
-        if field == "always_pull_new_image":
-            # False == False works in python but not with pytest for some reason
-            assert getattr(config, field) is getattr(config, field)
-        else:
-            assert getattr(config, field) == getattr(config2, field)
+        assert getattr(config, field) == getattr(config2, field)
 
 
 @pytest.mark.parametrize(

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -51,6 +51,7 @@ def test_serialize_kubernetes_run(config):
     msg = RunConfigSchema().dump(config)
     config2 = RunConfigSchema().load(msg)
     assert sorted(config.labels) == sorted(config2.labels)
+
     fields = [
         "job_template",
         "job_template_path",
@@ -62,9 +63,14 @@ def test_serialize_kubernetes_run(config):
         "memory_request",
         "service_account_name",
         "image_pull_secrets",
+        "always_pull_new_image",
     ]
     for field in fields:
-        assert getattr(config, field) == getattr(config2, field)
+        if field == "always_pull_new_image":
+            # False == False works in python but not with pytest for some reason
+            assert getattr(config, field) is getattr(config, field)
+        else:
+            assert getattr(config, field) == getattr(config2, field)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Adds an `image_pull_policy` to `KubernetesRun` config object

## Changes
<!-- What does this PR change? -->

- Adds an `image_pull_policy` kwarg to `KubernetesRun` config object
- Adds imagePullPolicy to job template if `image_pull_policy` is `Always`, `Never` or `IfNotPresent`

## Importance
<!-- Why is this PR important? -->
This is a common gotcha for Kubernetes jobs, and is a result of the discussion on #4445 

Closes #4445 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)