### PR TITLE
Allow `Azure` storage to overwrite existing blobs

### DIFF
--- a/changes/pr5103.yaml
+++ b/changes/pr5103.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow `Azure` flow storage to overwrite existing blobs - (https://github.com/PrefectHQ/prefect/pull/5103)"

--- a/src/prefect/storage/azure.py
+++ b/src/prefect/storage/azure.py
@@ -35,6 +35,8 @@ class Azure(Storage):
             `AZURE_STORAGE_CONNECTION_STRING` will be used
         - blob_name (str, optional): a unique key to use for uploading this Flow to Azure. This
             is only useful when storing a single Flow using this storage object.
+        - overwrite (bool, optional): if set, an existing blob with the same name will be overwritten.
+            By default, an error will be thrown if the blob already exists.
         - stored_as_script (bool, optional): boolean for specifying if the flow has been stored
             as a `.py` file. Defaults to `False`
         - **kwargs (Any, optional): any additional `Storage` initialization options
@@ -45,12 +47,14 @@ class Azure(Storage):
         container: str,
         connection_string_secret: str = None,
         blob_name: str = None,
+        overwrite: bool = False,
         stored_as_script: bool = False,
         **kwargs: Any
     ) -> None:
         self.container = container
         self.connection_string_secret = connection_string_secret
         self.blob_name = blob_name
+        self.overwrite = overwrite
 
         result = AzureResult(
             connection_string_secret=self.connection_string_secret,
@@ -148,7 +152,7 @@ class Azure(Storage):
                 "Uploading {} to {}".format(self.flows[flow_name], self.container)
             )
 
-            client.upload_blob(data)
+            client.upload_blob(data, overwrite=self.overwrite)
 
         return self
 

--- a/tests/backend/test_execution.py
+++ b/tests/backend/test_execution.py
@@ -233,6 +233,7 @@ def test_generate_flow_run_environ():
     }
 
 
+@pytest.mark.flaky
 class TestWaitForFlowRunStartTime:
     @pytest.fixture()
     def timing_mocks(self, monkeypatch):
@@ -316,7 +317,6 @@ class TestWaitForFlowRunStartTime:
         # Did not sleep
         timing_mocks.sleep.assert_not_called()
 
-    @pytest.mark.flaky
     def test_task_run_is_scheduled_in_the_past(self, timing_mocks):
         timing_mocks.get_flow_run_scheduled_start_time.return_value = None
         timing_mocks.get_next_task_run_start_time.return_value = (

--- a/tests/storage/test_azure_storage.py
+++ b/tests/storage/test_azure_storage.py
@@ -145,7 +145,7 @@ def test_upload_flow_to_azure_blob_overwrite(monkeypatch, overwrite):
     assert storage.add_flow(f)
     assert storage.build()
 
-    client.upload.assert_called_once_with(flow_to_bytes_pickle(f), overwite=overwrite)
+    client.upload_blob.assert_called_once_with(flow_to_bytes_pickle(f), overwite=overwrite)
 
 
 def test_upload_multiple_flows_to_azure_blob_name(monkeypatch):

--- a/tests/storage/test_azure_storage.py
+++ b/tests/storage/test_azure_storage.py
@@ -133,7 +133,7 @@ def test_upload_flow_to_azure_blob_name(monkeypatch):
     assert service.get_blob_client.call_args[1]["blob"] == "name"
 
 
-@pytest.mark.parameterize("overwrite", [True, False])
+@pytest.mark.parametrize("overwrite", [True, False])
 def test_upload_flow_to_azure_blob_overwrite(monkeypatch, overwrite):
     client = MagicMock(upload_blob=MagicMock())
     service = MagicMock(get_blob_client=MagicMock(return_value=client))

--- a/tests/storage/test_azure_storage.py
+++ b/tests/storage/test_azure_storage.py
@@ -1,3 +1,4 @@
+import unittest.mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -145,7 +146,7 @@ def test_upload_flow_to_azure_blob_overwrite(monkeypatch, overwrite):
     assert storage.add_flow(f)
     assert storage.build()
 
-    client.upload_blob.assert_called_once_with(flow_to_bytes_pickle(f), overwite=overwrite)
+    client.upload_blob.assert_called_once_with(unittest.mock.ANY, overwite=overwrite)
 
 
 def test_upload_multiple_flows_to_azure_blob_name(monkeypatch):

--- a/tests/storage/test_azure_storage.py
+++ b/tests/storage/test_azure_storage.py
@@ -146,7 +146,7 @@ def test_upload_flow_to_azure_blob_overwrite(monkeypatch, overwrite):
     assert storage.add_flow(f)
     assert storage.build()
 
-    client.upload_blob.assert_called_once_with(unittest.mock.ANY, overwite=overwrite)
+    client.upload_blob.assert_called_once_with(unittest.mock.ANY, overwrite=overwrite)
 
 
 def test_upload_multiple_flows_to_azure_blob_name(monkeypatch):

--- a/tests/storage/test_azure_storage.py
+++ b/tests/storage/test_azure_storage.py
@@ -4,6 +4,7 @@ import pytest
 
 from prefect import Flow, context
 from prefect.storage import Azure
+from prefect.utilities.storage import flow_to_bytes_pickle
 
 pytest.importorskip("azure.storage.blob")
 
@@ -113,7 +114,7 @@ def test_upload_flow_to_azure(monkeypatch):
     assert f.name not in storage
     assert storage.add_flow(f)
     assert storage.build()
-    assert client.upload_blob.called
+    client.upload_blob.assert_called_once_with(flow_to_bytes_pickle(f), overwrite=False)
     assert f.name in storage
 
 
@@ -130,6 +131,21 @@ def test_upload_flow_to_azure_blob_name(monkeypatch):
 
     assert service.get_blob_client.call_args[1]["container"] == "container"
     assert service.get_blob_client.call_args[1]["blob"] == "name"
+
+
+@pytest.mark.parameterize("overwrite", [True, False])
+def test_upload_flow_to_azure_blob_overwrite(monkeypatch, overwrite):
+    client = MagicMock(upload_blob=MagicMock())
+    service = MagicMock(get_blob_client=MagicMock(return_value=client))
+    monkeypatch.setattr("prefect.storage.Azure._azure_block_blob_service", service)
+
+    storage = Azure(container="container", overwrite=overwrite)
+
+    f = Flow("test")
+    assert storage.add_flow(f)
+    assert storage.build()
+
+    client.upload.assert_called_once_with(flow_to_bytes_pickle(f), overwite=overwrite)
 
 
 def test_upload_multiple_flows_to_azure_blob_name(monkeypatch):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Azure storage will fail if a blob already exists, however if setting a blob name manually you generally want to overwrite the existing blob instead of failing. This PR adds that option.


## Changes
<!-- What does this PR change? -->

- `overwrite: bool = False` is added to the `Azure` storage config


## Importance
<!-- Why is this PR important? -->

Allows `blob_name` use in non-trivial cases.

Closes #4618 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)