### PR TITLE
feat(GCSUpload): allow passing in BytesIO

### DIFF
--- a/changes/pr4482.yaml
+++ b/changes/pr4482.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "GCSUpload: allow passing in io.BytesIO - [#4482](https://github.com/PrefectHQ/prefect/pull/4482)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -260,7 +260,7 @@ class GCSUpload(GCSBaseTask):
     )
     def run(
         self,
-        data: Union[str, bytes, BytesIO],
+        data: Union[str, bytes, io.BytesIO],
         bucket: str = None,
         blob: str = None,
         project: str = None,
@@ -346,7 +346,9 @@ class GCSUpload(GCSBaseTask):
         elif type(data) == io.BytesIO:
             gcs_blob.upload_from_file(data, timeout=request_timeout)
         else:
-            raise TypeError(f"data must be str, bytes or BytesIO: got {type(data)} instead")
+            raise TypeError(
+                f"data must be str, bytes or BytesIO: got {type(data)} instead"
+            )
         return gcs_blob.name
 
 

--- a/src/prefect/tasks/gcp/storage.py
+++ b/src/prefect/tasks/gcp/storage.py
@@ -202,7 +202,8 @@ class GCSDownload(GCSBaseTask):
 
 class GCSUpload(GCSBaseTask):
     """
-    Task template for uploading data to Google Cloud Storage.  Data can be a string or bytes.
+    Task template for uploading data to Google Cloud Storage. Data can be a string, bytes or
+    io.BytesIO
 
     Args:
         - bucket (str): default bucket name to upload to
@@ -259,7 +260,7 @@ class GCSUpload(GCSBaseTask):
     )
     def run(
         self,
-        data: Union[str, bytes],
+        data: Union[str, bytes, BytesIO],
         bucket: str = None,
         blob: str = None,
         project: str = None,
@@ -280,7 +281,8 @@ class GCSUpload(GCSBaseTask):
         provided _either_ at initialization _or_ as arguments.
 
         Args:
-            - data (Union[str, bytes]): the data to upload; can be either string or bytes
+            - data (Union[str, bytes, BytesIO]): the data to upload; can be either string, bytes
+                or io.BytesIO
             - bucket (str, optional): the bucket name to upload to
             - blob (str, optional): blob name to upload to
                 a string beginning with `prefect-` and containing the Task Run ID will be used
@@ -328,20 +330,23 @@ class GCSUpload(GCSBaseTask):
             encryption_key_secret=encryption_key_secret,
         )
 
+        # Set content type and encoding if supplied.
+        # This is likely only desirable if uploading gzip data:
+        # https://cloud.google.com/storage/docs/metadata#content-encoding
+        if content_type:
+            gcs_blob.content_type = content_type
+        if content_encoding:
+            gcs_blob.content_encoding = content_encoding
+
         # Upload
         if type(data) == str:
             gcs_blob.upload_from_string(data, timeout=request_timeout)
         elif type(data) == bytes:
-            # Set content type and encoding if supplied.
-            # This is likely only desirable if uploading gzip data:
-            # https://cloud.google.com/storage/docs/metadata#content-encoding
-            if content_type:
-                gcs_blob.content_type = content_type
-            if content_encoding:
-                gcs_blob.content_encoding = content_encoding
             gcs_blob.upload_from_file(io.BytesIO(data), timeout=request_timeout)
+        elif type(data) == io.BytesIO:
+            gcs_blob.upload_from_file(data, timeout=request_timeout)
         else:
-            raise TypeError(f"data must be str or bytes: got {type(data)} instead")
+            raise TypeError(f"data must be str, bytes or BytesIO: got {type(data)} instead")
         return gcs_blob.name
 
 

--- a/tests/tasks/gcp/test_gcs_upload_download.py
+++ b/tests/tasks/gcp/test_gcs_upload_download.py
@@ -140,6 +140,6 @@ class TestRuntimeValidation:
         monkeypatch.setattr("prefect.tasks.gcp.storage.get_storage_client", client)
 
         with pytest.raises(
-            TypeError, match="data must be str or bytes: got .* instead"
+            TypeError, match="data must be str, bytes or BytesIO: got .* instead"
         ):
             task.run([1, 2, 3])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR enables GCSUpload to accept `io.BytesIO`. This allows more rich usage, e.g. making working with in memory buffers easier.



## Changes
<!-- What does this PR change? -->

This PR enables GCSUpload to accept `io.BytesIO`.


## Importance
<!-- Why is this PR important? -->

This allows more rich usage, e.g. making working with in memory buffers easier.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)