### PR TITLE
Set flow docker container names to flow run names

### DIFF
--- a/changes/pr4485.yaml
+++ b/changes/pr4485.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Set flow docker container names to flow run names - [#4485](https://github.com/PrefectHQ/prefect/pull/4485)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -448,23 +448,20 @@ class DockerAgent(Agent):
         # Generate a container name to match the flow run name, ensuring it is docker
         # compatible and unique. Must match `[a-zA-Z0-9][a-zA-Z0-9_.-]+` in the end
         container_name = slugified_name = (
-            re.sub(
-                # Docker does not allow leading _, -, . so we need to remove those from
-                # the slugified name
-                "^[._-]+",
-                "",
-                slugify(
-                    flow_run.name,
-                    lowercase=False,
-                    # Docker does not limit length but URL limits apply eventually so
-                    # limit the length for safety
-                    max_length=250,
-                    # Docker allows these characters for container names
-                    regex_pattern=r"[^a-zA-Z0-9_.-]+",
-                ),
+            slugify(
+                flow_run.name,
+                lowercase=False,
+                # Docker does not limit length but URL limits apply eventually so
+                # limit the length for safety
+                max_length=250,
+                # Docker allows these characters for container names
+                regex_pattern=r"[^a-zA-Z0-9_.-]+",
+            ).lstrip(
+                # Docker does not allow leading underscore, dash, or period
+                "_-."
             )
             # Docker does not allow 0 character names so use the flow run id if name
-            # would be empty
+            # would be empty after cleaning
             or flow_run.id
         )
         # Checking for container names here is a slight deploy performance hit. If


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Currently, `DockerAgent` container names are UUIDs (the default). It'd be nice to set the container names to the flow run name. However, container names must be unique so we must check for collisions to avoid blocking flow run execution. It seems like a rare case that there will be a collision (since we auto-remove containers) so we add a simple index `-{i}` to the end of the name if we encounter one.


## Changes
<!-- What does this PR change? -->

- Sets the container name during creation by a `DockerAgent`


## Importance
<!-- Why is this PR important? -->

Improves usability / interaction with flow run containers.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)