### PR TITLE
SpacyNLP task v3 compatibility

### DIFF
--- a/changes/issue5358.yaml
+++ b/changes/issue5358.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Adds support for SpacyNLP task for spacy version >= 3.0. Also adds a new `exclude` parameter - (#5358)[https://github.com/PrefectHQ/prefect/issues/5358]"
+
+contributor:
+  - "[Aneesh Makala](https://github.com/makalaaneesh)"

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ extras = {
     "redis": ["redis >= 3.2.1"],
     "rss": ["feedparser >= 5.0.1"],
     "snowflake": ["snowflake-connector-python >= 1.8.2"],
-    "spacy": ["spacy >= 2.0.0, < 3.0"],
+    "spacy": ["spacy >= 2.0.0"],
     "templates": ["jinja2 >= 2.0"],
     "test": test_requires,
     "vault": ["hvac >= 0.10"],

--- a/src/prefect/tasks/spacy/spacy_tasks.py
+++ b/src/prefect/tasks/spacy/spacy_tasks.py
@@ -54,14 +54,14 @@ class SpacyNLP(Task):
                     self.nlp = spacy.load(
                         spacy_model_name,
                         disable=self.disable,
-                        component_cfg=self.component_cfg
+                        component_cfg=self.component_cfg,
                     )
                 else:
                     self.nlp = spacy.load(
                         spacy_model_name,
                         disable=self.disable,
                         config=self.component_cfg,
-                        exclude=self.exclude
+                        exclude=self.exclude,
                     )
             except IOError as exc:
                 raise ValueError(

--- a/src/prefect/tasks/spacy/spacy_tasks.py
+++ b/src/prefect/tasks/spacy/spacy_tasks.py
@@ -3,6 +3,8 @@ import spacy
 from prefect import Task
 from prefect.utilities.tasks import defaults_from_attrs
 
+from packaging import version
+
 
 class SpacyNLP(Task):
     """
@@ -18,6 +20,8 @@ class SpacyNLP(Task):
             model is 'en_core_web_sm', will be ignored if nlp is provided
         - disable (List[str], optional): list of pipeline components
             to disable, only applicable to pipelines loaded from spacy_model_name
+        - exclude (List[str], optional): Names of pipeline components to exclude.
+            Excluded components won’t be loaded. (Only applicable in spacy >= 3.0)
         - component_cfg (dict, optional): a dictionary with extra keyword
             arguments for specific components, only applicable to pipelines loaded from
             spacy_model_name
@@ -32,10 +36,12 @@ class SpacyNLP(Task):
         spacy_model_name: str = "en_core_web_sm",
         disable: list = None,
         component_cfg: dict = None,
+        exclude: list = None,
         **kwargs
     ):
         self.text = text
         self.disable = disable or []
+        self.exclude = exclude or []
         self.component_cfg = component_cfg or {}
 
         # load spacy model
@@ -43,11 +49,20 @@ class SpacyNLP(Task):
             self.nlp = nlp
         else:
             try:
-                self.nlp = spacy.load(
-                    spacy_model_name,
-                    disable=self.disable,
-                    component_cfg=self.component_cfg,
-                )
+                # v3 introduced breaking changes.
+                if version.parse(spacy.__version__) < version.parse("3.0"):
+                    self.nlp = spacy.load(
+                        spacy_model_name,
+                        disable=self.disable,
+                        component_cfg=self.component_cfg
+                    )
+                else:
+                    self.nlp = spacy.load(
+                        spacy_model_name,
+                        disable=self.disable,
+                        config=self.component_cfg,
+                        exclude=self.exclude
+                    )
             except IOError as exc:
                 raise ValueError(
                     "spaCy model %s not found." % spacy_model_name

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import spacy
@@ -20,6 +20,15 @@ class TestSpacyNLP:
     def test_load_nlp_model(self):
         spacy.cli.download("en_core_web_sm")
         task = SpacyNLP(text="This is some text", spacy_model_name="en_core_web_sm")
+        assert task.nlp is not None
+
+    @patch("prefect.tasks.spacy.spacy_tasks.spacy")
+    def test_load_nlp_model_version_lt3(self, spacy_mock):
+        spacy_mock.configure_mock(__version__="2.3.7")  # some version less than 3.0
+        task = SpacyNLP(text="This is some text", spacy_model_name="en_core_web_sm")
+        spacy_mock.load.assert_called_once_with(
+            "en_core_web_sm", disable=[], component_cfg={}
+        )
         assert task.nlp is not None
 
     def test_bad_model_raises_error(self):

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -17,6 +17,13 @@ class TestSpacyNLP:
         task = SpacyNLP(text="This is some text", nlp=spacy.blank("en"))
         assert task.text == "This is some text"
 
+    def test_load_nlp_model(self):
+        spacy.cli.download("en_core_web_sm")
+        task = SpacyNLP(
+            text="This is some text", spacy_model_name="en_core_web_sm"
+        )
+        assert task.nlp is not None
+
     def test_bad_model_raises_error(self):
         with pytest.raises(ValueError, match="not_a_spacy_model"):
             task = SpacyNLP(

--- a/tests/tasks/spacy/test_spacy_tasks.py
+++ b/tests/tasks/spacy/test_spacy_tasks.py
@@ -19,9 +19,7 @@ class TestSpacyNLP:
 
     def test_load_nlp_model(self):
         spacy.cli.download("en_core_web_sm")
-        task = SpacyNLP(
-            text="This is some text", spacy_model_name="en_core_web_sm"
-        )
+        task = SpacyNLP(text="This is some text", spacy_model_name="en_core_web_sm")
         assert task.nlp is not None
 
     def test_bad_model_raises_error(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR addresses https://github.com/PrefectHQ/prefect/issues/5358 by making `SpacyNLP` task compatible with spacy version >= 3.0




## Changes
- The error was thrown by `spacy.load`. As per the [docs for spacy.load](https://spacy.io/api/top-level#spacy.load), the argument name is now `config`, making `component_cfg` invalid. Therefore, `config` is now used
- To maintain backward compatibility, both spacy <3 and >=3 are supported. 
- A new `exclude` param is added to `SpacyNLP` task



## Importance
This will help remove the upper bound constraints on `spacy` in requirements




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)