### PR TITLE
Kubernetes agent job YAML allowing imagePullSecrets to be unset as code intended

### DIFF
--- a/changes/pr5001.yaml
+++ b/changes/pr5001.yaml
@@ -1,3 +1,6 @@
 
 fix:
   - "Allow unsetting imagePullSecrets with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)"
+
+contributor:
+  - "[Andrew Farley](https://github.com/AndrewFarley)"

--- a/changes/pr5001.yaml
+++ b/changes/pr5001.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Allow unsetting imagePullSecrets with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)"

--- a/changes/pr5001.yaml
+++ b/changes/pr5001.yaml
@@ -3,4 +3,4 @@ fix:
   - "Allow unsetting imagePullSecrets with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)"
 
 contributor:
-  - "[Andrew Farley](https://github.com/AndrewFarley)"
+  - "[Farley Farley](https://github.com/AndrewFarley)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -113,7 +113,7 @@ class KubernetesAgent(Agent):
         )
         if image_pull_secrets is None:
             image_pull_secrets_env = os.getenv("IMAGE_PULL_SECRETS")
-            if image_pull_secrets_env is not None and image_pull_secrets_env != '':
+            if image_pull_secrets_env is not None and image_pull_secrets_env != "":
                 image_pull_secrets = (
                     [s.strip() for s in image_pull_secrets_env.split(",")]
                     if image_pull_secrets_env is not None

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -113,11 +113,14 @@ class KubernetesAgent(Agent):
         )
         if image_pull_secrets is None:
             image_pull_secrets_env = os.getenv("IMAGE_PULL_SECRETS")
-            image_pull_secrets = (
-                [s.strip() for s in image_pull_secrets_env.split(",")]
-                if image_pull_secrets_env is not None
-                else None
-            )
+            if image_pull_secrets_env is not None and image_pull_secrets_env != '':
+                image_pull_secrets = (
+                    [s.strip() for s in image_pull_secrets_env.split(",")]
+                    if image_pull_secrets_env is not None
+                    else None
+                )
+            else:
+                image_pull_secrets = None
         self.image_pull_secrets = image_pull_secrets
         self.job_template_path = job_template_path or DEFAULT_JOB_TEMPLATE_PATH
         self.volume_mounts = volume_mounts

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -114,7 +114,9 @@ class KubernetesAgent(Agent):
         if not image_pull_secrets:
             image_pull_secrets_env = os.getenv("IMAGE_PULL_SECRETS")
             if image_pull_secrets_env:
-                image_pull_secrets = [s.strip() for s in image_pull_secrets_env.split(",")]
+                image_pull_secrets = [
+                    s.strip() for s in image_pull_secrets_env.split(",")
+                ]
             else:
                 image_pull_secrets = None
         self.image_pull_secrets = image_pull_secrets

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -111,14 +111,10 @@ class KubernetesAgent(Agent):
         self.service_account_name = service_account_name or os.getenv(
             "SERVICE_ACCOUNT_NAME"
         )
-        if image_pull_secrets is None:
+        if not image_pull_secrets:
             image_pull_secrets_env = os.getenv("IMAGE_PULL_SECRETS")
-            if image_pull_secrets_env is not None and image_pull_secrets_env != "":
-                image_pull_secrets = (
-                    [s.strip() for s in image_pull_secrets_env.split(",")]
-                    if image_pull_secrets_env is not None
-                    else None
-                )
+            if image_pull_secrets_env:
+                image_pull_secrets = [s.strip() for s in image_pull_secrets_env.split(",")]
             else:
                 image_pull_secrets = None
         self.image_pull_secrets = image_pull_secrets
@@ -666,7 +662,7 @@ class KubernetesAgent(Agent):
             pod_spec["serviceAccountName"] = service_account_name
 
         # Configure `image_pull_secrets` if specified
-        if run_config.image_pull_secrets is not None:
+        if run_config.image_pull_secrets:
             # On run-config, always override
             image_pull_secrets = (
                 run_config.image_pull_secrets

--- a/src/prefect/utilities/compatibility.py
+++ b/src/prefect/utilities/compatibility.py
@@ -16,7 +16,6 @@ if sys.version_info < (3, 7):
     def nullcontext() -> Iterator[None]:
         yield
 
-
 else:
 
     from contextlib import nullcontext  # noqa: F401

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -729,8 +729,10 @@ def test_k8s_agent_generate_deployment_yaml_empty_image_pull_secrets(
     agent = KubernetesAgent()
 
     deployment = agent.generate_deployment_yaml(
-        token="test_token", api="test_api", namespace="test_namespace",
-        image_pull_secrets=""
+        token="test_token",
+        api="test_api",
+        namespace="test_namespace",
+        image_pull_secrets="",
     )
 
     deployment = yaml.safe_load(deployment)
@@ -741,7 +743,7 @@ def test_k8s_agent_generate_deployment_yaml_empty_image_pull_secrets(
 
 
 def test_k8s_agent_generate_deployment_yaml_env_contains_empty_image_pull_secrets(
-        monkeypatch, cloud_api
+    monkeypatch, cloud_api
 ):
     """
     A test to validate that generating the Deployment YAML works correctly if
@@ -757,7 +759,9 @@ def test_k8s_agent_generate_deployment_yaml_env_contains_empty_image_pull_secret
     agent = KubernetesAgent()
 
     deployment = agent.generate_deployment_yaml(
-        token="test_token", api="test_api", namespace="test_namespace",
+        token="test_token",
+        api="test_api",
+        namespace="test_namespace",
     )
 
     deployment = yaml.safe_load(deployment)

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -1661,13 +1661,11 @@ class TestK8sAgentRunConfig:
             {"name": "on-agent-template"}
         ]
 
-
     def test_generate_job_spec_without_image_pull_secrets(self, tmpdir):
         run_config = KubernetesRun()
         agent = KubernetesAgent(namespace="testing")
         job = agent.generate_job_spec(self.build_flow_run(run_config))
         assert "imagePullSecrets" not in job["spec"]["template"]["spec"]
-
 
     def test_generate_job_spec_image_pull_secrets_from_env(self, tmpdir, monkeypatch):
         run_config = KubernetesRun()
@@ -1678,15 +1676,15 @@ class TestK8sAgentRunConfig:
             {"name": "in-env"}
         ]
 
-
-    def test_generate_job_spec_image_pull_secrets_empty_string_in_env(self, tmpdir, monkeypatch):
+    def test_generate_job_spec_image_pull_secrets_empty_string_in_env(
+        self, tmpdir, monkeypatch
+    ):
         """Regression test for issue #5001."""
         run_config = KubernetesRun()
         monkeypatch.setenv("IMAGE_PULL_SECRETS", "")
         agent = KubernetesAgent(namespace="testing")
         job = agent.generate_job_spec(self.build_flow_run(run_config))
         assert "imagePullSecrets" not in job["spec"]["template"]["spec"]
-
 
     @pytest.mark.parametrize("image_pull_policy", ["Always", "Never", "IfNotPresent"])
     def test_generate_job_spec_sets_image_pull_policy_from_run_config(

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -713,6 +713,60 @@ def test_k8s_agent_generate_deployment_yaml_no_image_pull_secrets(
     assert agent_env[3]["value"] == ""
 
 
+def test_k8s_agent_generate_deployment_yaml_empty_image_pull_secrets(
+    monkeypatch, cloud_api
+):
+    """
+    A test to validate that generating the Deployment YAML works correctly if
+    the image_pull_secrets parameter is an empty string, per issue #5001.
+    """
+    get_jobs = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
+        get_jobs,
+    )
+
+    agent = KubernetesAgent()
+
+    deployment = agent.generate_deployment_yaml(
+        token="test_token", api="test_api", namespace="test_namespace",
+        image_pull_secrets=""
+    )
+
+    deployment = yaml.safe_load(deployment)
+
+    assert "imagePullSecrets" not in deployment["spec"]["template"]["spec"]
+    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert agent_env[3]["value"] == ""
+
+
+def test_k8s_agent_generate_deployment_yaml_env_contains_empty_image_pull_secrets(
+        monkeypatch, cloud_api
+):
+    """
+    A test to validate that generating the Deployment YAML works correctly if
+    the IMAGE_PULL_SECRETS env var is an empty string, per issue #5001.
+    """
+    get_jobs = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
+        get_jobs,
+    )
+    monkeypatch.setenv("IMAGE_PULL_SECRETS", "")
+
+    agent = KubernetesAgent()
+
+    deployment = agent.generate_deployment_yaml(
+        token="test_token", api="test_api", namespace="test_namespace",
+    )
+
+    deployment = yaml.safe_load(deployment)
+
+    assert "imagePullSecrets" not in deployment["spec"]["template"]["spec"]
+    agent_env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert agent_env[3]["value"] == ""
+
+
 def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
     monkeypatch, cloud_api
 ):
@@ -1682,6 +1736,15 @@ class TestK8sAgentRunConfig:
         """Regression test for issue #5001."""
         run_config = KubernetesRun()
         monkeypatch.setenv("IMAGE_PULL_SECRETS", "")
+        agent = KubernetesAgent(namespace="testing")
+        job = agent.generate_job_spec(self.build_flow_run(run_config))
+        assert "imagePullSecrets" not in job["spec"]["template"]["spec"]
+
+    def test_generate_job_spec_image_pull_secrets_empty_string_in_runconfig(
+        self, tmpdir
+    ):
+        """Regression test for issue #5001."""
+        run_config = KubernetesRun(image_pull_secrets="")
         agent = KubernetesAgent(namespace="testing")
         job = agent.generate_job_spec(self.build_flow_run(run_config))
         assert "imagePullSecrets" not in job["spec"]["template"]["spec"]


### PR DESCRIPTION
## Summary
Allowing imagePullSecrets in Kubernetes agent to be unset in job YAML when it is unused.  This patch fixes compatibility issues with releases of Kubernetes before (v1.19.13, v1.20.9, v1.21.3) because it triggers this bug https://github.com/kubernetes/kubernetes/pull/103133 which manifests issues such as this https://github.com/kubernetes/autoscaler/issues/4353 

## Changes
Very minor tweak that allows what appears to be intended to be possible which is to unset the imagePullSecrets key entirely if this value is unset or empty.  The supporting code in this file has certain code paths to `del` this key which would never be possible without this adjustment (lines 581 and 896 of `agent/kubernetes/agent.py`)

## Importance
Fixes an issue with cluster-autoscaler and Kubernetes releases prior to v1.19.13, v1.20.9, v1.21.3 by removing an optional and empty-set that doesn't need to be set if unused.  A google on this topic shows that this usage of an empty map has caused issues in a few other libraries and frameworks.

**Note:** This change has zero impact for functionality it merely adds what I believe was intended in the original code and thus should probably not require additional work such as tests or references.

## Checklist
- [X] (N/A) adds new tests
- [X] (N/A) adds a change file in the `changes/` directory
- [X] (N/A) updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs