### PR TITLE
Expose schedule activation from `prefect register` CLI

### DIFF
--- a/changes/pr4752.yaml
+++ b/changes/pr4752.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Exposes schedule activation from `prefect register CLI - [#4752](https://github.com/PrefectHQ/prefect/pull/4752)"
+
+contributor:
+  - "[Gabriel Montañola](https://github.com/gmontanola)"

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -746,8 +746,10 @@ REGISTER_EPILOG = """
 @click.option(
     "--schedule/--no-schedule",
     help=(
-        "Toggles the flow schedule activation upon registering. Default "
-        "behavior is activated. Useful for CI and development."
+        "Toggles the flow schedule upon registering. By default, the "
+        "flow's schedule will be activated and future runs will be created. "
+        "If disabled, the schedule will still be attached to the flow but "
+        "no runs will be created until it is activated."
     ),
     default=True,
 )

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -349,6 +349,8 @@ def register_serialized_flow(
         - force (bool, optional): If `False` (default), an idempotency key will
             be generated to avoid unnecessary re-registration. Set to `True` to
             force re-registration.
+        - schedule (bool, optional): If `True` (default) activates the flow schedule
+            upon registering.
 
     Returns:
         - flow_id (str): the flow id
@@ -430,6 +432,8 @@ def build_and_register(
         - labels (List[str], optional): Any extra labels to set on all flows
         - force (bool, optional): If false (default), an idempotency key will
             be used to avoid unnecessary register calls.
+        - schedule (bool, optional): If `True` (default) activates the flow schedule
+            upon registering.
 
     Returns:
         - Counter: stats about the number of successful, failed, and skipped flows.
@@ -518,6 +522,8 @@ def register_internal(
             flows.
         - force (bool, optional): If false (default), an idempotency key will
             be used to avoid unnecessary register calls.
+        - schedule (bool, optional): If `True` (default) activates the flow schedule
+            upon registering.
         - in_watch (bool, optional): Whether this call resulted from a
             `register --watch` call.
     """
@@ -654,6 +660,10 @@ REGISTER_EPILOG = """
 \b  Watch a directory of flows for changes, and re-register flows upon change.
 
 \b    $ prefect register --project my-project -p myflows/ --watch
+
+\b  Register a flow found in `flow.py` and disables its schedule.
+
+\b    $ prefect register --project my-project -p flow.py --no-schedule
 """
 
 
@@ -737,7 +747,7 @@ REGISTER_EPILOG = """
     "--schedule/--no-schedule",
     help=(
         "Toggles the flow schedule activation upon registering. Default "
-        "behavior is activated."
+        "behavior is activated. Useful for CI and development."
     ),
     default=True,
 )

--- a/src/prefect/cli/build_register.py
+++ b/src/prefect/cli/build_register.py
@@ -661,7 +661,7 @@ REGISTER_EPILOG = """
 
 \b    $ prefect register --project my-project -p myflows/ --watch
 
-\b  Register a flow found in `flow.py` and disables its schedule.
+\b  Register a flow found in `flow.py` and disable its schedule.
 
 \b    $ prefect register --project my-project -p flow.py --no-schedule
 """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Enables toggling schedule activation upon CLI flow registering. Useful for CI and development

Related issue: https://github.com/PrefectHQ/prefect/issues/4531



## Changes
1. New CLI option `--schedule/--no-schedule` for the `register` command. Defaults to `--schedule`.
2. This option is passed down util it reaches `register_serialized_flow` and adds a new `input` called `et_schedule_active` to GraphQL request.




## Importance
This will help with some CI use cases.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)