### PR TITLE
Fix broken `ETL` and `Map Reduce` urls of the `Multi Flow Storage` doc page

### DIFF
--- a/docs/orchestration/recipes/multi_flow_storage.md
+++ b/docs/orchestration/recipes/multi_flow_storage.md
@@ -1,7 +1,7 @@
 
 # Multi Flow Storage
 
-This recipe is for storing multiple flows inside a single [Docker storage object](/api/latest/storage.html#docker). This is useful when you have a suite of flows that registers off of a CI/CD process or if you want to reduce the number of images stored in a container registry. For this recipe we are going to put two example flows — [ETL](/core/examples/etl.html) and [Map Reduce](/core/examples/map_reduce.html) — inside of the same Docker storage object.
+This recipe is for storing multiple flows inside a single [Docker storage object](/api/latest/storage.html#docker). This is useful when you have a suite of flows that registers off of a CI/CD process or if you want to reduce the number of images stored in a container registry. For this recipe we are going to put two example flows — [ETL](/core/advanced_tutorials/etl.html) and [Map Reduce](/core/concepts/mapping.html#reduce) — inside of the same Docker storage object.
 
 [[toc]]
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
The links for the tutorials for `ETL` and `Map Reduce` on the top of the page are broken. 

## Changes
<!-- What does this PR change? -->

This PR changes both the `ETL` and the `Map Reduce`. The former seems to have been put in the `advanced tutorials` page, and the latter was updated to the `reduce` part of the `mapping` concept page.

## Importance
<!-- Why is this PR important? -->

This PR aims at enabling users to click the links in the `Multi Flow Storage` example and not receive a `404 Page Not Found` error.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)