### PR TITLE
Add `prefect run` example to `hello_world` module docstring

### DIFF
--- a/src/prefect/hello_world.py
+++ b/src/prefect/hello_world.py
@@ -18,6 +18,11 @@ Examples:
     ------------------------------------------
     $ prefect create project 'default'
     $ prefect register --project default -m prefect.hello_world
+
+
+    Run this flow with the Prefect backend and agent
+    ------------------------------------------
+    $ prefect run --name "hello-world" --watch
 """
 
 from prefect import task, Flow, Parameter

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -18,9 +18,9 @@ class DockerLoggingTestingUtilityMixin:
     @staticmethod
     def assert_logs_twice_on_success(task, caplog):
 
-        with caplog.at_level(logging.DEBUG, logger=task.logger.name):
-            # Silence error logs from asyncio/tornado
-            with caplog.at_level(logging.CRITICAL, logger="asyncio"):
+        # Silence error logs from asyncio/tornado
+        with caplog.at_level(logging.CRITICAL, logger="asyncio"):
+            with caplog.at_level(logging.DEBUG, logger=task.logger.name):
                 task.run()
                 assert len(caplog.records) == 2
 

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -17,18 +17,18 @@ from prefect.tasks.docker import (
 class DockerLoggingTestingUtilityMixin:
     @staticmethod
     def assert_logs_twice_on_success(task, caplog):
+        with caplog.at_level(logging.DEBUG):
+            task.run()
+            # Reduce to relevant records
+            records = [r for r in caplog.records if r.name == task.logger.name]
 
-        # Silence error logs from asyncio/tornado
-        with caplog.at_level(logging.CRITICAL, logger="asyncio"):
-            with caplog.at_level(logging.DEBUG, logger=task.logger.name):
-                task.run()
-                assert len(caplog.records) == 2
+            assert len(records) == 2
 
-                initial = caplog.records[0]
-                final = caplog.records[1]
+            initial = records[0]
+            final = records[1]
 
-                assert any(image in initial.msg for image in ["image", "Image"])
-                assert any(image in initial.msg for image in ["image", "Image"])
+            assert any(image in initial.msg for image in ["image", "Image"])
+            assert any(image in initial.msg for image in ["image", "Image"])
 
     @staticmethod
     def assert_logs_once_on_docker_api_failure(task, caplog):

--- a/tests/tasks/docker/test_images.py
+++ b/tests/tasks/docker/test_images.py
@@ -19,14 +19,16 @@ class DockerLoggingTestingUtilityMixin:
     def assert_logs_twice_on_success(task, caplog):
 
         with caplog.at_level(logging.DEBUG, logger=task.logger.name):
-            task.run()
-            assert len(caplog.records) == 2
+            # Silence error logs from asyncio/tornado
+            with caplog.at_level(logging.CRITICAL, logger="asyncio"):
+                task.run()
+                assert len(caplog.records) == 2
 
-            initial = caplog.records[0]
-            final = caplog.records[1]
+                initial = caplog.records[0]
+                final = caplog.records[1]
 
-            assert any(image in initial.msg for image in ["image", "Image"])
-            assert any(image in initial.msg for image in ["image", "Image"])
+                assert any(image in initial.msg for image in ["image", "Image"])
+                assert any(image in initial.msg for image in ["image", "Image"])
 
     @staticmethod
     def assert_logs_once_on_docker_api_failure(task, caplog):


### PR DESCRIPTION
Now that the `prefect run` changes are in `master`

Includes a fix to a flakey docker test