### PR TITLE
Do not look for a specific error code

### DIFF
--- a/tests/tasks/test_shell.py
+++ b/tests/tasks/test_shell.py
@@ -99,7 +99,7 @@ def test_shell_logs_non_zero_exit(caplog):
         task = ShellTask()(command="ls surely_a_dir_that_doesnt_exist")
     out = f.run()
     assert out.is_failed()
-    assert "Command failed with exit code 2" in caplog.text
+    assert "Command failed with exit code" in caplog.text
 
 
 def test_shell_attaches_result_to_failure(caplog):


### PR DESCRIPTION
- `test_shell_logs_non_zero_exit` fails with exit code 1 in my env
- no fixed rules for parsing nonzero codes, checking for 2 is brittle

## Summary

`test_shell_logs_non_zero_exit` fails because the `ShellTask` fails with exit code 1, instead of 2. After some digging, it looks like M1 Macs ship with an older version of `bash` that consistently returns a different error code than Intel-Macs when trying to `ls` a nonexistent directory.

Moreover, since the test is only looking to see that `ShellTask` can return a useful output, as opposed to checking that the error is tied to a specific shell implementation and there is no convention on how to parse nonzero exit codes, I think we should simply remove the error code check from the test.



## Changes
In `tests/tasks/test_shell.py::test_shell_logs_non_zero_exit` parse the `ShellTask` log for a generic error message, instead of looking specifically for exit code 2.




## Importance
Core tests currently fail on M1 Macs (and presumably systems with older version of `bash`, but this is unconfirmed).




## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)