### PR TITLE
Use pending state when flow run state is missing

### DIFF
--- a/changes/pr5554.yaml
+++ b/changes/pr5554.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Fixes bug where the FlowRunView could fail to initialize when the backend has no state data - [#5554](https://github.com/PrefectHQ/prefect/pull/5554)'
+
+contributor:
+  - '[Emre Akgün](https://github.com/Fraznist)'

--- a/tests/backend/test_flow_run.py
+++ b/tests/backend/test_flow_run.py
@@ -58,6 +58,17 @@ FLOW_RUN_DATA_2 = {
     "updated": pendulum.now().isoformat(),
     "run_config": UniversalRun().serialize(),
 }
+FLOW_RUN_DATA_NULL_STATE = {
+    "id": "id-null",
+    "name": "name-null",
+    "flow_id": "flow_id-null",
+    "serialized_state": None,
+    "parameters": {},
+    "context": {},
+    "labels": [],
+    "updated": pendulum.now().isoformat(),
+    "run_config": UniversalRun().serialize(),
+}
 
 TASK_RUN_DATA_FINISHED = {
     "id": "task-run-id-1",
@@ -174,6 +185,11 @@ def test_flow_run_view_from_returns_instance(patch_post, from_method):
         assert state.message == "past-state"
     # There are no cached tasks
     assert flow_run._cached_task_runs == {}
+
+
+def test_flow_run_view_from_flow_run_data_fills_empty_state_with_pending():
+    flow_run = FlowRunView._from_flow_run_data(FLOW_RUN_DATA_NULL_STATE)
+    assert flow_run.state.is_pending()
 
 
 def test_flow_run_view_from_returns_instance_with_loaded_static_tasks(


### PR DESCRIPTION


<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
There is a slight timeframe in which an initialized flow run does not have a serialized state. During this time a backend FlowRunView object cannot be initiated.




## Changes
<!-- What does this PR change? -->
With this change, `FlowRunView` instances can be initialized when `serialized_state` value is None. A default state of `Pending` is used to fill the null value instead, with a short message describing that the flow run state is not yet initialized.

## Importance
`wait_for_flow_run` task could fail, even though child flow executes correctly. See issue #5552 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)