### PR TITLE
Use rm=True as default while building docker images for storage

### DIFF
--- a/changes/issue5384.yaml
+++ b/changes/issue5384.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "While building docker images for storage, rm=True is used as default, which deletes intermediate containers - (#5384)[https://github.com/PrefectHQ/prefect/issues/5384]"
+
+contributor:
+  - "[Aneesh Makala](https://github.com/makalaaneesh)"

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -380,6 +380,7 @@ class Docker(Storage):
                 path="." if self.dockerfile else tempdir,
                 dockerfile=dockerfile_path,
                 tag="{}:{}".format(full_name, self.image_tag),
+                rm=self.build_kwargs.pop("rm", True),
                 **self.build_kwargs,
             )
             self._parse_generator_output(output)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Hey folks! This fixes https://github.com/PrefectHQ/prefect/issues/5384
While building docker images for storage, rm=True is used as default, which deletes intermediate containers. 



## Changes
<!-- What does this PR change? -->
The default while building images for docker storage is changed to now use `rm=True`




## Importance
<!-- Why is this PR important? -->
This prevents the situation where servers run out of disk space because intermediate docker containers are left behind after building images for flows.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)