### PR TITLE
Add proxies argument to slack_notifier

### DIFF
--- a/changes/pr5237.yaml
+++ b/changes/pr5237.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow passing of proxies argument to slack_notifier - [#5237](https://github.com/PrefectHQ/prefect/pull/5237)"
+
+contributor:
+  - "[Vincent Chéry](https://github.com/VincentAntoine)"

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -276,7 +276,7 @@ def slack_notifier(
         - backend_info (bool, optional): Whether to supply slack notification with urls
             pointing to backend pages; defaults to True
         - proxies (dict), optional): `dict` with "http" and/or "https" keys, passed to
-         `requests.get` - for situations where a proxy is required to send requests to the
+         `requests.post` - for situations where a proxy is required to send requests to the
           Slack webhook
 
     Returns:

--- a/src/prefect/utilities/notifications/notifications.py
+++ b/src/prefect/utilities/notifications/notifications.py
@@ -252,6 +252,7 @@ def slack_notifier(
     only_states: list = None,
     webhook_secret: str = None,
     backend_info: bool = True,
+    proxies: dict = None,
 ) -> "prefect.engine.state.State":
     """
     Slack state change handler; requires having the Prefect slack app installed.  Works as a
@@ -274,6 +275,9 @@ def slack_notifier(
             webhook URL; defaults to `"SLACK_WEBHOOK_URL"`
         - backend_info (bool, optional): Whether to supply slack notification with urls
             pointing to backend pages; defaults to True
+        - proxies (dict), optional): `dict` with "http" and/or "https" keys, passed to
+         `requests.get` - for situations where a proxy is required to send requests to the
+          Slack webhook
 
     Returns:
         - State: the `new_state` object that was provided
@@ -310,7 +314,7 @@ def slack_notifier(
     import requests
 
     form_data = slack_message_formatter(tracked_obj, new_state, backend_info)
-    r = requests.post(webhook_url, json=form_data)
+    r = requests.post(webhook_url, json=form_data, proxies=proxies)
     if not r.ok:
         raise ValueError("Slack notification for {} failed".format(tracked_obj))
     return new_state

--- a/tests/utilities/notifications/test_notifications.py
+++ b/tests/utilities/notifications/test_notifications.py
@@ -260,6 +260,16 @@ def test_slack_notifier_is_curried_and_uses_only_states(monkeypatch, state):
     assert ok.called is isinstance(state, TriggerFailed)
 
 
+def test_slack_notifier_uses_proxies(monkeypatch):
+    post = MagicMock(ok=True)
+    monkeypatch.setattr(requests, "post", post)
+    state = Failed(message="1", result=0)
+    with set_temporary_config({"cloud.use_local_secrets": True}):
+        with prefect.context(secrets=dict(SLACK_WEBHOOK_URL="")):
+            slack_notifier(Task(), "", state, proxies={"http": "some.proxy.I.P"})
+    assert post.call_args[1]["proxies"] == {"http": "some.proxy.I.P"}
+
+
 def test_gmail_notifier_sends_simple_email(monkeypatch):
     smtp = MagicMock()
     sendmail = MagicMock()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Add `proxies` argument to `slack_notifier`.



## Changes
<!-- What does this PR change? -->
`prefect.utilities.notifications.slack_notifier` now passes a new optional `proxies` argument to `requests.port` to send requests to the Slack webhook through proxies.


## Importance
<!-- Why is this PR important? -->
- Allows to send Slack notifications through proxies when required.
- Resolve #5236 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)