### PR TITLE
[RFC] Test+fix potential log upload race condition

### DIFF
--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -36,9 +36,9 @@ PREFECT_LOG_RECORD_ATTRIBUTES = (
 
 MAX_LOG_LENGTH = 1_000_000  # 1 MB - max length of a single log message
 MAX_BATCH_LOG_LENGTH = 3_999_000  # max total batch size for log messages
-                                  # 4 MB = 5 MB (backend limit)
-                                  #      - 1 MB (MAX_LOG_LENGTH)
-                                  #      - 1 kB (serialisation overhead)
+# 4 MB = 5 MB (backend limit)
+#      - 1 MB (MAX_LOG_LENGTH)
+#      - 1 kB (serialisation overhead)
 
 
 class LogManager:


### PR DESCRIPTION
Two potentials solutions:
* Extend https://github.com/PrefectHQ/prefect/blob/master/src/prefect/utilities/logging.py#L111 to do an exact measurement of the serialised (json.dumps) log dict or add some additional 200 bytes of assumed overhead (the while condition also needs to check that those 200 bytes are free) or
* Extend https://github.com/PrefectHQ/prefect/blob/master/src/prefect/utilities/logging.py#L167 to truncate until the whole serialised log dict size <= MAX_LOG_LENGTH (not only the message).

Implemented solution 1 with json.dumps.

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Avoid log upload race condition by better batch size measurement and parameter setup.



## Changes
<!-- What does this PR change? -->
* Lowers the MAX_BATCH_LOG_LENGTH to leave some room for the graphql serialisation overhead.
* Do more accurate pending_length measurement for the batched log entries.
* Require some extra free 200 bytes (the overhead of the log dict) before adding more log messages to the batch to be uploaded. 



## Importance
<!-- Why is this PR important? -->
This is important to avoid log upload deadlocks, where the client can not recover from via retries.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)