### PR TITLE
Add workaround for self kwarg

### DIFF
--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -736,6 +736,10 @@ class TaskRunner(Runner):
                 **raw_inputs,
             }
 
+            # self can't be used as a formatting parameter because it would ruin all method calls such as
+            # result.exists() by providing two values of self
+            formatting_kwargs.pop("self")
+
             if not isinstance(target, str):
                 target = target(**formatting_kwargs)
 

--- a/src/prefect/engine/task_runner.py
+++ b/src/prefect/engine/task_runner.py
@@ -738,7 +738,7 @@ class TaskRunner(Runner):
 
             # self can't be used as a formatting parameter because it would ruin all method calls such as
             # result.exists() by providing two values of self
-            formatting_kwargs.pop("self")
+            formatting_kwargs.pop("self", None)
 
             if not isinstance(target, str):
                 target = target(**formatting_kwargs)

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -830,10 +830,11 @@ def test_task_called_outside_flow_context_raises_helpful_error(use_function_task
 def test_task_call_with_self_succeeds():
     from pathlib import Path
 
-    seconds_task = task(Path.is_absolute, target="{{task_slug}}_{{map_index}}", result=LocalResult())
+    seconds_task = task(
+        Path.is_absolute, target="{{task_slug}}_{{map_index}}", result=LocalResult()
+    )
     initial = Path("foo")
 
     with Flow("test") as flow:
         seconds_task(initial)
         assert flow.run().is_successful()
-

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -828,12 +828,19 @@ def test_task_called_outside_flow_context_raises_helpful_error(use_function_task
 
 
 def test_task_call_with_self_succeeds():
-    from pathlib import Path
+    import dataclasses
+
+    @dataclasses.dataclass
+    class TestClass:
+        count: int
+
+        def increment(self):
+            self.count = self.count + 1
 
     seconds_task = task(
-        Path.is_absolute, target="{{task_slug}}_{{map_index}}", result=LocalResult()
+        TestClass.increment, target="{{task_slug}}_{{map_index}}", result=LocalResult()
     )
-    initial = Path("foo")
+    initial = TestClass(count=0)
 
     with Flow("test") as flow:
         seconds_task(initial)

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -825,3 +825,15 @@ def test_task_called_outside_flow_context_raises_helpful_error(use_function_task
         "If you're trying to run this task outside of a Flow context, "
         f"you need to call {run_call}" in str(exc_info)
     )
+
+
+def test_task_call_with_self_succeeds():
+    from pathlib import Path
+
+    seconds_task = task(Path.is_absolute, target="{{task_slug}}_{{map_index}}", result=LocalResult())
+    initial = Path("foo")
+
+    with Flow("test") as flow:
+        seconds_task(initial)
+        assert flow.run().is_successful()
+


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Fix a task failure when `self` is used as a task argument



## Changes
`self` is popped from the formatting dictionary used to populate result strings. This should not be included because it means that we get `result.exists(self="foo", self="bar")`, which is an error.

## Importance
<!-- Why is this PR important? -->
Currently there is a crash whenever any method is used directly as a function. For example, in the below code note how the task's function *is* `Path.is_absolute` which is a method that we are using like a function, and which therefore needs a `self` argument:

```python
    from pathlib import Path

    seconds_task = task(Path.is_absolute, target="{{task_slug}}_{{map_index}}", result=LocalResult())
    initial = Path("foo")

    with Flow("test") as flow:
        seconds_task(initial)
        flow.run()
```

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)