### PR TITLE
Support all arguments in MySQL Tasks' run methods and support SSL configuration

### DIFF
--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -216,24 +216,24 @@ class MySQLFetch(Task):
         Task run method. Executes a query against MySQL database and fetches results.
 
         Args:
-        - db_name (str): name of MySQL database
-        - user (str): user name used to authenticate
-        - password (str): password used to authenticate
-        - host (str): database host address
-        - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not
-            provided
-        - fetch (str, optional): one of "one" "many" or "all", used to determine how many
-            results to fetch from executed query
-        - fetch_count (int, optional): if fetch = 'many', determines the number of results to
-            fetch, defaults to 10
-        - query (str, optional): query to execute against database
-        - commit (bool, optional): set to True to commit transaction, defaults to false
-        - charset (str, optional): charset of the query, defaults to "utf8mb4"
-        - cursor_type (Union[str, Callable], optional): The cursor type to use.
-            Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
-            or a full cursor class.
-        - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
-                parameters used for establishing encrypted connections using SSL
+            - db_name (str): name of MySQL database
+            - user (str): user name used to authenticate
+            - password (str): password used to authenticate
+            - host (str): database host address
+            - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not
+                provided
+            - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+                results to fetch from executed query
+            - fetch_count (int, optional): if fetch = 'many', determines the number of results to
+                fetch, defaults to 10
+            - query (str, optional): query to execute against database
+            - commit (bool, optional): set to True to commit transaction, defaults to false
+            - charset (str, optional): charset of the query, defaults to "utf8mb4"
+            - cursor_type (Union[str, Callable], optional): The cursor type to use.
+                Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
+                or a full cursor class.
+            - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
+                    parameters used for establishing encrypted connections using SSL
 
         Returns:
             - results (tuple or list of tuples): records from provided query

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -20,6 +20,8 @@ class MySQLExecute(Task):
         - query (str, optional): query to execute against database
         - commit (bool, optional): set to True to commit transaction, defaults to false
         - charset (str, optional): charset you want to use (defaults to utf8mb4)
+        - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
+                parameters used for establishing encrypted connections using SSL
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -34,6 +36,7 @@ class MySQLExecute(Task):
         query: str = None,
         commit: bool = False,
         charset: str = "utf8mb4",
+        ssl: dict = None,
         **kwargs: Any,
     ):
         self.db_name = db_name
@@ -44,17 +47,49 @@ class MySQLExecute(Task):
         self.query = query
         self.commit = commit
         self.charset = charset
+        self.ssl = ssl
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("query", "commit", "charset")
-    def run(self, query: str, commit: bool = False, charset: str = "utf8mb4") -> int:
+    @defaults_from_attrs(
+        "db_name",
+        "user",
+        "password",
+        "host",
+        "port",
+        "query",
+        "commit",
+        "charset",
+        "ssl",
+    )
+    def run(
+        self,
+        db_name: str = None,
+        user: str = None,
+        password: str = None,
+        host: str = None,
+        port: int = 3306,
+        query: str = None,
+        commit: bool = False,
+        charset: str = "utf8mb4",
+        ssl: dict = None,
+    ) -> int:
         """
         Task run method. Executes a query against MySQL database.
 
         Args:
+            - db_name (str): name of MySQL database
+            - user (str): user name used to authenticate
+            - password (str): password used to authenticate
+            - host (str): database host address
+            - port (int, optional): port used to connect to MySQL database, defaults to 3307
+                if not provided
             - query (str, optional): query to execute against database
-            - commit (bool, optional): set to True to commit transaction, defaults to False
-            - charset (str, optional): charset of the query, defaults to "utf8mb4"
+            - commit (bool, optional): set to True to commit transaction, defaults to false
+            - charset (str, optional): charset you want to use (defaults to "utf8mb4")
+            - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
+                parameters used for establishing encrypted connections using SSL
+            - **kwargs (Any, optional): additional keyword arguments to pass to the
+                Task constructor
 
         Returns:
             - executed (int): number of affected rows
@@ -72,6 +107,7 @@ class MySQLExecute(Task):
             db=self.db_name,
             charset=self.charset,
             port=self.port,
+            ssl=ssl,
         )
 
         try:
@@ -111,6 +147,8 @@ class MySQLFetch(Task):
         - cursor_type (Union[str, Callable], optional): The cursor type to use.
             Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
             or a full cursor class.
+        - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
+                parameters used for establishing encrypted connections using SSL
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """
@@ -128,6 +166,7 @@ class MySQLFetch(Task):
         commit: bool = False,
         charset: str = "utf8mb4",
         cursor_type: Union[str, Callable] = "cursor",
+        ssl: dict = None,
         **kwargs: Any,
     ):
         self.db_name = db_name
@@ -141,34 +180,60 @@ class MySQLFetch(Task):
         self.commit = commit
         self.charset = charset
         self.cursor_type = cursor_type
+        self.ssl = ssl
         super().__init__(**kwargs)
 
     @defaults_from_attrs(
-        "fetch", "fetch_count", "query", "commit", "charset", "cursor_type"
+        "db_name",
+        "user",
+        "password",
+        "host",
+        "port",
+        "fetch",
+        "fetch_count",
+        "query",
+        "commit",
+        "charset",
+        "cursor_type",
+        "ssl",
     )
     def run(
         self,
-        query: str,
+        db_name: str,
+        user: str,
+        password: str,
+        host: str,
+        port: int = 3306,
         fetch: str = "one",
         fetch_count: int = 10,
+        query: str = None,
         commit: bool = False,
         charset: str = "utf8mb4",
         cursor_type: Union[str, Callable] = "cursor",
+        ssl: dict = None,
     ) -> Any:
         """
         Task run method. Executes a query against MySQL database and fetches results.
 
         Args:
-            - fetch (str, optional): one of "one" "many" or "all", used to determine how many
-                results to fetch from executed query
-            - fetch_count (int, optional): if fetch = 'many', determines the number of results
-                to fetch, defaults to 10
-            - query (str, optional): query to execute against database
-            - commit (bool, optional): set to True to commit transaction, defaults to false
-            - charset (str, optional): charset of the query, defaults to "utf8mb4"
-            - cursor_type (Union[str, Callable], optional): The cursor type to use.
-                Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
-                or a full cursor class.
+        - db_name (str): name of MySQL database
+        - user (str): user name used to authenticate
+        - password (str): password used to authenticate
+        - host (str): database host address
+        - port (int, optional): port used to connect to MySQL database, defaults to 3307 if not
+            provided
+        - fetch (str, optional): one of "one" "many" or "all", used to determine how many
+            results to fetch from executed query
+        - fetch_count (int, optional): if fetch = 'many', determines the number of results to
+            fetch, defaults to 10
+        - query (str, optional): query to execute against database
+        - commit (bool, optional): set to True to commit transaction, defaults to false
+        - charset (str, optional): charset of the query, defaults to "utf8mb4"
+        - cursor_type (Union[str, Callable], optional): The cursor type to use.
+            Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
+            or a full cursor class.
+        - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
+                parameters used for establishing encrypted connections using SSL
 
         Returns:
             - results (tuple or list of tuples): records from provided query
@@ -212,6 +277,7 @@ class MySQLFetch(Task):
             charset=self.charset,
             port=self.port,
             cursorclass=cursor_class,
+            ssl=ssl,
         )
 
         try:

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -154,20 +154,20 @@ class MySQLFetch(Task):
     """
 
     def __init__(
-            self,
-            db_name: str = None,
-            user: str = None,
-            password: str = None,
-            host: str = None,
-            port: int = 3306,
-            fetch: str = "one",
-            fetch_count: int = 10,
-            query: str = None,
-            commit: bool = False,
-            charset: str = "utf8mb4",
-            cursor_type: Union[str, Callable] = "cursor",
-            ssl: dict = None,
-            **kwargs: Any,
+        self,
+        db_name: str = None,
+        user: str = None,
+        password: str = None,
+        host: str = None,
+        port: int = 3306,
+        fetch: str = "one",
+        fetch_count: int = 10,
+        query: str = None,
+        commit: bool = False,
+        charset: str = "utf8mb4",
+        cursor_type: Union[str, Callable] = "cursor",
+        ssl: dict = None,
+        **kwargs: Any,
     ):
         self.db_name = db_name
         self.user = user

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -87,7 +87,8 @@ class MySQLExecute(Task):
             - commit (bool, optional): set to True to commit transaction, defaults to false
             - charset (str, optional): charset you want to use (defaults to "utf8mb4")
             - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
-                parameters used for establishing encrypted connections using SSL
+                parameters used for establishing encrypted connections using SSL. To connect
+                with SSL, at least `ssl_ca`, `ssl_cert`, and `ssl_key` must be specified.
 
         Returns:
             - executed (int): number of affected rows
@@ -146,7 +147,8 @@ class MySQLFetch(Task):
             Can be `'cursor'` (the default), `'dictcursor'`, `'sscursor'`, `'ssdictcursor'`,
             or a full cursor class.
         - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
-                parameters used for establishing encrypted connections using SSL
+                parameters used for establishing encrypted connections using SSL. To connect
+                with SSL, at least `ssl_ca`, `ssl_cert`, and `ssl_key` must be specified.
         - **kwargs (Any, optional): additional keyword arguments to pass to the
             Task constructor
     """

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -88,8 +88,6 @@ class MySQLExecute(Task):
             - charset (str, optional): charset you want to use (defaults to "utf8mb4")
             - ssl (dict, optional): A dict of arguments similar to mysql_ssl_set()’s
                 parameters used for establishing encrypted connections using SSL
-            - **kwargs (Any, optional): additional keyword arguments to pass to the
-                Task constructor
 
         Returns:
             - executed (int): number of affected rows

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -67,10 +67,10 @@ class MySQLExecute(Task):
         user: str = None,
         password: str = None,
         host: str = None,
-        port: int = 3306,
+        port: int = None,
         query: str = None,
-        commit: bool = False,
-        charset: str = "utf8mb4",
+        commit: bool = None,
+        charset: str = None,
         ssl: dict = None,
     ) -> int:
         """
@@ -201,13 +201,13 @@ class MySQLFetch(Task):
         user: str = None,
         password: str = None,
         host: str = None,
-        port: int = 3306,
-        fetch: str = "one",
-        fetch_count: int = 10,
+        port: int = None,
+        fetch: str = None,
+        fetch_count: int = None,
         query: str = None,
-        commit: bool = False,
-        charset: str = "utf8mb4",
-        cursor_type: Union[str, Callable] = "cursor",
+        commit: bool = None,
+        charset: str = None,
+        cursor_type: Union[str, Callable] = None,
         ssl: dict = None,
     ) -> Any:
         """

--- a/src/prefect/tasks/mysql/mysql.py
+++ b/src/prefect/tasks/mysql/mysql.py
@@ -28,10 +28,10 @@ class MySQLExecute(Task):
 
     def __init__(
         self,
-        db_name: str,
-        user: str,
-        password: str,
-        host: str,
+        db_name: str = None,
+        user: str = None,
+        password: str = None,
+        host: str = None,
         port: int = 3306,
         query: str = None,
         commit: bool = False,
@@ -154,20 +154,20 @@ class MySQLFetch(Task):
     """
 
     def __init__(
-        self,
-        db_name: str,
-        user: str,
-        password: str,
-        host: str,
-        port: int = 3306,
-        fetch: str = "one",
-        fetch_count: int = 10,
-        query: str = None,
-        commit: bool = False,
-        charset: str = "utf8mb4",
-        cursor_type: Union[str, Callable] = "cursor",
-        ssl: dict = None,
-        **kwargs: Any,
+            self,
+            db_name: str = None,
+            user: str = None,
+            password: str = None,
+            host: str = None,
+            port: int = 3306,
+            fetch: str = "one",
+            fetch_count: int = 10,
+            query: str = None,
+            commit: bool = False,
+            charset: str = "utf8mb4",
+            cursor_type: Union[str, Callable] = "cursor",
+            ssl: dict = None,
+            **kwargs: Any,
     ):
         self.db_name = db_name
         self.user = user
@@ -199,10 +199,10 @@ class MySQLFetch(Task):
     )
     def run(
         self,
-        db_name: str,
-        user: str,
-        password: str,
-        host: str,
+        db_name: str = None,
+        user: str = None,
+        password: str = None,
+        host: str = None,
         port: int = 3306,
         fetch: str = "one",
         fetch_count: int = 10,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR introduces changes that address two issues #3845 and #4377. This should enable the mysql tasks to be configured completely from just the `run` method via secrets/params and also allows `ssl` options to be configured when creating a mysql connection.



## Changes
- update all init args to be keyword args
- update all run args to have all the same keyword args as __init__ and overrided via the `defaults_from_attrs` decorator
- support passing a `ssl` keyword argument with a dict to configure ssl when connecting




## Importance
- Allows Parameters and Secrets to be used for this task, which makes this task better support prefect features
- Allows ssl options to be configured so MySQL DB's with TLS >= 1.2 can be connected to with these tasks.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)