### PR TITLE
Add flatten support to apply_map

### DIFF
--- a/changes/pr4996.yaml
+++ b/changes/pr4996.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - 'Add flatten support to apply_map [#4996](https://github.com/PrefectHQ/prefect/pull/4996)'
+
+contributor:
+  - '[Emre Akgün](https://github.com/Fraznist)'


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Adds `flatten` support to `apply_map`.



## Changes
<!-- What does this PR change? -->
`flatten` edge annotations were missing in the implementation of `apply_map` . Now, an edges flatten property is derived via the same way its mapped property is derived, and all instances of `flow.add_edge` in `apply_map` use this flattened edge indicator. 



## Importance
<!-- Why is this PR important? -->
Flattening nested structures before mapping over is a widespread use case. Complex mapping pipelines that necessitate `apply_map` should be able to benefit from `flatten` as well. 
Old behavior silently disregards the flatten edge annotation, therefore I think this is strictly an enhancement, and hope it doesn't make any breaking changes.

## Side Note
- I will add tests soon, and then make this an actual PR.
- Admittedly, I don't fully understand the `apply_map` implementation. I just put flatten bool values to where they are allowed to go :sweat_smile: 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)