### PR TITLE
Move artifacts functions to `prefect.backend.artifacts`

### DIFF
--- a/changes/pr5117.yaml
+++ b/changes/pr5117.yaml
@@ -1,0 +1,2 @@
+deprecation:
+  - "Move artifacts functions to `prefect.backend.artifacts` - [#5117](https://github.com/PrefectHQ/prefect/pull/5117)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -165,11 +165,6 @@ module.exports = {
           children: getChildren('docs/api/latest', 'agent')
         },
         {
-          title: 'prefect.artifacts',
-          collapsable: true,
-          children: getChildren('docs/api/latest', 'artifacts')
-        },
-        {
           title: 'prefect.utilities',
           collapsable: true,
           children: getChildren('docs/api/latest', 'utilities')

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -17,6 +17,17 @@ functions = [
     "some_successful",
 ]
 
+[pages.backend.artifacts]
+title = "Artifacts"
+module = "prefect.backend.artifacts"
+functions = [
+    "create_link_artifact",
+    "update_link_artifact",
+    "create_markdown_artifact",
+    "update_markdown_artifact",
+    "delete_artifact"
+]
+
 [pages.backend.flow]
 title = "Flow"
 module = "prefect.backend.flow"
@@ -654,18 +665,6 @@ classes = {ECSAgent = ["start"]}
 title = "Vertex Agent"
 module = "prefect.agent.vertex"
 classes = {VertexAgent = ["start"]}
-
-[pages.artifacts.artifacts]
-title = "Artifacts"
-module = "prefect.artifacts"
-functions = [
-    "create_link",
-    "update_link",
-    "create_markdown",
-    "update_markdown",
-    "delete_artifact"
-]
-experimental = true
 
 [pages.utilities.collections]
 title = "Collections"

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -11,7 +11,6 @@ import prefect.environments
 import prefect.storage
 import prefect.executors
 import prefect.engine.executors  # deprecated
-import prefect.artifacts
 
 from prefect.core import Task, Flow, Parameter
 import prefect.engine
@@ -25,6 +24,7 @@ from prefect.utilities.edges import mapped, unmapped, flatten
 import prefect.serialization
 import prefect.agent
 import prefect.backend
+import prefect.artifacts
 
 from ._version import get_versions
 

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -1,40 +1,13 @@
-import time
+import warnings
 from typing import Optional
 
-from prefect import context, Client
-from prefect.exceptions import ClientError
-
-
-def _running_with_backend() -> bool:
-    """
-    Determine if running in context of a backend. This is always true when running
-    using the `CloudTaskRunner`.
-
-    Returns:
-        - bool: if `_running_with_backend` is set in context
-    """
-    return bool(context.get("running_with_backend"))
-
-
-def _create_task_run_artifact(kind: str, data: dict) -> str:
-    client = Client()
-    task_run_id = context.get("task_run_id")
-    # XXX: there's a race condition in the cloud backend for mapped tasks where
-    # the task run lookup might fail temporarily. This should last a few
-    # seconds max, for now we retry a few times.
-    retries = 5
-    while True:
-        try:
-            return client.create_task_run_artifact(
-                task_run_id=task_run_id, kind=kind, data=data
-            )
-        except ClientError as exc:
-            # If it's a not found error and we still have retries left, retry
-            if "not found" in str(exc).lower() and retries:
-                time.sleep(1)
-                retries -= 1
-                continue
-            raise
+from prefect.backend import (
+    create_link_artifact,
+    create_markdown_artifact,
+    delete_artifact as delete_artifact_new,
+    update_link_artifact,
+    update_markdown_artifact,
+)
 
 
 def create_link(link: str) -> Optional[str]:
@@ -47,9 +20,11 @@ def create_link(link: str) -> Optional[str]:
     Returns:
         - str: the task run artifact ID
     """
-    if not _running_with_backend():
-        return None
-    return _create_task_run_artifact("link", {"link": link})
+    warnings.warn(
+        "`prefect.artifacts.create_link` has been moved to `prefect.backend.create_link_artifact`. "
+        "Please update your imports. The old function will be removed in 1.0.0."
+    )
+    return create_link_artifact(link)
 
 
 def update_link(task_run_artifact_id: str, link: str) -> None:
@@ -61,13 +36,11 @@ def update_link(task_run_artifact_id: str, link: str) -> None:
         - task_run_artifact_id (str): the ID of an existing task run artifact
         - link (str): the new link to update the artifact with
     """
-    if not _running_with_backend():
-        return
-
-    client = Client()
-    client.update_task_run_artifact(
-        task_run_artifact_id=task_run_artifact_id, data={"link": link}
+    warnings.warn(
+        "`prefect.artifacts.update_link` has been moved to `prefect.backend.update_link_artifact`. "
+        "Please update your imports. The old function will be removed in 1.0.0."
     )
+    return update_link_artifact(task_run_artifact_id, link)
 
 
 def create_markdown(markdown: str) -> Optional[str]:
@@ -80,9 +53,11 @@ def create_markdown(markdown: str) -> Optional[str]:
     Returns:
         - str: the task run artifact ID
     """
-    if not _running_with_backend():
-        return None
-    return _create_task_run_artifact("markdown", {"markdown": markdown})
+    warnings.warn(
+        "`prefect.artifacts.create_markdown` has been moved to `prefect.backend.create_markdown_artifact`. "
+        "Please update your imports. The old function will be removed in 1.0.0."
+    )
+    return create_markdown_artifact(markdown)
 
 
 def update_markdown(task_run_artifact_id: str, markdown: str) -> None:
@@ -94,13 +69,11 @@ def update_markdown(task_run_artifact_id: str, markdown: str) -> None:
         - task_run_artifact_id (str): the ID of an existing task run artifact
         - markdown (str): the new markdown to update the artifact with
     """
-    if not _running_with_backend():
-        return
-
-    client = Client()
-    client.update_task_run_artifact(
-        task_run_artifact_id=task_run_artifact_id, data={"markdown": markdown}
+    warnings.warn(
+        "`prefect.artifacts.update_markdown` has been moved to `prefect.backend.update_markdown_artifact`. "
+        "Please update your imports. The old function will be removed in 1.0.0."
     )
+    return update_markdown_artifact(task_run_artifact_id, markdown)
 
 
 def delete_artifact(task_run_artifact_id: str) -> None:
@@ -110,8 +83,8 @@ def delete_artifact(task_run_artifact_id: str) -> None:
     Args:
         - task_run_artifact_id (str): the ID of an existing task run artifact
     """
-    if not _running_with_backend():
-        return
-
-    client = Client()
-    client.delete_task_run_artifact(task_run_artifact_id=task_run_artifact_id)
+    warnings.warn(
+        "`prefect.artifacts.delete_artifact` has been moved to `prefect.backend.delete_artifact`. "
+        "Please update your imports. The old function will be removed in 1.0.0."
+    )
+    return delete_artifact_new(task_run_artifact_id)

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -1,3 +1,6 @@
+"""
+The functions here have been moved to `prefect.backend.artifacts`
+"""
 import warnings
 from typing import Optional
 

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -26,7 +26,7 @@ def create_link(link: str) -> Optional[str]:
     """
     warnings.warn(
         "`prefect.artifacts.create_link` has been moved to `prefect.backend.create_link_artifact`. "
-        "Please update your imports. The old function will be removed in 1.0.0."
+        "Please update your imports. This import path will be removed in 1.0.0."
     )
     return create_link_artifact(link)
 

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -42,7 +42,7 @@ def update_link(task_run_artifact_id: str, link: str) -> None:
     """
     warnings.warn(
         "`prefect.artifacts.update_link` has been moved to `prefect.backend.update_link_artifact`. "
-        "Please update your imports. The old function will be removed in 1.0.0."
+        "Please update your imports. This import path will be removed in 1.0.0."
     )
     return update_link_artifact(task_run_artifact_id, link)
 
@@ -59,7 +59,7 @@ def create_markdown(markdown: str) -> Optional[str]:
     """
     warnings.warn(
         "`prefect.artifacts.create_markdown` has been moved to `prefect.backend.create_markdown_artifact`. "
-        "Please update your imports. The old function will be removed in 1.0.0."
+        "Please update your imports. This import path will be removed in 1.0.0."
     )
     return create_markdown_artifact(markdown)
 
@@ -75,7 +75,7 @@ def update_markdown(task_run_artifact_id: str, markdown: str) -> None:
     """
     warnings.warn(
         "`prefect.artifacts.update_markdown` has been moved to `prefect.backend.update_markdown_artifact`. "
-        "Please update your imports. The old function will be removed in 1.0.0."
+        "Please update your imports. This import path will be removed in 1.0.0."
     )
     return update_markdown_artifact(task_run_artifact_id, markdown)
 
@@ -89,6 +89,6 @@ def delete_artifact(task_run_artifact_id: str) -> None:
     """
     warnings.warn(
         "`prefect.artifacts.delete_artifact` has been moved to `prefect.backend.delete_artifact`. "
-        "Please update your imports. The old function will be removed in 1.0.0."
+        "Please update your imports. This import path will be removed in 1.0.0."
     )
     return delete_artifact_new(task_run_artifact_id)

--- a/src/prefect/artifacts.py
+++ b/src/prefect/artifacts.py
@@ -1,6 +1,7 @@
 """
 The functions here have been moved to `prefect.backend.artifacts`
 """
+# flake8: noqa
 import warnings
 from typing import Optional
 

--- a/src/prefect/backend/__init__.py
+++ b/src/prefect/backend/__init__.py
@@ -3,3 +3,10 @@ from prefect.backend.flow_run import FlowRunView
 from prefect.backend.flow import FlowView
 from prefect.backend.tenant import TenantView
 from prefect.backend.kv_store import set_key_value, get_key_value, delete_key, list_keys
+from prefect.backend.artifacts import (
+    create_link_artifact,
+    create_markdown_artifact,
+    delete_artifact,
+    update_link_artifact,
+    update_markdown_artifact,
+)

--- a/src/prefect/backend/artifacts.py
+++ b/src/prefect/backend/artifacts.py
@@ -11,7 +11,7 @@ def _running_with_backend() -> bool:
     using the `CloudTaskRunner`.
 
     Returns:
-        - bool: if `_running_with_backend` is set in context
+        - bool: if `running_with_backend` is set in context
     """
     return bool(prefect.context.get("running_with_backend"))
 

--- a/src/prefect/backend/artifacts.py
+++ b/src/prefect/backend/artifacts.py
@@ -1,0 +1,117 @@
+import time
+from typing import Optional
+
+import prefect
+from prefect.exceptions import ClientError
+
+
+def _running_with_backend() -> bool:
+    """
+    Determine if running in context of a backend. This is always true when running
+    using the `CloudTaskRunner`.
+
+    Returns:
+        - bool: if `_running_with_backend` is set in context
+    """
+    return bool(prefect.context.get("running_with_backend"))
+
+
+def _create_task_run_artifact(kind: str, data: dict) -> str:
+    client = prefect.Client()
+    task_run_id = prefect.context.get("task_run_id")
+    # XXX: there's a race condition in the cloud backend for mapped tasks where
+    # the task run lookup might fail temporarily. This should last a few
+    # seconds max, for now we retry a few times.
+    retries = 5
+    while True:
+        try:
+            return client.create_task_run_artifact(
+                task_run_id=task_run_id, kind=kind, data=data
+            )
+        except ClientError as exc:
+            # If it's a not found error and we still have retries left, retry
+            if "not found" in str(exc).lower() and retries:
+                time.sleep(1)
+                retries -= 1
+                continue
+            raise
+
+
+def create_link_artifact(link: str) -> Optional[str]:
+    """
+    Create a link artifact
+
+    Args:
+        - link (str): the link to post
+
+    Returns:
+        - str: the task run artifact ID
+    """
+    if not _running_with_backend():
+        return None
+    return _create_task_run_artifact("link", {"link": link})
+
+
+def update_link_artifact(task_run_artifact_id: str, link: str) -> None:
+    """
+    Update an existing link artifact. This function will replace the current link
+    artifact with the new link provided.
+
+    Args:
+        - task_run_artifact_id (str): the ID of an existing task run artifact
+        - link (str): the new link to update the artifact with
+    """
+    if not _running_with_backend():
+        return
+
+    client = prefect.Client()
+    client.update_task_run_artifact(
+        task_run_artifact_id=task_run_artifact_id, data={"link": link}
+    )
+
+
+def create_markdown_artifact(markdown: str) -> Optional[str]:
+    """
+    Create a markdown artifact
+
+    Args:
+        - markdown (str): the markdown to post
+
+    Returns:
+        - str: the task run artifact ID
+    """
+    if not _running_with_backend():
+        return None
+    return _create_task_run_artifact("markdown", {"markdown": markdown})
+
+
+def update_markdown_artifact(task_run_artifact_id: str, markdown: str) -> None:
+    """
+    Update an existing markdown artifact. This function will replace the current markdown
+    artifact with the new markdown provided.
+
+    Args:
+        - task_run_artifact_id (str): the ID of an existing task run artifact
+        - markdown (str): the new markdown to update the artifact with
+    """
+    if not _running_with_backend():
+        return
+
+    client = prefect.Client()
+    client.update_task_run_artifact(
+        task_run_artifact_id=task_run_artifact_id, data={"markdown": markdown}
+    )
+
+
+def delete_artifact(task_run_artifact_id: str) -> None:
+    """
+    Delete an existing artifact
+
+    Args:
+        - task_run_artifact_id (str): the ID of an existing task run artifact
+    """
+    if not _running_with_backend():
+        return
+
+    client = prefect.Client()
+    client.delete_task_run_artifact(task_run_artifact_id=task_run_artifact_id)

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import prefect
 from prefect import Task
-from prefect.artifacts import create_markdown
+from prefect.backend.artifacts import create_markdown_artifact
 
 from prefect.engine import signals
 from prefect.utilities.tasks import defaults_from_attrs
@@ -282,7 +282,7 @@ class RunGreatExpectationsValidation(Task):
                 )
             )
 
-            create_markdown(markdown_artifact)
+            create_markdown_artifact(markdown_artifact)
 
         if results.success is False:
             raise signals.FAIL(result=results)

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -50,7 +50,7 @@ from urllib.parse import urlparse
 
 import prefect
 from prefect import Client, Task, task
-from prefect.artifacts import create_link
+from prefect.backend.artifacts import create_link_artifact
 from prefect.backend.flow_run import FlowRunView, FlowView, watch_flow_run
 from prefect.client import Client
 from prefect.engine.signals import signal_from_state
@@ -429,7 +429,7 @@ class StartFlowRun(Task):
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
-        create_link(urlparse(run_link).path)
+        create_link_artifact(urlparse(run_link).path)
         self.logger.info(f"Flow Run: {run_link}")
 
         if not self.wait:

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -11,18 +11,17 @@ def client(monkeypatch):
         update_task_run_artifact=MagicMock(return_value=True),
         delete_task_run_artifact=MagicMock(return_value=True),
     )
-    monkeypatch.setattr("prefect.artifacts.Client", MagicMock(return_value=c))
+    monkeypatch.setattr("prefect.Client", MagicMock(return_value=c))
     yield c
 
 
-def test_running_with_backend():
-    with context(running_with_backend=False):
-        assert artifacts._running_with_backend() is False
-
-
-def test_create_link(client, running_with_backend):
+def test_old_create_link(client, running_with_backend):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_link(link="link_here")
+        with pytest.warns(
+            UserWarning,
+            match="has been moved to `prefect.backend.create_link_artifact`",
+        ):
+            artifact_id = artifacts.create_link(link="link_here")
         assert artifact_id == "id"
         assert client.create_task_run_artifact.called
         assert client.create_task_run_artifact.call_args[1] == {
@@ -32,15 +31,13 @@ def test_create_link(client, running_with_backend):
         }
 
 
-def test_create_link_not_using_backend(client):
-    with context(task_run_id="trid"):
-        artifact_id = artifacts.create_link(link="link_here")
-        assert artifact_id == None
-        assert not client.create_task_run_artifact.called
+def test_old_update_link(client, running_with_backend):
+    with pytest.warns(
+        UserWarning,
+        match="has been moved to `prefect.backend.update_link_artifact`",
+    ):
+        artifacts.update_link(task_run_artifact_id="trid", link="link_here")
 
-
-def test_update_link(client, running_with_backend):
-    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
     assert client.update_task_run_artifact.called
     assert client.update_task_run_artifact.call_args[1] == {
         "data": {"link": "link_here"},
@@ -48,14 +45,13 @@ def test_update_link(client, running_with_backend):
     }
 
 
-def test_update_link_not_using_backend(client):
-    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
-    assert not client.update_task_run_artifact.called
-
-
-def test_create_markdown(client, running_with_backend):
+def test_old_create_markdown(client, running_with_backend):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_markdown(markdown="markdown_here")
+        with pytest.warns(
+            UserWarning,
+            match="has been moved to `prefect.backend.create_markdown_artifact`",
+        ):
+            artifact_id = artifacts.create_markdown(markdown="markdown_here")
         assert artifact_id == "id"
         assert client.create_task_run_artifact.called
         assert client.create_task_run_artifact.call_args[1] == {
@@ -65,15 +61,12 @@ def test_create_markdown(client, running_with_backend):
         }
 
 
-def test_create_markdown_not_using_backend(client):
-    with context(task_run_id="trid"):
-        artifact_id = artifacts.create_markdown(markdown="markdown_here")
-        assert artifact_id == None
-        assert not client.create_task_run_artifact.called
-
-
-def test_update_markdown(client, running_with_backend):
-    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
+def test_old_update_markdown(client, running_with_backend):
+    with pytest.warns(
+        UserWarning,
+        match="has been moved to `prefect.backend.update_markdown_artifact`",
+    ):
+        artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
     assert client.update_task_run_artifact.called
     assert client.update_task_run_artifact.call_args[1] == {
         "data": {"markdown": "markdown_here"},
@@ -81,19 +74,13 @@ def test_update_markdown(client, running_with_backend):
     }
 
 
-def test_update_markdown_not_using_backend(client):
-    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
-    assert not client.update_task_run_artifact.called
-
-
-def test_delete_artifact(client, running_with_backend):
-    artifacts.delete_artifact(task_run_artifact_id="trid")
+def test_old_delete_artifact(client, running_with_backend):
+    with pytest.warns(
+        UserWarning,
+        match="has been moved to `prefect.backend.delete_artifact`",
+    ):
+        artifacts.delete_artifact(task_run_artifact_id="trid")
     assert client.delete_task_run_artifact.called
     assert client.delete_task_run_artifact.call_args[1] == {
         "task_run_artifact_id": "trid",
     }
-
-
-def test_delete_artifact_not_using_backend(client):
-    artifacts.delete_artifact(task_run_artifact_id="trid")
-    assert not client.delete_task_run_artifact.called

--- a/tests/backend/test_artifacts.py
+++ b/tests/backend/test_artifacts.py
@@ -12,7 +12,7 @@ def client(monkeypatch):
         update_task_run_artifact=MagicMock(return_value=True),
         delete_task_run_artifact=MagicMock(return_value=True),
     )
-    monkeypatch.setattr("prefect.artifacts.Client", MagicMock(return_value=c))
+    monkeypatch.setattr("prefect.Client", MagicMock(return_value=c))
     yield c
 
 
@@ -21,9 +21,9 @@ def test_running_with_backend():
         assert artifacts._running_with_backend() is False
 
 
-def test_create_link(client, running_with_backend):
+def test_create_link_artifact(client, running_with_backend):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_link(link="link_here")
+        artifact_id = artifacts.create_link_artifact(link="link_here")
         assert artifact_id == "id"
         assert client.create_task_run_artifact.called
         assert client.create_task_run_artifact.call_args[1] == {
@@ -33,15 +33,15 @@ def test_create_link(client, running_with_backend):
         }
 
 
-def test_create_link_not_using_backend(client):
+def test_create_link_artifact_not_using_backend(client):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_link(link="link_here")
+        artifact_id = artifacts.create_link_artifact(link="link_here")
         assert artifact_id == None
         assert not client.create_task_run_artifact.called
 
 
-def test_update_link(client, running_with_backend):
-    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
+def test_update_link_artifact(client, running_with_backend):
+    artifacts.update_link_artifact(task_run_artifact_id="trid", link="link_here")
     assert client.update_task_run_artifact.called
     assert client.update_task_run_artifact.call_args[1] == {
         "data": {"link": "link_here"},
@@ -49,14 +49,14 @@ def test_update_link(client, running_with_backend):
     }
 
 
-def test_update_link_not_using_backend(client):
-    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
+def test_update_link_artifact_not_using_backend(client):
+    artifacts.update_link_artifact(task_run_artifact_id="trid", link="link_here")
     assert not client.update_task_run_artifact.called
 
 
-def test_create_markdown(client, running_with_backend):
+def test_create_markdown_artifact(client, running_with_backend):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_markdown(markdown="markdown_here")
+        artifact_id = artifacts.create_markdown_artifact(markdown="markdown_here")
         assert artifact_id == "id"
         assert client.create_task_run_artifact.called
         assert client.create_task_run_artifact.call_args[1] == {
@@ -66,15 +66,17 @@ def test_create_markdown(client, running_with_backend):
         }
 
 
-def test_create_markdown_not_using_backend(client):
+def test_create_markdown_artifact_not_using_backend(client):
     with context(task_run_id="trid"):
-        artifact_id = artifacts.create_markdown(markdown="markdown_here")
+        artifact_id = artifacts.create_markdown_artifact(markdown="markdown_here")
         assert artifact_id == None
         assert not client.create_task_run_artifact.called
 
 
-def test_update_markdown(client, running_with_backend):
-    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
+def test_update_markdown_artifact(client, running_with_backend):
+    artifacts.update_markdown_artifact(
+        task_run_artifact_id="trid", markdown="markdown_here"
+    )
     assert client.update_task_run_artifact.called
     assert client.update_task_run_artifact.call_args[1] == {
         "data": {"markdown": "markdown_here"},
@@ -82,8 +84,10 @@ def test_update_markdown(client, running_with_backend):
     }
 
 
-def test_update_markdown_not_using_backend(client):
-    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
+def test_update_markdown_artifact_not_using_backend(client):
+    artifacts.update_markdown_artifact(
+        task_run_artifact_id="trid", markdown="markdown_here"
+    )
     assert not client.update_task_run_artifact.called
 
 

--- a/tests/backend/test_artifacts.py
+++ b/tests/backend/test_artifacts.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import MagicMock
+
+from prefect.backend import artifacts
+from prefect import context
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    c = MagicMock(
+        create_task_run_artifact=MagicMock(return_value="id"),
+        update_task_run_artifact=MagicMock(return_value=True),
+        delete_task_run_artifact=MagicMock(return_value=True),
+    )
+    monkeypatch.setattr("prefect.artifacts.Client", MagicMock(return_value=c))
+    yield c
+
+
+def test_running_with_backend():
+    with context(running_with_backend=False):
+        assert artifacts._running_with_backend() is False
+
+
+def test_create_link(client, running_with_backend):
+    with context(task_run_id="trid"):
+        artifact_id = artifacts.create_link(link="link_here")
+        assert artifact_id == "id"
+        assert client.create_task_run_artifact.called
+        assert client.create_task_run_artifact.call_args[1] == {
+            "data": {"link": "link_here"},
+            "kind": "link",
+            "task_run_id": "trid",
+        }
+
+
+def test_create_link_not_using_backend(client):
+    with context(task_run_id="trid"):
+        artifact_id = artifacts.create_link(link="link_here")
+        assert artifact_id == None
+        assert not client.create_task_run_artifact.called
+
+
+def test_update_link(client, running_with_backend):
+    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
+    assert client.update_task_run_artifact.called
+    assert client.update_task_run_artifact.call_args[1] == {
+        "data": {"link": "link_here"},
+        "task_run_artifact_id": "trid",
+    }
+
+
+def test_update_link_not_using_backend(client):
+    artifacts.update_link(task_run_artifact_id="trid", link="link_here")
+    assert not client.update_task_run_artifact.called
+
+
+def test_create_markdown(client, running_with_backend):
+    with context(task_run_id="trid"):
+        artifact_id = artifacts.create_markdown(markdown="markdown_here")
+        assert artifact_id == "id"
+        assert client.create_task_run_artifact.called
+        assert client.create_task_run_artifact.call_args[1] == {
+            "data": {"markdown": "markdown_here"},
+            "kind": "markdown",
+            "task_run_id": "trid",
+        }
+
+
+def test_create_markdown_not_using_backend(client):
+    with context(task_run_id="trid"):
+        artifact_id = artifacts.create_markdown(markdown="markdown_here")
+        assert artifact_id == None
+        assert not client.create_task_run_artifact.called
+
+
+def test_update_markdown(client, running_with_backend):
+    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
+    assert client.update_task_run_artifact.called
+    assert client.update_task_run_artifact.call_args[1] == {
+        "data": {"markdown": "markdown_here"},
+        "task_run_artifact_id": "trid",
+    }
+
+
+def test_update_markdown_not_using_backend(client):
+    artifacts.update_markdown(task_run_artifact_id="trid", markdown="markdown_here")
+    assert not client.update_task_run_artifact.called
+
+
+def test_delete_artifact(client, running_with_backend):
+    artifacts.delete_artifact(task_run_artifact_id="trid")
+    assert client.delete_task_run_artifact.called
+    assert client.delete_task_run_artifact.call_args[1] == {
+        "task_run_artifact_id": "trid",
+    }
+
+
+def test_delete_artifact_not_using_backend(client):
+    artifacts.delete_artifact(task_run_artifact_id="trid")
+    assert not client.delete_task_run_artifact.called

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -289,9 +289,7 @@ def client(monkeypatch):
     monkeypatch.setattr(
         "prefect.tasks.prefect.flow_run.Client", MagicMock(return_value=cloud_client)
     )
-    monkeypatch.setattr(
-        "prefect.artifacts.Client", MagicMock(return_value=cloud_client)
-    )
+    monkeypatch.setattr("prefect.Client", MagicMock(return_value=cloud_client))
     yield cloud_client
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

With the introduction of `prefect.backend` in `0.15.0`, there was an intention to move the existing `artifacts` API there. This matches the location of other backend-only specific features like the kv-store.


## Changes
<!-- What does this PR change? -->

- Adds warnings to old artifact functions
- Moves artifact functions to new module
- Adds `_artifact` suffix where needed to artifact create/update functions

## Importance
<!-- Why is this PR important? -->

The old artifacts location can be removed in #5113 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)