### PR TITLE
Improve multiprocess based timeout handler

### DIFF
--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -411,6 +411,7 @@ def run_with_multiprocess_timeout(
             raise result
         return result
     except Empty:
+        logger.debug(f"{name}: No result returned within the timeout period!")
         raise TaskTimeoutSignal(f"Execution timed out for {name}.")
 
 

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -336,7 +336,10 @@ def multiprocessing_safe_run_and_retrieve(
             f"{name}: Failed to put result in queue to main process!",
             exc_info=True,
         )
+        logging.shutdown()
         raise
+    else:
+        logging.shutdown()
 
 
 def run_with_multiprocess_timeout(

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -315,7 +315,9 @@ def multiprocessing_safe_run_and_retrieve(
         )
 
     try:
+        logger.debug(f"{name}: Pickling value of size {sys.getsizeof(return_val)}...")
         pickled_val = cloudpickle.dumps(return_val)
+        logger.debug(f"{name}: Pickling successful!")
     except Exception as exc:
         err_msg = (
             f"Failed to pickle result of type {type(return_val).__name__!r} with "

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -252,8 +252,6 @@ def test_multiprocessing_safe_run_and_retrieve_logs_queue_errors(caplog):
     assert "Failed to put result in queue to main process!" in caplog.text
     assert "Exception: Test" in caplog.text
 
-    breakpoint()
-
 
 def test_recursion_go_case():
     @tail_recursive

--- a/tests/utilities/test_executors.py
+++ b/tests/utilities/test_executors.py
@@ -252,6 +252,8 @@ def test_multiprocessing_safe_run_and_retrieve_logs_queue_errors(caplog):
     assert "Failed to put result in queue to main process!" in caplog.text
     assert "Exception: Test" in caplog.text
 
+    breakpoint()
+
 
 def test_recursion_go_case():
     @tail_recursive


### PR DESCRIPTION
A user was running into an indeterminate issue with the multiprocess based handler. While investigating, I added some useful logs and discovered what `queue.empty()` is not reliable and the stdlib documentation recommends not using it at all. Additionally, joining a process before we've retrieved data from a queue can cause deadlocks. Previously, we even sent a SIGTERM to the process before retrieving the data.

## Changes
- Adds pickling/unpickling debug logs
- Uses `queue.get(block=True, timeout=timeout)` instead of `process.join(timeout)`