### PR TITLE
Add flaky test mark to `test_executor_logs_worker_events`

### DIFF
--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -469,6 +469,7 @@ class TestDaskExecutor:
             assert post._futures is None
             assert post._should_run_event is None
 
+    @pytest.mark.flaky
     def test_executor_logs_worker_events(self, caplog):
         caplog.set_level(logging.DEBUG, logger="prefect")
         with distributed.Client(


### PR DESCRIPTION
This test fails intermittently on Windows
