### PR TITLE
Add merge reference tasks option in flow update

### DIFF
--- a/changes/pr4644.yaml
+++ b/changes/pr4644.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Optionally retain reference tasks when updating two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)"
+
+contributor:
+  - "[Pawel Janowski, Recursion](https://github.com/pjanowski)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -687,7 +687,7 @@ class Flow:
         return edges
 
     def update(
-        self, flow: "Flow", merge_parameters: bool = False, validate: bool = None
+        self, flow: "Flow", merge_parameters: bool = False, validate: bool = None, merge_reference_tasks: bool = False
     ) -> None:
         """
         Take all tasks and edges in another flow and add it to this flow.
@@ -696,10 +696,12 @@ class Flow:
 
         Args:
             - flow (Flow): A flow which is used to update this flow.
-            - merge_parameters (bool, False): If `True`, duplicate paramaeters are replaced
+            - merge_parameters (bool, False): If `True`, duplicate parameters are replaced
                 with parameters from the provided flow. Defaults to `False`.
                 If `True`, validate will also be set to `True`.
             - validate (bool, optional): Whether or not to check the validity of the flow.
+            - merge_reference_tasks(bool, False): If `True`, add reference tasks from the provided
+                flow to the current flow reference tasks set.
 
         Returns:
             - None
@@ -725,6 +727,9 @@ class Flow:
                     flattened=edge.flattened,
                     validate=validate,
                 )
+
+        if merge_reference_tasks:
+            self.set_reference_tasks(self.reference_tasks().union(flow.reference_tasks()))
 
         self.constants.update(flow.constants or {})
 

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -687,7 +687,11 @@ class Flow:
         return edges
 
     def update(
-        self, flow: "Flow", merge_parameters: bool = False, validate: bool = None, merge_reference_tasks: bool = False
+        self,
+        flow: "Flow",
+        merge_parameters: bool = False,
+        validate: bool = None,
+        merge_reference_tasks: bool = False,
     ) -> None:
         """
         Take all tasks and edges in another flow and add it to this flow.
@@ -729,7 +733,9 @@ class Flow:
                 )
 
         if merge_reference_tasks:
-            self.set_reference_tasks(self.reference_tasks().union(flow.reference_tasks()))
+            self.set_reference_tasks(
+                self.reference_tasks().union(flow.reference_tasks())
+            )
 
         self.constants.update(flow.constants or {})
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1037,6 +1037,36 @@ def test_update_with_parameter_merge():
     assert add_res == 3
     assert sub_res == 0
 
+@pytest.mark.parametrize("merge, expected", [(True,3), (False,2)])
+def test_update_with_reference_task_merge(merge, expected):
+    @task
+    def add_one(a_number: int):
+        return a_number + 1
+
+    @task
+    def mult_one(z: int):
+        return z * 1
+
+    with Flow("Add") as add_fl:
+        a_number = Parameter("a_number", default=1)
+        the_result = add_one(a_number)
+        pos_two = mult_one(the_result)
+
+    @task
+    def sub_one(a_number: int, another_number: int):
+        return a_number - another_number
+
+    with Flow("Subtract") as subtract_fl:
+        a_number = Parameter("another_number", default=2)
+        another_number = Parameter("yet_another_number", default=2)
+        the_result = sub_one(a_number, another_number)
+        neg_one = mult_one(the_result)
+
+    subtract_fl.set_reference_tasks([the_result])
+
+    add_fl.update(subtract_fl, merge_reference_tasks=merge)
+    assert len(add_fl.reference_tasks()) == expected
+
 
 def test_upstream_and_downstream_error_msgs_when_task_is_not_in_flow():
     f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1037,7 +1037,8 @@ def test_update_with_parameter_merge():
     assert add_res == 3
     assert sub_res == 0
 
-@pytest.mark.parametrize("merge, expected", [(True,3), (False,2)])
+
+@pytest.mark.parametrize("merge, expected", [(True, 3), (False, 2)])
 def test_update_with_reference_task_merge(merge, expected):
     @task
     def add_one(a_number: int):


### PR DESCRIPTION
## Summary
Adds optional parameter to the `core.flow.update` method to preserve the reference tasks from the provided flow when updating the current flow with a provided flow.

## Changes
`update` method has an optional `merge_reference_tasks` parameter to add reference tasks from the provided flow to the updated flow.

## Importance
When stitching flows together sometimes it is desirable to not lose the reference tasks set on the two sub-flows.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory 
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)