### PR TITLE
Changed doc for command concurrency_limit -> concurrency-limit

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -359,7 +359,7 @@ You can set concurrency limits on as few or as many tags as you wish. You can se
 You can create, list, and remove concurrency limits by using Prefect CLI `concurrency-limit` commands.
 
 ```bash
-$ prefect concurrency_limit [command] [arguments]
+$ prefect concurrency-limit [command] [arguments]
 ```
 
 | Command | Description |
@@ -372,13 +372,13 @@ $ prefect concurrency_limit [command] [arguments]
 For example, to set a concurrency limit of 10 on the 'small_instance' tag:
 
 ```bash
-$ prefect concurrency_limit create small_instance 10
+$ prefect concurrency-limit create small_instance 10
 ```
 
 To delete the concurrency limit on the 'small_instance' tag:
 
 ```bash
-$ prefect concurrency_limit delete small_instance
+$ prefect concurrency-limit delete small_instance
 ```
 
 #### Python client


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This is a simple fix in the documentation. Replaced an underscore with a dash to show users the proper command.



## Changes
In the docs concurrency_limit -> concurrency-limit



## Importance
Helps new users avoid speedbumps when trying out orion. It also fixes this issue https://github.com/PrefectHQ/prefect/issues/5583




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:
This PR does none of these.
- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)