### PR TITLE
Replaced broken link to Hasura docs

### DIFF
--- a/docs/orchestration/ui/interactive-api.md
+++ b/docs/orchestration/ui/interactive-api.md
@@ -93,7 +93,7 @@ query {
     }
 }
 ```
-To learn more about the various query filters available (there are many more than the examples above!) head over to the [Hasura Docs](https://hasura.io/docs/2.0/graphql/core/databases/postgres/queries/index.html#queries).
+To learn more about the various query filters available (there are many more than the examples above!) head over to the [Hasura Docs](https://hasura.io/docs/1.0/graphql/core/queries/index.html).
 
 ### Schema
 

--- a/docs/orchestration/ui/interactive-api.md
+++ b/docs/orchestration/ui/interactive-api.md
@@ -93,7 +93,7 @@ query {
     }
 }
 ```
-You can see more about query filters in the [Hasura Docs](https://hasura.io/docs/1.0/graphql/manual/queries/query-filters.html).
+To learn more about the various query filters available (there are many more than the examples above!) head over to the [Hasura Docs](https://hasura.io/docs/2.0/graphql/core/databases/postgres/queries/index.html#queries).
 
 ### Schema
 


### PR DESCRIPTION
I replaced the broken link to the Hasura docs. (It was 404ing before.) Also added a bit more of a description to let people know that there are many more ways to query available described in the hasura docs.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Replaced a broken link to the Hasura docs and made it a bit more descriptive so people would understand that following the link would explain the many options for querying they have. 

## Changes
<!-- What does this PR change? -->
A broken link and a single sentence in the documentation.

## Importance
<!-- Why is this PR important? -->
I'm new to graphQL and using prefect for work. It wasn't super clear where I was supposed to go to read how to build more complex queries. (ie. the options available to query) I actually was reading the docs, clicked on that broken link, thought eh whatever, and spent hours just trying to look around for where I was actually supposed to find descriptions of how to use 'where' 'aggregate' etc. 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)