### PR TITLE
Fix bug where agents use scheduled_start_time instead of state.start_time

### DIFF
--- a/changes/pr4568.yaml
+++ b/changes/pr4568.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug where agent uses originally scheduled start time instead of latest state - [#4568](https://github.com/PrefectHQ/prefect/pull/4568)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -363,7 +363,7 @@ class Agent:
             #
             # There are two possible states the flow run could be in at this point
             # - Scheduled - in this case the flow run state will have a start time
-            # - Running - in this case the flow run state may not have a start time and we default to now
+            # - Running - in this case the flow run state will not have a start time so we default to now
             flow_run_state = StateSchema().load(flow_run.serialized_state)
             start_time = getattr(flow_run_state, "start_time", pendulum.now())
             delay_seconds = max(0, (start_time - pendulum.now()).total_seconds())

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -643,7 +643,7 @@ class Agent:
 
         query = {
             "query": {
-                with_args("flow_run", {"where": where,}): {
+                with_args("flow_run", {"where": where}): {
                     "id": True,
                     "version": True,
                     "state": True,

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -357,8 +357,8 @@ class Agent:
             # not need to start until up to 10 seconds later so we need to wait to
             # prevent the flow from starting early
             #
-            # `state.start_time` should be used instead of `scheduled_start_time` for
-            # execution, `scheduled_start_time` is only to record the originally scheduled
+            # `state.start_time` is used instead of `flow_run.scheduled_start_time` for
+            # execution; `scheduled_start_time` is only to record the originally scheduled
             # start time of the flow run
             #
             # There are two possible states the flow run could be in at this point

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -459,7 +459,7 @@ def test_deploy_flow_run_sleeps_until_start_time(monkeypatch, cloud_api):
                 "serialized_state": Scheduled(
                     start_time=dt.add(seconds=10)
                 ).serialize(),
-                "scheduled_start_time": str(dt.add(seconds=10)),
+                "scheduled_start_time": str(dt),
                 "version": 1,
                 "task_runs": [
                     GraphQLResult(

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -456,7 +456,9 @@ def test_deploy_flow_run_sleeps_until_start_time(monkeypatch, cloud_api):
         flow_run=GraphQLResult(
             {
                 "id": "id",
-                "serialized_state": Scheduled().serialize(),
+                "serialized_state": Scheduled(
+                    start_time=dt.add(seconds=10)
+                ).serialize(),
                 "scheduled_start_time": str(dt.add(seconds=10)),
                 "version": 1,
                 "task_runs": [
@@ -464,7 +466,9 @@ def test_deploy_flow_run_sleeps_until_start_time(monkeypatch, cloud_api):
                         {
                             "id": "id",
                             "version": 1,
-                            "serialized_state": Scheduled().serialize(),
+                            "serialized_state": Scheduled(
+                                start_time=dt.add(seconds=10)
+                            ).serialize(),
                         }
                     )
                 ],

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -239,7 +239,6 @@ def test_get_flow_run_metadata(monkeypatch, cloud_api):
                                 },
                             ],
                         },
-                        "order_by": {"scheduled_start_time": EnumValue("asc")},
                     },
                 ): {
                     "id": True,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes bug where agents use `FlowRun.scheduled_start_time` instead of `FlowRun.state/serialized_state.start_time`. 



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
For Scheduled Runs, the "Start Now" functionality does not work because agents are waiting until the FlowRun's originally scheduled start time to execute. See issue originally filed in Cloud here https://github.com/PrefectHQ/cloud/issues/3410



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~