### PR TITLE
Add "host.docker.internal" mapping for linux compatibility

### DIFF
--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -395,7 +395,11 @@ class DockerAgent(Agent):
         # Create a container
         self.logger.debug("Creating Docker container {}".format(image))
 
-        host_config = {"auto_remove": True}  # type: dict
+        host_config = {
+            "auto_remove": True,
+            # Compatibility for linux -- https://github.com/docker/cli/issues/2290
+            "extra_hosts": {"host.docker.internal": "host-gateway"},
+        }  # type: dict
         container_mount_paths = self.container_mount_paths
         if container_mount_paths:
             host_config.update(binds=self.host_spec)


### PR DESCRIPTION
Until something like https://github.com/docker/cli/issues/2290 is done, Docker on Linux treats "host.docker.internal" differently than on OSX/Win32 so users encounter connection issues as in https://github.com/PrefectHQ/server/issues/25

Per https://github.com/moby/moby/pull/40007 we add an extra host mapping with a "magic" string that is resolved to the correct host IP. This reimplements the workaround that was removed in https://github.com/PrefectHQ/prefect/pull/4446 but relies on docker to determine the host ip which we were doing ourselves before (leading to exceptions in edge-cases).