### PR TITLE
[cli] Prevent server access from the outside

### DIFF
--- a/changes/pr4821.yaml
+++ b/changes/pr4821.yaml
@@ -1,0 +1,8 @@
+breaking:
+  - Services run by `prefect server` cli are now local by default (listen to localhost instead of 0.0.0.0)
+
+enhancement:
+  - Add `--expose` flag to `prefect server` cli to make the Core server and UI listen to all interfaces
+
+contributor:
+  - "[Henri Hannetel](https://github.com/HenriTEL)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   postgres:
     image: "postgres:11"
     ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
+      - "${POSTGRES_HOST_IP:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -35,7 +35,7 @@ services:
   hasura:
     image: "hasura/graphql-engine:v1.3.3"
     ports:
-      - "${HASURA_HOST_PORT:-3000}:3000"
+      - "${HASURA_HOST_IP:-127.0.0.1}:${HASURA_HOST_PORT:-3000}:3000"
     command: "graphql-engine serve"
     environment:
       HASURA_GRAPHQL_DATABASE_URL: ${DB_CONNECTION_URL}
@@ -59,7 +59,7 @@ services:
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "${GRAPHQL_HOST_PORT:-4201}:4201"
+      - "${GRAPHQL_HOST_IP:-127.0.0.1}:${GRAPHQL_HOST_PORT:-4201}:4201"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
     environment:
       PREFECT_SERVER_DB_CMD: ${PREFECT_SERVER_DB_CMD:-"echo 'DATABASE MIGRATIONS SKIPPED'"}
@@ -96,7 +96,7 @@ services:
   apollo:
     image: "prefecthq/apollo:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "${APOLLO_HOST_PORT:-4200}:4200"
+      - "${APOLLO_HOST_IP:-127.0.0.1}:${APOLLO_HOST_PORT:-4200}:4200"
     command: bash -c "./post-start.sh && npm run serve"
     environment:
       HASURA_API_URL: ${HASURA_API_URL:-http://hasura:3000/v1alpha1/graphql}
@@ -124,7 +124,7 @@ services:
   ui:
     image: "prefecthq/ui:${PREFECT_UI_TAG:-latest}"
     ports:
-      - "${UI_HOST_PORT:-8080}:8080"
+      - "${UI_HOST_IP:-127.0.0.1}:${UI_HOST_PORT:-8080}:8080"
     command: "/intercept.sh"
     environment:
       PREFECT_SERVER__APOLLO_URL: ${APOLLO_URL:-http://localhost:4200/graphql}

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   postgres:
     image: "postgres:11"
     ports:
-      - "${POSTGRES_HOST_IP:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -35,7 +35,7 @@ services:
   hasura:
     image: "hasura/graphql-engine:v1.3.3"
     ports:
-      - "${HASURA_HOST_IP:-127.0.0.1}:${HASURA_HOST_PORT:-3000}:3000"
+      - "127.0.0.1:${HASURA_HOST_PORT:-3000}:3000"
     command: "graphql-engine serve"
     environment:
       HASURA_GRAPHQL_DATABASE_URL: ${DB_CONNECTION_URL}
@@ -59,7 +59,7 @@ services:
   graphql:
     image: "prefecthq/server:${PREFECT_SERVER_TAG:-latest}"
     ports:
-      - "${GRAPHQL_HOST_IP:-127.0.0.1}:${GRAPHQL_HOST_PORT:-4201}:4201"
+      - "127.0.0.1:${GRAPHQL_HOST_PORT:-4201}:4201"
     command: bash -c "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
     environment:
       PREFECT_SERVER_DB_CMD: ${PREFECT_SERVER_DB_CMD:-"echo 'DATABASE MIGRATIONS SKIPPED'"}

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -113,6 +113,12 @@ COMMON_SERVER_OPTIONS = [
         hidden=True,
     ),
     click.option(
+        "--expose",
+        help="Make the UI and Core  to listen on all interfaces",
+        is_flag=True,
+        hidden=True,
+    ),
+    click.option(
         "--server-port",
         help="The port used to serve the Core server",
         default=config.server.host_port,
@@ -245,6 +251,7 @@ def setup_compose_env(
     hasura_port=None,
     graphql_port=None,
     ui_port=None,
+    expose=False,
     server_port=None,
     volume_path=None,
 ):
@@ -273,6 +280,7 @@ def setup_compose_env(
         DB_CONNECTION_URL=db_connection_url,
         GRAPHQL_HOST_PORT=str(graphql_port),
         UI_HOST_PORT=str(ui_port),
+        UI_HOST_IP='0.0.0.0' if expose else config.server.ui.host_ip,
         # Pass the Core version so the Server API can return it
         PREFECT_CORE_VERSION=prefect.__version__,
         # Set the server image tag
@@ -285,6 +293,7 @@ def setup_compose_env(
         PREFECT_API_URL=f"http://graphql:{graphql_port}{config.server.graphql.path}",
         PREFECT_API_HEALTH_URL=f"http://graphql:{graphql_port}/health",
         APOLLO_HOST_PORT=str(server_port),
+        APOLLO_HOST_IP='0.0.0.0' if expose  else config.server.host_ip,
         PREFECT_SERVER__TELEMETRY__ENABLED=(
             "true" if config.server.telemetry.enabled is True else "false"
         ),
@@ -387,6 +396,7 @@ def config_cmd(
     hasura_port,
     graphql_port,
     ui_port,
+    expose,
     server_port,
     no_postgres_port,
     no_hasura_port,
@@ -473,6 +483,7 @@ def config_cmd(
         hasura_port=hasura_port,
         graphql_port=graphql_port,
         ui_port=ui_port,
+        expose=expose,
         server_port=server_port,
         volume_path=volume_path,
     )
@@ -508,6 +519,7 @@ def start(
     hasura_port,
     graphql_port,
     ui_port,
+    expose,
     server_port,
     no_postgres_port,
     no_hasura_port,
@@ -598,6 +610,7 @@ def start(
         hasura_port=hasura_port,
         graphql_port=graphql_port,
         ui_port=ui_port,
+        expose=expose,
         server_port=server_port,
         volume_path=volume_path,
     )

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -114,7 +114,7 @@ COMMON_SERVER_OPTIONS = [
     ),
     click.option(
         "--expose",
-        help="Make the UI and Core  to listen on all interfaces",
+        help="Make the UI and Core server listen on all interfaces",
         is_flag=True,
         hidden=True,
     ),
@@ -280,7 +280,7 @@ def setup_compose_env(
         DB_CONNECTION_URL=db_connection_url,
         GRAPHQL_HOST_PORT=str(graphql_port),
         UI_HOST_PORT=str(ui_port),
-        UI_HOST_IP='0.0.0.0' if expose else config.server.ui.host_ip,
+        UI_HOST_IP="0.0.0.0" if expose else config.server.ui.host_ip,
         # Pass the Core version so the Server API can return it
         PREFECT_CORE_VERSION=prefect.__version__,
         # Set the server image tag
@@ -293,7 +293,7 @@ def setup_compose_env(
         PREFECT_API_URL=f"http://graphql:{graphql_port}{config.server.graphql.path}",
         PREFECT_API_HEALTH_URL=f"http://graphql:{graphql_port}/health",
         APOLLO_HOST_PORT=str(server_port),
-        APOLLO_HOST_IP='0.0.0.0' if expose  else config.server.host_ip,
+        APOLLO_HOST_IP="0.0.0.0" if expose else config.server.host_ip,
         PREFECT_SERVER__TELEMETRY__ENABLED=(
             "true" if config.server.telemetry.enabled is True else "false"
         ),

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -10,6 +10,7 @@ backend = "cloud"
 host = "http://localhost"
 port = "4200"
 host_port = "4200"
+host_ip = "127.0.0.1"
 endpoint = "${server.host}:${server.port}"
 
     [server.database]
@@ -44,6 +45,7 @@ endpoint = "${server.host}:${server.port}"
     host = "http://localhost"
     port = "8080"
     host_port = "8080"
+    host_ip = "127.0.0.1"
     endpoint = "${server.ui.host}:${server.ui.port}"
     apollo_url = "http://localhost:4200/graphql"
 


### PR DESCRIPTION
## Summary
By default docker-compose services listen to all host interfaces, meaning all machines in the connected networks have direct access to services exposing a port.
This commit sets the binding IP to localhost by default to mitigate this security issue.


## Changes
* Limited services exposing ports to localhost in `prefect server` cli
* Add `--expose` flag to `prefect server` cli to make the Core server and UI listen to all interfaces


## Importance
This is quite important as it fixes a security issue when working with a local environment.