### PR TITLE
Docs: Remove beta tag from Artifacts

### DIFF
--- a/docs/orchestration/concepts/artifacts.md
+++ b/docs/orchestration/concepts/artifacts.md
@@ -1,4 +1,4 @@
-# Artifacts <Badge text="Beta"/>
+# Artifacts
 
 The [Artifacts API](/api/latest/backend/artifacts.html) enables you to publish data from task runs that is rendered natively in the Prefect UI, both Prefect Cloud and Prefect Server. 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Removes beta tag from the [Artifacts](https://deploy-preview-5506--prefect-docs.netlify.app/orchestration/concepts/artifacts.html) concept doc page.

Closes #5482


## Changes
<!-- What does this PR change? -->

- /orchestration/concepts/artifacts.html


## Importance
<!-- Why is this PR important? -->

No longer beta with 1.0 release.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~