### PR TITLE
Fix `import_object` handling of submodules that are not attributes

### DIFF
--- a/changes/pr4513.yaml
+++ b/changes/pr4513.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix `import_object` handling of submodules that are not attributes - [#4513](https://github.com/PrefectHQ/prefect/pull/4513)"

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -20,12 +20,17 @@ def import_object(name: str) -> Any:
     True
     ```
     """
-    try:
-        mod_name, attr_name = name.rsplit(".", 1)
-        mod = importlib.import_module(mod_name)
-        return getattr(mod, attr_name)
-    except ValueError:
-        pass
 
-    # When we can't split the string we'll just import the module
-    return importlib.import_module(name)
+    # Try importing it first so we support "module" or "module.sub_module"
+    try:
+        module = importlib.import_module(name)
+        return module
+    except ImportError:
+        # If no subitem was included raise the import error
+        if "." not in name:
+            raise
+
+    # Otherwise, we'll try to load it as an attribute of a module
+    mod_name, attr_name = name.rsplit(".", 1)
+    module = importlib.import_module(mod_name)
+    return getattr(module, attr_name)

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -1,3 +1,5 @@
+import pytest
+
 from prefect.utilities.importtools import import_object
 
 
@@ -8,3 +10,21 @@ def test_import_object():
 
     assert rand is random
     assert randint is random.randint
+
+
+def test_import_object_submodule_not_an_attribute():
+    # `hello_world` is not in the `prefect` top-level
+    hello_world = import_object("prefect.hello_world")
+    import prefect.hello_world
+
+    assert hello_world is prefect.hello_world
+
+
+def test_import_object_module_does_not_exist():
+    with pytest.raises(ImportError):
+        import_object("random_module_name_that_does_not_exist")
+
+
+def test_import_object_attribute_does_not_exist():
+    with pytest.raises(AttributeError):
+        import_object("random.random_attribute_that_does_not_exist")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

For sub modules that are not attributes of the top-level module (ie `prefect.hello_world` is not imported in the `prefect` `__init__.py`), `import_object` will not attempt to load the submodule and instead throw an attribute error.

This will certainly cause issues in `prefect register --module my_module.sub_module`


## Changes
<!-- What does this PR change? -->

- Updates `import_object` to be more robust



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)