### PR TITLE
Bump hasura image version to 2.1.1 to fix M1 support

### DIFF
--- a/changes/pr5335.yml
+++ b/changes/pr5335.yml
@@ -1,2 +1,2 @@
 enhancement:
-  "Upgrade version of Hasura GraphQL engine to v2.1.1 - [#5335](https://github.com/PrefectHQ/prefect/pull/5335)"
+  - "Upgrade version of Hasura GraphQL engine to v2.1.1 - [#5335](https://github.com/PrefectHQ/prefect/pull/5335)"

--- a/changes/pr5335.yml
+++ b/changes/pr5335.yml
@@ -1,0 +1,2 @@
+enhancement:
+  "Upgrade version of Hasura GraphQL engine to v2.1.1 - [#5335](https://github.com/PrefectHQ/prefect/pull/5335)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   # Hasura: automatically generates a GraphQL schema from Postgres, provides most of the 'query' API
   hasura:
-    image: "hasura/graphql-engine:v2.0.9"
+    image: "hasura/graphql-engine:v2.1.1"
     ports:
       - "127.0.0.1:${HASURA_HOST_PORT:-3000}:3000"
     command: "graphql-engine serve"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Proper Apple Silicon support was added to `hasura/graphql` engine in [v2.1.0](https://github.com/hasura/graphql-engine/releases/tag/v2.1.0). This brings it into the Server.


## Changes

Just the version of the `hasura/graphql` image in the server's composefile from 2.0.9 to 2.1.1




## Importance

This should mean the prefect server can start up on M1 Macs without them needing [8GB of RAM](https://github.com/hasura/graphql-engine/issues/6337#issuecomment-969300069)!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~~adds new tests (if appropriate)~~
- [x] adds a change file in the `changes/` directory (if appropriate)
- ~~updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~
