### PR TITLE
Fix git storage on windows

### DIFF
--- a/changes/pr4665.yaml
+++ b/changes/pr4665.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix cleanup issue with `Git` storage on Windows - [#4665](https://github.com/PrefectHQ/prefect/pull/4665)"

--- a/src/prefect/utilities/git.py
+++ b/src/prefect/utilities/git.py
@@ -52,6 +52,9 @@ class TemporaryGitRepo:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        # 'close' the repo so files are not still in use
+        self.repo.close()
+        # then remove the temporary files
         self.temp_dir.cleanup()
 
     def checkout_ref(self) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR fixes an issue with `Git` storage on Windows where the `dulwich` library was still accessing repo files, causing temporary directory cleanup to fail.


See related dulwich thread here https://github.com/dulwich/dulwich/issues/584

## Changes
<!-- What does this PR change? -->



## Importance
<!-- Why is this PR important? -->
`Git` storage needs to work on Windows.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~