### PR TITLE
Add offset and limit to prefect get logs CLI command

### DIFF
--- a/src/prefect/cli/get.py
+++ b/src/prefect/cli/get.py
@@ -381,7 +381,25 @@ def tasks(name, flow_name, flow_version, project, limit):
 @click.option(
     "--info", "-i", is_flag=True, help="Retrieve detailed logging info", hidden=True
 )
-def logs(name, id, info):
+@click.option(
+    "--limit",
+    "-l",
+    required=False,
+    help="A limit amount of log lines to query",
+    hidden=True,
+    default=None,
+    type=int,
+)
+@click.option(
+    "--offset",
+    "-o",
+    required=False,
+    help="An offset at which to start retrieving log lines from",
+    hidden=True,
+    default=None,
+    type=int,
+)
+def logs(name, id, info, limit, offset):
     """
     Query logs for a flow run.
 
@@ -394,13 +412,22 @@ def logs(name, id, info):
         --name, -n      TEXT    A flow run name to query
         --id            TEXT    A flow run ID to query
         --info, -i              Retrieve detailed logging info
+        --limit, -l     INTEGER A limit amount of log lines to query
+        --offset, -o    INTEGER An offset at which to start retrieving log lines from
     """
     if not name and not id:
         click.secho("Either --name or --id must be provided", fg="red")
         return
 
     log_query = {
-        with_args("logs", {"order_by": {EnumValue("timestamp"): EnumValue("asc")}}): {
+        with_args(
+            "logs",
+            {
+                "order_by": {EnumValue("timestamp"): EnumValue("asc")},
+                "limit": limit,
+                "offset": offset,
+            },
+        ): {
             "timestamp": True,
             "message": True,
             "level": True,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
These additional options allow users to pass in limits and offsets so users can paginate flow run logs that are super long. Addresses issue #4719. No tests added/included yet until feedback that this is going in the right direction.



## Changes
- add `offset` and `limit` options and passes them through to the client's graphql query.



## Importance
- allows users an alternative to acquiring super long logs by being able to paginate via offsets + limits.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)