### PR TITLE
Always retrieve the tenant id in the Client

### DIFF
--- a/docs/orchestration/concepts/api.md
+++ b/docs/orchestration/concepts/api.md
@@ -72,7 +72,7 @@ client = prefect.Client(api_key="API_KEY", tenant_id="<id>")
 If you do not pass a tenant, it will be left as `None` which means the default tenant associated with the API key will be used for requests. In that case, you can get the default tenant associated with the key from the client:
 
 ```python
-client.get_auth_tenant()
+client.tenant_id
 ```
 
 The tenant id can be changed on an existing client, but requests will fail if the API key is not valid for that tenant:

--- a/src/prefect/backend/tenant.py
+++ b/src/prefect/backend/tenant.py
@@ -139,4 +139,4 @@ class TenantView:
             A populated `TenantView` instance
         """
         client = Client()
-        return cls.from_tenant_id(client.tenant_id or client.get_auth_tenant())
+        return cls.from_tenant_id(client.tenant_id)

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -131,7 +131,7 @@ def login(key, token):
     client = Client(api_key=key or token, tenant_id=None)
 
     try:
-        tenant_id = client.get_auth_tenant()
+        tenant_id = client._get_auth_tenant()
     except AuthorizationError:
         if key:  # We'll catch an error again later if using a token
             raise TerminalError("Unauthorized. Invalid Prefect Cloud API key.")
@@ -315,7 +315,7 @@ def list_tenants():
     output = []
     for item in tenants:
         active = None
-        if item.id == (client.tenant_id or client.get_auth_tenant()):
+        if item.id == client.tenant_id:
             active = "*"
         output.append([item.name, item.slug, item.id, active])
 
@@ -380,7 +380,7 @@ def switch_tenants(id, slug, default):
             client.save_auth_to_disk()
             click.secho(
                 "Tenant restored to the default tenant for your API key: "
-                f"{client.get_auth_tenant()}",
+                f"{client._get_auth_tenant()}",
                 fg="green",
             )
             return
@@ -674,9 +674,7 @@ def status():
         click.echo("You are authenticating with an API key")
 
         try:
-            click.echo(
-                f"You are logged in to tenant {client.tenant_id or client.get_auth_tenant()}"
-            )
+            click.echo(f"You are logged in to tenant {client.tenant_id}")
         except Exception as exc:
             click.echo(f"Your authentication is not working: {exc}")
 

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -152,6 +152,7 @@ def login(key, token):
                     "which is deprecated. Please use `--key` instead.",
                     fg="yellow",
                 )
+            client.tenant_id = tenant_id
             client.save_auth_to_disk()
             tenant = TenantView.from_tenant_id(tenant_id)
             click.secho(

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -135,7 +135,7 @@ def login(key, token):
     except AuthorizationError:
         if key:  # We'll catch an error again later if using a token
             raise TerminalError("Unauthorized. Invalid Prefect Cloud API key.")
-    except ClientError as exc:
+    except ClientError:
         raise TerminalError("Error attempting to communicate with Prefect Cloud.")
     else:
         if not tenant_id and key:

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -138,28 +138,20 @@ def login(key, token):
     except ClientError:
         raise TerminalError("Error attempting to communicate with Prefect Cloud.")
     else:
-        if not tenant_id and key:
-            # This would be a weird case to encounter, Cloud would have to authorize the
-            # key without returning a tenant
-            raise TerminalError(
-                "Failed to find a tenant associated with the given API key!"
-            )
-
-        elif tenant_id:  # Successful login
-            if token:
-                click.secho(
-                    "WARNING: You logged in with an API key using the `--token` flag "
-                    "which is deprecated. Please use `--key` instead.",
-                    fg="yellow",
-                )
-            client.tenant_id = tenant_id
-            client.save_auth_to_disk()
-            tenant = TenantView.from_tenant_id(tenant_id)
+        if token:
             click.secho(
-                f"Logged in to Prefect Cloud tenant {tenant.name!r} ({tenant.slug})",
-                fg="green",
+                "WARNING: You logged in with an API key using the `--token` flag "
+                "which is deprecated. Please use `--key` instead.",
+                fg="yellow",
             )
-            return
+        client.tenant_id = tenant_id
+        client.save_auth_to_disk()
+        tenant = TenantView.from_tenant_id(tenant_id)
+        click.secho(
+            f"Logged in to Prefect Cloud tenant {tenant.name!r} ({tenant.slug})",
+            fg="green",
+        )
+        return
 
         # If there's not a tenant id, we've been given an actual token, fallthrough to
         # the backwards compatibility token auth

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -135,7 +135,7 @@ def login(key, token):
     except AuthorizationError:
         if key:  # We'll catch an error again later if using a token
             raise TerminalError("Unauthorized. Invalid Prefect Cloud API key.")
-    except ClientError:
+    except ClientError as exc:
         raise TerminalError("Error attempting to communicate with Prefect Cloud.")
     else:
         if not tenant_id and key:

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -118,7 +118,6 @@ class Client:
         self._access_token = None
         self._refresh_token = None
         self._access_token_expires_at = pendulum.now()
-        self._tenant_id = None
         self._attached_headers = {}  # type: Dict[str, str]
         self.logger = create_diagnostic_logger("Diagnostics")
 
@@ -133,18 +132,19 @@ class Client:
 
         # Load the API key
         cached_auth = self.load_auth_from_disk()
-        self.api_key = (
+        self.api_key: Optional[str] = (
             api_key
             or prefect.context.config.cloud.get("api_key")
             or cached_auth.get("api_key")
         )
 
         # Load the tenant id
-        self._tenant_id = (
+        self._tenant_id: Optional[str] = (
             tenant_id
             or prefect.context.config.cloud.get("tenant_id")
             or cached_auth.get("tenant_id")
         )
+
         # If not set at this point, when `Client.tenant_id` is accessed the default
         # tenant will be loaded and used for future requests.
 
@@ -311,7 +311,8 @@ class Client:
                 if not self._tenant_id and self._api_token:
                     self._init_tenant()
 
-                return self._tenant_id
+                # Should be set by `_init_tenant()` but we will not guarantee it
+                return self._tenant_id  # type: ignore
 
             if not self._tenant_id:
                 self._tenant_id = self._get_auth_tenant()

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -210,7 +210,7 @@ class Client:
         tenant_id = response.get("data", {}).get("auth_info", {}).get("tenant_id", "")
 
         if tenant_id == "":
-            raise ValueError(
+            raise ClientError(
                 "Unexpected response from the API while querying for the default "
                 f"tenant: {response}"
             )
@@ -218,7 +218,7 @@ class Client:
         elif tenant_id is None:
             # If the backend returns a `None` value tenant id, it indicates that an API
             # token was passed in as an API key
-            raise ValueError(
+            raise AuthorizationError(
                 "An API token was used as an API key. There is no tenant associated "
                 "with API tokens. Use an API key for authentication."
             )
@@ -230,12 +230,12 @@ class Client:
             response = self.graphql({"query": {"tenant": {"id"}}})
             tenants = response.get("data", {}).get("tenant", None)
             if tenants is None:
-                raise ValueError(
+                raise ClientError(
                     f"Unexpected response from the API while querying for tenants: {response}"
                 )
 
             if not tenants:  # The user has not created a tenant yet
-                raise ValueError(
+                raise ClientError(
                     "Your Prefect Server instance has no tenants. "
                     "Create a tenant with `prefect server create-tenant`"
                 )
@@ -327,7 +327,7 @@ class Client:
                 self._tenant_id = self._get_default_server_tenant()
 
         if not self._tenant_id:
-            raise ValueError(
+            raise ClientError(
                 "A tenant could not be determined. Please use `prefect auth status` "
                 "to get information about your authentication and file an issue."
             )

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -303,16 +303,20 @@ class Client:
 
         If it is has not been explicitly set, the default tenant id will be retrieved
         """
-        if self.api_key and prefect.config.backend == "cloud":
-            if not self._tenant_id:
-                self._tenant_id = self._get_auth_tenant()
-        elif prefect.config.backend == "server":
-            if not self._tenant_id:
-                self._tenant_id = self._get_default_server_tenant()
-        else:
+        if self._api_token and prefect.config.backend == "cloud":
             # Backwards compatibility for API tokens
             if not self._tenant_id and self._api_token:
                 self._init_tenant()
+
+            return self._tenant_id
+
+        elif prefect.config.backend == "cloud":
+            if not self._tenant_id:
+                self._tenant_id = self._get_auth_tenant()
+
+        elif prefect.config.backend == "server":
+            if not self._tenant_id:
+                self._tenant_id = self._get_default_server_tenant()
 
         if not self._tenant_id:
             raise ValueError(

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -305,14 +305,14 @@ class Client:
 
         If it is has not been explicitly set, the default tenant id will be retrieved
         """
-        if self._api_token and prefect.config.backend == "cloud":
-            # Backwards compatibility for API tokens
-            if not self._tenant_id and self._api_token:
-                self._init_tenant()
+        if prefect.config.backend == "cloud":
+            if self._api_token and not self.api_key:
+                # Backwards compatibility for API tokens
+                if not self._tenant_id and self._api_token:
+                    self._init_tenant()
 
-            return self._tenant_id
+                return self._tenant_id
 
-        elif prefect.config.backend == "cloud":
             if not self._tenant_id:
                 self._tenant_id = self._get_auth_tenant()
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1971,7 +1971,7 @@ class Client:
                     type=agent_type,
                     name=name,
                     labels=labels or [],
-                    tenant_id=self._get_auth_tenant(),
+                    tenant_id=self.tenant_id,
                     agent_config_id=agent_config_id,
                 )
             ),

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -218,7 +218,7 @@ class Client:
                 "Your backend is set to {prefect.config.backend!r}"
             )
 
-    def _get_default_server_tenant(self) -> Optional[str]:
+    def _get_default_server_tenant(self) -> str:
         if prefect.config.backend == "server":
             response = self.graphql({"query": {"tenant": {"id"}}})
             tenants = response.get("data", {}).get("tenant", None)
@@ -228,7 +228,10 @@ class Client:
                 )
 
             if not tenants:  # The user has not created a tenant yet
-                return None
+                raise ValueError(
+                    "Your Prefect Server instance has no tenants. "
+                    "Create a tenant with `prefect server create-tenant`"
+                )
 
             return tenants[0].id
 
@@ -310,6 +313,12 @@ class Client:
             # Backwards compatibility for API tokens
             if not self._tenant_id and self._api_token:
                 self._init_tenant()
+
+        if not self._tenant_id:
+            raise ValueError(
+                "A tenant could not be determined. Please use `prefect auth status` "
+                "to get information about your authentication and file an issue."
+            )
 
         return self._tenant_id
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -194,7 +194,7 @@ class Client:
         """
         Get the current tenant associated with the API key being used. If the client has
         a specific tenant id set, this will verify that the given tenant id is
-        compatible with the API key.
+        compatible with the API key because the tenant will be attached to the request.
         """
         if not prefect.config.backend == "cloud":
 
@@ -209,13 +209,18 @@ class Client:
         response = self.graphql({"query": {"auth_info": "tenant_id"}})
         tenant_id = response.get("data", {}).get("auth_info", {}).get("tenant_id", "")
 
-        # If the backend returns a `None` value tenant id, it indicates that an API
-        # token was passed in as an API key
-
         if tenant_id == "":
             raise ValueError(
                 "Unexpected response from the API while querying for the default "
                 f"tenant: {response}"
+            )
+
+        elif tenant_id is None:
+            # If the backend returns a `None` value tenant id, it indicates that an API
+            # token was passed in as an API key
+            raise ValueError(
+                "An API token was used as an API key. There is no tenant associated "
+                "with API tokens. Use an API key for authentication."
             )
 
         return tenant_id

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -171,6 +171,7 @@ def test_environment_has_api_key_from_config(api, tenant_id):
         }
     ):
         agent = DockerAgent()
+        agent.client._get_auth_tenant = MagicMock(return_value="ID")
 
         env_vars = agent.populate_env_vars(
             GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}),
@@ -179,7 +180,7 @@ def test_environment_has_api_key_from_config(api, tenant_id):
 
     assert env_vars["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
     assert env_vars["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-    assert env_vars.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+    assert env_vars["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
 
 @pytest.mark.parametrize("tenant_id", ["ID", None])
@@ -191,16 +192,16 @@ def test_environment_has_api_key_from_disk(api, monkeypatch, tenant_id):
     )
 
     agent = DockerAgent()
+    agent.client._get_auth_tenant = MagicMock(return_value="ID")
 
-    with set_temporary_config({"cloud.agent.auth_token": None}):
-        env = agent.populate_env_vars(
-            GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}),
-            "test-image",
-        )
+    env = agent.populate_env_vars(
+        GraphQLResult({"id": "id", "name": "name", "flow": {"id": "foo"}}),
+        "test-image",
+    )
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
     assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-    assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+    assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
 
 def test_populate_env_vars_includes_agent_labels(api):

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -424,6 +424,7 @@ class TestGenerateTaskDefinition:
 class TestGetRunTaskKwargs:
     def get_run_task_kwargs(self, run_config, **kwargs):
         agent = ECSAgent(**kwargs)
+        agent.client._get_auth_tenant = MagicMock(return_value="ID")
         flow_run = GraphQLResult(
             {
                 "flow": GraphQLResult(
@@ -587,7 +588,7 @@ class TestGetRunTaskKwargs:
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
         assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-        assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+        assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
     @pytest.mark.parametrize("tenant_id", ["ID", None])
     def test_environment_has_api_key_from_disk(self, monkeypatch, tenant_id):
@@ -604,7 +605,7 @@ class TestGetRunTaskKwargs:
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
         assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-        assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+        assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
     @pytest.mark.parametrize(
         "config, agent_env_vars, run_config_env_vars, expected_logging_level",

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1376,16 +1376,18 @@ class TestK8sAgentRunConfig:
                 "cloud.agent.auth_token": None,
             }
         ):
-            job = KubernetesAgent(
+            agent = KubernetesAgent(
                 namespace="testing",
-            ).generate_job_spec(flow_run)
+            )
+            agent.client._get_auth_tenant = MagicMock(return_value="ID")
+            job = agent.generate_job_spec(flow_run)
 
         env_list = job["spec"]["template"]["spec"]["containers"][0]["env"]
         env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
         assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-        assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+        assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
     @pytest.mark.parametrize("tenant_id", ["ID", None])
     def test_environment_has_api_key_from_disk(self, monkeypatch, tenant_id):
@@ -1396,16 +1398,18 @@ class TestK8sAgentRunConfig:
         )
 
         flow_run = self.build_flow_run(KubernetesRun())
-        job = KubernetesAgent(
+        agent = KubernetesAgent(
             namespace="testing",
-        ).generate_job_spec(flow_run)
+        )
+        agent.client._get_auth_tenant = MagicMock(return_value="ID")
+        job = agent.generate_job_spec(flow_run)
 
         env_list = job["spec"]["template"]["spec"]["containers"][0]["env"]
         env = {item["name"]: item["value"] for item in env_list}
 
         assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
         assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-        assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+        assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
     @pytest.mark.parametrize(
         "config, agent_env_vars, run_config_env_vars, expected_logging_level",

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -147,11 +147,12 @@ def test_environment_has_api_key_from_config(tenant_id):
         }
     ):
         agent = LocalAgent()
+        agent.client._get_auth_tenant = MagicMock(return_value="ID")
         env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
     assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-    assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+    assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
 
 @pytest.mark.parametrize("tenant_id", ["ID", None])
@@ -161,14 +162,14 @@ def test_environment_has_api_key_from_disk(monkeypatch, tenant_id):
         "prefect.Client.load_auth_from_disk",
         MagicMock(return_value={"api_key": "TEST_KEY", "tenant_id": tenant_id}),
     )
-
     with set_temporary_config({"cloud.agent.auth_token": None}):
         agent = LocalAgent()
-        env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
+    agent.client._get_auth_tenant = MagicMock(return_value="ID")
+    env = agent.populate_env_vars(TEST_FLOW_RUN_DATA)
 
     assert env["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
     assert env["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
-    assert env.get("PREFECT__CLOUD__TENANT_ID") == tenant_id
+    assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
 
 def test_populate_env_vars_from_agent_config():

--- a/tests/backend/test_tenant.py
+++ b/tests/backend/test_tenant.py
@@ -95,7 +95,7 @@ def test_tenant_view_from_returns_instance(patch_post, from_method, monkeypatch)
         tenant = TenantView.from_tenant_id("fake-id")
     elif from_method == "current_tenant":
         monkeypatch.setattr(
-            "prefect.client.client.Client.get_auth_tenant",
+            "prefect.client.client.Client._get_auth_tenant",
             MagicMock(return_value="fake-id"),
         )
         tenant = TenantView.from_current_tenant()

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -99,7 +99,7 @@ def test_auth_login_with_api_key(patch_post, monkeypatch, cloud_api, as_token):
     assert "Logged in to Prefect Cloud tenant 'Name' (tenant-slug)" in result.output
 
     # Client is instantiated with the correct key and null tenant
-    Client.assert_called_once_with(api_key="test", tenant_id=None)
+    Client.assert_called_with(api_key="test", tenant_id=None)
     # Auth tenant is retrieved to verify key
     Client()._get_auth_tenant.assert_called_once()
     # Auth tenant is set on Client and saved to disk

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -41,7 +41,7 @@ def test_auth_login_with_token(patch_post, monkeypatch, cloud_api):
     Client = MagicMock()
 
     # Raise an error during treating token as a key to get to token compat code
-    Client().get_auth_tenant = MagicMock(side_effect=AuthorizationError)
+    Client()._get_auth_tenant = MagicMock(side_effect=AuthorizationError)
     Client().api_key = None
 
     Client().login_to_tenant = MagicMock(return_value=True)
@@ -57,7 +57,7 @@ def test_auth_login_with_token_key_is_not_allowed(patch_post, monkeypatch, cloud
     Client = MagicMock()
 
     # Raise an error during treating token as a key to get to token compat code
-    Client().get_auth_tenant = MagicMock(side_effect=AuthorizationError)
+    Client()._get_auth_tenant = MagicMock(side_effect=AuthorizationError)
     Client().api_key = "foo"
     monkeypatch.setattr("prefect.cli.auth.Client", Client)
 
@@ -82,7 +82,7 @@ def test_auth_login_client_error(patch_post, cloud_api):
 @pytest.mark.parametrize("as_token", [True, False])
 def test_auth_login_with_api_key(patch_post, monkeypatch, cloud_api, as_token):
     Client = MagicMock()
-    Client().get_auth_tenant = MagicMock(return_value="tenant-id")
+    Client()._get_auth_tenant = MagicMock(return_value="tenant-id")
     TenantView = MagicMock()
     TenantView.from_tenant_id.return_value = prefect.backend.TenantView(
         tenant_id="id", name="Name", slug="tenant-slug"
@@ -128,7 +128,7 @@ def test_auth_logout_after_login(patch_post, monkeypatch, cloud_api):
 
     Client = MagicMock()
     # Raise an error during treating token as a key to get to token compat code
-    Client().get_auth_tenant = MagicMock(side_effect=AuthorizationError)
+    Client()._get_auth_tenant = MagicMock(side_effect=AuthorizationError)
     Client().api_key = None
     Client().login_to_tenant = MagicMock(return_value=True)
     monkeypatch.setattr("prefect.cli.auth.Client", Client)

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -244,7 +244,8 @@ def test_list_tenants(patch_post, cloud_api):
     )
 
     runner = CliRunner()
-    result = runner.invoke(auth, ["list-tenants"])
+    with set_temporary_config({"cloud.api_key": "foo"}):
+        result = runner.invoke(auth, ["list-tenants"])
     assert result.exit_code == 0
     assert "id" in result.output
     assert "slug" in result.output

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -94,8 +94,17 @@ def test_auth_login_with_api_key(patch_post, monkeypatch, cloud_api, as_token):
     # All `--token` args are treated as keys first for easier transition
     arg = "--token" if as_token else "--key"
     result = runner.invoke(auth, ["login", arg, "test"])
+
     assert result.exit_code == 0
     assert "Logged in to Prefect Cloud tenant 'Name' (tenant-slug)" in result.output
+
+    # Client is instantiated with the correct key and null tenant
+    Client.assert_called_once_with(api_key="test", tenant_id=None)
+    # Auth tenant is retrieved to verify key
+    Client()._get_auth_tenant.assert_called_once()
+    # Auth tenant is set on Client and saved to disk
+    assert Client().tenant_id == "tenant-id"
+    Client().save_auth_to_disk.assert_called_once()
 
 
 def test_auth_login_with_api_key_client_error(patch_post, cloud_api):

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -24,8 +24,10 @@ def test_create_help():
     )
 
 
-def test_create_project(patch_post, cloud_api):
-    patch_post(dict(data=dict(create_project=dict(id="id"))))
+def test_create_project(patch_post, server_api):
+    patch_post(
+        dict(data=dict(create_project=dict(id="id"), tenant=[dict(id="tenant")]))
+    )
 
     runner = CliRunner()
     result = runner.invoke(create, ["project", "test"])
@@ -33,7 +35,7 @@ def test_create_project(patch_post, cloud_api):
     assert "test created" in result.output
 
 
-def test_create_project_error(patch_post):
+def test_create_project_error(patch_post, server_api):
     patch_post(dict(errors=[dict(error={})]))
 
     runner = CliRunner()
@@ -42,8 +44,10 @@ def test_create_project_error(patch_post):
     assert "Error creating project" in result.output
 
 
-def test_create_project_description(patch_post, cloud_api):
-    patch_post(dict(data=dict(create_project=dict(id="id"))))
+def test_create_project_description(patch_post, server_api):
+    patch_post(
+        dict(data=dict(create_project=dict(id="id"), tenant=[dict(id="tenant")]))
+    )
 
     runner = CliRunner()
     result = runner.invoke(create, ["project", "test", "-d", "description"])
@@ -51,7 +55,7 @@ def test_create_project_description(patch_post, cloud_api):
     assert "test created" in result.output
 
 
-def test_create_project_that_already_exists(patch_posts):
+def test_create_project_that_already_exists(patch_posts, server_api):
     patch_posts(
         [
             {
@@ -60,7 +64,7 @@ def test_create_project_that_already_exists(patch_posts):
                 ],
                 "data": {"create_project": None},
             },
-            {"data": {"project": [{"id": "proj-id"}]}},
+            {"data": {"project": [{"id": "proj-id"}]}, "tenant": [{"id": "tenant"}]},
         ]
     )
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -62,7 +62,7 @@ class TestClientAuthentication:
 
         # No key should be present yet
         client = Client()
-        assert client.tenant_id is None
+        assert client._tenant_id is None
 
         # Save to disk (and set an API key so we don't enter API token logic)
         client = Client(api_key="KEY", tenant_id="DISK_TENANT")
@@ -73,15 +73,15 @@ class TestClientAuthentication:
 
             # Should ignore config/disk
             client = Client(tenant_id="DIRECT_TENANT")
-            assert client.tenant_id == "DIRECT_TENANT"
+            assert client._tenant_id == "DIRECT_TENANT"
 
             # Should load from config
             client = Client()
-            assert client.tenant_id == "CONFIG_TENANT"
+            assert client._tenant_id == "CONFIG_TENANT"
 
         # Should load from disk
         client = Client()
-        assert client.tenant_id == "DISK_TENANT"
+        assert client._tenant_id == "DISK_TENANT"
 
     def test_client_save_auth_to_disk(self):
         client = Client(api_key="KEY", tenant_id="ID")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -208,6 +208,15 @@ class TestClientAuthentication:
         assert client._get_auth_tenant() == "id"
         client.graphql.assert_called_once_with({"query": {"auth_info": "tenant_id"}})
 
+    def test_get_auth_tenant_errors_with_api_token_as_keye(self):
+        client = Client(api_key="pretend-this-is-a-token")
+        client.graphql = MagicMock(
+            return_value=GraphQLResult({"data": {"auth_info": {"tenant_id": None}}})
+        )
+
+        with pytest.raises(ValueError, match="API token was used as an API key"):
+            client._get_auth_tenant()
+
     def test_get_auth_tenant_errors_without_auth_set(self):
         client = Client()
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -200,13 +200,19 @@ class TestClientAuthentication:
             client._get_default_server_tenant.assert_called_once()
 
     def test_get_auth_tenant_queries_for_auth_info(self):
-        client = Client()
+        client = Client(api_key="foo")
         client.graphql = MagicMock(
             return_value=GraphQLResult({"data": {"auth_info": {"tenant_id": "id"}}})
         )
 
         assert client._get_auth_tenant() == "id"
         client.graphql.assert_called_once_with({"query": {"auth_info": "tenant_id"}})
+
+    def test_get_auth_tenant_errors_without_auth_set(self):
+        client = Client()
+
+        with pytest.raises(ValueError, match="have not set an API key"):
+            assert client._get_auth_tenant() == "id"
 
     def test_get_default_server_tenant_gets_first_tenant(self):
         with set_temporary_config({"backend": "server"}):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -18,7 +18,7 @@ from prefect.environments.execution import LocalEnvironment
 from prefect.storage import Local
 from prefect.run_configs import LocalRun
 from prefect.utilities.configuration import set_temporary_config
-from prefect.exceptions import ClientError
+from prefect.exceptions import ClientError, AuthorizationError
 from prefect.utilities.graphql import decompress
 
 
@@ -214,7 +214,9 @@ class TestClientAuthentication:
             return_value=GraphQLResult({"data": {"auth_info": {"tenant_id": None}}})
         )
 
-        with pytest.raises(ValueError, match="API token was used as an API key"):
+        with pytest.raises(
+            AuthorizationError, match="API token was used as an API key"
+        ):
             client._get_auth_tenant()
 
     def test_get_auth_tenant_errors_without_auth_set(self):
@@ -242,7 +244,7 @@ class TestClientAuthentication:
                 return_value=GraphQLResult({"data": {"tenant": []}})
             )
 
-            with pytest.raises(ValueError, match="no tenant"):
+            with pytest.raises(ClientError, match="no tenant"):
                 client._get_default_server_tenant()
 
 

--- a/tests/client/test_client_auth_compat.py
+++ b/tests/client/test_client_auth_compat.py
@@ -295,7 +295,10 @@ class TestTenantAuth:
         assert client.tenant_id == tenant_id
 
         # new client doesn't load the active tenant because there's no api token loaded
-        assert Client().tenant_id is None
+        client = Client()
+        client._init_tenant()
+        assert client._tenant_id is None
+        # Note: Using `.tenant_id` here would active api_key logic
 
     def test_logout_clears_access_token_and_tenant(self, patch_post, cloud_api):
         tenant_id = str(uuid.uuid4())
@@ -311,7 +314,7 @@ class TestTenantAuth:
                 }
             }
         )
-        client = Client()
+        client = Client(api_token="TOKEN")
         client.login_to_tenant(tenant_id=tenant_id)
 
         assert client._access_token is not None
@@ -325,7 +328,7 @@ class TestTenantAuth:
         assert client.tenant_id is None
 
         # new client doesn't load the active tenant
-        assert Client().tenant_id is None
+        assert Client(api_token="TOKEN").tenant_id is None
 
     def test_refresh_token_sets_attributes(self, patch_post, cloud_api):
         patch_post(


### PR DESCRIPTION
## Summary

Previously, if using an API key `Client.tenant_id` would return `None` if a tenant had not been explicitly set. The backend will infer the default tenant for us and there's no reason to query for it. However, `Client.tenant_id` is used by the agent during registration (why it's not just inferred from authentication, I'm not sure -- cc @cicdw). Unfortunately this means that #4676 broke launching agents with API keys. This behavior was generally confusing anyway as it required `client.tenant_id or client.get_auth_tenant()` if you wanted to _for sure_ get the current tenant id without always querying the backend so I think this is probably worth doing.

## Changes

- The `tenant_id` property now retrieves the default tenant for the key and sets `_tenant_id` for API keys on first use
- Saving auth to disk uses `_tenant_id` to prevent this pull from happening unexpectedly
- `test_register_agent` now actually covers the graphql query
- The `client.tenant_id or client.get_auth_tenant()` pattern can and has been replaced with just `client.tenant_id`
- Default tenant retrieval helper methods are now private
- When logging in, the tenant id is written to disk instead of being left blank to use the key default. This means if the default for a key changes after login, the tenant will not suddenly change.

## Other considerations

We could move the `tenant_id` property to a `get_active_tenant()` method which would stop it from hiding a query to the API but change the existing interface.