### PR TITLE
Remove Python 3.9 warning from install guide

### DIFF
--- a/docs/core/getting_started/install.md
+++ b/docs/core/getting_started/install.md
@@ -33,10 +33,6 @@ pipenv install --pre prefect
 
 ::::
 
-:::warning Python 3.9
-Prefect support for Python 3.9 is experimental and extras are not expected to work yet as we wait for required packages to be updated.
-:::
-
 ## Installing optional dependencies
 
 Prefect ships with a number of optional dependencies, which can be installed using "extras" syntax:


### PR DESCRIPTION
Addresses [this suggestion](https://github.com/PrefectHQ/prefect/issues/3453#issuecomment-1003677122)