### PR TITLE
Add waiting_interval parameter to StartFlowRun

### DIFF
--- a/changes/startflowrun_wait_interval_parameter.yaml
+++ b/changes/startflowrun_wait_interval_parameter.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add `poll_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish - [#4641](https://github.com/PrefectHQ/prefect/pull/4641)"
+
+contributor:
+  - "[Peter Roelants](https://github.com/peterroelants)"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Add `waiting_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish.



## Changes
<!-- What does this PR change? -->
- `waiting_interval` parameter added to `StartFlowRun` initializer.
- Adds a unit test for `StartFlowRun(wait=True).run()`


## Importance
<!-- Why is this PR important? -->
The [default (and fixed) 10 seconds wait](https://github.com/PrefectHQ/prefect/blob/1867f205405e1f68b828ce9dcf00bbd4969903bc/src/prefect/tasks/prefect/flow_run.py#L198) has been slowing down my flow unit tests with flows depending on `StartFlowRun` Tasks. By making this a variable parameter I can speed up my unit tests significantly. There might be other cases where we want to speed up the waiting polling frequency.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)