### PR TITLE
Install flaky to auto-rerun known/marked flaky tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pytest >= 6.0
 testfixtures >= 6.10.3
 pytest-env >= 0.6.0
 pytest-xdist >= 2.0
+flaky >= 3.0

--- a/tests/backend/test_execution.py
+++ b/tests/backend/test_execution.py
@@ -308,6 +308,7 @@ class TestWaitForFlowRunStartTime:
         # Did not sleep
         timing_mocks.sleep.assert_not_called()
 
+    @pytest.mark.flaky
     def test_task_run_is_scheduled_in_the_past(self, timing_mocks):
         timing_mocks.get_flow_run_scheduled_start_time.return_value = None
         timing_mocks.get_next_task_run_start_time.return_value = (

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2358,6 +2358,7 @@ class TestFlowRunMethod:
 
         assert storage == dict(y=[[1, 1, 1], [1, 1, 1], [3, 3, 3]])
 
+    @pytest.mark.flaky
     def test_flow_dot_run_handles_cached_states_across_runs_with_always_run_trigger(
         self, repeat_schedule
     ):

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -442,6 +442,7 @@ class TestDaskExecutor:
         assert any("Worker %s removed" == rec.msg for rec in caplog.records)
 
     @pytest.mark.parametrize("kind", ["external", "inproc"])
+    @pytest.mark.flaky
     def test_exit_early_with_external_or_inproc_cluster_waits_for_pending_futures(
         self, kind, monkeypatch
     ):


### PR DESCRIPTION
It is now consuming an unacceptable amount of time to re-run CI due to a few tests that always succeed on re-run. I'd rather fix the tests than auto-rerun them but that isn't entirely feasible at the moment and some tests are flaky by nature. At the very least, this will indicate to us which tests need additional attention when we have more throughput.