### PR TITLE
Fix default safe char for gitlab storage repo path

### DIFF
--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -88,7 +88,7 @@ class GitLab(Storage):
         client = self._get_gitlab_client()
 
         try:
-            project = client.projects.get(quote_plus(self.repo, safe='/'))
+            project = client.projects.get(quote_plus(self.repo), safe="/")
             contents = project.files.get(file_path=flow_location, ref=ref)
         except GitlabAuthenticationError:
             self.logger.error(
@@ -108,7 +108,7 @@ class GitLab(Storage):
 
     def add_flow(self, flow: "Flow") -> str:
         """
-        Method for storing a new flow as bytes in the local filesytem.
+        Method for storing a new flow as bytes in the local filesystem.
 
         Args:
             - flow (Flow): a Prefect Flow to add

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -88,7 +88,7 @@ class GitLab(Storage):
         client = self._get_gitlab_client()
 
         try:
-            project = client.projects.get(quote_plus(self.repo))
+            project = client.projects.get(quote_plus(self.repo), safe='/')
             contents = project.files.get(file_path=flow_location, ref=ref)
         except GitlabAuthenticationError:
             self.logger.error(

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -88,7 +88,7 @@ class GitLab(Storage):
         client = self._get_gitlab_client()
 
         try:
-            project = client.projects.get(quote_plus(self.repo), safe='/')
+            project = client.projects.get(quote_plus(self.repo, safe='/'))
             contents = project.files.get(file_path=flow_location, ref=ref)
         except GitlabAuthenticationError:
             self.logger.error(


### PR DESCRIPTION
## Summary
Current gitlab storage is broken for any repository paths containing forward slash. The structure is common in gitlab since repositories can belong to projects. [The function used for URL quoting](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote)(`urllib.parse.quote_plus`) defaults to escaping all characters. The PR mirrors behavior of a similar function `urllib.parse.quote` by setting safe character to `/`




## Changes
Sets default value for `urllib.parse.quote_plus` `safe` to `/`since originally it escapes all special characters



## Importance
Allow for repo paths to contain forward slashes which are common in gitlab projects and repositories structure.




## Checklist
Minor fix 
This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)