### PR TITLE
Enable parallel pytest runs with xdist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx
+          command: pytest tests -vvrfEsx --numprocesses 4 --dist=loadfile
 
   # test a standard install of prefect
   # this ensures we correctly capture all ImportError sitautions
@@ -158,7 +158,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests -vvrfEsx
+          command: pytest tests -vvrfEsx --numprocesses 4 --dist=loadfile
 
   # test task library explicitly
   test_task_library:
@@ -192,7 +192,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests/tasks -vvrfEsx
+          command: pytest tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   # ----------------------------------
   # Run unit tests in Python 3.6-3.8
@@ -226,7 +226,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests --ignore=tests/tasks -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   test_37:
     docker:
@@ -255,7 +255,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests --ignore=tests/tasks -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   test_38:
     docker:
@@ -284,7 +284,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests --ignore=tests/tasks -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   test_39:
     docker:
@@ -316,7 +316,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests --ignore=tests/tasks -vvrfEsx
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   build_docker_image:
     docker:

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -174,13 +174,14 @@ def setup_compose_file(
     no_ui_port=False,
     no_server_port=False,
     use_volume=True,
+    temp_dir: str = None,
 ) -> str:
     # Defaults should be set in the `click` command option, these defaults are to
     # simplify testing
 
     base_compose_path = Path(__file__).parents[0].joinpath("docker-compose.yml")
 
-    temp_dir = tempfile.gettempdir()
+    temp_dir = temp_dir or tempfile.gettempdir()
     temp_path = os.path.join(temp_dir, "docker-compose.yml")
 
     # Copy the docker-compose file to the temp location

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 5.0
+pytest >= 6.0
 testfixtures >= 6.10.3
 pytest-env >= 0.6.0
-pytest-xdist >= 1.23
+pytest-xdist >= 2.0

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -230,13 +230,15 @@ class TestSetupComposeFile:
     @pytest.mark.parametrize(
         "service", ["postgres", "hasura", "graphql", "ui", "server"]
     )
-    def test_disable_port_mapping(self, service):
-        compose_file = setup_compose_file(**{f"no_{service}_port": True})
+    def test_disable_port_mapping(self, service, tmpdir):
+        compose_file = setup_compose_file(
+            **{f"no_{service}_port": True}, temp_dir=str(tmpdir)
+        )
 
         with open(compose_file) as file:
             compose_yml = yaml.safe_load(file)
 
-        default_compose_file = setup_compose_file()
+        default_compose_file = setup_compose_file(temp_dir=str(tmpdir))
         with open(default_compose_file) as file:
             default_compose_yml = yaml.safe_load(file)
 
@@ -250,15 +252,13 @@ class TestSetupComposeFile:
         default_compose_yml["services"][service].pop("ports")
         assert compose_yml == default_compose_yml
 
-    def test_disable_ui_service(
-        self,
-    ):
-        compose_file = setup_compose_file(no_ui=True)
+    def test_disable_ui_service(self, tmpdir):
+        compose_file = setup_compose_file(no_ui=True, temp_dir=str(tmpdir))
 
         with open(compose_file) as file:
             compose_yml = yaml.safe_load(file)
 
-        default_compose_file = setup_compose_file()
+        default_compose_file = setup_compose_file(temp_dir=str(tmpdir))
         with open(default_compose_file) as file:
             default_compose_yml = yaml.safe_load(file)
 
@@ -269,13 +269,13 @@ class TestSetupComposeFile:
         default_compose_yml["services"].pop("ui")
         assert compose_yml == default_compose_yml
 
-    def test_external_postgres(self):
-        compose_file = setup_compose_file(external_postgres=True)
+    def test_external_postgres(self, tmpdir):
+        compose_file = setup_compose_file(external_postgres=True, temp_dir=str(tmpdir))
 
         with open(compose_file) as file:
             compose_yml = yaml.safe_load(file)
 
-        default_compose_file = setup_compose_file()
+        default_compose_file = setup_compose_file(temp_dir=str(tmpdir))
         with open(default_compose_file) as file:
             default_compose_yml = yaml.safe_load(file)
 
@@ -289,15 +289,13 @@ class TestSetupComposeFile:
         default_compose_yml["services"]["hasura"]["depends_on"].remove("postgres")
         assert compose_yml == default_compose_yml
 
-    def test_disable_postgres_volumes(
-        self,
-    ):
-        compose_file = setup_compose_file(use_volume=False)
+    def test_disable_postgres_volumes(self, tmpdir):
+        compose_file = setup_compose_file(use_volume=False, temp_dir=str(tmpdir))
 
         with open(compose_file) as file:
             compose_yml = yaml.safe_load(file)
 
-        default_compose_file = setup_compose_file()
+        default_compose_file = setup_compose_file(temp_dir=str(tmpdir))
         with open(default_compose_file) as file:
             default_compose_yml = yaml.safe_load(file)
 

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -269,7 +269,7 @@ class TestDaskExecutor:
 
         def record_times():
             start_time = time.time()
-            time.sleep(0.75)
+            time.sleep(2)
             end_time = time.time()
             return start_time, end_time
 

--- a/tests/utilities/test_edges.py
+++ b/tests/utilities/test_edges.py
@@ -3,7 +3,7 @@ import pytest
 from prefect import Flow, Task, task
 from prefect.utilities import edges, tasks
 
-ALL_ANNOTATIONS = {edges.unmapped, edges.mapped, edges.flatten}
+ALL_ANNOTATIONS = [edges.unmapped, edges.mapped, edges.flatten]
 
 
 class TestEdgeAnnotations:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Improves test times in CI from 4m 20s to 1m 30s for a ~3x speedup by using `pytest-xdist` to parallelize execution.

## Changes
<!-- What does this PR change? -->

- Identifies and reduces brittleness of some tests that are not robust to running in parallel
- Upgrades pytest/xdist
- Adds multiprocesss test execution to CI
- Fixes (hopefully) frequently brittle timeout test


## Importance
<!-- Why is this PR important? -->

Faster CI = Faster feedback

## Future work

- Do we want a makefile or something instead of repeating the pytest args repeatedly? It'd be nice for local development too
- Appveyor is still slow, ought to replace it soon anyway
- Netlify builds block merge; is that necessary? We're not publishing `master` docs anyway so can we just make sure it passes before a release manually?