### PR TITLE
fix pod logging in RunNamespacedJob

### DIFF
--- a/changes/pr5514.yaml
+++ b/changes/pr5514.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix pod logging in RunNamespacedJob - [#5514](https://github.com/PrefectHQ/prefect/pull/5514)"
+
+contributor:
+  - "[Brett Polivka](https://github.com/polivbr)"

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, cast
 from kubernetes import client
 from concurrent.futures import ThreadPoolExecutor
 
+import prefect
 from prefect import Task
 from prefect.engine import signals
 from prefect.utilities.tasks import defaults_from_attrs
@@ -724,7 +725,16 @@ class RunNamespacedJob(Task):
 
         pod_log_streams = {}
 
-        with ThreadPoolExecutor() as pool:
+        # Context is thread-local and isn't automatically copied
+        # to the threads spawned by ThreadPoolExecutor.
+        # Add an initializer which updates the thread's Context with
+        # values from the current Context.
+        context_copy = prefect.context.copy()
+
+        def initialize_thread(context):
+            prefect.context.update(context)
+
+        with ThreadPoolExecutor(initializer=initialize_thread, initargs=(context_copy,)) as pool:
             completed = False
             while not completed:
                 job = api_client_job.read_namespaced_job_status(

--- a/src/prefect/tasks/kubernetes/job.py
+++ b/src/prefect/tasks/kubernetes/job.py
@@ -734,7 +734,9 @@ class RunNamespacedJob(Task):
         def initialize_thread(context):
             prefect.context.update(context)
 
-        with ThreadPoolExecutor(initializer=initialize_thread, initargs=(context_copy,)) as pool:
+        with ThreadPoolExecutor(
+            initializer=initialize_thread, initargs=(context_copy,)
+        ) as pool:
             completed = False
             while not completed:
                 job = api_client_job.read_namespaced_job_status(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR addresses the issue where pod logs aren't getting property
logged in RunNamespacedJob.

## Changes
<!-- What does this PR change? -->

Because Context is thread-local, it isn't set properly in the threads
spawned by a ThreadPoolExecutor, and therefore the logs aren't sent
by the CloudHandler. Fix this by adding a thread initializer which
updates the thread's Context with a copy of the main thread's Context.

## Importance
<!-- Why is this PR important? -->

Without this fix, no output from pods is captured.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)