### PR TITLE
Fix missing secret while using kubernetes agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.9 <Badge text="beta" type="success" />
+
+Released on November 10, 2021.
+
+This hotfix release fixes an issue where the kubernetes agent would attempt to load a secret value and fail if it was not present.
+
+See [the PR](https://github.com/PrefectHQ/prefect/pull/5131) for details.
+
 ## 0.15.8 <Badge text="beta" type="success" />
 
 Released on November 10, 2021.

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -133,6 +133,7 @@ class KubernetesAgent(Agent):
 
         from prefect.utilities.kubernetes import get_kubernetes_client
 
+        # Explicitly do not attempt to load the client from a secret
         self.batch_client = get_kubernetes_client("job", kubernetes_api_key_secret=None)
         self.core_client = get_kubernetes_client(
             "service", kubernetes_api_key_secret=None

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -58,14 +58,14 @@ def get_kubernetes_client(
     Returns:
         - KubernetesClient: an initialized and authenticated Kubernetes Client
     """
-    k8s_client = K8S_CLIENTS[resource]
+    client_type = K8S_CLIENTS[resource]
 
     if kubernetes_api_key_secret:
         logger.debug("Loading configuration from secret")
         kubernetes_api_key = Secret(kubernetes_api_key_secret).get()
         configuration = client.Configuration()
         configuration.api_key["authorization"] = kubernetes_api_key
-        k8s_client = k8s_client(client.ApiClient(configuration))
+        k8s_client = client_type(client.ApiClient(configuration))
     else:
         try:
             logger.debug("Loading incluster configuration")
@@ -75,7 +75,7 @@ def get_kubernetes_client(
             logger.debug("Loading out of cluster configuration")
             kube_config.load_kube_config()
 
-        k8s_client = k8s_client()
+        k8s_client = client_type()
 
     if config.cloud.agent.kubernetes_keep_alive:
         _keep_alive(client=k8s_client)

--- a/src/prefect/utilities/kubernetes.py
+++ b/src/prefect/utilities/kubernetes.py
@@ -9,6 +9,7 @@ from kubernetes.config.config_exception import ConfigException
 
 from prefect import config
 from prefect.client import Secret
+from prefect.utilities.logging import get_logger
 
 
 K8S_CLIENTS = {
@@ -20,6 +21,8 @@ K8S_CLIENTS = {
 }
 
 KubernetesClient = Union[client.BatchV1Api, client.CoreV1Api, client.AppsV1Api]
+
+logger = get_logger("kubernetes")
 
 
 def get_kubernetes_client(
@@ -57,18 +60,19 @@ def get_kubernetes_client(
     """
     k8s_client = K8S_CLIENTS[resource]
 
-    kubernetes_api_key = None
     if kubernetes_api_key_secret:
+        logger.debug("Loading configuration from secret")
         kubernetes_api_key = Secret(kubernetes_api_key_secret).get()
-
-    if kubernetes_api_key:
         configuration = client.Configuration()
         configuration.api_key["authorization"] = kubernetes_api_key
         k8s_client = k8s_client(client.ApiClient(configuration))
     else:
         try:
+            logger.debug("Loading incluster configuration")
             kube_config.load_incluster_config()
-        except ConfigException:
+        except ConfigException as exc:
+            logger.warning("{} Using out of cluster configuration option.".format(exc))
+            logger.debug("Loading out of cluster configuration")
             kube_config.load_kube_config()
 
         k8s_client = k8s_client()

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -26,6 +26,7 @@ from prefect.utilities import kubernetes
 def mocked_k8s_config(monkeypatch):
     k8s_config = MagicMock()
     monkeypatch.setattr("kubernetes.config", k8s_config)
+    monkeypatch.setattr("prefect.utilities.kubernetes.kube_config", k8s_config)
 
 
 @pytest.fixture(autouse=True)
@@ -35,7 +36,7 @@ def mocked_k8s_clients(monkeypatch):
         monkeypatch.setitem(kubernetes.K8S_CLIENTS, job_key, client)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def kube_secret():
     with set_temporary_config({"cloud.use_local_secrets": True}):
         with prefect.context(secrets=dict(KUBERNETES_API_KEY="test_key")):

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -217,7 +217,7 @@ class TestLocalDaskExecutor:
     def test_captures_prefect_signals(self):
         e = LocalDaskExecutor()
 
-        @prefect.task(timeout=1)
+        @prefect.task(timeout=2)
         def succeed():
             raise SUCCESS()
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

Fixes breaking change introduced by https://github.com/PrefectHQ/prefect/pull/5066 where kubernetes agents will fail to initialize if the `KUBERNETES_API_KEY` secret does not exist.

The error looks like
```
  File "/usr/local/lib/python3.7/site-packages/prefect/agent/kubernetes/agent.py", line 142, in __init__
    self.batch_client = get_kubernetes_client("job")
  File "/usr/local/lib/python3.7/site-packages/prefect/utilities/kubernetes.py", line 62, in get_kubernetes_client
    kubernetes_api_key = Secret(kubernetes_api_key_secret).get()
  File "/usr/local/lib/python3.7/site-packages/prefect/client/secrets.py", line 169, in get
    ) from None
ValueError: Local Secret "KUBERNETES_API_KEY" was not found.
```

This PR restores the previous behavior where kubernetes agents do not attempt to use secrets while loading a kubernetes client. A future PR could allow secrets to be used, but avoid hard-failures if the key is missing.

_This will be released immediately after QA as 0.15.9_