### PR TITLE
Raise a better exception when a task run result type is not set

### DIFF
--- a/changes/pr4708.yaml
+++ b/changes/pr4708.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Raise a better exception when a task run result type is not set - [#4708](https://github.com/PrefectHQ/prefect/pull/4708)"

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -2,7 +2,7 @@ from typing import Any, List, Iterator
 
 from prefect import Client
 from prefect.engine.state import Scheduled, State
-from prefect.engine.result import Result
+from prefect.engine.result import Result, NoResultType
 from prefect.utilities.graphql import with_args, EnumValue
 from prefect.utilities.logging import get_logger
 
@@ -74,8 +74,7 @@ class TaskRunView:
         if not self.state.is_finished():
             raise ValueError("The task result cannot be loaded if it is not finished.")
 
-        self._assert_result_type_is_not_null()
-        self._assert_result_type_is_not_custom()
+        self._assert_result_type_is_okay()
 
         if self._result is NotLoaded:
             # Load the result from the result location
@@ -139,43 +138,46 @@ class TaskRunView:
                 )
 
             # Ensure the mapped children have valid result types
-            task_run._assert_result_type_is_not_null()
-            task_run._assert_result_type_is_not_custom()
+            task_run._assert_result_type_is_okay()
 
             # Update state
             self.state.map_states = [task_run.state for task_run in child_task_runs]
 
-    def _assert_result_type_is_not_custom(self) -> None:
+    def _assert_result_type_is_okay(self) -> None:
         """
         Since we do not have access to the user's custom Result class, we cannot load
         the result.
         """
+        # Mapped parents do not have result types
+        if self.state.is_mapped():
+            return
+
+        # If there is no result type, we cannot load it. Mapped parents don't apply
+        if not self.state._result or type(self.state._result) is NoResultType:
+            raise TypeError(
+                "The task has a no `Result` type so the result cannot be loaded."
+                "Set a `Result` type on your tasks so return values are persisted."
+            )
+
+        # Must have a location to be loaded
+        if not self.state._result.location:
+            raise ValueError(
+                "The task result has no `location` so the result cannot be loaded. "
+                "This often means that your task result has not been configured or has "
+                "been configured incorrectly."
+            )
+
         # TODO: Check for custom serializer types as well once they are added to the
         #       `ResultSchema`
         # TODO: Add the `result_type` to `TaskRunView` so we can report the qualified
         #       name of the custom result type used.
-
-        if type(self.state._result) is Result and not self.state.is_mapped():
+        if type(self.state._result) is Result:
             # The `Result` base class is used during deserialization if a custom result
             # class has been declared unless it's a mapped state in which it will be
             # an empty `Result` and this assertion will be called on the map children
             raise TypeError(
                 "The task has a custom `Result` type and its result cannot be loaded. "
                 "Only built-in `Result` types are supported."
-            )
-
-    def _assert_result_type_is_not_null(self) -> None:
-        """
-        If the task does not have a Result class set, we cannot load the result as it
-        was not persisted anywhere
-        """
-        if not self.state._result or (
-            self.state._result and not self.state._result.location
-        ):
-            raise TypeError(
-                "The task has a no `Result` type or location so the result cannot be "
-                "loaded. Set a `Result` type on your tasks so return values are "
-                "persisted."
             )
 
     def iter_mapped(self) -> Iterator["TaskRunView"]:

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -74,6 +74,7 @@ class TaskRunView:
         if not self.state.is_finished():
             raise ValueError("The task result cannot be loaded if it is not finished.")
 
+        self._assert_result_type_is_not_null()
         self._assert_result_type_is_not_custom()
 
         if self._result is NotLoaded:
@@ -160,6 +161,20 @@ class TaskRunView:
             raise TypeError(
                 "The task has a custom `Result` type and its result cannot be loaded. "
                 "Only built-in `Result` types are supported."
+            )
+
+    def _assert_result_type_is_not_null(self) -> None:
+        """
+        If the task does not have a Result class set, we cannot load the result as it
+        was not persisted anywhere
+        """
+        if not self.state._result or (
+            self.state._result and not self.state._result.location
+        ):
+            raise TypeError(
+                "The task has a no `Result` type or location so the result cannot be "
+                "loaded. Set a `Result` type on your tasks so return values are "
+                "persisted."
             )
 
     def iter_mapped(self) -> Iterator["TaskRunView"]:

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -138,7 +138,8 @@ class TaskRunView:
                     "supported."
                 )
 
-            # Ensure the mapped children have
+            # Ensure the mapped children have valid result types
+            task_run._assert_result_type_is_not_null()
             task_run._assert_result_type_is_not_custom()
 
             # Update state


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If a result is not set, it can be set to the `Result` base class which we detect as a "Custom" result type. This PR detects the case where there's actually no result type or location at all and raises an informative error.

After further investigation, I found there is a `NoResultType` class and mapped parents always have a `Result` base class and no location -- adding handling for those cases as well.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)