### PR TITLE
Drop upper bounds from extra requirements 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ extras = {
     "redis": ["redis >= 3.2.1"],
     "rss": ["feedparser >= 5.0.1"],
     "snowflake": ["snowflake-connector-python >= 1.8.2"],
-    "spacy": ["spacy >= 2.0.0"],
+    "spacy": ["spacy >= 2.0.0, < 3.0"],
     "templates": ["jinja2 >= 2.0"],
     "test": test_requires,
     "vault": ["hvac >= 0.10"],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras = {
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "firebolt": ["firebolt-sdk >= 0.2.1"],
-    "ge": ["great_expectations >= 0.13.84", "mistune"],
+    "ge": ["great_expectations >= 0.13.84", "mistune < 2.0"],
     "gcp": [
         "google-cloud-bigquery >= 1.6.0",
     ]

--- a/setup.py
+++ b/setup.py
@@ -29,44 +29,44 @@ dev_requires = open("dev-requirements.txt").read().strip().split("\n")
 test_requires = open("test-requirements.txt").read().strip().split("\n")
 
 orchestration_extras = {
-    "aws": ["boto3 >= 1.9, < 2.0"],
-    "azure": ["azure-storage-blob >= 12.1.0, < 13.0"],
+    "aws": ["boto3 >= 1.9"],
+    "azure": ["azure-storage-blob >= 12.1.0"],
     "bitbucket": ["atlassian-python-api >= 2.0.1"],
     "gcp": [
         "google-cloud-secret-manager >= 2.4.0",
-        "google-cloud-storage >= 1.13, < 2.0",
-        "google-cloud-aiplatform >= 1.4.0, < 2.0",
-        "google-auth >= 2.0, < 3.0",
+        "google-cloud-storage >= 1.13",
+        "google-cloud-aiplatform >= 1.4.0",
+        "google-auth >= 2.0",
     ],
     "git": ["dulwich >= 0.19.7"],
-    "github": ["PyGithub >= 1.51, < 2.0"],
-    "gitlab": ["python-gitlab >= 2.5.0, < 3.0"],
-    "kubernetes": ["kubernetes >= 9.0.0a1, <= 13.0"],
+    "github": ["PyGithub >= 1.51"],
+    "gitlab": ["python-gitlab >= 2.5.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1.0"],
 }
 
 extras = {
-    "airtable": ["airtable-python-wrapper >= 0.11, < 0.12"],
+    "airtable": ["airtable-python-wrapper >= 0.11"],
     "aws": orchestration_extras["aws"],
     "azure": [
-        "azure-storage-blob >= 12.1.0, < 13.0",
-        "azureml-sdk >= 1.0.65, < 1.1",
-        "azure-cosmos >= 3.1.1, <3.2",
+        "azure-storage-blob >= 12.1.0",
+        "azureml-sdk >= 1.0.6",
+        "azure-cosmos >= 3.1.1",
     ],
     "bitbucket": orchestration_extras["bitbucket"],
     "dask_cloudprovider": ["dask_cloudprovider[aws] >= 0.2.0"],
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "firebolt": ["firebolt-sdk >= 0.2.1"],
-    "ge": ["great_expectations >= 0.13.8, < 0.14", "mistune < 2"],
+    "ge": ["great_expectations >= 0.13.84", "mistune"],
     "gcp": [
-        "google-cloud-bigquery >= 1.6.0, < 3.0",
+        "google-cloud-bigquery >= 1.6.0",
     ]
     + orchestration_extras["gcp"],
     "git": orchestration_extras["git"],
     "github": orchestration_extras["github"],
     "gitlab": orchestration_extras["gitlab"],
     "google": [
-        "google-cloud-bigquery >= 1.6.0, < 3.0",
+        "google-cloud-bigquery >= 1.6.0",
     ]
     + orchestration_extras["gcp"],
     "gsheets": ["gspread >= 3.6.0"],
@@ -81,20 +81,20 @@ extras = {
     "sql_server": ["pyodbc >= 4.0.30"],
     "pushbullet": ["pushbullet.py >= 0.11.0"],
     "redis": ["redis >= 3.2.1"],
-    "rss": ["feedparser >= 5.0.1, < 6.0"],
-    "snowflake": ["snowflake-connector-python >= 1.8.2, < 2.5"],
-    "spacy": ["spacy >= 2.0.0, < 3.0.0"],
-    "templates": ["jinja2 >= 2.0, < 4.0"],
+    "rss": ["feedparser >= 5.0.1"],
+    "snowflake": ["snowflake-connector-python >= 1.8.2"],
+    "spacy": ["spacy >= 2.0.0"],
+    "templates": ["jinja2 >= 2.0"],
     "test": test_requires,
     "vault": ["hvac >= 0.10"],
     "viz": ["graphviz >= 0.8.3"],
-    "twitter": ["tweepy >= 3.5, < 4.0"],
+    "twitter": ["tweepy >= 3.5"],
     "dremio": ["pyarrow >= 5.0.0"],
     "exasol": ["pyexasol >= 0.16.1"],
     "sodasql": ["soda-sql >= 2.0.0b25"],
     "sodaspark": ["soda-spark >= 0.2.1"],
     "sendgrid": ["sendgrid >= 6.7.0"],
-    "cubejs": ["PyJWT >= 2.3.0, < 3.0"],
+    "cubejs": ["PyJWT >= 2.3.0"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras = {
     "dev": dev_requires + test_requires,
     "dropbox": ["dropbox ~= 9.0"],
     "firebolt": ["firebolt-sdk >= 0.2.1"],
-    "ge": ["great_expectations >= 0.13.84", "mistune < 2.0"],
+    "ge": ["great_expectations >= 0.13.8", "mistune < 2.0"],
     "gcp": [
         "google-cloud-bigquery >= 1.6.0",
     ]


### PR DESCRIPTION
Relaxes upper bound constraints on our extra requirements. These can unnecessarily limit installations.

Matches the changes to primary requirements in #5356

Opened #5359 and #5358 to fix constraints that are actually needed.
Opened #5360 to note some task library tests that are not running correctly.