### PR TITLE
Expose ports in docker run

### DIFF
--- a/changes/issue5130.yml
+++ b/changes/issue5130.yml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Expose container ports when using Prefect's DockerRun - [#5130](https://github.com/PrefectHQ/prefect/issues/5130)"
+
+contributor:
+  - "[Shahil Mawjee](https://github.com/s-mawjee)"

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -411,7 +411,7 @@ class DockerAgent(Agent):
         # By default, auto-remove containers
         host_config: Dict[str, Any] = {"auto_remove": True}
         # By default, no ports
-        ports: Iterable[int] = None
+        ports = None
 
         # Set up a host gateway for local communication; check the docker version since
         # this is not supported by older versions

--- a/src/prefect/run_configs/docker.py
+++ b/src/prefect/run_configs/docker.py
@@ -13,6 +13,8 @@ class DockerRun(RunConfig):
         - labels (Iterable[str], optional): an iterable of labels to apply to this
             run config. Labels are string identifiers used by Prefect Agents
             for selecting valid flow runs when polling for work
+        - ports (Iterable[int], optional): an iterable of ports to pass to the
+            Docker Agent which are used to expose container ports.
         - host_config (dict, optional): A dictionary or runtime arguments to pass to
             the Docker Agent. See link below for options.
             https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
@@ -38,8 +40,10 @@ class DockerRun(RunConfig):
         image: str = None,
         env: dict = None,
         labels: Iterable[str] = None,
-        host_config: dict = None
+        ports: Iterable[int] = None,
+        host_config: dict = None,
     ) -> None:
         super().__init__(env=env, labels=labels)
         self.image = image
         self.host_config = host_config
+        self.ports = ports

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -1,18 +1,18 @@
 from marshmallow import fields
 
-from prefect.utilities.serialization import (
-    JSONCompatible,
-    OneOfSchema,
-    ObjectSchema,
-    SortedList,
-)
 from prefect.run_configs import (
-    KubernetesRun,
-    LocalRun,
     DockerRun,
     ECSRun,
-    VertexRun,
+    KubernetesRun,
+    LocalRun,
     UniversalRun,
+    VertexRun,
+)
+from prefect.utilities.serialization import (
+    JSONCompatible,
+    ObjectSchema,
+    OneOfSchema,
+    SortedList,
 )
 
 
@@ -68,6 +68,7 @@ class DockerRunSchema(RunConfigSchemaBase):
     class Meta:
         object_class = DockerRun
 
+    ports = fields.List(fields.Int, allow_none=True)
     image = fields.String(allow_none=True)
     host_config = fields.Dict(keys=fields.String(), allow_none=True)
 

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -298,7 +298,6 @@ def test_prefect_logging_level_override_logic(
     ],
 )
 def test_docker_agent_deploy_flow(core_version, command, api):
-
     agent = DockerAgent()
     agent.deploy_flow(
         flow_run=GraphQLResult(
@@ -467,7 +466,6 @@ def test_docker_agent_deploy_flow_sets_container_name_with_slugify(
 @pytest.mark.parametrize("run_kind", ["docker", "missing", "universal"])
 @pytest.mark.parametrize("has_docker_storage", [True, False])
 def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
-
     if has_docker_storage:
         storage = Docker(
             registry_url="testing", image_name="on-storage", image_tag="tag"
@@ -479,14 +477,16 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
 
     if run_kind == "docker":
         env = {"TESTING": "VALUE"}
+        ports = [12001]
         host_config = {"auto_remove": False, "shm_size": "128m"}
         exp_host_config = {
             "auto_remove": False,
             "shm_size": "128m",
         }
-        run = DockerRun(image=image, env=env, host_config=host_config)
+        run = DockerRun(image=image, env=env, ports=ports, host_config=host_config)
     else:
         env = {}
+        ports = []
         host_config = {}
         exp_host_config = {
             "auto_remove": True,
@@ -519,6 +519,9 @@ def test_docker_agent_deploy_flow_run_config(api, run_kind, has_docker_storage):
     res_env = api.create_container.call_args[1]["environment"]
     for k, v in env.items():
         assert res_env[k] == v
+    res_ports = api.create_container.call_args[1]["ports"]
+    for i, v in enumerate(ports):
+        assert res_ports[i] == v
     res_host_config = api.create_host_config.call_args[1]
     for k, v in exp_host_config.items():
         assert res_host_config[k] == v

--- a/tests/run_configs/test_docker.py
+++ b/tests/run_configs/test_docker.py
@@ -5,6 +5,7 @@ def test_no_args():
     config = DockerRun()
     assert config.env is None
     assert config.image is None
+    assert config.ports is None
     assert config.labels == set()
     assert config.host_config is None
 
@@ -15,9 +16,11 @@ def test_all_args(tmpdir):
         env={"hello": "world"},
         image="testing",
         labels=["a", "b"],
+        ports=[12001],
         host_config={"host": "config"},
     )
     assert config.env == {"hello": "world"}
     assert config.image == "testing"
     assert config.labels == {"a", "b"}
+    assert config.ports == [12001]
     assert config.host_config == {"host": "config"}

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -95,9 +95,7 @@ def test_serialize_local_run(config):
     [
         DockerRun(),
         DockerRun(
-            env={"test": "foo"},
-            image="testing",
-            labels=["a", "b"],
+            env={"test": "foo"}, image="testing", labels=["a", "b"], ports=[12001]
         ),
     ],
 )
@@ -105,7 +103,7 @@ def test_serialize_docker_run(config):
     msg = RunConfigSchema().dump(config)
     config2 = RunConfigSchema().load(msg)
     assert sorted(config.labels) == sorted(config2.labels)
-    fields = ["env", "image"]
+    fields = ["env", "image", "ports"]
     for field in fields:
         assert getattr(config, field) == getattr(config2, field)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Expose container ports when using Prefect's DockerRun. 

closes #5130 


## Changes
<!-- What does this PR change? -->
`ports` (optional) argument in `DockerRun` run_config, which the are list of ports used to expose container ports.  




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)