### PR TITLE
Split the auth save/load functions out of the `Client

### DIFF
--- a/docs/orchestration/concepts/api.md
+++ b/docs/orchestration/concepts/api.md
@@ -84,14 +84,15 @@ client.tenant_id = "<new-id>"
 Authentication can be saved to disk. This will save the current API key and tenant id to `~/.prefect/auth.toml` and future clients instantiated without an API key or tenant id will load these values as defaults.
 
 ```python
-client.save_auth_to_disk()
+client.save_auth()
 ```
 
 
-To inspect the auth stored on disk, you may also use the client method `load_auth_from_disk()`:
+To inspect the auth stored on disk, you may also use the function `load_auth_from_disk`:
 
 ```python
-disk_auth = client.load_auth_from_disk()
+from prefect.client import load_auth_from_disk
+disk_auth = load_auth_from_disk(client.api_server)
 # {"api_key": "API_KEY", "tenant_id": "ID"}
 ```
 

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -5,6 +5,7 @@ from click.exceptions import Abort
 from tabulate import tabulate
 
 from prefect import Client, config
+from prefect.client.client import save_auth_to_disk
 from prefect.exceptions import AuthorizationError, ClientError
 from prefect.cli.build_register import handle_terminal_error, TerminalError
 from prefect.backend import TenantView
@@ -152,7 +153,7 @@ def login(key, token):
                     "which is deprecated. Please use `--key` instead.",
                     fg="yellow",
                 )
-            client.save_auth_to_disk()
+            client.save_auth()
             tenant = TenantView.from_tenant_id(tenant_id)
             click.secho(
                 f"Logged in to Prefect Cloud tenant {tenant.name!r} ({tenant.slug})",
@@ -250,10 +251,7 @@ def logout(token):
         )
 
         # Clear the key and tenant id then write to the cache
-        client.api_key = ""
-        client._tenant_id = ""
-        client.save_auth_to_disk()
-
+        save_auth_to_disk(client.api_server, api_key=None, tenant_id=None)
         click.secho("Logged out of Prefect Cloud", fg="green")
 
     elif client._api_token:
@@ -377,7 +375,7 @@ def switch_tenants(id, slug, default):
         if default:
             # Clear the set tenant on disk
             client.tenant_id = None
-            client.save_auth_to_disk()
+            client.save_auth()
             click.secho(
                 "Tenant restored to the default tenant for your API key: "
                 f"{client.get_auth_tenant()}",
@@ -392,7 +390,7 @@ def switch_tenants(id, slug, default):
     # `login_to_tenant` will write to disk if using an API token, if using an API key
     # we will write to disk manually here
     if client.api_key:
-        client.save_auth_to_disk()
+        client.save_auth()
 
     click.secho(f"Tenant switched to {client.tenant_id}", fg="green")
 

--- a/src/prefect/client/__init__.py
+++ b/src/prefect/client/__init__.py
@@ -1,2 +1,2 @@
-from prefect.client.client import Client
+from prefect.client.client import Client, load_auth_from_disk
 from prefect.client.secrets import Secret

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -181,7 +181,7 @@ def test_environment_has_api_key_from_config(api, tenant_id):
 def test_environment_has_api_key_from_disk(api, monkeypatch, tenant_id):
     """Check that the API key is passed through from the on disk cache"""
     monkeypatch.setattr(
-        "prefect.Client.load_auth_from_disk",
+        "prefect.client.client.load_auth_from_disk",
         MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
     )
 

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -588,7 +588,7 @@ class TestGetRunTaskKwargs:
     def test_environment_has_api_key_from_disk(self, monkeypatch, tenant_id):
         """Check that the API key is passed through from the on disk cache"""
         monkeypatch.setattr(
-            "prefect.Client.load_auth_from_disk",
+            "prefect.client.client.load_auth_from_disk",
             MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
         )
 

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1386,7 +1386,7 @@ class TestK8sAgentRunConfig:
     def test_environment_has_api_key_from_disk(self, monkeypatch, tenant_id):
         """Check that the API key is passed through from the on disk cache"""
         monkeypatch.setattr(
-            "prefect.Client.load_auth_from_disk",
+            "prefect.client.client.load_auth_from_disk",
             MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
         )
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -153,7 +153,7 @@ def test_environment_has_api_key_from_config(tenant_id):
 def test_environment_has_api_key_from_disk(monkeypatch, tenant_id):
     """Check that the API key is passed through from the on disk cache"""
     monkeypatch.setattr(
-        "prefect.Client.load_auth_from_disk",
+        "prefect.client.client.load_auth_from_disk",
         MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
     )
 

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -146,7 +146,7 @@ def test_auth_logout_not_confirm(patch_post, cloud_api):
     patch_post(dict(data=dict(auth_info=dict(tenant_id="id"))))
 
     client = prefect.Client(api_key="foo")
-    client.save_auth_to_disk()
+    client.save_auth()
 
     runner = CliRunner()
     result = runner.invoke(auth, ["logout"], input="N")


### PR DESCRIPTION

## Summary

Previously I provided asymmetric functions in the `Client`.

`Client.save_auth_to_disk() -> None` -- uses values from the client

and

`Client.load_auth_from_disk() -> dict` -- does not mutate client

I found this asymmetry confusing. It also led to cases where you'd do

```python
client = Client()
client.tenant_id = "foo"
client.save_auth_to_disk()
```

or where you'd instantiate a client just to see what auth would be used

```python
client = Client()
api_key = client.api_key
```

To resolve this, I split out these methods into

`load_auth_from_disk(api_server: str) -> dict`
`save_auth_to_disk(api_server: str, api_key: str = None, tenant_id: str = None) -> None`

and retained

`Client.save_auth() -> None`

I'm not sure this is better. I think what might make the most sense is

`get_default_auth(api_server: str = prefect.config.cloud.api, token_only: bool = False) -> dict`

which will return an API key that has been properly resolved from disk / config _or_ a token if there's no API key and a token exists _or_ just do token resolving for places where we need that backwards compatible. This would be helpful for lowering the boilerplate in https://github.com/PrefectHQ/prefect/pull/4683

