### PR TITLE
Add per-agent flow concurrency limits

### DIFF
--- a/changes/pr4532.yaml
+++ b/changes/pr4532.yaml
@@ -1,0 +1,3 @@
+
+feature:
+  - "Add per-agent flow concurrency limits - [#4532](https://github.com/PrefectHQ/prefect/pull/4532)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -551,7 +551,10 @@ class Agent:
                     "flow_run_aggregate",
                     {
                         "where": {
-                            "state": {"_eq": "Running"},
+                            "_or": [
+                                {"state": {"_eq": "Running"}},
+                                {"state": {"_eq": "Submitted"}},
+                            ],
                             "agent_id": {"_eq": self.agent_id},
                         },
                     },

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -541,7 +541,7 @@ class Agent:
     # Backend API queries --------------------------------------------------------------
 
     def _get_running_flow_count(self) -> int:
-        self.logger.debug("Checking for running flow run count...")
+        self.logger.debug("Checking flow run concurrency count...")
         if not self.agent_id:
             raise ValueError("Missing value for `agent_id`. Is the agent started?")
 
@@ -551,8 +551,8 @@ class Agent:
                     "flow_run_aggregate",
                     {
                         "where": {
-                            {"state": {"_eq": "Running"}},
-                            {"agent_id": {"_eq": self.agent_id}},
+                            "state": {"_eq": "Running"},
+                            "agent_id": {"_eq": self.agent_id},
                         },
                     },
                 ): {"aggregate": {"count"}}
@@ -560,7 +560,12 @@ class Agent:
         }
 
         result = self.client.graphql(query)
-        count = result.get("data", {}).get("aggregate", {}).get("count")
+        count = (
+            result.get("data", {})
+            .get("flow_run_aggregate", {})
+            .get("aggregate", {})
+            .get("count")
+        )
 
         if count is None:
             raise ValueError(

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -8,7 +8,7 @@ import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Generator, Iterable, Optional, Set, Type, cast
+from typing import Any, Generator, Optional, Set, Type, cast
 from urllib.parse import urlparse
 
 import pendulum
@@ -551,6 +551,14 @@ class Agent:
         if not self.agent_id:
             raise ValueError("Missing value for `agent_id`. Is the agent started?")
 
+        if not self.max_concurrent_runs:
+            raise ValueError(
+                "`_get_running_flow_count` should not be called unless "
+                "`max_concurrent_runs` is set"
+            )
+
+        # TODO: This query will likely be replaced with a more performant query with a
+        #       dedicated backend route
         query = {
             "query": {
                 with_args(

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -541,6 +541,12 @@ class Agent:
     # Backend API queries --------------------------------------------------------------
 
     def _get_running_flow_count(self) -> int:
+        """
+        Query the Prefect API for the number of running flows created by this agent id;
+        limits returned count to `self.max_concurrent_runs` to avoid querying over more
+        data than necessary
+        """
+
         self.logger.debug("Checking flow run concurrency count...")
         if not self.agent_id:
             raise ValueError("Missing value for `agent_id`. Is the agent started?")
@@ -557,6 +563,8 @@ class Agent:
                             ],
                             "agent_id": {"_eq": self.agent_id},
                         },
+                        # Add one so we could check if the metric has been exceeded
+                        "limit": self.max_concurrent_runs + 1,
                     },
                 ): {"aggregate": {"count"}}
             }

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -50,22 +50,6 @@ class DockerAgent(Agent):
     ```
 
     Args:
-        - agent_config_id (str, optional): An optional agent configuration ID that can be used to set
-            configuration based on an agent from a backend API. If set all configuration values will be
-            pulled from backend agent configuration.
-        - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string
-            identifiers used by Prefect Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will
-            be set on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
-            for flow runs; defaults to infinite
-        - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server
-            (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
-            and all deployed flow runs
         - base_url (str, optional): URL for a Docker daemon server. Defaults to
             `unix:///var/run/docker.sock` however other hosts such as
             `tcp://0.0.0.0:2375` can be provided
@@ -83,17 +67,11 @@ class DockerAgent(Agent):
         - docker_client_timeout (int, optional): The timeout to use for docker
             API calls, defaults to 60 seconds.
         - docker_interface: This option has been deprecated and has no effect.
+        - kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(
         self,
-        agent_config_id: str = None,
-        name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
-        max_polls: int = None,
-        agent_address: str = None,
-        no_cloud_logs: bool = False,
         base_url: str = None,
         no_pull: bool = None,
         volumes: List[str] = None,
@@ -103,16 +81,9 @@ class DockerAgent(Agent):
         reg_allow_list: List[str] = None,
         docker_client_timeout: int = None,
         docker_interface: bool = None,
+        **kwargs,
     ) -> None:
-        super().__init__(
-            agent_config_id=agent_config_id,
-            name=name,
-            labels=labels,
-            env_vars=env_vars,
-            max_polls=max_polls,
-            agent_address=agent_address,
-            no_cloud_logs=no_cloud_logs,
-        )
+        super().__init__(**kwargs)
         if platform == "win32":
             default_url = "npipe:////./pipe/docker_engine"
         else:

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -67,7 +67,7 @@ class DockerAgent(Agent):
         - docker_client_timeout (int, optional): The timeout to use for docker
             API calls, defaults to 60 seconds.
         - docker_interface: This option has been deprecated and has no effect.
-        - kwargs: Additional keyword arguments are passed to the `Agent` base class
+        - **kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(
@@ -81,7 +81,7 @@ class DockerAgent(Agent):
         reg_allow_list: List[str] = None,
         docker_client_timeout: int = None,
         docker_interface: bool = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if platform == "win32":

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from slugify import slugify
 from sys import platform
-from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple, Any
 
 from prefect import config, context
 from prefect.agent import Agent

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -107,7 +107,7 @@ class ECSAgent(Agent):
         - botocore_config (dict, optional): Additional botocore configuration
             options to be passed to the boto3 client. See [the boto3
             configuration docs][2] for more information.
-        - kwargs: Additional keyword arguments are passed to the `Agent` base class
+        - **kwargs: Additional keyword arguments are passed to the `Agent` base class
 
 
     [1]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -70,25 +70,6 @@ class ECSAgent(Agent):
     Agent which deploys flow runs as ECS tasks.
 
     Args:
-        - agent_config_id (str, optional): An optional agent configuration ID
-            that can be used to set configuration based on an agent from a
-            backend API. If set all configuration values will be pulled from
-            the backend agent configuration.
-        - name (str, optional): An optional name to give this agent. Can also
-            be set through the environment variable `PREFECT__CLOUD__AGENT__NAME`.
-            Defaults to "agent".
-        - labels (List[str], optional): A list of labels, which are arbitrary
-            string identifiers used by Prefect Agents when polling for work.
-        - env_vars (dict, optional): A dictionary of environment variables and
-            values that will be set on each flow run that this agent submits
-            for execution.
-        - max_polls (int, optional): Maximum number of times the agent will
-            poll Prefect Cloud for flow runs; defaults to infinite.
-        - agent_address (str, optional):  Address to serve internal api at.
-            Currently this is just health checks for use by an orchestration
-            layer. Leave blank for no api server (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend
-            for this agent and all deployed flow runs. Defaults to `False`.
         - task_definition_path (str, optional): Path to a task definition
             template to use when defining new tasks. If not provided, the
             default template will be used.
@@ -126,6 +107,7 @@ class ECSAgent(Agent):
         - botocore_config (dict, optional): Additional botocore configuration
             options to be passed to the boto3 client. See [the boto3
             configuration docs][2] for more information.
+        - kwargs: Additional keyword arguments are passed to the `Agent` base class
 
 
     [1]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
@@ -135,13 +117,6 @@ class ECSAgent(Agent):
 
     def __init__(  # type: ignore
         self,
-        agent_config_id: str = None,
-        name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
-        max_polls: int = None,
-        agent_address: str = None,
-        no_cloud_logs: bool = False,
         task_definition_path: str = None,
         run_task_kwargs_path: str = None,
         aws_access_key_id: str = None,
@@ -153,16 +128,9 @@ class ECSAgent(Agent):
         task_role_arn: str = None,
         execution_role_arn: str = None,
         botocore_config: dict = None,
+        **kwargs,
     ) -> None:
-        super().__init__(
-            agent_config_id=agent_config_id,
-            name=name,
-            labels=labels,
-            env_vars=env_vars,
-            max_polls=max_polls,
-            agent_address=agent_address,
-            no_cloud_logs=no_cloud_logs,
-        )
+        super().__init__(**kwargs)
 
         from botocore.config import Config
         from prefect.utilities.aws import get_boto_client

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -77,34 +77,21 @@ class KubernetesAgent(Agent):
         - delete_finished_jobs (bool, optional): A boolean to toggle if finished Prefect jobs
             in the agent's namespace should be deleted. Defaults to the environment variable
             `DELETE_FINISHED_JOBS` or `True`.
+        - kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(
         self,
-        agent_config_id: str = None,
         namespace: str = None,
         service_account_name: str = None,
         image_pull_secrets: Iterable[str] = None,
         job_template_path: str = None,
-        name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
-        max_polls: int = None,
-        agent_address: str = None,
-        no_cloud_logs: bool = False,
         volume_mounts: List[dict] = None,
         volumes: List[dict] = None,
         delete_finished_jobs: bool = True,
+        **kwargs,
     ) -> None:
-        super().__init__(
-            agent_config_id=agent_config_id,
-            name=name,
-            labels=labels,
-            env_vars=env_vars,
-            max_polls=max_polls,
-            agent_address=agent_address,
-            no_cloud_logs=no_cloud_logs,
-        )
+        super().__init__(**kwargs)
 
         self.namespace = namespace or os.getenv("NAMESPACE", "default")
         self.service_account_name = service_account_name or os.getenv(

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -77,7 +77,7 @@ class KubernetesAgent(Agent):
         - delete_finished_jobs (bool, optional): A boolean to toggle if finished Prefect jobs
             in the agent's namespace should be deleted. Defaults to the environment variable
             `DELETE_FINISHED_JOBS` or `True`.
-        - kwargs: Additional keyword arguments are passed to the `Agent` base class
+        - **kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(
@@ -89,7 +89,7 @@ class KubernetesAgent(Agent):
         volume_mounts: List[dict] = None,
         volumes: List[dict] = None,
         delete_finished_jobs: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -42,7 +42,7 @@ class LocalAgent(Agent):
             flows which are stored on the local filesystem.
         - storage_labels (boolean, optional, DEPRECATED): a boolean specifying whether this agent should
             auto-label itself with all of the storage options labels.
-        - kwargs: Additional keyword arguments are passed to the `Agent` base class
+        - **kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -32,22 +32,6 @@ class LocalAgent(Agent):
     ```
 
     Args:
-        - agent_config_id (str, optional): An optional agent configuration ID that can be used to set
-            configuration based on an agent from a backend API. If set all configuration values will be
-            pulled from backend agent configuration.
-        - name (str, optional): An optional name to give this agent. Can also be set through
-            the environment variable `PREFECT__CLOUD__AGENT__NAME`. Defaults to "agent"
-        - labels (List[str], optional): a list of labels, which are arbitrary string
-            identifiers used by Prefect Agents when polling for work
-        - env_vars (dict, optional): a dictionary of environment variables and values that will
-            be set on each flow run that this agent submits for execution
-        - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
-            for flow runs; defaults to infinite
-        - agent_address (str, optional):  Address to serve internal api at. Currently this is
-            just health checks for use by an orchestration layer. Leave blank for no api server
-            (default).
-        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend for this agent
-            and all deployed flow runs
         - import_paths (List[str], optional): system paths which will be provided to each
             Flow's runtime environment; useful for Flows which import from locally hosted
             scripts or packages
@@ -58,34 +42,22 @@ class LocalAgent(Agent):
             flows which are stored on the local filesystem.
         - storage_labels (boolean, optional, DEPRECATED): a boolean specifying whether this agent should
             auto-label itself with all of the storage options labels.
+        - kwargs: Additional keyword arguments are passed to the `Agent` base class
     """
 
     def __init__(
         self,
-        agent_config_id: str = None,
-        name: str = None,
-        labels: Iterable[str] = None,
-        env_vars: dict = None,
         import_paths: List[str] = None,
         show_flow_logs: bool = False,
         hostname_label: bool = True,
-        max_polls: int = None,
-        agent_address: str = None,
-        no_cloud_logs: bool = False,
         storage_labels: bool = None,
+        **kwargs,
     ) -> None:
         self.processes = set()
         self.import_paths = import_paths or []
         self.show_flow_logs = show_flow_logs
-        super().__init__(
-            agent_config_id=agent_config_id,
-            name=name,
-            labels=labels,
-            env_vars=env_vars,
-            max_polls=max_polls,
-            agent_address=agent_address,
-            no_cloud_logs=no_cloud_logs,
-        )
+        super().__init__(**kwargs)
+
         hostname = socket.gethostname()
 
         # Resolve common Docker hostname by using IP

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -61,6 +61,17 @@ COMMON_START_OPTIONS = [
             "environment."
         ),
     ),
+    click.option(
+        "--concurrency-limit",
+        "-L",
+        "max_concurrent_runs",
+        type=int,
+        default=None,
+        help=(
+            "The maximum number of concurrent flow runs this agent can submit. "
+            "Defaults to unlimited."
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->


## Summary
<!-- A sentence summarizing the PR -->

Adds flow concurrency limits at the agent level. This allows the user to limit the number of running or submitted flows spawned by a single agent.

## Changes
<!-- What does this PR change? -->

- Adds `--concurrency-limit/-L <int>` to the agent CLI
- Adds `max_concurrent_runs: Optional[int]` to the `Agent` base class
- Uses `**kwargs` to pass `Agent` subclass settings to the base class. Having duplicated default settings and documentation seems like it'll expose issues and introduces maintenance pains as the base class is extended.
- Adds a query to check for concurrency limits before submitting ready flow runs for deployment

## Importance
<!-- Why is this PR important? -->


Closes https://github.com/PrefectHQ/server/issues/213 although there are a few things listed in that ticket that are unaddressed:
- The agent screen in the UI. This is in progress and should be updated in the future to display this limit.
- Storing the limit in the backend. This PR sets the limit locally via CLI flag and does not use the API for storing the limit. In the future, we'd likely want to be able to set the limit from the backend as well.
- Agent ids can still be shared by multiple agent processes. Enforcing unique names in the future seems ideal, but for now it's on the user if they run into concurrency issues with agents sharing an id.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)