### PR TITLE
Fix small-flow parallelism issues with multiprocess `LocalDaskExecutor`

### DIFF
--- a/changes/pr4602.yaml
+++ b/changes/pr4602.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix small-flow parallelism issues with multiprocess `LocalDaskExecutor` - [#4602](https://github.com/PrefectHQ/prefect/pull/4602)"

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -4,7 +4,7 @@ import uuid
 import sys
 import weakref
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, TYPE_CHECKING, Union, Optional
+from typing import Any, Callable, Iterator, TYPE_CHECKING, Union, Optional, Dict
 
 from prefect import context
 from prefect.executors.base import Executor
@@ -592,7 +592,7 @@ class LocalDaskExecutor(Executor):
         # import dask here to reduce prefect import times
         import dask
 
-        config = {}  # Extra config options for dask
+        config: Dict[str, Any] = {}  # Extra config options for dask
 
         # dask's multiprocessing scheduler hardcodes task fusion in a way
         # that's not exposed via a `compute` kwarg. Until that's fixed, we

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -592,6 +592,8 @@ class LocalDaskExecutor(Executor):
         # import dask here to reduce prefect import times
         import dask
 
+        config = {}  # Extra config options for dask
+
         # dask's multiprocessing scheduler hardcodes task fusion in a way
         # that's not exposed via a `compute` kwarg. Until that's fixed, we
         # disable fusion globally for the multiprocessing scheduler only.
@@ -614,13 +616,23 @@ class LocalDaskExecutor(Executor):
                 finally:
                     dask.multiprocessing.cull = cull
 
-            config = {"optimization.fuse.active": False}
+            config["optimization.fuse.active"] = False
         else:
-            config = {}
 
             @contextmanager
             def patch() -> Iterator[None]:
                 yield
+
+        # Patch around https://github.com/PrefectHQ/prefect/issues/4537
+        # dask >= 2021.04.0 adds task submission batching in the multiprocessing case
+        # to offset performance concerns from switching to a concurrent.Futures based
+        # process pool. Since we are using our own pool to handle cancellation robustly,
+        # we do not gain anything from the batched submission and the default task
+        # submission batch size of 6 makes users think their flows will not run in
+        # parallel. When/if we switch to using the new futures based multiprocessing in
+        # dask, we should remove this to retain performance
+        if self.scheduler == "processes":
+            config["chunksize"] = 1
 
         with patch(), dask.config.set(config):
             return dask.compute(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
dask >= 2021.04.0 adds task submission batching in the multiprocessing case
to offset performance concerns from switching to a concurrent.Futures based
process pool. Since we are using our own pool to handle cancellation robustly,
we do not gain anything from the batched submission and the default task
submission batch size of 6 makes users think their flows will not run in
parallel. When/if we switch to using the new futures based multiprocessing in
dask, we should remove this to retain performance


## Changes
<!-- What does this PR change? -->

- Sets `chunksize=1` for the process based `LocalDaskExecutor`


## Importance
<!-- Why is this PR important? -->


Closes https://github.com/PrefectHQ/prefect/issues/4537


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~