### PR TITLE
Adds ability to use ECS Capacity Provider in ECS Agent and ECS Run

### DIFF
--- a/changes/pr4356.yaml
+++ b/changes/pr4356.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Adding ability to add capacity provider in run-task-kwargs for ECSAgent and ECSRun- [#4356](https://github.com/PrefectHQ/prefect/issues/4356)"

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -38,9 +38,14 @@ def merge_run_task_kwargs(opts1: dict, opts2: dict) -> dict:
 
     out = deepcopy(opts1)
 
-    # if out contains keys for capacityProviderStrategy and LaunchType delete launchType
+    # if opts2 contains keys for capacityProviderStrategy and LaunchType delete launchType
     if "capacityProviderStrategy" in opts2 and "launchType" in out:
         del out["launchType"]
+
+    # if opts2 contains keys for launchType delete capacityProviderStrategy
+    if "capacityProviderStrategy" in out and "launchType" in opts2:
+        del out["capacityProviderStrategy"]
+
 
     # Everything except 'overrides' merge directly
     for k, v in opts2.items():
@@ -242,13 +247,7 @@ class ECSAgent(Agent):
                     self.run_task_kwargs[
                         "networkConfiguration"
                     ] = self.infer_network_configuration()
-            else:
-                msg = (
-                    "It seems you are using a capacity provider please explicitly "
-                    "configure networkMode and networkConfiguration, using `--run-task-kwargs`"
-                )
-                self.logger.error(msg)
-                raise ValueError(msg)
+
 
     def infer_network_configuration(self) -> dict:
         """Infer default values for `networkConfiguration`.

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -235,17 +235,17 @@ class ECSAgent(Agent):
         if not self.run_task_kwargs.get("capacityProviderStrategy"):
             self.launch_type = launch_type.upper() if launch_type else "FARGATE"
 
-            self.logger.error(
+            self.logger.debug(
                 "No launch type or capacity provider given. Setting launch type to FARGATE.",
             )
-            # If running on fargate, auto-configure `networkConfiguration` for the
-            # user if they didn't configure it themselves.
-        if not self.run_task_kwargs.get("networkConfiguration"):
-            if self.launch_type:
-                if self.launch_type == "FARGATE":
-                    self.run_task_kwargs[
-                        "networkConfiguration"
-                    ] = self.infer_network_configuration()
+        # If running on fargate, auto-configure `networkConfiguration` for the
+        # user if they didn't configure it themselves.
+        if self.launch_type == "FARGATE" and not self.run_task_kwargs.get(
+            "networkConfiguration"
+        ):
+            self.run_task_kwargs[
+                "networkConfiguration"
+            ] = self.infer_network_configuration()
 
     def infer_network_configuration(self) -> dict:
         """Infer default values for `networkConfiguration`.
@@ -448,7 +448,6 @@ class ECSAgent(Agent):
         # Set agent defaults
         out = deepcopy(self.run_task_kwargs)
         # Use launchType only if capacity provider is not specified
-
         if not out.get("capacityProviderStrategy"):
             out["launchType"] = self.launch_type
 

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -244,7 +244,7 @@ class ECSAgent(Agent):
                     ] = self.infer_network_configuration()
             else:
                 msg = (
-                    "It seems you are using a capcacity provider please explicitly "
+                    "It seems you are using a capacity provider please explicitly "
                     "configure networkMode and networkConfiguration, using `--run-task-kwargs`"
                 )
                 self.logger.error(msg)

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -46,7 +46,6 @@ def merge_run_task_kwargs(opts1: dict, opts2: dict) -> dict:
     if "capacityProviderStrategy" in out and "launchType" in opts2:
         del out["capacityProviderStrategy"]
 
-
     # Everything except 'overrides' merge directly
     for k, v in opts2.items():
         if k != "overrides":
@@ -247,7 +246,6 @@ class ECSAgent(Agent):
                     self.run_task_kwargs[
                         "networkConfiguration"
                     ] = self.infer_network_configuration()
-
 
     def infer_network_configuration(self) -> dict:
         """Infer default values for `networkConfiguration`.

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -73,11 +73,15 @@ class TestMergeRunTaskKwargs:
         opt1 = {"cluster": "testing", "launchType": "FARGATE"}
         opt2 = {
             "cluster": "new",
-            "capacityProviderStrategy": [{"capacityProvider": "SPOT_GPU"}],
+            "capacityProviderStrategy": [{"capacityProvider": "FARGATE_SPOT"}],
         }
         assert merge_run_task_kwargs(opt1, opt2) == {
-            "capacityProviderStrategy": [{"capacityProvider": "SPOT_GPU"}],
+            "capacityProviderStrategy": [{"capacityProvider": "FARGATE_SPOT"}],
             "cluster": "new",
+        }
+        assert merge_run_task_kwargs(opt2, opt1) == {
+            "launchType": "FARGATE",
+            "cluster": "testing",
         }
 
     def test_merge_run_task_kwargs_overrides(self):
@@ -341,6 +345,15 @@ class TestGenerateTaskDefinition:
         taskdef = self.generate_task_definition(ECSRun(), launch_type=launch_type)
         assert taskdef["requiresCompatibilities"] == [launch_type or "FARGATE"]
 
+    def test_generate_task_definition_requires_compatibilities_capacity_provider(self, tmpdir):
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {"capacityProviderStrategy": [{"capacityProvider", "FARGATE_SPOT"}]}, f
+            )
+        taskdef = self.generate_task_definition(ECSRun(), run_task_kwargs_path=path)
+        assert taskdef.get("requiresCompatibilities") == None
+
     @pytest.mark.parametrize(
         "on_run_config, on_agent, expected",
         [
@@ -517,14 +530,20 @@ class TestGetRunTaskKwargs:
         "on_run_config, on_agent, expected_run_config, expected_agent",
         [
             (
-                {"capacityProviderStrategy": [{"capacityProvider": "SPOT_GPU"}]},
+                {"capacityProviderStrategy": [{"capacityProvider": "FARGATE_SPOT"}]},
                 "FARGATE",
-                [{"capacityProvider": "SPOT_GPU"}],
+                [{"capacityProvider": "FARGATE_SPOT"}],
+                None,
+            ),
+            (
+                {"capacityProviderStrategy": [{"capacityProvider": "FARGATE_SPOT"}]},
+                "EC2",
+                [{"capacityProvider": "FARGATE_SPOT"}],
                 None,
             ),
         ],
     )
-    def test_get_task_run_kwargs_capacity_provider_run(
+    def test_get_task_run_kwargs_capacity_provider_run_config(
         self, on_run_config, on_agent, expected_run_config, expected_agent
     ):
         kwargs = self.get_run_task_kwargs(
@@ -533,7 +552,21 @@ class TestGetRunTaskKwargs:
         assert kwargs.get("capacityProviderStrategy") == expected_run_config
         assert kwargs.get("launchType") == expected_agent
 
-  
+    def test_get_task_run_kwargs_capacity_provider_agent_config(self, tmpdir):
+        path = str(tmpdir.join("kwargs.yaml"))
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {"capacityProviderStrategy": [{"capacityProvider", "FARGATE_SPOT"}]}, f
+            )
+        kwargs = self.get_run_task_kwargs(
+            ECSRun(run_task_kwargs={"launchType": "EC2"}),
+            run_task_kwargs_path=path,
+        )
+        del kwargs["overrides"]
+        assert kwargs == {
+            "launchType": "EC2"
+        }
+
     @pytest.mark.parametrize(
         "on_run_config, on_agent, expected",
         [

--- a/tests/agent/test_ecs_agent.py
+++ b/tests/agent/test_ecs_agent.py
@@ -345,7 +345,9 @@ class TestGenerateTaskDefinition:
         taskdef = self.generate_task_definition(ECSRun(), launch_type=launch_type)
         assert taskdef["requiresCompatibilities"] == [launch_type or "FARGATE"]
 
-    def test_generate_task_definition_requires_compatibilities_capacity_provider(self, tmpdir):
+    def test_generate_task_definition_requires_compatibilities_capacity_provider(
+        self, tmpdir
+    ):
         path = str(tmpdir.join("kwargs.yaml"))
         with open(path, "w") as f:
             yaml.safe_dump(
@@ -563,9 +565,7 @@ class TestGetRunTaskKwargs:
             run_task_kwargs_path=path,
         )
         del kwargs["overrides"]
-        assert kwargs == {
-            "launchType": "EC2"
-        }
+        assert kwargs == {"launchType": "EC2"}
 
     @pytest.mark.parametrize(
         "on_run_config, on_agent, expected",


### PR DESCRIPTION
## Summary
<!-- A sentence summarizing the PR -->

PR to add the ability to  use capacity providers in ECS Agent and ECSRun when set in run_task_kwargs 

## Changes
<!-- What does this PR change? -->

- Updates the way ECSAgent set's the launchType and default network configuration when a capacity provider is passed in via run-task-kwargs. 

- Deletes launchType in ECSAgent run_config (opts) in merge_run_task_kwargs if capacityProvider is found in ECSRun's run_config (opts2) and vice versa

## Importance
<!-- Why is this PR important? -->

Being able to use capacity providers in ECS enables the use of Fargate Spot and ASG's. 

Found in Issues:
#4356 and #5210 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x]  adds a change file in the `changes/` directory (if appropriate)
- [x]  updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)