### PR TITLE
Fixup changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Released on July 20, 2021.
 
 - Fix duplicate task runs in `FlowRunView.get_all_task_runs` - [#4774](https://github.com/PrefectHQ/prefect/pull/4774)
 - Fix zombie processes from exited heartbeats - [#4733](https://github.com/PrefectHQ/prefect/pull/4733)
-- Missing `auth_file` directory is created when saving credentials - [#4774](https://github.com/PrefectHQ/prefect/pull/4792)
+- Missing `auth_file` directory is created when saving credentials - [#4792](https://github.com/PrefectHQ/prefect/pull/4792)
 
 ### Task Library
 


### PR DESCRIPTION
~The docs appear to have not built from #4794 so this is an empty commit to ask netlify to rebuild them so I can update the site~

The docs built, netlify was just slow. This just fixes a PR tag in the changelog.