### PR TITLE
Task timeout as either int or timedelta

### DIFF
--- a/changes/task_timeout_as_int_or_timedelta.yaml
+++ b/changes/task_timeout_as_int_or_timedelta.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Task timeout can be timedelta as well as integer in seconds - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)"
+
+contributor:
+  - "[Peter Roelants](https://github.com/peterroelants)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -240,9 +240,9 @@ class Task(metaclass=TaskMetaclass):
         - tags ([str], optional): A list of tags for this task
         - max_retries (int, optional): The maximum amount of times this task can be retried
         - retry_delay (timedelta, optional): The amount of time to wait until task is retried
-        - timeout (int, optional): The amount of time (in seconds) to wait while
+        - timeout (Union[int, timedelta], optional): The amount of time (in seconds) to wait while
             running this task before a timeout occurs; note that sub-second
-            resolution is not supported
+            resolution is not supported, even when passing in a timedelta.
         - trigger (callable, optional): a function that determines whether the
             task should run, based on the states of any upstream tasks.
         - skip_on_upstream_skip (bool, optional): if `True`, if any immediately
@@ -315,7 +315,7 @@ class Task(metaclass=TaskMetaclass):
         tags: Iterable[str] = None,
         max_retries: int = None,
         retry_delay: timedelta = None,
-        timeout: int = None,
+        timeout: Union[int, timedelta] = None,
         trigger: "Callable[[Dict[Edge, State]], bool]" = None,
         skip_on_upstream_skip: bool = True,
         cache_for: timedelta = None,
@@ -373,7 +373,16 @@ class Task(metaclass=TaskMetaclass):
             raise ValueError(
                 "A `max_retries` argument greater than 0 must be provided if specifying "
                 "a retry delay."
+                "a retry delay."
             )
+        # Make sure timeout is an integer in seconds
+        if isinstance(timeout, timedelta):
+            if timeout.microseconds > 0:
+                warnings.warn(
+                    "Sub-seconds of Task timeout will be ignored!",
+                    stacklevel=2,
+                )
+            timeout = int(timeout.total_seconds())
         if timeout is not None and not isinstance(timeout, int):
             raise TypeError(
                 "Only integer timeouts (representing seconds) are supported."

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -379,7 +379,8 @@ class Task(metaclass=TaskMetaclass):
         if isinstance(timeout, timedelta):
             if timeout.microseconds > 0:
                 warnings.warn(
-                    "Sub-seconds of Task timeout will be ignored!",
+                    "Task timeouts do not support a sub-second resolution; "
+                    "smaller units will be ignored!",
                     stacklevel=2,
                 )
             timeout = int(timeout.total_seconds())

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -108,6 +108,13 @@ class TestCreateTask:
             t4 = Task()
             assert t4.timeout == 3
 
+        t4 = Task(timeout=timedelta(seconds=2))
+        assert t4.timeout == 2
+
+        with pytest.warns(UserWarning):
+            t5 = Task(timeout=timedelta(seconds=3, milliseconds=1, microseconds=1))
+        assert t5.timeout == 3
+
     def test_create_task_with_trigger(self):
         t1 = Task()
         assert t1.trigger is prefect.triggers.all_successful


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Besides the original seconds `int`, the Task timeout parameter can also be a `timedelta` object.

## Changes
- Task timeout parameter from `int` type to `Union[int, timedelta]` type.
- `Task.timeout` is still an `int`, `Task.__init__` converts the `timedelta` to seconds.
- Does not break changes, and sub-second timeouts are still not supported.


## Importance
Consistency with other Task parameters such as `retry_delay` which do take a `timedelta` object.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)