### PR TITLE
Add `--agent-config-id` to `prefect agent <kubernetes|local> install

### DIFF
--- a/changes/pr4876.yaml
+++ b/changes/pr4876.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Add `--agent-config-id` to `prefect agent <kubernetes|local> install - [#4876](https://github.com/PrefectHQ/prefect/pull/4876)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -771,6 +771,7 @@ class KubernetesAgent(Agent):
         backend: str = None,
         key: str = None,
         tenant_id: str = None,
+        agent_config_id: str = None,
     ) -> str:
         """
         Generate and output an installable YAML spec for the agent.
@@ -805,6 +806,8 @@ class KubernetesAgent(Agent):
                 with Prefect Cloud
             - tenant_id (str, optional): A tenant ID for the agent to connect to. If not
                 set, the default tenant associated with the API key will be used.
+            - agent_config_id (str, optional): An agent config id to link to for health
+                check automations
 
         Returns:
             - str: A string representation of the generated YAML
@@ -834,6 +837,10 @@ class KubernetesAgent(Agent):
             os.path.join(os.path.dirname(__file__), "deployment.yaml"), "r"
         ) as deployment_file:
             deployment = yaml.safe_load(deployment_file)
+
+        cmd_args = deployment["spec"]["template"]["spec"]["containers"][0]["args"]
+        if agent_config_id:
+            cmd_args[0] += f" --agent-config-id {agent_config_id}"
 
         agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -242,6 +242,7 @@ class LocalAgent(Agent):
         show_flow_logs: bool = False,
         key: str = None,
         tenant_id: str = None,
+        agent_config_id: str = None,
     ) -> str:
         """
         Generate and output an installable supervisorctl configuration file for the agent.
@@ -262,6 +263,8 @@ class LocalAgent(Agent):
                 with Prefect Cloud
             - tenant_id (str, optional): A tenant ID for the agent to connect to. If not
                 set, the default tenant associated with the API key will be used.
+            - agent_config_id (str, optional): An agent config id to link to for health
+                check automations
 
         Returns:
             - str: A string representation of the generated configuration file
@@ -295,6 +298,8 @@ class LocalAgent(Agent):
             add_opts += f"-k {key} "
         if tenant_id:
             add_opts += f"--tenant-id {tenant_id} "
+        if agent_config_id:
+            add_opts += f"--agent-config-id {agent_config_id}"
 
         # Tokens are deprecated
         if token:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -118,6 +118,10 @@ COMMON_INSTALL_OPTIONS = [
         "-t",
         help="A Prefect Cloud API token with RUNNER scope. DEPRECATED.",
     ),
+    click.option(
+        "--agent-config-id",
+        help="An agent ID to link this agent instance with",
+    ),
 ]
 
 

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -573,6 +573,23 @@ def test_k8s_agent_generate_deployment_yaml_env_vars(monkeypatch, cloud_api):
     assert agent_env[-1]["value"] == json.dumps(env_vars)
 
 
+@pytest.mark.parametrize("agent_config_id", [None, "foobar"])
+def test_k8s_agent_generate_deployment_yaml_agent_config_id(
+    monkeypatch, cloud_api, agent_config_id
+):
+    agent = KubernetesAgent()
+    deployment = yaml.safe_load(
+        agent.generate_deployment_yaml(agent_config_id=agent_config_id)
+    )
+
+    cmd_args = deployment["spec"]["template"]["spec"]["containers"][0]["args"]
+
+    if agent_config_id:
+        assert cmd_args == ["prefect agent kubernetes start --agent-config-id foobar"]
+    else:
+        assert cmd_args == ["prefect agent kubernetes start"]
+
+
 def test_k8s_agent_generate_deployment_yaml_backend_default(monkeypatch, server_api):
     c = MagicMock()
     monkeypatch.setattr("prefect.agent.agent.Client", c)

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -185,7 +185,7 @@ def test_agent_local_install(monkeypatch, use_token):
     command.extend(
         (
             "-l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
-            "-p path1 -p path2 --show-flow-logs"
+            "-p path1 -p path2 --show-flow-logs --agent-config-id foo"
         ).split()
     )
 
@@ -197,6 +197,7 @@ def test_agent_local_install(monkeypatch, use_token):
         "env_vars": {"KEY1": "VALUE1", "KEY2": "VALUE2"},
         "import_paths": ["path1", "path2"],
         "show_flow_logs": True,
+        "agent_config_id": "foo",
     }
 
     if use_token:
@@ -234,7 +235,7 @@ def test_agent_kubernetes_install(monkeypatch, use_token):
             "--latest --image-pull-secrets secret-test --mem-request mem_req "
             "--mem-limit mem_lim --cpu-request cpu_req --cpu-limit cpu_lim "
             "--image-pull-policy custom_policy --service-account-name svc_name "
-            "-b backend-test"
+            "-b backend-test --agent-config-id foo"
         ).split()
     )
 
@@ -256,6 +257,7 @@ def test_agent_kubernetes_install(monkeypatch, use_token):
         "image_pull_policy": "custom_policy",
         "service_account_name": "svc_name",
         "backend": "backend-test",
+        "agent_config_id": "foo",
     }
 
     if use_token:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->


Users are trying to set the `agent-config-id` for installed agents so they can use SLAs

## Changes
<!-- What does this PR change? -->

- Adds the `--agent-config-id` CLI option


## Importance
<!-- Why is this PR important? -->

Easier to install SLAs w/ kubernetes agents


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)