### PR TITLE
Run hasura service with init

### DIFF
--- a/changes/pr_5476.yaml
+++ b/changes/pr_5476.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Run hasura service with `init: true` flag to reap zombie processes - [#5476](https://github.com/PrefectHQ/prefect/pull/5479)"
+
+contributor:
+  - "[VincentAntoine](https://github.com/VincentAntoine)"

--- a/src/prefect/cli/docker-compose.yml
+++ b/src/prefect/cli/docker-compose.yml
@@ -1,5 +1,6 @@
-version: "3.5"
+version: "3.7"
 # Features driving version requirement
+# - init                          3.7
 # - networks.name                 3.5
 # - healthcheck.start_period      2.3
 # - healthcheck                   2.1
@@ -34,6 +35,7 @@ services:
   # Hasura: automatically generates a GraphQL schema from Postgres, provides most of the 'query' API
   hasura:
     image: "hasura/graphql-engine:v2.1.1"
+    init: true
     ports:
       - "127.0.0.1:${HASURA_HOST_PORT:-3000}:3000"
     command: "graphql-engine serve"


### PR DESCRIPTION
## Summary
- Run hasura container with `init`

## Changes
- Run the `hasura` service with `init: true` flag in compose file
- Change compose file version to 3.7 to use the `init` flag (not available in lower versions)

## Importance
Reaps the zombie processes generated by the hasura service : solves https://github.com/PrefectHQ/server/issues/335 (I might be wrong but I think this should be done in this repo although the issue is in the server repo)

## ChecklistThis PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)