### PR TITLE
Add evaluation parameters to `RunGreatExpectationsValidation`

### DIFF
--- a/changes/ge_task.yaml
+++ b/changes/ge_task.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add new `evaluation_parameters` parameter to `RunGreatExpectationsValidation` task"
+
+contributor:
+  - "[Michal Zawadzki](https://github.com/trymzet)"

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -56,9 +56,11 @@ class RunGreatExpectationsValidation(Task):
         batch_kwargs = get_batch_kwargs(datasource_name, dataset)
 
         expectation_suite_name = Parameter("expectation_suite_name")
+        prev_run_row_count = 100  # can be taken eg. from Prefect KV store
         validation_task(
             batch_kwargs=batch_kwargs,
             expectation_suite_name=expectation_suite_name,
+            evaluation_parameters=dict(prev_run_row_count=prev_run_row_count)
         )
 
     flow.run(
@@ -94,7 +96,12 @@ class RunGreatExpectationsValidation(Task):
         - disable_markdown_artifact (bool, optional): toggle the posting of a markdown artifact from
             this tasks. Defaults to `False`.
         - validation_operator (str, optional): configure the actions to be executed after running
-            validation. Defaults to `action_list_operator`.
+            validation. Defaults to `action_list_operator`
+        - evaluation_parameters (Optional[dict], optional): the evaluation parameters to use when
+            running validation. For more information, see
+            [example](https://docs.prefect.io/api/latest/tasks/great_expectations.html#rungreatexpectationsvalidation)
+            and
+            [docs](https://docs.greatexpectations.io/en/latest/reference/core_concepts/evaluation_parameters.html).
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
@@ -111,6 +118,7 @@ class RunGreatExpectationsValidation(Task):
         run_info_at_end: bool = True,
         disable_markdown_artifact: bool = False,
         validation_operator: str = "action_list_operator",
+        evaluation_parameters: Optional[dict] = None,
         **kwargs
     ):
         self.checkpoint_name = checkpoint_name
@@ -124,6 +132,7 @@ class RunGreatExpectationsValidation(Task):
         self.run_info_at_end = run_info_at_end
         self.disable_markdown_artifact = disable_markdown_artifact
         self.validation_operator = validation_operator
+        self.evaluation_parameters = evaluation_parameters
 
         super().__init__(**kwargs)
 
@@ -139,6 +148,7 @@ class RunGreatExpectationsValidation(Task):
         "run_info_at_end",
         "disable_markdown_artifact",
         "validation_operator",
+        "evaluation_parameters",
     )
     def run(
         self,
@@ -153,6 +163,7 @@ class RunGreatExpectationsValidation(Task):
         run_info_at_end: bool = True,
         disable_markdown_artifact: bool = False,
         validation_operator: str = "action_list_operator",
+        evaluation_parameters: Optional[dict] = None,
     ):
         """
         Task run method.
@@ -179,6 +190,11 @@ class RunGreatExpectationsValidation(Task):
                 task. Defaults to `True`.
             - disable_markdown_artifact (bool, optional): toggle the posting of a markdown artifact from
                 this tasks. Defaults to `False`.
+            - evaluation_parameters (Optional[dict], optional): the evaluation parameters to use when
+                running validation. For more information, see
+                [example](https://docs.prefect.io/api/latest/tasks/great_expectations.html#rungreatexpectationsvalidation)
+                and
+                [docs](https://docs.greatexpectations.io/en/latest/reference/core_concepts/evaluation_parameters.html).
             - validation_operator (str, optional): configure the actions to be executed after running
                 validation. Defaults to `action_list_operator`.
 
@@ -244,6 +260,7 @@ class RunGreatExpectationsValidation(Task):
             validation_operator,
             assets_to_validate=assets_to_validate,
             run_id={"run_name": run_name or prefect.context.get("task_slug")},
+            evaluation_parameters=evaluation_parameters,
         )
 
         # Generate artifact markdown

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -199,7 +199,7 @@ class RunGreatExpectationsValidation(Task):
                 validation. Defaults to `action_list_operator`.
 
         Raises:
-            - 'signals.VALIDATIONFAIL' if the validation was not a success
+            - 'signals.FAIL' if the validation was not a success
 
         Returns:
             - result

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -28,6 +28,7 @@ class TestInitialization:
             run_name="1234",
             run_info_at_end=False,
             disable_markdown_artifact=True,
+            evaluation_parameters=dict(prev_run_row_count=100),
         )
         assert t.checkpoint_name == "checkpoint"
         assert t.context == 1234
@@ -41,6 +42,7 @@ class TestInitialization:
         assert t.run_name == "1234"
         assert t.run_info_at_end == False
         assert t.disable_markdown_artifact == True
+        assert t.evaluation_parameters == dict(prev_run_row_count=100)
 
     def test_raises_if_params_not_mutually_exclusive(self):
         task = RunGreatExpectationsValidation(context="test")


### PR DESCRIPTION
## Summary
Added support for passing evaluation parameters as an argument to the `RunGreatExpectationsValidation` task.


## Importance
Makes it easy to calculate evaluation parameters on the fly, obtain from Prefect `Parameter`s, or anywhere else. Example with [KV Store](https://docs.prefect.io/orchestration/concepts/kv_store.html#ui):

```python
from prefect.tasks.great_expectations import RunGreatExpectationsValidation
from prefect.backend import get_key_value

prev_run_row_count= get_key_value(key="prev_run_row_count")
great_expectations_task = RunGreatExpectationsValidation()
great_expectations_task.run(
    batch_kwargs=batch_kwargs,
    expectation_suite_name=expectation_suite_name,
    evaluation_parameters=dict(prev_run_row_count=prev_run_row_count)
)
```


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)