### PR TITLE
Release 0.14.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Released on May 25, 2021.
 - Refactor `Agent` base class for readability - [#4341](https://github.com/PrefectHQ/prefect/pull/4341)
 - Display the agent config id on agent startup if set - [#4524](https://github.com/PrefectHQ/prefect/pull/4524)
 - Add debug logs during agent auth verification - [#4547](https://github.com/PrefectHQ/prefect/pull/4547)
+- Sending logs to Cloud can be globally disabled via config in addition to the agent flag - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)
 
 ### Task Library
 
@@ -24,7 +25,7 @@ Released on May 25, 2021.
 
 ### Deprecations
 
-- `logging.log_to_cloud` has been deprecated in favor of `cloud.send_flow_run_logs` which can be toggled in the config - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)
+- `logging.log_to_cloud` has been deprecated in favor of `cloud.send_flow_run_logs` - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.14.20 <Badge text="beta" type="success" />
+
+Released on May 25, 2021.
+
+### Enhancements
+
+- Refactor `Agent` base class for readability - [#4341](https://github.com/PrefectHQ/prefect/pull/4341)
+- Display the agent config id on agent startup if set - [#4524](https://github.com/PrefectHQ/prefect/pull/4524)
+- Add debug logs during agent auth verification - [#4547](https://github.com/PrefectHQ/prefect/pull/4547)
+
+### Task Library
+
+- Enable sending attachments with emails in the `EmailTask` - [#4457](https://github.com/PrefectHQ/prefect/pull/4457)
+- Add Google Cloud Platform `GCPSecret` task - [#4561](https://github.com/PrefectHQ/prefect/pull/4561)
+
+### Fixes
+
+- Fix `import_object` handling of submodules that are not attributes - [#4513](https://github.com/PrefectHQ/prefect/pull/4513)
+- Fix `DockerStorage` building with python slim image - [#4523](https://github.com/PrefectHQ/prefect/pull/4523)
+- Gracefully handle events with missing timestamps in K8s agent - [#4544](https://github.com/PrefectHQ/prefect/pull/4544)
+- Fix bug where agent uses originally scheduled start time instead of latest state time - [#4568](https://github.com/PrefectHQ/prefect/pull/4568)
+
+### Deprecations
+
+- `logging.log_to_cloud` has been deprecated in favor of `cloud.send_flow_run_logs` which can be toggled in the config - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)
+
+### Contributors
+
+- [Stéphan Taljaard](https://github.com/taljaards)
+- [Thomas Heyenbrock](https://github.com/thomasheyenbrock)
+
 ## 0.14.19 <Badge text="beta" type="success" />
 
 Released on May 11, 2021 as a hotfix for 0.14.18

--- a/changes/pr4341.yaml
+++ b/changes/pr4341.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Refactor `Agent` base class for readability - [#4341](https://github.com/PrefectHQ/prefect/pull/4341)"

--- a/changes/pr4457.yaml
+++ b/changes/pr4457.yaml
@@ -1,5 +1,0 @@
-feature:
-  - "Enable sending attachments with emails in the EmailTask - [#4457](https://github.com/PrefectHQ/prefect/pull/4457)"
-
-contributor:
-  - "[Thomas Heyenbrock](https://github.com/thomasheyenbrock)"

--- a/changes/pr4487.yaml
+++ b/changes/pr4487.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Replace `logging.log_to_cloud` with `cloud.send_flow_run_logs` and allow user to toggle in config - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)"

--- a/changes/pr4513.yaml
+++ b/changes/pr4513.yaml
@@ -1,3 +1,0 @@
-
-fix:
-  - "Fix `import_object` handling of submodules that are not attributes - [#4513](https://github.com/PrefectHQ/prefect/pull/4513)"

--- a/changes/pr4523.yaml
+++ b/changes/pr4523.yaml
@@ -1,3 +1,0 @@
-
-fix:
-  - "Fix `DockerStorage` building with python slim image - [#4523](https://github.com/PrefectHQ/prefect/pull/4523)"

--- a/changes/pr4524.yaml
+++ b/changes/pr4524.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Display the agent config id on agent startup if set - [#4524](https://github.com/PrefectHQ/prefect/pull/4524)"

--- a/changes/pr4544.yaml
+++ b/changes/pr4544.yaml
@@ -1,3 +1,0 @@
-
-fix:
-  - "Handle events with missing timestamps in K8s agent - [#4544](https://github.com/PrefectHQ/prefect/pull/4544)"

--- a/changes/pr4547.yaml
+++ b/changes/pr4547.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Add debug logs during agent auth verification - [#4547](https://github.com/PrefectHQ/prefect/pull/4547)"

--- a/changes/pr4561.yaml
+++ b/changes/pr4561.yaml
@@ -1,6 +1,0 @@
-
-task:
-  - "Add Google Cloud Platform GCPSecret task - [#4561](https://github.com/PrefectHQ/prefect/pull/4561)"
-
-contributor:
-  - "[Stéphan Taljaard](https://github.com/taljaards)"

--- a/changes/pr4568.yaml
+++ b/changes/pr4568.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Fix bug where agent uses originally scheduled start time instead of latest state - [#4568](https://github.com/PrefectHQ/prefect/pull/4568)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -80,7 +80,7 @@ module.exports = {
       {
         text: 'API Reference',
         items: [
-          { text: 'Latest (0.14.19)', link: '/api/latest/' },
+          { text: 'Latest (0.14.20)', link: '/api/latest/' },
           { text: '0.13.19', link: '/api/0.13.19/' },
           { text: '0.12.6', link: '/api/0.12.6/' },
           { text: '0.11.5', link: '/api/0.11.5/' },


### PR DESCRIPTION
# Changelog

## 0.14.20 <Badge text="beta" type="success" />

Released on May 25, 2021.

### Enhancements

- Refactor `Agent` base class for readability - [#4341](https://github.com/PrefectHQ/prefect/pull/4341)
- Display the agent config id on agent startup if set - [#4524](https://github.com/PrefectHQ/prefect/pull/4524)
- Add debug logs during agent auth verification - [#4547](https://github.com/PrefectHQ/prefect/pull/4547)
- Sending logs to Cloud can be globally disabled via config in addition to the agent flag - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)

### Task Library

- Enable sending attachments with emails in the `EmailTask` - [#4457](https://github.com/PrefectHQ/prefect/pull/4457)
- Add Google Cloud Platform `GCPSecret` task - [#4561](https://github.com/PrefectHQ/prefect/pull/4561)

### Fixes

- Fix `import_object` handling of submodules that are not attributes - [#4513](https://github.com/PrefectHQ/prefect/pull/4513)
- Fix `DockerStorage` building with python slim image - [#4523](https://github.com/PrefectHQ/prefect/pull/4523)
- Gracefully handle events with missing timestamps in K8s agent - [#4544](https://github.com/PrefectHQ/prefect/pull/4544)
- Fix bug where agent uses originally scheduled start time instead of latest state time - [#4568](https://github.com/PrefectHQ/prefect/pull/4568)

### Deprecations

- `logging.log_to_cloud` has been deprecated in favor of `cloud.send_flow_run_logs` - [#4487](https://github.com/PrefectHQ/prefect/pull/4487)

### Contributors

- [Stéphan Taljaard](https://github.com/taljaards)
- [Thomas Heyenbrock](https://github.com/thomasheyenbrock)
