### PR TITLE
Docs changes to address 1.0.0rc deprecations (revised)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -288,6 +288,20 @@ module.exports = {
           collapsable: true,
           children: getChildren('docs/orchestration', 'faq')
         },
+        {
+          title: 'Legacy Environments',
+          collapsable: true,
+          children: [
+            'execution/overview',
+            'execution/storage_options',
+            'execution/local_environment',
+            'execution/dask_cloud_provider_environment',
+            'execution/dask_k8s_environment',
+            'execution/k8s_job_environment',
+            'execution/fargate_task_environment',
+            'execution/custom_environment'
+          ]
+        }
       ],
       '/core/': [
         '/core/',

--- a/docs/orchestration/concepts/api_keys.md
+++ b/docs/orchestration/concepts/api_keys.md
@@ -200,11 +200,11 @@ mutation {
 ## Using API keys with older versions of Prefect
 
 ::: warning
-API tokens are no longer supported as an authentication method.
+As of version 1.0.0, API tokens are no longer supported as an authentication method.
 
-If you are running a version of Prefect older than 0.15.0, this section describes how you can use API keys for authentication.
+This section describes how you can use API keys for authentication in place of how you may have previously used tokens.
 
-If you have logged in with an API key, but a token still exists on your machine, the API key will be used and the token will be ignored.
+Note that, if you have logged in with an API key, but a token still exists on your machine, the API key will be used and the token will be ignored.
 :::
 
 If you are running a version of Prefect older than 0.15.0, note that:
@@ -212,7 +212,8 @@ If you are running a version of Prefect older than 0.15.0, note that:
 - The `prefect auth login` CLI command will not work with API keys.
 - The `PREFECT__CLOUD__API_KEY` setting will be ignored. 
 
-Versions prior to Prefect 0.15.0 used _authentication tokens_. You can use API keys in these older versions of Prefect by setting them in the config or the environment in the `PREFECT__CLOUD__AUTH_TOKEN` setting.
+
+In most cases you can use API keys as you previously used tokens. Here are a few examples where API keys are used in place of tokens.
 
 Using an API key as a token for registering flows:
 ```bash
@@ -230,13 +231,11 @@ $ export PREFECT__CLOUD__AGENT__AUTH_TOKEN="<YOUR-KEY>"
 $ prefect agent local start
 ```
 
-`PREFECT__CLOUD__AUTH_TOKEN` is no longer passed through to non-container flow run jobs.
-
-`PREFECT__CLOUD__AUTH_TOKEN` is set to the value of `PREFECT__CLOUD__API_KEY` for containerized flow run jobs, which will allow containers running old versions of Prefect to work with current agents with the caveat that the API key must be used with the default tenant.
-
 ## Removing API tokens
 
-As of version 1.0.0, support for API tokens has been removed. If you used `prefect auth login` with an API token or had set an API token in your config or environment, you would have received warnings starting with version 0.15.0. 
+As of version 1.0.0, API tokens are no longer supported. 
+
+If you used `prefect auth login` with an API token or had set an API token in your config or environment, you would have received warnings starting with version 0.15.0. 
 
 `prefect auth status` will warn about existing authentication tokens and advise on removal.
 
@@ -252,6 +251,4 @@ If you set your token in the environment, you can unset it with `unset PREFECT__
 
 If you set your token in the config, you will have to modify `~/.prefect/config.toml` to remove it.
 
-::: warning 
-If you have logged in with an API key but a token still exists on your machine, the API key will be used and the token will be ignored.
-:::
+If you have logged in with an API key, but a token still exists on your machine, the API key will be used and the token will be ignored.

--- a/docs/orchestration/concepts/api_keys.md
+++ b/docs/orchestration/concepts/api_keys.md
@@ -199,29 +199,54 @@ mutation {
 
 ## Using API keys with older versions of Prefect
 
-The `prefect auth login` command will not work with API keys and the  `PREFECT__CLOUD__API_KEY` setting will be ignored before version 0.15.0. In older versions, there were authentication tokens. Keys can be used in-place in older versions by setting them in the config or the environment in the `PREFECT__CLOUD__AUTH_TOKEN` setting.
+::: warning
+API tokens are no longer supported as an authentication method.
 
-Using an API key as a token for registering flows
+If you are running a version of Prefect older than 0.15.0, this section describes how you can use API keys for authentication.
+
+If you have logged in with an API key, but a token still exists on your machine, the API key will be used and the token will be ignored.
+:::
+
+If you are running a version of Prefect older than 0.15.0, note that:
+
+- The `prefect auth login` CLI command will not work with API keys.
+- The `PREFECT__CLOUD__API_KEY` setting will be ignored. 
+
+Versions prior to Prefect 0.15.0 used _authentication tokens_. You can use API keys in these older versions of Prefect by setting them in the config or the environment in the `PREFECT__CLOUD__AUTH_TOKEN` setting.
+
+Using an API key as a token for registering flows:
 ```bash
 export PREFECT__CLOUD__AUTH_TOKEN="<YOUR-KEY>"
 ```
 
-Using an API key as a token for starting an agent by CLI
+Using an API key as a token for starting an agent by CLI:
 ```bash
 $ prefect agent local start -k "<SERVICE_ACCOUNT_API_KEY>"
 ```
 
-Using an API key as a token for starting an agent by environment
+Using an API key as a token for starting an agent by environment:
 ```bash
 $ export PREFECT__CLOUD__AGENT__AUTH_TOKEN="<YOUR-KEY>"
 $ prefect agent local start
 ```
 
+`PREFECT__CLOUD__AUTH_TOKEN` is no longer passed through to non-container flow run jobs.
+
+`PREFECT__CLOUD__AUTH_TOKEN` is set to the value of `PREFECT__CLOUD__API_KEY` for containerized flow run jobs, which will allow containers running old versions of Prefect to work with current agents with the caveat that the API key must be used with the default tenant.
+
 ## Removing API tokens
 
-If you've used `prefect auth login` with an API token or have set an API token in your config or environment, you will receieve warnings starting with version 0.15.0 that tokens have been deprecated. As of version 1.0.0, support for API tokens has been removed. API keys are more secure and simpler to use, we urge you to switch over. 
+As of version 1.0.0, support for API tokens has been removed. If you used `prefect auth login` with an API token or had set an API token in your config or environment, you would have received warnings starting with version 0.15.0. 
 
-If you logged in with `prefect auth login`, you can remove your token with `prefect auth purge-tokens` or `rm -r ~/.prefect/client`.
+`prefect auth status` will warn about existing authentication tokens and advise on removal.
+
+If you logged in with `prefect auth login`, you can remove your token with the CLI command:
+
+```bash
+prefect auth purge-tokens
+``` 
+
+You can remove the tokens manually by using the command `rm -r ~/.prefect/client`.
 
 If you set your token in the environment, you can unset it with `unset PREFECT__CLOUD__AUTH_TOKEN`.
 

--- a/docs/orchestration/concepts/api_keys.md
+++ b/docs/orchestration/concepts/api_keys.md
@@ -61,9 +61,9 @@ You may also provide your key with an environment variable or the config. This i
 ::: tab Environment
 
 ```bash
-export PREFECT__CLOUD__API_KEY="<YOUR-KEY>"
+$ export PREFECT__CLOUD__API_KEY="<YOUR-KEY>"
 # Optional
-export PREFECT__CLOUD__TENANT_ID="<TENANT-ID>"
+$ export PREFECT__CLOUD__TENANT_ID="<TENANT-ID>"
 ```
 :::
 
@@ -88,7 +88,7 @@ tenant_id = "<TENANT-ID>"
 Agents will load keys from these default locations as described above, but you can also pass an override directly to the agent when you start it. For example:
 
 ```bash
-prefect agent local start --key "<YOUR-KEY>"
+$ prefect agent local start --key "<YOUR-KEY>"
 ```
 :::
 
@@ -176,7 +176,7 @@ To revoke an API key in the UI navigate to Team Settings > Service Accounts or A
 To revoke an API key from the Prefect CLI, use the `prefect auth revoke-key` command. You will likely need to retrieve the ID of they key with `prefect auth list-keys` first.
 
 ```bash
-prefect auth revoke-key --id API_KEY_ID
+$ prefect auth revoke-key --id API_KEY_ID
 ```
 
 :::
@@ -216,7 +216,7 @@ Versions prior to Prefect 0.15.0 used _authentication tokens_. You can use API k
 
 Using an API key as a token for registering flows:
 ```bash
-export PREFECT__CLOUD__AUTH_TOKEN="<YOUR-KEY>"
+$ export PREFECT__CLOUD__AUTH_TOKEN="<YOUR-KEY>"
 ```
 
 Using an API key as a token for starting an agent by CLI:
@@ -243,7 +243,7 @@ As of version 1.0.0, support for API tokens has been removed. If you used `prefe
 If you logged in with `prefect auth login`, you can remove your token with the CLI command:
 
 ```bash
-prefect auth purge-tokens
+$ prefect auth purge-tokens
 ``` 
 
 You can remove the tokens manually by using the command `rm -r ~/.prefect/client`.

--- a/docs/orchestration/execution/custom_environment.md
+++ b/docs/orchestration/execution/custom_environment.md
@@ -1,0 +1,139 @@
+# Custom Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+Prefect environments allow for completely custom, user-created environments. The only requirement is that your custom environment inherit from the base `Environment` class.
+
+### Process
+
+Custom environments can be attached to flows in the same manner as any preexisting Prefect environment, and are stored in the storage option alongside your flow. It will never be sent to the Prefect API and will only exist inside your Flow's storage.
+
+:::warning Custom Environment Naming
+Make sure the name of your custom environment does not match the names of any preexisting [Prefect environments](/api/latest/environments/execution.html) because it could behave unpredictably when working with Prefect Serializers.
+:::
+
+### Custom Environment Example
+
+```python
+from typing import Any, Callable, List
+
+from prefect import config
+from prefect.environments.execution import Environment
+from prefect.storage import Storage
+
+
+class MyCustomEnvironment(Environment):
+    """
+    MyCustomEnvironment is my environment that uses the default executor to run a Flow.
+
+    Args:
+        - labels (List[str], optional): a list of labels, which are arbitrary string identifiers used by Prefect Agents when polling for work
+        - on_start (Callable, optional): a function callback which will be called before the flow begins to run
+        - on_exit (Callable, optional): a function callback which will be called after the flow finishes its run
+    """
+
+    def __init__(
+        self,
+        labels: List[str] = None,
+        on_start: Callable = None,
+        on_exit: Callable = None,
+    ) -> None:
+        super().__init__(labels=labels, on_start=on_start, on_exit=on_exit)
+
+    # Optionally specify any required dependencies
+    # that will be checked for during the deployment healthchecks
+    @property
+    def dependencies(self) -> list:
+        return []
+
+    def setup(self, storage: "Storage") -> None:
+        """
+        Sets up any infrastructure needed for this Environment
+
+        Args:
+            - storage (Storage): the Storage object that contains the flow
+        """
+        # Do some set up here if needed, otherwise pass
+        pass
+
+    def execute(  # type: ignore
+        self, storage: "Storage", flow_location: str, **kwargs: Any
+    ) -> None:
+        """
+        Run a flow from the `flow_location` here using the default executor
+
+        Args:
+            - storage (Storage): the storage object that contains information relating
+                to where and how the flow is stored
+            - flow_location (str): the location of the Flow to execute
+            - **kwargs (Any): additional keyword arguments to pass to the runner
+        """
+
+        # Call on_start callback if specified
+        if self.on_start:
+            self.on_start()
+
+        try:
+            from prefect.engine import (
+                get_default_executor_class,
+                get_default_flow_runner_class,
+            )
+
+            # Load serialized flow from file and run it with a DaskExecutor
+            flow = storage.get_flow(flow_location)
+
+            # Get default executor and flow runner
+            executor = get_default_executor_class()
+            runner_cls = get_default_flow_runner_class()
+
+            # Run flow
+            runner_cls(flow=flow).run(executor=executor)
+        except Exception as exc:
+            self.logger.exception(
+                "Unexpected error raised during flow run: {}".format(exc)
+            )
+            raise exc
+        finally:
+            # Call on_exit callback if specified
+            if self.on_exit:
+                self.on_exit()
+
+
+# ###################### #
+#          FLOW          #
+# ###################### #
+
+
+from prefect import task, Flow
+from prefect.storage import Docker
+
+
+@task
+def get_value():
+    return "Example!"
+
+
+@task
+def output_value(value):
+    print(value)
+
+
+flow = Flow(
+    "Custom Environment Example",
+    environment=MyCustomEnvironment(),  # Use our custom Environment
+    storage=Docker(
+        registry_url="gcr.io/dev/", image_name="custom-env-flow", image_tag="0.1.0"
+    ),
+)
+
+# set task dependencies using imperative API
+output_value.set_upstream(get_value, flow=flow)
+output_value.bind(value=get_value, flow=flow)
+```

--- a/docs/orchestration/execution/custom_environment.md
+++ b/docs/orchestration/execution/custom_environment.md
@@ -1,10 +1,7 @@
 # Custom Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]

--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -1,10 +1,7 @@
 # Dask Cloud Provider Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]

--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -1,0 +1,310 @@
+# Dask Cloud Provider Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+
+## Overview
+
+The Dask Cloud Provider Environment executes each Flow run on a dynamically created Dask cluster. It uses
+the [Dask Cloud Provider](https://cloudprovider.dask.org/) project to create a Dask scheduler and
+workers using cloud provider services, e.g. AWS Fargate. This Environment aims to provide a very
+easy way to achieve high scalability without the complexity of Kubernetes.
+
+:::tip AWS, Azure Only
+Dask Cloud Provider currently supports AWS (using either Fargate or ECS)
+and Azure (using AzureML).
+Support for GCP is [coming soon](https://github.com/dask/dask-cloudprovider/pull/131).
+:::
+
+:::warning Security Considerations
+By default, Dask Cloud Provider may create a Dask cluster in some environments (e.g. Fargate)
+that is accessible via a public IP, without any authentication, and configured to NOT encrypt
+network traffic. Please be conscious of security issues if you test this environment.
+(Also see pull requests [85](https://github.com/dask/dask-cloudprovider/pull/85) and
+[91](https://github.com/dask/dask-cloudprovider/pull/91) in the Dask Cloud Provider project.)
+:::
+
+## Process
+
+#### Initialization
+
+The `DaskCloudProviderEnvironment` serves largely to pass kwargs through to the specific class
+from the Dask Cloud Provider project that you're using. You can find the list of
+available arguments in the Dask Cloud Provider
+[API documentation](https://cloudprovider.dask.org/en/latest/api.html).
+
+```python
+from dask_cloudprovider import FargateCluster
+
+from prefect import Flow, task
+from prefect.environments import DaskCloudProviderEnvironment
+
+environment = DaskCloudProviderEnvironment(
+    provider_class=FargateCluster,
+    task_role_arn="arn:aws:iam::<your-aws-account-number>:role/<your-aws-iam-role-name>",
+    execution_role_arn="arn:aws:iam::<your-aws-account-number>:role/ecsTaskExecutionRole",
+    n_workers=1,
+    scheduler_cpu=256,
+    scheduler_mem=512,
+    worker_cpu=512,
+    worker_mem=1024
+)
+```
+
+The above code will create a Dask scheduler and one Dask worker using AWS Fargate each
+time that a Flow using that environment runs.
+
+
+:::warning Fargate Task Startup Latency
+AWS Fargate Task startup time can be slow and increases as your Docker
+image size increases. Total startup time for a Dask scheduler and workers can
+be several minutes. This environment is appropriate for production
+deployments of scheduled Flows where there's little sensitivity to startup
+time. `DaskCloudProviderEnvironment` is a particularly good fit for automated
+deployment of scheduled Flows in a CI/CD pipeline where the infrastructure for each Flow
+should be as independent as possible, e.g. each Flow could have its own docker
+image, dynamically create the Dask cluster for each Flow run, etc. However, for
+development and interactive testing, either using ECS (instead of Fargate) or
+creating a Dask cluster manually (with Dask Cloud Provider or otherwise) and then using
+`LocalEnvironment` configured with a `DaskExecutor` will result
+in a much better and faster development experience.
+:::
+
+#### Requirements
+
+The Dask Cloud Provider environment requires sufficient privileges with your cloud provider
+in order to run Docker containers for the Dask scheduler and workers. It's a good idea to
+test Dask Cloud Provider directly and confirm that it's working properly before using
+`DaskCloudProviderEnvironment`. See [this documentation](https://cloudprovider.dask.org/)
+for more details.
+
+Here's an example of creating a Dask cluster using Dask Cloud Provider directly,
+running a Flow on it, and then closing the cluster to tear down all cloud resoures
+that were created.
+
+```python
+from dask_cloudprovider import FargateCluster
+
+from prefect import Flow, Parameter, task
+from prefect.executors import DaskExecutor
+
+cluster = FargateCluster(
+    image="prefecthq/prefect:latest",
+    task_role_arn="arn:aws:iam::<your-aws-account-number>:role/<your-aws-iam-role-name>",
+    execution_role_arn="arn:aws:iam::<your-aws-account-number>:role/ecsTaskExecutionRole",
+    n_workers=1,
+    scheduler_cpu=256,
+    scheduler_mem=512,
+    worker_cpu=256,
+    worker_mem=512,
+    scheduler_timeout="15 minutes",
+)
+# Be aware of scheduler_timeout. In this case, if no Dask client (e.g. Prefect
+# Dask Executor) has connected to the Dask scheduler in 15 minutes, the Dask
+# cluster will terminate. For development, you may want to increase this timeout.
+
+
+@task
+def times_two(x):
+    return x * 2
+
+
+@task
+def get_sum(x_list):
+    return sum(x_list)
+
+
+with Flow("Dask Cloud Provider Test") as flow:
+    x = Parameter("x", default=[1, 2, 3])
+    y = times_two.map(x)
+    results = get_sum(y)
+
+# cluser.scheduler.address is the private ip 
+# use cluster.scheduler_address if connecting on the public ip
+flow.run(executor=DaskExecutor(cluster.scheduler.address),
+         parameters={"x": list(range(10))})
+
+# Tear down the Dask cluster. If you're developing and testing your flow you would
+# not do this after each Flow run, but when you're done developing and testing.
+cluster.close()
+```
+
+One of the coolest and most useful features of Dask is the visual dashboard that
+updates in real time as a cluster executes a Flow. Here's a view of the Dask dashboard
+while the above Flow processed a list of 100 items with 4 Dask workers:
+
+![](/orchestration/dask/dask-cloud-provider-dashboard.png)
+
+You can find the URL for the Dask dashboard of your cluster in the Flow logs:
+
+```
+April 26th 2020 at 12:17:41pm | prefect.DaskCloudProviderEnvironment
+Dask cluster created. Scheduler address: tls://172.33.18.197:8786 Dashboard: http://172.33.18.197:8787
+```
+
+#### Setup
+
+The Dask Cloud Provider environment has no setup step because it has no infrastructure requirements.
+
+#### Execute
+
+Create a new cluster consisting of one Dask scheduler and one or more Dask workers on your
+cloud provider. By default, `DaskCloudProviderEnvironment` will use the same Docker image
+as your Flow for the Dask scheduler and worker. This ensures that the Dask workers have the
+same dependencies (python modules, etc.) as the environment where the Flow runs. This drastically
+simplifies dependency management and avoids the need for separately distributing softare
+to Dask workers.
+
+Following creation of the Dask cluster, the Flow will be run using the
+[Dask Executor](/api/latest/executors.html#daskexecutor) pointed
+to the newly-created Dask cluster. All Task execution will take place on the
+Dask workers.
+
+## Examples
+
+#### Adaptive Number of Dask Workers
+
+The following example will execute your Flow on a cluster that uses Dask's adaptive scaling
+to dynamically select the number of workers based on load of the Flow. The cluster
+will start with a single worker and dynamically scale up to five workers as needed.
+
+:::tip Dask Adaptive Mode vs. Fixed Number of Workers
+While letting Dask dynamically choose the number of workers with adaptive mode is
+attractive, the slow startup time of Fargate workers may cause Dask to quickly request
+the maximum number of workers. You may find that manually specifying the number of
+workers with `n_workers` is more effective. You can also do your own calculation
+of `n_workers` based on Flow run parameters at execution time in your own `on_execute()`
+callback function. (See the last code example on this page.)
+:::
+
+```python
+from dask_cloudprovider import FargateCluster
+
+from prefect import Flow, task, Parameter
+from prefect.environments import DaskCloudProviderEnvironment
+
+environment = DaskCloudProviderEnvironment(
+    provider_class=FargateCluster,
+    cluster_arn="arn:aws:ecs:us-west-2:<your-aws-account-number>:cluster/<your-ecs-cluster-name>",
+    task_role_arn="arn:aws:iam::<your-aws-account-number>:role/<your-aws-iam-role-name>",
+    execution_role_arn="arn:aws:iam::<your-aws-account-number>:role/ecsTaskExecutionRole",
+    adaptive_min_workers=1,
+    adaptive_max_workers=5,
+    scheduler_cpu=256,
+    scheduler_mem=512,
+    worker_cpu=512,
+    worker_mem=1024
+)
+
+
+@task
+def times_two(x):
+    return x * 2
+
+
+@task
+def get_sum(x_list):
+    return sum(x_list)
+
+
+with Flow("Dask Cloud Provider Test", environment=environment) as flow:
+    x = Parameter("x", default=[1, 2, 3])
+    y = times_two.map(x)
+    results = get_sum(y)
+```
+
+#### Advanced Example: Dynamic Worker Sizing from Parameters & TLS Encryption
+
+In this example we enable TLS encryption with Dask and dynamically calculate the number of Dask
+workers based on the parameters to a Flow run just prior to execution.
+
+- The `on_execute` callback function examines parameters for that Flow run and modifies the kwargs
+that will get passed to the constructor of the provider class from Dask Cloud Provider.
+
+- TLS ecryption requires that the cert, key, and CA files are available in the Flow's Docker image
+
+- The `scheduler_extra_args` and `worker_extra_args` kwargs are not yet available in Dask Cloud Provider,
+but there is an [open pull request](https://github.com/dask/dask-cloudprovider/pull/91) to include them.
+
+```python
+import math
+
+from typing import Any, List, Dict
+
+from distributed.security import Security
+from dask_cloudprovider import FargateCluster
+
+import prefect
+from prefect import Flow, Parameter, task
+from prefect.environments import DaskCloudProviderEnvironment
+
+
+security = Security(
+    tls_client_cert="/opt/tls/your-cert-file.pem",
+    tls_client_key="/opt/tls/your-key-file.key",
+    tls_ca_file="/opt/tls/your-ca-file.pem",
+    require_encryption=True,
+)
+
+
+def on_execute(parameters: Dict[str, Any], provider_kwargs: Dict[str, Any]) -> None:
+    length_of_x = len(parameters.get("x"))
+    natural_log_of_length = int(math.log(length_of_x))
+    n_workers = min(1, max(10, natural_log_of_length))  # At least 1 worker & no more than 10
+    provider_kwargs["n_workers"] = n_workers
+
+
+environment = DaskCloudProviderEnvironment(
+    provider_class=FargateCluster,
+    cluster_arn="arn:aws:ecs:us-west-2:<your-aws-account-number>:cluster/<your-ecs-cluster-name>",
+    task_role_arn="arn:aws:iam::<your-aws-account-number>:role/<your-aws-iam-role-name>",
+    execution_role_arn="arn:aws:iam::<your-aws-account-number>:role/ecsTaskExecutionRole",
+    n_workers=1,
+    scheduler_cpu=256,
+    scheduler_mem=512,
+    worker_cpu=512,
+    worker_mem=1024,
+    on_execute=on_execute,
+    security=security,
+    scheduler_extra_args=[
+        "--tls-cert",
+        "/opt/tls/your-cert-file.pem",
+        "--tls-key",
+        "/opt/tls/your-key-file.key",
+        "--tls-ca-file",
+        "/opt/tls/your-ca-file.pem",
+    ],
+    worker_extra_args=[
+        "--tls-cert",
+        "/opt/tls/your-cert-file.pem",
+        "--tls-key",
+        "/opt/tls/your-key-file.key",
+        "--tls-ca-file",
+        "/opt/tls/your-ca-file.pem",
+    ]
+)
+
+
+@task
+def times_two(x):
+    return x * 2
+
+
+@task
+def get_sum(x_list):
+    return sum(x_list)
+
+
+with Flow("DaskCloudProviderEnvironment Test", environment=environment) as flow:
+    x = Parameter("x", default=list(range(10)))
+    y = times_two.map(x)
+    results = get_sum(y)
+
+```

--- a/docs/orchestration/execution/dask_k8s_environment.md
+++ b/docs/orchestration/execution/dask_k8s_environment.md
@@ -1,10 +1,7 @@
 # Dask Kubernetes Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]

--- a/docs/orchestration/execution/dask_k8s_environment.md
+++ b/docs/orchestration/execution/dask_k8s_environment.md
@@ -1,0 +1,195 @@
+# Dask Kubernetes Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+## Overview
+
+The Dask Kubernetes environment uses the [dask-kubernetes](https://kubernetes.dask.org/en/latest/) library to dynamically spawn Dask clusters on Kubernetes. This environment is intended for use in cases where you do not want a static, long-standing Dask cluster, but would rather have a temporary Dask cluster created for each Flow run. The Dask Kubernetes environment has both low-configuration options to quickly get up and running and the ability to specify completely custom [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/) specifications for the Dask scheduler and workers.
+
+_For more information on the Dask Kubernetes environment visit the relevant [API documentation](/api/latest/environments/execution.html#daskkubernetesenvironment)._
+
+## Process
+
+#### Initialization
+
+**Quick Configuration:**
+
+The `DaskKubernetesEnvironment` can optionally accept two worker-dependent arguments `min_workers` and `max_workers`. These options set the minimum and maximum number of workers you want to dynamically scale to for your Dask cluster; these default to 1 and 2 workers respectively.
+
+:::tip Auto Scaling
+If you do not want your Dask cluster to automatically scale the number of workers between the bounds of `min_workers` and `max_workers` then set the two options to the same value.
+:::
+
+:::warning Private Registries
+When running your flows that are registered with a private container registry, you should either specify the name of an `image_pull_secret` on the flow's `DaskKubernetesEnvironment` or directly set the `imagePullSecrets` on your custom worker/scheduler specs.
+:::
+
+**Custom Configuration:**
+
+The `DaskKubernetesEnvironment` also has two optional arguments for loading completely custom scheduler and worker YAML specifications: `scheduler_spec_file` and `worker_spec_file`. These options should be file paths to YAML files containing the spec. On initialization these files will be loaded and stored in the environment; they will _never be sent to Prefect Cloud_ and will exist _only inside your Flow's Docker storage_. You may choose to specify only one of these files as both are not required. It is a common use case for users to only specify a `worker_spec_file` because when using Dask all execution takes place on the workers.
+
+Providing custom YAML configuration is useful in a lot of cases, especially when you may want to control resource usage, node allocation, RBAC, etc.
+
+:::warning YAML Override
+If you choose to provide any custom YAML spec files they will take precedence over the quick configuration arguments when creating the Dask cluster.
+:::
+
+:::warning Image
+When using the custom YAML spec files it is recommended that you ensure the `image` is the same image name and tag that was built for your Flow on registration. This is to ensure consistency of dependencies for your Flow's execution.
+
+e.g. If you push a Flow's storage as `gcr.io/dev/etl-flow:0.1.0` then your custom YAML spec should contain `- image: gcr.io/dev/etl-flow:0.1.0`.
+:::
+
+#### Requirements
+
+The Dask Kubernetes environment requires [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to be configured in a way in which it can work with both jobs and pods in its namespace. The Prefect CLI provides a convenient `--rbac` flag for automatically attaching this Role and RoleBinding to the Agent deployment YAML.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: prefect-agent-rbac
+rules:
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: default
+  name: prefect-agent-rbac
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  kind: Role
+  name: prefect-agent-rbac
+  apiGroup: rbac.authorization.k8s.io
+```
+
+#### Setup
+
+::: warning Deprecated
+As of version `0.11.3` setting `docker_secret` and `private_registry` is deprecated. Image pull secrets should be set on custom YAML for the scheduler and worker pods or directly through the `image_pull_secret` kwarg. For more information on Kubernetes imagePullSecets go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
+:::
+
+The Dask Kubernetes environment setup step is responsible for checking the [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for a provided `docker_secret` only if `private_registry=True`. If the Kubernetes Secret is not found then it will attempt to create one based off of the value set in the Prefect Secret matching the name specified for `docker_secret`.
+
+_For more information on how Docker registry credentials are used as Kubernetes imagePullSecrets go [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)._
+
+#### Execute
+
+Create a new [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) with the configuration provided at initialization of this environment. That Job is responsible for creating a `KubeCluster` object from the `dask_kubernetes` library with the provided configuration. Previously configured custom worker YAML and min/max worker settings are applied at this point as `dask_kubernetes` takes care of automatic worker creation.
+
+Following creation of the Dask cluster, the Flow will be run using the [Dask Executor](/api/latest/executors.html#daskexecutor) pointing to the newly-created Dask cluster. All Task execution will take place on the Dask worker pods.
+
+## Examples
+
+#### Dask Kubernetes Environment w/ Min & Max Workers
+
+The following example will execute your Flow on an auto-scaling Dask cluster in Kubernetes. The cluster will start with a single worker and dynamically scale up to five workers as needed.
+
+```python
+from prefect import task, Flow
+from prefect.environments import DaskKubernetesEnvironment
+
+
+@task
+def get_value():
+    return "Example!"
+
+
+@task
+def output_value(value):
+    print(value)
+
+
+flow = Flow(
+    "Min / Max Workers Dask Kubernetes Example",
+    environment=DaskKubernetesEnvironment(min_workers=1, max_workers=3),
+)
+
+# set task dependencies using imperative API
+output_value.set_upstream(get_value, flow=flow)
+output_value.bind(value=get_value, flow=flow)
+
+```
+
+#### Dask Kubernetes Environment w/ Custom Worker YAML
+
+In this example we specify a custom worker specification. There are a few things of note here:
+
+- The worker YAML is contained in a file called `worker_spec.yaml`. This YAML is placed in the same directory as the Flow and is loaded in your environment with `worker_spec_file="worker_spec.yaml"`.
+
+- The Flow's storage is set to have a registry url, image name, and image tag as `gcr.io/dev/dask-k8s-flow:0.1.0`. Note that this is the same image specified in the YAML.
+
+- The worker spec has `replicas: 2` which means that on creation of the Dask cluster there will be two worker pods for executing the Tasks of your Flow.
+
+```yaml
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+spec:
+  replicas: 2
+  restartPolicy: Never
+  containers:
+    - image: gcr.io/dev/dask-k8s-flow:0.1.0
+      imagePullPolicy: IfNotPresent
+      args: [dask-worker, --nthreads, "2", --no-bokeh, --memory-limit, 4GB]
+      name: dask-worker
+      env:
+        - name: EXTRA_PIP_PACKAGES
+          value: fastparquet git+https://github.com/dask/distributed
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4G
+        requests:
+          cpu: "2"
+          memory: 2G
+```
+
+```python
+from prefect import task, Flow
+from prefect.environments import DaskKubernetesEnvironment
+from prefect.storage import Docker
+
+
+@task
+def get_value():
+    return "Example!"
+
+
+@task
+def output_value(value):
+    print(value)
+
+
+flow = Flow(
+    "Custom Worker Spec Dask Kubernetes Example",
+    environment=DaskKubernetesEnvironment(worker_spec_file="worker_spec.yaml"),
+    storage=Docker(
+        registry_url="gcr.io/dev/", image_name="dask-k8s-flow", image_tag="0.1.0"
+    ),
+)
+
+# set task dependencies using imperative API
+output_value.set_upstream(get_value, flow=flow)
+output_value.bind(value=get_value, flow=flow)
+
+```

--- a/docs/orchestration/execution/fargate_task_environment.md
+++ b/docs/orchestration/execution/fargate_task_environment.md
@@ -1,0 +1,188 @@
+# Fargate Task Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+## Overview
+
+The Fargate Task Environment runs a Flow on a completely custom [Fargate Task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html). This Environment is intended for use in cases where you want complete control over the Fargate Task your Flow runs on.
+
+_For more information on the Fargate Task Environment visit the relevant [API documentation](/api/latest/environments/execution.html#fargatetaskenvironment)._
+
+## Process
+
+#### Initialization
+
+The `FargateTaskEnvironment` has two groups of keyword arguments: boto3-related arguments and task-related arguments. All of this configuration revolves around how the [boto3]() library communicates with AWS. The design of this Environment is meant to be open to all access methodologies for AWS instead of adhering to a single mode of authentication.
+
+This Environment accepts similar arguments to how boto3 authenticates with AWS: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, and `region_name`. These arguments are directly passed to the [boto3 client]() which means you should initialize this Environment in the same way you would normally use boto3.
+
+The other group of kwargs are those you would pass into boto3 for [registering](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition) a task definition and [running](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task) that task.
+
+Accepted kwargs for [`register_task_definition`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition):
+
+```
+family                      string
+taskRoleArn                 string
+executionRoleArn            string
+networkMode                 string
+containerDefinitions        list
+volumes                     list
+placementConstraints        list
+requiresCompatibilities     list
+cpu                         string
+memory                      string
+tags                        list
+pidMode                     string
+ipcMode                     string
+proxyConfiguration          dict
+inferenceAccelerators       list
+```
+
+Accepted kwargs for [`run_task`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task):
+
+```
+cluster                     string
+taskDefinition              string
+count                       integer
+startedBy                   string
+group                       string
+placementConstraints        list
+placementStrategy           list
+platformVersion             string
+networkConfiguration        dict
+tags                        list
+enableECSManagedTags        boolean
+propagateTags               string
+```
+
+All of these kwargs will be loaded and stored upon initialization of the Environment. It will _never be sent to Prefect Cloud_ and will only exist inside your Flow's Docker storage object.
+
+:::tip Task IAM Roles
+Users have seen great performance in using [Task IAM Roles](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html) for their Flow execution.
+:::
+
+#### Setup
+
+The Fargate Task Environment setup step is responsible for registering the Fargate Task if it does not already exist. First it checks for the existence of a task definition based on the `family` that was provided at initialization of this Environment. If the task definition is not found then it is created. This means that if a Flow is run multiple times the task definition will only need to be created once.
+
+#### Execute
+
+Create a new Fargate Task with the configuration provided at initialization of this Environment. That task is responsible for running your flow.
+
+#### Task Spec Configuration
+
+There are a few caveats to using the Fargate Task Environment that revolve around the provided boto3 kwargs. In the `containerDefinitions` that you provide, the **first container** listed will be the container that is used to run the Flow. This means that the first container will always be overridden during the `setup` step of this Environment.
+
+```python
+containerDefinitions=[
+    {
+        "name": "flow",
+        "image": "image",
+        "command": [],
+        "environment": [],
+        "essential": True,
+    }
+],
+```
+
+The container dictionary above will be changed during setup:
+
+- `name` will become _flow-container_
+- `image` will become the _registry_url/image_name:image_tag_ of your Flow's storage
+- `command` will take the form of:
+
+```python
+[
+    "/bin/sh",
+    "-c",
+    "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
+]
+```
+
+- `environment` will have some extra variables automatically appended to it for Cloud-based Flow runs:
+
+```
+PREFECT__CLOUD__GRAPHQL
+PREFECT__CLOUD__USE_LOCAL_SECRETS
+PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS
+PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS
+PREFECT__CLOUD__SEND_FLOW_RUN_LOGS
+PREFECT__LOGGING__EXTRA_LOGGERS
+```
+
+All other aspects of your `containerDefinitions` will remain untouched. In some cases it is easiest to use a dummy first container similar to the code block above.
+
+During the execute step of your Environment the following container overrides will be set for boto3's `run_task`:
+
+```
+PREFECT__CLOUD__API_KEY
+PREFECT__CONTEXT__FLOW_RUN_ID
+PREFECT__CONTEXT__IMAGE
+PREFECT__CONTEXT__FLOW_FILE_PATH
+```
+
+## Examples
+
+#### Fargate Task Environment w/ Resources
+
+The following example will execute your Flow using the Fargate Task Environment with the provided Task specification taking advantage of resource requests. This example also makes use of an `aws_session_token` and [IAM Role for task execution](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html).
+
+```python
+from prefect import task, Flow
+from prefect.environments import FargateTaskEnvironment
+from prefect.storage import Docker
+
+
+@task
+def get_value():
+    return "Example!"
+
+
+@task
+def output_value(value):
+    print(value)
+
+
+flow = Flow(
+    "Fargate Task Environment",
+    environment=FargateTaskEnvironment(
+        launch_type="FARGATE",
+        aws_session_token="MY_AWS_SESSION_TOKEN",
+        region="us-east-1",
+        cpu="256",
+        memory="512",
+        networkConfiguration={
+            "awsvpcConfiguration": {
+                "assignPublicIp": "ENABLED",
+                "subnets": ["MY_SUBNET_ID"],
+                "securityGroups": ["MY_SECURITY_GROUP"],
+            }
+        },
+        family="my_flow",
+        taskDefinition="my_flow",
+        taskRoleArn="MY_TASK_ROLE_ARN",
+        executionRoleArn="MY_EXECUTION_ROLE_ARN",
+        containerDefinitions=[{
+            "name": "flow-container",
+            "image": "image",
+            "command": [],
+            "environment": [],
+            "essential": True,
+        }]
+    ),
+    storage=Docker(
+        registry_url="gcr.io/dev/", image_name="fargate-task-flow", image_tag="0.1.0"
+    ),
+)
+
+# set task dependencies using imperative API
+output_value.set_upstream(get_value, flow=flow)
+output_value.bind(value=get_value, flow=flow)
+```

--- a/docs/orchestration/execution/fargate_task_environment.md
+++ b/docs/orchestration/execution/fargate_task_environment.md
@@ -1,10 +1,7 @@
 # Fargate Task Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]
@@ -19,9 +16,9 @@ _For more information on the Fargate Task Environment visit the relevant [API do
 
 #### Initialization
 
-The `FargateTaskEnvironment` has two groups of keyword arguments: boto3-related arguments and task-related arguments. All of this configuration revolves around how the [boto3]() library communicates with AWS. The design of this Environment is meant to be open to all access methodologies for AWS instead of adhering to a single mode of authentication.
+The `FargateTaskEnvironment` has two groups of keyword arguments: boto3-related arguments and task-related arguments. All of this configuration revolves around how the boto3 library communicates with AWS. The design of this Environment is meant to be open to all access methodologies for AWS instead of adhering to a single mode of authentication.
 
-This Environment accepts similar arguments to how boto3 authenticates with AWS: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, and `region_name`. These arguments are directly passed to the [boto3 client]() which means you should initialize this Environment in the same way you would normally use boto3.
+This Environment accepts similar arguments to how boto3 authenticates with AWS: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, and `region_name`. These arguments are directly passed to the boto3 client which means you should initialize this Environment in the same way you would normally use boto3.
 
 The other group of kwargs are those you would pass into boto3 for [registering](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition) a task definition and [running](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task) that task.
 

--- a/docs/orchestration/execution/k8s_job_environment.md
+++ b/docs/orchestration/execution/k8s_job_environment.md
@@ -1,10 +1,7 @@
 # Kubernetes Job Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]

--- a/docs/orchestration/execution/k8s_job_environment.md
+++ b/docs/orchestration/execution/k8s_job_environment.md
@@ -1,0 +1,154 @@
+# Kubernetes Job Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+## Overview
+
+The Kubernetes Job Environment is an Environment that runs a Flow on a completely custom [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/). This Environment is intended for use in cases where you want complete control over the Job your Flow runs on. This Environment is commonly used for resource management, node allocation, and sidecar containers.
+
+_For more information on the Kubernetes Job Environment visit the relevant [API documentation](/api/latest/environments/execution.html#kubernetesjobenvironment)._
+
+## Process
+
+#### Initialization
+
+The `KubernetesJobEnvironment` accepts an argument `job_spec_file` which is a string representation of a path to a Kubernetes Job YAML file. On initialization that Job spec file is loaded and stored in the Environment. It will _never be sent to Prefect Cloud_ and will only exist inside your Flow's Docker storage.
+
+#### Setup
+
+The Kubernetes Job Environment has no setup step because there are no infrastructure requirements needed to use this Environment.
+
+#### Execute
+
+Create a new [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) with the configuration provided at initialization of this Environment. That Job is responsible for running the Flow.
+
+#### Job Spec Configuration
+
+There are a few caveats to using the Kubernetes Job Environment that revolve around the format of the provided Job YAML. In the Job specification that you provide, the **first container** listed will be the container that is used to run the Flow. This means that the first container will always be overridden during the `execute` step of this Environment.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-prefect-job
+  labels:
+    identifier: ""
+    flow_run_id: ""
+spec:
+  template:
+    metadata:
+      labels:
+        identifier: ""
+    spec:
+      containers:
+        - name: flow-container
+          image: ""
+          command: []
+          args: []
+          env:
+            - name: MY_ENV
+              value: foo
+```
+
+In the above YAML block, `flow-container` will be changed during execution:
+
+- The metadata labels `identifier` and `flow_run_id` will be replaced with a unique identifier for this run and the id of this Flow run respectively
+- `image` will become the _registry_url/image_name:image_tag_ of your Flow's storage
+- `command` and `args` will take the form of:
+
+```bash
+/bin/sh -c "python -c 'import prefect; prefect.environments.execution.load_and_run_flow()'",
+```
+
+- `env` will have some extra variables automatically appended to it for Cloud-based Flow runs:
+
+```
+PREFECT__CLOUD__GRAPHQL
+PREFECT__CLOUD__API_KEY
+PREFECT__CONTEXT__FLOW_RUN_ID
+PREFECT__CONTEXT__NAMESPACE
+PREFECT__CONTEXT__IMAGE
+PREFECT__CONTEXT__FLOW_FILE_PATH
+PREFECT__CLOUD__USE_LOCAL_SECRETS
+PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS
+PREFECT__ENGINE__TASK_RUNNER__DEFAULT_CLASS
+PREFECT__CLOUD__SEND_FLOW_RUN_LOGS
+PREFECT__LOGGING__EXTRA_LOGGERS
+```
+
+All other aspects of your Job will remain untouched. In some cases it is easiest to use a dummy first container similar to the YAML block above.
+
+## Examples
+
+#### Kubernetes Job Environment w/ Resource Requests & Limits
+
+The following example will execute your Flow using the custom Job specification with user provided resource requests and limits.
+
+The Job spec YAML is contained in a file called `job_spec.yaml` which should be placed in the same directory as the Flow and is loaded in your Environment with `job_spec_file="job_spec.yaml"`.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-prefect-job
+  labels:
+    identifier: ""
+spec:
+  template:
+    metadata:
+      labels:
+        identifier: ""
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: flow-container
+          image: ""
+          command: []
+          args: []
+          env:
+            - name: MY_ENV
+              value: foo
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4G
+            requests:
+              cpu: "1"
+              memory: 2G
+```
+
+```python
+from prefect import task, Flow
+from prefect.environments import KubernetesJobEnvironment
+from prefect.storage import Docker
+
+
+@task
+def get_value():
+    return "Example!"
+
+
+@task
+def output_value(value):
+    print(value)
+
+
+flow = Flow(
+    "Kubernetes Job Environment w/ Resource Requests & Limits",
+    environment=KubernetesJobEnvironment(job_spec_file="job_spec.yaml"),
+    storage=Docker(
+        registry_url="gcr.io/dev/", image_name="k8s-job-flow", image_tag="0.1.0"
+    ),
+)
+
+# set task dependencies using imperative API
+output_value.set_upstream(get_value, flow=flow)
+output_value.bind(value=get_value, flow=flow)
+```

--- a/docs/orchestration/execution/local_environment.md
+++ b/docs/orchestration/execution/local_environment.md
@@ -1,0 +1,102 @@
+# Local Environment
+
+::: warning
+Flows configured with environments are being deprecated - we recommend users
+transition to using "Run Configs" instead. See [flow
+configuration](/orchestration/flow_config/overview.md) and [upgrading
+tips](/orchestration/flow_config/upgrade.md) for more information.
+:::
+
+[[toc]]
+
+## Overview
+
+The Local Environment (`LocalEnvironment`) is meant to be a simple and
+minimally configurable execution Environment for Flow runs, and is the default
+Environment for all Flows registered with the Prefect API. The Local
+Environment functions as a way to execute Flows without any pre-existing
+infrastructure requirements and instead opts to run Flows directly in process.
+
+The only needed configuration for the Local Environment is the specification
+of an [Executor](/core/concepts/engine.html#executors) however if it is not
+specified then it defaults to the
+[LocalExecutor](/api/latest/executors.html#localexecutor).
+
+_For more information on the Local Environment visit the relevant [API
+documentation](/api/latest/environments/execution.html#localenvironment)._
+
+## Process
+
+#### Initialization
+
+The `LocalEnvironment` takes an optional `executor` argument.  The `executor`
+argument accepts an [Executor](/core/concepts/engine.html#executors) object
+that should be used to run this flow. If not specified, the local default
+executor is used.
+
+#### Setup
+
+The `LocalEnvironment` has no setup step because it has no infrastructure
+requirements.
+
+#### Execute
+
+The `LocalEnvironment` executes the flow locally in process, using the
+configured `executor`.
+
+## Examples
+
+#### Using a LocalExecutor
+
+Here we configure a `LocalEnvironment` to run a flow using a `LocalExecutor`.
+Note that this is the same as the default behavior - if you don't specify an
+`environment` on a `Flow` the same configuration will be created for you.
+
+```python
+from prefect import Flow
+from prefect.environments import LocalEnvironment
+from prefect.executors import LocalExecutor
+
+flow = Flow(
+    "Local Executor Example",
+    environment=LocalEnvironment(executor=LocalExecutor()),
+)
+```
+
+#### Using a DaskExecutor, with a local Dask cluster
+
+Here we configure a `LocalEnvironment` to run a flow using a
+[DaskExecutor](/api/latest/executors.html#daskexecutor), connected to a
+local temporary [Dask](https://dask.org") cluster. When the flow run starts, a
+temporary local Dask cluster will be created just for that flow run.
+
+```python
+from prefect import Flow
+from prefect.environments import LocalEnvironment
+from prefect.executors import DaskExecutor
+
+flow = Flow(
+    "Dask Executor Example",
+    environment=LocalEnvironment(executor=DaskExecutor())
+)
+```
+
+#### Using a DaskExecutor, with an existing Dask cluster
+
+Here we configure a `LocalEnvironment` to run a flow using a `DaskExecutor`,
+connected to an existing Dask cluster.
+
+```python
+from prefect import Flow
+from prefect.environments import LocalEnvironment
+from prefect.executors import DaskExecutor
+
+flow = Flow(
+    "Dask Executor Example",
+    environment=LocalEnvironment(
+        executor=DaskExecutor(
+            "tcp://address-of-the-dask-cluster:8786",
+        )
+    )
+)
+```

--- a/docs/orchestration/execution/local_environment.md
+++ b/docs/orchestration/execution/local_environment.md
@@ -1,10 +1,7 @@
 # Local Environment
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
 :::
 
 [[toc]]

--- a/docs/orchestration/execution/overview.md
+++ b/docs/orchestration/execution/overview.md
@@ -12,7 +12,7 @@ Executing flows using the Prefect API is accomplished through two powerful abstr
 
 ## Storage
 
-[Storage](/api/latest/storage.html) objects are pieces of functionality which define how and where a Flow should be stored. Prefect supports storage options ranging from ephemeral in-memory storage to Docker images which can be stored in registries.
+[Storage](/api/latest/storage.html) objects define how and where a Flow should be stored. Prefect supports many [storage types](/orchestration/flow_config/storage.html#storage-types) ranging from local storage to Docker containers, code repositories including GitHub, and cloud storage with AWS, Azure, and Google Cloud.
 
 ### How Storage is Used
 

--- a/docs/orchestration/execution/overview.md
+++ b/docs/orchestration/execution/overview.md
@@ -1,4 +1,4 @@
-# Execution Overview
+# Environments Overview
 
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
@@ -24,7 +24,7 @@ from prefect.storage import Docker
 f = Flow("example-storage", storage=Docker(registry_url="prefecthq/storage-example"))
 ```
 
-or assign it directly:
+Or assign it directly:
 
 ```python
 from prefect.storage import Docker

--- a/docs/orchestration/execution/overview.md
+++ b/docs/orchestration/execution/overview.md
@@ -1,10 +1,9 @@
 # Execution Overview
 
 ::: warning
-Flows configured with environments are being no longer supported - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
+
+See [Storage](/orchestration/flow_config/storage.html) for current Flow definition storage capabilities.
 :::
 
 Executing flows using the Prefect API is accomplished through two powerful abstractions — storage and environments. By combining these two abstractions, flows can be saved, shared, and executed across various platforms.
@@ -13,7 +12,7 @@ Executing flows using the Prefect API is accomplished through two powerful abstr
 
 ## Storage
 
-[Storage](https://docs.prefect.io/api/latest/storage.html) objects are pieces of functionality which define how and where a Flow should be stored. Prefect supports storage options ranging from ephemeral in-memory storage to Docker images which can be stored in registries.
+[Storage](/api/latest/storage.html) objects are pieces of functionality which define how and where a Flow should be stored. Prefect supports storage options ranging from ephemeral in-memory storage to Docker images which can be stored in registries.
 
 ### How Storage is Used
 
@@ -67,7 +66,7 @@ f.register("My First Project", build=False)
 
 ## Environments
 
-While Storage objects provide a way to save and retrieve Flows, [Environments](https://docs.prefect.io/api/latest/environments/execution.html) specify _how your Flow should be run_ e.g., which executor to use and whether there are any auxiliary infrastructure requirements for your Flow's execution. For example, if you want to run your Flow on Kubernetes using an auto-scaling Dask cluster then you're going to want to use an environment for that!
+While Storage objects provide a way to save and retrieve Flows, [Environments](/api/latest/environments/execution.html) specify _how your Flow should be run_ e.g., which executor to use and whether there are any auxiliary infrastructure requirements for your Flow's execution. For example, if you want to run your Flow on Kubernetes using an auto-scaling Dask cluster then you're going to want to use an environment for that!
 
 ### How Environments are Used
 
@@ -94,7 +93,7 @@ f.environment = LocalEnvironment(executor=DaskExecutor())
 
 ### Setup & Execute
 
-The two main environment functions are `setup` and `execute`. The `setup` function is responsible for creating or prepping any infrastructure requirements before the Flow is executed e.g., spinning up a Dask cluster or checking available platform resources. The `execute` function is responsible for actually telling the Flow where and how it needs to run e.g., running the Flow in process, as per the [`LocalEnvironment`](https://docs.prefect.io/api/latest/environments/execution.html##localenvironment), or registering a new Fargate task, as per the [`FargateTaskEnvironment`](https://docs.prefect.io/api/latest/environments/execution.html#fargatetaskenvironment).
+The two main environment functions are `setup` and `execute`. The `setup` function is responsible for creating or prepping any infrastructure requirements before the Flow is executed e.g., spinning up a Dask cluster or checking available platform resources. The `execute` function is responsible for actually telling the Flow where and how it needs to run e.g., running the Flow in process, as per the [`LocalEnvironment`](/api/latest/environments/execution.html##localenvironment), or registering a new Fargate task, as per the [`FargateTaskEnvironment`](/api/latest/environments/execution.html#fargatetaskenvironment).
 
 ### Environment Callbacks
 

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -1,10 +1,9 @@
 # Storage Options
 
 ::: warning
-Flows configured with environments are being deprecated - we recommend users
-transition to using "Run Configs" instead. See [flow
-configuration](/orchestration/flow_config/overview.md) and [upgrading
-tips](/orchestration/flow_config/upgrade.md) for more information.
+Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading](/orchestration/flow_config/upgrade.md) documentation for more information.
+
+See [Storage](/orchestration/flow_config/storage.html) for current Flow definition storage capabilities.
 :::
 
 Prefect includes a variety of `Storage` options for saving flows.

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -60,7 +60,7 @@ In more recent releases of Core your flow will default to using a `AzureResult` 
 :::
 
 :::tip Azure Credentials
-Azure Storage uses an Azure [connection string](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) for Azure authentication in aim to upload (build) or download flows, so make sure to provide a  valid connection string for your Azure account. A connection string can be set as a [secret](https://docs.prefect.io/orchestration/concepts/secrets.html#secrets) or an environment variable `AZURE_STORAGE_CONNECTION_STRING` in run configuration if it is not passed as `connection_string_secret`.
+Azure Storage uses an Azure [connection string](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) for Azure authentication in aim to upload (build) or download flows, so make sure to provide a  valid connection string for your Azure account. A connection string can be set as a [secret](/orchestration/concepts/secrets.html#secrets) or an environment variable `AZURE_STORAGE_CONNECTION_STRING` in run configuration if it is not passed as `connection_string_secret`.
 :::
 
 ## AWS S3

--- a/src/prefect/storage/gitlab.py
+++ b/src/prefect/storage/gitlab.py
@@ -31,7 +31,7 @@ class GitLab(Storage):
 
     - Push this `flow.py` file to the `my/repo` repository under `/flows/flow.py`.
 
-    - Call `prefect register flow -f flow.py` to register this flow with GitLab storage.
+    - Call `prefect register -f flow.py` to register this flow with GitLab storage.
 
     Args:
         - repo (str): the project path (i.e., 'namespace/project') or ID


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->
note this PR merges into a 1.0.0 release candidate branch instead of master

## Summary
Documentation edits to reflect deprecations in 1.0.0rc

## Changes
Reflects the following changes with deprecation PR noted.

[1.0.0] Drop client handling of authentication tokens #5140
https://github.com/PrefectHQ/prefect/pull/5140

Added warning for legacy token usage and additional notes on from the PR:

status CLI command
Configuration for containers

Affects https://docs.prefect.io/orchestration/concepts/api_keys.html#using-api-keys

Retain legacy environment docs, but update note that environments are no longer supported #5072
https://github.com/PrefectHQ/prefect/pull/5072

Revised warning to note that environments are deprecated and links to current RunConfig documentation.

Remove docs.prefect.io domain from API doc links.

To do: update links to 0.15.x API docs when available.

Affects:

https://docs.prefect.io/orchestration/execution/overview.html
https://docs.prefect.io/orchestration/execution/storage_options.html
https://docs.prefect.io/orchestration/execution/local_environment.html
https://docs.prefect.io/orchestration/execution/dask_cloud_provider_environment.html
https://docs.prefect.io/orchestration/execution/dask_k8s_environment.html
https://docs.prefect.io/orchestration/execution/k8s_job_environment.html
https://docs.prefect.io/orchestration/execution/fargate_task_environment.html
https://docs.prefect.io/orchestration/execution/custom_environment.html

New flow registration CLI #4256
https://github.com/PrefectHQ/prefect/pull/4256

Fix Gitlab flow registration example in gitlab.py.

Affects: https://docs.prefect.io/api/latest/storage.html#gitlab

## Importance
Makes clear deprecated features, and begins to detach legacy components from current documentation.

Note: Environment topics will need API URL links edited to reference an 0.15.x version of the API when that is created. Currently they point to "latest", which will be incorrect on release of 1.0.0.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)