### PR TITLE
Fixes `Glob` task to correctly accept a `str` for `path`

### DIFF
--- a/changes/pr_5499.yaml
+++ b/changes/pr_5499.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fixes Glob task to correctly accept a str for path - [#5499](https://github.com/PrefectHQ/prefect/pull/54990)"
+
+contributor:
+  - "[Paul Gierz](https://github.com/pgierz)"

--- a/src/prefect/tasks/files/operations.py
+++ b/src/prefect/tasks/files/operations.py
@@ -216,7 +216,8 @@ class Glob(Task):
         if not path:
             raise ValueError("No `path` provided.")
 
-        globpath = Path(path).joinpath(pattern)
-        self.logger.debug(f"Glob path: {globpath}")
+        path = Path(path)
+
+        self.logger.debug("Glob path: %s", path.joinpath(pattern))
 
         return list(path.glob(pattern))

--- a/tests/tasks/files/test_operations.py
+++ b/tests/tasks/files/test_operations.py
@@ -161,7 +161,7 @@ class TestGlob:
         with pytest.raises(ValueError, match="No `path` provided"):
             ld.run()
 
-    def test_list_dir(self, tmp_path: pathlib.Path):
+    def test_list_dir_path(self, tmp_path: pathlib.Path):
         dir = tmp_path / "source"
         dir.mkdir(exist_ok=True)
         file = dir / "testfile"
@@ -170,7 +170,19 @@ class TestGlob:
         ld = Glob(path=dir)
         res = ld.run()
 
-        assert res[0] == Path(str(file))
+        assert res[0] == file
+        assert isinstance(res[0], Path)
+
+    def test_list_dir_str(self, tmp_path: pathlib.Path):
+        dir = tmp_path / "source"
+        dir.mkdir(exist_ok=True)
+        file = dir / "testfile"
+        file.write_text("test")
+
+        ld = Glob(path=str(dir))
+        res = ld.run()
+
+        assert res[0] == file
         assert isinstance(res[0], Path)
 
     def test_list_dir_recursive(self, tmp_path: pathlib.Path):
@@ -189,8 +201,8 @@ class TestGlob:
         ld = Glob(path=parent_dir, pattern="**/*")
         res = ld.run()
 
-        assert Path(str(file1)) in res
-        assert Path(str(file2)) in res
+        assert file1 in res
+        assert file2 in res
         assert len(res) == 4
 
     def test_glob_pattern(self, tmp_path: pathlib.Path):
@@ -205,4 +217,4 @@ class TestGlob:
         res = ld.run()
 
         assert len(res) == 1
-        assert res[0] == Path(str(file2))
+        assert res[0] == file2


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Fixes bug in `Glob` task where string paths are not handled correctly. Work originally performed in #5264 by @pgierz. Builds upon the original work by adding test coverage.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)