### PR TITLE
Explicitly unset the tenant id during `prefect auth login`

### DIFF
--- a/changes/pr5355.yaml
+++ b/changes/pr5355.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Fix bug where logout was required before logging in with a new key if the new key does not have access to the old tenant - [#5355](https://github.com/PrefectHQ/prefect/pull/5355)"

--- a/src/prefect/cli/auth.py
+++ b/src/prefect/cli/auth.py
@@ -128,7 +128,8 @@ def login(key, token):
 
     # Attempt to treat the input like an API key even if it is passed as a token
     # Ignore any tenant id that has been previously set via login
-    client = Client(api_key=key or token, tenant_id=None)
+    client = Client(api_key=key or token)
+    client._tenant_id = None
 
     try:
         tenant_id = client._get_auth_tenant()

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -98,8 +98,9 @@ def test_auth_login_with_api_key(patch_post, monkeypatch, cloud_api, as_token):
     assert result.exit_code == 0
     assert "Logged in to Prefect Cloud tenant 'Name' (tenant-slug)" in result.output
 
-    # Client is instantiated with the correct key and null tenant
-    Client.assert_called_with(api_key="test", tenant_id=None)
+    # Client is instantiated with the correct key and the tenant id is reset
+    Client.assert_called_with(api_key="test")
+    assert Client()._tenant_id is None
     # Auth tenant is retrieved to verify key
     Client()._get_auth_tenant.assert_called_once()
     # Auth tenant is set on Client and saved to disk


### PR DESCRIPTION
This fixes a bug where the cached tenant id could be loaded when a new key is used which would result in unauthorized errors if the new key was not compatible with the old tenant
