### PR TITLE
Add padding to code blocks to remove scroll bar

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -476,7 +476,7 @@ pre.vue-container
         border-radius: 0.5em
         border: solid 0.125em color-grey-border
         margin: 0.85rem 0
-        padding: 1.25rem 1.5rem
+        padding: 1.5rem 1.5rem
 
         code,
         code{lang}


### PR DESCRIPTION
## Summary
Increase vertical padding on code blocks in the [docs](https://docs.prefect.io/) from `1.25rem` to `1.5rem` to stop a scroll bar from appearing.

## Changes
Before:
![before](https://user-images.githubusercontent.com/19817302/140103803-926489f5-02cc-40f0-956d-63a258a14a3f.png)

After:
![after](https://user-images.githubusercontent.com/19817302/140103875-7b08a527-4700-4882-a268-41bd0270207e.png)

## Importance
Not very important.

## Checklist
This PR:
- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)