### PR TITLE
Cleanly handle unpicklable exceptions in tasks

### DIFF
--- a/changes/pr4605.yaml
+++ b/changes/pr4605.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Cleanly handle unpicklable exceptions in tasks - [#4605](https://github.com/PrefectHQ/prefect/pull/4605)"

--- a/changes/pr4605.yaml
+++ b/changes/pr4605.yaml
@@ -1,3 +1,3 @@
 
-enhancement:
+fix:
   - "Cleanly handle unpicklable exceptions in tasks - [#4605](https://github.com/PrefectHQ/prefect/pull/4605)"

--- a/src/prefect/engine/runner.py
+++ b/src/prefect/engine/runner.py
@@ -66,6 +66,8 @@ def call_state_handlers(method: Callable[..., State]) -> Callable[..., State]:
             self.logger.exception(formatted)
             if raise_on_exception:
                 raise exc
+            # TODO: Add some more logs here
+            # TODO: Handle failed
             new_state = Failed(formatted, result=exc)
 
         if new_state is not state:

--- a/src/prefect/engine/runner.py
+++ b/src/prefect/engine/runner.py
@@ -66,8 +66,6 @@ def call_state_handlers(method: Callable[..., State]) -> Callable[..., State]:
             self.logger.exception(formatted)
             if raise_on_exception:
                 raise exc
-            # TODO: Add some more logs here
-            # TODO: Handle failed
             new_state = Failed(formatted, result=exc)
 
         if new_state is not state:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -96,19 +96,15 @@ class State:
         ):
 
             # Check for an exception during pickling of the 'Exception' type result
-            pickle_exc: Optional[Exception] = None
             try:
                 cloudpickle.dumps(self.result)
             except Exception as exc:
-                pickle_exc = exc
-
-            if pickle_exc:
                 # Update the result in the dict without modifying the local object
                 data = data.copy()
                 new_result = data["_result"].copy()
                 new_result.value = (
-                    f"The following exception could not be pickled due to "
-                    f"{pickle_exc!r}: {self.result!r}"
+                    f"The following exception could not be pickled due to {exc!r}: "
+                    f"{self.result!r}"
                 )
                 data["_result"] = new_result
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -94,11 +94,14 @@ class State:
                 cloudpickle.dumps(self.result)
             except TypeError as exc:
                 if "cannot pickle" in str(exc):
-                    self.result = (
+                    # Update the result in the dict without modifying the local object
+                    data = data.copy()
+                    new_result = data["_result"].copy()
+                    new_result.value = (
                         f"The following exception could not be pickled due to {exc!r}: "
                         + repr(self.result)
                     )
-                    return self.__getstate__()
+                    data["_result"] = new_result
 
         return data
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -12,7 +12,6 @@ execution. During execution a run will enter a `Running` state. Finally, runs be
 """
 import datetime
 from typing import Any, Dict, List, Optional, Type, Mapping
-from pickle import PicklingError
 
 import pendulum
 import cloudpickle
@@ -100,10 +99,7 @@ class State:
             pickle_exc: Optional[Exception] = None
             try:
                 cloudpickle.dumps(self.result)
-            except TypeError as exc:
-                if "cannot pickle" in str(exc):
-                    pickle_exc = exc
-            except PicklingError as exc:
+            except Exception as exc:
                 pickle_exc = exc
 
             if pickle_exc:

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -90,8 +90,8 @@ class State:
         # For 'Exception' results, we will check if it can be pickled successfully and
         # on failure convert the exception to a string instead. This allows the engine
         # to handle tasks with unpickable exceptions successfully. We must explicitly
-        # ignore state signals here or we will recurse forever because they are
-        # exceptions that contain a state with `_result` set to the state signal itself
+        # ignore state signals here or we will get stuck in a recursive loop because
+        # signals are exceptions that contain a state with `_result` set to the signal
         if isinstance(self.result, Exception) and not isinstance(
             self.result, prefect.engine.signals.PrefectStateSignal
         ):

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -733,6 +733,13 @@ def test_state_pickle_with_unpicklable_exception_converts_to_repr():
     state = State(result=UnpicklableException())
     new_state = cloudpickle.loads(cloudpickle.dumps(state))
 
+    # Get the pickle error directly -- this is robust to changes across python versions
+    pickle_exc = None
+    try:
+        cloudpickle.dumps(UnpicklableException())
+    except Exception as exc:
+        pickle_exc = exc
+
     # Cast to a string
     assert isinstance(new_state.result, str)
     # Includes the repr of our exception result
@@ -740,7 +747,7 @@ def test_state_pickle_with_unpicklable_exception_converts_to_repr():
     # Includes context for the exception
     assert "The following exception could not be pickled" in new_state.result
     # Includes pickle error
-    assert "TypeError(\"cannot pickle '_thread.RLock' object\")" in new_state.result
+    assert repr(pickle_exc) in new_state.result
 
     # Does not alter the original object
     assert isinstance(state.result, UnpicklableException)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from dataclasses import dataclass, field
 from threading import RLock
 
 import pendulum
@@ -695,12 +694,8 @@ def test_state_pickle():
 
 
 def test_state_pickle_with_unpicklable_result_raises():
-    @dataclass
-    class UnpickleableData:
-        x: RLock = field(default_factory=lambda: RLock())
-
-    state = State(result=UnpickleableData())
-    with pytest.raises(TypeError, match="cannot pickle"):
+    state = State(result=RLock())  # An unpickable result type
+    with pytest.raises(TypeError, match="pickle"):
         cloudpickle.dumps(state)
 
 

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -733,9 +733,14 @@ def test_state_pickle_with_unpicklable_exception_converts_to_repr():
     state = State(result=UnpicklableException())
     new_state = cloudpickle.loads(cloudpickle.dumps(state))
 
+    # Cast to a string
+    assert isinstance(new_state.result, str)
     # Includes the repr of our exception result
     assert repr(UnpicklableException()) in new_state.result
     # Includes context for the exception
     assert "The following exception could not be pickled" in new_state.result
     # Includes pickle error
     assert "TypeError(\"cannot pickle '_thread.RLock' object\")" in new_state.result
+
+    # Does not alter the original object
+    assert isinstance(state.result, UnpicklableException)

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from threading import RLock
+from dataclasses import dataclass
 
 import pendulum
 import cloudpickle

--- a/tests/engine/test_state.py
+++ b/tests/engine/test_state.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 from threading import RLock
-from dataclasses import dataclass
 
 import pendulum
 import cloudpickle
@@ -682,10 +681,13 @@ def test_init_with_falsey_value():
 
 
 def test_state_pickle():
-    @dataclass
     class Data:
-        bar: str
-        foo: int = 1
+        def __init__(self, foo: int = 1, bar: str = "") -> None:
+            self.foo = foo
+            self.bar = bar
+
+        def __eq__(self, o: object) -> bool:
+            return o.bar == self.bar and o.foo == self.foo
 
     state = State(message="message", result=Data(bar="bar"))
     new_state = cloudpickle.loads(cloudpickle.dumps(state))


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

While using the `DaskExecutor`, if a task fails with an exception that cannot be pickled by `cloudpickle`, Dask will fail to send the failure back to the flow runner as the `Failed` state containing the exception as a result cannot be pickled. This PR adds more robust handling to `State` pickling to handle exception pickle failures.


## Changes
<!-- What does this PR change? -->

- Adds `State.__getstate__` which will cast unpickable exception results to a string with helpful information

## Importance
<!-- Why is this PR important? -->

Prefect should be able to report task failure cleanly


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)