### PR TITLE
Add client side check for value size

### DIFF
--- a/changes/pr4655.yaml
+++ b/changes/pr4655.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add client side check for key value size - [#4655](https://github.com/PrefectHQ/prefect/pull/4655)"

--- a/src/prefect/backend/kv_store.py
+++ b/src/prefect/backend/kv_store.py
@@ -26,6 +26,7 @@ def set_key_value(key: str, value: Any) -> str:
 
     Raises:
         - ClientError: if using Prefect Server instead of Cloud
+        - ValueError: if `value` exceeds 10 KB limit
     """
     if prefect.config.backend != "cloud":
         raise ClientError(NON_CLOUD_BACKEND_ERROR_MESSAGE)

--- a/src/prefect/backend/kv_store.py
+++ b/src/prefect/backend/kv_store.py
@@ -1,3 +1,5 @@
+import sys
+import json
 from typing import Any, List
 
 import prefect
@@ -27,6 +29,12 @@ def set_key_value(key: str, value: Any) -> str:
     """
     if prefect.config.backend != "cloud":
         raise ClientError(NON_CLOUD_BACKEND_ERROR_MESSAGE)
+
+    # check value is under size limit
+    # note this will be enforced by the API
+    value_size = sys.getsizeof(json.dumps(value))
+    if value_size > 10000:  # 10 KB max
+        raise ValueError("Value payload exceedes 10 KB limit.")
 
     mutation = {
         "mutation($input: set_key_value_input!)": {


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR adds a check for the size of value in a kv pair before sending to Cloud.



## Changes
<!-- What does this PR change? -->

- Adds a check for value size
- Adds tests for value over 10 KB limit
- Adds test cases for setting json-like objects



## Importance
<!-- Why is this PR important? -->
This limit is also enforced by the API, but handling it on the client side makes debugging easier.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)