### PR TITLE
Add `--idempotency-key` to `prefect run`

### DIFF
--- a/changes/pr4928.yaml
+++ b/changes/pr4928.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Add `--idempotency-key` to `prefect run` - [#4928](https://github.com/PrefectHQ/prefect/pull/4928)"

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -431,6 +431,16 @@ See `prefect run --help` for more details on the options.
     default=None,
 )
 @click.option(
+    "--idempotency-key",
+    help=(
+        "A key to prevent duplicate flow runs. If a flow run has already been started "
+        "with the provided value, the command will display information for the "
+        "existing run. If using `--execute`, duplicate flow runs will exit with an "
+        "error. If not using the backing API, this flag has no effect."
+    ),
+    default=None,
+)
+@click.option(
     "--execute",
     help=(
         "Execute the flow run in-process without an agent. If this process exits, the "
@@ -484,6 +494,7 @@ def run(
     context_vars,
     params,
     execute,
+    idempotency_key,
     schedule,
     log_level,
     param_file,
@@ -665,6 +676,7 @@ def run(
                 run_name=run_name,
                 # We only use the run config for setting logging levels right now
                 run_config=run_config,
+                idempotency_key=idempotency_key,
             )
 
         if quiet:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -528,6 +528,7 @@ def test_run_local_handles_flow_load_failure_with_missing_module_attr(tmpdir):
             ["--no-logs"],
             dict(),
         ),
+        (["--idempotency-key", "foo-key"], dict(idempotency_key="foo-key")),
     ],
 )
 def test_run_cloud_creates_flow_run(
@@ -552,6 +553,7 @@ def test_run_cloud_creates_flow_run(
     cloud_kwargs.setdefault("labels", None)
     cloud_kwargs.setdefault("run_name", None)
     cloud_kwargs.setdefault("run_config", None)
+    cloud_kwargs.setdefault("idempotency_key", None)
 
     if execute_flag:
         labels = cloud_kwargs["labels"] or []


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Exposes the `idempotency_key` flow run setting with `prefect run --idempotency-key <key>`


## Importance
<!-- Why is this PR important? -->

Requested by user, CLI/client feature parity


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)