### PR TITLE
Add `--expose` to API docs

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -420,6 +420,8 @@ def config_cmd(
         --no-upgrade, -n            Flag to avoid running a database upgrade when the
                                     database spins up
         --no-ui, -u                 Flag to avoid starting the UI
+        --expose                    Flag to expose the server to external hosts by listening
+                                    to 0.0.0.0 instead of localhost.
 
     \b
         --external-postgres, -ep    Disable the Postgres service, connect to an external one instead


### PR DESCRIPTION
Adds missing docstring for API docs page for `prefect server start --expose`