### PR TITLE
Fix tenant slug retrieval when using auth tokens

### DIFF
--- a/changes/pr4758.yaml
+++ b/changes/pr4758.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix bug where the tenant could not be inferred during flow runs while using token auth - [#4758](https://github.com/PrefectHQ/prefect/pull/4758)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1242,8 +1242,11 @@ class Client:
             slug = user.default_membership.tenant.slug
         else:
             tenants = res["data"]["tenant"]
-            for tenant in tenants:
-                if tenant.id == self.tenant_id:
+            for tenant in tenant:
+                # Return the slug if it matches the current tenant id, if there is no
+                # current tenant id we are using a RUNNER API token and we'll return
+                # the first (and only) tenant
+                if tenant.id == self.tenant_id or self.tenant_id is None:
                     return tenant.slug
             raise ValueError(
                 f"Failed to find current tenant {self.tenant_id!r} in result {res}"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1242,7 +1242,7 @@ class Client:
             slug = user.default_membership.tenant.slug
         else:
             tenants = res["data"]["tenant"]
-            for tenant in tenant:
+            for tenant in tenants:
                 # Return the slug if it matches the current tenant id OR if there is no
                 # current tenant id we are using a RUNNER API token so we'll return
                 # the first (and only) tenant

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1243,8 +1243,8 @@ class Client:
         else:
             tenants = res["data"]["tenant"]
             for tenant in tenant:
-                # Return the slug if it matches the current tenant id, if there is no
-                # current tenant id we are using a RUNNER API token and we'll return
+                # Return the slug if it matches the current tenant id OR if there is no
+                # current tenant id we are using a RUNNER API token so we'll return
                 # the first (and only) tenant
                 if tenant.id == self.tenant_id or self.tenant_id is None:
                     return tenant.slug

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1675,6 +1675,33 @@ def test_get_default_tenant_slug_not_as_user(patch_post):
         assert slug == "tslug"
 
 
+def test_get_default_tenant_slug_not_as_user_with_no_tenant_id(patch_post):
+    # Generally, this would occur when using a RUNNER API token
+    response = {
+        "data": {
+            "tenant": [
+                {"slug": "firstslug", "id": "tenant-id"},
+                {"slug": "wrongslug", "id": "foo"},
+            ]
+        }
+    }
+
+    patch_post(response)
+
+    with set_temporary_config(
+        {
+            "cloud.api": "http://my-cloud.foo",
+            "cloud.auth_token": "secret_token",
+            "backend": "cloud",
+        }
+    ):
+        client = Client()
+        client._tenant_id = None  # Ensure tenant id is not set
+        slug = client.get_default_tenant_slug(as_user=False)
+
+        assert slug == "firstslug"
+
+
 def test_get_cloud_url_as_user(patch_post, cloud_api):
     response = {
         "data": {"user": [{"default_membership": {"tenant": {"slug": "tslug"}}}]}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When using tokens for authentication, we have a few routes that call `get_cloud_url` with an explicit `as_user=False` because they are expected to be called from flow runs with a RUNNER (vs USER) scoped token. When using an agent with a RUNNER scoped token, a tenant id is not set by `_init_tenant` and is `None` during tenant slug lookup required for generating a cloud url.

Supersedes https://github.com/PrefectHQ/prefect/pull/4755 -- this will throw a better error if no tenants are returned.
Unlike https://github.com/PrefectHQ/prefect/pull/4753, this keeps the `as_user` interface for compatibility. We can remove it once API tokens are removed in the next major version.


## Changes
<!-- What does this PR change? -->

- Returns the first tenant id if none is set and `as_user` is `False`


## Importance
<!-- Why is this PR important? -->

Resolves a bug where `slack_notifier` and `StartFlowRun` will fail when using tokens for authentication.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~