### PR TITLE
Resolve marshmallow deprecation warning

### DIFF
--- a/changes/issue4540.yaml
+++ b/changes/issue4540.yaml
@@ -1,0 +1,2 @@
+fix:
+  - Re-fix use of marshmallow.fields.Dict to use keys correctly as a kwarg rather than key. - [#4540](https://github.com/PrefectHQ/prefect/issues/4540), [#4903](https://github.com/PrefectHQ/prefect/pull/4903)

--- a/src/prefect/serialization/schedule.py
+++ b/src/prefect/serialization/schedule.py
@@ -153,7 +153,7 @@ class RRuleClockSchema(ObjectSchema):
     start_date = DateTimeTZ(allow_none=True)
     end_date = DateTimeTZ(allow_none=True)
     parameter_defaults = fields.Dict(
-        key=fields.Str(), values=JSONCompatible(), allow_none=True
+        keys=fields.Str(), values=JSONCompatible(), allow_none=True
     )
     labels = fields.List(fields.Str(), allow_none=True)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This change fixes a deprecation warning that had been previously taken care of by PR #4903. It seems after that PR was merged some code using marshmallow's fields.Dict class was added that used the deprecated keyword argument `key` again. This just switches that over to use `keys` instead. The marshmallow deprecation itself was [made in marshmallow 3.10](https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#3100-2020-12-19) and you can see the issue in https://github.com/marshmallow-code/marshmallow/issues/1350.

There are no new tests with this because the code change is so small. Nothing has changed which existing tests would not cover.

For more information see #4903

This should resolve #4540


## Changes
<!-- What does this PR change? -->
When using `marshmallow.fields.Dict` use `keys` as a kwarg rather than `key`.



## Importance
<!-- Why is this PR important? -->
It's just a deprecation warning fix, so it's not a high priority. I expect it's just a minor annoyance for anyone running into this message.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)