### PR TITLE
If not watching/executing, exit without trying to display final state

### DIFF
--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -733,6 +733,10 @@ def run(
             quiet_echo("Exiting without cancelling flow run!", fg="yellow")
             raise  # Re-raise the interrupt
 
+    else:
+        # If not watching or executing, exit without checking state
+        return
+
     # Get the final flow run state
     flow_run = FlowRunView.from_flow_run_id(flow_run_id)
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -518,6 +518,13 @@ def test_run_cloud_creates_flow_run(
         **cloud_kwargs,
     )
 
+    if not execute_flag:
+        # Called once to retrieve information
+        cloud_mocks.FlowRunView.from_flow_run_id.assert_called_once()
+    else:
+        # Called again later to check final state
+        assert cloud_mocks.FlowRunView.from_flow_run_id.call_count == 2
+
 
 def test_run_cloud_handles_create_flow_run_failure(cloud_mocks):
     cloud_mocks.FlowView.from_flow_id.return_value = TEST_FLOW_VIEW


### PR DESCRIPTION
This is a silly thing I did with the agentless branch merge that makes it show an unexpected state when not watching a flow run.

```
mz@mz-test-instance:~$ prefect run --name "hello-world"
Looking up flow metadata... Done
Creating run for flow 'hello-world'... Done
└── Name: bronze-whale
└── UUID: c8234085-a220-414e-97d9-39f8784ed24f
└── Labels: ['mz-test-instance']
└── Parameters: {}
└── Context: {}
└── URL: http://localhost:8080/default/flow-run/c8234085-a220-414e-97d9-39f8784ed24f
Flow run is in unexpected state: <Scheduled: "Flow run scheduled.">
```