### PR TITLE
Damien/working poc

### DIFF
--- a/docs/orchestration/agents/overview.md
+++ b/docs/orchestration/agents/overview.md
@@ -29,6 +29,9 @@ platforms.
 - **Kubernetes**: The [Kubernetes Agent](./kubernetes.md) executes flow runs as
   [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/).
 
+- **Kubernetes**: The [Vertex Agent](./vertex.md) executes flow runs as
+  [Vertex Custom Jobs](https://cloud.google.com/vertex-ai/docs/training/create-custom-job).
+
 - **AWS ECS**: The [ECS Agent](./ecs.md) executes flow runs as [AWS ECS
   tasks](https://aws.amazon.com/ecs/) (on either ECS or Fargate).
 

--- a/docs/orchestration/agents/vertex.md
+++ b/docs/orchestration/agents/vertex.md
@@ -1,0 +1,106 @@
+# Vertex Agent
+
+The Vertex Agent executes flow runs as [Vertex Custom Jobs](https://cloud.google.com/vertex-ai/docs/training/create-custom-job).
+Vertex describes these as "training" jobs, but they can be used to run any kind of flow
+
+## Requirements
+
+The required dependencies for the Vertex Agent aren't [installed by
+default](/core/getting_started/installation.md). If you're a `pip` user you'll
+need to add the `gcp` extra. Likewise, with `conda` you'll need to install
+`google-cloud-aiplatform`:
+
+:::: tabs
+::: tab Pip
+
+```bash
+pip install prefect[gcp]
+```
+
+:::
+::: tab Conda
+
+```bash
+conda install -c conda-forge prefect google-cloud-aiplatform
+```
+
+:::
+::::
+
+::: warning Prefect Server
+In order to use this agent with Prefect Server the server's GraphQL API
+endpoint must be accessible. This _may_ require changes to your Prefect Server
+deployment and/or [configuring the Prefect API
+address](./overview.md#prefect-api-address) on the agent.
+:::
+
+## Flow Configuration
+
+The Vertex Agent will deploy flows using either a
+[UniversalRun](/orchestration/flow_config/run_configs.md#universalrun) (the
+default) or [VertexRun](/orchestration/flow_config/run_configs.md#vertexrun)
+`run_config`. Using a `VertexRun` object lets you customize the deployment
+environment for a flow (exposing `env`, `image`, `machine_type`, etc...):
+
+```python
+from prefect.run_configs import VertexRun
+
+# Configure extra environment variables for this flow,
+# and set a custom image and machine type
+flow.run_config = VertexRun(
+    env={"SOME_VAR": "VALUE"},
+    image="my-custom-image",
+    machine_type="e2-highmem-16",
+)
+```
+
+See the [VertexRun](/orchestration/flow_config/run_configs.md#vertexrun)
+documentation for more information.
+
+## Agent Configuration
+
+The Vertex agent can be started from the Prefect CLI as
+
+```bash
+prefect agent vertex start
+```
+
+::: tip API Keys <Badge text="Cloud"/>
+When using Prefect Cloud, this will require a service account API key, see
+[here](./overview.md#api_keys) for more information.
+:::
+
+Below we cover a few common configuration options, see the [CLI
+docs](/api/latest/cli/agent.md#vertex-start) for a full list of options.
+
+### Project
+
+By default the agent will deploy flow run tasks into the current project (as defined by [google.auth.default](https://google-auth.readthedocs.io/en/latest/reference/google.auth.html))
+You can specify a different project using the `--project` option:
+
+```bash
+prefect agent vertex start --project my-project
+```
+
+This can be a different project than the agent is running in, as long as the account has permissions
+to start Vertex CustomJobs in the specified project.
+
+### Region
+
+Vertex requires a region in which to run the flow, and will default to `us-central1`
+You can specify a different region using the `--region` option:
+
+```bash
+prefect agent vertex start --region us-east1
+```
+
+### Service Account
+
+Vertex jobs can run as a specified service account. Vertex provides a default, but specifying a specific
+account can give you more control over what resources the flow runs are allowed to access.
+You can specify a non-default account using the `--service_account` option:
+
+```bash
+prefect agent vertex start --service_account my-account@my-project.iam.gserviceaccount.com
+```
+

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -237,3 +237,67 @@ for this flow, stored in S3:
 ```python
 flow.run_config = ECSRun(task_definition_path="s3://bucket/path/to/definition.yaml")
 ```
+
+### VertexRun
+
+[VertexRun](/api/latest/run_configs.md#vertexrun) configures flow runs
+deployed as Vertex CustomJobs with a VertexAgent.
+
+#### Examples
+
+Use the defaults set on the agent:
+
+```python
+from prefect.run_configs import VertexRun
+
+flow.run_config = VertexRun()
+```
+
+Set an environment variable in the flow run container:
+
+```python
+flow.run_config = VertexRun(env={"SOME_VAR": "value"})
+```
+
+Specify an [image](./docker.md) to use, if not using `Docker` storage:
+
+```python
+flow.run_config = VertexRun(image="example/image-name:with-tag")
+```
+
+Specify the machine type for this flow
+
+```python
+flow.run_config = VertexRun(machine_type='e2-highmem-16')
+```
+
+Set a specific service account or network ID for this flow run
+```python
+flow.run_config = VertexRun(service_account='my-account@my-project.iam.gserviceaccount.com', network="my-network")
+```
+
+Use the [scheduling](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/CustomJobSpec#Scheduling) option to set a timeout for the CustomJob
+```python
+flow.run_config = VertexRun(scheduling={'timeout': '3600s'})
+```
+
+
+Customize the full [worker pool specs](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/CustomJobSpec#workerpoolspec),
+which can be used for more advanced setups:
+
+```python
+worker_pool_specs = [
+    {"machine_spec": {"machine_type": "e2-standard-4"}, "replica_count": 1},
+    {
+        "machine_spec": {"machine_type": "e2-highmem-16"},
+        "replica_count": 3,
+        "container_spec": {"image": "my-image"},
+    },
+]
+
+flow.run_config = VertexRun(worker_pool_specs=worker_pool_specs)
+```
+
+Note that prefect will always control the container spec on the 0th entry in the worker pool spec,
+which is the pool that is reserved to run the flow. Other pool specs will need you to provide a container
+spec.

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -268,7 +268,7 @@ classes = {Executor=[], LocalExecutor=[], LocalDaskExecutor=[], DaskExecutor=[]}
 [pages.run_configs]
 title = "Run Configuration"
 module = "prefect.run_configs"
-classes = ["RunConfig", "UniversalRun", "LocalRun", "DockerRun", "KubernetesRun", "ECSRun"]
+classes = ["RunConfig", "UniversalRun", "LocalRun", "DockerRun", "KubernetesRun", "ECSRun", "VertexRun"]
 
 [pages.storage]
 title = "Storage"
@@ -632,6 +632,11 @@ classes = {FargateAgent = ["start"]}
 title = "ECS Agent"
 module = "prefect.agent.ecs"
 classes = {ECSAgent = ["start"]}
+
+[pages.agent.vertex]
+title = "Vertex Agent"
+module = "prefect.agent.vertex"
+classes = {VertexAgent = ["start"]}
 
 [pages.artifacts.artifacts]
 title = "Artifacts"

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ orchestration_extras = {
     "gcp": [
         "google-cloud-secret-manager >= 2.4.0",
         "google-cloud-storage >= 1.13, < 2.0",
+        "google-cloud-aiplatform",
+        "google-auth",
     ],
     "git": ["dulwich >= 0.19.7"],
     "github": ["PyGithub >= 1.51, < 2.0"],

--- a/src/prefect/agent/__init__.py
+++ b/src/prefect/agent/__init__.py
@@ -7,3 +7,4 @@ import prefect.agent.fargate
 import prefect.agent.kubernetes
 import prefect.agent.local
 import prefect.agent.ecs
+import prefect.agent.vertex

--- a/src/prefect/agent/vertex/__init__.py
+++ b/src/prefect/agent/vertex/__init__.py
@@ -1,0 +1,1 @@
+from prefect.agent.vertex.agent import VertexAgent

--- a/src/prefect/agent/vertex/agent.py
+++ b/src/prefect/agent/vertex/agent.py
@@ -1,0 +1,246 @@
+import os
+from copy import deepcopy
+from typing import Iterable, Dict, Any
+import slugify
+from prefect import config
+from prefect.agent import Agent
+from prefect.run_configs import VertexRun
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
+from prefect.utilities.graphql import GraphQLResult
+
+
+DEFAULT_TASK_DEFINITION_PATH = os.path.join(
+    os.path.dirname(__file__), "task_definition.yaml"
+)
+
+
+class VertexAgent(Agent):
+    """
+    Agent which deploys flow runs as Vertex Training tasks.
+
+    Args:
+        - project (str): The project in which to submit the Vertex Jobs
+            This does not necessarily need to be the same project as the where
+            this agent is running, but the service account running the agent
+            needs permissions to start Vertex Job in this project.
+        - region_name(str): Region the job is running in for the endpoint
+        - service_account(str): Service account to submit jobs as on Vertex
+        - agent_config_id (str, optional): An optional agent configuration ID
+            that can be used to set configuration based on an agent from a
+            backend API. If set all configuration values will be pulled from
+            the backend agent configuration.
+        - name (str, optional): An optional name to give this agent. Can also
+            be set through the environment variable `PREFECT__CLOUD__AGENT__NAME`.
+            Defaults to "agent".
+        - labels (List[str], optional): A list of labels, which are arbitrary
+            string identifiers used by Prefect Agents when polling for work.
+        - env_vars (dict, optional): A dictionary of environment variables and
+            values that will be set on each flow run that this agent submits
+            for execution.
+        - max_polls (int, optional): Maximum number of times the agent will
+            poll Prefect Cloud for flow runs; defaults to infinite.
+        - agent_address (str, optional):  Address to serve internal api at.
+            Currently this is just health checks for use by an orchestration
+            layer. Leave blank for no api server (default).
+        - no_cloud_logs (bool, optional): Disable logging to a Prefect backend
+            for this agent and all deployed flow runs. Defaults to `False`.
+    """
+
+    def __init__(  # type: ignore
+        self,
+        project: str = None,
+        region_name: str = None,
+        service_account: str = None,
+        agent_config_id: str = None,
+        name: str = None,
+        labels: Iterable[str] = None,
+        env_vars: dict = None,
+        max_polls: int = None,
+        agent_address: str = None,
+        no_cloud_logs: bool = None,
+    ) -> None:
+        super().__init__(
+            agent_config_id=agent_config_id,
+            name=name,
+            labels=labels,
+            env_vars=env_vars,
+            max_polls=max_polls,
+            agent_address=agent_address,
+            no_cloud_logs=no_cloud_logs,
+        )
+        if project is None:
+            import google.auth
+
+            _, project = google.auth.default()
+        self.project = project
+
+        if region_name is None:
+            region_name = "us-central1"
+
+        self.region_name = region_name
+        self.service_account = service_account
+        from google.cloud import aiplatform
+
+        # Initialize client that will be used to create and send requests.
+        # This client only needs to be created once, and can be reused for multiple requests.
+        self.client_options = {
+            "api_endpoint": f"{self.region_name}-aiplatform.googleapis.com"
+        }
+        self.vertex_client = aiplatform.gapic.JobServiceClient(
+            client_options=self.client_options
+        )
+
+    def deploy_flow(self, flow_run: GraphQLResult) -> str:
+        """
+        Deploy a flow run as an Vertex task.
+
+        Args:
+            - flow_run (GraphQLResult): A GraphQLResult flow run object
+
+        Returns:
+            - str: Information about the deployment
+        """
+        taskdef = self.generate_task_definition(flow_run)
+        parent = f"projects/{self.project}/locations/{self.region_name}"
+
+        print(parent)
+        self.logger.debug(
+            "Created task definition for flow %s",
+            flow_run.flow.id,
+        )
+
+        resp = self.vertex_client.create_custom_job(parent=parent, custom_job=taskdef)
+        self.logger.info(resp)
+        # The full name includes a projects key, to form the url we exclude it
+        path = "/".join(resp.name.split("/")[2:]).replace("customJobs", "training")
+        # return a url to navigate to the submitted flow
+        url = f"https://console.cloud.google.com/vertex-ai/{path}"
+        return url
+
+    def generate_task_definition(self, flow_run: GraphQLResult) -> Dict[str, Any]:
+        """Generate an Vertex task definition from a flow run
+
+        Args:
+            - flow_run (GraphQLResult): A flow run object
+
+        Returns:
+            - dict: a dictionary representation of an Vertex task definition
+        """
+
+        run_config = self._get_run_config(flow_run, VertexRun)
+        assert isinstance(run_config, VertexRun)  # mypy
+
+        image = get_flow_image(flow_run)
+        job_name = slugify.slugify(
+            flow_run.flow.name + "-" + flow_run.name,
+            max_length=255,
+            word_boundary=True,
+            save_order=True,
+        )
+        machine_type = run_config.machine_type
+
+        command = get_flow_run_command(flow_run)
+        env = self.populate_env_vars(flow_run)
+        env_list = self._to_env_list(env)
+
+        # Start with a default taskdef
+        taskdef = {
+            "display_name": job_name,
+            "job_spec": {
+                "worker_pool_specs": [
+                    {"machine_spec": {"machine_type": machine_type}, "replica_count": 1}
+                ]
+            },
+        }
+
+        if run_config.worker_pool_specs is not None:
+            taskdef["job_spec"]["worker_pool_specs"] = run_config.worker_pool_specs
+
+        if run_config.network is not None:
+            taskdef["job_spec"]["network"] = run_config.network
+
+        if run_config.service_account is not None:
+            taskdef["job_spec"]["service_account"] = run_config.service_account
+        else:
+            taskdef["job_spec"]["service_account"] = self.service_account
+
+        if run_config.scheduling is not None:
+            taskdef["job_spec"]["scheduling"] = run_config.scheduling
+
+        # We always set the container spec on the zeroth pool spec to ensure it will run the flow
+        taskdef["job_spec"]["worker_pool_specs"][0]["container_spec"] = {
+            "image_uri": image,
+            "command": command.split(),
+            "args": [],
+            "env": env_list,
+        }
+
+        return taskdef
+
+    def populate_env_vars(self, flow_run: GraphQLResult) -> dict:
+        """
+        Populate metadata and variables in the environment variables for a flow run
+        Args:
+            - flow_run (GraphQLResult): A flow run object
+            - image (str): The image for this flow
+            - run_config (VertexRun, optional): The `run_config` for the flow, if any.
+        Returns:
+            - dict: a dictionary representing the populated environment variables
+        """
+
+        run_config = self._get_run_config(flow_run, VertexRun)
+        image = get_flow_image(flow_run)
+
+        env = {}
+        # Populate environment variables, later sources overriding
+
+        # 1. Logging level from config
+        # Default to the config logging level, allowing it to be overriden
+        # by later config soruces
+        env.update({"PREFECT__LOGGING__LEVEL": config.logging.level})
+
+        # 2. Values set on the agent via `--env`
+        env.update(self.env_vars)
+
+        # 3. Values set on a RunConfig (if present)
+        if run_config is not None and run_config.env is not None:
+            env.update(run_config.env)
+
+        # 4. Non-overrideable required env vars
+        env.update(
+            {
+                "PREFECT__BACKEND": config.backend,
+                "PREFECT__CLOUD__API": config.cloud.api,
+                "PREFECT__CLOUD__AUTH_TOKEN": (
+                    # Pull an auth token if it exists but fall back to an API key so
+                    # flows in pre-0.15.0 containers still authenticate correctly
+                    config.cloud.agent.get("auth_token")
+                    or self.flow_run_api_key
+                    or ""
+                ),
+                "PREFECT__CLOUD__API_KEY": self.flow_run_api_key or "",
+                "PREFECT__CLOUD__TENANT_ID": (
+                    # Providing a tenant id is only necessary for API keys (not tokens)
+                    self.client.tenant_id
+                    if self.flow_run_api_key
+                    else ""
+                ),
+                "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
+                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
+                "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
+                "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,  # type: ignore
+                "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
+                "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
+                "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+                # Backwards compatibility variable for containers on Prefect <0.15.0
+                "PREFECT__LOGGING__LOG_TO_CLOUD": str(self.log_to_cloud).lower(),
+            }
+        )
+        return env
+
+    def _to_env_list(self, env):
+        """Convert from dictionary to the expected vertex env list format"""
+        env_list = []
+        for k, v in env.items():
+            env_list.append({"name": k, "value": v})
+        return env_list

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -450,3 +450,34 @@ def start(**kwargs):
     from prefect.agent.ecs import ECSAgent
 
     start_agent(ECSAgent, **kwargs)
+
+
+#############
+# Vertex Agent #
+#############
+
+
+@agent.group()
+def vertex():
+    """Manage Prefect Vertex agents."""
+
+
+@vertex.command()
+@add_options(COMMON_START_OPTIONS)
+@click.option(
+    "--project",
+    help="The Google cloud project where flow runs will be launched in vertex.",
+)
+@click.option(
+    "--region_name",
+    help="The region where flow runs will be launched in vertex.",
+)
+@click.option(
+    "--service_account",
+    help="The service account that flow runs will act as in vertex.",
+)
+def start(**kwargs):
+    """Start a Vertex agent"""
+    from prefect.agent.vertex.agent import VertexAgent
+
+    start_agent(VertexAgent, **kwargs)

--- a/src/prefect/run_configs/__init__.py
+++ b/src/prefect/run_configs/__init__.py
@@ -3,3 +3,4 @@ from .kubernetes import KubernetesRun
 from .local import LocalRun
 from .docker import DockerRun
 from .ecs import ECSRun
+from .vertex import VertexRun

--- a/src/prefect/run_configs/vertex.py
+++ b/src/prefect/run_configs/vertex.py
@@ -1,0 +1,91 @@
+from typing import List, Iterable
+
+import yaml
+
+from prefect.run_configs.base import RunConfig
+from prefect.utilities.filesystems import parse_path
+
+
+class VertexRun(RunConfig):
+    """Configure a flow-run to run as a Vertex CustomJob.
+
+    The most common configuration is for the run to use a single machine, and
+    prefect will provide a default workerPoolSpec from the machine_type
+    argument. But this can be customized by providing the worker_pool_spec arg
+    with the content described in [workerPoolSpec][1]. Prefect will always
+    provide the container spec for the 0th workerPoolSpec, which is used to
+    actually run the flow
+
+    Args:
+        - env (dict, optional): Additional environment variables to set.
+        - labels (Iterable[str], optional): an iterable of labels to apply to this
+            run config. Labels are string identifiers used by Prefect Agents
+            for selecting valid flow runs when polling for work
+        - image (str, optional): The image to use for this task. If not
+            provided, will be either inferred from the flow's storage (if using
+            `Docker` storage), or use the default configured on the agent.
+        - machine_type (str, optional): The machine type to use for the run,
+            which controls the available CPU and memory. See [machine_types][2]
+            for valid choices.
+        - scheduling (dictionary, optional): The scheduling for the custom job, which
+            can be used to set a timeout (maximum run time). See
+            [CustomJobSpec][1] for the expected format.
+        - service_account (str, optional): Specifies the service account to use
+            as the run-as account in vertex. The agent submitting jobs must have
+            act-as permission on this run-as account. If unspecified, the AI
+            Platform Custom Code Service Agent for the CustomJob's project is
+            used.
+        - network (str, optional): The full name of the Compute Engine network
+            to which the Job should be peered. Private services access must
+            already be configured for the network. If left unspecified, the job
+            is not peered with any network.
+        - worker_pool_specs (list, optional): The full worker pool specs
+            for the custom job, which can be used for advanced configuration.
+            If provided, it will overwrite the default constructed from the
+            machine type arg.
+
+
+    Examples:
+
+    Use the defaults set on the agent:
+
+    ```python
+    flow.run_config = VertexRun()
+    ```
+
+    Use the default task definition, but override the image and machine type:
+
+    ```python
+    flow.run_config = VertexRun(
+        image="example/my-custom-image:latest",
+        machine_type="e2-highmem-8",
+    )
+    ```
+
+    [1]: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/\
+CustomJobSpec
+    [2]: https://cloud.google.com/vertex-ai/docs/training/\
+configure-compute#machine-types
+
+    """
+
+    # TODO ADD GPUS SUPPORT
+    def __init__(
+        self,
+        *,
+        env: dict = None,
+        labels: Iterable[str] = None,
+        image: str = None,
+        machine_type: str = "e2-standard-4",
+        scheduling: dict = None,
+        service_account: str = None,
+        network: str = None,
+        worker_pool_specs: List[dict] = None,
+    ) -> None:
+        super().__init__(env=env, labels=labels)
+        self.image = image
+        self.machine_type = machine_type
+        self.scheduling = scheduling
+        self.service_account = service_account
+        self.network = network
+        self.worker_pool_specs = worker_pool_specs

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -6,7 +6,14 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     SortedList,
 )
-from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun, UniversalRun
+from prefect.run_configs import (
+    KubernetesRun,
+    LocalRun,
+    DockerRun,
+    ECSRun,
+    VertexRun,
+    UniversalRun,
+)
 
 
 class RunConfigSchemaBase(ObjectSchema):
@@ -65,6 +72,20 @@ class DockerRunSchema(RunConfigSchemaBase):
     host_config = fields.Dict(keys=fields.String(), allow_none=True)
 
 
+class VertexRunSchema(RunConfigSchemaBase):
+    class Meta:
+        object_class = VertexRun
+
+    image = fields.String(allow_none=True)
+    machine_type = fields.String(allow_none=True)
+    scheduling = fields.Dict(keys=fields.String(), allow_none=True)
+    service_account = fields.String(allow_none=True)
+    network = fields.String(allow_none=True)
+    worker_pool_specs = fields.List(
+        fields.Dict(keys=fields.String(), allow_none=True), allow_none=True
+    )
+
+
 class RunConfigSchema(OneOfSchema):
     type_schemas = {
         "KubernetesRun": KubernetesRunSchema,
@@ -72,4 +93,5 @@ class RunConfigSchema(OneOfSchema):
         "LocalRun": LocalRunSchema,
         "DockerRun": DockerRunSchema,
         "UniversalRun": UniversalRunSchema,
+        "VertexRun": VertexRunSchema,
     }

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -88,7 +88,7 @@ class GitLab(Storage):
         client = self._get_gitlab_client()
 
         try:
-            project = client.projects.get(quote_plus(self.repo), safe="/")
+            project = client.projects.get(quote_plus(self.repo, safe="/"))
             contents = project.files.get(file_path=flow_location, ref=ref)
         except GitlabAuthenticationError:
             self.logger.error(

--- a/tests/agent/test_vertex_agent.py
+++ b/tests/agent/test_vertex_agent.py
@@ -1,0 +1,322 @@
+from unittest.mock import MagicMock
+
+import box
+import box
+import pytest
+
+from prefect import config
+from prefect.storage import Local, Docker
+from prefect.agent.vertex import VertexAgent
+from prefect.run_configs import LocalRun, UniversalRun, VertexRun
+from prefect.utilities.agent import get_flow_image, get_flow_run_command
+from prefect.utilities.graphql import GraphQLResult
+from prefect.utilities.configuration import set_temporary_config
+
+
+@pytest.fixture
+def project():
+    return "example"
+
+
+@pytest.fixture
+def region():
+    return "us-central1"
+
+
+@pytest.fixture
+def agent(project, region):
+    return VertexAgent(project, region)
+
+
+def graphql_result(run_config):
+    return GraphQLResult(
+        {
+            "flow": GraphQLResult(
+                {
+                    "storage": Local().serialize(),
+                    "id": "flow-id",
+                    "version": 1,
+                    "name": "Test Flow",
+                    "core_version": "0.13.0",
+                }
+            ),
+            "run_config": run_config.serialize(),
+            "id": "flow-run-id",
+            "name": "flow-run-name",
+        }
+    )
+
+
+def test_agent_defaults(agent, project, region):
+    assert set(agent.labels) == set()
+    assert agent.name == "agent"
+    assert agent.project == project
+    assert agent.service_account is None
+    assert agent.client_options["api_endpoint"] == f"{region}-aiplatform.googleapis.com"
+
+
+class TestEnvVars:
+    DEFAULT = {
+        "PREFECT__LOGGING__LEVEL": config.logging.level,
+        "PREFECT__BACKEND": config.backend,
+        "PREFECT__CLOUD__API": config.cloud.api,
+        "PREFECT__CLOUD__AUTH_TOKEN": "",
+        "PREFECT__CLOUD__API_KEY": "",
+        "PREFECT__CLOUD__TENANT_ID": "",
+        "PREFECT__CLOUD__AGENT__LABELS": "[]",
+        "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": "true",
+        "PREFECT__CONTEXT__FLOW_RUN_ID": "flow-run-id",
+        "PREFECT__CONTEXT__FLOW_ID": "flow-id",
+        "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
+        "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
+        "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudTaskRunner",
+        "PREFECT__LOGGING__LOG_TO_CLOUD": "true",
+    }
+
+    def test_environment_defaults(self, agent):
+        run_config = UniversalRun()
+        flow_run = graphql_result(run_config)
+
+        env = agent.populate_env_vars(flow_run)
+        assert env == self.DEFAULT
+
+    def test_environment_overrides(self, project, region):
+        # The precedent order is agent, then run, except for the required env vars
+        agent = VertexAgent(
+            project,
+            region,
+            env_vars={"a": 0, "b": 2, "PREFECT__LOGGING__LEVEL": "test0"},
+        )
+        run_config = UniversalRun(
+            env={"a": 1, "c": 2, "PREFECT__LOGGING__LEVEL": "test1"}
+        )
+        flow_run = graphql_result(run_config)
+
+        env = agent.populate_env_vars(flow_run)
+        expected = self.DEFAULT.copy()
+        expected["PREFECT__LOGGING__LEVEL"] = "test1"
+        expected["a"] = 1
+        expected["b"] = 2
+        expected["c"] = 2
+        assert env == expected
+
+    @pytest.mark.parametrize("tenant_id", ["ID", None])
+    def test_environment_has_api_key_from_config(self, agent, tenant_id):
+        with set_temporary_config(
+            {
+                "cloud.api_key": "TEST_KEY",
+                "cloud.tenant_id": tenant_id,
+                "cloud.agent.auth_token": None,
+            }
+        ):
+            run_config = UniversalRun()
+            flow_run = graphql_result(run_config)
+            env = agent.populate_env_vars(flow_run)
+
+        expected = self.DEFAULT.copy()
+        expected["PREFECT__CLOUD__API_KEY"] == "TEST_KEY"
+        expected["PREFECT__CLOUD__AUTH_TOKEN"] == "TEST_KEY"
+        expected["PREFECT__CLOUD__TENANT_ID"] == "ID"
+        assert env == expected
+
+    def test_environment_has_agent_token_from_config(self, agent):
+        with set_temporary_config({"cloud.agent.auth_token": "TEST_TOKEN"}):
+            run_config = UniversalRun()
+            flow_run = graphql_result(run_config)
+            env = agent.populate_env_vars(flow_run)
+
+        expected = self.DEFAULT.copy()
+        expected["PREFECT__CLOUD__AUTH_TOKEN"] = "TEST_TOKEN"
+        assert env == expected
+
+    def test_env_overrides(self, agent):
+        pass
+
+
+class TestGenerateTaskDefinition:
+    def test_env_list(self, agent):
+        # test to ensure the content in the env list is the expected format
+        run_config = UniversalRun(env={"a": 1})
+        flow_run = graphql_result(run_config)
+        task_def = agent.generate_task_definition(flow_run)
+
+        env_list = task_def["job_spec"]["worker_pool_specs"][0]["container_spec"]["env"]
+        assert {"name": "a", "value": 1} in env_list
+
+    def test_generate_task_definition_defaults(self, agent):
+        run_config = UniversalRun()
+        flow_run = graphql_result(run_config)
+        task_def = agent.generate_task_definition(flow_run)
+        job_spec = task_def["job_spec"]
+        pool_spec = job_spec["worker_pool_specs"][0]
+        env_list = agent._to_env_list(agent.populate_env_vars(flow_run))
+
+        assert task_def["display_name"]
+
+        for unspecified in ["network", "service_account", "scheduling"]:
+            assert job_spec.get(unspecified) is None
+
+        assert pool_spec["machine_spec"] == {"machine_type": "e2-standard-4"}
+        assert pool_spec["replica_count"] == 1
+        assert pool_spec["container_spec"] == {
+            "image_uri": "prefecthq/prefect:0.13.0",  # from the core version above
+            "command": ["prefect", "execute", "flow-run"],
+            "args": [],
+            "env": env_list,
+        }
+
+    def test_generate_task_definition_simple(self, agent):
+        # These are set inside the pool spec
+        run_config = VertexRun(
+            image="prefecthq/prefect:xyz",
+            machine_type="e2-highmem-16",
+        )
+        flow_run = graphql_result(run_config)
+        task_def = agent.generate_task_definition(flow_run)
+        job_spec = task_def["job_spec"]
+        pool_spec = job_spec["worker_pool_specs"][0]
+        env_list = agent._to_env_list(agent.populate_env_vars(flow_run))
+
+        assert task_def["display_name"]
+
+        for unspecified in ["network", "service_account", "scheduling"]:
+            assert job_spec.get(unspecified) is None
+
+        assert pool_spec["machine_spec"] == {"machine_type": "e2-highmem-16"}
+        assert pool_spec["replica_count"] == 1
+        assert pool_spec["container_spec"] == {
+            "image_uri": "prefecthq/prefect:xyz",
+            "command": ["prefect", "execute", "flow-run"],
+            "args": [],
+            "env": env_list,
+        }
+
+    def test_generate_task_definition_customization(self, agent):
+        machine_spec = {
+            "machine_type": "e2-standard-16",
+            "acceleratorType": "NVIDIA_TESLA_K80",
+            "acceleartorCount": 1,
+        }
+        run_config = VertexRun(
+            image="prefecthq/prefect:xyz",  # should be used
+            machine_type="e2-highmem-16",  # should not be used
+            scheduling={"a": 1},
+            service_account="b",
+            network="c",
+            worker_pool_specs=[
+                {
+                    "machine_spec": machine_spec,
+                    "container_spec": {
+                        "image_uri": "prefecthq/prefect:abc"
+                    },  # This should be overwritten
+                }
+            ],
+        )
+        flow_run = graphql_result(run_config)
+        task_def = agent.generate_task_definition(flow_run)
+        job_spec = task_def["job_spec"]
+        pool_spec = job_spec["worker_pool_specs"][0]
+        env_list = agent._to_env_list(agent.populate_env_vars(flow_run))
+
+        assert task_def["display_name"]
+
+        assert job_spec["scheduling"] == {"a": 1}
+        assert job_spec["network"] == "c"
+        assert job_spec["service_account"] == "b"
+
+        assert pool_spec["machine_spec"] == machine_spec
+        assert pool_spec["container_spec"] == {
+            "image_uri": "prefecthq/prefect:xyz",  # from the core version above
+            "command": ["prefect", "execute", "flow-run"],
+            "args": [],
+            "env": env_list,
+        }
+
+
+class TestDeployFlow:
+    DEFAULT_JOB = {
+        "display_name": "test-flow-flow-run-name",
+        "job_spec": {
+            "worker_pool_specs": [
+                {
+                    "machine_spec": {"machine_type": "e2-standard-4"},
+                    "replica_count": 1,
+                    "container_spec": {
+                        "image_uri": "prefecthq/prefect:0.13.0",
+                        "command": ["prefect", "execute", "flow-run"],
+                        "args": [],
+                        "env": [
+                            {
+                                "name": "PREFECT__LOGGING__LEVEL",
+                                "value": config.logging.level,
+                            },
+                            {"name": "PREFECT__BACKEND", "value": config.backend},
+                            {
+                                "name": "PREFECT__CLOUD__API",
+                                "value": config.cloud.api,
+                            },
+                            {"name": "PREFECT__CLOUD__AUTH_TOKEN", "value": ""},
+                            {"name": "PREFECT__CLOUD__API_KEY", "value": ""},
+                            {"name": "PREFECT__CLOUD__TENANT_ID", "value": ""},
+                            {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
+                            {
+                                "name": "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS",
+                                "value": "true",
+                            },
+                            {
+                                "name": "PREFECT__CONTEXT__FLOW_RUN_ID",
+                                "value": "flow-run-id",
+                            },
+                            {"name": "PREFECT__CONTEXT__FLOW_ID", "value": "flow-id"},
+                            {
+                                "name": "PREFECT__CLOUD__USE_LOCAL_SECRETS",
+                                "value": "false",
+                            },
+                            {
+                                "name": "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS",
+                                "value": "prefect.engine.cloud.CloudFlowRunner",
+                            },
+                            {
+                                "name": "PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS",
+                                "value": "prefect.engine.cloud.CloudTaskRunner",
+                            },
+                            {"name": "PREFECT__LOGGING__LOG_TO_CLOUD", "value": "true"},
+                        ],
+                    },
+                }
+            ],
+            "service_account": None,
+        },
+    }
+
+    def deploy_flow(self, agent, run_config):
+        flow_run = graphql_result(run_config)
+        return agent.deploy_flow(flow_run)
+
+    def test_deploy_flow_errors_if_not_vertex_run_config(self, agent):
+        with pytest.raises(
+            TypeError,
+            match="`run_config` of type `LocalRun`, only `VertexRun` is supported",
+        ):
+            self.deploy_flow(agent, LocalRun())
+
+    def test_deploy_flow_job_spec(self, agent, region, project):
+        client = MagicMock()
+        agent.vertex_client = client
+
+        client.create_custom_job.return_value = box.Box(name="custom_job_name")
+
+        result = self.deploy_flow(agent, UniversalRun())
+
+        # Check that we repsected the vertex response name in the url info
+        assert result.endswith(f"{agent.region_name}/training/custom_job_name")
+
+        client.create_custom_job.assert_called_once()
+
+        # correct region and project
+        assert (
+            client.create_custom_job.call_args[1]["parent"]
+            == f"projects/{project}/locations/{region}"
+        )
+        # correct job spec for a default job
+        assert client.create_custom_job.call_args[1]["custom_job"] == self.DEFAULT_JOB


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adding in GCP Vertex agent and run config: https://cloud.google.com/vertex-ai.
Vertex will run containers in a similar way to fargate, just in GCS, with no limits on machines size or runtime.



## Changes
+ Vertex agent
+ Vertex Runconfig
+ examples
+ tests




## Importance
Allowing a serverless way to run flows in GCP opens the door for many organizations that do not want to manage GKE clusters or GCE instances




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)