### PR TITLE
Raise an error when Airbyte sync job fails to mark the task run as Failed

### DIFF
--- a/changes/pr5362.yml
+++ b/changes/pr5362.yml
@@ -1,0 +1,2 @@
+fix:
+  - "Raise an error when Airbyte sync job fails to mark the task run as Failed - [#5362](https://github.com/PrefectHQ/prefect/pull/5362)"

--- a/src/prefect/tasks/airbyte/airbyte.py
+++ b/src/prefect/tasks/airbyte/airbyte.py
@@ -21,6 +21,10 @@ class JobNotFoundException(Exception):
     pass
 
 
+class AirbyteSyncJobFailed(Exception):
+    pass
+
+
 class AirbyteConnectionTask(Task):
     """
     Task for triggering Airbyte Connections, where "A connection is
@@ -278,6 +282,7 @@ class AirbyteConnectionTask(Task):
                     self.logger.info(f"Job {job_id} succeeded.")
                 elif job_status == self.JOB_STATUS_FAILED:
                     self.logger.error(f"Job {job_id} failed.")
+                    raise AirbyteSyncJobFailed(f"Job {job_id} failed.")
                 else:
                     # wait for next poll interval
                     sleep(poll_interval_s)


### PR DESCRIPTION
## Summary
Airbyte task currently checks for the job status here:
https://github.com/PrefectHQ/prefect/blob/01705d38b9819a8e38d2696ee56999bc7a3faf89/src/prefect/tasks/airbyte/airbyte.py#L271

However, when the job status is failed, it only logs the error rather than raising an exception:
https://github.com/PrefectHQ/prefect/blob/01705d38b9819a8e38d2696ee56999bc7a3faf89/src/prefect/tasks/airbyte/airbyte.py#L280

## Changes
Raising an exception to mark the task run as Failed.


## Importance
Fixes a bug flagged by a community user in [this Slack thread](https://prefect-community.slack.com/archives/CL09KU1K7/p1643021910053100).


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)