### PR TITLE
Pass API keys as tokens as well when creating flow run environments

### DIFF
--- a/changes/pr4683.yaml
+++ b/changes/pr4683.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Pass API keys as tokens as well when creating flow run environments - [#4683](https://github.com/PrefectHQ/prefect/pull/4683)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -542,7 +542,13 @@ class DockerAgent(Agent):
             {
                 "PREFECT__BACKEND": config.backend,
                 "PREFECT__CLOUD__API": api,
-                "PREFECT__CLOUD__AUTH_TOKEN": config.cloud.agent.get("auth_token", ""),
+                "PREFECT__CLOUD__AUTH_TOKEN": (
+                    # Pull an auth token if it exists but fall back to an API key so
+                    # flows in pre-0.15.0 containers still authenticate correctly
+                    config.cloud.agent.get("auth_token")
+                    or self.flow_run_api_key
+                    or ""
+                ),
                 "PREFECT__CLOUD__API_KEY": self.flow_run_api_key or "",
                 "PREFECT__CLOUD__TENANT_ID": (
                     # Providing a tenant id is only necessary for API keys (not tokens)

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -498,7 +498,13 @@ class ECSAgent(Agent):
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
                 "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
-                "PREFECT__CLOUD__AUTH_TOKEN": config.cloud.agent.get("auth_token", ""),
+                "PREFECT__CLOUD__AUTH_TOKEN": (
+                    # Pull an auth token if it exists but fall back to an API key so
+                    # flows in pre-0.15.0 containers still authenticate correctly
+                    config.cloud.agent.get("auth_token")
+                    or self.flow_run_api_key
+                    or ""
+                ),
                 "PREFECT__CLOUD__API_KEY": self.flow_run_api_key or "",
                 "PREFECT__CLOUD__TENANT_ID": (
                     # Providing a tenant id is only necessary for API keys (not tokens)

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -206,7 +206,12 @@ class LocalAgent(Agent):
             {
                 "PREFECT__BACKEND": config.backend,
                 "PREFECT__CLOUD__API": config.cloud.api,
-                "PREFECT__CLOUD__AUTH_TOKEN": self.client._api_token,
+                "PREFECT__CLOUD__AUTH_TOKEN": (
+                    # Pull an auth token if it exists but fall back to an API key so
+                    # flows in pre-0.15.0 containers still authenticate correctly
+                    self.client._api_token
+                    or self.flow_run_api_key
+                ),
                 "PREFECT__CLOUD__API_KEY": self.flow_run_api_key,
                 "PREFECT__CLOUD__TENANT_ID": (
                     # Providing a tenant id is only necessary for API keys (not tokens)

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -170,7 +170,10 @@ class Client:
                 "API tokens are deprecated, please use API keys instead."
             )
 
-        if self._api_token and self.api_key:
+        # Warn if using both a token and API key, but only if they have different values
+        # because we pass the api key as an api token in some places for backwards
+        # compatibility
+        if self._api_token and self.api_key and self._api_token != self.api_key:
             warnings.warn(
                 "Found both an API token and an API key. API tokens have been "
                 "deprecated and it will be ignored in favor of the API key."

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -164,7 +164,11 @@ def test_environment_has_agent_token_from_config(api, config_with_token):
 @pytest.mark.parametrize("tenant_id", ["ID", None])
 def test_environment_has_api_key_from_config(api, tenant_id):
     with set_temporary_config(
-        {"cloud.api_key": "TEST_KEY", "cloud.tenant_id": tenant_id}
+        {
+            "cloud.api_key": "TEST_KEY",
+            "cloud.tenant_id": tenant_id,
+            "cloud.agent.auth_token": None,
+        }
     ):
         agent = DockerAgent()
 
@@ -174,6 +178,7 @@ def test_environment_has_api_key_from_config(api, tenant_id):
         )
 
     assert env_vars["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+    assert env_vars["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
     assert env_vars.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
 
@@ -186,12 +191,15 @@ def test_environment_has_api_key_from_disk(api, monkeypatch, tenant_id):
     )
 
     agent = DockerAgent()
-    env = agent.populate_env_vars(
-        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}),
-        "test-image",
-    )
+
+    with set_temporary_config({"cloud.agent.auth_token": None}):
+        env = agent.populate_env_vars(
+            GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}),
+            "test-image",
+        )
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+    assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
     assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
 

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -574,7 +574,11 @@ class TestGetRunTaskKwargs:
     @pytest.mark.parametrize("tenant_id", ["ID", None])
     def test_environment_has_api_key_from_config(self, tenant_id):
         with set_temporary_config(
-            {"cloud.api_key": "TEST_KEY", "cloud.tenant_id": tenant_id}
+            {
+                "cloud.api_key": "TEST_KEY",
+                "cloud.tenant_id": tenant_id,
+                "cloud.agent.auth_token": None,
+            }
         ):
             env_list = self.get_run_task_kwargs(ECSRun())["overrides"][
                 "containerOverrides"
@@ -582,6 +586,7 @@ class TestGetRunTaskKwargs:
             env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+        assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
         assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
     @pytest.mark.parametrize("tenant_id", ["ID", None])
@@ -598,6 +603,7 @@ class TestGetRunTaskKwargs:
         env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+        assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
         assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
     @pytest.mark.parametrize(

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1370,7 +1370,11 @@ class TestK8sAgentRunConfig:
         flow_run = self.build_flow_run(KubernetesRun())
 
         with set_temporary_config(
-            {"cloud.api_key": "TEST_KEY", "cloud.tenant_id": tenant_id}
+            {
+                "cloud.api_key": "TEST_KEY",
+                "cloud.tenant_id": tenant_id,
+                "cloud.agent.auth_token": None,
+            }
         ):
             job = KubernetesAgent(
                 namespace="testing",
@@ -1380,6 +1384,7 @@ class TestK8sAgentRunConfig:
         env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+        assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
         assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
     @pytest.mark.parametrize("tenant_id", ["ID", None])
@@ -1399,6 +1404,7 @@ class TestK8sAgentRunConfig:
         env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+        assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
         assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
     @pytest.mark.parametrize(

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -140,12 +140,17 @@ def test_environment_has_api_key_from_config(tenant_id):
     """Check that the API key is passed through from the config via environ"""
 
     with set_temporary_config(
-        {"cloud.api_key": "TEST_KEY", "cloud.tenant_id": tenant_id}
+        {
+            "cloud.api_key": "TEST_KEY",
+            "cloud.tenant_id": tenant_id,
+            "cloud.agent.auth_token": None,
+        }
     ):
         agent = LocalAgent()
         env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+    assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
     assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
 
@@ -157,10 +162,12 @@ def test_environment_has_api_key_from_disk(monkeypatch, tenant_id):
         MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
     )
 
-    agent = LocalAgent()
-    env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
+    with set_temporary_config({"cloud.agent.auth_token": None}):
+        agent = LocalAgent()
+        env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+    assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
     assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This provides backwards compatibility when running an agent authenticated with a 0.15.0 API key that deploys flow runs running in containers that require token based authentication


## Changes
<!-- What does this PR change? -->

- All agents set `PREFECT__CLOUD__AUTH_TOKEN` to `PREFECT__CLOUD__API_KEY` if an auth token is not available.
- The `Client` will not warn if it receives an API key and an API token but they are identical

## Importance
<!-- Why is this PR important? -->

Backwards compatibility for flow runs

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)