### PR TITLE
Fix PostgresFetch with headers for one row

### DIFF
--- a/changes/pr4968.yaml
+++ b/changes/pr4968.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix PostgresFetch with headers for one row - [#4968](https://github.com/PrefectHQ/prefect/pull/4968)"
+
+contributor:
+  - "[Noah Holm](https://github.com/noppaz)"

--- a/src/prefect/tasks/postgres/postgres.py
+++ b/src/prefect/tasks/postgres/postgres.py
@@ -313,6 +313,10 @@ class PostgresFetch(Task):
                         col_description[0] for col_description in cursor.description
                     ]
                     header = [tuple(col_name for col_name in names_list)]
+
+                    if isinstance(records, tuple):
+                        records = [records]
+
                     records = header + records
 
             return records


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This fixes a bug in PostgresFetch where TypeError is raised when fetch = "one" (default) and col_names = True.


## Changes
<!-- What does this PR change? -->

As the psycopg cursor.fetchone() method returns a Tuple[Any] and not a List[Tuple[Any]] as cursor.fetchall and cursor.fetchmany the concatenation of tuple and list fails. This puts the single tuple row into a list when col_names is true.


## Importance
<!-- Why is this PR important? -->

Fixes a bug, "one" is the default fetch argument but I don't think it's used that often and less so in conjunction with headers and therefore not discovered yet.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)