### PR TITLE
Checkpoint task results when `SUCCESS` is raised

### DIFF
--- a/changes/pr4744.yaml
+++ b/changes/pr4744.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Checkpoint task results when `SUCCESS` is raised - [#4744](https://github.com/PrefectHQ/prefect/pull/4744)"

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -879,14 +879,11 @@ class TaskRunner(Runner):
                 new_state.loop_count
             )
 
-        except signals.PrefectStateSignal:
-            # Other state signals will be handled by the `call_state_handlers`
-            # decorator. Once Prefect signal exceptions are modified to inherit
-            # from `BaseException` instead of `Exception`, this can be removed
-            raise
-        except signals.ENDRUN:
-            # As above, the `ENDRUN` is a special exception
-            raise
+        except signals.SUCCESS as exc:
+            # Success signals can be treated like a normal result
+            new_state = exc.state
+            assert isinstance(new_state, Success)
+            value = new_state.result
 
         except Exception as exc:  # Handle exceptions in the task
             if prefect.context.get("raise_on_exception"):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If a user wants to customize the state message but still end successfully, they can do

```python
raise prefect.engine.signals.SUCCESS("My custom message", result=<data>)
```

but because state signals bypass checkpointing logic, this task result is not stored in the provided `Result` location.

## Changes
<!-- What does this PR change? -->


- Removes a signal re-raise that was a workaround while waiting for #4664 
- `SUCCESS` signals are treated like a successful task run instead of falling through

## Importance
<!-- Why is this PR important? -->

- Allows setting custom state messages while returning data
- Makes task run result checkpointing more consistent


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)