### PR TITLE
Use allowed_methods in Retry as method_whitelist is depreciated 

### DIFF
--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -18,7 +18,7 @@ BITBUCKET_CLOUD_RETRY = Retry(
     total=10,
     backoff_factor=0.5,
     status_forcelist=[429],
-    method_whitelist=["HEAD", "GET", "OPTIONS"],
+    allowed_methods=["HEAD", "GET", "OPTIONS"],
 )
 
 if TYPE_CHECKING:

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -6,7 +6,7 @@ from urllib.error import HTTPError
 import requests
 from requests.exceptions import HTTPError as RequestsHTTPError
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 import prefect
 from prefect.client import Secret
@@ -18,7 +18,8 @@ BITBUCKET_CLOUD_RETRY = Retry(
     total=10,
     backoff_factor=0.5,
     status_forcelist=[429],
-    allowed_methods=["HEAD", "GET", "OPTIONS"],
+    # ignoring new allowed_methods param until mypy update
+    allowed_methods=["HEAD", "GET", "OPTIONS"],  # type: ignore
 )
 
 if TYPE_CHECKING:

--- a/src/prefect/storage/bitbucket.py
+++ b/src/prefect/storage/bitbucket.py
@@ -18,7 +18,7 @@ BITBUCKET_CLOUD_RETRY = Retry(
     total=10,
     backoff_factor=0.5,
     status_forcelist=[429],
-    # ignoring new allowed_methods param until mypy update
+    # typeshed is out of date with urllib3 and missing `allowed_methods`
     allowed_methods=["HEAD", "GET", "OPTIONS"],  # type: ignore
 )
 


### PR DESCRIPTION
## Summary

This is a simple PR to stop a `DeprecationWarning`

```
Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
``` 


## Changes
Use `allowed_methods` instead of `method_whitelist` in the Retry object


## Importance
This will ensure compatibility with future versions 


## Checklist

These points are all pretty much n/a

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)