### PR TITLE
Exit with non-zero status on flow run failure when watched

### DIFF
--- a/changes/pr4709.yaml
+++ b/changes/pr4709.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Exit with non-zero status on flow run failure when watched - [#4709](https://github.com/PrefectHQ/prefect/pull/4709)"

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -593,6 +593,7 @@ def run(
 
         if result_state.is_failed():
             quiet_echo("Flow run failed!", fg="red")
+            sys.exit(1)
         else:
             quiet_echo("Flow run succeeded!", fg="green")
 

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -746,10 +746,12 @@ def run(
     # Display the final state
     if flow_run.state.is_failed():
         quiet_echo("Flow run failed!", fg="red")
+        sys.exit(1)
     elif flow_run.state.is_successful():
         quiet_echo("Flow run succeeded!", fg="green")
     else:
         quiet_echo(f"Flow run is in unexpected state: {flow_run.state}", fg="yellow")
+        sys.exit(1)
 
 
 # DEPRECATED: prefect run flow ---------------------------------------------------------

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -451,7 +451,7 @@ def test_run_passes_context(caplog, context_flow_file):
 
 def test_run_local_handles_flow_run_failure(caplog, runtime_failing_flow):
     result = CliRunner().invoke(run, ["--path", runtime_failing_flow])
-    assert not result.exit_code
+    assert result.exit_code == 1
     assert "Running flow locally..." in result.output
     assert "Flow run failed" in result.output
     # Flow runner logged exception


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When watching, executing, or locally executing a flow, we will return an non-zero exit code if the flow run is not successful. This means in something like CI it would actually mark the step as failed.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)