### PR TITLE
Remove timeouts from CI windows tests

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -27,4 +27,4 @@ jobs:
           pip install -e .[dev]
       - name: Test with pytest
         run: |
-          pytest tests -v --dist=loadfile -n auto --timeout 600 --timeout-method=thread
+          pytest tests -v --dist=loadfile -n auto

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ pytest >= 6.0
 testfixtures >= 6.10.3
 pytest-env >= 0.6.0
 pytest-xdist >= 2.0
-pytest-timeout >= 1.0, < 2.0


### PR DESCRIPTION
Encountering things like `ValueError: signal only works in main thread of the main interpreter` intermittently on Windows. Likely introduced by timeouts or parallelism or both together. Investigating a fix...

Re-ran this job 3x and didn't see any failures; hopefully this resolves flakeyness