### PR TITLE
Attempt to lower the OOM score for hearbeat processes on startup

### DIFF
--- a/changes/pr4808.yaml
+++ b/changes/pr4808.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Attempt to lower the OOM score for hearbeat processes on startup - [#4808](https://github.com/PrefectHQ/prefect/pull/4808)"

--- a/src/prefect/cli/heartbeat.py
+++ b/src/prefect/cli/heartbeat.py
@@ -1,5 +1,5 @@
 import time
-import os
+import sys
 
 import click
 
@@ -98,13 +98,9 @@ def flow_run(id, num):
     # Lower the OOM score for the hearbeat process so it is not killed before the flow
     # run
     try:
-        if os.path.exists("/proc/self/oom_score_adj"):
+        if sys.platform == "linux":
             with open("/proc/self/oom_score_adj", "wb") as f:
                 f.write("-500".encode("ascii"))
-        else:
-            logger.debug(
-                "Cannot set OOM score for heartbeat thread, `oom_score_adj` not available."
-            )
     except Exception:
         logger.debug("Failed to lower OOM score for hearbeat thread.", exc_info=True)
 

--- a/src/prefect/cli/heartbeat.py
+++ b/src/prefect/cli/heartbeat.py
@@ -100,7 +100,7 @@ def flow_run(id, num):
     try:
         if sys.platform == "linux":
             with open("/proc/self/oom_score_adj", "wb") as f:
-                f.write("-500".encode("ascii"))
+                f.write("0".encode("ascii"))
     except Exception:
         logger.debug("Failed to lower OOM score for hearbeat thread.", exc_info=True)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Users running memory intensive tasks find that their heartbeat process is killed while their flow is running. This means that if the task is long-running, we'll kill it think it's a zombie flow run. In an attempt to reduce the chances of the heartbeat being killed before the flow run process, we adjust the OOM score. This will only be available on linux.


## Changes
<!-- What does this PR change? -->

- `prefect heartbeat flow-run` sets a low OOM score


## Importance
<!-- Why is this PR important? -->

Less false-positive zombie runs

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)