### PR TITLE
Add release candidate support to `Docker` storage

### DIFF
--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -177,7 +177,12 @@ class Docker(Storage):
 
         version = prefect.__version__.split("+")
         if prefect_version is None:
-            self.prefect_version = "master" if len(version) > 1 else version[0]
+            self.prefect_version = (
+                "master"
+                # The release candidate is a special development version
+                if len(version) > 1 and not version[0].endswith("rc0")
+                else version[0]
+            )
         else:
             self.prefect_version = prefect_version
 
@@ -189,9 +194,9 @@ class Docker(Storage):
                 self.base_image = "prefecthq/prefect:{}-python{}".format(
                     self.prefect_version, python_version
                 )
-            elif self.prefect_version.startswith("1.0rc0"):
+            elif self.prefect_version.endswith("rc0"):
                 # Development release candidate
-                self.base_image = "prefecthq/prefect:1.0rc0"
+                self.base_image = f"prefecthq/prefect:{self.prefect_version}"
             elif (
                 re.match(r"^[0-9]+\.[0-9]+rc[0-9]+$", self.prefect_version) is not None
             ):

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -189,6 +189,16 @@ class Docker(Storage):
                 self.base_image = "prefecthq/prefect:{}-python{}".format(
                     self.prefect_version, python_version
                 )
+            elif self.prefect_version.startswith("1.0rc0"):
+                # Development release candidate
+                self.base_image = "prefecthq/prefect:1.0rc0"
+            elif (
+                re.match(r"^[0-9]+\.[0-9]+rc[0-9]+$", self.prefect_version) is not None
+            ):
+                # Actual release candidate
+                self.base_image = "prefecthq/prefect:{}-python{}".format(
+                    self.prefect_version, python_version
+                )
             else:
                 # create an image from python:*-slim directly
                 self.base_image = "python:{}-slim".format(python_version)

--- a/tests/storage/test_docker_storage.py
+++ b/tests/storage/test_docker_storage.py
@@ -122,6 +122,23 @@ def test_empty_docker_storage_on_tagged_commit(
     assert not storage.local_image
 
 
+@pytest.mark.parametrize("dev_version", ["1.0rc0", "1.0rc0+c2394823"])
+def test_base_image_release_candidate_dev_image(monkeypatch, dev_version):
+    monkeypatch.setattr(sys, "version_info", MagicMock(major=3, minor=7))
+    monkeypatch.setattr(prefect, "__version__", dev_version)
+
+    storage = Docker()
+    assert storage.base_image == "prefecthq/prefect:1.0rc0"
+
+
+def test_base_image_release_candidate(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", MagicMock(major=3, minor=7))
+    monkeypatch.setattr(prefect, "__version__", "1.0rc1")
+
+    storage = Docker()
+    assert storage.base_image == "prefecthq/prefect:1.0rc1-python3.7"
+
+
 @pytest.mark.parametrize("version_info", [(3, 5), (3, 6), (3, 7)])
 def test_docker_init_responds_to_python_version(monkeypatch, version_info):
     version_mock = MagicMock(major=version_info[0], minor=version_info[1])


### PR DESCRIPTION
`Docker` storage needs special handling to detect release candidate versioning and use the proper base image tag