### PR TITLE
Fix missing event timestamp attribute errors in K8s agent

### DIFF
--- a/changes/pr4693.yaml
+++ b/changes/pr4693.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix missing event timestamp attribute errors in K8s agent - [#4693](https://github.com/PrefectHQ/prefect/pull/4693)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Optional, Iterable, List, Any
 
 import json
+import pendulum
 import yaml
 
 import prefect
@@ -228,8 +229,15 @@ class KubernetesAgent(Agent):
 
                                 for event in sorted(
                                     pod_events.items,
-                                    key=lambda e: getattr(e, "last_timestamp", None),
+                                    key=lambda e: (
+                                        # Some events are missing timestamp attrs and
+                                        # `None` is not sortable vs datetimes so we
+                                        # default to 'now'
+                                        getattr(e, "last_timestamp", None)
+                                        or pendulum.now()
+                                    ),
                                 ):
+
                                     # Skip events without timestamps
                                     if not getattr(event, "last_timestamp", None):
                                         self.logger.debug(

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -230,10 +230,17 @@ class KubernetesAgent(Agent):
                                     pod_events.items,
                                     key=lambda e: getattr(e, "last_timestamp", None),
                                 ):
-                                    # Skip old events or events without timestamps
+                                    # Skip events without timestamps
+                                    if not getattr(event, "last_timestamp", None):
+                                        self.logger.debug(
+                                            f"Encountered K8s event on pod {pod_name!r}"
+                                            " with no timestamp: {event!r}"
+                                        )
+                                        continue
+
+                                    # Skip old events
                                     if (
-                                        not event.last_timestamp
-                                        or event.last_timestamp
+                                        event.last_timestamp
                                         < self.job_pod_event_timestamps[job_name][
                                             pod_name
                                         ]

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -227,7 +227,8 @@ class KubernetesAgent(Agent):
                                 )
 
                                 for event in sorted(
-                                    pod_events.items, key=lambda x: x.last_timestamp
+                                    pod_events.items,
+                                    key=lambda e: getattr(e, "last_timestamp", None),
                                 ):
                                     # Skip old events or events without timestamps
                                     if (

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -234,7 +234,7 @@ class KubernetesAgent(Agent):
                                     if not getattr(event, "last_timestamp", None):
                                         self.logger.debug(
                                             f"Encountered K8s event on pod {pod_name!r}"
-                                            " with no timestamp: {event!r}"
+                                            f" with no timestamp: {event!r}"
                                         )
                                         continue
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Follow-up to https://github.com/PrefectHQ/prefect/pull/4544 which dropped events with null timestamps which now accounts for events missing timestamp attributes _entirely_

## Changes

- Uses `getattr` to check for the attribute
- Logs these events so we can see what's going on