### PR TITLE
remove usage stats information

### DIFF
--- a/tests/tasks/great_expectations/v2_api/checkpoints/.ge_store_backend_id
+++ b/tests/tasks/great_expectations/v2_api/checkpoints/.ge_store_backend_id
@@ -1,1 +1,0 @@
-store_backend_id = 2d1df717-ce13-4988-a121-459c863a5072

--- a/tests/tasks/great_expectations/v2_api/expectations/.ge_store_backend_id
+++ b/tests/tasks/great_expectations/v2_api/expectations/.ge_store_backend_id
@@ -1,1 +1,0 @@
-store_backend_id = 73999387-e31a-4e53-a3b4-9bfb5acc285e

--- a/tests/tasks/great_expectations/v2_api/great_expectations.yml
+++ b/tests/tasks/great_expectations/v2_api/great_expectations.yml
@@ -123,7 +123,4 @@ data_docs_sites:
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 
-anonymous_usage_statistics:
-  data_context_id: 7fc932eb-f469-44aa-a0f9-1bad66cb8a87
-  enabled: true
 notebooks:

--- a/tests/tasks/great_expectations/v3_api/expectations/.ge_store_backend_id
+++ b/tests/tasks/great_expectations/v3_api/expectations/.ge_store_backend_id
@@ -1,1 +1,0 @@
-store_backend_id = 2c8220c3-63db-42c7-be97-b7909cc59f8b

--- a/tests/tasks/great_expectations/v3_api/great_expectations.yml
+++ b/tests/tasks/great_expectations/v3_api/great_expectations.yml
@@ -106,7 +106,4 @@ data_docs_sites:
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 
-anonymous_usage_statistics:
-  enabled: true
-  data_context_id: 2c8220c3-63db-42c7-be97-b7909cc59f8b
 notebooks:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This removes usage stats information from the sample fixtures to prevent inaccurate records from being sent.

## Changes
See above.

## Importance
See above.




## Checklist
I don't believe any of these would be necessary for this PR.

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)