### PR TITLE
Cleanup `Agent._get_flow_run_metadata`

### DIFF
--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -588,7 +588,7 @@ class Agent:
         flow_run_ids: Iterable[str],
     ) -> List["GraphQLResult"]:
         """
-        Get metadata about a collection of flow run ids to that the agent is preparing
+        Get metadata about a collection of flow run ids that the agent is preparing
         to submit
 
         This function will filter the flow runs to a collection where:

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -8,7 +8,7 @@ import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Generator, Iterable, Optional, Set, Type, cast
+from typing import Any, Generator, Iterable, Optional, Set, Type, cast, Set, List
 from urllib.parse import urlparse
 
 import pendulum
@@ -308,11 +308,20 @@ class Agent:
         # Query for ready runs -- allowing for intermittent failures by handling
         # exceptions
         try:
-            flow_runs = self._get_ready_flow_runs()
+            flow_run_ids = self._get_ready_flow_runs()
         except Exception:
             self.logger.error("Failed to query for ready flow runs", exc_info=True)
             return []
 
+        # Get the flow run metadata necessary for deployment in bulk; this also filters
+        # flow runs that may have been submitted by another agent in the meantime
+        try:
+            flow_runs = self._get_flow_run_metadata(flow_run_ids)
+        except Exception:
+            self.logger.error("Failed to query for flow run metadata", exc_info=True)
+            return []
+
+        # Deploy each flow run in parallel with the executor
         for flow_run in flow_runs:
             self.logger.debug(f"Submitting flow run {flow_run.id} for deployment...")
             executor.submit(self._deploy_flow_run, flow_run).add_done_callback(
@@ -511,9 +520,11 @@ class Agent:
 
     # Backend API queries --------------------------------------------------------------
 
-    def _get_ready_flow_runs(self, prefetch_seconds: int = 10) -> list:
+    def _get_ready_flow_runs(self, prefetch_seconds: int = 10) -> Set[str]:
         """
-        Query the Prefect API for flow runs which need to be deployed and executed
+        Query the Prefect API for flow runs in the 'ready' queue. Results from here
+        should be filtered by '_get_flow_run_metadata' to prevent duplicate submissions
+        across agents.
 
         Args:
             - prefetch_seconds: The number of seconds in the future to fetch runs for.
@@ -523,7 +534,7 @@ class Agent:
                 deploying the flow.
 
         Returns:
-            - list: A list of GraphQLResult flow run objects
+            - set: A set of flow run ids that are ready
         """
         self.logger.debug("Querying for ready flow runs...")
 
@@ -543,7 +554,7 @@ class Agent:
             mutation,
             variables={
                 "input": {
-                    "before": str(now.add(seconds=prefetch_seconds)),
+                    "before": now.add(seconds=prefetch_seconds).isoformat(),
                     "labels": list(self.labels),
                     "tenant_id": self.client.active_tenant_id,
                 }
@@ -570,15 +581,24 @@ class Agent:
             )
 
         self.logger.debug(msg)
-        return self._get_flow_run_metadata(
-            target_flow_run_ids, start_time=now.subtract(seconds=3)
-        )
+        return target_flow_run_ids
 
     def _get_flow_run_metadata(
-        self, flow_run_ids: Iterable[str], start_time: pendulum.DateTime
-    ) -> list:
+        self,
+        flow_run_ids: Iterable[str],
+    ) -> List["GraphQLResult"]:
         """
-        Get metadata about a collection of flow run ids
+        Get metadata about a collection of flow run ids to that the agent is preparing
+        to submit
+
+        This function will filter the flow runs to a collection where:
+
+        - The flow run is in a 'Scheduled' state. This prevents flow runs that have
+          been submitted by another agent from being submitted again.
+
+        - The flow run is in another state, but has task runs in a 'Running' state
+          scheduled to start now. This is for retries in which the flow run is placed
+          back into the ready queue but is not in a Scheduled state.
 
         Args:
             flow_run_ids: Flow run ids to query (order will not be respected)
@@ -593,29 +613,34 @@ class Agent:
         flow_run_ids = list(flow_run_ids)
         self.logger.debug(f"Retrieving metadata for {len(flow_run_ids)} flow run(s)...")
 
+        # This buffer allows flow runs to retry immediately in their own deployment
+        # without the agent creating a second deployment
+        retry_start_time_buffer = pendulum.now("UTC").subtract(seconds=3).isoformat()
+
+        where = {
+            # Only get flow runs in the requested set
+            "id": {"_in": flow_run_ids},
+            # and filter by the additional criteria...
+            "_or": [
+                # This flow run has not been taken by another agent
+                {"state": {"_eq": "Scheduled"}},
+                # Or, this flow run has been set to retry and has not been immediately
+                # retried in its own process
+                {
+                    "state": {"_eq": "Running"},
+                    "task_runs": {
+                        "state_start_time": {"_lte": retry_start_time_buffer}
+                    },
+                },
+            ],
+        }
+
         query = {
             "query": {
                 with_args(
                     "flow_run",
                     {
-                        # match flow runs in the flow_run_ids list
-                        "where": {
-                            "id": {"_in": flow_run_ids},
-                            "_or": [
-                                # who are EITHER scheduled...
-                                {"state": {"_eq": "Scheduled"}},
-                                # OR running with task runs scheduled to start more than 3
-                                # seconds ago
-                                {
-                                    "state": {"_eq": "Running"},
-                                    "task_runs": {
-                                        "state_start_time": {
-                                            "_lte": str(start_time)  # type: ignore
-                                        }
-                                    },
-                                },
-                            ],
-                        },
+                        "where": where,
                         "order_by": {"scheduled_start_time": EnumValue("asc")},
                     },
                 ): {
@@ -635,13 +660,13 @@ class Agent:
                         "version",
                         "core_version",
                     },
+                    # Collect and return task run metadata as well so the state can be
+                    # updated in `_mark_flow_as_submitted`
                     with_args(
                         "task_runs",
                         {
                             "where": {
-                                "state_start_time": {
-                                    "_lte": str(start_time)  # type: ignore
-                                }
+                                "state_start_time": {"_lte": retry_start_time_buffer}
                             }
                         },
                     ): {"id", "version", "task_id", "serialized_state"},

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -156,7 +156,7 @@ def test_get_ready_flow_runs(monkeypatch, cloud_api):
 
     agent = Agent()
     flow_runs = agent._get_ready_flow_runs()
-    assert flow_runs == [GraphQLResult({"id": "id", "scheduled_start_time": str(dt)})]
+    assert flow_runs == {"id"}
 
 
 def test_get_ready_flow_runs_ignores_currently_submitting_runs(monkeypatch, cloud_api):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -10,7 +10,7 @@ from prefect.agent import Agent
 from prefect.engine.state import Scheduled, Failed, Submitted
 from prefect.utilities.configuration import set_temporary_config
 from prefect.utilities.exceptions import AuthorizationError
-from prefect.utilities.graphql import GraphQLResult
+from prefect.utilities.graphql import GraphQLResult, EnumValue, with_args
 from prefect.utilities.compatibility import nullcontext
 
 
@@ -160,58 +160,102 @@ def test_get_ready_flow_runs(monkeypatch, cloud_api):
 
 
 def test_get_ready_flow_runs_ignores_currently_submitting_runs(monkeypatch, cloud_api):
-    gql_return = MagicMock(
-        return_value=MagicMock(
-            data=MagicMock(
-                get_runs_in_queue=MagicMock(flow_run_ids=["id1", "id2"]),
-                flow_run=[
-                    GraphQLResult(
-                        {"id": "id", "scheduled_start_time": str(pendulum.now())}
-                    )
-                ],
-            )
-        )
-    )
-    client = MagicMock()
-    client.return_value.graphql = gql_return
-    monkeypatch.setattr("prefect.agent.agent.Client", client)
+    Client = MagicMock()
+    Client().graphql.return_value.data.get_runs_in_queue.flow_run_ids = ["id1", "id2"]
+    monkeypatch.setattr("prefect.agent.agent.Client", Client)
 
     agent = Agent()
     agent.submitting_flow_runs.add("id2")
-    agent._get_ready_flow_runs()
-
-    assert len(gql_return.call_args_list) == 2
-    assert (
-        'id: { _in: ["id1"] }'
-        in list(gql_return.call_args_list[1][0][0]["query"].keys())[0]
-    )
+    assert agent._get_ready_flow_runs() == {"id1"}
 
 
-def test_get_ready_flow_runs_does_not_use_submitting_flow_runs_directly(
+def test_get_ready_flow_runs_copies_submitting_flow_runs(
     monkeypatch, caplog, cloud_api
 ):
-    gql_return = MagicMock(
-        return_value=MagicMock(
-            data=MagicMock(
-                get_runs_in_queue=MagicMock(flow_run_ids=["already-submitted-id"]),
-                flow_run=[{"id": "id"}],
-            )
-        )
-    )
-    client = MagicMock()
-    client.return_value.graphql = gql_return
-    monkeypatch.setattr("prefect.agent.agent.Client", client)
+    Client = MagicMock()
+    Client().graphql.return_value.data.get_runs_in_queue.flow_run_ids = [
+        "already-submitted-id"
+    ]
+    monkeypatch.setattr("prefect.agent.agent.Client", Client)
 
     agent = Agent()
     agent.logger.setLevel(logging.DEBUG)
-    copy_mock = MagicMock(return_value=set(["already-submitted-id"]))
-    agent.submitting_flow_runs = MagicMock(copy=copy_mock)
+    agent.submitting_flow_runs = MagicMock()
+    agent.submitting_flow_runs.copy.return_value = {"already-submitted-id"}
 
     flow_runs = agent._get_ready_flow_runs()
-
-    assert flow_runs == []
+    assert flow_runs == set()
     assert "1 already being submitted: ['already-submitted-id']" in caplog.text
-    copy_mock.assert_called_once_with()
+    agent.submitting_flow_runs.copy.assert_called_once_with()
+
+
+def test_get_flow_run_metadata(monkeypatch, cloud_api):
+    Client = MagicMock()
+    monkeypatch.setattr("prefect.agent.agent.Client", Client)
+    now = pendulum.now()
+    monkeypatch.setattr("prefect.agent.agent.pendulum.now", lambda *args: now)
+
+    agent = Agent()
+    agent._get_flow_run_metadata(["id1", "id2"])
+
+    Client().graphql.assert_called_with(
+        {
+            "query": {
+                with_args(
+                    "flow_run",
+                    {
+                        "where": {
+                            "id": {"_in": ["id1", "id2"]},
+                            "_or": [
+                                {"state": {"_eq": "Scheduled"}},
+                                {
+                                    "state": {"_eq": "Running"},
+                                    "task_runs": {
+                                        "state_start_time": {
+                                            "_lte": now.subtract(seconds=3).isoformat()
+                                        }
+                                    },
+                                },
+                            ],
+                        },
+                        "order_by": {"scheduled_start_time": EnumValue("asc")},
+                    },
+                ): {
+                    "id": True,
+                    "version": True,
+                    "state": True,
+                    "serialized_state": True,
+                    "parameters": True,
+                    "scheduled_start_time": True,
+                    "run_config": True,
+                    "name": True,
+                    "flow": {
+                        "version",
+                        "id",
+                        "environment",
+                        "core_version",
+                        "name",
+                        "storage",
+                    },
+                    with_args(
+                        "task_runs",
+                        {
+                            "where": {
+                                "state_start_time": {
+                                    "_lte": now.subtract(seconds=3).isoformat()
+                                }
+                            }
+                        },
+                    ): {
+                        "serialized_state",
+                        "version",
+                        "id",
+                        "task_id",
+                    },
+                }
+            }
+        }
+    )
 
 
 @pytest.mark.parametrize("with_task_runs", [True, False])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds some comments explaining the query that is used during metadata retrieval and clarifies the filtering used for retries and duplicate submission prevention.  

## Changes
<!-- What does this PR change? -->

- `_get_ready_flow_runs` returns a `Set[str]` of flow run ids instead of calling `_get_flow_run_metadata` directly
- `_get_flow_run_metadata` is called separately after `_get_ready_flow_runs` which will be useful for #4532 in which we may want to skip metadata queries


## Importance
<!-- Why is this PR important? -->

Clarifies confusing behavior; refactors a little to make #4532 simpler

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~ not user facing
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)