### PR TITLE
Updating ENDRUN Docstring

### DIFF
--- a/changes/pr4871.yml
+++ b/changes/pr4871.yml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Clarifying docs that ENDRUN does not end flows - [#4871](https://github.com/PrefectHQ/prefect/pull/4871)"

--- a/changes/pr4871.yml
+++ b/changes/pr4871.yml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Clarifying docs that ENDRUN does not end flows - [#4871](https://github.com/PrefectHQ/prefect/pull/4871)"

--- a/src/prefect/engine/signals.py
+++ b/src/prefect/engine/signals.py
@@ -39,7 +39,8 @@ def signal_from_state(state: state.State) -> Type["PrefectStateSignal"]:
 class ENDRUN(PrefectSignal):
     """
     An ENDRUN exception is used to indicate that _all_ state processing should
-    stop. The pipeline result should be the state contained in the exception.
+    stop for a given task. An ENDRUN exception with a Failed state will not retry
+    the task. The pipeline result should be the state contained in the exception.
 
     Args:
         - state (State): the state that should be used as the result of the Runner's run


### PR DESCRIPTION
## Summary

I am just changing two lines with the ENDRUN docstring. Multiple users have gotten the expectation that it would shut down the entire Flow because of the way it is currently written. I also just added a use case to use this to avoid task retries.

## Checklist

This PR:

- [x] adds a change file in the `changes/` directory (if appropriate)