### PR TITLE
Display return code on local agent flow process failure

### DIFF
--- a/changes/pr4715.yaml
+++ b/changes/pr4715.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Display return code on local agent flow process failure - [#4715](https://github.com/PrefectHQ/prefect/pull/4715)"

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -102,7 +102,8 @@ class LocalAgent(Agent):
                 self.processes.remove(process)
                 if process.returncode:
                     self.logger.info(
-                        "Process PID {} returned non-zero exit code".format(process.pid)
+                        f"Process PID {process.pid} returned non-zero exit code "
+                        f"{process.returncode}!"
                     )
         super().heartbeat()
 

--- a/tests/agent/test_local_agent.py
+++ b/tests/agent/test_local_agent.py
@@ -541,9 +541,13 @@ def test_generate_supervisor_conf_with_token_and_key():
         (
             1,
             False,
-            (("agent", "INFO", "Process PID 1234 returned non-zero exit code"),),
+            (("agent", "INFO", "Process PID 1234 returned non-zero exit code 1!"),),
         ),
-        (1, True, (("agent", "INFO", "Process PID 1234 returned non-zero exit code"),)),
+        (
+            2,
+            True,
+            (("agent", "INFO", "Process PID 1234 returned non-zero exit code 2!"),),
+        ),
     ),
 )
 def test_local_agent_heartbeat(monkeypatch, returncode, show_flow_logs, logs):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If a flow process fails, we want to show the return code value for some transparency into what went wrong.