### PR TITLE
Release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ Released on July 20, 2021.
 - Allow CLI registration of flows without starting their schedule `prefect register --no-schedule` - [#4752](https://github.com/PrefectHQ/prefect/pull/4752)
 - Add `host_config` to `DockerRun` to expose deeper settings for Docker flow runs - [#4733](https://github.com/PrefectHQ/prefect/issues/4773)
 - Enable loading additional repository files with `Git` storage - [#4767](https://github.com/PrefectHQ/prefect/pull/4767)
+- Update flow run heartbeats to be robust to exceptions - [#4736](https://github.com/PrefectHQ/prefect/pull/4736)
+- Allow `prefect build/register` paths to contain globs for recursion - [#4761](https://github.com/PrefectHQ/prefect/pull/4761)
 
 ### Fixes
 
 - Fix duplicate task runs in `FlowRunView.get_all_task_runs` - [#4774](https://github.com/PrefectHQ/prefect/pull/4774)
 - Fix zombie processes from exited heartbeats - [#4733](https://github.com/PrefectHQ/prefect/pull/4733)
+- Missing `auth_file` directory is created when saving credentials - [#4774](https://github.com/PrefectHQ/prefect/pull/4792)
 
 ### Task Library
 

--- a/changes/pr4736.yaml
+++ b/changes/pr4736.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Update flow run heartbeats to be robust to exceptions - [#4736](https://github.com/PrefectHQ/prefect/pull/4736)"

--- a/changes/pr4761.yaml
+++ b/changes/pr4761.yaml
@@ -1,3 +1,0 @@
-
-enhancement:
-  - "Allow `prefect build/register` paths to contain globs for recursion - [#4761](https://github.com/PrefectHQ/prefect/pull/4761)"

--- a/changes/pr4792.yaml
+++ b/changes/pr4792.yaml
@@ -1,5 +1,0 @@
-fix:
-  - "Missing auth_file directory is handled properly - [#4774](https://github.com/PrefectHQ/prefect/pull/4792)"
-
-contributor:
-  - "[Pawel Janowski](https://github.com/pjanowski)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -80,7 +80,7 @@ module.exports = {
       {
         text: 'API Reference',
         items: [
-          { text: 'Latest (0.15.1)', link: '/api/latest/' },
+          { text: 'Latest (0.15.2)', link: '/api/latest/' },
           { text: '0.14.22', link: '/api/0.14.22/' },
           { text: '0.13.19', link: '/api/0.13.19/' },
           { text: '0.12.6', link: '/api/0.12.6/' },


### PR DESCRIPTION
### Enhancements

- Allow CLI registration of flows without starting their schedule `prefect register --no-schedule` - [#4752](https://github.com/PrefectHQ/prefect/pull/4752)
- Add `host_config` to `DockerRun` to expose deeper settings for Docker flow runs - [#4733](https://github.com/PrefectHQ/prefect/issues/4773)
- Enable loading additional repository files with `Git` storage - [#4767](https://github.com/PrefectHQ/prefect/pull/4767)
- Update flow run heartbeats to be robust to exceptions - [#4736](https://github.com/PrefectHQ/prefect/pull/4736)
- Allow `prefect build/register` paths to contain globs for recursion - [#4761](https://github.com/PrefectHQ/prefect/pull/4761)

### Fixes

- Fix duplicate task runs in `FlowRunView.get_all_task_runs` - [#4774](https://github.com/PrefectHQ/prefect/pull/4774)
- Fix zombie processes from exited heartbeats - [#4733](https://github.com/PrefectHQ/prefect/pull/4733)
- Missing `auth_file` directory is created when saving credentials - [#4774](https://github.com/PrefectHQ/prefect/pull/4792)

### Task Library

- Add `VaultSecret` task for retrieving secrets from private Vault instances - [#4656](https://github.com/PrefectHQ/prefect/pull/4656)
