### PR TITLE
Fix usage of `sys.getsizeof`

### DIFF
--- a/changes/pr5390.yaml
+++ b/changes/pr5390.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix usage of `sys.getsizeof` to restore support for PyPy - [#5390](https://github.com/PrefectHQ/prefect/issues/5390)"

--- a/changes/pr5390.yaml
+++ b/changes/pr5390.yaml
@@ -1,2 +1,3 @@
 fix:
   - "Fix usage of `sys.getsizeof` to restore support for PyPy - [#5390](https://github.com/PrefectHQ/prefect/issues/5390)"
+  - "Fix issues with log size estimates from [#5316](https://github.com/PrefectHQ/prefect/pull/5316) - [#5390](https://github.com/PrefectHQ/prefect/issues/5390)"

--- a/src/prefect/backend/kv_store.py
+++ b/src/prefect/backend/kv_store.py
@@ -1,4 +1,3 @@
-import sys
 import json
 from typing import Any, List
 

--- a/src/prefect/backend/kv_store.py
+++ b/src/prefect/backend/kv_store.py
@@ -33,7 +33,7 @@ def set_key_value(key: str, value: Any) -> str:
 
     # check value is under size limit
     # note this will be enforced by the API
-    value_size = sys.getsizeof(json.dumps(value))
+    value_size = len(json.dumps(value))
     if value_size > 10000:  # 10 KB max
         raise ValueError("Value payload exceedes 10 KB limit.")
 

--- a/src/prefect/engine/state.py
+++ b/src/prefect/engine/state.py
@@ -112,7 +112,7 @@ class State:
         return data
 
     def __sizeof__(self) -> int:
-        return super().__sizeof__() + sys.getsizeof(self.result)
+        return super().__sizeof__() + sys.getsizeof(self.result, 0)
 
     @property
     def result(self) -> Any:

--- a/src/prefect/utilities/executors.py
+++ b/src/prefect/utilities/executors.py
@@ -315,7 +315,7 @@ def multiprocessing_safe_run_and_retrieve(
 
     try:
         logger.debug(
-            "%s: Pickling value of size %s...", name, sys.getsizeof(return_val)
+            "%s: Pickling value of size %s...", name, sys.getsizeof(return_val, -1)
         )  # Only calculate the size if debug logs are enabled
         pickled_val = cloudpickle.dumps(return_val)
         logger.debug(f"{name}: Pickling successful!")

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -14,9 +14,11 @@ import sys
 import threading
 import time
 import warnings
+import json
 from queue import Empty, Queue
 from typing import Any, List, Optional, Generator, Union
 from contextlib import contextmanager
+from uuid import uuid4
 
 import pendulum
 
@@ -35,6 +37,25 @@ PREFECT_LOG_RECORD_ATTRIBUTES = (
 
 MAX_LOG_SIZE = 1_000_000  # 1 MB - max size of a single log record
 MAX_BATCH_LOG_SIZE = 4_000_000  # 4 MB - max total batch size for log records
+
+LOG_OVERHEAD = len(
+    # Calculate the expected overhead from a log record by serializing a record with
+    # metadata
+    json.dumps(
+        {
+            "flow_run_id": uuid4().hex,
+            "task_run_id": uuid4().hex,
+            "timestamp": pendulum.from_timestamp(time.time()).isoformat(),
+            "name": "X" * 100,
+            "level": "WARNING",
+            "message": "",
+        }
+    )
+)
+
+
+def getlogsize(log: dict) -> int:
+    return len(log.get("message", "")) + LOG_OVERHEAD
 
 
 class LogManager:
@@ -109,9 +130,7 @@ class LogManager:
             try:
                 while self.pending_length < max_batch_length:
                     log = self.queue.get_nowait()
-                    self.pending_length += sys.getsizeof(
-                        log, len(log.get("message", "")) + 150
-                    )
+                    self.pending_length += getlogsize(log)
                     self.pending_logs.append(log)
 
             except Empty:
@@ -175,16 +194,13 @@ class CloudHandler(logging.Handler):
             "message": msg,
         }
 
-        # The dictionary size is greater than the size after json.dumps so this will
-        # always overestimate log size which is ideal for avoiding hitting real limits
-        log_size = sys.getsizeof(log, len(log["message"]) + 150)
+        log_size = getlogsize(log)
         if log_size > MAX_LOG_SIZE:
             warnings.warn(
                 "Received a log of size %d bytes, exceeding the limit of %d. "
                 "The message will be truncated." % (log_size, MAX_LOG_SIZE)
             )
-            # Account for 150 bytes of overhead for the non-message fields
-            log["message"] = msg[: MAX_LOG_SIZE - 150]
+            log["message"] = msg[: MAX_LOG_SIZE - LOG_OVERHEAD]
 
         LOG_MANAGER.enqueue(log)
 

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -109,7 +109,7 @@ class LogManager:
             try:
                 while self.pending_length < max_batch_length:
                     log = self.queue.get_nowait()
-                    self.pending_length += sys.getsizeof(log)
+                    self.pending_length += sys.getsizeof(log, len(log["message"] + 150))
                     self.pending_logs.append(log)
 
             except Empty:
@@ -175,7 +175,7 @@ class CloudHandler(logging.Handler):
 
         # The dictionary size is greater than the size after json.dumps so this will
         # always overestimate log size which is ideal for avoiding hitting real limits
-        log_size = sys.getsizeof(log)
+        log_size = sys.getsizeof(log, len(log["message"]) + 150)
         if log_size > MAX_LOG_SIZE:
             warnings.warn(
                 "Received a log of size %d bytes, exceeding the limit of %d. "

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -109,7 +109,9 @@ class LogManager:
             try:
                 while self.pending_length < max_batch_length:
                     log = self.queue.get_nowait()
-                    self.pending_length += sys.getsizeof(log, len(log["message"]) + 150)
+                    self.pending_length += sys.getsizeof(
+                        log, len(log.get("message", "")) + 150
+                    )
                     self.pending_logs.append(log)
 
             except Empty:

--- a/src/prefect/utilities/logging.py
+++ b/src/prefect/utilities/logging.py
@@ -109,7 +109,7 @@ class LogManager:
             try:
                 while self.pending_length < max_batch_length:
                     log = self.queue.get_nowait()
-                    self.pending_length += sys.getsizeof(log, len(log["message"] + 150))
+                    self.pending_length += sys.getsizeof(log, len(log["message"]) + 150)
                     self.pending_logs.append(log)
 
             except Empty:

--- a/tests/utilities/test_logging.py
+++ b/tests/utilities/test_logging.py
@@ -113,7 +113,7 @@ def test_cloud_handler_emit_noop_if_below_log_level_in_context(logger, log_manag
     assert log_manager.thread is None
 
 
-def test_getlogsize_produces_realistic_estimate(monkeypatch, logger, log_manager):
+def test_getlogsize_produces_realistic_estimate(logger, log_manager):
     logger.info("h" * 2000)
 
     assert log_manager.enqueue.call_count == 1


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/5389 by including defaults for usage of `sys.getsizeof` which will otherwise throw a `TypeError` when using PyPy.

Fixes a related issue where `sys.getsizeof` would underestimate the size of log messages. This was a regression introduced in #5316. This improves test coverage to address that case and introduces realistic log size calculations.