### PR TITLE
Support for RRule (iCal style recurrence rule) clocks / schedules.

### DIFF
--- a/src/prefect/schedules/schedules.py
+++ b/src/prefect/schedules/schedules.py
@@ -2,6 +2,7 @@ import heapq
 import itertools
 import operator
 from datetime import datetime, timedelta
+from dateutil import rrule
 from typing import Callable, Iterable, List, Optional, cast
 
 import prefect.schedules.adjustments
@@ -272,4 +273,27 @@ def CronSchedule(
                 cron=cron, start_date=start_date, end_date=end_date, day_or=day_or
             )
         ]
+    )
+
+
+def RRuleSchedule(
+    rrule_obj: rrule.rrulebase, start_date: datetime = None, end_date: datetime = None
+) -> Schedule:
+    """
+    A schedule formed from a iCal style recurrence rule (RRule).
+
+    See below links for helpful info:
+        - https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html
+        - https://dateutil.readthedocs.io/en/stable/rrule.html
+
+    Args:
+        - rrule_obj (rrulebase): an rrule or rruleset object
+        - start_date (datetime, optional): an optional start date for the clock
+        - end_date (datetime, optional): an optional end date for the clock
+
+    Raises:
+        - TypeError: if provided rrule_obj is not an rrule object
+    """
+    return Schedule(
+        clocks=[prefect.schedules.clocks.RRuleClock(rrule_obj, start_date, end_date)]
     )

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -1,5 +1,6 @@
 import itertools
 from datetime import time, timedelta
+from dateutil import rrule
 
 import pendulum
 import pytest
@@ -717,3 +718,72 @@ class TestDatesClock:
 
         clock = clocks.DatesClock(dates=[dt.add(days=1), dt.add(days=2), dt])
         assert islice(clock.events(), 3) == [dt, dt.add(days=1), dt.add(days=2)]
+
+
+class TestRRuleClock:
+    def test_rrule_clock_creation(self):
+        c = clocks.RRuleClock(rrule.rrule(freq=rrule.DAILY))
+        assert c.parameter_defaults == dict()
+        assert c.labels is None
+        assert c.start_date is None
+        assert c.end_date is None
+
+    def test_rrule_create_without_rrule(self):
+        with pytest.raises(TypeError):
+            clocks.RRuleClock(42)
+
+    @pytest.mark.parametrize("params", [dict(), dict(x=1)])
+    @pytest.mark.parametrize("labels", [[], ["dev"]])
+    def test_rrule_clock_events(self, params, labels):
+        start = pendulum.now().replace(microsecond=0)
+        c = clocks.RRuleClock(
+            rrule.rrule(freq=rrule.DAILY, dtstart=start),
+            parameter_defaults=params,
+            labels=labels,
+        )
+
+        output = islice(c.events(), 3)
+        assert all(isinstance(e, clocks.ClockEvent) for e in output)
+        assert all(e.parameter_defaults == params for e in output)
+        assert all(e.labels == labels for e in output)
+        assert output == [
+            start,
+            start.add(days=1),
+            start.add(days=2),
+        ]
+
+    def test_rrule_clock_events_with_after_argument(self):
+        start_date = pendulum.datetime(2018, 1, 1, microsecond=0)
+        after = pendulum.datetime(2025, 1, 5)
+        c = clocks.RRuleClock(rrule.rrule(freq=rrule.HOURLY, dtstart=start_date))
+        assert islice(c.events(after=after), 3) == [
+            after.add(hours=1),
+            after.add(hours=2),
+            after.add(hours=3),
+        ]
+
+    def test_rrule_clock_doesnt_compute_dates_before_start_date(self):
+        dtstart = pendulum.datetime(2018, 1, 1, microsecond=0)
+        start_date = pendulum.datetime(2020, 1, 1, microsecond=0)
+        c = clocks.RRuleClock(
+            rrule.rrule(freq=rrule.HOURLY, dtstart=dtstart), start_date=start_date
+        )
+        assert islice(c.events(), 3) == [
+            start_date,
+            start_date.add(hours=1),
+            start_date.add(hours=2),
+        ]
+
+    def test_rrule_clock_doesnt_compute_dates_after_end_date(self):
+        dtstart = pendulum.datetime(2018, 1, 1, microsecond=0)
+        end_date = pendulum.datetime(2020, 1, 1, microsecond=0)
+        c = clocks.RRuleClock(
+            rrule.rrule(freq=rrule.DAILY, dtstart=dtstart), end_date=end_date
+        )
+        assert islice(c.events(after=end_date), 3) == []
+
+        after = end_date.subtract(days=2)
+        assert islice(c.events(after=after), 3) == [
+            after.add(days=1),
+            after.add(days=2),
+        ]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adds support for RRule (iCal style recurrence rule) clocks / schedules.

## Changes
Adds `RRuleClock` and `RRuleSchedule`

## Importance
RRules are much more powerful than the existing clock impls. This makes it easy for Prefect to work with organizations that are already leveraging iCal style event logic.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)