### PR TITLE
Extend warning in case of log writing issues

### DIFF
--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -121,7 +121,12 @@ class LogManager:
                 except Exception as exc:
                     # An error occurred on upload, warn and exit the loop (will
                     # retry later)
-                    warnings.warn(f"Failed to write logs with error: {exc!r}")
+                    warnings.warn(
+                        f"Failed to write logs with error: {exc!r}, "
+                        f"Pending log length: {self.pending_length:,}, "
+                        f"Max batch log length: {MAX_BATCH_LOG_LENGTH:,}, "
+                        f"Queue size: {self.queue.qsize():,}"
+                    )
                     cont = False
 
     def enqueue(self, message: dict) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Extend warning in case of log writing issues for better understanding of the current log pressure.




## Changes
Extends the _write_logs exception handler to contain more information.




## Importance
Helps to better understand the current tried to send log size (pending_length) and the current log pressure in case of log sending issues like:

```
.../prefect/lib/python3.9/site-packages/prefect/utilities/logging.py:124: 
UserWarning: Failed to write logs with error: 
HTTPError('413 Client Error: Request Entity Too Large for 
url: https://api.prefect.io/graphql')
warnings.warn(f"Failed to write logs with error: {exc!r}")
```

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)