### PR TITLE
Use `schedule=` keyword

### DIFF
--- a/docs/core/concepts/schedules.md
+++ b/docs/core/concepts/schedules.md
@@ -19,7 +19,7 @@ def say_hello():
 
 schedule = IntervalSchedule(interval=timedelta(minutes=2))
 
-with Flow("Hello", schedule) as flow:
+with Flow("Hello", schedule=schedule) as flow:
     say_hello()
 
 flow.run()


### PR DESCRIPTION
The description mentions: 
"Simple schedules can be attached to Flows via the schedule keyword argument:"

But the example doesn't actually utilize the schedule keyword argument explicitly (only implicitly). This adds the explicit keyword argument `schedule=`

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->




## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)