### PR TITLE
Allow override of Prefect API url in docker runs and improve inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ Released on November 30, 2021.
 - Clarify `ECSRun` documentation, especially the ambiguities in setting IAM roles - [#5110](https://github.com/PrefectHQ/prefect/issues/5110)
 - Fix deprecated usage of `marshmallow.fields.Dict` in RRule schedules - [#4540](https://github.com/PrefectHQ/prefect/issues/4540), [#4903](https://github.com/PrefectHQ/prefect/pull/4903)
 
+### Fixes
+
+- Fix connection to local server instances when using `DockerAgent` on linux - [#5182](https://github.com/PrefectHQ/prefect/pull/5182)
 
 ### Task Library
 
 - Add `AirbyteConnectionTask` - [#5078](https://github.com/PrefectHQ/prefect/pull/5078)
 - Add artifact publishing to `DbtCloudRunJob` task - [#5135](https://github.com/PrefectHQ/prefect/pull/5135)
 - Add support for running data quality checks on Spark DataFrames using `soda-spark` - [#4901](https://github.com/PrefectHQ/prefect/pull/5144)
+
 
 ### Contributors
 

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -558,7 +558,7 @@ class DockerAgent(Agent):
             - dict: a dictionary representing the populated environment variables
         """
         if "localhost" in config.cloud.api:
-            if "prefect-server" in self.networks:
+            if self.networks and "prefect-server" in self.networks:
                 api = "http://apollo:{}".format(config.server.port)
             else:
                 api = "http://host.docker.internal:{}".format(config.server.port)

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -558,12 +558,18 @@ class DockerAgent(Agent):
             - dict: a dictionary representing the populated environment variables
         """
         if "localhost" in config.cloud.api:
-            api = "http://host.docker.internal:{}".format(config.server.port)
+            if "prefect-server" in self.networks:
+                api = "http://apollo:{}".format(config.server.port)
+            else:
+                api = "http://host.docker.internal:{}".format(config.server.port)
         else:
             api = config.cloud.api
 
-        env = {}
         # Populate environment variables, later sources overriding
+        # Set the API to be the same as the agent connects to, but since the flow run
+        # will be in a container and our inferences above are not perfect, allow the
+        # user to override the value
+        env = {"PREFECT__CLOUD__API": api}
 
         # 1. Logging level from config
         # Default to the config logging level, allowing it to be overriden
@@ -581,7 +587,6 @@ class DockerAgent(Agent):
         env.update(
             {
                 "PREFECT__BACKEND": config.backend,
-                "PREFECT__CLOUD__API": api,
                 "PREFECT__CLOUD__AUTH_TOKEN": (
                     # Pull an auth token if it exists but fall back to an API key so
                     # flows in pre-0.15.0 containers still authenticate correctly

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -252,6 +252,70 @@ def test_populate_env_vars_from_run_config(api):
     assert env_vars["PREFECT__LOGGING__LEVEL"] == "TEST"
 
 
+def test_api_url_can_be_overridden_at_agent_level(api):
+    agent = DockerAgent(env_vars={"PREFECT__CLOUD__API": "FOO"})
+
+    env_vars = agent.populate_env_vars(
+        GraphQLResult(
+            {
+                "id": "id",
+                "name": "name",
+                "flow": {"id": "foo"},
+            }
+        ),
+        "test-image",
+    )
+    assert env_vars["PREFECT__CLOUD__API"] == "FOO"
+
+
+def test_api_url_can_be_overridden_with_run_config(api):
+    agent = DockerAgent(env_vars={"PREFECT__CLOUD__API": "FOO"})
+
+    run = DockerRun(
+        env={"PREFECT__CLOUD__API": "BAR"},
+    )
+
+    env_vars = agent.populate_env_vars(
+        GraphQLResult(
+            {
+                "id": "id",
+                "name": "name",
+                "flow": {"id": "foo"},
+                "run_config": run.serialize(),
+            }
+        ),
+        "test-image",
+        run_config=run,
+    )
+    assert env_vars["PREFECT__CLOUD__API"] == "BAR"
+
+
+def test_api_url_uses_server_network(api, backend):
+    """
+    If the `prefect-server` network is provided and the backend is 'server' then we
+    will replace the API url with 'apollo' instead of 'host.docker.internal' to make
+    use of the network for connections to the API
+    """
+    agent = DockerAgent(networks=["prefect-server"])
+
+    env_vars = agent.populate_env_vars(
+        GraphQLResult(
+            {
+                "id": "id",
+                "name": "name",
+                "flow": {"id": "foo"},
+                "run_config": {},
+            }
+        ),
+        "test-image",
+    )
+
+    if backend == "server":
+        assert env_vars["PREFECT__CLOUD__API"] == "http://apollo:4200"
+    else:
+        assert env_vars["PREFECT__CLOUD__API"] == "https://api.prefect.io"
+
+
 @pytest.mark.parametrize(
     "config, agent_env_vars, run_config_env_vars, expected_logging_level",
     [


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The API URL used by the agent can be unconnectable from within a spawned flow run container when using Prefect Server. Currently, we replace `localhost` with `host.docker.internal` to fix this. However, this is brittle in some cases which we've been patching (e.g. #4714, #4809, #2433)

With the change to limit exposure of the API by default in #4821, when `--expose` is not used on server startup, it is not connectable even with `host.docker.internal`. In #5156, I documented adding the `prefect-server` network to the run containers to allow them to connect, but this does not work on Linux. This PR replaces `host.docker.internal` with `apollo` if the `prefect-server` network is detected so that the internal network is used. This allows running an agent and server side-by-side without the `--expose` flag.

Additionally, this allows the API URL to be overridden entirely by users so that, if there is another brittle edge-case, they can just provide the proper URL.

Closes https://github.com/PrefectHQ/prefect/issues/4963


## Changes
<!-- What does this PR change? -->

- Allows `--env PREFECT__CLOUD__API=...` and `DockerRun(env=...)` to override the API the flow run will connect to once spawned.
- Updates inference to "just work" when the `prefect-server` network is provided.

## Importance
<!-- Why is this PR important? -->

Fixes major connection issues with `DockerAgent` spawned containers while using Prefect Server

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)