### PR TITLE
docs(gql): use flow_runs instead of flow_run

### DIFF
--- a/docs/orchestration/concepts/api.md
+++ b/docs/orchestration/concepts/api.md
@@ -155,7 +155,7 @@ query {
   flow(where: { name: { _ilike: "%train" } }) {
     id
     name
-    flow_run(order_by: { start_time: desc }, limit: 1) {
+    flow_runs(order_by: { start_time: desc }, limit: 1) {
       id
       state
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Corrects the graphql query docs to use `flow_runs` in place of `flow_run`


## Changes
<!-- What does this PR change? -->

Change gql query to fetch flow in https://docs.prefect.io/orchestration/concepts/api.html#queries

```diff
- flow_run(order_by: { start_time: desc }, limit: 1) {
+ flow_runs(order_by: { start_time: desc }, limit: 1) {
```



## Importance
<!-- Why is this PR important? -->

As stated in #4922 Previous docs used `flow_run` which would not work

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~ 
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~