### PR TITLE
Docs - run a flow explanation missing step to save as a file

### DIFF
--- a/docs/orchestration/getting-started/basic-core-flow.md
+++ b/docs/orchestration/getting-started/basic-core-flow.md
@@ -24,12 +24,23 @@ flow.run()
 You should see the following logs after running `flow.run()` :
 
 ```
-[2020-01-08 23:49:00,239] INFO - prefect.FlowRunner | Beginning Flow run for 'hello-flow'
-[2020-01-08 23:49:00,242] INFO - prefect.FlowRunner | Starting flow run.
-[2020-01-08 23:49:00,249] INFO - prefect.TaskRunner | Task 'hello_task': Starting task run...
-[2020-01-08 23:49:00,249] INFO - prefect.Task: hello_task | Hello world!
-[2020-01-08 23:49:00,251] INFO - prefect.TaskRunner | Task 'hello_task': finished task run for task with final state: 'Success'
-[2020-01-08 23:49:00,252] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
+[2021-12-17 14:55:05-0500] INFO - prefect.FlowRunner | Beginning Flow run for 'hello-flow'
+[2021-12-17 14:55:05-0500] INFO - prefect.TaskRunner | Task 'hello_task': Starting task run...
+[2021-12-17 14:55:05-0500] INFO - prefect.hello_task | Hello world!
+[2021-12-17 14:55:05-0500] INFO - prefect.TaskRunner | Task 'hello_task': Finished task run for task with final state: 'Success'
+[2021-12-17 14:55:05-0500] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
+<Success: "All reference tasks succeeded.">
+```
+
+You can also save this code to a file called `hello_flow.py` and run it from a terminal session:
+
+```
+$ python hello_flow.py
+[2021-12-17 14:52:24-0500] INFO - prefect.FlowRunner | Beginning Flow run for 'hello-flow'
+[2021-12-17 14:52:24-0500] INFO - prefect.TaskRunner | Task 'hello_task': Starting task run...
+[2021-12-17 14:52:24-0500] INFO - prefect.hello_task | Hello world!
+[2021-12-17 14:52:24-0500] INFO - prefect.TaskRunner | Task 'hello_task': Finished task run for task with final state: 'Success'
+[2021-12-17 14:52:24-0500] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
 ```
 
 If you're running into issues, check that your Python environment is properly set up to run Prefect. Refer to the [Prefect Core Installation](/core/getting_started/install.html) documentation for further details.

--- a/docs/orchestration/getting-started/registering-and-running-a-flow.md
+++ b/docs/orchestration/getting-started/registering-and-running-a-flow.md
@@ -68,7 +68,7 @@ itself remains safe and secure on your infrastructure.
 
 For more information on flow registration, see the [registration docs](/orchestration/concepts/flows.md#registration).
 
-Running the above should output some details about your flow:
+Assuming you saved the code shown above to a file called `hello_flow.py` (or edited the file created in a [previous step](/orchestration/getting-started/basic-core-flow.html)), running it in a terminal session should output some details about your flow:
 
 ```bash
 $ python hello_flow.py
@@ -109,7 +109,7 @@ machine.
 In a new terminal session, run the following to start a local Agent.
 
 ```bash
-prefect agent local start
+$ prefect agent local start
 ```
 
 This should output some initial logs, then sit idle waiting for scheduled flow


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Fixes issue in https://github.com/PrefectHQ/prefect/issues/5098

Orchestration Getting Started tutorial starts by demonstrating in a REPL and is missing the explicit instructions to save the flow as a file, but the file is used in later steps.

## Changes
Adds example of running from a file in https://docs.prefect.io/orchestration/getting-started/basic-core-flow.html

Adds reference to previously saved file, and updates terminal output to reflect 0.15.10 output in https://docs.prefect.io/orchestration/getting-started/registering-and-running-a-flow.html

## Importance
Responds to user confusion about where the file to run was created.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~