### PR TITLE
Build Docker image for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,6 +605,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+      - build_docker_image:
+          python_version: '3.9'
+          extras: 'all_orchestration_extras'
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - release_to_pypi:
           filters:
             branches:
@@ -612,7 +620,7 @@ workflows:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - build_core_docker_image:
-          python_version: '3.8'
+          python_version: '3.9'
           tag_latest: true
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.vcs-ref=${GIT_SHA}
 LABEL org.label-schema.build-date=${BUILD_DATE}
 
 RUN apt update && \
-    apt install -y gcc git tini && \
+    apt install -y gcc git tini build-essential && \
     mkdir /root/.prefect/ && \
     pip install "pip==20.2.4" && \
     pip install --no-cache-dir git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[${EXTRAS}] && \


### PR DESCRIPTION
Noticed these images don't exist but Prefect has supported 3.9 for almost a year so it seems about time 🙂 