### PR TITLE
Add `end_time` to `FlowRunView.get_logs`

### DIFF
--- a/changes/pr5138.yaml
+++ b/changes/pr5138.yaml
@@ -1,0 +1,6 @@
+
+enhancement:
+  - "Add `end_time` to `FlowRunView.get_logs` - [#5138](https://github.com/PrefectHQ/prefect/pull/5138)"
+  - "`watch_flow_run` streams logs immediately instead of waiting for flow run state changes - [#5138](https://github.com/PrefectHQ/prefect/pull/5138)"
+
+

--- a/tests/backend/test_flow_run.py
+++ b/tests/backend/test_flow_run.py
@@ -288,6 +288,54 @@ def test_check_for_compatible_agents_no_agents_returned(patch_post):
     assert "no healthy agents" in result
 
 
+def test_flow_run_view_get_logs(monkeypatch):
+    post = MagicMock(return_value={"data": {"flow_run": [FLOW_RUN_DATA_1]}})
+    monkeypatch.setattr("prefect.client.client.Client.post", post)
+
+    flow_run_view = FlowRunView._from_flow_run_data(FLOW_RUN_DATA_1)
+
+    flow_run_view.get_logs()
+
+    query = post.call_args[1]["params"]["query"]
+
+    assert (
+        'flow_run(where: { id: { _eq: "id-1" } })' in query
+    ), "Queries for the correct flow run"
+
+    assert (
+        "logs(order_by: { timestamp: asc }" in query
+    ), "Retrieves logs, orders ascending"
+    assert (
+        'where: { _and: [{ timestamp: { _lte: "%s" } }, {}] }'
+        % flow_run_view.updated_at.isoformat()
+        in query
+    ), ("Where is less than the last time the flow run was updated\n" + query)
+
+
+def test_flow_run_view_get_logs_start_and_end_times(monkeypatch):
+    post = MagicMock(return_value={"data": {"flow_run": [FLOW_RUN_DATA_1]}})
+    monkeypatch.setattr("prefect.client.client.Client.post", post)
+
+    flow_run_view = FlowRunView._from_flow_run_data(FLOW_RUN_DATA_1)
+
+    start = pendulum.now()
+    end = pendulum.now()
+
+    flow_run_view.get_logs(start_time=start, end_time=end)
+
+    query = post.call_args[1]["params"]["query"]
+
+    assert 'flow_run(where: { id: { _eq: "id-1" } })' in query
+    assert "logs(order_by: { timestamp: asc }" in query
+
+    #
+    assert (
+        'where: { _and: [{ timestamp: { _lte: "%s" } }, { timestamp: { _gt: "%s" } }]'
+        % (end.isoformat(), start.isoformat())
+        in query
+    ), ("Where includes start and end time bounds\n" + query)
+
+
 def test_check_for_compatible_agents_healthy_without_matching_labels(patch_post):
     patch_post(
         {


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`watch_flow_run` uses `FlowRunView.get_logs` to stream logs from the flow run. Since `get_logs` only would retrieve logs _before_ `FlowRunView.updated_at`, the logs would not stream until the flow run object changed in the backend (ie, the state changed). Instead, we'd like to stream logs as they are written. We resolve this by adding an optional `end_time` parameter to `get_logs` and `watch_flow_run` always sends `pendulum.now()`.

Note: `FlowRunView.get_logs` used `updated_at` by default still because we want the logs to be _scoped_ to the view.

## Changes
<!-- What does this PR change? -->

- Adds `FlowRunView.get_logs` tests
- Adds `end_time` to `get_logs`
- Uses `end_time=pendulum.now()` in `watch_flow_run`


## Importance
<!-- Why is this PR important? -->

Resolves a bad UX.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)