### PR TITLE
docs: update idempotency docs to indicate no expiry

### DIFF
--- a/docs/orchestration/flow-runs/creation.md
+++ b/docs/orchestration/flow-runs/creation.md
@@ -198,7 +198,7 @@ GraphQL expects ISO formatted datetime strings. This is default when you cast a 
 
 ### Idempotency
 
-If you provide an `idempotency_key` when creating a flow run, you can safely attempt to recreate that run again without actually recreating it. This is helpful when you have a substandard network connection or when you're worried about redundancy in your run triggers. Note that Idempotency keys do not expire. To create a new run, a new idempotent request must be made. 
+If you provide an `idempotency_key` when creating a flow run, you can safely attempt to recreate that run again without actually recreating it. This is helpful when you have a substandard network connection or when you're worried about redundancy in your run triggers. Note that idempotency keys do not expire. To create a new run, a new idempotency key must be provided. 
 
 :::: tabs
 

--- a/docs/orchestration/flow-runs/creation.md
+++ b/docs/orchestration/flow-runs/creation.md
@@ -198,7 +198,7 @@ GraphQL expects ISO formatted datetime strings. This is default when you cast a 
 
 ### Idempotency
 
-If you provide an `idempotency_key` when creating a flow run, you can safely attempt to recreate that run again without actually recreating it. This is helpful when you have a substandard network connection or when you're worried about redundancy in your run triggers. Idempotency is preserved for 24 hours, after which time a new run will be created for the same key. Each idempotent request refreshes the cache for an additional 24 hours.
+If you provide an `idempotency_key` when creating a flow run, you can safely attempt to recreate that run again without actually recreating it. This is helpful when you have a substandard network connection or when you're worried about redundancy in your run triggers. Note that Idempotency keys do not expire. To create a new run, a new idempotent request must be made. 
 
 :::: tabs
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Update the docs for Idempotency to indicate non-expiry of idempotency keys.

## Changes
<!-- What does this PR change? -->

This PR updates the docs for Idempotency to indicate the non-expiry of idempotency keys, updating the previous stale docs for the same as discussed in #4976 

## Importance
<!-- Why is this PR important? -->

Closes #4976 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~~[ ] adds new tests (if appropriate)~~
- ~~[ ] adds a change file in the `changes/` directory (if appropriate)~~
- ~~[ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~