### PR TITLE
Fix possible race condition in `LocalResult` directory creation

### DIFF
--- a/changes/pr4587.yaml
+++ b/changes/pr4587.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix possible race condition in `LocalResult` directory creation - [#4587](https://github.com/PrefectHQ/prefect/pull/4587)"

--- a/src/prefect/engine/results/local_result.py
+++ b/src/prefect/engine/results/local_result.py
@@ -52,8 +52,7 @@ class LocalResult(Result):
 
         if validate_dir:
             abs_directory = os.path.abspath(os.path.expanduser(directory))
-            if not os.path.exists(abs_directory):
-                os.makedirs(abs_directory)
+            os.makedirs(abs_directory, exist_ok=True)
         else:
             abs_directory = directory
         self.dir = abs_directory


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

It's possible for the result directory to be created between the `exists` check and creation. Noticed this during a CI failure.