### PR TITLE
Patch client.py to properly retrieve the api_server from the prefect context.

### DIFF
--- a/changes/pr4914.yaml
+++ b/changes/pr4914.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix client instantiation to properly use the api server defined in the prefect context."
+
+contributor:
+  - "[Vincent Xue](https://github.com/xuevin)"

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -153,7 +153,7 @@ class Client:
 
         self._api_token = api_token or prefect.context.config.cloud.get("auth_token")
 
-        if not self.api_key and not api_server:
+        if not self.api_key and not self.api_server:
             # The default value for the `api_server` changed for API keys but we want
             # to load API tokens from the correct backwards-compatible location on disk
             self.api_server = prefect.config.cloud.graphql

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -153,7 +153,7 @@ class Client:
 
         self._api_token = api_token or prefect.context.config.cloud.get("auth_token")
 
-        if not self.api_key and not self.api_server and self._api_token:
+        if not self.api_key and not api_server and self._api_token:
             # The default value for the `api_server` changed for API keys but we want
             # to load API tokens from the correct backwards-compatible location on disk
             self.api_server = prefect.config.cloud.graphql

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -153,7 +153,7 @@ class Client:
 
         self._api_token = api_token or prefect.context.config.cloud.get("auth_token")
 
-        if not self.api_key and not self.api_server:
+        if not self.api_key and not self.api_server and self._api_token:
             # The default value for the `api_server` changed for API keys but we want
             # to load API tokens from the correct backwards-compatible location on disk
             self.api_server = prefect.config.cloud.graphql

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -153,7 +153,11 @@ class Client:
 
         self._api_token = api_token or prefect.context.config.cloud.get("auth_token")
 
-        if not self.api_key and not api_server and self._api_token:
+        if (
+            not self.api_key
+            and not api_server
+            and prefect.context.config.backend == "cloud"
+        ):
             # The default value for the `api_server` changed for API keys but we want
             # to load API tokens from the correct backwards-compatible location on disk
             self.api_server = prefect.config.cloud.graphql

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -258,7 +258,7 @@ def test_client_posts_to_api_server(patch_post):
 
     with set_temporary_config(
         {
-            "cloud.graphql": "http://my-cloud.foo",
+            "cloud.api": "http://my-cloud.foo",
             "cloud.auth_token": "secret_token",
             "backend": "cloud",
             "backend": "cloud",
@@ -330,7 +330,7 @@ def test_client_posts_graphql_to_api_server(patch_post):
 
     with set_temporary_config(
         {
-            "cloud.graphql": "http://my-cloud.foo",
+            "cloud.api": "http://my-cloud.foo",
             "cloud.auth_token": "secret_token",
             "backend": "cloud",
         }

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1881,3 +1881,19 @@ def test_artifacts_client_functions(patch_post, cloud_api):
 
     with pytest.raises(ValueError):
         client.delete_task_run_artifact(task_run_artifact_id=None)
+
+
+def test_client_posts_graphql_to_api_server_backend_server(patch_post):
+    post = patch_post(dict(data=dict(success=True)))
+
+    with set_temporary_config(
+        {
+            "cloud.api": "http://my-cloud.foo",
+            "backend": "server",
+        }
+    ):
+        client = Client()
+    result = client.graphql("{projects{name}}")
+    assert result.data == {"success": True}
+    assert post.called
+    assert post.call_args[0][0] == "http://my-cloud.foo"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -258,7 +258,7 @@ def test_client_posts_to_api_server(patch_post):
 
     with set_temporary_config(
         {
-            "cloud.api": "http://my-cloud.foo",
+            "cloud.graphql": "http://my-cloud.foo",
             "cloud.auth_token": "secret_token",
             "backend": "cloud",
             "backend": "cloud",
@@ -330,7 +330,7 @@ def test_client_posts_graphql_to_api_server(patch_post):
 
     with set_temporary_config(
         {
-            "cloud.api": "http://my-cloud.foo",
+            "cloud.graphql": "http://my-cloud.foo",
             "cloud.auth_token": "secret_token",
             "backend": "cloud",
         }

--- a/tests/client/test_client_auth_compat.py
+++ b/tests/client/test_client_auth_compat.py
@@ -28,7 +28,7 @@ class TestClientConfig:
     def test_client_initializes_from_config(self):
         with set_temporary_config(
             {
-                "cloud.graphql": "api_server",
+                "cloud.api": "api_server",
                 "cloud.auth_token": "token",
                 "backend": "cloud",
             }
@@ -40,7 +40,7 @@ class TestClientConfig:
     def test_client_initializes_and_prioritizes_kwargs(self):
         with set_temporary_config(
             {
-                "cloud.graphql": "api_server",
+                "cloud.api": "api_server",
                 "cloud.auth_token": "token",
                 "backend": "cloud",
             }
@@ -74,7 +74,7 @@ class TestClientConfig:
 
     def test_client_token_initializes_from_file(selfmonkeypatch, cloud_api):
         with tempfile.TemporaryDirectory() as tmp:
-            with set_temporary_config({"home_dir": tmp, "cloud.graphql": "xyz"}):
+            with set_temporary_config({"home_dir": tmp, "cloud.api": "xyz"}):
                 path = Path(tmp) / "client" / "xyz" / "settings.toml"
                 path.parent.mkdir(parents=True)
                 with path.open("w") as f:
@@ -108,7 +108,7 @@ class TestClientConfig:
 
     def test_save_local_settings(self, cloud_api):
         with tempfile.TemporaryDirectory() as tmp:
-            with set_temporary_config({"home_dir": tmp, "cloud.graphql": "xyz"}):
+            with set_temporary_config({"home_dir": tmp, "cloud.api": "xyz"}):
                 path = Path(tmp) / "client" / "xyz" / "settings.toml"
 
                 client = Client(api_token="a")

--- a/tests/client/test_client_auth_compat.py
+++ b/tests/client/test_client_auth_compat.py
@@ -28,7 +28,7 @@ class TestClientConfig:
     def test_client_initializes_from_config(self):
         with set_temporary_config(
             {
-                "cloud.api": "api_server",
+                "cloud.graphql": "api_server",
                 "cloud.auth_token": "token",
                 "backend": "cloud",
             }
@@ -40,7 +40,7 @@ class TestClientConfig:
     def test_client_initializes_and_prioritizes_kwargs(self):
         with set_temporary_config(
             {
-                "cloud.api": "api_server",
+                "cloud.graphql": "api_server",
                 "cloud.auth_token": "token",
                 "backend": "cloud",
             }
@@ -74,7 +74,7 @@ class TestClientConfig:
 
     def test_client_token_initializes_from_file(selfmonkeypatch, cloud_api):
         with tempfile.TemporaryDirectory() as tmp:
-            with set_temporary_config({"home_dir": tmp, "cloud.api": "xyz"}):
+            with set_temporary_config({"home_dir": tmp, "cloud.graphql": "xyz"}):
                 path = Path(tmp) / "client" / "xyz" / "settings.toml"
                 path.parent.mkdir(parents=True)
                 with path.open("w") as f:
@@ -108,7 +108,7 @@ class TestClientConfig:
 
     def test_save_local_settings(self, cloud_api):
         with tempfile.TemporaryDirectory() as tmp:
-            with set_temporary_config({"home_dir": tmp, "cloud.api": "xyz"}):
+            with set_temporary_config({"home_dir": tmp, "cloud.graphql": "xyz"}):
                 path = Path(tmp) / "client" / "xyz" / "settings.toml"
 
                 client = Client(api_token="a")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Patch `client.py` to properly retrieve the `api_server` from the prefect context. 


## Changes
Add a missing `self` for api_server



## Importance
<!-- Why is this PR important? -->
This bug caused downstream issues when spawning dask workers on a kubernetes cluster. The api_server was reset to the cloud api instead of the one provided in the context. 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)