### PR TITLE
A few register CLI fixes

### DIFF
--- a/changes/pr4593.yaml
+++ b/changes/pr4593.yaml
@@ -1,0 +1,3 @@
+fix:
+  - "Use absolute paths when registering flows in `prefect register` - [#4593](https://github.com/PrefectHQ/prefect/pull/4593)"
+  - "Propagate storage labels (e.g. hostname label on `Local` storage) when registering flows with `prefect register` - [#4593](https://github.com/PrefectHQ/prefect/pull/4593)"

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -303,14 +303,13 @@ def prepare_flows(flows: "List[FlowLike]", labels: List[str] = None) -> None:
                 flow.result = flow.storage.result
 
             # Add a `run_config` if not configured explicitly
-            # Also add any extra labels to the flow
-            if flow.run_config is None:
-                if flow.environment is not None:
-                    flow.environment.labels.update(labels)
-                else:
-                    flow.run_config = UniversalRun(labels=labels)
-            else:
-                flow.run_config.labels.update(labels)
+            if flow.run_config is None and flow.environment is None:
+                flow.run_config = UniversalRun()
+            # Add any extra labels to the flow (either specified via the CLI,
+            # or from the storage object).
+            obj = flow.run_config or flow.environment
+            obj.labels.update(labels)
+            obj.labels.update(flow.storage.labels)
 
             # Add the flow to storage
             flow.storage.add_flow(flow)

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -273,6 +273,11 @@ class TestRegister:
     def test_load_flows_from_script(self, tmpdir, relative):
         abs_path = str(tmpdir.join("test.py"))
         if relative:
+            if os.name == "nt":
+                pytest.skip(
+                    "This test can fail on windows if the test file is on a different "
+                    "drive. This should have no effect during actual execution."
+                )
             path = os.path.relpath(abs_path)
         else:
             path = abs_path

--- a/tests/cli/test_build_register.py
+++ b/tests/cli/test_build_register.py
@@ -569,12 +569,18 @@ class TestRegister:
         if not names:
             names = ["flow 1", "flow 2"]
 
+        storage_labels = Local().labels
+
         assert register_serialized_flow.call_count == len(names)
         for args, kwargs in register_serialized_flow.call_args_list:
             assert not args
             assert kwargs["project_id"] == "my-project-id"
             assert kwargs["serialized_flow"]["name"] in names
-            assert set(kwargs["serialized_flow"]["run_config"]["labels"]) == {"a", "b"}
+            assert set(kwargs["serialized_flow"]["run_config"]["labels"]) == {
+                "a",
+                "b",
+                *storage_labels,
+            }
             assert kwargs["force"] == force
 
         # Bulk of the output is tested elsewhere, only a few smoketests here
@@ -747,7 +753,8 @@ class TestBuild:
         written_names = [f["name"] for f in out["flows"]]
         assert written_names == exp_names
 
-        assert flow2["run_config"]["labels"] == ["a", "b", "new"]
+        storage_labels = Local().labels
+        assert set(flow2["run_config"]["labels"]) == {"a", "b", "new", *storage_labels}
         assert flow2["run_config"]["type"] == "LocalRun"
 
         build_logs = "\n".join(


### PR DESCRIPTION
- Fixes bug where relative path was used instead of absolute path when auto-creating `Local` storage
- Fixes bug where `flow.storage.labels` weren't being mirrored to the `run_config`/`environment` labels. This only affected local storage flows (no hostname label applied).

Fixes #4572

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)