### PR TITLE
Fixed ReadTimeoutErrors for kubernetes client after connection reset by keep-alive connections

### DIFF
--- a/changes/pr5066.yaml
+++ b/changes/pr5066.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Introduced keep-alive connections for kubernetes client API connections - [#5066](https://github.com/PrefectHQ/prefect/pull/5066)"
+
+contributor:
+  - "[Jonas Miederer](https://github.com/jonasmiederer)"

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -126,6 +126,7 @@ class KubernetesAgent(Agent):
             os.getenv("DELETE_FINISHED_JOBS", "True") == "True"
         )
 
+        from prefect.utilities.kubernetes import get_kubernetes_client
         from kubernetes import client, config
 
         try:
@@ -138,8 +139,8 @@ class KubernetesAgent(Agent):
             self.logger.debug("Loading out of cluster configuration")
             config.load_kube_config()
 
-        self.batch_client = client.BatchV1Api()
-        self.core_client = client.CoreV1Api()
+        self.batch_client = get_kubernetes_client("job")
+        self.core_client = get_kubernetes_client("service")
         self.k8s_client = client
 
         min_datetime = datetime.min.replace(tzinfo=pytz.UTC)

--- a/src/prefect/config.toml
+++ b/src/prefect/config.toml
@@ -90,6 +90,9 @@ tenant_id = ""
     # Internal address for agent health checks, etc...
     agent_address = ""
 
+    # Enable keep-alive packages for the kubernetes agent
+    kubernetes_keep_alive = false
+
         [cloud.agent.resource_manager]
         # Separate loop interval for resource managers
         loop_interval = 60

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -39,9 +39,11 @@ def get_kubernetes_client(
     2. Attempt in-cluster connection (will only work when running on a Pod in a cluster)
     3. Attempt out-of-cluster connection using the default location for a kube config file
 
-    In some cases connections to the kubernetes server are dropped after being idle for some time (e.g. Azure
-    Firewall drops idle connections after 4 minutes) which would result in ReadTimeoutErrors. In order to prevent
-    that a periodic keep-alive message can be sent to the server to keep the connection open.
+    In some cases connections to the kubernetes server are dropped after being idle for some time
+    (e.g. Azure Firewall drops idle connections after 4 minutes) which would result in
+    ReadTimeoutErrors.
+    In order to prevent that a periodic keep-alive message can be sent to the server to keep the
+    connection open.
 
     Args:
         - resource (str): the name of the resource to retrieve a client for. Currently
@@ -80,11 +82,13 @@ def get_kubernetes_client(
 def _keep_alive(client: KubernetesClient) -> None:
     """
     Setting the keep-alive flags on the kubernetes client object.
-    Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using internally offer
-    the functionality to enable keep-alive messages. Thus the flags are added to be used on the underlying sockets.
+    Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using
+    internally offer the functionality to enable keep-alive messages. Thus the flags are added to
+    be used on the underlying sockets.
 
     Args:
-        - client (KubernetesClient): the kubernetes client object on which the keep-alive should be enabled
+        - client (KubernetesClient): the kubernetes client object on which the keep-alive should be
+            enabled
     """
     import socket
 

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -1,11 +1,13 @@
 """
 Utility functions for interacting with Kubernetes API.
 """
-from typing import Union
+import sys
+from typing import Union, Optional
 
-from kubernetes import client, config
+from kubernetes import client, config as kube_config
 from kubernetes.config.config_exception import ConfigException
 
+from prefect import config
 from prefect.client import Secret
 
 
@@ -17,12 +19,11 @@ K8S_CLIENTS = {
     "secret": client.CoreV1Api,
 }
 
-
 KubernetesClient = Union[client.BatchV1Api, client.CoreV1Api, client.AppsV1Api]
 
 
 def get_kubernetes_client(
-    resource: str, kubernetes_api_key_secret: str = "KUBERNETES_API_KEY"
+    resource: str, kubernetes_api_key_secret: Optional[str] = "KUBERNETES_API_KEY"
 ) -> KubernetesClient:
     """
     Utility function for loading kubernetes client object for a given resource.
@@ -37,6 +38,10 @@ def get_kubernetes_client(
     an override for the remote connection.
     2. Attempt in-cluster connection (will only work when running on a Pod in a cluster)
     3. Attempt out-of-cluster connection using the default location for a kube config file
+
+    In some cases connections to the kubernetes server are dropped after being idle for some time (e.g. Azure
+    Firewall drops idle connections after 4 minutes) which would result in ReadTimeoutErrors. In order to prevent
+    that a periodic keep-alive message can be sent to the server to keep the connection open.
 
     Args:
         - resource (str): the name of the resource to retrieve a client for. Currently
@@ -60,10 +65,44 @@ def get_kubernetes_client(
         k8s_client = k8s_client(client.ApiClient(configuration))
     else:
         try:
-            config.load_incluster_config()
+            kube_config.load_incluster_config()
         except ConfigException:
-            config.load_kube_config()
+            kube_config.load_kube_config()
 
         k8s_client = k8s_client()
 
+    if config.cloud.agent.kubernetes_keep_alive:
+        _keep_alive(client=k8s_client)
+
     return k8s_client
+
+
+def _keep_alive(client: KubernetesClient):
+    """
+    Setting the keep-alive flags on the kubernetes client object.
+    Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using internally offer
+    the functionality to enable keep-alive messages. Thus the flags are added to be used on the underlying sockets.
+
+    Args:
+        - client (KubernetesClient): the kubernetes client object on which the keep-alive should be enabled
+    """
+    import socket
+
+    socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30))
+
+    if hasattr(socket, "TCP_KEEPCNT"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6))
+
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 6))
+
+    if sys.platform == "darwin":
+        # TCP_KEEP_ALIVE not available on socket module in macOS, but defined in
+        # https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/netinet/tcp.h#L215
+        TCP_KEEP_ALIVE = 0x10
+        socket_options.append((socket.IPPROTO_TCP, TCP_KEEP_ALIVE, 30))
+
+    client.api_client.rest_client.pool_manager.connection_pool_kw['socket_options'] = socket_options

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -105,4 +105,6 @@ def _keep_alive(client: KubernetesClient):
         TCP_KEEP_ALIVE = 0x10
         socket_options.append((socket.IPPROTO_TCP, TCP_KEEP_ALIVE, 30))
 
-    client.api_client.rest_client.pool_manager.connection_pool_kw['socket_options'] = socket_options
+    client.api_client.rest_client.pool_manager.connection_pool_kw[
+        "socket_options"
+    ] = socket_options

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -77,7 +77,7 @@ def get_kubernetes_client(
     return k8s_client
 
 
-def _keep_alive(client: KubernetesClient):
+def _keep_alive(client: KubernetesClient) -> None:
     """
     Setting the keep-alive flags on the kubernetes client object.
     Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using internally offer

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -30,7 +30,7 @@ def mocked_k8s_config(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def mocked_k8s_clients(monkeypatch):
-    client = MagicMock(return_value=MagicMock())
+    client = MagicMock()
     for job_key in kubernetes.K8S_CLIENTS.keys():
         monkeypatch.setitem(kubernetes.K8S_CLIENTS, job_key, client)
 
@@ -1456,6 +1456,7 @@ class TestK8sAgentRunConfig:
         expected_logging_level,
         tmpdir,
         backend,
+        kube_secret
     ):
         """
         Check that PREFECT__LOGGING__LEVEL is set in precedence order

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -87,7 +87,9 @@ def test_k8s_agent_config_options(monkeypatch, cloud_api, kube_secret):
         ("0.13.1+134", "prefect execute flow-run"),
     ],
 )
-def test_k8s_agent_deploy_flow(core_version, command, monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_deploy_flow(
+    core_version, command, monkeypatch, cloud_api, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -126,7 +128,9 @@ def test_k8s_agent_deploy_flow(core_version, command, monkeypatch, cloud_api, ku
     ]["spec"]["containers"][0]["args"] == [command]
 
 
-def test_k8s_agent_deploy_flow_uses_environment_metadata(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_deploy_flow_uses_environment_metadata(
+    monkeypatch, cloud_api, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -268,7 +272,9 @@ def test_k8s_agent_replace_yaml_uses_user_env_vars(monkeypatch, cloud_api, kube_
         ]
 
 
-def test_k8s_agent_replace_yaml_respects_multiple_image_secrets(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_replace_yaml_respects_multiple_image_secrets(
+    monkeypatch, cloud_api, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -389,7 +395,7 @@ def test_k8s_agent_replace_yaml(monkeypatch, cloud_api, kube_secret):
 
 @pytest.mark.parametrize("flag", [True, False])
 def test_k8s_agent_replace_yaml_responds_to_logging_config(
-        monkeypatch, cloud_api, flag, kube_secret
+    monkeypatch, cloud_api, flag, kube_secret
 ):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
@@ -505,7 +511,9 @@ def test_k8s_agent_includes_agent_labels_in_job(monkeypatch, cloud_api, kube_sec
 
 
 @pytest.mark.parametrize("use_token", [True, False])
-def test_k8s_agent_generate_deployment_yaml(monkeypatch, cloud_api, use_token, kube_secret):
+def test_k8s_agent_generate_deployment_yaml(
+    monkeypatch, cloud_api, use_token, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -540,7 +548,9 @@ def test_k8s_agent_generate_deployment_yaml(monkeypatch, cloud_api, use_token, k
     }
 
 
-def test_k8s_agent_generate_deployment_yaml_env_vars(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_generate_deployment_yaml_env_vars(
+    monkeypatch, cloud_api, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -576,7 +586,9 @@ def test_k8s_agent_generate_deployment_yaml_agent_config_id(
         assert cmd_args == ["prefect agent kubernetes start"]
 
 
-def test_k8s_agent_generate_deployment_yaml_backend_default(monkeypatch, server_api, kube_secret):
+def test_k8s_agent_generate_deployment_yaml_backend_default(
+    monkeypatch, server_api, kube_secret
+):
     c = MagicMock()
     monkeypatch.setattr("prefect.agent.agent.Client", c)
 
@@ -726,7 +738,9 @@ def test_k8s_agent_generate_deployment_yaml_contains_image_pull_secrets(
     assert agent_env[3]["value"] == "secrets"
 
 
-def test_k8s_agent_generate_deployment_yaml_contains_resources(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_generate_deployment_yaml_contains_resources(
+    monkeypatch, cloud_api, kube_secret
+):
     get_jobs = MagicMock(return_value=[])
     monkeypatch.setattr(
         "prefect.agent.kubernetes.agent.KubernetesAgent.manage_jobs",
@@ -836,7 +850,9 @@ def test_k8s_agent_manage_jobs_delete_jobs(monkeypatch, cloud_api, kube_secret):
     assert agent.batch_client.delete_namespaced_job.called
 
 
-def test_k8s_agent_manage_jobs_does_not_delete_if_disabled(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_manage_jobs_does_not_delete_if_disabled(
+    monkeypatch, cloud_api, kube_secret
+):
     job_mock = MagicMock()
     job_mock.metadata.labels = {
         "prefect.io/identifier": "id",
@@ -923,7 +939,9 @@ def test_k8s_agent_manage_jobs_reports_failed_pods(monkeypatch, cloud_api, kube_
     assert agent.core_client.list_namespaced_pod.called
 
 
-def test_k8s_agent_manage_jobs_reports_empty_status(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_manage_jobs_reports_empty_status(
+    monkeypatch, cloud_api, kube_secret
+):
     gql_return = MagicMock(
         return_value=MagicMock(
             data=MagicMock(
@@ -1010,7 +1028,9 @@ def test_k8s_agent_manage_jobs_client_call(monkeypatch, cloud_api, kube_secret):
     agent.manage_jobs()
 
 
-def test_k8s_agent_manage_jobs_continues_on_client_error(monkeypatch, cloud_api, kube_secret):
+def test_k8s_agent_manage_jobs_continues_on_client_error(
+    monkeypatch, cloud_api, kube_secret
+):
     gql_return = MagicMock(
         return_value=MagicMock(data=MagicMock(set_flow_run_state=None))
     )
@@ -1181,7 +1201,9 @@ class TestK8sAgentRunConfig:
         )
 
     @pytest.mark.parametrize("run_config", [None, UniversalRun()])
-    def test_generate_job_spec_null_or_universal_run_config(self, run_config, kube_secret):
+    def test_generate_job_spec_null_or_universal_run_config(
+        self, run_config, kube_secret
+    ):
         self.agent.generate_job_spec_from_run_config = MagicMock(
             wraps=self.agent.generate_job_spec_from_run_config
         )
@@ -1189,14 +1211,18 @@ class TestK8sAgentRunConfig:
         self.agent.generate_job_spec(flow_run)
         assert self.agent.generate_job_spec_from_run_config.called
 
-    def test_generate_job_spec_errors_if_non_kubernetesrun_run_config(self, kube_secret):
+    def test_generate_job_spec_errors_if_non_kubernetesrun_run_config(
+        self, kube_secret
+    ):
         with pytest.raises(
             TypeError,
             match="`run_config` of type `LocalRun`, only `KubernetesRun` is supported",
         ):
             self.agent.generate_job_spec(self.build_flow_run(LocalRun()))
 
-    def test_generate_job_spec_uses_job_template_provided_in_run_config(self, kube_secret):
+    def test_generate_job_spec_uses_job_template_provided_in_run_config(
+        self, kube_secret
+    ):
         template = self.read_default_template()
         labels = template.setdefault("metadata", {}).setdefault("labels", {})
         labels["TEST"] = "VALUE"
@@ -1309,13 +1335,17 @@ class TestK8sAgentRunConfig:
             ("0.14.0", "prefect execute flow-run"),
         ],
     )
-    def test_generate_job_spec_container_args(self, core_version, expected, kube_secret):
+    def test_generate_job_spec_container_args(
+        self, core_version, expected, kube_secret
+    ):
         flow_run = self.build_flow_run(KubernetesRun(), core_version=core_version)
         job = self.agent.generate_job_spec(flow_run)
         args = job["spec"]["template"]["spec"]["containers"][0]["args"]
         assert args == expected.split()
 
-    def test_generate_job_spec_environment_variables(self, tmpdir, backend, kube_secret):
+    def test_generate_job_spec_environment_variables(
+        self, tmpdir, backend, kube_secret
+    ):
         """Check that environment variables are set in precedence order
 
         - CUSTOM1 & CUSTOM2 are set on the template
@@ -1409,7 +1439,9 @@ class TestK8sAgentRunConfig:
         assert env["PREFECT__CLOUD__TENANT_ID"] == "ID"
 
     @pytest.mark.parametrize("tenant_id", ["ID", None])
-    def test_environment_has_api_key_from_disk(self, monkeypatch, tenant_id, kube_secret):
+    def test_environment_has_api_key_from_disk(
+        self, monkeypatch, tenant_id, kube_secret
+    ):
         """Check that the API key is passed through from the on disk cache"""
         monkeypatch.setattr(
             "prefect.Client.load_auth_from_disk",
@@ -1456,7 +1488,7 @@ class TestK8sAgentRunConfig:
         expected_logging_level,
         tmpdir,
         backend,
-        kube_secret
+        kube_secret,
     ):
         """
         Check that PREFECT__LOGGING__LEVEL is set in precedence order

--- a/tests/utilities/test_kubernetes.py
+++ b/tests/utilities/test_kubernetes.py
@@ -82,7 +82,7 @@ class TestGetKubernetesClient:
         with set_temporary_config(
             {"cloud.agent.kubernetes_keep_alive": keep_alive_enabled}
         ):
-            k8s_client = get_kubernetes_client("job", kubernetes_api_key_secret=None)
+            k8s_client = get_kubernetes_client("job")
 
             assert (
                 not (

--- a/tests/utilities/test_kubernetes.py
+++ b/tests/utilities/test_kubernetes.py
@@ -76,11 +76,25 @@ class TestGetKubernetesClient:
         assert config.load_kube_config.called
 
     @pytest.mark.parametrize("keep_alive_enabled", [True, False])
-    def test_kube_client_with_keep_alive(self, keep_alive_enabled, monkeypatch, cloud_api, kube_secret):
-        with set_temporary_config({"cloud.agent.kubernetes_keep_alive": keep_alive_enabled}):
+    def test_kube_client_with_keep_alive(
+        self, keep_alive_enabled, monkeypatch, cloud_api, kube_secret
+    ):
+        with set_temporary_config(
+            {"cloud.agent.kubernetes_keep_alive": keep_alive_enabled}
+        ):
             k8s_client = get_kubernetes_client("job", kubernetes_api_key_secret=None)
 
-            assert not ('socket_options' in k8s_client.api_client.rest_client.pool_manager.connection_pool_kw) ^ \
-                   keep_alive_enabled
-            assert not ('socket_options' in k8s_client.api_client.rest_client.pool_manager.connection_pool_kw) ^ \
-                   keep_alive_enabled
+            assert (
+                not (
+                    "socket_options"
+                    in k8s_client.api_client.rest_client.pool_manager.connection_pool_kw
+                )
+                ^ keep_alive_enabled
+            )
+            assert (
+                not (
+                    "socket_options"
+                    in k8s_client.api_client.rest_client.pool_manager.connection_pool_kw
+                )
+                ^ keep_alive_enabled
+            )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
In some environments, the [kubernetes agent fails to deploy flows (and also on other tasks involving the kubernetes API server) due to the server closing the connection after some time being idle.

[This has been observed when running the kubernetes cluster within the Azure Kubernetes Service](https://prefect-community.slack.com/archives/C014Z8DPDSR/p1631240218210500) (but possibly others too). The firewall / loadbalancer closes idle connections after 4 minutes. The urllib3 connection pool used by the kubernetes client library then tries to connect to the server which results in a ReadTimeoutError. Thus the flow deployment is stuck in the submitted state and is only rescued by the Lazarus agent after 15 minutes.

This PR introduces keep-alive messages so that the connection will be kept open for a longer time.
It is disabled by default to avoid problems on existing configurations which are running fine.

If the `cloud.agent.kubernetes_keep_alive` is set to `true` the connection pool will use keep-alive messages.

Since neither the kubernetes nor the urllib3 offer keep-alive functionality out of the box, the solution is a little hacky by setting the flags directly within the socket options.

Moreover the `KubernetesAgent` constructor was slightly refactored to leverage the `prefect.utilities.kubernetes.get_kubernetes_client` function for  `batch_client` and `core_client` in order to make the creation more consistent across the project.



## Changes
<!-- What does this PR change? -->
- Adds `keep-alive` functionality for kubernetes clients
- Use existing factory for client creation in `KubernetesAgent`


## Importance
<!-- Why is this PR important? -->
- Flow deployments are failing
- ReadTimeoutErrors are occurring
- Communication with Kubernetes API is unstable 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)