### PR TITLE
Fix AWS secret manager not parsing `plaintext` secrets.

### DIFF
--- a/changes/issue5451.yaml
+++ b/changes/issue5451.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Adds support for AWS secret manager to parse non key-value type secrets - (#5451)[https://github.com/PrefectHQ/prefect/issues/5451]"
+
+contributor:
+  - "[Raymond Yu](https://github.com/raymonds-backyard)"

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -1,4 +1,6 @@
 import json
+from json import JSONDecodeError
+from typing import Union
 
 from prefect.tasks.secrets.base import SecretBase
 from prefect.utilities.aws import get_boto_client
@@ -17,10 +19,10 @@ class AWSSecretsManager(SecretBase):
     for `boto3`.
 
     Args:
-        - secret (str, optional): the name of the secret to retrieve
-        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
-        - **kwargs (dict, optional): additional keyword arguments to pass to the
-            Task constructor
+        - secret (str, optional): The name of the secret to retrieve.
+        - boto_kwargs (dict, optional): Additional keyword arguments to forward to the boto client.
+        - **kwargs (dict, optional): Additional keyword arguments to pass to the
+            Task constructor.
     """
 
     def __init__(self, secret: str = None, boto_kwargs: dict = None, **kwargs):
@@ -34,20 +36,21 @@ class AWSSecretsManager(SecretBase):
         super().__init__(**kwargs)
 
     @defaults_from_attrs("secret")
-    def run(self, secret: str = None, credentials: str = None) -> dict:
+    def run(self, secret: str = None, credentials: str = None) -> Union[dict, str]:
         """
         Task run method.
 
         Args:
-            - secret (str): the name of the secret to retrieve
-            - credentials (dict, optional): your AWS credentials passed from an upstream
+            - secret (str): The name of the secret to retrieve.
+            - credentials (dict, optional): Your AWS credentials passed from an upstream
                 Secret task; this Secret must be a JSON string
                 with two keys: `ACCESS_KEY` and `SECRET_ACCESS_KEY` which will be
                 passed directly to `boto3`.  If not provided here or in context, `boto3`
                 will fall back on standard AWS rules for authentication.
 
         Returns:
-            - dict: the contents of this secret, as a dictionary
+            - Union[dict, str]: The contents of this secret. Either as a dictionary or
+            as a string.
         """
 
         if secret is None:
@@ -59,6 +62,11 @@ class AWSSecretsManager(SecretBase):
 
         secret_string = secrets_client.get_secret_value(SecretId=secret)["SecretString"]
 
-        secret_dict = json.loads(secret_string)
+        try:
+            secret_dict = json.loads(secret_string)
+        except JSONDecodeError:
+            self.logger.info("Secret value could not be parsed as json, returning "
+                             "as a string.")
+            return secret_string
 
         return secret_dict

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -65,8 +65,9 @@ class AWSSecretsManager(SecretBase):
         try:
             secret_dict = json.loads(secret_string)
         except JSONDecodeError:
-            self.logger.info("Secret value could not be parsed as json, returning "
-                             "as a string.")
+            self.logger.info(
+                "Secret value could not be parsed as json, returning " "as a string."
+            )
             return secret_string
 
         return secret_dict

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -66,7 +66,7 @@ class AWSSecretsManager(SecretBase):
             secret_dict = json.loads(secret_string)
         except JSONDecodeError:
             self.logger.info(
-                "Secret value could not be parsed as json, returning " "as a string."
+                "Secret value could not be parsed as json, returning value as a string."
             )
             return secret_string
 

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -65,9 +65,7 @@ class AWSSecretsManager(SecretBase):
         try:
             secret_dict = json.loads(secret_string)
         except JSONDecodeError:
-            self.logger.info(
-                "Secret value could not be parsed as json, returning value as a string."
-            )
+            secret_string = secret_string.strip('{"}')
             return secret_string
 
         return secret_dict

--- a/src/prefect/tasks/aws/secrets_manager.py
+++ b/src/prefect/tasks/aws/secrets_manager.py
@@ -65,7 +65,6 @@ class AWSSecretsManager(SecretBase):
         try:
             secret_dict = json.loads(secret_string)
         except JSONDecodeError:
-            secret_string = secret_string.strip('{"}')
             return secret_string
 
         return secret_dict

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -37,8 +37,9 @@ class TestAWSSecretsManager:
     def test_retrieve_plaintext_secret(self, mocked_boto_client):
         def mocked_response(*args, **kwargs):
             return {
-                "SecretString": "{\"top-secret-string\"}",
+                "SecretString": '{"top-secret-string"}',
             }
+
         task = AWSSecretsManager(secret="test")
         mocked_boto_client.get_secret_value.side_effect = mocked_response
         returned_data = task.run()
@@ -48,8 +49,9 @@ class TestAWSSecretsManager:
     def test_retrieve_key_value_secret(self, mocked_boto_client):
         def mocked_response(*args, **kwargs):
             return {
-                "SecretString": "{\"Key\":\"top-secret-value\"}",
+                "SecretString": '{"Key":"top-secret-value"}',
             }
+
         task = AWSSecretsManager(secret="test")
         mocked_boto_client.get_secret_value.side_effect = mocked_response
         returned_data = task.run()

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -39,7 +39,7 @@ class TestAWSSecretsManager:
 
         def mocked_response(*args, **kwargs):
             return {
-                "SecretString": f'{{"{secret_value}"}}',
+                "SecretString": f"{secret_value}",
             }
 
         task = AWSSecretsManager(secret="test")

--- a/tests/tasks/aws/test_secrets_manager.py
+++ b/tests/tasks/aws/test_secrets_manager.py
@@ -35,16 +35,18 @@ class TestAWSSecretsManager:
             task.run()
 
     def test_retrieve_plaintext_secret(self, mocked_boto_client):
+        secret_value = "top-secret-string"
+
         def mocked_response(*args, **kwargs):
             return {
-                "SecretString": '{"top-secret-string"}',
+                "SecretString": f'{{"{secret_value}"}}',
             }
 
         task = AWSSecretsManager(secret="test")
         mocked_boto_client.get_secret_value.side_effect = mocked_response
         returned_data = task.run()
 
-        assert returned_data == mocked_response()["SecretString"]
+        assert returned_data == secret_value
 
     def test_retrieve_key_value_secret(self, mocked_boto_client):
         def mocked_response(*args, **kwargs):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes the AWS secrets manager to return non key-value secrets as strings instead of erroring out.


## Changes
<!-- What does this PR change? -->
Adds a try clause to the AWS secrets manager to allow for parsing non key-value type secrets.


## Importance
<!-- Why is this PR important? -->
Solves issue #5451 
Currently the AWS secrets manager errors out on parsing a non key value pair secret value. 
I.e A secret storing just "token" would fail to parse. 
This PR fixes this issue.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)