### PR TITLE
StepActivate task now accepts run args

### DIFF
--- a/changes/pr5231.yaml
+++ b/changes/pr5231.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "`StepActivate` task accepts `run` arguments - [#5231](https://github.com/PrefectHQ/prefect/pull/5231)"
+
+contributor:
+  - "[Mathijs Miermans](https://github.com/mmiermans)"

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -37,7 +37,7 @@ class StepActivate(Task):
         if execution_name is not None:
             self.logger.warn(
                 f"It's not recommended to set execution_name={execution_name} in the StepActivate "
-                f"constructor, because the name has to be unique across executions in our account "
+                f"constructor, because the name has to be unique across executions in your account "
                 f"and AWS region. Set execution_name when running your task instead."
             )
 

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -44,6 +44,7 @@ class StepActivate(Task):
         "state_machine_arn",
         "execution_name",
         "execution_input",
+        "boto_kwargs",
     )
     def run(
         self,
@@ -51,6 +52,7 @@ class StepActivate(Task):
         state_machine_arn: str = None,
         execution_name: str = None,
         execution_input: str = None,
+        boto_kwargs: dict = None,
     ) -> Dict:
         """
         Task run method. Activates AWS Step function.
@@ -67,6 +69,8 @@ class StepActivate(Task):
                 your AWS account, region, and state machine for 90 days
             - execution_input (str, optional): string that contains the JSON input data for
                 the execution, defaults to `"{}"`
+            - boto_kwargs (dict, optional): additional keyword arguments to forward to the
+                boto client.
 
         Returns:
             - dict: response from AWS StartExecution endpoint
@@ -75,7 +79,7 @@ class StepActivate(Task):
             raise ValueError("A state machine ARN must be provided")
 
         step_client = get_boto_client(
-            "stepfunctions", credentials=credentials, **self.boto_kwargs
+            "stepfunctions", credentials=credentials, **boto_kwargs
         )
 
         response = step_client.start_execution(

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -14,8 +14,9 @@ class StepActivate(Task):
             to execute
         - execution_name (str): the name of the execution, this name must be unique for
             your AWS account, region, and state machine for 90 days
-        - execution_input (str, optional): string that contains the JSON input data for
-            the execution, defaults to `"{}"`
+        - execution_input (str, optional, DEPRECATED): string that contains the JSON input data for
+            the execution, defaults to `"{}"`. Setting `execution_input` through the constructor is
+            deprecated. Set it when running this task instead.
         - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -27,11 +28,18 @@ class StepActivate(Task):
         execution_name: str = None,
         execution_input: str = "{}",
         boto_kwargs: dict = None,
-        **kwargs
+        **kwargs,
     ):
         self.state_machine_arn = state_machine_arn
         self.execution_name = execution_name
         self.execution_input = execution_input
+
+        if execution_name is not None:
+            self.logger.warn(
+                f"It's not recommended to set execution_name={execution_name} in the StepActivate "
+                f"constructor, because the name has to be unique across executions in our account "
+                f"and AWS region. Set execution_name when running your task instead."
+            )
 
         if boto_kwargs is None:
             self.boto_kwargs = {}

--- a/src/prefect/tasks/aws/step_function.py
+++ b/src/prefect/tasks/aws/step_function.py
@@ -1,5 +1,8 @@
+from typing import Dict
+
 from prefect import Task
 from prefect.utilities.aws import get_boto_client
+from prefect.utilities.tasks import defaults_from_attrs
 
 
 class StepActivate(Task):
@@ -12,7 +15,7 @@ class StepActivate(Task):
         - execution_name (str): the name of the execution, this name must be unique for
             your AWS account, region, and state machine for 90 days
         - execution_input (str, optional): string that contains the JSON input data for
-            the execution
+            the execution, defaults to `"{}"`
         - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
@@ -20,8 +23,8 @@ class StepActivate(Task):
 
     def __init__(
         self,
-        state_machine_arn: str,
-        execution_name: str,
+        state_machine_arn: str = None,
+        execution_name: str = None,
         execution_input: str = "{}",
         boto_kwargs: dict = None,
         **kwargs
@@ -37,7 +40,18 @@ class StepActivate(Task):
 
         super().__init__(**kwargs)
 
-    def run(self, credentials: dict = None):
+    @defaults_from_attrs(
+        "state_machine_arn",
+        "execution_name",
+        "execution_input",
+    )
+    def run(
+        self,
+        credentials: dict = None,
+        state_machine_arn: str = None,
+        execution_name: str = None,
+        execution_input: str = None,
+    ) -> Dict:
         """
         Task run method. Activates AWS Step function.
 
@@ -47,19 +61,27 @@ class StepActivate(Task):
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
+            - state_machine_arn (str): the Amazon Resource Name (ARN) of the state machine
+                to execute
+            - execution_name (str): the name of the execution, this name must be unique for
+                your AWS account, region, and state machine for 90 days
+            - execution_input (str, optional): string that contains the JSON input data for
+                the execution, defaults to `"{}"`
 
         Returns:
             - dict: response from AWS StartExecution endpoint
         """
+        if not state_machine_arn:
+            raise ValueError("A state machine ARN must be provided")
 
         step_client = get_boto_client(
             "stepfunctions", credentials=credentials, **self.boto_kwargs
         )
 
         response = step_client.start_execution(
-            stateMachineArn=self.state_machine_arn,
-            name=self.execution_name,
-            input=self.execution_input,
+            stateMachineArn=state_machine_arn,
+            name=execution_name,
+            input=execution_input,
         )
 
         return response

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -12,9 +12,7 @@ class TestStepActivate:
         task = StepActivate(state_machine_arn="arn")
 
     def test_initialization_passes_to_task_constructor(self):
-        task = StepActivate(
-            state_machine_arn="arn", name="test", tags=["AWS"]
-        )
+        task = StepActivate(state_machine_arn="arn", name="test", tags=["AWS"])
         assert task.name == "test"
         assert task.tags == {"AWS"}
 
@@ -27,4 +25,8 @@ class TestStepActivate:
 
         called_method = client.mock_calls[1]
         assert called_method[0] == "().start_execution"
-        assert called_method[2] == {"stateMachineArn": "arn", "name": "name", "input": "{}"}
+        assert called_method[2] == {
+            "stateMachineArn": "arn",
+            "name": "name",
+            "input": "{}",
+        }

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -4,31 +4,27 @@ import pytest
 
 pytest.importorskip("boto3")
 
-import prefect
 from prefect.tasks.aws import StepActivate
-from prefect.utilities.configuration import set_temporary_config
 
 
 class TestStepActivate:
     def test_initialization(self):
-        task = StepActivate(state_machine_arn="arn", execution_name="name")
+        task = StepActivate(state_machine_arn="arn")
 
     def test_initialization_passes_to_task_constructor(self):
         task = StepActivate(
-            state_machine_arn="arn", execution_name="name", name="test", tags=["AWS"]
+            state_machine_arn="arn", name="test", tags=["AWS"]
         )
         assert task.name == "test"
         assert task.tags == {"AWS"}
 
     def test_exposes_boto3_start_execution_api(self, monkeypatch):
-        task = StepActivate(state_machine_arn="arn", execution_name="name")
+        task = StepActivate(state_machine_arn="arn")
         client = MagicMock()
         boto3 = MagicMock(client=client)
         monkeypatch.setattr("prefect.utilities.aws.boto3", boto3)
-        task.run()
+        task.run(execution_name="name")
 
         called_method = client.mock_calls[1]
         assert called_method[0] == "().start_execution"
-        called_method.assert_called_once_with(
-            {"stateMachineArn": "arn", "name": "name", "input": {}}
-        )
+        assert called_method[2] == {"stateMachineArn": "arn", "name": "name", "input": "{}"}

--- a/tests/tasks/aws/test_step_function.py
+++ b/tests/tasks/aws/test_step_function.py
@@ -25,8 +25,6 @@ class TestStepActivate:
 
         called_method = client.mock_calls[1]
         assert called_method[0] == "().start_execution"
-        assert called_method[2] == {
-            "stateMachineArn": "arn",
-            "name": "name",
-            "input": "{}",
-        }
+        client().start_execution.assert_called_once_with(
+            stateMachineArn="arn", name="name", input="{}"
+        )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Allow the StepActivate task to accept arguments in the `run` method.




## Changes
- Allow arguments to be passed to the `run` method.
- Fix the assertion to check which arguments were passed to the `start_execution` boto call. `called_method.assert_called_once_with` was passing regardless of which arguments it was checking against.




## Importance
AWS requires step functions to have a unique name for every execution. Only prefect's `run` method allows for arguments to be dynamic.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)