### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # global owners
-*   @madkinsz
+*                           @madkinsz
 
 # task library owners
-/src/prefect/tasks           @desertaxle
-/tests/tasks                 @desertaxle
-/docs/core/task_library      @desertaxle
+/src/prefect/tasks          @desertaxle
+/tests/tasks                @desertaxle
+/docs/core/task_library     @desertaxle
 
 # documentation owners
-/docs                        @tpdorsey
+/docs                       @tpdorsey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 /src/prefect/tasks           @desertaxle
 /tests/tasks                 @desertaxle
 /docs/core/task_library      @desertaxle
+
+# documentation owners
+/docs                        @tpdorsey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # global owners
-*   @madkinsz @zangell44
+*   @madkinsz
+
+# task library owners
+/src/prefect/tasks           @desertaxle
+/tests/tasks                 @desertaxle
+/docs/core/task_library      @desertaxle


### PR DESCRIPTION
- Removes @zangell44 as a global owner
- Adds @desertaxle as an owner for task library stuffs
- Adds @tpdorsey as owner for documentation