### PR TITLE
Docker run host config

### DIFF
--- a/changes/issue4773.yaml
+++ b/changes/issue4773.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Exposed the host_config for the Docker Agent in the DockerRun to pass arguments at runtime. - [#4733](https://github.com/PrefectHQ/prefect/issues/4773)"
+
+contributor:
+  - "[Nelson Griffiths](https://github.com/ngriffiths13)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -403,7 +403,7 @@ class DockerAgent(Agent):
         container_mount_paths = self.container_mount_paths
         if container_mount_paths:
             host_config.update(binds=self.host_spec)
-        if run_config and run_config.host_config:
+        if run_config is not None and run_config.host_config:
             # The host_config passed from the run_config will overwrite defaults
             host_config.update(run_config.host_config)
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -403,7 +403,7 @@ class DockerAgent(Agent):
         container_mount_paths = self.container_mount_paths
         if container_mount_paths:
             host_config.update(binds=self.host_spec)
-        if run_config is not None:
+        if run_config is not None and run_config.host_config is not None:
             # The host_config passed from the run_config will overwrite defaults
             host_config.update(run_config.host_config)
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -403,6 +403,9 @@ class DockerAgent(Agent):
         container_mount_paths = self.container_mount_paths
         if container_mount_paths:
             host_config.update(binds=self.host_spec)
+        if run_config is not None:
+            # The host_config passed from the run_config will overwrite defaults
+            host_config.update(run_config.host_config)
 
         networking_config = None
         # At the time of creation, you can only connect a container to a single network,

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -403,7 +403,7 @@ class DockerAgent(Agent):
         container_mount_paths = self.container_mount_paths
         if container_mount_paths:
             host_config.update(binds=self.host_spec)
-        if run_config is not None and run_config.host_config is not None:
+        if run_config and run_config.host_config:
             # The host_config passed from the run_config will overwrite defaults
             host_config.update(run_config.host_config)
 

--- a/src/prefect/run_configs/docker.py
+++ b/src/prefect/run_configs/docker.py
@@ -13,6 +13,9 @@ class DockerRun(RunConfig):
         - labels (Iterable[str], optional): an iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
             for selecting valid flow runs when polling for work
+        - host_config (dict, optional): A dictionary or runtime arguments to pass to
+            the Docker Agent. See link below for options.
+            https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
 
     Examples:
 

--- a/src/prefect/run_configs/docker.py
+++ b/src/prefect/run_configs/docker.py
@@ -30,7 +30,13 @@ class DockerRun(RunConfig):
     """
 
     def __init__(
-        self, *, image: str = None, env: dict = None, labels: Iterable[str] = None
+        self,
+        *,
+        image: str = None,
+        env: dict = None,
+        labels: Iterable[str] = None,
+        host_config: dict = {}
     ) -> None:
         super().__init__(env=env, labels=labels)
         self.image = image
+        self.host_config = host_config

--- a/src/prefect/run_configs/docker.py
+++ b/src/prefect/run_configs/docker.py
@@ -38,7 +38,7 @@ class DockerRun(RunConfig):
         image: str = None,
         env: dict = None,
         labels: Iterable[str] = None,
-        host_config: dict = {}
+        host_config: dict = None
     ) -> None:
         super().__init__(env=env, labels=labels)
         self.image = image

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -62,6 +62,7 @@ class DockerRunSchema(RunConfigSchemaBase):
         object_class = DockerRun
 
     image = fields.String(allow_none=True)
+    host_config = fields.Dict(keys=fields.String(), allow_none=True)
 
 
 class RunConfigSchema(OneOfSchema):

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -476,9 +476,9 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
 
     if run_kind == "docker":
         env = {"TESTING": "VALUE"}
-        host_config = {"shm_size": "128m"}
+        host_config = {"auto_remove": False, "shm_size": "128m"}
         exp_host_config = {
-            "auto_remove": True,
+            "auto_remove": False,
             "extra_hosts": {"host.docker.internal": "host-gateway"},
             "shm_size": "128m",
         }

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -476,9 +476,20 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
 
     if run_kind == "docker":
         env = {"TESTING": "VALUE"}
-        run = DockerRun(image=image, env=env)
+        host_config = {"shm_size": "128m"}
+        exp_host_config = {
+            "auto_remove": True,
+            "extra_hosts": {"host.docker.internal": "host-gateway"},
+            "shm_size": "128m",
+        }
+        run = DockerRun(image=image, env=env, host_config=host_config)
     else:
         env = {}
+        host_config = {}
+        exp_host_config = {
+            "auto_remove": True,
+            "extra_hosts": {"host.docker.internal": "host-gateway"},
+        }
         run = None if run_kind == "missing" else UniversalRun()
 
     agent = DockerAgent()
@@ -505,6 +516,9 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
     res_env = api.create_container.call_args[1]["environment"]
     for k, v in env.items():
         assert res_env[k] == v
+    res_host_config = api.create_host_config.call_args[1]
+    for k, v in exp_host_config.items():
+        assert res_host_config[k] == v
 
 
 def test_docker_agent_deploy_flow_unsupported_run_config(api):

--- a/tests/run_configs/test_docker.py
+++ b/tests/run_configs/test_docker.py
@@ -6,6 +6,7 @@ def test_no_args():
     assert config.env is None
     assert config.image is None
     assert config.labels == set()
+    assert config.host_config == {}
 
 
 def test_all_args(tmpdir):
@@ -14,7 +15,9 @@ def test_all_args(tmpdir):
         env={"hello": "world"},
         image="testing",
         labels=["a", "b"],
+        host_config={"host": "config"},
     )
     assert config.env == {"hello": "world"}
     assert config.image == "testing"
     assert config.labels == {"a", "b"}
+    assert config.host_config == {"host": "config"}

--- a/tests/run_configs/test_docker.py
+++ b/tests/run_configs/test_docker.py
@@ -6,7 +6,7 @@ def test_no_args():
     assert config.env is None
     assert config.image is None
     assert config.labels == set()
-    assert config.host_config == {}
+    assert config.host_config is None
 
 
 def test_all_args(tmpdir):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR allows to pass runtime commands to the Docker Agent via a host_config dictionary in the DockerRun config.



## Changes
<!-- What does this PR change? -->
The DockerRun config allows for an additional argument which is the host_config. The Docker agent
adds the provided host_config to the default host_config, overwriting any defaults.



## Importance
<!-- Why is this PR important? -->
This PR will allow for more flexibility in how Prefect Flows are deployed with Docker.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ x] adds new tests (if appropriate)
- [ x] adds a change file in the `changes/` directory (if appropriate)
- [ x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)