### PR TITLE
feat(KubernetesAgent): provide path to custom kube config

### DIFF
--- a/changes/pr4486.yaml
+++ b/changes/pr4486.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "KubernetesAgent: allow to customize cluster by providing path to kube config - [#4486](https://github.com/PrefectHQ/prefect/pull/4486)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/docs/orchestration/agents/kubernetes.md
+++ b/docs/orchestration/agents/kubernetes.md
@@ -155,7 +155,18 @@ prefect agent kubernetes start --job-template /path/to/my_template.yaml
 prefect agent kubernetes start --job-template s3://bucket/path/to/my_template.yaml
 ```
 
-## Running In-Cluster
+### Custom Kube Config
+
+By default the Kubernetes Jobs created by the agent are created in the cluster
+where the agent is running. It is also possible to customize the cluster the
+agent is using by supplying a custom kube config file with the `--kube-config-file`
+flag:
+
+```bash
+prefect agent kubernetes start --kube-config-file /path/custom/kube-config
+```
+
+## Deployment
 
 For production deployments, we recommend running the Kubernetes Agent inside
 the Kubernetes Cluster as a

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -281,6 +281,11 @@ def kubernetes():
     is_flag=True,
     default=True,  # Defaults to `True` because setting this flag sets `delete_finished_jobs` to `False`
 )
+@click.option(
+    "--kube-config-file",
+    "kube_config_file",
+    help="Path to kube config file to customize where agent creates flow runs.",
+)
 def start(image_pull_secrets=None, **kwargs):
     """Start a Kubernetes agent"""
     from prefect.agent.kubernetes import KubernetesAgent


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR adds feature to Kubernetes Agent to use a custom Kubernetes cluster to spawn / monitor jobs. It does so by allowing an additional parameter `kube_config_file` to specify a path to kube config instead of assuming the default. Alternatively, it is possible to supply this with the `KUBE_CONFIG_FILE` environment variable.


## Changes
<!-- What does this PR change? -->

Add parameter `kube_config_file` to specify a path to kube config instead of assuming the default. Alternatively, it is possible to supply this with the `KUBE_CONFIG_FILE` environment variable.


## Importance
<!-- Why is this PR important? -->

This allows to run a Kubernetes agent in cluster `foo`, while running actual jobs in cluster `bar`. Making the agent more flexible :) 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)