### PR TITLE
Allow kwargs to be passed to Merge

### DIFF
--- a/src/prefect/tasks/control_flow/conditional.py
+++ b/src/prefect/tasks/control_flow/conditional.py
@@ -127,7 +127,7 @@ def ifelse(
         switch(condition=bool_condition, cases=cases, mapped=mapped)
 
 
-def merge(*tasks: Task, flow=None, mapped: bool = False) -> Task:
+def merge(*tasks: Task, flow=None, mapped: bool = False, **kwargs) -> Task:
     """
     Merges conditional branches back together.
 
@@ -162,7 +162,7 @@ def merge(*tasks: Task, flow=None, mapped: bool = False) -> Task:
         - Task: a Task representing the merged result.
 
     """
-    return Merge().bind(
+    return Merge(**kwargs).bind(
         **{"task_{}".format(i + 1): t for i, t in enumerate(tasks)},
         flow=flow,
         mapped=mapped

--- a/tests/tasks/test_control_flow.py
+++ b/tests/tasks/test_control_flow.py
@@ -162,6 +162,26 @@ def test_merge_imperative_flow():
     assert state.result[c].result == 2
 
 
+def test_merge_imperative_flow_checkpoint_false():
+    flow = Flow("test")
+
+    cond = identity.copy().bind(True, flow=flow)
+    with case(cond, True):
+        a = inc.copy().bind(1, flow=flow)
+
+    with case(cond, False):
+        b = inc.copy().bind(2, flow=flow)
+
+    c = merge(a, b, flow=flow, checkpoint=False)
+
+    state = flow.run()
+    assert state.result[cond].result is True
+    assert state.result[a].result == 2
+    assert state.result[b].is_skipped()
+    assert state.result[c].result == 2
+    assert c.checkpoint == False
+
+
 def test_mapped_switch_and_merge():
     with Flow("iterated map") as flow:
         mapped_result = identity.copy().map(["a", "b", "c"])


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Allows for passing of kwargs to `merge()` to influence `Merge` task.


## Changes
<!-- What does this PR change? -->

Changes functionality of `merge()` to influence `Merge` task. Related issue: https://github.com/PrefectHQ/prefect/issues/5217


## Importance
<!-- Why is this PR important? -->

Currently, you cannot turn off checkpointing for Merge tasks.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)