### PR TITLE
Allow to setup HOST and PORT via env vars

### DIFF
--- a/src/prefect/utilities/settings.py
+++ b/src/prefect/utilities/settings.py
@@ -121,6 +121,10 @@ class APISettings(BaseSettings):
     """Settings related to the Orion API. To change these settings via
     environment variable, set `PREFECT_ORION_API_{SETTING}=X`.
     """
+    
+    class Config:
+        env_prefix = "PREFECT_ORION_API_"
+        frozen = True
 
     # a default limit for queries
     default_limit: int = Field(

--- a/src/prefect/utilities/settings.py
+++ b/src/prefect/utilities/settings.py
@@ -121,7 +121,7 @@ class APISettings(BaseSettings):
     """Settings related to the Orion API. To change these settings via
     environment variable, set `PREFECT_ORION_API_{SETTING}=X`.
     """
-    
+
     class Config:
         env_prefix = "PREFECT_ORION_API_"
         frozen = True


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Small fix to allow setup HOST and PORT via env vars




## Changes
Added missed `class Config` for class APISettings




## Importance
Currently you can not change HOST/PORT for web UI 




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)