### PR TITLE
Handle events with missing timestamps in K8s agent

### DIFF
--- a/changes/pr4544.yaml
+++ b/changes/pr4544.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Handle events with missing timestamps in K8s agent - [#4544](https://github.com/PrefectHQ/prefect/pull/4544)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -229,9 +229,10 @@ class KubernetesAgent(Agent):
                                 for event in sorted(
                                     pod_events.items, key=lambda x: x.last_timestamp
                                 ):
-                                    # Skip old events
+                                    # Skip old events or events without timestamps
                                     if (
-                                        event.last_timestamp
+                                        not event.last_timestamp
+                                        or event.last_timestamp
                                         < self.job_pod_event_timestamps[job_name][
                                             pod_name
                                         ]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

It looks like the event timestamp can be null per https://prefect-community.slack.com/archives/CL09KU1K7/p1621293779234300 while streaming event logs from K8s

## Changes
<!-- What does this PR change? -->

- Events with null timestamps are ignored


## Importance
<!-- Why is this PR important? -->

Fixes bug


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)