### PR TITLE
Fix response key in airbyte task health check

### DIFF
--- a/changes/pr5314.yaml
+++ b/changes/pr5314.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Fix response key in airbyte task health check - [#5314](https://github.com/PrefectHQ/prefect/pull/5314)"
+
+contributor:
+  - "[Dennis Hinnenkamp](https://github.com/sikwel)"

--- a/src/prefect/tasks/airbyte/airbyte.py
+++ b/src/prefect/tasks/airbyte/airbyte.py
@@ -76,7 +76,7 @@ class AirbyteConnectionTask(Task):
         try:
             response = session.get(get_connection_url)
             self.logger.info(response.json())
-            health_status = response.json()["db"]
+            health_status = response.json()["available"]
             if not health_status:
                 raise AirbyteServerNotHealthyException(
                     f"Airbyte Server health status: {health_status}"

--- a/src/prefect/tasks/airbyte/airbyte.py
+++ b/src/prefect/tasks/airbyte/airbyte.py
@@ -76,9 +76,7 @@ class AirbyteConnectionTask(Task):
         try:
             response = session.get(get_connection_url)
             self.logger.info(response.json())
-            key = "db"
-            if "available" in response.json():
-                key = "available"
+            key = "available" if "available" in response.json() else "db"
             health_status = response.json()[key]
             if not health_status:
                 raise AirbyteServerNotHealthyException(

--- a/src/prefect/tasks/airbyte/airbyte.py
+++ b/src/prefect/tasks/airbyte/airbyte.py
@@ -76,7 +76,10 @@ class AirbyteConnectionTask(Task):
         try:
             response = session.get(get_connection_url)
             self.logger.info(response.json())
-            health_status = response.json()["available"]
+            key = "db"
+            if "available" in response.json():
+                key = "available"
+            health_status = response.json()[key]
             if not health_status:
                 raise AirbyteServerNotHealthyException(
                     f"Airbyte Server health status: {health_status}"

--- a/tests/tasks/airbyte/test_airbyte.py
+++ b/tests/tasks/airbyte/test_airbyte.py
@@ -41,7 +41,10 @@ class TestAirbyte:
     def test_check_health_status(self):
         airbyte_base_url = f"http://localhost:8000/api/v1"
         responses.add(
-            responses.GET, airbyte_base_url + "/health/", json={"available": True}, status=200
+            responses.GET,
+            airbyte_base_url + "/health/",
+            json={"available": True},
+            status=200,
         )
         session = requests.Session()
         task = AirbyteConnectionTask(
@@ -54,7 +57,10 @@ class TestAirbyte:
     def test_check_health_status_2(self):
         airbyte_base_url = f"http://localhost:8000/api/v1"
         responses.add(
-            responses.GET, airbyte_base_url + "/health/", json={"available": False}, status=200
+            responses.GET,
+            airbyte_base_url + "/health/",
+            json={"available": False},
+            status=200,
         )
         session = requests.Session()
         task = AirbyteConnectionTask(

--- a/tests/tasks/airbyte/test_airbyte.py
+++ b/tests/tasks/airbyte/test_airbyte.py
@@ -43,7 +43,7 @@ class TestAirbyte:
         responses.add(
             responses.GET,
             airbyte_base_url + "/health/",
-            json={"available": True},
+            json={"db": True},
             status=200,
         )
         session = requests.Session()
@@ -55,6 +55,38 @@ class TestAirbyte:
 
     @responses.activate
     def test_check_health_status_2(self):
+        airbyte_base_url = f"http://localhost:8000/api/v1"
+        responses.add(
+            responses.GET,
+            airbyte_base_url + "/health/",
+            json={"db": False},
+            status=200,
+        )
+        session = requests.Session()
+        task = AirbyteConnectionTask(
+            connection_id="749c19dc-4f97-4f30-bb0f-126e53506960"
+        )
+        with pytest.raises(AirbyteServerNotHealthyException):
+            task._check_health_status(session, airbyte_base_url)
+
+    @responses.activate
+    def test_check_health_status_3(self):
+        airbyte_base_url = f"http://localhost:8000/api/v1"
+        responses.add(
+            responses.GET,
+            airbyte_base_url + "/health/",
+            json={"available": True},
+            status=200,
+        )
+        session = requests.Session()
+        task = AirbyteConnectionTask(
+            connection_id="749c19dc-4f97-4f30-bb0f-126e53506960"
+        )
+        response = task._check_health_status(session, airbyte_base_url)
+        assert response
+
+    @responses.activate
+    def test_check_health_status_4(self):
         airbyte_base_url = f"http://localhost:8000/api/v1"
         responses.add(
             responses.GET,

--- a/tests/tasks/airbyte/test_airbyte.py
+++ b/tests/tasks/airbyte/test_airbyte.py
@@ -41,7 +41,7 @@ class TestAirbyte:
     def test_check_health_status(self):
         airbyte_base_url = f"http://localhost:8000/api/v1"
         responses.add(
-            responses.GET, airbyte_base_url + "/health/", json={"db": True}, status=200
+            responses.GET, airbyte_base_url + "/health/", json={"available": True}, status=200
         )
         session = requests.Session()
         task = AirbyteConnectionTask(
@@ -54,7 +54,7 @@ class TestAirbyte:
     def test_check_health_status_2(self):
         airbyte_base_url = f"http://localhost:8000/api/v1"
         responses.add(
-            responses.GET, airbyte_base_url + "/health/", json={"db": False}, status=200
+            responses.GET, airbyte_base_url + "/health/", json={"available": False}, status=200
         )
         session = requests.Session()
         task = AirbyteConnectionTask(


### PR DESCRIPTION
## Summary
Currently an exception is thrown within the health check function when trying to trigger a connection in Airbyte.




## Changes
The non-existing key from the response used for the health check is replaced by a valid, existing key.




## Importance
Without the change it is not possible to execute an AirbyteTask successfully, because this will always lead to a KeyError: 'db'.




## Checklist
<img width="1459" alt="Bildschirmfoto 2022-01-11 um 14 40 34" src="https://user-images.githubusercontent.com/39857259/148953225-a26c73fb-3af9-46b7-9520-74ff8b83dcd0.png">


This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)