### PR TITLE
SendGrid.SendEmail task - use Secret value

### DIFF
--- a/changes/pr4669.yaml
+++ b/changes/pr4669.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Change SendGrid SendEmail task to use secret value - [#4669](https://github.com/PrefectHQ/prefect/pull/4669)"
+
+contributor:
+  - "[Stéphan Taljaard](https://github.com/taljaards)"

--- a/src/prefect/tasks/sendgrid/sendgrid.py
+++ b/src/prefect/tasks/sendgrid/sendgrid.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 
-from prefect.client import Secret
 from prefect.core import Task
 from prefect.utilities.tasks import defaults_from_attrs
 from python_http_client.client import Response

--- a/src/prefect/tasks/sendgrid/sendgrid.py
+++ b/src/prefect/tasks/sendgrid/sendgrid.py
@@ -22,7 +22,7 @@ class SendEmail(Task):
         - attachment_file_path (Union[str, Path], optional): The file path of the email attachment;
             can also be provided at runtime
         - sendgrid_api_key (str): The SendGrid API key used for authentication;
-            can also be provided at runtime (it is preferred, actually!)
+            can also be provided at runtime, which is preferred since a secret can be used
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 

--- a/src/prefect/tasks/sendgrid/sendgrid.py
+++ b/src/prefect/tasks/sendgrid/sendgrid.py
@@ -117,7 +117,7 @@ class SendEmail(Task):
             from_email=from_email,
             to_emails=to_emails,
             subject=subject,
-            html_content=html_content,
+            html_content=html_content or "\n",
         )
 
         if category:

--- a/src/prefect/tasks/sendgrid/sendgrid.py
+++ b/src/prefect/tasks/sendgrid/sendgrid.py
@@ -9,9 +9,7 @@ from python_http_client.client import Response
 
 class SendEmail(Task):
     """
-    A task for sending an email via Twilio SendGrid. For this task to
-    function properly, you must have a Prefect Secret set which stores
-    your SendGrid API Key (defaults to `"SENDGRID_API_KEY"`).
+    A task for sending an email via Twilio SendGrid.
 
     Args:
         - from_email (str): The email address of the sender; defaults to notifications@prefect.io
@@ -24,8 +22,8 @@ class SendEmail(Task):
             can also be provided at runtime
         - attachment_file_path (Union[str, Path], optional): The file path of the email attachment;
             can also be provided at runtime
-        - sendgrid_secret (str, optional): the name of the Prefect Secret which stores your
-            SendGrid API key; defaults to `"SENDGRID_API_KEY"`
+        - sendgrid_api_key (str): The SendGrid API key used for authentication;
+            can also be provided at runtime (it is preferred, actually!)
         - **kwargs (optional): additional kwargs to pass to the `Task` constructor
     """
 
@@ -37,7 +35,7 @@ class SendEmail(Task):
         html_content: str = None,
         category: Union[str, List[str]] = None,
         attachment_file_path: Union[str, Path] = None,
-        sendgrid_secret: str = "SENDGRID_API_KEY",
+        sendgrid_api_key: str = None,
         **kwargs: Any
     ):
         self.from_email = from_email
@@ -46,7 +44,7 @@ class SendEmail(Task):
         self.html_content = html_content
         self.category = category
         self.attachment_file_path = attachment_file_path
-        self.sendgrid_secret = sendgrid_secret
+        self.sendgrid_api_key = sendgrid_api_key
         super().__init__(**kwargs)
 
     @defaults_from_attrs(
@@ -56,7 +54,7 @@ class SendEmail(Task):
         "html_content",
         "category",
         "attachment_file_path",
-        "sendgrid_secret",
+        "sendgrid_api_key",
     )
     def run(
         self,
@@ -66,7 +64,7 @@ class SendEmail(Task):
         html_content: str = None,
         category: Union[str, List[str]] = None,
         attachment_file_path: Union[str, Path] = None,
-        sendgrid_secret: str = None,
+        sendgrid_api_key: str = None,
     ) -> Response:
         """
         Run message which sends an email via SendGrid.
@@ -85,9 +83,11 @@ class SendEmail(Task):
                 defaults to those provided at initialization
             - attachment_file_path (Union[str, Path], optional): The file path of the email attachment;
                 defaults to the one provided at initialization
-            - sendgrid_secret (str, optional): the name of the Prefect Secret which stores your
-                SendGrid API key; defaults to `"SENDGRID_API_KEY"`; if not provided here,
-                will use the value provided at initialization
+            - sendgrid_api_key (str, optional): The SendGrid API key used for authentication;
+                if not provided here, will use the value provided at initialization
+
+        Raises:
+            - ValueError: if no API key is provided
 
         Returns:
             - python_http_client.client.Response:
@@ -98,7 +98,8 @@ class SendEmail(Task):
         # Based on the SendGrid example use-case code here:
         # https://github.com/sendgrid/sendgrid-python/blob/aa39f715a061f0de993811faea0adb8223657d01/use_cases/attachment.md
 
-        sendgrid_api_key = Secret(sendgrid_secret).get()
+        if not sendgrid_api_key:
+            raise ValueError("A SendGrid API key must be provided.")
 
         import base64
         import mimetypes

--- a/tests/tasks/sendgrid/test_sendgrid.py
+++ b/tests/tasks/sendgrid/test_sendgrid.py
@@ -22,7 +22,7 @@ class TestInitialization:
             "subject",
             "html_content",
             "attachment_file_path",
-            "sendgrid_secret",
+            "sendgrid_api_key",
         ],
     )
     def test_initializes_attr_from_kwargs(self, attr):

--- a/tests/tasks/sendgrid/test_sendgrid.py
+++ b/tests/tasks/sendgrid/test_sendgrid.py
@@ -28,3 +28,14 @@ class TestInitialization:
     def test_initializes_attr_from_kwargs(self, attr):
         task = SendEmail(**{attr: "my-value"})
         assert getattr(task, attr) == "my-value"
+
+    def test_raises_if_secret_not_eventually_provided(self):
+        task = SendEmail(
+            from_email="hello@itsme.com",
+            to_emails=["hello@itsme.com"],
+            subject="Subject",
+            html_content="Hello!",
+        )
+
+        with pytest.raises(ValueError, match="SendGrid API key"):
+            task.run()


### PR DESCRIPTION
## Summary
Change SendGrid SendEmail task to just use the given secret _value_, instead of manually using the secret name to get the secret value.




## Changes
Remove use of hardcoded `SENDGRID_API_KEY` secret.
This change then outsources the `get`ting of the secret's value.




## Importance
This change allows more flexibility with how the key is given to the Task.
Previously, "Prefect-native" secrets had to be used.
This change allows getting the secret value manually in a flow, e.g. a secret saved in GCP Secret Manager, or AWS Secrets Manger. It also allows more flexibility, since the user can now save the actual secret value as a JSON blob (they just need to convert the value to a string before using this Task).




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)