### PR TITLE
Adds lower version pin for azure-core to fix intermittent pipeline failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extras = {
     "airtable": ["airtable-python-wrapper >= 0.11"],
     "aws": orchestration_extras["aws"],
     "azure": [
+        "azure-core >= 1.10.0",
         "azure-storage-blob >= 12.1.0",
         "azureml-sdk >= 1.0.6",
         "azure-cosmos >= 3.1.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
There's a version conflict for the version of `azure-core` required by `azure-storage-blob` and `azureml-sdk`. Specifying a lower bound of the `azure-core` version should fix the intermittent failures that we've been seeing in the task library tests.



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)