### PR TITLE
Fix bug where `apply_map` could create cyclic flows

### DIFF
--- a/changes/pr4970.yaml
+++ b/changes/pr4970.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix bug where `apply_map` could create acyclic flows - [#4970](https://github.com/PrefectHQ/prefect/pull/4970)"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Given the following flow
```python
from prefect import Flow, apply_map, task

@task
def do_something_one(item):
    return item + 1


@task
def do_something_two(item, item_one):
    return item + item_one


@task
def do_something_three(item_combination):
    return item_combination[0] + item_combination[1]


# mapping function one
def apply_map_one_two(item):
    result_one = do_something_one(item)
    result_two = do_something_two(item, result_one)
    return (result_one, result_two)


# mapping function two
def apply_map_three(item):
    return do_something_three(item)


with Flow("test flow") as flow:
    l = [1, 2, 3]
    results = apply_map(apply_map_one_two, l)
    results_results = apply_map(apply_map_three, results)

```

We were creating this graph which adds an edge in the _wrong_ direction from `Tuple` to `do_something_one`

![wrong-graph](https://user-images.githubusercontent.com/2586601/133499752-7591ebe9-c47c-40f7-a140-2ab71c8d5e89.jpg)

This flow now has a cycle and will not execute. The graph should look like this

![right-graph](https://user-images.githubusercontent.com/2586601/133499751-1342a020-b126-4801-91cf-f16050233d2c.jpg)

This appears to be an issue with how the 'new tasks' were selected for dependency creation at the end of `apply_map`

## Changes
<!-- What does this PR change? -->

- Filters all of the original flow tasks when creating upstream edges


## Importance
<!-- Why is this PR important? -->

Closes #4865 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)