### PR TITLE
Add data parameter to SQLiteQuery

### DIFF
--- a/changes/pr4981.yaml
+++ b/changes/pr4981.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add data parameter to SQLiteQuery task - [#4981](https://github.com/PrefectHQ/prefect/pull/4981)"

--- a/changes/pr4981.yaml
+++ b/changes/pr4981.yaml
@@ -1,2 +1,5 @@
 enhancement:
   - "Add data parameter to SQLiteQuery task - [#4981](https://github.com/PrefectHQ/prefect/pull/4981)"
+
+contributor:
+  - "[Daniel Saxton](https://github.com/dsaxton)"

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -16,17 +16,22 @@ class SQLiteQuery(Task):
         - query (str, optional): the optional _default_ query to execute at runtime;
             can also be provided as a keyword to `run`, which takes precedence over this default.
             Note that a query should consist of a _single SQL statement_.
+        - data (tuple, optional): values to use when `query` is a parametrized string. See
+            https://docs.python.org/3/library/sqlite3.html for more details.
         - **kwargs (optional): additional keyword arguments to pass to the
             standard Task initalization
     """
 
-    def __init__(self, db: str = None, query: str = None, **kwargs: Any):
+    def __init__(
+        self, db: str = None, query: str = None, data: tuple = None, **kwargs: Any
+    ):
         self.db = db
         self.query = query
+        self.data = data
         super().__init__(**kwargs)
 
     @defaults_from_attrs("db", "query")
-    def run(self, db: str = None, query: str = None):
+    def run(self, db: str = None, query: str = None, data: tuple = None):
         """
         Args:
             - db (str, optional): the location of the database (.db) file;
@@ -34,17 +39,22 @@ class SQLiteQuery(Task):
             - query (str, optional): the optional query to execute at runtime;
                 if not provided, `self.query` will be used instead. Note that a
                 query should consist of a _single SQL statement_.
+            - data (tuple, optional): values to use when query is a parametrized string. See
+                https://docs.python.org/3/library/sqlite3.html for more details.
 
         Returns:
             - [Any]: the results of the query
         """
         db = cast(str, db)
         query = cast(str, query)
-        with closing(sql.connect(db)) as conn:
-            with closing(conn.cursor()) as cursor:
+        data = cast(tuple, data)
+        with closing(sql.connect(db)) as conn, closing(conn.cursor()) as cursor:
+            if data is None:
                 cursor.execute(query)
-                out = cursor.fetchall()
-                conn.commit()
+            else:
+                cursor.execute(query, data)
+            out = cursor.fetchall()
+            conn.commit()
         return out
 
 

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -31,7 +31,7 @@ class SQLiteQuery(Task):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("db", "query")
-    def run(self, db: str = None, query: str = None, data: tuple = None):
+    def run(self, db: str = None, query: str = None, data: tuple = ()):
         """
         Args:
             - db (str, optional): the location of the database (.db) file;
@@ -49,7 +49,7 @@ class SQLiteQuery(Task):
         query = cast(str, query)
         data = cast(tuple, data)
         with closing(sql.connect(db)) as conn, closing(conn.cursor()) as cursor:
-            cursor.execute(query, () if data is None else data)
+            cursor.execute(query, data)
             out = cursor.fetchall()
             conn.commit()
         return out

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -23,7 +23,7 @@ class SQLiteQuery(Task):
     """
 
     def __init__(
-        self, db: str = None, query: str = None, data: tuple = None, **kwargs: Any
+        self, db: str = None, query: str = None, data: tuple = (), **kwargs: Any
     ):
         self.db = db
         self.query = query

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -30,7 +30,7 @@ class SQLiteQuery(Task):
         self.data = data
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("db", "query")
+    @defaults_from_attrs("db", "query", "data")
     def run(self, db: str = None, query: str = None, data: tuple = ()):
         """
         Args:

--- a/src/prefect/tasks/database/sqlite.py
+++ b/src/prefect/tasks/database/sqlite.py
@@ -49,10 +49,7 @@ class SQLiteQuery(Task):
         query = cast(str, query)
         data = cast(tuple, data)
         with closing(sql.connect(db)) as conn, closing(conn.cursor()) as cursor:
-            if data is None:
-                cursor.execute(query)
-            else:
-                cursor.execute(query, data)
+            cursor.execute(query, () if data is None else data)
             out = cursor.fetchall()
             conn.commit()
         return out

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -62,6 +62,15 @@ class TestSQLiteQuery:
         assert out.is_failed()
         assert "one statement at a time" in str(out.result[task].result)
 
+    def test_parametrized_query(self, database):
+        with Flow(name="test") as f:
+            task = SQLiteQuery(db=database)(
+                query="SELECT * FROM TEST WHERE NUMBER in (?, ?)", data=(12, 13)
+            )
+        out = f.run()
+        assert out.is_successful()
+        assert out.result[task].result == [(12, "second"), (13, "third")]
+
 
 class TestSQLiteScript:
     def test_initialization(self):

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -71,6 +71,13 @@ class TestSQLiteQuery:
         assert out.is_successful()
         assert out.result[task].result == [(12, "second"), (13, "third")]
 
+    def test_unparametrized_query_none_data(self, database):
+        with Flow(name="test") as f:
+            task = SQLiteQuery(db=database)(query="SELECT * FROM TEST;", data=None)
+        out = f.run()
+        assert out.is_successful()
+        assert out.result[task].result == [(11, "first"), (12, "second"), (13, "third")]
+
 
 class TestSQLiteScript:
     def test_initialization(self):

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -71,9 +71,9 @@ class TestSQLiteQuery:
         assert out.is_successful()
         assert out.result[task].result == [(12, "second"), (13, "third")]
 
-    def test_unparametrized_query_none_data(self, database):
+    def test_unparametrized_query_no_data(self, database):
         with Flow(name="test") as f:
-            task = SQLiteQuery(db=database)(query="SELECT * FROM TEST;", data=None)
+            task = SQLiteQuery(db=database)(query="SELECT * FROM TEST;", data=())
         out = f.run()
         assert out.is_successful()
         assert out.result[task].result == [(11, "first"), (12, "second"), (13, "third")]

--- a/tests/tasks/test_sqlite.py
+++ b/tests/tasks/test_sqlite.py
@@ -71,6 +71,15 @@ class TestSQLiteQuery:
         assert out.is_successful()
         assert out.result[task].result == [(12, "second"), (13, "third")]
 
+    def test_query_parameterization_data_on_init(self, database):
+        with Flow(name="test") as f:
+            task = SQLiteQuery(db=database, data=(12, 13))(
+                query="SELECT * FROM TEST WHERE NUMBER in (?, ?)"
+            )
+        out = f.run()
+        assert out.is_successful()
+        assert out.result[task].result == [(12, "second"), (13, "third")]
+
     def test_unparametrized_query_no_data(self, database):
         with Flow(name="test") as f:
             task = SQLiteQuery(db=database)(query="SELECT * FROM TEST;", data=())


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This allows for query parameterization when running queries against a SQLite database using the `SQLiteQuery` task. Currently if users want to include variables in a query string they'll have to do manual string formatting / escaping which is error-prone and in some cases dangerous. Adding this capability also aligns the API with that of other database tasks such as `PostgresExecute`.

Side comment, but since other database engines are in their own directories (e.g., `postgres`, `mysql`), should this directory be called `sqlite` instead of `database`?

## Changes
<!-- What does this PR change? -->

Adds an optional `data` argument to the `SQLiteQuery` task.

## Importance
<!-- Why is this PR important? -->

More API consistency and helps end users avoid certain types of errors.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)