### PR TITLE
Pass existing environment variables to agentless flow runs

### DIFF
--- a/changes/pr4917.yaml
+++ b/changes/pr4917.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Pass existing environment variables to agentless flow runs - [#4917](https://github.com/PrefectHQ/prefect/pull/4917)"

--- a/src/prefect/backend/execution.py
+++ b/src/prefect/backend/execution.py
@@ -26,7 +26,7 @@ logger = get_logger("backend.execution")
 
 
 def execute_flow_run_in_subprocess(
-    flow_run_id: str, run_api_key: str = None
+    flow_run_id: str, run_api_key: str = None, include_local_env: bool = True
 ) -> FlowRunView:
     """
     Execute a flow run in a subprocess.
@@ -44,6 +44,9 @@ def execute_flow_run_in_subprocess(
         - run_api_key: The authentication key to provide to the flow run for
             communicating with the Prefect Cloud API. If not set, it will be inferred
             from the current config.
+        - include_local_env: If `True`, the currently available environment variables
+            will be passed through to the flow run. Defaults to `True` to match
+            subprocess behavior.
 
     Returns:
         FlowRunView: The final flow run object
@@ -56,6 +59,7 @@ def execute_flow_run_in_subprocess(
         flow_id=flow_run.flow_id,
         run_api_key=run_api_key,
         run_config=flow_run.run_config,
+        include_local_env=include_local_env,
     )
 
     if not flow_run.state.is_scheduled():
@@ -226,7 +230,7 @@ def generate_flow_run_environ(
         - run_api_key: An optional API key to pass to the flow run for authenticating
             with the backend. If not set, it will be pulled from the Client
         - include_local_env: If `True`, the currently available environment variables
-            will be passed through to the flow run. Defaults to `False`
+            will be passed through to the flow run. Defaults to `False` for security.
 
     Returns:
         - A dictionary of environment variables

--- a/tests/backend/test_execution.py
+++ b/tests/backend/test_execution.py
@@ -1,5 +1,6 @@
 import pendulum
 import pytest
+import os
 import sys
 from unittest.mock import MagicMock, call
 from subprocess import CalledProcessError
@@ -58,34 +59,42 @@ class TestExecuteFlowRunInSubprocess:
 
         return mocks
 
-    def test_creates_subprocess_correctly(self, cloud_mocks, mocks):
+    @pytest.mark.parametrize("include_local_env", [True, False])
+    def test_creates_subprocess_correctly(self, cloud_mocks, mocks, include_local_env):
         # Returned a scheduled flow run to start
         cloud_mocks.FlowRunView.from_flow_run_id().state = Scheduled()
         # Return a finished flow run after the first iteration
         cloud_mocks.FlowRunView().get_latest().state = Success()
 
-        execute_flow_run_in_subprocess("flow-run-id")
+        execute_flow_run_in_subprocess(
+            "flow-run-id", include_local_env=include_local_env
+        )
 
         # Should pass the correct flow run id to wait for
         mocks.wait_for_flow_run_start_time.assert_called_once_with("flow-run-id")
 
+        # Merge the starting env and the env generated for a flow run
+        base_env = os.environ.copy() if include_local_env else {}
+        generated_env = {
+            "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": "True",
+            "PREFECT__LOGGING__LEVEL": "INFO",
+            "PREFECT__LOGGING__FORMAT": "[%(asctime)s] %(levelname)s - %(name)s | %(message)s",
+            "PREFECT__LOGGING__DATEFMT": "%Y-%m-%d %H:%M:%S%z",
+            "PREFECT__BACKEND": "cloud",
+            "PREFECT__CLOUD__API": "https://api.prefect.io",
+            "PREFECT__CLOUD__TENANT_ID": "",
+            "PREFECT__CLOUD__API_KEY": cloud_mocks.Client().api_key,
+            "PREFECT__CONTEXT__FLOW_RUN_ID": "flow-run-id",
+            "PREFECT__CONTEXT__FLOW_ID": cloud_mocks.FlowRunView.from_flow_run_id().flow_id,
+            "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
+            "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+        }
+        expected_env = {**base_env, **generated_env}
+
         # Calls the correct command w/ environment variables
         mocks.subprocess.run.assert_called_once_with(
             [sys.executable, "-m", "prefect", "execute", "flow-run"],
-            env={
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": "True",
-                "PREFECT__LOGGING__LEVEL": "INFO",
-                "PREFECT__LOGGING__FORMAT": "[%(asctime)s] %(levelname)s - %(name)s | %(message)s",
-                "PREFECT__LOGGING__DATEFMT": "%Y-%m-%d %H:%M:%S%z",
-                "PREFECT__BACKEND": "cloud",
-                "PREFECT__CLOUD__API": "https://api.prefect.io",
-                "PREFECT__CLOUD__TENANT_ID": "",
-                "PREFECT__CLOUD__API_KEY": cloud_mocks.Client().api_key,
-                "PREFECT__CONTEXT__FLOW_RUN_ID": "flow-run-id",
-                "PREFECT__CONTEXT__FLOW_ID": cloud_mocks.FlowRunView.from_flow_run_id().flow_id,
-                "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
-                "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
-            },
+            env=expected_env,
         )
 
         # Return code is checked

--- a/tests/backend/test_execution.py
+++ b/tests/backend/test_execution.py
@@ -15,7 +15,6 @@ from prefect.backend.execution import (
     generate_flow_run_environ,
     execute_flow_run_in_subprocess,
 )
-from prefect.backend import FlowRunView as FlowRunView
 from prefect.run_configs import UniversalRun
 from prefect.engine.state import Failed, Scheduled, Success, Running, Submitted
 from prefect.utilities.graphql import GraphQLResult


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Includes the local environment in agentless flow runs by default. This was previously not available as I did not want to expose the entire local environment to flow runs--it seemed like a security risk. 

Alternatively, we could allow opt-in for a list of environment variables or encourage users to pass thing via prefect local secrets.


## Importance
<!-- Why is this PR important? -->

Users frequently store environment variables that their flows needs on the machine their flow runs on

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)