### PR TITLE
Update 01-etl-before-prefect.md

### DIFF
--- a/docs/core/tutorial/01-etl-before-prefect.md
+++ b/docs/core/tutorial/01-etl-before-prefect.md
@@ -54,7 +54,7 @@ db.add_live_aircraft_data(live_aircraft_data)
 db.update_reference_data(ref_data)
 ```
 
-The advantages of the above code is that it is simple to read. However, it's simplicity is matched only by the number of disadvantages. First and foremost, the workflow is strictly linear:
+The advantages of the above code is that it is simple to read. However, its simplicity is matched only by the number of disadvantages. First and foremost, the workflow is strictly linear:
 
 ![Linear ETL](/prefect-tutorial-etl-linear.png)
 


### PR DESCRIPTION
Wrong 'its'. I'm including a reference from the FAA since the tutorial example involves airplanes: https://www.faa.gov/about/initiatives/plain_language/articles/its/

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Wrong 'its'. 


## Changes
<!-- What does this PR change? -->

"it's" (contraction) to "its" (possessive)


## Importance
<!-- Why is this PR important? -->

Proper grammar is more clear.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ n/a ] adds new tests (if appropriate)
- [ n/a ] adds a change file in the `changes/` directory (if appropriate)
- [ n/a ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)