### PR TITLE
Reference a `before` time when querying task runs

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -591,7 +591,7 @@ class Agent:
                                     "state": {"_eq": "Running"},
                                     "task_runs": {
                                         "state_start_time": {
-                                            "_lte": str(now.subtract(seconds=3))  # type: ignore
+                                            "_lte": str(before or now.subtract(seconds=3))  # type: ignore
                                         }
                                     },
                                 },
@@ -619,7 +619,7 @@ class Agent:
                         {
                             "where": {
                                 "state_start_time": {
-                                    "_lte": str(now.subtract(seconds=3))  # type: ignore
+                                    "_lte": str(before or now.subtract(seconds=3))  # type: ignore
                                 }
                             }
                         },


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Minor change to update task run queries to respect the `before` parameter introduced in #4158.

cc @madkinsz 



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)