### PR TITLE
Add custom serializer support to retrieving task run results

### DIFF
--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -57,6 +57,7 @@ from prefect.engine.signals import signal_from_state
 from prefect.run_configs import RunConfig
 from prefect.utilities.graphql import EnumValue, with_args
 from prefect.utilities.tasks import defaults_from_attrs
+from prefect.engine.serializers import Serializer
 
 
 @task
@@ -169,7 +170,11 @@ def create_flow_run(
 
 @task
 def get_task_run_result(
-    flow_run_id: str, task_slug: str, map_index: int = -1, poll_time: int = 5
+    flow_run_id: str,
+    task_slug: str,
+    map_index: int = -1,
+    poll_time: int = 5,
+    serializer: Serializer = None,
 ) -> Any:
     """
     Task to get the result of a task from a flow run.
@@ -230,7 +235,7 @@ def get_task_run_result(
     logger.debug(
         f"Loading task run result from {type(task_run.state._result).__name__}..."
     )
-    return task_run.get_result()
+    return task_run.get_result(serializer=serializer)
 
 
 @task


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

If using a custom serializer for a task result, the `get_task_run_result` / `TaskRun.get_result` methods will fail as the custom serializer is not stored in the serialized state and the client defaults to using a `PickleSerializer`. 

When writing tasks like

```
@task(slug="output", result=GCSResult("<path>", serializer=PandasSerializer(file_type="parquet")), checkpoint=True)
```

The serializer will not be used.


## Changes
<!-- What does this PR change? -->

This extends `get_result` to allow a custom serializer e.g. `serializer=PandasSerializer(file_type="parquet")` to be passed in for restoring the value. 

## Importance
<!-- Why is this PR important? -->

Extends `get_result` to support our full feature-set for tasks which use custom serializers to store data in more efficient ways.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)