### PR TITLE
Release 0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.15.6 <Badge text="beta" type="success" />
+
+Released on September 21, 2021.
+
+### Enhancements
+
+- Improve setting the Azure storage connection string - [#4955](https://github.com/PrefectHQ/prefect/pull/4955)
+- Allow disabling retries for a task with `max_retries=0` when retries are globally configured - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)
+
+### Task Library
+
+- Allow Exasol Tasks to handle Prefect Secrets directly - [#4436](https://github.com/PrefectHQ/prefect/pull/4436)
+- Adding [Census](https://www.getcensus.com/) Syncs to the task library - [#4935](https://github.com/PrefectHQ/prefect/pull/4935)
+
+### Fixes
+
+- Fix bug where `LocalDaskExecutor` did not respond to a `PrefectSignal` - [#4924](https://github.com/PrefectHQ/prefect/pull/4924)
+- Fix `PostgresFetch` with headers for one row - [#4968](https://github.com/PrefectHQ/prefect/pull/4968)
+- Fix bug where `apply_map` could create acyclic flows - [#4970](https://github.com/PrefectHQ/prefect/pull/4970)
+
+### Contributors
+
+- [Donny Flynn](https://github.com/dflynn20)
+- [Noah Holm](https://github.com/noppaz)
+- [Timo S.](https://github.com/sti0)
+
 ## 0.15.5 <Badge text="beta" type="success" />
 
 Released on September 2, 2021.

--- a/changes/pr4436.yaml
+++ b/changes/pr4436.yaml
@@ -1,5 +1,0 @@
-task:
-  - "Allow Exasol Tasks to handle Prefect Secrets directly - [#4436](https://github.com/PrefectHQ/prefect/pull/4436)"
-
-contributor:
-  - "[Timo S.](https://github.com/sti0)"

--- a/changes/pr4924.yaml
+++ b/changes/pr4924.yaml
@@ -1,3 +1,0 @@
-
-fix:
-  - "Fix bug where `LocalDaskExecutor` did not respond to a `PrefectSignal` - [#4924](https://github.com/PrefectHQ/prefect/pull/4924)"

--- a/changes/pr4943.yaml
+++ b/changes/pr4943.yaml
@@ -1,5 +1,0 @@
-task:
-  - "Adding [Census](https://www.getcensus.com/) Syncs to the task library - [#4935](https://github.com/PrefectHQ/prefect/pull/4935)"
-
-contributor:
-  - "[Donny Flynn](https://github.com/dflynn20)"

--- a/changes/pr4955.yaml
+++ b/changes/pr4955.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Update setting a connection string for Azure storage - [#4955](https://github.com/PrefectHQ/prefect/pull/4955)"

--- a/changes/pr4968.yaml
+++ b/changes/pr4968.yaml
@@ -1,5 +1,0 @@
-fix:
-  - "Fix PostgresFetch with headers for one row - [#4968](https://github.com/PrefectHQ/prefect/pull/4968)"
-
-contributor:
-  - "[Noah Holm](https://github.com/noppaz)"

--- a/changes/pr4970.yaml
+++ b/changes/pr4970.yaml
@@ -1,3 +1,0 @@
-
-fix:
-  - "Fix bug where `apply_map` could create acyclic flows - [#4970](https://github.com/PrefectHQ/prefect/pull/4970)"

--- a/changes/pr4971.yaml
+++ b/changes/pr4971.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Allow disabling retries for a task with `max_retries=0` when retries are globally configured - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,7 +4,7 @@ const sidebar1422 = require('../api/0.14.22/sidebar')
 const glob = require('glob')
 
 // function for loading all MD files in a directory
-const getChildren = function(parent_path, dir) {
+const getChildren = function (parent_path, dir) {
   return glob
     .sync(parent_path + '/' + dir + '/**/*.md')
     .map(path => {
@@ -80,7 +80,7 @@ module.exports = {
       {
         text: 'API Reference',
         items: [
-          { text: 'Latest (0.15.5)', link: '/api/latest/' },
+          { text: 'Latest (0.15.6)', link: '/api/latest/' },
           { text: '0.14.22', link: '/api/0.14.22/' },
           { text: '0.13.19', link: '/api/0.13.19/' },
           { text: '0.12.6', link: '/api/0.12.6/' },


### PR DESCRIPTION

### Enhancements

- Improve setting the Azure storage connection string - [#4955](https://github.com/PrefectHQ/prefect/pull/4955)
- Allow disabling retries for a task with `max_retries=0` when retries are globally configured - [#4971](https://github.com/PrefectHQ/prefect/pull/4971)

### Task Library

- Allow Exasol Tasks to handle Prefect Secrets directly - [#4436](https://github.com/PrefectHQ/prefect/pull/4436)
- Adding [Census](https://www.getcensus.com/) Syncs to the task library - [#4935](https://github.com/PrefectHQ/prefect/pull/4935)

### Fixes

- Fix bug where `LocalDaskExecutor` did not respond to a `PrefectSignal` - [#4924](https://github.com/PrefectHQ/prefect/pull/4924)
- Fix `PostgresFetch` with headers for one row - [#4968](https://github.com/PrefectHQ/prefect/pull/4968)
- Fix bug where `apply_map` could create acyclic flows - [#4970](https://github.com/PrefectHQ/prefect/pull/4970)

### Contributors

- [Donny Flynn](https://github.com/dflynn20)
- [Noah Holm](https://github.com/noppaz)
- [Timo S.](https://github.com/sti0)