### PR TITLE
Orion: Fix typo SavedSearchs

### DIFF
--- a/src/prefect/orion/api/saved_searches.py
+++ b/src/prefect/orion/api/saved_searches.py
@@ -14,7 +14,7 @@ from prefect.orion import models, schemas
 from prefect.orion.api import dependencies
 from prefect.orion.utilities.server import OrionRouter
 
-router = OrionRouter(prefix="/saved_searches", tags=["SavedSearchs"])
+router = OrionRouter(prefix="/saved_searches", tags=["SavedSearches"])
 
 
 @router.put("/")

--- a/src/prefect/orion/models/saved_searches.py
+++ b/src/prefect/orion/models/saved_searches.py
@@ -103,7 +103,7 @@ async def read_saved_searches(
     limit: int = None,
 ):
     """
-    Read SavedSearchs.
+    Read SavedSearches.
 
     Args:
         session (sa.orm.Session): A database session
@@ -111,7 +111,7 @@ async def read_saved_searches(
         limit(int): Query limit
 
     Returns:
-        List[db.SavedSearch]: SavedSearchs
+        List[db.SavedSearch]: SavedSearches
     """
 
     query = select(db.SavedSearch).order_by(db.SavedSearch.name)

--- a/tests/orion/api/test_saved_searches.py
+++ b/tests/orion/api/test_saved_searches.py
@@ -84,7 +84,7 @@ class TestReadSavedSearch:
         assert response.status_code == 404
 
 
-class TestReadSavedSearchs:
+class TestReadSavedSearches:
     @pytest.fixture
     async def saved_searches(self, session, flow, flow_function):
         await models.saved_searches.create_saved_search(

--- a/tests/orion/models/test_saved_searches.py
+++ b/tests/orion/models/test_saved_searches.py
@@ -63,7 +63,7 @@ class TestReadSavedSearch:
         )
 
 
-class TestReadSavedSearchs:
+class TestReadSavedSearches:
     @pytest.fixture
     async def saved_searches(self, session):
 


### PR DESCRIPTION
Fix typo "SavedSearchs" -> "SavedSearches" (missing "e").