### PR TITLE
Include the `map_index` in the default `create_flow_run` idempotency key 

### DIFF
--- a/changes/pr5443.yaml
+++ b/changes/pr5443.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix the default idempotency key for `create_flow_run` when mapping during a local flow run - [#5443](https://github.com/PrefectHQ/prefect/pulls/5443)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -103,8 +103,8 @@ def create_flow_run(
         - idempotency_key: a unique idempotency key for scheduling the
             flow run. Duplicate flow runs with the same idempotency key will only create
             a single flow run. This is useful for ensuring that only one run is created
-            if this task is retried. If not provided, defaults to the active `task_run_id`
-            and its map index.
+            if this task is retried. If not provided, defaults to the active task run
+            id and its map index.
 
     Returns:
         str: The UUID of the created flow run

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -103,7 +103,8 @@ def create_flow_run(
         - idempotency_key: a unique idempotency key for scheduling the
             flow run. Duplicate flow runs with the same idempotency key will only create
             a single flow run. This is useful for ensuring that only one run is created
-            if this task is retried. If not provided, defaults to the active `task_run_id`.
+            if this task is retried. If not provided, defaults to the active `task_run_id`
+            and its map index.
 
     Returns:
         str: The UUID of the created flow run
@@ -141,7 +142,12 @@ def create_flow_run(
     logger.info(f"Creating flow run {run_name_dsp!r} for flow {flow.name!r}...")
 
     if idempotency_key is None:
-        idempotency_key = prefect.context.get("task_run_id", None)
+        map_index = prefect.context.get("map_index")
+        task_run_id = prefect.context.get("task_run_id")
+        if task_run_id:
+            idempotency_key = task_run_id
+        if map_index is not None:
+            idempotency_key += f"-{map_index}"
 
     if isinstance(scheduled_start_time, (pendulum.Duration, datetime.timedelta)):
         scheduled_start_time = pendulum.now("utc") + scheduled_start_time

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -142,11 +142,11 @@ def create_flow_run(
     logger.info(f"Creating flow run {run_name_dsp!r} for flow {flow.name!r}...")
 
     if idempotency_key is None:
+        # Generate a default key, if the context is missing this data just fall through
+        # to `None`
+        idempotency_key = prefect.context.get("task_run_id")
         map_index = prefect.context.get("map_index")
-        task_run_id = prefect.context.get("task_run_id")
-        if task_run_id:
-            idempotency_key = task_run_id
-        if map_index is not None:
+        if idempotency_key and map_index is not None:
             idempotency_key += f"-{map_index}"
 
     if isinstance(scheduled_start_time, (pendulum.Duration, datetime.timedelta)):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Task in local `flow.run` calls do not have unique task run ids when mapped. Since `create_flow_run` uses the `task_run_id` as the default idempotency key, mapped calls in local runs will only result in a single flow run. To resolve this, we can include the `map_index` in the default idempotency key.

Note that when running with a backend, each task run (mapped or not) has a distinct UUID.


## Changes
<!-- What does this PR change? -->

Appends the `map_index` to the default idempotency key if present in the context.

Extends test coverage for local runs, run names, and idempotency keys.

## Importance
<!-- Why is this PR important? -->

Mapping with `create_flow_run` in `flow.run()` does not work as intended otherwise.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)