### PR TITLE
Fix backwards compatibility for flows without a `terminal_state_handler`

### DIFF
--- a/changes/pr4695.yaml
+++ b/changes/pr4695.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix backwards compatibility for flows without a `terminal_state_handler` - [#4695](https://github.com/PrefectHQ/prefect/pull/4695)"

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -717,7 +717,7 @@ class FlowRunner(Runner):
             self.logger.info("Flow run SUCCESS: no reference tasks failed")
             state = Success(message="No reference tasks failed.", result=return_states)
 
-        if self.flow.terminal_state_handler:
+        if getattr(self.flow, "terminal_state_handler"):  # use getattr for compat
             new_state = self.flow.terminal_state_handler(self.flow, state, key_states)
             if new_state is not None:
                 return new_state

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -718,6 +718,7 @@ class FlowRunner(Runner):
             state = Success(message="No reference tasks failed.", result=return_states)
 
         if getattr(self.flow, "terminal_state_handler", None):
+            assert callable(self.flow.terminal_state_handler)  # mypy assertion
             # Uses `getattr` for compatibility with old flows without the attr
             new_state = self.flow.terminal_state_handler(self.flow, state, key_states)
             if new_state is not None:

--- a/src/prefect/engine/flow_runner.py
+++ b/src/prefect/engine/flow_runner.py
@@ -717,7 +717,8 @@ class FlowRunner(Runner):
             self.logger.info("Flow run SUCCESS: no reference tasks failed")
             state = Success(message="No reference tasks failed.", result=return_states)
 
-        if getattr(self.flow, "terminal_state_handler"):  # use getattr for compat
+        if getattr(self.flow, "terminal_state_handler", None):
+            # Uses `getattr` for compatibility with old flows without the attr
             new_state = self.flow.terminal_state_handler(self.flow, state, key_states)
             if new_state is not None:
                 return new_state

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -3343,6 +3343,14 @@ class TestTerminalStateHandler:
         assert flow_state.is_successful()
         assert flow_state.message == "Custom message here"
 
+    def test_terminal_state_handler_check_is_backwards_compatible(self):
+        with Flow("test") as flow:
+            pass
+
+        flow.__dict__.pop("terminal_state_handler")
+        flow_state = flow.run()
+        assert flow_state.is_successful()
+
     def test_flow_state_used_if_terminal_state_handler_does_not_return_a_new_state(
         self,
     ):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If a flow is loaded from an older version of Prefect, it may not have a `terminal_state_handler` attribute and the check in the `FlowRunner` will result in a failed flow like so

```

INFO     prefect.FlowRunner:flow_runner.py:710 Flow run SUCCESS: all reference tasks succeeded
ERROR    prefect.FlowRunner:runner.py:66 Unexpected error: AttributeError("'Flow' object has no attribute 'terminal_state_handler'")
Traceback (most recent call last):
  File "/Users/mz/prefect/core/src/prefect/engine/runner.py", line 48, in inner
    new_state = method(self, state, *args, **kwargs)
  File "/Users/mz/prefect/core/src/prefect/engine/flow_runner.py", line 669, in get_flow_run_state
    state = self.determine_final_state(
  File "/Users/mz/prefect/core/src/prefect/engine/flow_runner.py", line 720, in determine_final_state
    if self.flow.terminal_state_handler:
AttributeError: 'Flow' object has no attribute 'terminal_state_handler'
DEBUG    prefect.FlowRunner:flow_runner.py:108 Flow 'test': Handling state change from Running to Failed
ERROR    prefect.test:flow.py:1286 Unexpected error occured in FlowRunner: AttributeError("'Flow' object has no attribute 'terminal_state_handler'")
```


## Changes
<!-- What does this PR change? -->

- Uses `getattr` to check for attribute instead of accessing directly

## Importance
<!-- Why is this PR important? -->

Fixes a version incompatibility bug

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~