### PR TITLE
Documentation fixes: ECSRun ambiguities in IAM roles in the ECSRun docstring

### DIFF
--- a/changes/issue5110.yml
+++ b/changes/issue5110.yml
@@ -1,0 +1,2 @@
+fix:
+  - "Clarifying documentation, especially the ambiguities in setting IAM roles on the ECSRun" - [#5110](https://github.com/PrefectHQ/prefect/issues/5110)"

--- a/changes/issue5110.yml
+++ b/changes/issue5110.yml
@@ -1,2 +1,2 @@
 fix:
-  - "Clarifying documentation, especially the ambiguities in setting IAM roles on the ECSRun" - [#5110](https://github.com/PrefectHQ/prefect/issues/5110)"
+  - "Clarifying documentation, especially the ambiguities in setting IAM roles on the ECSRun - [#5110](https://github.com/PrefectHQ/prefect/issues/5110)"

--- a/docs/core/about_prefect/why-not-airflow.md
+++ b/docs/core/about_prefect/why-not-airflow.md
@@ -292,7 +292,7 @@ In Prefect Cloud, we have elevated versioned workflows to a first-class concept.
 - versioning automatically occurs when you deploy a flow to a Project that already contains a flow of the same name
 - when a flow is versioned, it gets an incremented version number and any prior versions are automatically archived (which turns off automatic scheduling)
 
-Both of these settings can be customized if you have more complicated versioning requirements. For example, you could specify that any flow is a version of any other flow, regardless of name or project. You could override the automatic version promotion to unarchive and enable old versions (for example, for A/B testing). Or you could use versioning to maintain a history of your workflow without polluting your UI.
+Both of these settings can be customized if you have more complicated versioning requirements. For more information, visit the [Versioning documentation](/orchestration/concepts/flows.html#versioning).
 
 ## Local Testing
 

--- a/docs/core/about_prefect/why-not-airflow.md
+++ b/docs/core/about_prefect/why-not-airflow.md
@@ -292,7 +292,7 @@ In Prefect Cloud, we have elevated versioned workflows to a first-class concept.
 - versioning automatically occurs when you deploy a flow to a Project that already contains a flow of the same name
 - when a flow is versioned, it gets an incremented version number and any prior versions are automatically archived (which turns off automatic scheduling)
 
-Both of these settings can be customized if you have more complicated versioning requirements. For more information, visit the [Versioning documentation](/orchestration/concepts/flows.html#versioning).
+Both of these settings can be customized if you have more complicated versioning requirements. For more information, see the documentation for [Flow Versioning](/orchestration/concepts/flows.html#versioning).
 
 ## Local Testing
 

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -109,7 +109,7 @@ class LocalAgent(Agent):
 
     def deploy_flow(self, flow_run: GraphQLResult) -> str:
         """
-        Deploy flow runs on your local machine as Docker containers
+        Deploy flow runs on your local machine as subprocesses
 
         Args:
             - flow_run (GraphQLResult): A GraphQLResult flow run object

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -31,27 +31,27 @@ class ECSRun(RunConfig):
             directly in Prefect Cloud/Server - use `task_definition_path`
             instead if you wish to avoid this.
         - task_definition_path (str, optional): Path to a task definition spec
-            to use. If you started your agent in a local process (with 
-            `prefect agent ecs start --label your-label`), then you can reference a path 
-            on that machine (use either no file scheme, or a `file`/`local` scheme). 
-            The task definition will then be loaded on initialization 
+            to use. If you started your agent in a local process (with
+            `prefect agent ecs start --label your-label`), then you can reference a path
+            on that machine (use either no file scheme, or a `file`/`local` scheme).
+            The task definition will then be loaded on initialization
             and stored on the `ECSRun` object as the `task_definition` field.
             Otherwise the task definition will be loaded at runtime on the
             agent.  Supported runtime file schemes include `s3`, `gcs`, and
-            `agent` (for paths local to the runtime agent). 
+            `agent` (for paths local to the runtime agent).
         - task_definition_arn (str, optional): A pre-registered task definition
             ARN to use (either `family:revision`, or a full task
             definition ARN). This task definition must include a container
-            named `flow` (which will be used to run the flow). 
+            named `flow` (which will be used to run the flow).
         - image (str, optional): The image to use for this task. If not
             provided, will be either inferred from the flow's storage (if using
-            `Docker` storage), or use the default configured on the agent. Note that 
-            when using an ECR image, you need to explicitly provide the 
-            `execution_role_arn`, unless you set this role explicitly in a custom `task_definition`. 
-            This means: either you provide a custom `task_definition` that contains 
-            both the image and `execution_role_arn` (with ECR permissions), 
-            or you provide both a custom `image` and an `execution_role_arn` 
-            simultaneously. 
+            `Docker` storage), or use the default configured on the agent. Note that
+            when using an ECR image, you need to explicitly provide the
+            `execution_role_arn`, unless you set this role explicitly in a custom `task_definition`.
+            This means: either you provide a custom `task_definition` that contains
+            both the image and `execution_role_arn` (with ECR permissions),
+            or you provide both a custom `image` and an `execution_role_arn`
+            simultaneously.
         - env (dict, optional): Additional environment variables to set on the task.
         - cpu (int or str, optional): The amount of CPU available to the task. Can
             be ether an integer in CPU units (e.g. `1024`), or a string using
@@ -64,20 +64,20 @@ class ECSRun(RunConfig):
             what values this can take, see the [ECS documentation][2] for more
             information.
         - task_role_arn (str, optional): The full ARN of the IAM role
-            to use for this task. If you provide a custom `task_definition` that 
-            already contains the `task_role_arn`, then you can skip this argument. 
-            You can also skip it, when your flow doesn't need access to any AWS 
-            resources such as S3. But if you use S3 storage (or results) and you don't set 
+            to use for this task. If you provide a custom `task_definition` that
+            already contains the `task_role_arn`, then you can skip this argument.
+            You can also skip it, when your flow doesn't need access to any AWS
+            resources such as S3. But if you use S3 storage (or results) and you don't set
             a custom `task_definition`, this role must be set explicitly.
         - execution_role_arn (str, optional): The execution role ARN to use
-            when registering a task definition for this task. If you provide a custom 
-            `task_definition` that already contains the `execution_role_arn`, then you 
-            can skip this argument. But if you don't set any custom `task_definition`, 
-            and you supply an ECR `image`, then you need to set an `execution_role_arn` 
-            explicitly to grant ECR access. 
+            when registering a task definition for this task. If you provide a custom
+            `task_definition` that already contains the `execution_role_arn`, then you
+            can skip this argument. But if you don't set any custom `task_definition`,
+            and you supply an ECR `image`, then you need to set an `execution_role_arn`
+            explicitly to grant ECR access.
         - run_task_kwargs (dict, optional): Additional keyword arguments to
-            pass to `run_task` when starting this task. It should be used only for 
-            runtime-specific arguments such as `cpu`, `memory`, `cluster`, `launchType`, 
+            pass to `run_task` when starting this task. It should be used only for
+            runtime-specific arguments such as `cpu`, `memory`, `cluster`, `launchType`,
             rather than `task_definition`-specific arguments.
             See the [ECS.Client.run_task][3] docs for more information.
         - labels (Iterable[str], optional): An iterable of labels to apply to this
@@ -92,9 +92,9 @@ class ECSRun(RunConfig):
     flow.run_config = ECSRun(labels=["prod"])
     ```
 
-    2) Use a custom task definition uploaded to S3 as a YAML file. This task definition contains 
-    a container named "flow", as well as a custom execution role and task role. The flow should 
-    be picked up for execution by agent with label "prod" and should be deployed to a cluster 
+    2) Use a custom task definition uploaded to S3 as a YAML file. This task definition contains
+    a container named "flow", as well as a custom execution role and task role. The flow should
+    be picked up for execution by agent with label "prod" and should be deployed to a cluster
     called "prefectEcsCluster".
 
     ```python
@@ -133,20 +133,20 @@ class ECSRun(RunConfig):
             awslogs-create-group: "true"
     ```
 
-    3) Use a custom pre-registered task definition (referenced by `family:revision` 
+    3) Use a custom pre-registered task definition (referenced by `family:revision`
     or by a full ARN), then deploy the flow to a cluster called "prefectEcsCluster":
 
     ```python
     flow.run_config = ECSRun(
         labels=["prod"],
-        task_definition_arn="prefectFlow:1", 
-        # or using a full ARN: 
+        task_definition_arn="prefectFlow:1",
+        # or using a full ARN:
         # task_definition_arn="arn:aws:ecs:us-east-1:XXX:task-definition/prefectFlow:1"
         run_task_kwargs=dict(cluster="prefectEcsCluster"),
     )
     ```
 
-    4) Let Prefect register a new task definition for a flow with S3 storage and a custom 
+    4) Let Prefect register a new task definition for a flow with S3 storage and a custom
     ECR image:
 
     ```python
@@ -169,7 +169,7 @@ class ECSRun(RunConfig):
     )
     ```
 
-    6) Use an explicit task definition stored in S3 as a YAML file, 
+    6) Use an explicit task definition stored in S3 as a YAML file,
     but override the image and CPU:
 
     ```python
@@ -180,7 +180,7 @@ class ECSRun(RunConfig):
     )
     ```
 
-    7) An example flow showing ECSRun with a `task_definition` defined as dictionary, 
+    7) An example flow showing ECSRun with a `task_definition` defined as dictionary,
     and S3 storage:
     ```python
     import prefect

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -169,7 +169,7 @@ class ECSRun(RunConfig):
     )
     ```
 
-    6) Use an explicit task definition stored in S3 as YAML file, 
+    6) Use an explicit task definition stored in S3 as a YAML file, 
     but override the image and CPU:
 
     ```python
@@ -178,6 +178,56 @@ class ECSRun(RunConfig):
         image="XXXX.dkr.ecr.us-east-1.amazonaws.com/image_name:latest",
         cpu="2 vcpu",
     )
+    ```
+
+    7) An example flow showing ECSRun with a `task_definition` defined as dictionary, 
+    and S3 storage:
+    ```python
+    import prefect
+    from prefect.storage import S3
+    from prefect.run_configs import ECSRun
+    from prefect import task, Flow
+    from prefect.client.secrets import Secret
+
+
+    FLOW_NAME = "ecs_demo_ecr"
+    ACCOUNT_ID = Secret("AWS_ACCOUNT_ID").get()
+    STORAGE = S3(
+        bucket="prefect-datasets",
+        key=f"flows/{FLOW_NAME}.py",
+        stored_as_script=True,
+        local_script_path=f"{FLOW_NAME}.py",
+    )
+    RUN_CONFIG = ECSRun(
+        labels=["prod"],
+        task_definition=dict(
+            family=FLOW_NAME,
+            requiresCompatibilities=["FARGATE"],
+            networkMode="awsvpc",
+            cpu=1024,
+            memory=2048,
+            taskRoleArn=f"arn:aws:iam::{ACCOUNT_ID}:role/prefectTaskRole",
+            executionRoleArn=f"arn:aws:iam::{ACCOUNT_ID}:role/prefectECSAgentTaskExecutionRole",
+            containerDefinitions=[
+                dict(
+                    name="flow",
+                    image=f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/your_image_name:latest",
+                )
+            ],
+        ),
+        run_task_kwargs=dict(cluster="prefectEcsCluster"),
+    )
+
+
+    @task
+    def say_hi():
+        logger = prefect.context.get("logger")
+        logger.info("Hi from Prefect %s from flow %s", prefect.__version__, FLOW_NAME)
+
+
+    with Flow(FLOW_NAME, storage=STORAGE, run_config=RUN_CONFIG,) as flow:
+        say_hi()
+
     ```
 
     [1]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/\

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -86,60 +86,55 @@ class ECSRun(RunConfig):
 
     Examples:
 
-    Use the defaults set on the agent (assuming label "prod"):
+    1) Use the defaults set on the agent (assuming label "prod"):
 
     ```python
     flow.run_config = ECSRun(labels=["prod"])
     ```
 
-    Use a custom task definition uploaded to S3. This task definition contains a container 
-    named "flow", as well as a custom execution role and task role. The flow should be 
-    picked up for execution by agent with label "prod" and should be deployed to a cluster 
+    2) Use a custom task definition uploaded to S3 as a YAML file. This task definition contains 
+    a container named "flow", as well as a custom execution role and task role. The flow should 
+    be picked up for execution by agent with label "prod" and should be deployed to a cluster 
     called "prefectEcsCluster".
 
     ```python
     flow.run_config = ECSRun(
         labels=["prod"],
-        task_definition_path="s3://bucket/task_definition.json",
+        task_definition_path="s3://bucket/flow_task_definition.yaml",
         run_task_kwargs=dict(cluster="prefectEcsCluster"),
     )
     ```
 
-    Example of a task definition file `task_definition.json`:
-    ```json
-    {
-        "family": "prefectFlow",
-        "requiresCompatibilities": ["FARGATE"],
-        "networkMode": "awsvpc",
-        "cpu": "512",
-        "memory": "1024",
-        "taskRoleArn": "arn:aws:iam::XXXX:role/prefectTaskRole",
-        "executionRoleArn": "arn:aws:iam::XXXX:role/prefectECSAgentTaskExecutionRole",
-        "containerDefinitions": [
-            {
-                "name": "flow",
-                "image": "XXXX.dkr.ecr.us-east-1.amazonaws.com/image_name:latest",
-                "essential": true,
-                "environment": [
-                    {"name": "AWS_RETRY_MODE", "value": "adaptive"},
-                    {"name": "AWS_MAX_ATTEMPTS", "value": "10"}
-                ],
-                "logConfiguration": {
-                    "logDriver": "awslogs",
-                    "options": {
-                        "awslogs-group": "/ecs/prefectEcsAgent",
-                        "awslogs-region": "us-east-1",
-                        "awslogs-stream-prefix": "ecs",
-                        "awslogs-create-group": "true"
-                    }
-                }
-            }
-        ]
-    }
+    An example of `flow_task_definition.yaml`:
+    ```yaml
+    family: prefectFlow
+    requiresCompatibilities:
+        - FARGATE
+    networkMode: awsvpc
+    cpu: 1024
+    memory: 2048
+    taskRoleArn: arn:aws:iam::XXX:role/prefectTaskRole
+    executionRoleArn: arn:aws:iam::XXX:role/prefectECSAgentTaskExecutionRole
+    containerDefinitions:
+    - name: flow
+        image: "XXX.dkr.ecr.us-east-1.amazonaws.com/image_name:latest"
+        essential: true
+        environment:
+        - name: AWS_RETRY_MODE
+            value: "adaptive"
+        - name: AWS_MAX_ATTEMPTS
+            value: "10"
+        logConfiguration:
+        logDriver: awslogs
+        options:
+            awslogs-group: "/ecs/prefectEcsAgent"
+            awslogs-region: "us-east-1"
+            awslogs-stream-prefix: "ecs"
+            awslogs-create-group: "true"
     ```
 
-    Use a custom pre-registered task definition, then deploy the flow to a cluster called 
-    "prefectEcsCluster":
+    3) Use a custom pre-registered task definition (referenced by `family:revision` 
+    or by a full ARN), then deploy the flow to a cluster called "prefectEcsCluster":
 
     ```python
     flow.run_config = ECSRun(
@@ -151,7 +146,7 @@ class ECSRun(RunConfig):
     )
     ```
 
-    Let Prefect register a new task definition for a flow with S3 storage and a custom 
+    4) Let Prefect register a new task definition for a flow with S3 storage and a custom 
     ECR image:
 
     ```python
@@ -164,7 +159,7 @@ class ECSRun(RunConfig):
     )
     ```
 
-    Use the default task definition, but override the image and CPU:
+    5) Use the default task definition, but override the image and CPU:
 
     ```python
     flow.run_config = ECSRun(
@@ -174,11 +169,12 @@ class ECSRun(RunConfig):
     )
     ```
 
-    Use an explicit task definition stored in s3, but override the image and CPU:
+    6) Use an explicit task definition stored in S3 as YAML file, 
+    but override the image and CPU:
 
     ```python
     flow.run_config = ECSRun(
-        task_definition="s3://bucket/task_definition.json",
+        task_definition="s3://bucket/flow_task_definition.yaml",
         image="XXXX.dkr.ecr.us-east-1.amazonaws.com/image_name:latest",
         cpu="2 vcpu",
     )

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -193,7 +193,7 @@ class ECSRun(RunConfig):
     FLOW_NAME = "ecs_demo_ecr"
     ACCOUNT_ID = Secret("AWS_ACCOUNT_ID").get()
     STORAGE = S3(
-        bucket="prefect-datasets",
+        bucket="your_bucket_name",
         key=f"flows/{FLOW_NAME}.py",
         stored_as_script=True,
         local_script_path=f"{FLOW_NAME}.py",

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -40,7 +40,7 @@ class ECSRun(RunConfig):
             agent.  Supported runtime file schemes include `s3`, `gcs`, and
             `agent` (for paths local to the runtime agent). 
         - task_definition_arn (str, optional): A pre-registered task definition
-            ARN to use (either `family:version`, or a full task
+            ARN to use (either `family:revision`, or a full task
             definition ARN). This task definition must include a container
             named `flow` (which will be used to run the flow). 
         - image (str, optional): The image to use for this task. If not

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -77,7 +77,7 @@ class ECSRun(RunConfig):
             explicitly to grant ECR access.
         - run_task_kwargs (dict, optional): Additional keyword arguments to
             pass to `run_task` when starting this task. It should be used only for
-            runtime-specific arguments such as `cpu`, `memory`, `cluster`, `launchType`,
+            runtime-specific arguments such as `cpu`, `memory`, `cluster`, or `launchType`,
             rather than `task_definition`-specific arguments.
             See the [ECS.Client.run_task][3] docs for more information.
         - labels (Iterable[str], optional): An iterable of labels to apply to this

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -94,7 +94,7 @@ class ECSRun(RunConfig):
 
     2) Use a custom task definition uploaded to S3 as a YAML file. This task definition contains
     a container named "flow", as well as a custom execution role and task role. The flow should
-    be picked up for execution by agent with label "prod" and should be deployed to a cluster
+    be picked up for execution by an agent with label "prod" and should be deployed to a cluster
     called "prefectEcsCluster".
 
     ```python

--- a/src/prefect/run_configs/ecs.py
+++ b/src/prefect/run_configs/ecs.py
@@ -66,7 +66,7 @@ class ECSRun(RunConfig):
         - task_role_arn (str, optional): The full ARN of the IAM role
             to use for this task. If you provide a custom `task_definition` that
             already contains the `task_role_arn`, then you can skip this argument.
-            You can also skip it, when your flow doesn't need access to any AWS
+            You can also skip it when your flow doesn't need access to any AWS
             resources such as S3. But if you use S3 storage (or results) and you don't set
             a custom `task_definition`, this role must be set explicitly.
         - execution_role_arn (str, optional): The execution role ARN to use


### PR DESCRIPTION
## Changes
- added examples in ECSRun to show when custom IAM roles must be provided and when those can be skipped
- clarified that all roles must be passed using a full ARN
- fixed confusing docs about versioning and local agent

Related to #5110 