### PR TITLE
Fix RunNamespacedJob Logging Issue

### DIFF
--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -724,56 +724,56 @@ class RunNamespacedJob(Task):
 
         pod_log_streams = {}
 
-        with ThreadPoolExecutor() as pool:
-            completed = False
-            while not completed:
-                job = api_client_job.read_namespaced_job_status(
-                    name=job_name, namespace=namespace
+        completed = False
+        while not completed:
+            job = api_client_job.read_namespaced_job_status(
+                name=job_name, namespace=namespace
+            )
+
+            if log_level is not None:
+                func_log = getattr(self.logger, log_level)
+
+                pod_selector = (
+                    f"controller-uid={job.metadata.labels['controller-uid']}"
+                )
+                pods_list = api_client_pod.list_namespaced_pod(
+                    namespace=namespace, label_selector=pod_selector
                 )
 
-                if log_level is not None:
-                    func_log = getattr(self.logger, log_level)
+                for pod in pods_list.items:
+                    pod_name = pod.metadata.name
 
-                    pod_selector = (
-                        f"controller-uid={job.metadata.labels['controller-uid']}"
+                    # Can't start logs when phase is pending
+                    if pod.status.phase == "Pending":
+                        continue
+                    if pod_name in pod_log_streams:
+                        continue
+
+                    read_pod_logs = ReadNamespacedPodLogs(
+                        pod_name=pod_name,
+                        namespace=namespace,
+                        kubernetes_api_key_secret=kubernetes_api_key_secret,
+                        on_log_entry=lambda log: func_log(f"{pod_name}: {log}"),
                     )
-                    pods_list = api_client_pod.list_namespaced_pod(
-                        namespace=namespace, label_selector=pod_selector
-                    )
 
-                    for pod in pods_list.items:
-                        pod_name = pod.metadata.name
+                    self.logger.info(f"Started following logs for {pod_name}")
+                    read_pod_logs.run()
+                    pod_log_streams[pod_name] = 1
 
-                        # Can't start logs when phase is pending
-                        if pod.status.phase == "Pending":
-                            continue
-                        if pod_name in pod_log_streams:
-                            continue
-
-                        read_pod_logs = ReadNamespacedPodLogs(
-                            pod_name=pod_name,
-                            namespace=namespace,
-                            kubernetes_api_key_secret=kubernetes_api_key_secret,
-                            on_log_entry=lambda log: func_log(f"{pod_name}: {log}"),
-                        )
-
-                        self.logger.info(f"Started following logs for {pod_name}")
-                        pod_log_streams[pod_name] = pool.submit(read_pod_logs.run)
-
-                if job.status.active:
-                    time.sleep(job_status_poll_interval)
-                elif job.status.failed:
-                    raise signals.FAIL(
-                        f"Job {job_name} failed, check Kubernetes pod logs for more information."
-                    )
-                elif job.status.succeeded:
-                    self.logger.info(f"Job {job_name} has been completed.")
-                    break
-
-            if delete_job_after_completion:
-                api_client_job.delete_namespaced_job(
-                    name=job_name,
-                    namespace=namespace,
-                    body=client.V1DeleteOptions(propagation_policy="Foreground"),
+            if job.status.active:
+                time.sleep(job_status_poll_interval)
+            elif job.status.failed:
+                raise signals.FAIL(
+                    f"Job {job_name} failed, check Kubernetes pod logs for more information."
                 )
-                self.logger.info(f"Job {job_name} has been deleted.")
+            elif job.status.succeeded:
+                self.logger.info(f"Job {job_name} has been completed.")
+                break
+
+        if delete_job_after_completion:
+            api_client_job.delete_namespaced_job(
+                name=job_name,
+                namespace=namespace,
+                body=client.V1DeleteOptions(propagation_policy="Foreground"),
+            )
+            self.logger.info(f"Job {job_name} has been deleted.")


### PR DESCRIPTION
## Summary
The current `RunNamespacedJob` logging function on UI is broken as reported in issue: #4675 .

As described from [user @arodus's analysis](https://github.com/PrefectHQ/prefect/issues/4675#issuecomment-869378484), the issue is because of the missing context for the `ReadNamespacedPodLogs` task running from the Flow. 

I removed the `with ThreadPoolExecutor() as pool:` method from it and tested in our project, the logging function is working as expected now:

![image](https://user-images.githubusercontent.com/12002662/138338175-65c54316-8ea6-4e5f-bb0d-85dae84964bc.png)

## Importance
Blocking users from using `RunNamespacedJob` to properly log the k8s pods output. 


## Checklist

This PR:

- [ ] adds new tests (if appropriate) 
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)