### PR TITLE
Add the ability to plot graphs horizontally.

### DIFF
--- a/changes/pr5472.yaml
+++ b/changes/pr5472.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add a new parameter into visualize() function to change orientation - [#5472](https://github.com/PrefectHQ/prefect/pull/5472)"
+
+contributor:
+  - "[Julio Faracco](https://github.com/jcfaracco)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1299,6 +1299,7 @@ class Flow:
         flow_state: "prefect.engine.state.State" = None,
         filename: str = None,
         format: str = None,
+        horizontal: bool = False,
     ) -> Any:
         """
         Creates graphviz object for representing the current flow; this graphviz
@@ -1313,6 +1314,7 @@ class Flow:
                 automatically
             - format (str, optional): a format specifying the output file type; defaults to 'pdf'.
               Refer to http://www.graphviz.org/doc/info/output.html for valid formats
+            - horizontal (bool, optional): plot the task graph horizontally
 
         Raises:
             - ImportError: if `graphviz` is not installed
@@ -1341,6 +1343,9 @@ class Flow:
             return "#00000080"
 
         graph = graphviz.Digraph()
+
+        if horizontal:
+            graph.graph_attr["rankdir"] = "LR"
 
         for t in self.tasks:
             is_mapped = any(edge.mapped for edge in self.edges_to(t))

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1545,6 +1545,7 @@ class TestFlowVisualize:
                 graph = f.visualize(filename=tmp.name, format="png", horizontal=True)
                 assert os.path.exists(os.path.join(tmpdir, f"{tmp.name}.png"))
 
+
 class TestCache:
     def test_cache_created(self):
         f = Flow(name="test")

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1534,6 +1534,16 @@ class TestFlowVisualize:
                     graph = f.visualize(filename=tmp.name, format=_format)
                     assert os.path.exists(os.path.join(tmpdir, f"{tmp.name}.{_format}"))
 
+    def test_viz_saves_graph_object_with_different_orientation(self):
+        import graphviz
+
+        f = Flow(name="test")
+        f.add_task(Task(name="a_nice_task"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "viz"), "wb") as tmp:
+                graph = f.visualize(filename=tmp.name, format="png", horizontal=True)
+                assert os.path.exists(os.path.join(tmpdir, f"{tmp.name}.png"))
 
 class TestCache:
     def test_cache_created(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This feature request introduces a new orientation to plot graphviz graphs.
If you need to save or display this figure in a doc or any other page, you should have the option to plot it in two different orientations.


## Changes
<!-- What does this PR change? -->

This PR adds a new argument into `visualize()` function to change the image orientation.


## Importance
<!-- Why is this PR important? -->

This can be important to give the option to users to plot using a different orientation instead of saving it to `.dot` and change it manually. It is good for notebooks also.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)