### PR TITLE
Orion: Fix docs execution example

### DIFF
--- a/docs/tutorials/dask-task-runner.md
+++ b/docs/tutorials/dask-task-runner.md
@@ -23,11 +23,12 @@ By default, when you use a `DaskTaskRunner` it creates a temporary local Dask
 cluster.
 
 ```python
+from prefect import flow
 from prefect.task_runners import DaskTaskRunner
 
 # By default this will use a temporary local Dask cluster
-@flow
-def my_flow(task_runner=DaskTaskRunner()):
+@flow(task_runner=DaskTaskRunner())
+def my_flow():
     pass
 ```
 

--- a/docs/tutorials/execution.md
+++ b/docs/tutorials/execution.md
@@ -67,7 +67,7 @@ async def async_flow():
     await print_values([1, 2]) # runs immediately
     coros = [] 
     coros.append(print_values("abcd"))
-    coros.append(print_values("6789", "\n"))
+    coros.append(print_values("6789"))
 
     # asynchronously gather the tasks
     await asyncio.gather(*coros)


### PR DESCRIPTION
Fix error in example in `docs/tutorials/execution.md`:
```
TypeError: too many positional arguments
```