### PR TITLE
Set labels to null during `prefect build/register` if none are provided

### DIFF
--- a/changes/pr4469.yaml
+++ b/changes/pr4469.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Set labels to null during `prefect build/register` if none are provided - [#4469](https://github.com/PrefectHQ/prefect/pull/4469)"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

Note: RunConfigs actually cast `None` labels into an empty set so I'm not sure why this wasn't working before. Will need further investigation.

## Summary
<!-- A sentence summarizing the PR -->

An empty set has a different meaning than `None` which means that
flows built without labels in this setup cannot be run on an agent
unless it also has explicitly empty labels. It's better to have
these flows be runnable on any agent if labels are not provided by
the user.

Note that the `labels.union` change is merely for a shorter line
by avoiding an unecessary `set` cast since `.union` takes any
iterable as an arg

## Changes
<!-- What does this PR change? -->

- Labels will be set to `None` if they have not been set in any other way instead of an empty list


## Importance
<!-- Why is this PR important? -->

Fixes confusing default behavior where flows I register without labels (via `prefect register`) cannot be run on a `LocalAgent` unless I start it with `--no-hostname-label`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)