### PR TITLE
Fix bug where an agent using token auth could clear the tenant from disk

### DIFF
--- a/changes/pr4759.yaml
+++ b/changes/pr4759.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix bug where an agent using token auth could clear the tenant from disk - [#4759](https://github.com/PrefectHQ/prefect/pull/4759)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -483,9 +483,23 @@ class Client:
                 try:
                     self.login_to_tenant(tenant_id=self._tenant_id)
                 except AuthorizationError:
-                    # if an authorization error is raised, then the token is invalid and should
-                    # be cleared
-                    self.logout_from_tenant()
+                    # Either the token is invalid _or_ it is not USER scoped. Try
+                    # pulling the correct tenant id from the API
+                    try:
+                        result = self.graphql({"query": {"tenant": {"id"}}})
+                        tenants = result["data"]["tenant"]
+                        # TENANT or RUNNER scoped tokens should have a single tenant
+                        if len(tenants) != 1:
+                            raise ValueError(
+                                "Failed to authorize with Prefect Cloud. "
+                                f"Could not log in to tenant {self._tenant_id!r}. "
+                                f"Found available tenants: {tenants}"
+                            )
+                        self._tenant_id = tenants[0].id
+                    except AuthorizationError:
+                        # On failure, we've just been given an invalid token and should
+                        # delete the auth information from disk
+                        self.logout_from_tenant()
 
         # This code should now be superceded by the `tenant_id` property but will remain
         # here for backwards compat until API tokens are removed entirely

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -313,7 +313,7 @@ class Client:
         if prefect.config.backend == "cloud":
             if self._api_token and not self.api_key:
                 # Backwards compatibility for API tokens
-                if not self._tenant_id and self._api_token:
+                if not self._tenant_id:
                     self._init_tenant()
 
                 # Should be set by `_init_tenant()` but we will not guarantee it


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When an agent is spawned with a token `prefect agent local start -t <RUNNER_TOKEN>` on a machine that has auth saved with `prefect auth login -t <USER_TOKEN>`, it can result in broken authentication. When a tenant id is loaded from disk, the `Client` attempts to log in to the tenant. On failure, it will log out which clears auth information from disk. A non-user scoped token will _always_ fail to log in even though it is authenticated for other operations. Before 0.15.0, the agent used a different api server url than the default `Client` which would prevent this from clearing the user's login information. Now that the api server url is consistent, the agent can actually log out the user by clearing the `active_tenant_id` from disk.


## Changes
<!-- What does this PR change? -->

Now, on failure to login, we will check that the token is actually invalid. If it can retrieve a single tenant id, we do not clear the tenant id from disk since it is a RUNNER or TENANT scoped token.

## Importance
<!-- Why is this PR important? -->

Fixes a bug where running an agent locally could break authentication handled by the CLI.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~