### PR TITLE
Fix loading of `PREFECT__CLOUD__API_KEY` environment variable when starting agents

### DIFF
--- a/changes/pr4751.yaml
+++ b/changes/pr4751.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix loading of `PREFECT__CLOUD__API_KEY` environment variable when starting agents - [#4751](https://github.com/PrefectHQ/prefect/pull/4751)"

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -126,8 +126,8 @@ def start_agent(agent_cls, token, api, label, env, log_level, key, tenant_id, **
     env_vars = dict(e.split("=", 1) for e in env)
     tmp_config = {
         "cloud.agent.auth_token": token or config.cloud.agent.auth_token,
-        "cloud.api_key": key,  # The agent client will load the default API key if null
-        "cloud.tenant_id": tenant_id,
+        "cloud.api_key": key or config.cloud.api_key,
+        "cloud.tenant_id": tenant_id or config.cloud.tenant_id,
         "cloud.agent.level": log_level or config.cloud.agent.level,
         "cloud.api": api or config.cloud.api,
     }

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -161,6 +161,7 @@ def test_agent_start(name, import_path, extra_cmd, extra_kwargs, monkeypatch):
 
     result = CliRunner().invoke(agent, command)
 
+    print(result.output)
     assert result.exit_code == 0
 
     agent_cls.assert_called_once()

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -3,6 +3,7 @@ from importlib import import_module
 
 from click.testing import CliRunner
 import pytest
+import sys
 
 import prefect
 from prefect.cli import cli
@@ -150,7 +151,7 @@ def test_agent_start(name, import_path, extra_cmd, extra_kwargs, monkeypatch):
 
     def check_config(*args, **kwargs):
         assert prefect.config.cloud.agent.auth_token == "TEST-TOKEN"
-        assert prefect.config.cloud.agent.level == "DEBUG"
+        assert prefect.config.cloud.agent.level.upper() == "DEBUG"
         assert prefect.config.cloud.api == "TEST-API"
         return agent_obj
 
@@ -161,8 +162,8 @@ def test_agent_start(name, import_path, extra_cmd, extra_kwargs, monkeypatch):
 
     result = CliRunner().invoke(agent, command)
 
-    print(result.output)
-    assert result.exit_code == 0
+    if result.exception:
+        raise result.exception
 
     agent_cls.assert_called_once()
     kwargs = agent_cls.call_args[1]
@@ -289,4 +290,7 @@ def test_agent_start_sets_or_uses_existing_api_key(use_existing, monkeypatch):
     )
 
     with set_temporary_config({"cloud.api_key": "FOO"}):
-        CliRunner().invoke(agent, command)
+        result = CliRunner().invoke(agent, command)
+
+    if result.exception:
+        raise result.exception

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -9,10 +9,6 @@ from prefect.cli import cli
 from prefect.cli.agent import agent
 from prefect.utilities.configuration import set_temporary_config
 
-pytest.importorskip("boto3")
-pytest.importorskip("botocore")
-pytest.importorskip("kubernetes")
-
 
 @pytest.mark.parametrize(
     "cmd",

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -282,11 +282,12 @@ def test_agent_start_sets_or_uses_existing_api_key(use_existing, monkeypatch):
     if not use_existing:
         command.extend(["--key", "BAR"])
 
-    def check_config():
+    def assert_correct_api_key(*args, **kwargs):
         assert prefect.config.cloud.api_key == "FOO" if use_existing else "BAR"
+        return MagicMock()
 
     monkeypatch.setattr(
-        "prefect.agent.local.LocalAgent", MagicMock(side_effect=check_config)
+        "prefect.agent.local.LocalAgent", MagicMock(side_effect=assert_correct_api_key)
     )
 
     with set_temporary_config({"cloud.api_key": "FOO"}):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->


When starting an agent, `--key` can be provided. This sets a temporary config so the agent client will load the value. We were not falling back to the default though so if `--key` as not provided and it was set in the config or env it would be ignored.

Users can workaround by providing `--key` when starting the agent, using `prefect auth login`, or passing the key as an `PREFECT__CLOUD__AUTH_TOKEN`

## Changes
<!-- What does this PR change? -->

- Fixes this by falling back to the default if `--key` or `--tenant-id` are not provided


## Importance
<!-- Why is this PR important? -->

Fixes bug where agents cannot be started with env based auth

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)