### PR TITLE
Release 0.15.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.15.11 <Badge text="beta" type="success" />
+
+Released on December 22, 2021.
+
+### Enhancements
+
+- Allow passing kwargs to `Merge` task constructor via `merge()` function - [#5233](https://github.com/PrefectHQ/prefect/pull/5233)
+- Allow passing proxies to `slack_notifier` - [#5237](https://github.com/PrefectHQ/prefect/pull/5237)
+
+### Fixes
+
+- Update `RunGreatExpectationsValidation` task to work with latest version of `great_expectations` - [#5172](https://github.com/PrefectHQ/prefect/issues/5172)
+- Allow unsetting kubernetes `imagePullSecrets` with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)
+- Improve agent handling of kubernetes jobs for flow runs that have been deleted - [#5190](https://github.com/PrefectHQ/prefect/pull/5190)
+- Remove `beta1` from kubernetes agent template - [#5194](https://github.com/PrefectHQ/prefect/pull/5194)
+- Documentation improvements - [#5220](https://github.com/PrefectHQ/prefect/pull/5220), [#5232](https://github.com/PrefectHQ/prefect/pull/5232), [#5288](https://github.com/PrefectHQ/prefect/pull/5288)
+
+### Contributors
+
+- [Connor Martin](https://github.com/cjmartian)
+- [Farley Farley](https://github.com/AndrewFarley)
+- [Vincent Chéry](https://github.com/VincentAntoine)
+
 ## 0.15.10 <Badge text="beta" type="success" />
 
 Released on November 30, 2021.

--- a/changes/issue5172.yaml
+++ b/changes/issue5172.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Update `RunGreatExpectationsValidation` task to work with latest version of `great_expectations` - [#5172](https://github.com/PrefectHQ/prefect/issues/5172)"

--- a/changes/pr5001.yaml
+++ b/changes/pr5001.yaml
@@ -1,6 +1,0 @@
-
-fix:
-  - "Allow unsetting imagePullSecrets with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)"
-
-contributor:
-  - "[Farley Farley](https://github.com/AndrewFarley)"

--- a/changes/pr5190.yaml
+++ b/changes/pr5190.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Improve handling of kubernetes jobs for flow runs that have been deleted - [#5190](https://github.com/PrefectHQ/prefect/pull/5190)"

--- a/changes/pr5194.yaml
+++ b/changes/pr5194.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Removing beta1 from Kubernetes agent template - [#5194](https://github.com/PrefectHQ/prefect/pull/5194)"

--- a/changes/pr5220.yaml
+++ b/changes/pr5220.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Fixing serialized example in docs - [#5220](https://github.com/PrefectHQ/prefect/pull/5220)"

--- a/changes/pr5232.yaml
+++ b/changes/pr5232.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Adding a section to the local agent documentation - [#5232](https://github.com/PrefectHQ/prefect/pull/5232)"

--- a/changes/pr5233.yaml
+++ b/changes/pr5233.yaml
@@ -1,6 +1,0 @@
-
-enhancement:
-  - "Allow passing of kwargs to Merge constructor via merge() function - [#5233](https://github.com/PrefectHQ/prefect/pull/5233)"
-
-contributor:
-  - "[Connor Martin](https://github.com/cjmartian)"

--- a/changes/pr5237.yaml
+++ b/changes/pr5237.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Allow passing of proxies argument to slack_notifier - [#5237](https://github.com/PrefectHQ/prefect/pull/5237)"
-
-contributor:
-  - "[Vincent Chéry](https://github.com/VincentAntoine)"

--- a/changes/pr5288.yaml
+++ b/changes/pr5288.yaml
@@ -1,2 +1,0 @@
-fix:
-  - "Fixing Flow of flows sample code - [#5288](https://github.com/PrefectHQ/prefect/pull/5288)"

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -79,7 +79,7 @@ module.exports = {
       {
         text: 'API Reference',
         items: [
-          { text: 'Latest (0.15.9)', link: '/api/latest/' },
+          { text: 'Latest (0.15.11)', link: '/api/latest/' },
           { text: '0.14.22', link: '/api/0.14.22/' },
           { text: '0.13.19', link: '/api/0.13.19/' },
           { text: 'Legacy', link: 'https://docs-legacy.prefect.io' }


### PR DESCRIPTION
## Changes

### Enhancements

- Allow passing kwargs to `Merge` task constructor via `merge()` function - [#5233](https://github.com/PrefectHQ/prefect/pull/5233)
- Allow passing proxies to `slack_notifier` - [#5237](https://github.com/PrefectHQ/prefect/pull/5237)

### Fixes

- Update `RunGreatExpectationsValidation` task to work with latest version of `great_expectations` - [#5172](https://github.com/PrefectHQ/prefect/issues/5172)
- Allow unsetting kubernetes `imagePullSecrets` with an empty string - [#5001](https://github.com/PrefectHQ/prefect/pull/5001)
- Improve agent handling of kubernetes jobs for flow runs that have been deleted - [#5190](https://github.com/PrefectHQ/prefect/pull/5190)
- Remove `beta1` from kubernetes agent template - [#5194](https://github.com/PrefectHQ/prefect/pull/5194)
- Documentation improvements - [#5220](https://github.com/PrefectHQ/prefect/pull/5220), [#5232](https://github.com/PrefectHQ/prefect/pull/5232), [#5288](https://github.com/PrefectHQ/prefect/pull/5288)

### Contributors

- [Connor Martin](https://github.com/cjmartian)
- [Farley Farley](https://github.com/AndrewFarley)
- [Vincent Chéry](https://github.com/VincentAntoine)