### PR TITLE
add flow_run.get_logs() example

### DIFF
--- a/docs/orchestration/flow-runs/inspection.md
+++ b/docs/orchestration/flow-runs/inspection.md
@@ -66,7 +66,21 @@ flow_run.state.message
 
 ### Getting flow run logs
 
-<!-- TODO after CLI merged -->
+Get a List of `FlowRunLog` from the flow run using `.get_logs()`
+
+```python
+flow_run.get_logs()
+# [
+#   FlowRunLog(timestamp=DateTime(1978, 03, 08, 22, 30, 00, 000000, tzinfo=Timezone('+00:00')), level=20, message='Submitted for execution: Task XXXXXXX'),
+#   FlowRunLog(timestamp=DateTime(1978, 03, 08, 22, 30, 01, 123456, tzinfo=Timezone('+00:00')), level=20, message="Beginning Flow run for 'radio_show'"),
+#   FlowRunLog(timestamp=DateTime(1978, 03, 08, 22, 30, 02, 234567, tzinfo=Timezone('+00:00')), level=20, message="Task 'series_one': Starting task run..."),
+#   FlowRunLog(timestamp=DateTime(1978, 03, 08, 22, 42, 42, 424242, tzinfo=Timezone('+00:00')), level=20, message='It feels like I just had my brains smashed out by a slice of lemon wrapped round a large gold brick.'),
+#   FlowRunLog(timestamp=DateTime(1978, 04, 12, 22, 59, 59, 987654, tzinfo=Timezone('+00:00')), level=20, message="Task 'series_one': Finished task run for task with final state: 'Success'"),
+#   FlowRunLog(timestamp=DateTime(1978, 04, 12, 23, 00, 00, 000000, tzinfo=Timezone('+00:00')), level=20, message='Flow run SUCCESS: all reference tasks succeeded')
+# ]
+```
+
+Each `FlowRunLog` in the list contains a log message, along with the log level and timestamp
 
 ### Getting flow metadata
 

--- a/docs/orchestration/flow-runs/inspection.md
+++ b/docs/orchestration/flow-runs/inspection.md
@@ -66,7 +66,7 @@ flow_run.state.message
 
 ### Getting flow run logs
 
-Get a List of `FlowRunLog` from the flow run using `.get_logs()`
+Get a List of `FlowRunLog` from the flow run using `.get_logs()`:
 
 ```python
 flow_run.get_logs()
@@ -80,7 +80,7 @@ flow_run.get_logs()
 # ]
 ```
 
-Each `FlowRunLog` in the list contains a log message, along with the log level and timestamp
+Each `FlowRunLog` in the list contains a log message, along with the log level and timestamp.
 
 ### Getting flow metadata
 


### PR DESCRIPTION
## Summary

adds an example of `flow_run.get_logs()`

## Importance

Example was missing, had to look in the source/object for the call


## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)