### PR TITLE
Fix bug where null `run_config` fields cause deserialization errors in backend views

### DIFF
--- a/changes/pr5310.yaml
+++ b/changes/pr5310.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix bug where null `run_config` field caused deserialization errors in backend views  - [#1234](https://github.com/PrefectHQ/prefect/pull/1234)"

--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -83,7 +83,10 @@ class FlowView:
         flow_group_labels = flow_group_data["labels"]
         project_name = flow_data.pop("project")["name"]
         storage = StorageSchema().load(flow_data.pop("storage"))
-        run_config = RunConfigSchema().load(flow_data.pop("run_config"))
+        run_config_data = flow_data.pop("run_config")
+        run_config = (
+            RunConfigSchema().load(run_config_data) if run_config_data else None
+        )
 
         # Combine the data from `flow_data` with `kwargs`
         flow_args = {

--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -526,7 +526,10 @@ class FlowRunView:
 
         flow_run_id = flow_run_data.pop("id")
         state = State.deserialize(flow_run_data.pop("serialized_state"))
-        run_config = RunConfigSchema().load(flow_run_data.pop("run_config"))
+        run_config_data = flow_run_data.pop("run_config")
+        run_config = (
+            RunConfigSchema().load(run_config_data) if run_config_data else None
+        )
 
         states_data = flow_run_data.pop("states", [])
         states = list(

--- a/tests/backend/test_flow.py
+++ b/tests/backend/test_flow.py
@@ -180,3 +180,10 @@ def test_flow_view_handles_extra_and_missing_fields_in_serialized_flows():
     serialized.pop("parameters")  # missing data
     flow_view = FlowView._from_flow_data(flow_data)
     assert isinstance(flow_view.flow, Flow)
+
+
+def test_flow_view_handles_null_run_config():
+    flow_data = FLOW_DATA_1.copy()
+    flow_data["run_config"] = None
+    flow_view = FlowView._from_flow_data(flow_data)
+    assert flow_view.run_config is None

--- a/tests/backend/test_flow_run.py
+++ b/tests/backend/test_flow_run.py
@@ -587,3 +587,10 @@ def test_watch_flow_run_timeout(monkeypatch):
     with pytest.raises(RuntimeError, match="timed out after 12 hours of waiting"):
         for log in watch_flow_run("id"):
             pass
+
+
+def test_flow_run_view_handles_null_run_config():
+    flow_run_data = FLOW_RUN_DATA_1.copy()
+    flow_run_data["run_config"] = None
+    flow_run_view = FlowRunView._from_flow_run_data(flow_run_data)
+    assert flow_run_view.run_config is None


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If the `Flow/FlowRun.run_config` is null then the `Flow` and `FlowView` will fail to deserialize it.


## Changes
<!-- What does this PR change? -->

- Only deserialize run configs if they exist


## Importance
<!-- Why is this PR important? -->

Fixes a bug in the `prefect run` CLI when a flow is registered with an `Environment`.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)