### PR TITLE
Increase opensky request timeout to 5m

### DIFF
--- a/examples/tutorial/aircraftlib/opensky.py
+++ b/examples/tutorial/aircraftlib/opensky.py
@@ -58,7 +58,7 @@ def _api_request_json(req: str, options: Dict[str, Any] = None) -> Dict[str, Any
         "https://opensky-network.org/api/{}".format(req),
         auth=(),
         params=options or {},
-        timeout=10.00,
+        timeout=300.00,
     )
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
Change opensky api request timeout to 300 seconds.

I tried to run the tutorial code, but the timeout window of only 10 seconds was far too low.

I tried to run the request manually and got the following request time in seconds:

![image](https://user-images.githubusercontent.com/19720037/122604405-4c3ba000-d04c-11eb-92ad-b2e88b89a6f2.png)

Setting this timeout to 300 will help to not break the code when facing low quality internet problems. 