### PR TITLE
Allow max_retries=0 override at task level

### DIFF
--- a/changes/pr4971.yaml
+++ b/changes/pr4971.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Allow max_retries to be set to 0 when overriding the config level parameter - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)"

--- a/changes/pr4971.yaml
+++ b/changes/pr4971.yaml
@@ -1,2 +1,2 @@
-fix:
-  - "Allow max_retries to be set to 0 when overriding the config level parameter - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)"
+enhancement:
+  - "Allow disabling retries for a task with `max_retries=0` when retries are globally configured - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -357,7 +357,7 @@ class Task(metaclass=TaskMetaclass):
         )
         retry_delay = (
             retry_delay
-            if retry_delay is not None
+            if retry_delay is not None or not max_retries
             else prefect.config.tasks.defaults.retry_delay
         )
         timeout = (
@@ -372,7 +372,6 @@ class Task(metaclass=TaskMetaclass):
         if retry_delay is not None and not max_retries:
             raise ValueError(
                 "A `max_retries` argument greater than 0 must be provided if specifying "
-                "a retry delay."
                 "a retry delay."
             )
         # Make sure timeout is an integer in seconds

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -92,6 +92,21 @@ class TestCreateTask:
         ):
             Task(retry_delay=timedelta(seconds=30), max_retries=max_retries)
 
+    def test_create_task_with_max_retry_override_to_0(self):
+        with set_temporary_config(
+            {"tasks.defaults.max_retries": 3, "tasks.defaults.retry_delay": 3}
+        ) as config:
+            process_task_defaults(config)
+            t = Task(max_retries=0, retry_delay=None)
+            assert t.max_retries == 0
+            assert t.retry_delay is None
+
+            # max_retries set to 0 will not pull retry_delay from the config
+            process_task_defaults(config)
+            t = Task(max_retries=0)
+            assert t.max_retries == 0
+            assert t.retry_delay is None
+
     def test_create_task_with_timeout(self):
         t1 = Task()
         assert t1.timeout is None

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -181,6 +181,13 @@ def test_task_that_fails_gets_retried_up_to_max_retry_time():
     assert isinstance(state, Failed)
 
 
+def test_task_with_max_retries_0_does_not_retry():
+    task = ErrorTask(max_retries=0, retry_delay=None)
+    task_runner = TaskRunner(task)
+    state = task_runner.run()
+    assert isinstance(state, Finished) and not isinstance(state, Retrying)
+
+
 def test_task_that_raises_retry_has_start_time_recognized():
     now = pendulum.now("utc")
 


### PR DESCRIPTION
## Summary
Allow `max_retries` to be set at the task level to 0, overriding config setting

## Changes
This PR resolves https://github.com/PrefectHQ/prefect/issues/4880

The below code now executes correctly when `max_retries` and `retry_delay` is already specified at the config level.

```
@task(max_retries=0, retry_delay=None)
def my_task():
    ...
```

## Importance
This PR is important because it can be useful to have a single specific task not retry and it matches what the parameters intended.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)