### PR TITLE
Fix load of serialized flows with bad edge task schemas

### DIFF
--- a/src/prefect/serialization/edge.py
+++ b/src/prefect/serialization/edge.py
@@ -1,4 +1,4 @@
-from marshmallow import fields
+from marshmallow import fields, pre_load
 
 import prefect
 from prefect.serialization.task import TaskSchema
@@ -8,6 +8,16 @@ from prefect.utilities.serialization import ObjectSchema
 class EdgeSchema(ObjectSchema):
     class Meta:
         object_class = lambda: prefect.core.Edge
+
+    @pre_load(pass_many=True)
+    def drop_edges_with_bad_task_schemas(self, data, **kwargs):
+        new_data = []
+        for seredge in data:
+            if isinstance(seredge["upstream_task"], dict) and isinstance(
+                seredge["downstream_task"], dict
+            ):
+                new_data.append(seredge)
+        return new_data
 
     upstream_task = fields.Nested(TaskSchema, only=["slug"])
     downstream_task = fields.Nested(TaskSchema, only=["slug"])

--- a/src/prefect/serialization/edge.py
+++ b/src/prefect/serialization/edge.py
@@ -10,14 +10,18 @@ class EdgeSchema(ObjectSchema):
         object_class = lambda: prefect.core.Edge
 
     @pre_load(pass_many=True)
-    def drop_edges_with_bad_task_schemas(self, data, **kwargs):
-        new_data = []
+    def cast_task_slug_strings_to_task_schema_dicts(self, data, **kwargs):
         for seredge in data:
-            if isinstance(seredge["upstream_task"], dict) and isinstance(
-                seredge["downstream_task"], dict
-            ):
-                new_data.append(seredge)
-        return new_data
+            if not isinstance(seredge, dict):
+                continue
+            upstream_task = seredge.get("upstream_task")
+            downstream_task = seredge.get("downstream_task")
+            if isinstance(upstream_task, str):
+                seredge["upstream_task"] = {"slug": upstream_task}
+            if isinstance(upstream_task, str):
+                seredge["downstream_task"] = {"slug": downstream_task}
+
+        return data
 
     upstream_task = fields.Nested(TaskSchema, only=["slug"])
     downstream_task = fields.Nested(TaskSchema, only=["slug"])


### PR DESCRIPTION
Changes in #4930 resulted in dropping tasks/edges from the serialized flow stored in the backend. This caused the `FlowView` to break in some cases (https://github.com/PrefectHQ/prefect/issues/4957). The serialized flow was reconstructed in the backend in https://github.com/PrefectHQ/server/pull/306 but somehow the duplicate edges have bad data in the `upstream_task` and `downstream_task` fields, just containing a `slug` string and not a `{"slug": slug}` dict.

This attempts to fix this by updating task schemas that are just strings within edge schemas to be in a slug dictionary format. This may be better resolved in the backend.