### PR TITLE
Fix `create_flow_run` compatibility with auth tokens

### DIFF
--- a/changes/pr4801.yaml
+++ b/changes/pr4801.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix `create_flow_run` compatibility with auth tokens - [#4801](https://github.com/PrefectHQ/prefect/pull/4801)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -139,7 +139,7 @@ def create_flow_run(
         scheduled_start_time=scheduled_start_time,
     )
 
-    run_url = client.get_cloud_url("flow-run", flow_run_id)
+    run_url = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
     logger.info(f"Created flow run {run_name_dsp!r}: {run_url}")
     return flow_run_id
 

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -130,7 +130,9 @@ class TestCreateFlowRun:
         MockClient().create_flow_run.return_value = "flow-run-id"
         MockClient().get_cloud_url.return_value = "fake-url"
         create_flow_run.run(flow_id="flow-id")
-        MockClient().get_cloud_url.assert_called_once_with("flow-run", "flow-run-id")
+        MockClient().get_cloud_url.assert_called_once_with(
+            "flow-run", "flow-run-id", as_user=False
+        )
         assert "Created flow run '<generated-name>': fake-url" in caplog.text
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When retrieving URLs from tasks using auth tokens (vs API keys) we need to specify that we are not using a USER scoped token or it will lack permissions to find the default tenant.


## Changes
<!-- What does this PR change? -->

Passes `as_user=False` when retrieving a flow run URL


## Importance
<!-- Why is this PR important? -->

Closes #4799 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)