### PR TITLE
Move mapped task interation from `FlowRunView` to `TaskRunView`

### DIFF
--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -296,7 +296,7 @@ class FlowView:
                 [
                     f"flow_id={self.flow_id!r}",
                     f"name={self.name!r}",
-                    f"project_name={self.project_name!r}"
+                    f"project_name={self.project_name!r}",
                     f"storage_type={type(self.storage).__name__}",
                 ]
             )

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -10,7 +10,6 @@ from typing import (
     Dict,
     Set,
     Any,
-    Iterator,
     Iterable,
     Type,
     Mapping,
@@ -486,72 +485,6 @@ class FlowRunView:
         raise ValueError(
             "One of `task_run_id`, `task`, or `task_slug` must be provided!"
         )
-
-    def iter_mapped_task_runs(
-        self,
-        task: Task = None,
-        task_slug: str = None,
-        cache_results: bool = True,
-    ) -> Iterator["TaskRunView"]:
-        """
-        Iterate over the results of a mapped task, yielding a `TaskRunView` for each map
-        index. This query is not performed in bulk so the results can be lazily
-        consumed. If you want all of the task results at once, use `get_task_run` on
-        the mapped task instead.
-
-        Args:
-            - task: A `prefect.Task` object to use for the lookup. The slug will be
-                pulled from the task to actually perform the query
-            - task_slug: A task slug string to use for the lookup
-            - cache_results: By default, task run data is cached for future lookups.
-                However, since we lazily generate the mapped results, caching can be
-                disabled to reduce memory consumption for large mapped tasks.
-
-        Yields:
-            A TaskRunView object for each mapped item
-        """
-        if task is not None:
-            if task_slug is not None and task_slug != task.slug:
-                raise ValueError(
-                    "Both `task` and `task_slug` were provided but "
-                    f"`task.slug == {task.slug!r}` and `task_slug == {task_slug!r}`"
-                )
-            task_slug = task.slug
-
-        if task_slug is None:
-            raise ValueError("Either `task` or `task_slug` must be provided!")
-
-        where = lambda index: {
-            "task": {"slug": {"_eq": task_slug}},
-            "flow_run_id": {"_eq": self.flow_run_id},
-            "map_index": {"_eq": index},
-        }
-        task_run = TaskRunView._from_task_run_data(
-            TaskRunView._query_for_task_run(where=where(-1))
-        )
-        if not task_run.state.is_mapped():
-            raise TypeError(
-                f"Task run {task_run.task_run_id!r} ({task_run.task_slug}) is not a "
-                "mapped task."
-            )
-
-        map_index = 0
-        while task_run:
-            task_run_data = TaskRunView._query_for_task_run(
-                where=where(map_index), error_on_empty=False
-            )
-            if not task_run_data:
-                break
-
-            task_run = TaskRunView._from_task_run_data(task_run_data)
-
-            # Allow the user to skip the cache if they have a lot of task runs
-            if cache_results:
-                self._cache_task_run_if_finished(task_run)
-
-            yield task_run
-
-            map_index += 1
 
     def get_all_task_runs(self) -> List["TaskRunView"]:
         """

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -147,7 +147,9 @@ class TaskRunView:
         )
 
     @classmethod
-    def from_task_slug(cls, task_slug: str, flow_run_id: str) -> "TaskRunView":
+    def from_task_slug(
+        cls, task_slug: str, flow_run_id: str, map_index: int = -1
+    ) -> "TaskRunView":
         """
         Get an instance of this class; query by task slug and flow run id.
 
@@ -155,6 +157,8 @@ class TaskRunView:
             - task_slug: The unique string identifying this task in the flow. Typically
                 `<task-name>-1`.
             - flow_run_id: The UUID identifying the flow run the task run occurred in
+            - map_index (optional): The index to access for mapped tasks; defaults to
+                the parent task with a map index of -1
 
         Returns:
             A populated `TaskRunView` instance
@@ -164,9 +168,7 @@ class TaskRunView:
                 where={
                     "task": {"slug": {"_eq": task_slug}},
                     "flow_run_id": {"_eq": flow_run_id},
-                    # Since task slugs can be duplicated for mapped tasks, only allow
-                    # the root task to be pulled by this
-                    "map_index": {"_eq": -1},
+                    "map_index": {"_eq": map_index},
                 }
             )
         )

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -108,19 +108,20 @@ class TaskRunView:
         Yields:
             A `TaskRunView` for each mapped item
         """
-        where = lambda index: {
-            "task": {"slug": {"_eq": self.task_slug}},
-            "flow_run_id": {"_eq": self.flow_run_id},
-            "map_index": {"_eq": index},
-        }
         if not self.state.is_mapped():
             raise TypeError(
                 f"Task run {self.task_run_id!r} ({self.task_slug}) is not a "
                 "mapped task."
             )
 
+        # Generate a where clause given the map index
+        where = lambda index: {
+            "task": {"slug": {"_eq": self.task_slug}},
+            "flow_run_id": {"_eq": self.flow_run_id},
+            "map_index": {"_eq": index},
+        }
         map_index = 0
-        while True:
+        while True:  # Iterate until we are out of child task runs
             task_run_data = self._query_for_task_run(
                 where=where(map_index), error_on_empty=False
             )

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -143,17 +143,23 @@ def test_task_run_view_from_task_run_id_where_clause(monkeypatch):
     )
 
 
-def test_task_run_view_from_task_slug_where_clause(monkeypatch):
+@pytest.mark.parametrize("map_index", [None, -1, 0, 3])
+def test_task_run_view_from_task_slug_where_clause(monkeypatch, map_index):
     post = MagicMock(return_value={"data": {"task_run": [TASK_RUN_DATA_1]}})
     monkeypatch.setattr("prefect.client.client.Client.post", post)
 
-    TaskRunView.from_task_slug(task_slug="task-slug-1", flow_run_id="flow-run-id-1")
+    kwargs = {}
+    if map_index is not None:  # None indicating not to pass an arg
+        kwargs["map_index"] = map_index
 
+    TaskRunView.from_task_slug(
+        task_slug="task-slug-1", flow_run_id="flow-run-id-1", **kwargs
+    )
     assert (
         "task_run(where: { "
         'task: { slug: { _eq: "task-slug-1" } }, '
         'flow_run_id: { _eq: "flow-run-id-1" }, '
-        "map_index: { _eq: -1 } "
+        f"map_index: {{ _eq: {map_index if map_index is not None else -1} }} "
         "})"
     ) in post.call_args[1]["params"]["query"]
 

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -279,6 +279,7 @@ def test_task_run_view_iter_mapped():
     query_mock = MagicMock(side_effect=return_index)
     task_run._query_for_task_run = query_mock
 
+    # Yields each mapped task
     for index, child_run in enumerate(task_run.iter_mapped()):
         assert isinstance(child_run, TaskRunView)
         assert child_run.map_index == index


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Previously, `FlowRunView` supplied a `iter_mapped_task_runs` but it doesn't really make sense to have it there since the whole point of iterating is that your mapped results are too big to cache. The new workflow looks like...

```python
flow_run = FlowRunView.from_flow_run_id("...")

task_run = flow_run.get_task_run(my_mapped_task)

# Access all child results at once
task_run.result  # [1,2,3,4,5]

# Lazily iterate over child tasks
for child in task_run.iter_mapped():
    print(child.result)
# 1
# 2
# 3
# 4
# 5
```



## Changes
<!-- What does this PR change? -->

- Removes `FlowRunView` mapped task iteration
- Adds `TaskRunView.iter_mapped()`
- Fixes `FlowView` repr missing newline
- Adds `map_index` kwarg to `TaskRunView.from_task_slug`

## Importance
<!-- Why is this PR important? -->

A better API

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)