### PR TITLE
Ensure stack traces are included in logs during task run exceptions

### DIFF
--- a/changes/pr4657.yaml
+++ b/changes/pr4657.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Ensure stack traces are included in logs during task run exceptions - [#4657](https://github.com/PrefectHQ/prefect/pull/4657)"

--- a/src/prefect/agent/agent.py
+++ b/src/prefect/agent/agent.py
@@ -407,7 +407,7 @@ class Agent:
                 return
 
             self.logger.error(
-                f"Encountered exception while deploying flow run {flow_run.id}",
+                f"Exception encountered while deploying flow run {flow_run.id}",
                 exc_info=True,
             )
 

--- a/src/prefect/engine/runner.py
+++ b/src/prefect/engine/runner.py
@@ -63,7 +63,7 @@ def call_state_handlers(method: Callable[..., State]) -> Callable[..., State]:
 
         except Exception as exc:
             formatted = "Unexpected error: {}".format(repr(exc))
-            self.logger.exception(formatted)
+            self.logger.exception(formatted, exc_info=True)
             if raise_on_exception:
                 raise exc
             new_state = Failed(formatted, result=exc)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -892,7 +892,7 @@ class TaskRunner(Runner):
             if prefect.context.get("raise_on_exception"):
                 raise
             self.logger.error(
-                f"Task {task_name!r}: Encountered exception during task execution!",
+                f"Task {task_name!r}: Exception encountered during task execution!",
                 exc_info=True,
             )
             state = Failed(f"Error during execution of task: {exc!r}", result=exc)

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -888,6 +888,9 @@ class TaskRunner(Runner):
             # decorator. Once Prefect signal exceptions are modified to inherit
             # from `BaseException` instead of `Exception`, this can be removed
             raise
+        except signals.ENDRUN:
+            # As above, the `ENDRUN` is a special exception
+            raise
 
         except Exception as exc:  # Handle exceptions in the task
             if prefect.context.get("raise_on_exception"):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -514,7 +514,7 @@ def test_deploy_flow_run_logs_flow_run_exceptions(monkeypatch, caplog, cloud_api
     client.write_run_logs.assert_called_with(
         [dict(flow_run_id="id", level="ERROR", message="Error Here", name="agent")]
     )
-    assert "Encountered exception while deploying flow run id" in caplog.text
+    assert "Exception encountered while deploying flow run id" in caplog.text
 
 
 def test_submit_deploy_flow_run_jobs_raises_exception_and_logs(monkeypatch, cloud_api):

--- a/tests/engine/cloud/test_cloud_task_runner.py
+++ b/tests/engine/cloud/test_cloud_task_runner.py
@@ -605,7 +605,10 @@ def test_state_handler_failures_are_handled_appropriately(client, caplog):
 
     error_logs = [r.message for r in caplog.records if r.levelname == "ERROR"]
     assert len(error_logs) >= 2
-    assert any("This task failed somehow" in elog for elog in error_logs)
+    assert any(
+        "Exception encountered during task execution" in elog for elog in error_logs
+    )
+    assert "Traceback" in caplog.text
     assert "SyntaxError" in error_logs[-1]
     assert "unique" in error_logs[-1]
     assert "state handler" in error_logs[-1]

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -144,8 +144,7 @@ def test_task_with_error_has_good_messages(caplog):
     assert "ValueError: custom-error-message" in caplog.text
     assert "Traceback" in caplog.text  # Traceback should be included
     assert (
-        "Task 'ErrorTask': Encountered exception during task execution!"
-        in caplog.text
+        "Task 'ErrorTask': Exception encountered during task execution!" in caplog.text
     )
 
 

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -133,6 +133,18 @@ def test_task_that_has_an_error_is_marked_fail():
     assert isinstance(task_runner.run(), Failed)
 
 
+def test_task_with_error_has_good_messages(caplog):
+    task_runner = TaskRunner(task=ErrorTask())
+    state = task_runner.run()
+    assert state.is_failed()
+    assert (
+        state.message
+        == "Error during execution of task: ValueError('custom-error-message')"
+    )
+    assert "ValueError: custom-error-message" in caplog.text
+    assert "Traceback" in caplog.text  # Traceback should be included
+
+
 def test_task_that_raises_fail_is_marked_fail():
     task_runner = TaskRunner(task=RaiseFailTask())
     assert isinstance(task_runner.run(), Failed)

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -133,7 +133,7 @@ def test_task_that_has_an_error_is_marked_fail():
     assert isinstance(task_runner.run(), Failed)
 
 
-def test_task_with_error_has_good_messages(caplog):
+def test_task_with_error_has_helpful_messages(caplog):
     task_runner = TaskRunner(task=ErrorTask())
     state = task_runner.run()
     assert state.is_failed()

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -137,10 +137,13 @@ def test_task_with_error_has_helpful_messages(caplog):
     task_runner = TaskRunner(task=ErrorTask())
     state = task_runner.run()
     assert state.is_failed()
-    assert (
-        state.message
-        == "Error during execution of task: ValueError('custom-error-message')"
+    exc_repr = (
+        # Support py3.6 exception reprs
+        "ValueError('custom-error-message',)"
+        if sys.version_info < (3, 7)
+        else "ValueError('custom-error-message')"
     )
+    assert state.message == f"Error during execution of task: {exc_repr}"
     assert "ValueError: custom-error-message" in caplog.text
     assert "Traceback" in caplog.text  # Traceback should be included
     assert (

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -143,6 +143,10 @@ def test_task_with_error_has_good_messages(caplog):
     )
     assert "ValueError: custom-error-message" in caplog.text
     assert "Traceback" in caplog.text  # Traceback should be included
+    assert (
+        "Task 'ErrorTask': Encountered exception during task execution!"
+        in caplog.text
+    )
 
 
 def test_task_that_raises_fail_is_marked_fail():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`get_task_run_state` calls `task.run(...)`. This method is wrapped with `call_state_handlers` which will turn an exception into an `Failed(f"Unexpected error: {repr(exc)}")` state. I want to try to reserve "Unexpected" errors for errors that _we_ do not expect to occur rather than errors in user code. I've added a new exception -> `Failed` state trap in `get_task_run_state` that more clearly states the source of the error and logs the stack trace.


## Changes
<!-- What does this PR change? -->

- Adds `Exception` -> `Failed` handling directly in `get_task_run_state`
- Adds `exc_info` to show a stack trace for unexpected exceptions in `call_state_handlers`

## Importance
<!-- Why is this PR important? -->

We should strive never to hide stack traces from the logs & have consistent error messaging.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~