### PR TITLE
Update docs for custom Kubernetes Container JobSpec

### DIFF
--- a/docs/api/0.15.13/run_configs.md
+++ b/docs/api/0.15.13/run_configs.md
@@ -162,38 +162,6 @@ flow.run_config = KubernetesRun(
 
 ```
 
-Augment the `job_template` with a custom label (use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used):
-
-
-```python
-flow.run_config = KubernetesRun(
-    image="example/my-custom-image:my-tag,
-    job_template={
-        {
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "spec": {
-                "template": {
-                    "metadata": {
-                        "labels": {
-                            "my-custom-label": "something"
-                        }
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": "flow"
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-    }
-)
-
-```
-
 
 ---
 <br>

--- a/docs/api/0.15.13/run_configs.md
+++ b/docs/api/0.15.13/run_configs.md
@@ -162,6 +162,38 @@ flow.run_config = KubernetesRun(
 
 ```
 
+Augment the `job_template` with a custom label (use the [default](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as the default, once a `job_template` is specified, the default is no longer used):
+
+
+```python
+flow.run_config = KubernetesRun(
+    image="example/my-custom-image:my-tag,
+    job_template={
+        {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "my-custom-label": "something"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "flow"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+)
+
+```
+
 
 ---
 <br>

--- a/docs/api/0.15.13/run_configs.md
+++ b/docs/api/0.15.13/run_configs.md
@@ -162,7 +162,7 @@ flow.run_config = KubernetesRun(
 
 ```
 
-Augment the `job_template` with a custom label (use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml). Once a `job_template` is specified, the default is no longer used):
+Augment the `job_template` with a custom label (use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used):
 
 
 ```python

--- a/docs/api/0.15.13/run_configs.md
+++ b/docs/api/0.15.13/run_configs.md
@@ -162,7 +162,7 @@ flow.run_config = KubernetesRun(
 
 ```
 
-Augment the `job_template` with a custom label (use the [default](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as the default, once a `job_template` is specified, the default is no longer used):
+Augment the `job_template` with a custom label (use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml). Once a `job_template` is specified, the default is no longer used):
 
 
 ```python

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -77,6 +77,36 @@ class KubernetesRun(RunConfig):
         image_pull_policy="Always"
     )
     ```
+    
+    Use a custom `job_template` with a custom label (or any other necessary changes to the default)
+    
+    (_Note_: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used):
+    
+    ```python
+    flow.run_config = KubernetesRun(
+        image="example/my-custom-image:my-tag,
+        job_template={
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "my-custom-label": "something"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "flow"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    )
+    ```
     """
 
     def __init__(

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -82,7 +82,7 @@ class KubernetesRun(RunConfig):
     the default).
 
     Note: use the default
-    [job template](
+    `/prefect/src/prefect/agent/kubernetes/job_template.yaml` in the repository,
     https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/
     job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -78,9 +78,12 @@ class KubernetesRun(RunConfig):
     )
     ```
     
-    Use a custom `job_template` with a custom label (or any other necessary changes to the default).
+    Use a custom `job_template` with a custom label (or any other necessary changes to
+    the default).
     
-    Note: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used:
+    Note: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml)
+    as a base to build on. Once a `job_template` is specified, the default is no longer
+    used:
     
     ```python
     flow.run_config = KubernetesRun(

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -82,7 +82,9 @@ class KubernetesRun(RunConfig):
     the default).
 
     Note: use the default
-    [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml)
+    [job template](
+    https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/
+    job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:
 

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -81,7 +81,7 @@ class KubernetesRun(RunConfig):
     Use a custom `job_template` with a custom label (or any other necessary changes to
     the default).
 
-    Note: use the default
+    Note: you can use the default job template, found at
     `/prefect/src/prefect/agent/kubernetes/job_template.yaml` in the repository,
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -83,7 +83,6 @@ class KubernetesRun(RunConfig):
 
     Note: use the default
     `/prefect/src/prefect/agent/kubernetes/job_template.yaml` in the repository,
-    job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:
 

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -83,7 +83,6 @@ class KubernetesRun(RunConfig):
 
     Note: use the default
     `/prefect/src/prefect/agent/kubernetes/job_template.yaml` in the repository,
-    https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/
     job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -81,7 +81,8 @@ class KubernetesRun(RunConfig):
     Use a custom `job_template` with a custom label (or any other necessary changes to
     the default).
     
-    Note: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml)
+    Note: use the default
+    [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:
     

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -80,7 +80,7 @@ class KubernetesRun(RunConfig):
     
     Use a custom `job_template` with a custom label (or any other necessary changes to the default).
     
-    (_Note_: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used):
+    Note: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used:
     
     ```python
     flow.run_config = KubernetesRun(

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -77,15 +77,15 @@ class KubernetesRun(RunConfig):
         image_pull_policy="Always"
     )
     ```
-    
+
     Use a custom `job_template` with a custom label (or any other necessary changes to
     the default).
-    
+
     Note: use the default
     [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml)
     as a base to build on. Once a `job_template` is specified, the default is no longer
     used:
-    
+
     ```python
     flow.run_config = KubernetesRun(
         image="example/my-custom-image:my-tag,

--- a/src/prefect/run_configs/kubernetes.py
+++ b/src/prefect/run_configs/kubernetes.py
@@ -78,7 +78,7 @@ class KubernetesRun(RunConfig):
     )
     ```
     
-    Use a custom `job_template` with a custom label (or any other necessary changes to the default)
+    Use a custom `job_template` with a custom label (or any other necessary changes to the default).
     
     (_Note_: use the default [job template](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml) as a base to build on. Once a `job_template` is specified, the default is no longer used):
     


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adding a little documentation from a Slack Conversation.

I need to add a Kubernetes label to the Pod, so adding that as an example.

## Changes
 - Updates API docs for 0.15.13 to include an example of specifying a custom `job_template` as a `dict`.

## Importance
I had a question in Slack that I thought would be in docs

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)