### PR TITLE
Docs: Remove conda example from Vertex agent

### DIFF
--- a/docs/orchestration/agents/vertex.md
+++ b/docs/orchestration/agents/vertex.md
@@ -6,26 +6,12 @@ Vertex describes these as "training" jobs, but they can be used to run any kind 
 ## Requirements
 
 The required dependencies for the Vertex Agent aren't [installed by
-default](/core/getting_started/installation.md). If you're a `pip` user you'll
-need to add the `gcp` extra. Likewise, with `conda` you'll need to install
-`google-cloud-aiplatform`:
-
-:::: tabs
-::: tab Pip
+default](/core/getting_started/installation.md). You'll
+need to add the `gcp` extra via `pip`. 
 
 ```bash
 pip install prefect[gcp]
 ```
-
-:::
-::: tab Conda
-
-```bash
-conda install -c conda-forge prefect google-cloud-aiplatform
-```
-
-:::
-::::
 
 ::: warning Prefect Server
 In order to use this agent with Prefect Server the server's GraphQL API


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Removes the conda example from the Vertex agent doc. The suggested package does not actually exist for conda.

Closes #5199

## Changes
<!-- What does this PR change? -->
- Removes conda example from /orchestration/agents/vertex.html#requirements


## Importance
<!-- Why is this PR important? -->
- conda configuration example does not work.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~