### PR TITLE
Fix binding of named volumes to flow containers with Docker agent

### DIFF
--- a/changes/pr4800.yaml
+++ b/changes/pr4800.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix binding of named volumes to flow containers with Docker agent - [#4800](https://github.com/PrefectHQ/prefect/pull/4800)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -289,6 +289,7 @@ class DockerAgent(Agent):
                 # no internal container path given, assume the host path is the same as the
                 # internal path
                 external = internal
+
             host_spec[external] = {
                 "bind": internal,
                 "mode": mode,
@@ -333,15 +334,16 @@ class DockerAgent(Agent):
                             mode
                         )
                     )
-            else:
-                if not external:
-                    # no internal container path given, assume the host path is the same as the
-                    # internal path
-                    external = internal
-                host_spec[external] = {
-                    "bind": internal,
-                    "mode": mode,
-                }
+
+            if not external:
+                # no internal container path given, assume the host path is the same as the
+                # internal path
+                external = internal
+
+            host_spec[external] = {
+                "bind": internal,
+                "mode": mode,
+            }
 
         return named_volumes, container_mount_paths, host_spec
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -284,15 +284,15 @@ class DockerAgent(Agent):
                             mode
                         )
                     )
-            else:
-                if not external:
-                    # no internal container path given, assume the host path is the same as the
-                    # internal path
-                    external = internal
-                host_spec[external] = {
-                    "bind": internal,
-                    "mode": mode,
-                }
+
+            if not external:
+                # no internal container path given, assume the host path is the same as the
+                # internal path
+                external = internal
+            host_spec[external] = {
+                "bind": internal,
+                "mode": mode,
+            }
 
         return named_volumes, container_mount_paths, host_spec
 

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -898,7 +898,7 @@ def test_docker_agent_is_named_volume_win32(monkeypatch, api, path, result):
             ["some-name:/ctr/path"],
             ["some-name"],
             ["/ctr/path"],
-            {},
+            {"some-name": {"bind": "/ctr/path", "mode": "rw"}},
         ),
         (
             # multiple volumes
@@ -912,6 +912,7 @@ def test_docker_agent_is_named_volume_win32(monkeypatch, api, path, result):
             {
                 "/another/path": {"bind": "/ctr/path2", "mode": "ro"},
                 "/some/path": {"bind": "/ctr/path1", "mode": "rw"},
+                "some-name": {"bind": "/ctr/path3", "mode": "rw"},
             },
         ),
     ],
@@ -961,7 +962,7 @@ def test_docker_agent_parse_volume_spec_unix(
             ["some-name:/ctr/path"],
             ["some-name"],
             ["/ctr/path"],
-            {},
+            {"some-name": {"bind": "/ctr/path", "mode": "rw"}},
         ),
         (
             # multiple volumes
@@ -975,6 +976,7 @@ def test_docker_agent_parse_volume_spec_unix(
             {
                 "D:\\another\\path": {"bind": "/ctr/path2", "mode": "ro"},
                 "C:\\some\\path": {"bind": "/ctr/path1", "mode": "rw"},
+                "some-name": {"bind": "/ctr/path3", "mode": "rw"},
             },
         ),
     ],


### PR DESCRIPTION
Supersedes #4800 

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

A `bind` was not being generated in the `host_spec` for named volumes. Consequently, the volumes were attached but not available from inside the container as expected. This PR adds proper `bind` specs for named volumes.

## Changes
<!-- What does this PR change? -->

- `bind` clauses are generated for named volumes


## Importance
<!-- Why is this PR important? -->

Fixes a bug on win32/unix where named volumes were not available in the flow container


## Example

`prefect agent docker start --volume my_named_volume:/tmp`

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)