### PR TITLE
Raise error if flow.run called within Flow ctx

### DIFF
--- a/changes/pr5588.yaml
+++ b/changes/pr5588.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - 'Raise RuntimeError when calling flow.run within Flow context - [#5588](https://github.com/PrefectHQ/prefect/pull/5588)'
+
+contributor:
+  - '[Emre Akgün](https://github.com/Fraznist)'

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1211,6 +1211,19 @@ class Flow:
         Returns:
             - State: the state of the flow after its final run
         """
+        if hasattr(self, "_ctx"):
+            raise RuntimeError(
+                "Don't call `flow.run()` from within a `Flow` context manager.\n\n"
+                "Do:\n\n"
+                "  with Flow(...) as flow:\n"
+                "      ...\n"
+                "  flow.run(...)\n\n"
+                "Don't:\n\n"
+                "  with Flow(...) as flow:\n"
+                "      ...\n"
+                "      flow.run(...)"
+            )
+
         if prefect.context.get("loading_flow", False):
             warnings.warn(
                 "Attempting to call `flow.run` during execution of flow file will lead to "

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -2662,6 +2662,12 @@ class TestFlowRunMethod:
         f.run()
         assert REPORTED_START_TIMES == start_times
 
+    def test_flow_dot_run_errors_if_in_flow_context(self):
+        with pytest.raises(RuntimeError) as exc:
+            with Flow("test") as flow:
+                flow.run()
+        assert "`flow.run()` from within a `Flow` context manager" in str(exc.value)
+
 
 class TestFlowDiagnostics:
     def test_flow_diagnostics(self, monkeypatch):

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -852,4 +852,4 @@ def test_task_call_with_self_succeeds():
 
     with Flow("test") as flow:
         seconds_task(initial)
-        assert flow.run().is_successful()
+    assert flow.run().is_successful()

--- a/tests/engine/test_task_runner.py
+++ b/tests/engine/test_task_runner.py
@@ -2454,10 +2454,10 @@ class TestTaskRunNames:
                 .pipe(add_time, minutes=1)
             )
 
-            state = flow.run()
-            assert state.result[result].result == datetime(
-                year=1970, month=1, day=2, hour=1, minute=1
-            )
+        state = flow.run()
+        assert state.result[result].result == datetime(
+            year=1970, month=1, day=2, hour=1, minute=1
+        )
 
     def test_task_pipeline_no_varargs(self):
         """
@@ -2490,8 +2490,8 @@ class TestTaskRunNames:
             res = accepts_anything("initial arg").pipe(
                 accepts_anything, task="some kwarg"
             )
-            state = flow.run()
-            assert state.result[res].result == dict(task="some kwarg")
+        state = flow.run()
+        assert state.result[res].result == dict(task="some kwarg")
 
     def test_task_pipeline_keyword_self(self):
         """
@@ -2508,4 +2508,4 @@ class TestTaskRunNames:
                 res = accepts_anything("initial arg").pipe(
                     accepts_anything, self="some kwarg"
                 )
-            state = flow.run()
+        state = flow.run()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Implements #5556 -> Raise informative error when `flow.run()` is called within a flow context.

## Details
Found a check in `flow.register()` that uses `hasattr` instead of `'flow' in prefect.context`. Opted to use that for consistency. 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)