### PR TITLE
Run Flow API: Cleanup view object interfaces

### DIFF
--- a/docs/orchestration/flow-runs/inspection.md
+++ b/docs/orchestration/flow-runs/inspection.md
@@ -4,6 +4,28 @@ For monitoring flow runs from the UI, see the [UI documentation on flow runs](..
 
 ## Prefect library
 
+::: warning Experimental
+<div class="experimental-warning">
+<svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    >
+<path
+fill="#e90"
+d="M437.2 403.5L320 215V64h8c13.3 0 24-10.7 24-24V24c0-13.3-10.7-24-24-24H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h8v151L10.8 403.5C-18.5 450.6 15.3 512 70.9 512h306.2c55.7 0 89.4-61.5 60.1-108.5zM137.9 320l48.2-77.6c3.7-5.2 5.8-11.6 5.8-18.4V64h64v160c0 6.9 2.2 13.2 5.8 18.4l48.2 77.6h-172z"
+>
+</path>
+</svg>
+
+<div>
+The functionality here is experimental, and may change between versions without notice. Use at your own risk.
+</div>
+</div>
+:::
+
 The Prefect library provides an object for inspecting flow runs without writing queries at `prefect.backend.FlowRunView`.
 
 ### Creating a `FlowRunView`

--- a/docs/orchestration/flow-runs/inspection.md
+++ b/docs/orchestration/flow-runs/inspection.md
@@ -48,10 +48,10 @@ flow_run.state.message
 
 ### Getting flow metadata
 
-Metadata about the flow that the flow run was created for is accessible using the `.flow` property
+Metadata about the flow that the flow run was created for is accessible using `.get_flow_metadata()`
 
 ```python
-flow_run.flow
+flow_run.get_flow_metdata()
 # FlowView(
 #   flow_id='8bdcf5b5-7598-49d1-a885-61612ca550de', 
 #   name='hello-world', 
@@ -64,7 +64,8 @@ This object contains the metadata that the Prefect backend stores about your flo
 
 ::: tip Flow metadata caching
 Flow metadata is lazily loaded by request then _cached_ in the `FlowRunView` for later access.
-This means the first call to `.flow` requires network IO but future calls are instant.
+This means the first call requires network IO but future calls are instant.
+If you want to force the `FlowView` to be reloaded, pass `no_cache=True`.
 :::
 
 ### Getting flow task runs

--- a/docs/orchestration/flow-runs/task-runs.md
+++ b/docs/orchestration/flow-runs/task-runs.md
@@ -10,6 +10,29 @@ Prefect does not store the _results_ of your task runs. The data that your task 
 
 ### Prefect library
 
+::: warning Experimental
+<div class="experimental-warning">
+<svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    >
+<path
+fill="#e90"
+d="M437.2 403.5L320 215V64h8c13.3 0 24-10.7 24-24V24c0-13.3-10.7-24-24-24H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h8v151L10.8 403.5C-18.5 450.6 15.3 512 70.9 512h306.2c55.7 0 89.4-61.5 60.1-108.5zM137.9 320l48.2-77.6c3.7-5.2 5.8-11.6 5.8-18.4V64h64v160c0 6.9 2.2 13.2 5.8 18.4l48.2 77.6h-172z"
+>
+</path>
+</svg>
+
+<div>
+The functionality here is experimental, and may change between versions without notice. Use at your own risk.
+</div>
+</div>
+:::
+
+
 The Prefect library provides an object for inspecting task runs without writing queries at `prefect.backend.TaskRunView`.
 
 #### Creating a `TaskRunView`

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -22,17 +22,21 @@ functions = [
 title = "Flow"
 module = "prefect.backend.flow"
 classes = ["FlowView"]
+experimental = true
 
 [pages.backend.flow_run]
 title = "Flow Run"
 module = "prefect.backend.flow_run"
 classes = ["FlowRunView"]
-methods = ["execute_flow_run", "watch_flow_run"]
+functions = ["watch_flow_run"]
+experimental = true
 
 [pages.backend.task_run]
 title = "Task Run"
 module = "prefect.backend.task_run"
 classes = ["TaskRunView"]
+experimental = true
+
 [pages.backend.kv_store]
 title = "KV Store"
 module = "prefect.backend.kv_store"

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -14,10 +14,12 @@ logger = get_logger("backend.flow")
 
 class FlowView:
     """
-    A view of Flow data stored in the Prefect API.
+    A view of Flow metadata stored in the Prefect API.
 
     This object is designed to be an immutable view of the data stored in the Prefect
     backend API at the time it is created
+
+    EXPERIMENTAL: This interface is experimental and subject to change
 
     Args:
         - flow_id: The uuid of the flow

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -64,9 +64,9 @@ def watch_flow_run(
     EXPERIMENTAL: This interface is experimental and subject to change
 
     Args:
-        flow_run_id: The flow run to watch
-        stream_states: If set, flow run state changes will be streamed as logs
-        stream_logs: If set, logs will be streamed from the flow run
+        - flow_run_id: The flow run to watch
+        - stream_states: If set, flow run state changes will be streamed as logs
+        - stream_logs: If set, logs will be streamed from the flow run
 
     Yields:
         FlowRunLog: Sorted log entries

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -937,6 +937,7 @@ class FlowRunView:
                     f"flow_run_id={self.flow_run_id!r}",
                     f"name={self.name!r}",
                     f"state={self.state!r}",
+                    f"labels={self.labels!r}",
                     f"cached_task_runs={len(self._cached_task_runs)}",
                 ]
             )

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -37,6 +37,8 @@ logger = get_logger("backend.flow_run")
 def stream_flow_run_logs(flow_run_id: str) -> None:
     """
     Basic wrapper for `watch_flow_run` to print the logs of the run
+
+    EXPERIMENTAL: This interface is experimental and subject to change
     """
     for log in watch_flow_run(flow_run_id):
         level_name = logging.getLevelName(log.level)
@@ -58,6 +60,8 @@ def watch_flow_run(
 
     If both stream_states and stream_logs are `False` then this will just block until
     the flow run finishes.
+
+    EXPERIMENTAL: This interface is experimental and subject to change
 
     Args:
         flow_run_id: The flow run to watch
@@ -185,6 +189,8 @@ def execute_flow_run(
     The primary entry point for executing a flow run. The flow run will be run
     in-process using the given `runner_cls` which defaults to the `CloudFlowRunner`.
 
+    EXPERIMENTAL: This interface is experimental and subject to change
+
     Args:
         - flow_run_id: The flow run id to execute; this run id must exist in the database
         - flow: A Flow object can be passed to execute a flow without loading t from
@@ -271,7 +277,8 @@ def execute_flow_run(
 def check_for_compatible_agents(labels: Iterable[str], since_minutes: int = 1) -> str:
     """
     Checks for agents compatible with a set of labels returning a user-friendly message
-    indicating the status, roughly one of the following cases
+    indicating the status, roughly one of the following cases:
+
     - There is a healthy agent with matching labels
     - There are N healthy agents with matching labels
     - There is an unhealthy agent with matching labels but no healthy agents matching
@@ -279,6 +286,7 @@ def check_for_compatible_agents(labels: Iterable[str], since_minutes: int = 1) -
     - There are no healthy agents at all and no unhealthy agents with matching labels
     - There are healthy agents but no healthy or unhealthy agent has matching labels
 
+    EXPERIMENTAL: This interface is experimental and subject to change
 
     Args:
         - labels: A set of labels; typically associated with a flow run
@@ -392,6 +400,7 @@ def fail_flow_run_on_exception(
     the flow run state to 'Cancelled' instead and will not use the message. All errors
     will be re-raised.
 
+
     Args:
         - flow_run_id: The flow run id to update the state of
         - message: The message to include in the state and logs. `{exc}` will be formatted
@@ -425,6 +434,8 @@ def fail_flow_run_on_exception(
 class FlowRunLog(NamedTuple):
     """
     Small wrapper for backend log objects
+
+    EXPERIMENTAL: This interface is experimental and subject to change
     """
 
     timestamp: pendulum.DateTime
@@ -470,6 +481,8 @@ class FlowRunView:
     backend API at the time it is created. However, each time a task run is retrieved
     the latest data for that task will be pulled since they are loaded lazily. Finished
     task runs will be cached in this object to reduce the amount of network IO.
+
+    EXPERIMENTAL: This interface is experimental and subject to change
 
     Args:
         - flow_run_id: The uuid of the flow run

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -212,7 +212,7 @@ def execute_flow_run(
 
     # Get data about the flow run from the backend
     flow_run = FlowRunView.from_flow_run_id(flow_run_id=flow_run_id)
-    flow_metadata = FlowRunView.get_flow_metadata()
+    flow_metadata = flow_run.get_flow_metadata()
 
     logger.info(f"Constructing execution environment for flow run {flow_run_id!r}")
 

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -482,11 +482,6 @@ class FlowRunView:
         - run_config: The `RunConfig` this flow run was configured with
         - states: A sorted list of past states the flow run has been in
         - task_runs: An iterable of task run metadata to cache in this view
-
-    Properties:
-        - flow: Metadata for the flow this run is associated with; lazily retrived on
-            first use
-
     """
 
     def __init__(
@@ -851,7 +846,7 @@ class FlowRunView:
         Returns:
             A list of TaskRunView objects
         """
-        if len(self.task_run_ids) > 1000:
+        if len(self.get_task_run_ids()) > 1000:
             raise ValueError(
                 "Refusing to `get_all_task_runs` for a flow with more than 1000 tasks. "
                 "Please load the tasks you are interested in individually."
@@ -871,8 +866,7 @@ class FlowRunView:
 
         return task_runs + list(self._cached_task_runs.values())
 
-    @property
-    def task_run_ids(self) -> List[str]:
+    def get_task_run_ids(self) -> List[str]:
         """
         Get all task run ids associated with this flow run. Lazily loaded at call time
         then cached for future calls.

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -2,6 +2,7 @@ from typing import Any, List, Iterator
 
 from prefect import Client
 from prefect.engine.state import Scheduled, State
+from prefect.engine.result import Result
 from prefect.utilities.graphql import with_args, EnumValue
 from prefect.utilities.logging import get_logger
 
@@ -73,6 +74,8 @@ class TaskRunView:
         if not self.state.is_finished():
             raise ValueError("The task result cannot be loaded if it is not finished.")
 
+        self._assert_result_type_is_not_custom()
+
         if self._result is NotLoaded:
             # Load the result from the result location
             self._result = self._load_result()
@@ -134,8 +137,30 @@ class TaskRunView:
                     "supported."
                 )
 
+            # Ensure the mapped children have
+            task_run._assert_result_type_is_not_custom()
+
             # Update state
             self.state.map_states = [task_run.state for task_run in child_task_runs]
+
+    def _assert_result_type_is_not_custom(self):
+        """
+        Since we do not have access to the user's custom Result class, we cannot load
+        the result.
+        """
+        # TODO: Check for custom serializer types as well once they are added to the
+        #       `ResultSchema`
+        # TODO: Add the `result_type` to `TaskRunView` so we can report the qualified
+        #       name of the custom result type used.
+
+        if type(self.state._result) is Result and not self.state.is_mapped():
+            # The `Result` base class is used during deserialization if a custom result
+            # class has been declared unless it's a mapped state in which it will be
+            # an empty `Result` and this assertion will be called on the map children
+            raise TypeError(
+                "The task has a custom `Result` type and its result cannot be loaded. "
+                "Only built-in `Result` types are supported."
+            )
 
     def iter_mapped(self) -> Iterator["TaskRunView"]:
         """

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -20,6 +20,8 @@ class TaskRunView:
     This object is designed to be an immutable view of the data stored in the Prefect
     backend API at the time it is created.
 
+    EXPERIMENTAL: This interface is experimental and subject to change
+
     Args:
         - task_run_id: The task run uuid
         - task_id: The uuid of the task associated with this task run

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -29,10 +29,6 @@ class TaskRunView:
         - map_index: The map index of the task run. Is -1 if it is not a mapped subtask,
              otherwise it is in the index of the task run in the mapping
         - flow_run_id: The uuid of the flow run associated with this task run
-
-    Properties:
-        - result: The result of this task run loaded from the `Result` location; lazily
-            retrieved on first use
     """
 
     def __init__(

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -72,7 +72,7 @@ def create_flow_run(
     scheduled_start_time: Optional[Union[pendulum.DateTime, datetime.datetime]] = None,
 ) -> str:
     """
-    Create a flow run in the Prefect backend.
+    Task to create a flow run in the Prefect backend.
 
     The flow to run must be registered and an agent must be available to deploy the
     flow run.
@@ -152,8 +152,10 @@ def get_task_run_result(
     flow_run_id: str, task_slug: str, map_index: int = -1, poll_time: int = 5
 ) -> Any:
     """
-    Get the result of a task from a flow run. Will wait for the flow run to finish
-    entirely or dynamic task runs will not be properly populated.
+    Task to get the result of a task from a flow run.
+
+    Will wait for the flow run to finish entirely or dynamic task run results will not
+    be properly populated.
 
     Results are loaded from the `Result` location of the task which may not be
     accessible from where this task is executed. You will need to ensure results can
@@ -207,7 +209,7 @@ def wait_for_flow_run(
     flow_run_id: str, stream_states: bool = True, stream_logs: bool = False
 ) -> "FlowRunView":
     """
-    Wait for a flow run to finish executing, streaming state and log information
+    Task to wait for a flow run to finish executing, streaming state and log information
 
     Args:
         - flow_run_id: The flow run id to wait for

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -181,6 +181,15 @@ def get_task_run_result(
 
     task_dsp = repr(task_slug) if map_index == -1 else f"'{task_slug}[{map_index}]'"
 
+    if prefect.context.get("flow_run_id") == flow_run_id:
+        # Since we are going to wait for flow run completion, if they pass this flow
+        # run id, we will hang forever.
+        raise ValueError(
+            "Given `flow_run_id` is the same as the currently running flow. The "
+            "`get_task_run_result` task cannot be used to retrieve results from the "
+            "flow run it belongs to."
+        )
+
     # Get the parent flow run state
     flow_run = FlowRunView.from_flow_run_id(flow_run_id)
 

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -215,7 +215,7 @@ def test_task_run_view_get_result_errors_on_missing_result_data(tmpdir):
     )
 
     # The result is not loaded
-    with pytest.raises(FileNotFoundError, match=result.location):
+    with pytest.raises(FileNotFoundError, match=repr(result.location)):
         task_run.get_result()
 
     # Still flagged as not loaded

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -216,9 +216,7 @@ def test_task_run_view_get_result_errors_on_missing_result_data(tmpdir):
     )
 
     # The result is not loaded
-    with pytest.raises(
-        FileNotFoundError, match=result.location if sys.platform != "win32" else ""
-    ):
+    with pytest.raises(FileNotFoundError):
         task_run.get_result()
 
     # Still flagged as not loaded

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -3,6 +3,7 @@ Tests for `TaskRunView`
 """
 import time
 import pytest
+import sys
 import os
 from unittest.mock import MagicMock, call
 
@@ -215,7 +216,9 @@ def test_task_run_view_get_result_errors_on_missing_result_data(tmpdir):
     )
 
     # The result is not loaded
-    with pytest.raises(FileNotFoundError, match=repr(result.location)):
+    with pytest.raises(
+        FileNotFoundError, match=result.location if sys.platform != "win32" else ""
+    ):
         task_run.get_result()
 
     # Still flagged as not loaded

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -180,6 +180,14 @@ class TestGetTaskRunResult:
         with pytest.raises(ValueError, match="`task_slug` is empty"):
             get_task_run_result.run(flow_run_id="id", task_slug="")
 
+    def test_does_not_allow_current_flow_run(self):
+        with prefect.context(flow_run_id="id"):
+            with pytest.raises(
+                ValueError,
+                match="`flow_run_id` is the same as the currently running flow",
+            ):
+                get_task_run_result.run(flow_run_id="id", task_slug="foo")
+
     def test_waits_for_flow_run_to_finish(self, MockFlowRunView, monkeypatch):
         # Create a fake flow run that is 'Running' then 'Finished'
         flow_run = MagicMock()


### PR DESCRIPTION
Finalizing `FlowRunView`, `FlowView`, and `TaskRunView` interfaces


## Changes

- Add experimental warnings
- Adds labels to `FlowRunView` repr
- Convert properties to methods if they hit the API
- Add check for current flow run id to `get_task_run_result`
- Cleanup flow run task docstrings
- Add error for custom result types which we cannot support yet (discovered via https://github.com/PrefectHQ/prefect/issues/4636)