### PR TITLE
Prevent run_id to be modified outside of run() method

### DIFF
--- a/changes/issue4958.yaml
+++ b/changes/issue4958.yaml
@@ -1,0 +1,2 @@
+fix:
+  - 'Prevent Databricks run_id to be modified outside of run() method [#4958](https://github.com/PrefectHQ/prefect/issues/4958)'


### PR DESCRIPTION
to make it work with mapped tasks. Details in the issue: https://github.com/PrefectHQ/prefect/issues/4958

## Importance
The Databricks task classes can now be used with mapped tasks and Dask executors.