### PR TITLE
single quote doc fix

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -221,7 +221,7 @@ def tags(*new_tags: str) -> Set[str]:
         >>>     with tags("c", "d"):
         >>>         with tags("e", "f") as current_tags:
         >>>              print(current_tags)
-        >>> with tags("a", b"):
+        >>> with tags("a", "b"):
         >>>     my_flow()
         {"a", "b", "c", "d", "e", "f"}
     """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Fixing a single quote in the documentation because it somehow annoyed me more than it should.




## Changes
A single quote for the documentation of tags.




## Importance
It kinda isn't. Just... cleaning up.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)