### PR TITLE
Remove $ from code examples for copy and paste

### DIFF
--- a/docs/core/getting_started/install.md
+++ b/docs/core/getting_started/install.md
@@ -14,7 +14,7 @@ To install Prefect, run:
 ::: tab Pip
 
 ```bash
-$ pip install prefect
+pip install prefect
 ```
 
 :::
@@ -22,7 +22,7 @@ $ pip install prefect
 ::: tab Conda
 
 ```bash
-$ conda install -c conda-forge prefect
+conda install -c conda-forge prefect
 ```
 
 :::


### PR DESCRIPTION

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

I'm not sure which style applies, but the `$` in some of the CLI commands means that you cannot paste as-is. This PR removes the `$`. The other approach is to modify the copy and paste script to strip any leading `^$\s?`.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)