### PR TITLE
Add upper version click pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click >= 7.0
+click >= 7.0, <8.0
 cloudpickle >=1.3.0
 croniter >= 0.3.24, <1.0
 dask >= 2.17.0; python_version > '3.6'


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Pins `click` < 8.0. There's a dependency issue with `dask-distributed` here https://github.com/dask/distributed/issues/4812.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
Dask executors using the Prefect image will not work if the newest version of `click` is installed.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)