### PR TITLE
Allow `prefect build/register --module` to accept full import path to flow

### DIFF
--- a/changes/pr4468.yaml
+++ b/changes/pr4468.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Allow `prefect build/register --module` to accept full import path to flow - [#4468](https://github.com/PrefectHQ/prefect/pull/4468)"

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -162,7 +162,7 @@ def load_flows_from_module(name: str) -> "List[prefect.Flow]":
             raise TerminalError
 
     if isinstance(mod_or_obj, ModuleType):
-        flows = [f for f in vars(mod).values() if isinstance(f, prefect.Flow)]
+        flows = [f for f in vars(mod_or_obj).values() if isinstance(f, prefect.Flow)]
     elif isinstance(mod_or_obj, prefect.Flow):
         flows = [mod_or_obj]
         # Get a valid module name for f.storage

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -156,6 +156,8 @@ def load_flows_from_module(name: str) -> "List[prefect.Flow]":
             or (name.startswith(exc.name) and name[len(exc.name)] == ".")
         ):
             raise TerminalError(str(exc))
+        elif isinstance(exc, AttributeError):
+            raise TerminalError(str(exc))
         else:
             click.secho(f"Error loading {name!r}:", fg="red")
             log_exception(exc, 2)

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -636,6 +636,10 @@ REGISTER_EPILOG = """
 
 \b    $ prefect register --project my-project -m "myproject.flows"
 
+\b  Register a flow in variable `flow_x` in a module `myproject.flows`.
+
+\b    $ prefect register --project my-project -m "myproject.flows.flow_x"
+
 \b  Register all pre-built flows from a remote JSON file.
 
 \b    $ prefect register --project my-project --json https://some-url/flows.json
@@ -667,8 +671,9 @@ REGISTER_EPILOG = """
     "-m",
     "modules",
     help=(
-        "A python module name containing the flow(s) to register. May be "
-        "passed multiple times to specify multiple modules."
+        "A python module name containing the flow(s) to register. May be the full "
+        "import path to a flow. May be passed multiple times to specify multiple "
+        "modules. "
     ),
     multiple=True,
 )

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -25,4 +25,7 @@ def import_object(name: str) -> Any:
         mod = importlib.import_module(mod_name)
         return getattr(mod, attr_name)
     except ValueError:
-        return importlib.import_module(name)
+        pass
+
+    # When we can't split the string we'll just import the module
+    return importlib.import_module(name)

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -343,7 +343,8 @@ class TestRegister:
             load_flows_from_module("mymodule3.submodule")
 
         with pytest.raises(
-            TerminalError, match="No module named 'mymodule1.submodule'"
+            TerminalError,
+            match="module 'mymodule1' has no attribute 'submodule'",
         ):
             load_flows_from_module("mymodule1.submodule")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Currently `prefect register --module my_module` does not allow you to pass a full import path to a single flow. This PR modifies the logic slightly to allow `prefect register --module my_module.flow` to import a single flow from a module.


## Changes
<!-- What does this PR change? -->

- Allows a full import path to a flow within a module to be passed
- Fixes bug in `import_object` when passed a module with no `.`

## Importance
<!-- Why is this PR important? -->

This allows me to:
- Create an example like `prefect register --project default --module prefect.hello_world`
- Disambiguate flows by full path rather than `--module` and `--name` pairing (which is still valid)
- Run a single flow given an import path e.g. `prefect run --module prefect.hello_world.flow --watch` (I use these functions in #4463)


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)