### PR TITLE
Add clarification about default secrets

### DIFF
--- a/docs/core/concepts/secrets.md
+++ b/docs/core/concepts/secrets.md
@@ -68,7 +68,7 @@ For Cloud users, if the secret is not found in local context and `config.cloud.u
 
 ## Default Secrets
 
-A few common secrets, such as authentication keys for GCP or AWS, have a standard naming convention as Prefect secrets for use by the Prefect pipeline or tasks in Prefect's task library. If you follow this naming convention when storing your secrets, all supported Prefect interactions with those services will be automatically configured.
+A few common secrets, such as authentication keys for GCP or AWS, have a standard naming convention as Prefect secrets for use by the Prefect pipeline or tasks in Prefect's task library. If you follow this naming convention when storing your secrets in Local Context or Environment Variables, all supported Prefect interactions with those services will be automatically configured.
 
 The following is a list of the default names and contents of Prefect Secrets that, if set and declared, can be used to automatically authenticate your flow with the listed service:
 

--- a/docs/core/concepts/secrets.md
+++ b/docs/core/concepts/secrets.md
@@ -68,7 +68,7 @@ For Cloud users, if the secret is not found in local context and `config.cloud.u
 
 ## Default Secrets
 
-A few common secrets, such as authentication keys for GCP or AWS, have a standard naming convention as Prefect secrets for use by the Prefect pipeline or tasks in Prefect's task library. If you follow this naming convention when storing your secrets in Local Context or Environment Variables, all supported Prefect interactions with those services will be automatically configured.
+A few common secrets, such as authentication keys for GCP or AWS, have a standard naming convention as Prefect secrets for use by the Prefect pipeline or tasks in Prefect's task library. If you follow this naming convention when storing your secrets in local context or environment variables, all supported Prefect interactions with those services will be automatically configured.
 
 The following is a list of the default names and contents of Prefect Secrets that, if set and declared, can be used to automatically authenticate your flow with the listed service:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Based on https://github.com/PrefectHQ/prefect/blob/57dbb113114603a743bec2fc407307336a9f2385/src/prefect/storage/github.py#L159-L166, it seems to me that Default Secrets can only come from locally configured settings, not from Cloud Secrets. This updates the documentation to reflect that.


## Changes



## Importance
Clarify where Default Secrets can come from, to try to avoid confusion



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)