### PR TITLE
Update the `FlowView` to be more robust to serialized flow changes in the backend

### DIFF
--- a/changes/pr5116.yaml
+++ b/changes/pr5116.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Update the `FlowView` to be more robust to serialized flow changes in the backend"

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -27,8 +27,6 @@ class FlowView:
 
     Args:
         - flow_id: The uuid of the flow
-        - flow: A deserialized copy of the flow. This is not loaded from storage, so
-             tasks will not be runnable but the DAG can be explored.
         - settings: A dict of flow settings
         - run_config: A dict representation of the flow's run configuration
         - serialized_flow: A serialized copy of the flow

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -1,6 +1,8 @@
 from typing import List, Dict, Any
 from dataclasses import dataclass
 
+import marshmallow
+
 import prefect
 from prefect.run_configs.base import RunConfig
 from prefect.serialization.flow import FlowSchema
@@ -39,7 +41,6 @@ class FlowView:
     """
 
     flow_id: str
-    flow: "prefect.Flow"
     settings: dict
     run_config: RunConfig
     serialized_flow: dict
@@ -49,6 +50,21 @@ class FlowView:
     storage: prefect.storage.Storage
     name: str
     flow_group_labels: List[str]
+
+    @property
+    def flow(self) -> "prefect.Flow":
+        """
+        Deserialize the flow from the backend into a 'Flow' object.
+
+        The deserialized flow is not expected to contain all of the same data as the flow
+        object that was originally registered. The backend is free to manipulate the
+        serialized flow for optimization.
+        """
+        # Perform this deserialization lazily (in a property) because it is more likely
+        # to fail and we do not want to break the entire view because of bad flow data
+        return FlowSchema().load(
+            data=self.serialized_flow, partial=True, unknown=marshmallow.EXCLUDE
+        )
 
     @classmethod
     def _from_flow_data(cls, flow_data: dict, **kwargs: Any) -> "FlowView":
@@ -68,7 +84,6 @@ class FlowView:
         flow_group_data = flow_data.pop("flow_group")
         flow_group_labels = flow_group_data["labels"]
         project_name = flow_data.pop("project")["name"]
-        deserialized_flow = FlowSchema().load(data=flow_data["serialized_flow"])
         storage = StorageSchema().load(flow_data.pop("storage"))
         run_config = RunConfigSchema().load(flow_data.pop("run_config"))
 
@@ -77,7 +92,6 @@ class FlowView:
             **dict(
                 flow_id=flow_id,
                 project_name=project_name,
-                flow=deserialized_flow,
                 storage=storage,
                 flow_group_labels=flow_group_labels,
                 run_config=run_config,

--- a/tests/backend/test_flow.py
+++ b/tests/backend/test_flow.py
@@ -171,3 +171,12 @@ def test_flow_view_from_flow_group_id_where_and_order_clauses(monkeypatch):
         in post.call_args[1]["params"]["query"]
     )
     assert "order_by: { created: desc }" in post.call_args[1]["params"]["query"]
+
+
+def test_flow_view_handles_extra_and_missing_fields_in_serialized_flows():
+    flow_data = FLOW_DATA_1.copy()
+    serialized = flow_data["serialized_flow"]
+    serialized["extra_field"] = "foo"  # extra data
+    serialized.pop("parameters")  # missing data
+    flow_view = FlowView._from_flow_data(flow_data)
+    assert isinstance(flow_view.flow, Flow)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -29,7 +29,6 @@ TEST_FLOW_VIEW = FlowView(
     name="flow-name",
     settings={"key": "value"},
     run_config=UniversalRun(env={"ENV": "VAL"}),
-    flow=Flow("flow"),
     serialized_flow=Flow("flow").serialize(),
     archived=False,
     project_name="project",


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Because the backend can manipulate the serialized flow for optimization reasons (#4930) and the `FlowView` eagerly deserialized the data, we encountered full breaking changes everywhere a `FlowView` was used (https://github.com/PrefectHQ/server/pull/309, https://github.com/PrefectHQ/prefect/issues/4957). Here, the `FlowView` only deserializes the flow when requested and allows some bad data. A disclaimer has been added to the docstring.


## Changes
<!-- What does this PR change? -->

- Adds `FlowView.flow` property instead of deserializing at init time

## Importance
<!-- Why is this PR important? -->

`FlowView` is used in things like the CLI and shouldn't break entirely because the serialized flow doesn't load correctly.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)