### PR TITLE
Remove "server" changelog heading from contribution docs

### DIFF
--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -44,7 +44,6 @@ the `changes/` directory. To add a new entry:
    headers:
     - `feature`
     - `enhancement`
-    - `server`
     - `task`
     - `fix`
     - `deprecation`


### PR DESCRIPTION


<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The docs listed `server` as a possible heading for a changelog file, but this contradicts the linter. 
The section list in the docs has been changed to match [the list in the linter](https://github.com/PrefectHQ/prefect/blob/master/update_changelog.py#L10).


## Importance
<!-- Why is this PR important? -->
Guidelines without this change can lead you to write a PR that doesn't pass in CI.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)