### PR TITLE
Fix `DockerStorage` building with python slim image

### DIFF
--- a/changes/pr4523.yaml
+++ b/changes/pr4523.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix `DockerStorage` building with python slim image - [#4523](https://github.com/PrefectHQ/prefect/pull/4523)"

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -189,7 +189,7 @@ class Docker(Storage):
                 # create an image from python:*-slim directly
                 self.base_image = "python:{}-slim".format(python_version)
                 self.installation_commands.append(
-                    "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*"
+                    "apt update && apt install -y gcc git make && rm -rf /var/lib/apt/lists/*"
                 )
         elif base_image and dockerfile:
             raise ValueError(

--- a/tests/storage/test_docker_storage.py
+++ b/tests/storage/test_docker_storage.py
@@ -575,7 +575,7 @@ def test_create_dockerfile_from_dockerfile_uses_tempdir_path():
             "424be6b5ed8d3be85064de4b95b5c3d7cb665510",
             (
                 "FROM python:3.6-slim",
-                "apt update && apt install -y gcc git && rm -rf /var/lib/apt/lists/*",
+                "apt update && apt install -y gcc git make && rm -rf /var/lib/apt/lists/*",
                 "pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@424be6b5ed8d3be85064de4b95b5c3d7cb665510#egg=prefect[all_orchestration_extras]",
             ),
         ),


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This base image is used when a user is not using a tagged Prefect version and was erroring on build. `pynacl` requires `make` which is apparently not installed in this image.

## Changes
<!-- What does this PR change? -->

- Installs `make` during slim python base image builds

## Importance
<!-- Why is this PR important? -->

- Fixes a blocking `DockerStorage` error; likely mostly encountered by developers

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~