### PR TITLE
Running ECS Service correction

### DIFF
--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -305,14 +305,10 @@ Let's see an example of creating a Fargate service type for Prefect Agent using 
     "containerDefinitions": [
         {
             "name": "prefect-agent",
-            "image": "prefecthq/prefect:0.14.13-python3.8",
+            "image": "prefecthq/prefect:0.15.1-python3.8",
             "essential": true,
-            "command": ["prefect","agent","ecs","start"],
+            "command": ["prefect","agent","ecs","start","--key","<your-key>"],
             "environment": [
-                {
-                    "name": "PREFECT__CLOUD__API_KEY",
-                    "value": "<your-key>"
-                },
                 {
                     "name": "PREFECT__CLOUD__AGENT__LABELS",
                     "value": "['label1', 'label2']"},


### PR DESCRIPTION
The PREFECT__CLOUD__API__KEY environment variable cause an runtime error trying to start the agent. However, providing it as a a command line argument with '--key' (not '-k') does work.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->




## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)