### PR TITLE
Enforce logging limits by size instead of message length

### DIFF
--- a/changes/pr5316.yaml
+++ b/changes/pr5316.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Ensure that maximum log payload sizes are not exceeded - [#5316](https://github.com/PrefectHQ/prefect/pull/5316)"

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -33,8 +33,8 @@ PREFECT_LOG_RECORD_ATTRIBUTES = (
     "task_run_id",
 )
 
-MAX_LOG_LENGTH = 1_000_000  # 1 MB - max length of a single log message
-MAX_BATCH_LOG_LENGTH = 4_000_000  # 4 MB - max total batch size for log messages
+MAX_LOG_SIZE = 1_000_000  # 1 MB - max size of a single log record
+MAX_BATCH_LOG_SIZE = 4_000_000  # 4 MB - max total batch size for log records
 
 
 class LogManager:
@@ -103,13 +103,15 @@ class LogManager:
         # large a payload at once. This call will continue to loop until
         # the queue is empty or an error occurs on upload (usually only one
         # iteration is sufficient)
+        max_batch_length = max(MAX_BATCH_LOG_SIZE - MAX_LOG_SIZE, MAX_LOG_SIZE)
         cont = True
         while cont:
             try:
-                while self.pending_length < MAX_BATCH_LOG_LENGTH:
+                while self.pending_length < max_batch_length:
                     log = self.queue.get_nowait()
-                    self.pending_length += len(log.get("message", ""))
+                    self.pending_length += sys.getsizeof(log)
                     self.pending_logs.append(log)
+
             except Empty:
                 cont = False
 
@@ -124,7 +126,7 @@ class LogManager:
                     warnings.warn(
                         f"Failed to write logs with error: {exc!r}, "
                         f"Pending log length: {self.pending_length:,}, "
-                        f"Max batch log length: {MAX_BATCH_LOG_LENGTH:,}, "
+                        f"Max batch log length: {MAX_BATCH_LOG_SIZE:,}, "
                         f"Queue size: {self.queue.qsize():,}"
                     )
                     cont = False
@@ -164,14 +166,6 @@ class CloudHandler(logging.Handler):
             return
 
         msg = self.format(record)
-        if len(msg) > MAX_LOG_LENGTH:
-            get_logger("prefect.logging").warning(
-                "Received a log message of %d bytes, exceeding the limit of %d. "
-                "The output will be truncated",
-                len(msg),
-                MAX_LOG_LENGTH,
-            )
-            msg = msg[:MAX_LOG_LENGTH]
 
         log = {
             "flow_run_id": context.get("flow_run_id"),
@@ -183,6 +177,18 @@ class CloudHandler(logging.Handler):
             "level": getattr(record, "levelname", None),
             "message": msg,
         }
+
+        # The dictionary size is greater than the size after json.dumps so this will
+        # always overestimate log size which is ideal for avoiding hitting real limits
+        log_size = sys.getsizeof(log)
+        if log_size > MAX_LOG_SIZE:
+            warnings.warn(
+                "Received a log of size %d bytes, exceeding the limit of %d. "
+                "The message will be truncated." % (log_size, MAX_LOG_SIZE)
+            )
+            # Account for 150 bytes of overhead for the non-message fields
+            log["message"] = msg[: MAX_LOG_SIZE - 150]
+
         LOG_MANAGER.enqueue(log)
 
 

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -123,7 +123,7 @@ def test_cloud_handler_emit_warns_and_truncates_long_messages(
 
     with pytest.warns(
         UserWarning,
-        match="Received a log of size 360 bytes, exceeding the limit of 200",
+        match="Received a log of size 3[0-9][0-9] bytes, exceeding the limit of 200",
     ):
         logger.info("h" * 220)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This builds on the work in https://github.com/PrefectHQ/prefect/pull/4902 and logging in Orion to adjust the calculations for logging payload limits.


## Changes
<!-- What does this PR change? -->



Since we remove an item from the queue to place it in the batch, the pending limit could exceed the batch limit by the size of a single log. When batching logs, we enforce a limit as `MAX_BATCH_LOG_SIZE - MAX_LOG_SIZE` to ensure we never exceed the `MAX_BATCH_LOG_SIZE`. If `MAX_LOG_SIZE` is greater than `MAX_BATCH_LOG_SIZE`, we will batch with `MAX_LOG_SIZE` instead.

Here, we also use `sys.getsizeof(log)` to check sizes instead of `len(log.message)`. This accounts for the overhead of the additional log fields without special calculations. `sys.getsizeof(dict(...))` should always exceed `len(json.dumps(dict(...)))` due to the overhead of a Python dictionary so we should only see a reduction in size on serialization. This means we're overestimating log sizes, which results in more batches but we shouldn't exceed the maximums.


## Importance
<!-- Why is this PR important? -->


Maximums are _enforced_ server side, so the client should _never_ exceed the maximum or the logs will not be sent. If any log batches exceed the maximum, no future logs will be sent because batches are never dropped.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)