### PR TITLE
Rename `TaskRunView.result` to `TaskRunView.get_result()`

### DIFF
--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -56,8 +56,7 @@ class TaskRunView:
         # Uses NotLoaded so to separate from return values of `None`
         self._result: Any = NotLoaded
 
-    @property
-    def result(self) -> Any:
+    def get_result(self) -> Any:
         """
         The result of this task run loaded from the `Result` location. Lazily loaded
         on the first call then cached for repeated access. For the parent of mapped
@@ -65,6 +64,9 @@ class TaskRunView:
         credentials to be present if the result location is remote (ie S3). If your
         flow was run on another machine and `LocalResult` was used, we will fail
         to load the result.
+
+        See `TaskRunView.iter_mapped` for lazily iterating through mapped tasks instead
+        of retrieving all of the results at once.
 
         Returns:
             Any: The value your task returned
@@ -289,7 +291,7 @@ class TaskRunView:
         return task_runs
 
     def __repr__(self) -> str:
-        result = "<not loaded>" if self._result is NotLoaded else repr(self.result)
+        result = "<not loaded>" if self._result is NotLoaded else repr(self._result)
         return (
             f"{type(self).__name__}"
             "("

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -165,7 +165,7 @@ def test_task_run_view_from_task_slug_where_clause(monkeypatch, map_index):
 
 
 @pytest.mark.parametrize("result_value", [None, "hello-world"])
-def test_task_run_view_result_loads_result_data(tmpdir, result_value):
+def test_task_run_view_get_result_loads_result_data(tmpdir, result_value):
     result = LocalResult(dir=tmpdir).write(result_value)
 
     # Instantiate a very minimal task run view
@@ -184,17 +184,17 @@ def test_task_run_view_result_loads_result_data(tmpdir, result_value):
     assert "result=<not loaded>" in repr(task_run)
 
     # The result is loaded
-    assert task_run.result == result_value
+    assert task_run.get_result() == result_value
 
     # Future calls are cached
     assert task_run._result == result_value
-    assert task_run.result is task_run.result
+    assert task_run.get_result() is task_run.get_result()
 
     # Displays in the repr now
     assert f"result={result_value!r}" in repr(task_run)
 
 
-def test_task_run_view_result_loads_mapped_result_data(tmpdir):
+def test_task_run_view_get_result_loads_mapped_result_data(tmpdir):
     # Instantiate a very minimal task run view
     task_run = TaskRunView(
         task_run_id="fake-id",
@@ -225,11 +225,11 @@ def test_task_run_view_result_loads_mapped_result_data(tmpdir):
     task_run._query_for_task_runs = query_mock
 
     # The result is loaded
-    assert task_run.result == [1, 2]
+    assert task_run.get_result() == [1, 2]
 
     # Future calls are cached
     assert task_run._result == [1, 2]
-    assert task_run.result is task_run.result
+    assert task_run.get_result() is task_run.get_result()
 
     # Displays in the repr now
     assert f"result={[1, 2]!r}" in repr(task_run)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Per discussion at #4530, updating this from a property to a method.