### PR TITLE
update bigquery dependency to support version 2.0

### DIFF
--- a/changes/pr5084.yaml
+++ b/changes/pr5084.yaml
@@ -1,5 +1,5 @@
-fix:
-  - "Allow developers on more recent versions of google-cloud-bigquery to also use the prefect GCP extra. - [#5084](https://github.com/PrefectHQ/prefect/pull/5084)"
+enhancement:
+  - "Bump maximum `google-cloud-bigquery` version to support 2.x - [#5084](https://github.com/PrefectHQ/prefect/pull/5084)"
 
 contributor:
   - "[Josh Wang](https;//github.com/wangjoshuah)"

--- a/changes/pr5084.yaml
+++ b/changes/pr5084.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Allow developers on more recent versions of google-cloud-bigquery to also use the prefect GCP extra. - [#5084](https://github.com/PrefectHQ/prefect/pull/5084)"
+
+contributor:
+  - "[Josh Wang](https;//github.com/wangjoshuah)"

--- a/setup.py
+++ b/setup.py
@@ -58,14 +58,14 @@ extras = {
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],
     "gcp": [
-        "google-cloud-bigquery >= 1.6.0, < 2.0",
+        "google-cloud-bigquery >= 1.6.0",
     ]
     + orchestration_extras["gcp"],
     "git": orchestration_extras["git"],
     "github": orchestration_extras["github"],
     "gitlab": orchestration_extras["gitlab"],
     "google": [
-        "google-cloud-bigquery >= 1.6.0, < 2.0",
+        "google-cloud-bigquery >= 1.6.0",
     ]
     + orchestration_extras["gcp"],
     "gsheets": ["gspread >= 3.6.0"],

--- a/setup.py
+++ b/setup.py
@@ -58,14 +58,14 @@ extras = {
     "dropbox": ["dropbox ~= 9.0"],
     "ge": ["great_expectations >= 0.11.1"],
     "gcp": [
-        "google-cloud-bigquery >= 1.6.0",
+        "google-cloud-bigquery >= 1.6.0, < 3.0",
     ]
     + orchestration_extras["gcp"],
     "git": orchestration_extras["git"],
     "github": orchestration_extras["github"],
     "gitlab": orchestration_extras["gitlab"],
     "google": [
-        "google-cloud-bigquery >= 1.6.0",
+        "google-cloud-bigquery >= 1.6.0, < 3.0",
     ]
     + orchestration_extras["gcp"],
     "gsheets": ["gspread >= 3.6.0"],


### PR DESCRIPTION
## Summary
Remove constraint on bigquery dependency that it must be below version 2.0.



## Changes
My project is now using a newer (2.x) version of Biquery and is incompatible with the constraints in prefect's setup.py if I want the GCP extra.

No APIs need to be changed according to the migration guide since we are not using any removed/deprecated items. 
https://googleapis.dev/python/bigquery/latest/UPGRADING.html


## Importance
Other users probably have encountered this issue or will likely encounter it. The 2.x google bigquery library has been out since September 2020. https://pypi.org/project/google-cloud-bigquery/#history 




## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)