### PR TITLE
Tell people about the UI repository on GitHub

### DIFF
--- a/docs/core/getting_started/why-not-airflow.md
+++ b/docs/core/getting_started/why-not-airflow.md
@@ -341,7 +341,9 @@ The Prefect UI supports:
 - timezones (this one's for you, Airflow users!)
 - ...and quite a bit more
 
-The UI is part of Prefect Cloud because it is backed by the same infrastructure that allows us to deliver production-grade workflow management to our customers. However, we are committed to making it increasingly available to users of our open-source products, beginning with its inclusion in Cloud's [free tier](https://prefect.io/download). We are working on other ways of delivering elements from the UI to our open-source users.
+Get started with the UI [on GitHub](https://github.com/PrefectHQ/ui) today. The code is source available, released under the Prefect Community License.
+
+Want to see the UI in action without hosting it yourself? Check [Prefect Cloud](https://www.prefect.io/cloud/), our production-grade workflow management product.
 
 ## Conclusions
 


### PR DESCRIPTION
## Summary

Update the page _Why Not Airflow?_ to talk about the UI repository on GitHub.

## Changes
This PR updates the language to talk about the new (2020) UI repository.

## Importance
The page _Why Not Airflow?_ is the #1 Google hit for the query "airflow vs prefect," but the section on Prefect's UI claims that the UI is only available in Prefect Cloud. 

## Checklist
This PR:
- Updates docs only