### PR TITLE
Add a _on_scheduler_message callback to the DaskExecutor. Closes #4874

### DIFF
--- a/changes/pr4874.yaml
+++ b/changes/pr4874.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add a _on_scheduler_message callback to the DaskExecutor - [#4874](https://github.com/PrefectHQ/prefect/pull/4874)"
+
+contributor:
+  - "[Tom Forbes](https://github.com/orf)"

--- a/changes/pr4874.yaml
+++ b/changes/pr4874.yaml
@@ -17,7 +17,7 @@
 # Here's an example of a PR that adds an enhancement
 
 enhancement:
-  - "Add a _on_scheduler_message callback to the DaskExecutor - [#4874](https://github.com/PrefectHQ/prefect/pull/4874)"
+  - "Add a on_worker_status_changed callback to the DaskExecutor - [#4874](https://github.com/PrefectHQ/prefect/pull/4874)"
 
 contributor:
   - "[Tom Forbes](https://github.com/orf)"

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -238,7 +238,7 @@ class DaskExecutor(Executor):
         finally:
             self.client = None
 
-    async def _on_scheduler_message(self, op, message):
+    async def _on_scheduler_message(self, op: str, message: dict) -> None:
         if op == "add":
             for worker in message.get("workers", ()):
                 self.logger.debug("Worker %s added", worker)

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -238,7 +238,14 @@ class DaskExecutor(Executor):
         finally:
             self.client = None
 
-    async def _on_scheduler_message(self, op: str, message: dict) -> None:
+    async def on_worker_status_changed(self, op: str, message: dict) -> None:
+        """
+        This method is triggered when a worker is added or removed from the cluster.
+
+        Args:
+            - op (str): Either "add" or "remove"
+            - message (dict): Information about the event that the scheduler has sent
+        """
         if op == "add":
             for worker in message.get("workers", ()):
                 self.logger.debug("Worker %s added", worker)
@@ -267,7 +274,7 @@ class DaskExecutor(Executor):
                 except OSError:
                     break
                 for op, msg in msgs:
-                    await self._on_scheduler_message(op, msg)
+                    await self.on_worker_status_changed(op, msg)
         except asyncio.CancelledError:
             pass
         except Exception:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Described in #4874 - the tl;dr is that it would be handy to allow subclasses of the `DaskExecutor` to handle scheduler messages in their own way.


## Changes

This refactors the current `_watch_dask_events` loop to call `_on_scheduler_message`, where it can be overriden

## Importance

Watching scheduler events seems non-trivial, making it easily extensible is very handy to some use-cases. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)