### PR TITLE
Allow custom clone urls with `Git` storage

### DIFF
--- a/changes/pr4870.yaml
+++ b/changes/pr4870.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow custom git clone url for `Git` storage - [#4870](https://github.com/PrefectHQ/cloud/pull/4870)"

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -284,6 +284,20 @@ storage = Git(
 )
 ```
 
+`Git` storage will attempt to build the correct git clone url based on the parameters provided. Users can override this logic and provide their git clone url directly.
+
+To use a custom git clone url, first create a Secret containing the url. Next, specify the name of the secret when creating your `Git` storage class.
+
+```python
+# example using Azure devops url
+# using a secret named 'MY_REPO_CLONE_URL' with value 'https://<username>:<personal_access_token>@dev.azure.com/<organization>/<project>/_git/<repo>'
+
+storage = Git(
+    path="flows/my_flow.py",
+    git_clone_url_secret_name="MY_REPO_CLONE_URL" # use the value of this secret to clone the repository
+)
+```
+
 :::tip Git Deploy Keys
 To use `Git` storage with Deploy Keys, ensure your environment is configured to use Deploy Keys. Then, create a `Git` storage class with `use_ssh=True`.
 

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -161,6 +161,7 @@ class GitSchema(BaseStorageSchema):
     flow_name = fields.String(allow_none=True)
     git_token_secret_name = fields.String(allow_none=True)
     git_token_username = fields.String(allow_none=True)
+    git_clone_url_secret_name = fields.String(allow_none=True)
     branch_name = fields.String(allow_none=True)
     tag = fields.String(allow_none=True)
     commit = fields.String(allow_none=True)

--- a/tests/storage/test_git_storage.py
+++ b/tests/storage/test_git_storage.py
@@ -1,11 +1,9 @@
 from unittest.mock import MagicMock
-from tempfile import TemporaryDirectory
 
 import pytest
 
 dulwich = pytest.importorskip("dulwich")
 
-import prefect
 from prefect import context, Flow
 from prefect.storage import Git
 
@@ -76,6 +74,21 @@ def test_create_git_storage_with_use_ssh_and_git_token_secret_name_logs_warning(
     )
 
 
+def test_create_git_storage_with_git_clone_url_secret_name_and_other_repo_params_logs_warning(
+    caplog,
+):
+    storage = Git(
+        flow_path="flow.py",
+        repo="test/repo",
+        git_clone_url_secret_name="MY_SECRET",
+    )
+
+    assert (
+        "Git storage initialized with a `git_clone_url_secret_name`. The value of this Secret will be used to clone the repository, ignoring"
+        in caplog.text
+    )
+
+
 def test_create_git_storage_with_tag_and_branch_name_errors():
     with pytest.raises(ValueError):
         storage = Git(
@@ -91,6 +104,7 @@ def test_serialize_git_storage():
         flow_name="my-flow",
         git_token_secret_name="MY_TOKEN",
         git_token_username="my_user",
+        git_clone_url_secret_name="MY_GIT_URL",
         branch_name="my_branch",
         tag=None,
         commit=None,
@@ -107,6 +121,7 @@ def test_serialize_git_storage():
     assert serialized_storage["flow_name"] == "my-flow"
     assert serialized_storage["git_token_secret_name"] == "MY_TOKEN"
     assert serialized_storage["git_token_username"] == "my_user"
+    assert serialized_storage["git_clone_url_secret_name"] == "MY_GIT_URL"
     assert serialized_storage["branch_name"] == "my_branch"
     assert serialized_storage["tag"] == None
     assert serialized_storage["commit"] == None
@@ -137,7 +152,7 @@ def test_add_flow_to_git_already_added():
 
 
 @pytest.mark.parametrize(
-    "repo_host, repo, access_token_secret_name, access_token_secret, access_token_username, use_ssh, format_access_token, expected_git_clone_url",
+    "repo_host, repo, access_token_secret_name, access_token_secret, access_token_username, use_ssh, format_access_token, git_clone_url_secret_name, git_clone_url_secret, expected_git_clone_url",
     [
         # no access token secret provided
         (
@@ -148,6 +163,8 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             True,
+            None,
+            None,
             "https://@github.com/my/repo.git",
         ),
         # github + access token
@@ -159,6 +176,8 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             True,
+            None,
+            None,
             "https://user:MY_SECRET_TOKEN@github.com/user/repo.git",
         ),
         # github + access token + custom token username
@@ -170,6 +189,8 @@ def test_add_flow_to_git_already_added():
             "another_git_user",
             False,
             True,
+            None,
+            None,
             "https://another_git_user:MY_SECRET_TOKEN@github.com/user/repo.git",
         ),
         # bitbucket + access token
@@ -181,6 +202,8 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             True,
+            None,
+            None,
             "https://user:MY_SECRET_TOKEN@bitbucket.org/user/repo.git",
         ),
         # gitlab + access token
@@ -192,6 +215,8 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             True,
+            None,
+            None,
             "https://user:MY_SECRET_TOKEN@gitlab.com/user/repo.git",
         ),
         # unknown hostname + access token
@@ -203,6 +228,8 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             True,
+            None,
+            None,
             "https://user:MY_SECRET_TOKEN@randomsite.com/user/repo.git",
         ),
         # ssh
@@ -214,6 +241,8 @@ def test_add_flow_to_git_already_added():
             None,
             True,  # use ssh instead of https
             True,
+            None,
+            None,
             "git@github.com:user/repo.git",
         ),
         # skip access token formatting
@@ -225,7 +254,22 @@ def test_add_flow_to_git_already_added():
             None,
             False,
             False,  # skip access token formatting
+            None,
+            None,
             "https://MY_SECRET_TOKEN@github.com/user/repo.git",
+        ),
+        # provide git clone url secret name directly
+        (
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+            True,
+            "GIT_CLONE_URL_SECRET",  # provide the url as a secret
+            "https://my-secret-url.com/repo.git",
+            "https://my-secret-url.com/repo.git",
         ),
     ],
 )
@@ -237,6 +281,8 @@ def test_get_git_clone_url(
     access_token_username,
     use_ssh,
     format_access_token,
+    git_clone_url_secret_name,
+    git_clone_url_secret,
     expected_git_clone_url,
 ):
     storage = Git(
@@ -245,10 +291,16 @@ def test_get_git_clone_url(
         repo_host=repo_host,
         git_token_secret_name=access_token_secret_name,
         git_token_username=access_token_username,
+        git_clone_url_secret_name=git_clone_url_secret_name,
         use_ssh=use_ssh,
         format_access_token=format_access_token,
     )
-    with context(secrets={access_token_secret_name: access_token_secret}):
+    with context(
+        secrets={
+            access_token_secret_name: access_token_secret,
+            git_clone_url_secret_name: git_clone_url_secret,
+        }
+    ):
         assert storage.git_clone_url == expected_git_clone_url
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR allows users to pass a secret name containing the exact clone url for `Git` storage.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
Resolves #4850. I suspect there will be other cases where providers don't use standard syntax for cloning and this logic should cover those cases.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)