### PR TITLE
fix StartFlowRun doc

### DIFF
--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -287,9 +287,8 @@ class StartFlowRun(Task):
     Args:
         - flow_name (str, optional): the name of the flow to schedule; this value may also be
             provided at run time
-        - project_name (str, optional): if running with Cloud as a backend, this is the project
-            in which the flow is located; this value may also be provided at runtime. If
-            running with Prefect Core's server as the backend, this should not be provided.
+        - project_name (str, optional): the name of the project in which the flow is located; 
+            this value may also be provided at runtime.
         - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
             this value may also be provided at run time
         - run_config (RunConfig, optional): a run-config to use for this flow
@@ -375,9 +374,8 @@ class StartFlowRun(Task):
         Args:
             - flow_name (str, optional): the name of the flow to schedule; if not provided,
                 this method will use the flow name provided at initialization
-            - project_name (str, optional): the Cloud project in which the flow is located; if
-                not provided, this method will use the project provided at initialization. If
-                running with Prefect Core's server as the backend, this should not be provided.
+            - project_name (str, optional): the project in which the flow is located; if
+                not provided, this method will use the project provided at initialization.
             - parameters (dict, optional): the parameters to pass to the flow run being
                 scheduled; if not provided, this method will use the parameters provided at
                 initialization

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -287,7 +287,7 @@ class StartFlowRun(Task):
     Args:
         - flow_name (str, optional): the name of the flow to schedule; this value may also be
             provided at run time
-        - project_name (str, optional): the name of the project in which the flow is located; 
+        - project_name (str, optional): the name of the project in which the flow is located;
             this value may also be provided at runtime.
         - parameters (dict, optional): the parameters to pass to the flow run being scheduled;
             this value may also be provided at run time


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
API documentation regarding StartFlowRun parameter `project_name` did not match what the code does.



## Changes
<!-- What does this PR change? -->
Removes any mention of difference between Cloud & Core Server in the documentation of the `project_name` parameter of StartFlowRun (init & run).



## Importance
<!-- Why is this PR important? -->
Doc should match what the code does.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)