### PR TITLE
Fix get cloud url bug

### DIFF
--- a/changes/pr4753.yaml
+++ b/changes/pr4753.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix bug in `Client.get_cloud_url` when using API tokens - [#4753](https://github.com/PrefectHQ/prefect/pull/4753)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1224,8 +1224,9 @@ class Client:
 
         # if the current tenant is not known, just return the first tenant
         if not self.tenant_id and tenants:
-            self.logger.warning(
-                f"Unknown tenant_id configured in Client when determining tenant slug. Returning first tenant slug {tenants[0].slug!r}."
+            warnings.warn(
+                f"Unknown tenant_id configured in Client when determining tenant slug. "
+                f"Returning first tenant slug {tenants[0].slug!r}."
             )
             return tenants[0].slug
 

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -338,6 +338,14 @@ class Client:
     def tenant_id(self, tenant_id: str) -> None:
         self._tenant_id = tenant_id
 
+    @property
+    def _using_cloud_api(self) -> bool:
+        """
+        Returns True if using Prefect Cloud API
+        """
+        # Search for matching cloud API because we can't guarantee that the backend config is set
+        return ".prefect.io" in prefect.config.cloud.api
+
     # ----------------------------------------------------------------------------------
 
     def create_tenant(self, name: str, slug: str = None) -> str:
@@ -1237,14 +1245,6 @@ class Client:
         raise ValueError(
             f"Failed to find current tenant {self.tenant_id!r} in result {res}"
         )
-
-    @property
-    def _using_cloud_api(self):
-        """
-        Returns True if using Prefect Cloud API
-        """
-        # Search for matching cloud API because we can't guarantee that the backend config is set
-        return ".prefect.io" in prefect.config.cloud.api
 
     def create_project(self, project_name: str, project_description: str = None) -> str:
         """

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -428,7 +428,7 @@ class StartFlowRun(Task):
         self.logger.debug(f"Flow Run {flow_run_id} created.")
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
-        run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
+        run_link = client.get_cloud_url("flow-run", flow_run_id)
         create_link(urlparse(run_link).path)
         self.logger.info(f"Flow Run: {run_link}")
 

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -155,11 +155,11 @@ def slack_message_formatter(
 
         if isinstance(tracked_obj, prefect.Flow):
             url = prefect.client.Client().get_cloud_url(
-                "flow-run", prefect.context["flow_run_id"], as_user=False
+                "flow-run", prefect.context["flow_run_id"]
             )
         elif isinstance(tracked_obj, prefect.Task):
             url = prefect.client.Client().get_cloud_url(
-                "task-run", prefect.context.get("task_run_id", ""), as_user=False
+                "task-run", prefect.context.get("task_run_id", "")
             )
 
         if url:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1734,6 +1734,7 @@ def test_get_cloud_url_different_regex(patch_post, cloud_api):
         }
     ):
         client = Client()
+        client._tenant_id = "tenant-id"
 
         url = client.get_cloud_url(subdirectory="flow", id="id")
         assert url == "http://hello.prefect.io/tslug/flow/id"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR addresses edge cases in using `Client.get_cloud_url` when using legacy API tokens.



## Changes
<!-- What does this PR change? -->
Simplifies the logic for `get_cloud_url` by
- eliminating the `as_user` parameter
- adding a check for edge case where `Client.tenant_id` is `None`

I think we can do without the `as_user`. For legacy API tokens, the token will only have permission to view one tenant and the correct tenant slug will be returned. For API Keys, `tenant_id` should be correctly populated and we can determine correct tenant slug based on the query.



## Importance
<!-- Why is this PR important? -->
Makes current code backwards compatible with API Tokens.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)