### PR TITLE
Pass base url to ui env

### DIFF
--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -128,6 +128,7 @@ services:
     command: "/intercept.sh"
     environment:
       PREFECT_SERVER__APOLLO_URL: ${APOLLO_URL:-http://localhost:4200/graphql}
+      PREFECT_SERVER__BASE_URL: ${BASE_URL:-/}
     networks:
       - prefect-server
     healthcheck:

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -302,7 +302,9 @@ def setup_compose_env(
     )
 
     UI_ENV = dict(
-        APOLLO_URL=config.server.ui.apollo_url, PREFECT_UI_TAG=ui_version or default_tag
+        APOLLO_URL=config.server.ui.apollo_url,
+        BASE_URL=config.server.ui.base_url,
+        PREFECT_UI_TAG=ui_version or default_tag,
     )
 
     HASURA_ENV = dict(HASURA_HOST_PORT=str(hasura_port))


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Passes a base url to the UI container on Server startup, allowing serving the UI from a subdirectory/reverse proxy.



## Changes
<!-- What does this PR change? -->
Changes the CLI server command UI env vars and injects those env vars to the UI docker container



## Importance
<!-- Why is this PR important? -->
Resolves: https://github.com/PrefectHQ/ui/pull/450 and https://github.com/PrefectHQ/ui/issues/109



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)