### PR TITLE
Check truthiness instead of identity in checkpointing logic

### DIFF
--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -901,8 +901,8 @@ class TaskRunner(Runner):
         # checkpoint tasks if a result is present, except for when the user has opted out by
         # disabling checkpointing
         if (
-            prefect.context.get("checkpointing") is True
-            and self.task.checkpoint is not False
+            prefect.context.get("checkpointing")
+            and self.task.checkpoint
             and value is not None
         ):
             try:
@@ -989,8 +989,8 @@ class TaskRunner(Runner):
                 # checkpoint tasks if a result is present, except for when the user has opted
                 # out by disabling checkpointing
                 if (
-                    prefect.context.get("checkpointing") is True
-                    and self.task.checkpoint is not False
+                    prefect.context.get("checkpointing")
+                    and self.task.checkpoint
                     and loop_result.value is not None
                 ):
                     try:


### PR DESCRIPTION
Curious if I'm missing something here since the current style is pretty unorthodox which maybe suggests it's like that for a reason? But in addition to violating [PEP8](https://www.python.org/dev/peps/pep-0008/#programming-recommendations), the current logic behaves incorrectly for the default `Task.checkpoint` value of `None` https://github.com/PrefectHQ/prefect/blob/master/src/prefect/core/task.py#L324, which I've run into locally with checkpointing enabled.

Doesn't look like this has been touched lately but @cicdw might be the most recent.