### PR TITLE
Display the agent config id on agent startup if set

### DIFF
--- a/changes/pr4524.yaml
+++ b/changes/pr4524.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Display the agent config id on agent startup if set - [#4524](https://github.com/PrefectHQ/prefect/pull/4524)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -158,7 +158,6 @@ class Agent:
         self.logger.debug(f"Max polls: {self.max_polls}")
         self.logger.debug(f"Agent address: {self.agent_address}")
         self.logger.debug(f"Log to Cloud: {self.log_to_cloud}")
-
         self.logger.debug(f"Prefect backend: {config.backend}")
 
     def _verify_token(self, token: str) -> None:
@@ -187,6 +186,12 @@ class Agent:
         Returns:
             - The agent ID as a string
         """
+
+        config_id_blub = (
+            f" with config {self.agent_config_id}" if self.agent_config_id else ""
+        )
+        self.logger.info(f"Registering agent{config_id_blub}...")
+
         agent_id = self.client.register_agent(
             agent_type=type(self).__name__,
             name=self.name,
@@ -194,7 +199,8 @@ class Agent:
             agent_config_id=self.agent_config_id,
         )
 
-        self.logger.debug(f"Agent ID: {agent_id}")
+        self.logger.info(f"Registration successful!")
+        self.logger.debug(f"Assigned agent id: {agent_id}")
 
         if self.agent_config_id:
             self._retrieve_agent_config()

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -199,7 +199,7 @@ class Agent:
             agent_config_id=self.agent_config_id,
         )
 
-        self.logger.info(f"Registration successful!")
+        self.logger.info("Registration successful!")
         self.logger.debug(f"Assigned agent id: {agent_id}")
 
         if self.agent_config_id:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Users are easily confused about whether or not their agent has actually respected the config arg since the UI does not display it. Here, we display it

## Changes
<!-- What does this PR change? -->

- Adds a "registering" INFO log to `_register_agent` that includes the config id if set

## Importance
<!-- Why is this PR important? -->

Displaying the id that we are using at startup is useful for displaying that we have met their expectation

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~