### PR TITLE
Fixing Serialized Flow Examples in Docs

### DIFF
--- a/changes/pr5220.yaml
+++ b/changes/pr5220.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fixing serialized example in docs - [#5220](https://github.com/PrefectHQ/prefect/pull/5220)"

--- a/docs/core/examples/overview.md
+++ b/docs/core/examples/overview.md
@@ -25,8 +25,12 @@ $ prefect register --json https://docs.prefect.io/examples.json \
     --name "Example: Mapping"
 ```
 
-These can then be run using any agent with a ``prefect-examples`` label. For
-example, to start a local agent for running the examples:
+These can then be run using any agent with a ``prefect-examples`` label. Before starting the agent, 
+make sure the Github extra is installed so the agent can pull the flows by doing:
+
+`pip install "prefect[github]"` 
+
+Then to start a local agent for running the examples:
 
 ```
 $ prefect agent local start -l prefect-examples

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -438,7 +438,7 @@ def build_example(path):
             if not f.run_config:
                 f.run_config = UniversalRun()
             f.run_config.labels.add("prefect-examples")
-            flows[f.name] = f.serialize()
+            flows[f.name] = f.serialize(build=True)
 
     source = "\n".join(contents.splitlines()[offset:]).strip()
 

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -496,4 +496,4 @@ def test_example(path):
     rendered, flows = build_example(path)
     for f in flows.keys():
         # Assert there is a serialized Flow in storage
-        assert len(flows[f]['storage']['flows']) > 0
+        assert len(flows[f]["storage"]["flows"]) > 0

--- a/docs/test_generate_docs.py
+++ b/docs/test_generate_docs.py
@@ -493,4 +493,7 @@ def test_section_headers_are_properly_formatted(obj):
 
 @pytest.mark.parametrize("path", glob.glob(os.path.join(ROOT, "examples", "*.py")))
 def test_example(path):
-    build_example(path)
+    rendered, flows = build_example(path)
+    for f in flows.keys():
+        # Assert there is a serialized Flow in storage
+        assert len(flows[f]['storage']['flows']) > 0


### PR DESCRIPTION
## Summary

The examples we have in [this docs](https://docs.prefect.io/orchestration/tutorial/next-steps.html#examples) page don't work as reported in [this discussion](https://github.com/PrefectHQ/prefect/discussions/5215). 

Trying to run these vie the UI raises:

`Failed to load and execute Flow's environment: ValueError('Flow is not contained in this Storage')`

There are three Flows there and all of their storage look like the following. The important part is that `flows` is empty. When the Flow Run is triggered, there is no Flow to search for in the storage.
```
"storage": {"access_token_secret": null, "path": "examples/parameters.py", "ref": "d44b72a950ebda9f7bc6a9712fc71e2e9c680d25", "flows": {}, "repo": "PrefectHQ/prefect", "base_url": null, "secrets": [], "__version__": "0.15.6+74.gd44b72a95", "type": "GitHub"}}
```

Normally, this isn't an issue because registering a flow serializes it. However, this is never registered and the JSON is just output.

## Changes

We serialize the Flow and add the appropriate check to ensure that there is a Flow in storage.

## Importance
Users need this working for example Flows in the UI

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)