### PR TITLE
Fix format string not interpolated in error message

### DIFF
--- a/src/prefect/backend/flow_run.py
+++ b/src/prefect/backend/flow_run.py
@@ -99,7 +99,7 @@ def watch_flow_run(
         if total_time_elapsed > 60 * 60 * 12:
             raise RuntimeError(
                 "`watch_flow_run` timed out after 12 hours of waiting for completion. "
-                "Your flow run is still in state: {flow_run.state}"
+                f"Your flow run is still in state: {flow_run.state}"
             )
 
         if (


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

When a flow run errors with this RuntimeError, the message did not display the actual flow run state, but literally the variables in curly braces.


## Changes
<!-- What does this PR change? -->

This PR marks a string as format string.


## Importance
<!-- Why is this PR important? -->

It allows Prefect encountering this error to get more insight into the flow run state and why the error could have happened.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)