### PR TITLE
Fix broken doc links

### DIFF
--- a/docs/core/tutorial/07-next-steps.md
+++ b/docs/core/tutorial/07-next-steps.md
@@ -60,8 +60,8 @@ In this tutorial we could have gone one step further and asked for fetching all 
 
 ::: tip More about Control Structures
 - [Mapping](/core/concepts/mapping.html#mapping)
-- [Task Looping](/core/examples/task_looping.html#task-looping)
-- [Signaling](/core/getting_started/next-steps.html#signals)
+- [Task Looping](/core/advanced_tutorials/task_looping.html)
+- [Signaling](/core/concepts/execution.html#state-signals)
 :::
 
 ## Ready-made Task Library
@@ -84,4 +84,3 @@ flow.run()
 ```
 
 The Task library includes integrations with Kubernetes, GitHub, Slack, Docker, AWS, GCP, [and more](/core/task_library/)!
-


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

It looks like the links for "Task Looping" and "Signalling" are broken here: https://docs.prefect.io/core/tutorial/07-next-steps.html#advanced-control-structures. I made some semi-educated guesses about where these should point, but please let me know if this should be changed. Thanks!