### PR TITLE
Add in a new task for fetching values from AWS parameter store

### DIFF
--- a/changes/issue5439.yaml
+++ b/changes/issue5439.yaml
@@ -1,0 +1,5 @@
+task:
+  - "Adds a new task: AWS parameter store manager - (#5439)[https://github.com/PrefectHQ/prefect/issues/5439]"
+
+contributor:
+  - "[Raymond Yu](https://github.com/raymonds-backyard)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -305,7 +305,7 @@ classes = ["WriteAirtableRow", "ReadAirtableRow"]
 [pages.tasks.aws]
 title = "AWS Tasks"
 module = "prefect.tasks.aws"
-classes = ["S3Download", "S3Upload", "S3List", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate", "AWSSecretsManager", "BatchSubmit", "AWSClientWait"]
+classes = ["S3Download", "S3Upload", "S3List", "LambdaCreate", "LambdaDelete" , "LambdaInvoke", "LambdaList", "StepActivate", "AWSSecretsManager", "AWSParametersManager", "BatchSubmit", "AWSClientWait"]
 
 [pages.tasks.azure]
 title = "Azure Tasks"

--- a/src/prefect/tasks/aws/__init__.py
+++ b/src/prefect/tasks/aws/__init__.py
@@ -13,6 +13,7 @@ try:
     )
     from prefect.tasks.aws.step_function import StepActivate
     from prefect.tasks.aws.secrets_manager import AWSSecretsManager
+    from prefect.tasks.aws.parameter_store_manager import AWSParametersManager
     from prefect.tasks.aws.batch import BatchSubmit
     from prefect.tasks.aws.client_waiter import AWSClientWait
 except ImportError as err:
@@ -23,6 +24,7 @@ except ImportError as err:
 __all__ = [
     "AWSClientWait",
     "AWSSecretsManager",
+    "AWSParametersManager",
     "BatchSubmit",
     "LambdaCreate",
     "LambdaDelete",

--- a/src/prefect/tasks/aws/parameter_store_manager.py
+++ b/src/prefect/tasks/aws/parameter_store_manager.py
@@ -1,0 +1,54 @@
+from prefect.tasks.secrets.base import SecretBase
+from prefect.utilities.aws import get_boto_client
+from prefect.utilities.tasks import defaults_from_attrs
+
+
+class AWSParametersManager(SecretBase):
+    """
+    Task for retrieving values from AWS SSM Parameters Store and returning the parameter value.
+    Note that all initialization arguments can optionally be provided or overwritten at runtime.
+    For authentication, there are two options: you can set the `AWS_CREDENTIALS` Prefect Secret
+    containing your AWS access keys which will be passed directly to the `boto3` client, or you
+    can [configure your flow's runtime
+    environment](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration)
+    for `boto3`.
+    Args:
+        - parameter_name (str, optional): the name of the parameter to retrieve via ssm
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
+        - **kwargs (dict, optional): additional keyword arguments to pass to the
+            Task constructor
+    """
+
+    def __init__(self, parameter_name: str = None, boto_kwargs: dict = None, **kwargs):
+        self.parameter_name = parameter_name
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
+        super().__init__(**kwargs)
+
+    @defaults_from_attrs("parameter_name")
+    def run(self, parameter_name: str = None, credentials: str = None) -> str:
+        """
+        Task run method.
+        Args:
+            - parameter_name (str): the name of the parameter to retrieve
+            - credentials (dict, optional): your AWS credentials passed from an upstream
+                Secret task; this Secret must be a JSON string
+                with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
+                passed directly to `boto3`.  If not provided here or in context, `boto3`
+                will fall back on standard AWS rules for authentication.
+        Returns:
+            - str: the parameter value, as a string
+        """
+
+        if parameter_name is None:
+            raise ValueError("A parameter name must be provided.")
+
+        ssm_client = get_boto_client("ssm", credentials=credentials, **self.boto_kwargs)
+
+        parameter_value = ssm_client.get_parameter(Name=parameter_name)
+
+        return parameter_value["Parameter"]["Value"]

--- a/tests/tasks/aws/test_parameter_store_manager.py
+++ b/tests/tasks/aws/test_parameter_store_manager.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.plexflow.tasks.aws.parameter_store_manager import AWSParametersManager
+
+pytest.importorskip("boto3")
+
+
+class TestAWSParameterManager:
+    def test_initialization(self):
+        AWSParametersManager("test")
+
+    def test_initialization_passes_to_task_constructor(self):
+        task = AWSParametersManager(name="test", tags=["AWS"])
+        assert task.name == "test"
+        assert task.tags == {"AWS"}
+
+    def test_raises_if_parameter_name_not_eventually_provided(self):
+        task = AWSParametersManager()
+
+        with pytest.raises(ValueError, match="parameter"):
+            task.run()


### PR DESCRIPTION
## Summary
<!-- A sentence summarizing the PR -->
Creates a new task to fetch ssm parameter values based closely on the existing AWS secrets_manager task for consistency. Makes fetching configuration or sensitive values from parameter store simpler.


## Changes
<!-- What does this PR change? -->
- Adds in a manager for fetching values on AWS SSM parameter store.
- Adds in corresponding tests for the new task


## Importance
<!-- Why is this PR important? -->
This PR adds in another way to fetch config or secrets from AWS.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)