### PR TITLE
Release 0.14.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ Released on June 15, 2021.
 ### Enhancements
 
 - Use `functools.update_wrapper` for `FunctionTask` - [#4608](https://github.com/PrefectHQ/prefect/pull/4608)
-- Optionally retain reference tasks when updating two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)
+- Add ability to merge reference tasks when combining two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)
 - Add client side check for key value size - [#4655](https://github.com/PrefectHQ/prefect/pull/4655)
 - Ensure stack traces are included in logs during task run exceptions - [#4657](https://github.com/PrefectHQ/prefect/pull/4657)
 - Add `poll_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish - [#4641](https://github.com/PrefectHQ/prefect/pull/4641)
-- Task timeout can be timedelta as well as integer in seconds - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)
+- Add ability to set task timeouts with `timedelta` objects - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.14.22 <Badge text="beta" type="success" />
+
+Released on June 15, 2021.
+
+### Enhancements
+
+- Use `functools.update_wrapper` for `FunctionTask` - [#4608](https://github.com/PrefectHQ/prefect/pull/4608)
+- Optionally retain reference tasks when updating two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)
+- Add client side check for key value size - [#4655](https://github.com/PrefectHQ/prefect/pull/4655)
+- Ensure stack traces are included in logs during task run exceptions - [#4657](https://github.com/PrefectHQ/prefect/pull/4657)
+- Add `poll_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish - [#4641](https://github.com/PrefectHQ/prefect/pull/4641)
+- Task timeout can be timedelta as well as integer in seconds - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)
+
+### Fixes
+
+- Add ssh documentation - [#4539](https://github.com/PrefectHQ/prefect/pull/4539)
+
+### Contributors
+
+- [Pawel Janowski, Recursion](https://github.com/pjanowski)
+- [Peter Roelants](https://github.com/peterroelants)
+
 ## 0.14.21 <Badge text="beta" type="success" />
 
 Released on June 2, 2021.

--- a/changes/pr4539.yaml
+++ b/changes/pr4539.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Add ssh documentation - [#4539](https://github.com/PrefectHQ/prefect/pull/4539)"

--- a/changes/pr4608.yaml
+++ b/changes/pr4608.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Use `functools.update_wrapper` for `FunctionTask` - [#4608](https://github.com/PrefectHQ/prefect/pull/4608)"

--- a/changes/pr4644.yaml
+++ b/changes/pr4644.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Optionally retain reference tasks when updating two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)"
-
-contributor:
-  - "[Pawel Janowski, Recursion](https://github.com/pjanowski)"

--- a/changes/pr4655.yaml
+++ b/changes/pr4655.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Add client side check for key value size - [#4655](https://github.com/PrefectHQ/prefect/pull/4655)"

--- a/changes/pr4657.yaml
+++ b/changes/pr4657.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Ensure stack traces are included in logs during task run exceptions - [#4657](https://github.com/PrefectHQ/prefect/pull/4657)"

--- a/changes/startflowrun_wait_interval_parameter.yaml
+++ b/changes/startflowrun_wait_interval_parameter.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Add `poll_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish - [#4641](https://github.com/PrefectHQ/prefect/pull/4641)"
-
-contributor:
-  - "[Peter Roelants](https://github.com/peterroelants)"

--- a/changes/task_timeout_as_int_or_timedelta.yaml
+++ b/changes/task_timeout_as_int_or_timedelta.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Task timeout can be timedelta as well as integer in seconds - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)"
-
-contributor:
-  - "[Peter Roelants](https://github.com/peterroelants)"


### PR DESCRIPTION
## 0.14.22 <Badge text="beta" type="success" />

Released on June 15, 2021.

### Enhancements

- Use `functools.update_wrapper` for `FunctionTask` - [#4608](https://github.com/PrefectHQ/prefect/pull/4608)
- Optionally retain reference tasks when updating two flows - [#4644](https://github.com/PrefectHQ/prefect/pull/4644)
- Add client side check for key value size - [#4655](https://github.com/PrefectHQ/prefect/pull/4655)
- Ensure stack traces are included in logs during task run exceptions - [#4657](https://github.com/PrefectHQ/prefect/pull/4657)
- Add `poll_interval` parameter to `StartFlowRun` to define the polling interval when waiting for the flow run to finish - [#4641](https://github.com/PrefectHQ/prefect/pull/4641)
- Task timeout can be timedelta as well as integer in seconds - [#4619](https://github.com/PrefectHQ/prefect/pull/4619)

### Fixes

- Add ssh documentation - [#4539](https://github.com/PrefectHQ/prefect/pull/4539)

### Contributors

- [Pawel Janowski, Recursion](https://github.com/pjanowski)
- [Peter Roelants](https://github.com/peterroelants)