### PR TITLE
Fix auto-quoting for strings that begin with numeric characters

### DIFF
--- a/changes/pr4802.yaml
+++ b/changes/pr4802.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix auto-quoting for strings that begin with numeric characters - [#4802](https://github.com/PrefectHQ/prefect/pull/4802)"

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -269,7 +269,9 @@ def load_json_key_values(
         try:
             return json.loads(value)
         except ValueError as exc:
-            if "Expecting value" in str(exc) and '"' not in value:
+            if (
+                "Extra data" in str(exc) or "Expecting value" in str(exc)
+            ) and '"' not in value:
                 return cast_value(f'"{value}"')
             raise exc
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -221,8 +221,9 @@ def cloud_mocks(monkeypatch):
         ("2", 2),
         ("2.0", 2.0),
         ('"2.0"', "2.0"),
-        ("foo", "foo"),
-        ('"foo"', "foo"),  # auto-quoted
+        ("foo", "foo"),  # auto-quoted
+        ('"foo"', "foo"),
+        ("0foo", "0foo"),  # auto-quote when starting with a number
         ('{"key": "value"}', {"key": "value"}),
     ],
 )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When using a param like `--param foo=0xxx`, the JSON package throws an error noting that there's "Extra data" after the numeric character which does not match our auto-quoting exception check.


## Changes
<!-- What does this PR change? -->

- Parameters with a leading numeric character are quoted for the user


## Importance
<!-- Why is this PR important? -->

Fixes auto-quoting expectations


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)