### PR TITLE
Fix marshmallow metadata kwarg deprecation warning

### DIFF
--- a/changes/pr4903.yaml
+++ b/changes/pr4903.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fixes uses of marshmallow.fields.Dict to use keys correctly as a kwarg rather than key. - [#4903](https://github.com/PrefectHQ/prefect/pull/4903)"

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -39,7 +39,7 @@ class IntervalClockSchema(ObjectSchema):
     end_date = DateTimeTZ(allow_none=True)
     interval = fields.TimeDelta(precision="microseconds", required=True)
     parameter_defaults = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     labels = fields.List(fields.Str(), allow_none=True)
 
@@ -72,7 +72,7 @@ class CronClockSchema(ObjectSchema):
     end_date = DateTimeTZ(allow_none=True)
     cron = fields.String(required=True)
     parameter_defaults = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     labels = fields.List(fields.Str(), allow_none=True)
     day_or = fields.Boolean(allow_none=True)
@@ -84,7 +84,7 @@ class DatesClockSchema(ObjectSchema):
 
     dates = fields.List(DateTimeTZ(), required=True)
     parameter_defaults = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     labels = fields.List(fields.Str(), allow_none=True)
 

--- a/src/prefect/serialization/state.py
+++ b/src/prefect/serialization/state.py
@@ -28,11 +28,11 @@ class BaseStateSchema(ObjectSchema):
     class Meta:
         object_class = state.State
 
-    context = fields.Dict(key=fields.Str(), values=JSONCompatible(), allow_none=True)
+    context = fields.Dict(keys=fields.Str(), values=JSONCompatible(), allow_none=True)
     message = fields.String(allow_none=True)
     _result = Nested(StateResultSchema, allow_none=False, value_selection_fn=get_safe)
     cached_inputs = fields.Dict(
-        key=fields.Str(),
+        keys=fields.Str(),
         values=Nested(StateResultSchema, value_selection_fn=get_safe),
         allow_none=True,
     )
@@ -123,7 +123,7 @@ class CachedSchema(SuccessSchema):
 
     cached_parameters = JSONCompatible(allow_none=True)
     cached_result_expiration = fields.DateTime(allow_none=True)
-    hashed_inputs = fields.Dict(key=fields.Str(), values=fields.Str(), allow_none=True)
+    hashed_inputs = fields.Dict(keys=fields.Str(), values=fields.Str(), allow_none=True)
 
 
 class MappedSchema(SuccessSchema):

--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -3,19 +3,19 @@ from typing import Any
 from marshmallow import fields, post_load
 
 from prefect.storage import (
+    GCS,
+    S3,
     Azure,
     Bitbucket,
     CodeCommit,
     Docker,
-    GCS,
+    Git,
     GitHub,
     GitLab,
     Local,
     Module,
-    S3,
     Storage,
     Webhook,
-    Git,
 )
 from prefect.utilities.serialization import JSONCompatible, ObjectSchema, OneOfSchema
 
@@ -24,7 +24,7 @@ class BaseStorageSchema(ObjectSchema):
     class Meta:
         object_class = Storage
 
-    flows = fields.Dict(key=fields.Str(), values=fields.Str())
+    flows = fields.Dict(keys=fields.Str(), values=fields.Str())
     secrets = fields.List(fields.Str(), allow_none=True)
 
     @post_load
@@ -87,7 +87,7 @@ class S3Schema(BaseStorageSchema):
     key = fields.String(allow_none=True)
     stored_as_script = fields.Bool(allow_none=True)
     client_options = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
 
 
@@ -136,7 +136,7 @@ class CodeCommitSchema(BaseStorageSchema):
     path = fields.String(allow_none=True)
     commit = fields.String(allow_none=True)
     client_options = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
 
 
@@ -144,9 +144,9 @@ class WebhookSchema(BaseStorageSchema):
     class Meta:
         object_class = Webhook
 
-    build_request_kwargs = fields.Dict(key=fields.Str, allow_none=False)
+    build_request_kwargs = fields.Dict(keys=fields.Str, allow_none=False)
     build_request_http_method = fields.String(allow_none=False)
-    get_flow_request_kwargs = fields.Dict(key=fields.Str, allow_none=False)
+    get_flow_request_kwargs = fields.Dict(keys=fields.Str, allow_none=False)
     get_flow_request_http_method = fields.String(allow_none=False)
     stored_as_script = fields.Bool(allow_none=True)
 


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/issues/4540

`serialization` was erroneously using the kwarg `key` to
marshmallow.fields.Dict, this should be `keys`. Marshmallow was seeing
this as `additional_metadata`, so showing a deprecation warning.


## Summary

Fixes uses of `marshmallow.fields.Dict` to use `keys` correctly as a kwarg
rather than `key`. 

(See https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html#marshmallow.fields.Dict).


## Changes

Fixes uses of `marshmallow.fields.Dict` to use `keys` correctly as a kwarg
rather than `key`.


## Importance

Fixes a warning raised by prefect. Our test flow has errors raised on warnings, so we had to
explicitly ignore this error throughout our test runs.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)