### PR TITLE
Run Flow API: Update `watch_flow_run` to be an iterator

### DIFF
--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -154,6 +154,7 @@ class LocalAgent(Agent):
         # dictate the lifecycle of the flow run. However, if the user has elected to
         # show flow logs, these log entries will continue to stream to the users terminal
         # until these child processes exit, even if the agent has already exited.
+        print("HERE!")
         p = Popen(
             [sys.executable, "-m", "prefect", "execute", "flow-run"],
             stdout=stdout,

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -25,6 +25,7 @@ import prefect
 from prefect import Flow
 from prefect.backend.flow import FlowView
 from prefect.backend.task_run import TaskRunView
+from prefect.cli.run import load_json_key_values
 from prefect.engine.state import State
 from prefect.run_configs import RunConfig
 from prefect.serialization.run_config import RunConfigSchema
@@ -673,7 +674,7 @@ class FlowRunView:
     def from_flow_run_id(
         cls,
         flow_run_id: str,
-        load_static_tasks: bool = True,
+        load_static_tasks: bool = False,
         _cached_task_runs: Iterable["TaskRunView"] = None,
     ) -> "FlowRunView":
         """

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -53,17 +53,16 @@ def watch_flow_run(
     stream_logs: bool = True,
 ) -> Iterator["FlowRunLog"]:
     """
-    Watch execution of a flow run displaying state changes. This function will hang
-    until the flow run enters a 'Finished' state.
+    Watch execution of a flow run displaying state changes. This function will yield
+    `FlowRunLog` objects until the flow run enters a 'Finished' state.
 
     Args:
         flow_run_id: The flow run to watch
-        stream_logs: If set, logs will be streamed from the flow run to here
-        output_fn: A callable to use to display output. Must take a log level and
-            message.
+        stream_logs: If set, logs will be streamed from the flow run to here in addition
+            to state messages
 
-    Returns:
-        FlowRunView: A view of the final state of the flow run
+    Yields:
+        FlowRunLog: Sorted log entries
 
     """
 

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -6,7 +6,6 @@ import sys
 import textwrap
 import time
 from contextlib import contextmanager
-from functools import partial
 from types import ModuleType
 from typing import Callable, Dict, List, Union, Any
 
@@ -16,7 +15,7 @@ from tabulate import tabulate
 
 import prefect
 from prefect.backend.flow import FlowView
-from prefect.backend.flow_run import FlowRunView, watch_flow_run, FlowRunLog
+from prefect.backend.flow_run import FlowRunView, watch_flow_run
 from prefect.cli.build_register import (
     TerminalError,
     handle_terminal_error,
@@ -99,7 +98,6 @@ def echo_with_log_color(log_level: int, message: str, **kwargs: Any):
     else:
         kwargs.setdefault("fg", "white")
 
-    level_name = logging.getLevelName(log_level)
     click.secho(
         message,
         **kwargs,

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -608,8 +608,8 @@ def run(
             f"Creating run for flow {flow_view.name!r}...",
             quiet_echo,
             traceback=True,
-            # Display 'Done' manually after querying for data to display so there is not a
-            # lag
+            # Display 'Done' manually after querying for data to display so there is not
+            # a lag
             skip_done=True,
         ):
             flow_run_id = client.create_flow_run(
@@ -671,19 +671,14 @@ def run(
             stream_logs=not no_logs,
         ):
             level_name = logging.getLevelName(log.level)
-            timestamp =log.timestamp.in_tz(tz='local')
+            timestamp = log.timestamp.in_tz(tz="local")
             echo_with_log_color(
-                log.level,
-                (
-                    f"└── {timestamp:%H:%M:%S} | {level_name:<7} | {log.message}"
-                ),
+                log.level, f"└── {timestamp:%H:%M:%S} | {level_name:<7} | {log.message}"
             )
 
     except KeyboardInterrupt:
         quiet_echo("Keyboard interrupt detected!", fg="yellow")
         try:
-            # TODO: Improve and clarify this messaging, consider having this
-            #       apply from flow run creation -> now
             cancel = click.confirm(
                 "On exit, we can leave your flow run executing or cancel it.\n"
                 "Do you want to cancel this flow run?",

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -224,16 +224,16 @@ def wait_for_flow_run(
 
     flow_run = FlowRunView.from_flow_run_id(flow_run_id)
 
-    def log_with_flow_run_prefix(log: FlowRunLog):
-        message = f"Flow {flow_run.name!r}: {log.message}"
-        prefect.context.logger.log(log.level, message)
-
-    output_fn = log_with_flow_run_prefix if stream_state else lambda *_, **__: None
-
     if not stream_state and stream_logs:
         warnings.warn("`stream_logs` will be ignored since `stream_state` is `False`")
 
-    return watch_flow_run(flow_run_id, stream_logs=stream_logs, output_fn=output_fn)
+    for log in watch_flow_run(flow_run_id, stream_logs=stream_logs):
+        if stream_state:
+            message = f"Flow {flow_run.name!r}: {log.message}"
+            prefect.context.logger.log(log.level, message)
+
+    # Return the final view of the flow run
+    return flow_run.get_latest()
 
 
 # Legacy -------------------------------------------------------------------------------

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -206,7 +206,7 @@ def get_task_run_result(
 
 @task
 def wait_for_flow_run(
-    flow_run_id: str, stream_state: bool = True, stream_logs: bool = False
+    flow_run_id: str, stream_states: bool = True, stream_logs: bool = False
 ) -> "FlowRunView":
     """
     Wait for a flow run to finish executing, streaming state and log information
@@ -224,13 +224,11 @@ def wait_for_flow_run(
 
     flow_run = FlowRunView.from_flow_run_id(flow_run_id)
 
-    if not stream_state and stream_logs:
-        warnings.warn("`stream_logs` will be ignored since `stream_state` is `False`")
-
-    for log in watch_flow_run(flow_run_id, stream_logs=stream_logs):
-        if stream_state:
-            message = f"Flow {flow_run.name!r}: {log.message}"
-            prefect.context.logger.log(log.level, message)
+    for log in watch_flow_run(
+        flow_run_id, stream_states=stream_states, stream_logs=stream_logs
+    ):
+        message = f"Flow {flow_run.name!r}: {log.message}"
+        prefect.context.logger.log(log.level, message)
 
     # Return the final view of the flow run
     return flow_run.get_latest()

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -51,7 +51,7 @@ from urllib.parse import urlparse
 import prefect
 from prefect import Client, Task, task
 from prefect.artifacts import create_link
-from prefect.backend.flow_run import FlowRunLog, FlowRunView, FlowView, watch_flow_run
+from prefect.backend.flow_run import FlowRunView, FlowView, watch_flow_run
 from prefect.client import Client
 from prefect.engine.signals import signal_from_state
 from prefect.engine.state import State

--- a/tests/backend/test_flow_run.py
+++ b/tests/backend/test_flow_run.py
@@ -3,11 +3,16 @@ Tests for `FlowRunView`
 """
 import pendulum
 import pytest
+import logging
 from unittest.mock import MagicMock
 
 from prefect.backend import FlowRunView, TaskRunView
-from prefect.backend.flow_run import check_for_compatible_agents
-from prefect.engine.state import Success, Running, Submitted
+from prefect.backend.flow_run import (
+    FlowRunLog,
+    check_for_compatible_agents,
+    watch_flow_run,
+)
+from prefect.engine.state import Scheduled, Success, Running, Submitted
 from prefect.run_configs import UniversalRun
 
 
@@ -397,3 +402,112 @@ def test_check_for_compatible_agents_matching_labels_in_multiple_unhealthy(patch
         "Found 2 healthy agents with matching labels. One of them should pick up your flow"
         in result
     )
+
+
+def test_watch_flow_run_already_finished(patch_post):
+    data = FLOW_RUN_DATA_1.copy()
+    # Change the updated timestamp for the "ago" message
+    data["updated"] = pendulum.now().subtract(minutes=5).isoformat()
+    patch_post({"data": {"flow_run": [data]}})
+
+    logs = [log for log in watch_flow_run("id")]
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.message == "Your flow run finished 5 minutes ago"
+    assert log.level == logging.INFO
+
+
+def test_watch_flow_run(monkeypatch):
+    flow_run = FlowRunView._from_flow_run_data(FLOW_RUN_DATA_1)
+    flow_run.state = Scheduled()  # Not running
+    flow_run.states = []
+    flow_run.get_latest = MagicMock(return_value=flow_run)
+    flow_run.get_logs = MagicMock()
+
+    MockView = MagicMock()
+    MockView.from_flow_run_id.return_value = flow_run
+
+    monkeypatch.setattr("prefect.backend.flow_run.FlowRunView", MockView)
+    monkeypatch.setattr(
+        "prefect.backend.flow_run.check_for_compatible_agents",
+        MagicMock(return_value="Helpful agent message."),
+    )
+
+    # Mock sleep so that we do not have a slow test
+    monkeypatch.setattr("prefect.backend.flow_run.time.sleep", MagicMock())
+
+    for i, log in enumerate(watch_flow_run("id")):
+        # Assert that we get the agent warning a couple times then update the state
+        if i == 0:
+            assert log.message == (
+                "It has been 10 seconds and your flow run has not started. "
+                "Helpful agent message."
+            )
+            assert log.level == logging.WARNING
+
+        elif i == 1:
+            assert log.message == (
+                "It has been 40 seconds and your flow run has not started. "
+                "Helpful agent message."
+            )
+
+            # Mark the flow run as finished and give it a few past states to log
+            # If this test times out, we did not reach this log
+            flow_run.state = Success()
+            scheduled = Scheduled("My message")
+            scheduled.timestamp = pendulum.now()
+            running = Running("Another message")
+            running.timestamp = pendulum.now().add(seconds=10)
+
+            # Given intentionally out of order states to prove sorting
+            flow_run.states = [running, scheduled]
+
+            # Add a log between the states and a log at the end
+            flow_run.get_logs = MagicMock(
+                return_value=[
+                    FlowRunLog(
+                        timestamp=pendulum.now().add(seconds=5),
+                        message="Foo",
+                        level=logging.DEBUG,
+                    ),
+                    FlowRunLog(
+                        timestamp=pendulum.now().add(seconds=15),
+                        message="Bar",
+                        level=logging.ERROR,
+                    ),
+                ]
+            )
+
+        elif i == 2:
+            assert log.message == "Entered state <Scheduled>: My message"
+            assert log.level == logging.INFO
+        elif i == 3:
+            assert log.message == "Foo"
+            assert log.level == logging.DEBUG
+        elif i == 4:
+            assert log.message == "Entered state <Running>: Another message"
+            assert log.level == logging.INFO
+        elif i == 5:
+            assert log.message == "Bar"
+            assert log.level == logging.ERROR
+
+    assert i == 5  # Assert we saw all of the expected logs
+
+
+def test_watch_flow_run_timeout(monkeypatch):
+    flow_run = FlowRunView._from_flow_run_data(FLOW_RUN_DATA_1)
+    flow_run.state = Running()  # Not finished
+    flow_run.get_latest = MagicMock(return_value=flow_run)
+    flow_run.get_logs = MagicMock()
+
+    MockView = MagicMock()
+    MockView.from_flow_run_id.return_value = flow_run
+
+    monkeypatch.setattr("prefect.backend.flow_run.FlowRunView", MockView)
+
+    # Mock sleep so that we do not have a slow test
+    monkeypatch.setattr("prefect.backend.flow_run.time.sleep", MagicMock())
+
+    with pytest.raises(RuntimeError, match="timed out after 12 hours of waiting"):
+        for log in watch_flow_run("id"):
+            pass


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

It seems clunky to pass a callable so instead I'm yielding log objects and the consumer can do as they wish with them without a callback


## Changes
<!-- What does this PR change? -->

- `watch_flow_run` has a 12hr timeout; makes sense and prevents a test from hanging forever
- Adds a test for `watch_flow_run`
- `watch_flow_run` is of type `Iterator[FlowRunLog]` instead of taking a `Callable[[FlowRunLog], None]` and returning a `FlowRunView`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)