### PR TITLE
Fix the broken URL in the entrypoint.sh

### DIFF
--- a/changes/pr5490.yaml
+++ b/changes/pr5490.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix the broken URL in the entrypoint.sh - [#5490](https://github.com/PrefectHQ/prefect/pull/5490)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ Thanks for using Prefect!!!
 
 This is the official docker image for Prefect Core, intended for executing
 Prefect Flows. For more information, please see the docs:
-https://docs.prefect.io/core/getting_started/installation.html#docker
+https://docs.prefect.io/core/getting_started/quick-start.html
 "
   exec bash --login
 else


### PR DESCRIPTION
When starting the container, it shows a welcome message with a broken URL https://docs.prefect.io/core/getting_started/installation.html#docker:
![image](https://user-images.githubusercontent.com/86264395/155983220-8520348e-797a-4da6-bb61-ef38e1abc549.png)

This PR fixes the URL