### PR TITLE
Add `raise_final_state` bool to `wait_for_flow_run`

### DIFF
--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -149,8 +149,8 @@ def create_flow_run(
     )
 
     run_url = client.get_cloud_url("flow-run", flow_run_id, as_user=False)
-    create_link_artifact(urlparse(run_url).path)
     logger.info(f"Created flow run {run_name_dsp!r}: {run_url}")
+
     return flow_run_id
 
 


### PR DESCRIPTION

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Artifact creation was added to `create_flow_run` in #5125 but when users map over this task it will create _many_ artifacts which is not particularly helpful. I'd rather encourage users to create artifacts in a subsequent task. We could consider adding this later with a toggle, but I'd rather lean minimal.

`wait_for_flow_run` does not reflect the final state of the child flow run like `StartFlowRun(wait=True)` does. Here, we add this functionality with an opt-in `raise_final_state` bool. This was noted in #5095 and will unblock that work.


## Changes
<!-- What does this PR change? -->

- Remove artifact creation from `create_flow_run`
- Add `raise_final_state` bool to `wait_for_flow_run`


## Importance
<!-- Why is this PR important? -->


Additional feature parity for new child flow run tasks


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- ![ ] adds a change file in the `changes/` directory (if appropriate)~ Will add directly in release
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)