### PR TITLE
Task Library: Add Google Cloud Platform Secret Manager

### DIFF
--- a/changes/pr4561.yaml
+++ b/changes/pr4561.yaml
@@ -1,0 +1,6 @@
+
+task:
+  - "Add Google Cloud Platform GCPSecret task - [#4561](https://github.com/PrefectHQ/prefect/pull/4561)"
+
+contributor:
+  - "[Stéphan Taljaard](https://github.com/taljaards)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -384,6 +384,7 @@ classes = [
 title = "Google Cloud Tasks"
 module = "prefect.tasks.gcp"
 classes = [
+        "GCPSecret",
         "GCSDownload",
         "GCSUpload",
         "GCSCopy",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ orchestration_extras = {
     "aws": ["boto3 >= 1.9, < 2.0"],
     "azure": ["azure-storage-blob >= 12.1.0, < 13.0"],
     "bitbucket": ["atlassian-python-api >= 2.0.1"],
-    "gcp": ["google-cloud-storage >= 1.13, < 2.0"],
+    "gcp": [
+        "google-cloud-secret-manager = >=2.4.0",
+        "google-cloud-storage >= 1.13, < 2.0"
+    ],
     "git": ["dulwich >= 0.19.7"],
     "github": ["PyGithub >= 1.51, < 2.0"],
     "gitlab": ["python-gitlab >= 2.5.0, < 3.0"],

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ orchestration_extras = {
     "azure": ["azure-storage-blob >= 12.1.0, < 13.0"],
     "bitbucket": ["atlassian-python-api >= 2.0.1"],
     "gcp": [
-        "google-cloud-secret-manager = >=2.4.0",
-        "google-cloud-storage >= 1.13, < 2.0"
+        "google-cloud-secret-manager >= 2.4.0",
+        "google-cloud-storage >= 1.13, < 2.0",
     ],
     "git": ["dulwich >= 0.19.7"],
     "github": ["PyGithub >= 1.51, < 2.0"],

--- a/src/prefect/tasks/gcp/__init__.py
+++ b/src/prefect/tasks/gcp/__init__.py
@@ -11,6 +11,7 @@ All GCP related tasks can be authenticated using the `GCP_CREDENTIALS` Prefect S
 """
 try:
     from prefect.tasks.gcp.storage import GCSDownload, GCSUpload, GCSCopy, GCSBlobExists
+    from prefect.tasks.gcp.secretmanager import GCPSecret
     from prefect.tasks.gcp.bigquery import (
         BigQueryTask,
         BigQueryLoadGoogleCloudStorage,

--- a/src/prefect/tasks/gcp/secretmanager.py
+++ b/src/prefect/tasks/gcp/secretmanager.py
@@ -1,4 +1,3 @@
-import json
 from typing import Union
 
 from google.cloud import secretmanager
@@ -49,7 +48,7 @@ class GCPSecret(SecretBase):
         secret_id: str = None,
         version_id: Union[str, int] = "latest",
         credentials: dict = None,
-    ) -> dict:
+    ) -> str:
         """
         Task run method.
 
@@ -63,7 +62,7 @@ class GCPSecret(SecretBase):
                 (https://googleapis.dev/python/google-api-core/latest/auth.html) will be used.
 
         Returns:
-            - dict: the contents of this secret, as a dictionary
+            - str: the contents of this secret
         """
         if project_id is None:
             raise ValueError("A GCP project ID must be provided.")
@@ -80,8 +79,4 @@ class GCPSecret(SecretBase):
         response = client.access_secret_version(name=name)
 
         # Return the decoded payload.
-        secret_string = response.payload.data.decode("UTF-8")
-
-        secret_dict = json.loads(secret_string)
-
-        return secret_dict
+        return response.payload.data.decode("UTF-8")

--- a/src/prefect/tasks/gcp/secretmanager.py
+++ b/src/prefect/tasks/gcp/secretmanager.py
@@ -13,13 +13,16 @@ class GCPSecret(SecretBase):
     Note that all initialization arguments can optionally be provided or overwritten at runtime.
 
     For authentication, there are three options: you can set the `GCP_CREDENTIALS` Prefect Secret
-    containing your GCP access keys, or [explicitly provide a credentials dictionary](https://googleapis.dev/python/google-api-core/latest/auth.html#explicit-credentials)
-    , or otherwise it will use [default Google client logic](https://googleapis.dev/python/google-api-core/latest/auth.html).
+    containing your GCP access keys, or [explicitly provide a credentials dictionary]
+    (https://googleapis.dev/python/google-api-core/latest/auth.html#explicit-credentials),
+    or otherwise it will use [default Google client logic]
+    (https://googleapis.dev/python/google-api-core/latest/auth.html).
 
     Args:
         - project_id (Union[str, int], optional): the name of the project where the Secret is saved
         - secret_id (str, optional): the name of the secret to retrieve
-        - version_id (Union[str, int], optional): the version number of the secret to use; defaults to 'latest'
+        - version_id (Union[str, int], optional): the version number of the secret to use;
+            defaults to 'latest'
         - credentials (dict, optional): dictionary containing GCP credentials
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -53,10 +56,11 @@ class GCPSecret(SecretBase):
         Args:
             - project_id (Union[str, int], optional): the name of the project where the Secret is saved
             - secret_id (str, optional): the name of the secret to retrieve
-            - version_id (Union[str, int], optional): the version number of the secret to use; defaults to "latest"
+            - version_id (Union[str, int], optional): the version number of the secret to use;
+                defaults to "latest"
             - credentials (dict, optional): your GCP credentials passed from an upstream Secret task.
-                If not provided here [default Google client logic](https://googleapis.dev/python/google-api-core/latest/auth.html)
-                will be used.
+                If not provided here [default Google client logic]
+                (https://googleapis.dev/python/google-api-core/latest/auth.html) will be used.
 
         Returns:
             - dict: the contents of this secret, as a dictionary

--- a/src/prefect/tasks/gcp/secretmanager.py
+++ b/src/prefect/tasks/gcp/secretmanager.py
@@ -1,0 +1,83 @@
+import json
+from typing import Union
+
+from google.cloud import secretmanager
+
+from prefect.tasks.secrets.base import SecretBase
+from prefect.utilities.tasks import defaults_from_attrs
+
+
+class GCPSecret(SecretBase):
+    """
+    Task for retrieving a secret from GCP Secrets Manager and returning it as a dictionary.
+    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+
+    For authentication, there are three options: you can set the `GCP_CREDENTIALS` Prefect Secret
+    containing your GCP access keys, or [explicitly provide a credentials dictionary](https://googleapis.dev/python/google-api-core/latest/auth.html#explicit-credentials)
+    , or otherwise it will use [default Google client logic](https://googleapis.dev/python/google-api-core/latest/auth.html).
+
+    Args:
+        - project_id (Union[str, int], optional): the name of the project where the Secret is saved
+        - secret_id (str, optional): the name of the secret to retrieve
+        - version_id (Union[str, int], optional): the version number of the secret to use; defaults to 'latest'
+        - credentials (dict, optional): dictionary containing GCP credentials
+        - **kwargs (dict, optional): additional keyword arguments to pass to the
+            Task constructor
+    """
+
+    def __init__(
+        self,
+        project_id: Union[str, int] = None,
+        secret_id: str = None,
+        version_id: Union[str, int] = "latest",
+        credentials: dict = None,
+        **kwargs,
+    ):
+        self.project_id = project_id
+        self.secret_id = secret_id
+        self.version_id = version_id
+        self.credentials = credentials
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs("project_id", "secret_id", "version_id", "credentials")
+    def run(
+        self,
+        project_id: Union[str, int] = None,
+        secret_id: str = None,
+        version_id: Union[str, int] = "latest",
+        credentials: dict = None,
+    ) -> dict:
+        """
+        Task run method.
+
+        Args:
+            - project_id (Union[str, int], optional): the name of the project where the Secret is saved
+            - secret_id (str, optional): the name of the secret to retrieve
+            - version_id (Union[str, int], optional): the version number of the secret to use; defaults to "latest"
+            - credentials (dict, optional): your GCP credentials passed from an upstream Secret task.
+                If not provided here [default Google client logic](https://googleapis.dev/python/google-api-core/latest/auth.html)
+                will be used.
+
+        Returns:
+            - dict: the contents of this secret, as a dictionary
+        """
+        if project_id is None:
+            raise ValueError("A GCP project ID must be provided.")
+        if secret_id is None:
+            raise ValueError("A GCP Secret Manager secret ID must be provided.")
+
+        # Create the Secret Manager client.
+        client = secretmanager.SecretManagerServiceClient(credentials=credentials)
+
+        # Build the resource name of the secret version.
+        name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
+
+        # Access the secret version.
+        response = client.access_secret_version(name=name)
+
+        # Return the decoded payload.
+        secret_string = response.payload.data.decode('UTF-8')
+
+        secret_dict = json.loads(secret_string)
+
+        return secret_dict

--- a/src/prefect/tasks/gcp/secretmanager.py
+++ b/src/prefect/tasks/gcp/secretmanager.py
@@ -76,7 +76,7 @@ class GCPSecret(SecretBase):
         response = client.access_secret_version(name=name)
 
         # Return the decoded payload.
-        secret_string = response.payload.data.decode('UTF-8')
+        secret_string = response.payload.data.decode("UTF-8")
 
         secret_dict = json.loads(secret_string)
 

--- a/tests/tasks/gcp/__init__.py
+++ b/tests/tasks/gcp/__init__.py
@@ -1,3 +1,4 @@
 import pytest
 
 pytest.importorskip("google.cloud")
+pytest.importorskip("google.cloud.secretmanager")

--- a/tests/tasks/gcp/test_secretmanager.py
+++ b/tests/tasks/gcp/test_secretmanager.py
@@ -1,0 +1,26 @@
+import pytest
+
+from prefect.tasks.gcp.secretmanager import GCPSecret
+
+
+class TestGCPSecretsTask:
+    def test_initialization(self):
+        task = GCPSecret("test")
+        assert task
+
+    def test_initialization_passes_to_task_constructor(self):
+        task = GCPSecret(name="test", tags=["GCP"])
+        assert task.name == "test"
+        assert task.tags == {"GCP"}
+
+    def test_raises_if_project_not_eventually_provided(self):
+        task = GCPSecret(secret_id="sherbet-lemon")
+
+        with pytest.raises(ValueError, match="project ID"):
+            task.run()
+
+    def test_raises_if_secret_not_eventually_provided(self):
+        task = GCPSecret(project_id="majestic-meerkat")
+
+        with pytest.raises(ValueError, match="secret ID"):
+            task.run()


### PR DESCRIPTION
## Summary
Added a task to pull a secret from [Google Cloud Platform's Secret Manager](https://cloud.google.com/secret-manager).
(Used the [AWS Secrets Manager task](https://github.com/PrefectHQ/prefect/blob/0ef255107b7b3b00165772b29e675536368a1e03/src/prefect/tasks/aws/secrets_manager.py) as example).




## Changes
- Adds a new task to optional extra `gcp` (`prefect.tasks.gcp.secretmanager.GCPSecret`).




## Importance
This allows more seamless interaction with the Google Cloud Platform and brings the `gcp` extra just a little bit more inline with the `aws` one.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests
- [x] adds a change file in the `changes/` directory
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs