### PR TITLE
Allow up to 5 retries for read-based client errors

### DIFF
--- a/changes/pr5600.yaml
+++ b/changes/pr5600.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Allows the Prefect Client to retry up to 5 times for read-based errors - [#5600](https://github.com/PrefectHQ/prefect/pull/5600)'
+
+contributor:
+  - '[Jason Bertman](https://github.com/jbertman)'

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -633,6 +633,7 @@ class Client:
         retries = requests.packages.urllib3.util.retry.Retry(
             total=retry_total,
             backoff_factor=1,
+            read=5,
             status_forcelist=[500, 502, 503, 504],
             # typeshed is out of date with urllib3 and missing `allowed_methods`
             allowed_methods=["DELETE", "GET", "POST"],  # type: ignore

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -260,6 +260,7 @@ def test_client_requests_use_retries(monkeypatch):
     Retry.assert_called_once_with(
         total=6,
         backoff_factor=1,
+        read=5,
         status_forcelist=[500, 502, 503, 504],
         allowed_methods=["DELETE", "GET", "POST"],  # type: ignore
     )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
The following Slack thread contains a summary of the reasoning for this change: https://prefect-community.slack.com/archives/CL09KU1K7/p1648056360270909

Task State getting and setting is a critical operation. When the Apollo services misses this request for one reason or another, the entire flow can fail as a side-effect of a set of tasks that never finish (stuck in a Pending state).

In general, this operation is performed by the Prefect GraphQL client. GQL requests are retried according to the policy set in the retrier here: https://github.com/PrefectHQ/prefect/blob/a2041c7ff1a619e611f614ed3394fccd05bb2005/src/prefect/client/client.py#L633-L639

In a self-managed k8s cluster, the Apollo service can become unresponsive and reject requests if the throughput is too high. This is caught on the Python client as a `ConnectionError`:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prefect/engine/cloud/task_runner.py", line 91, in call_runner_target_handlers
    state = self.client.set_task_run_state(
  File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 1922, in set_task_run_state
    result = self.graphql(
...
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='prefecthq-apollo.prefect', port=4200): Max retries exceeded with url: /graphql (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f12486259d0>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

While this seems like a DNS or service issue, the Apollo service drops the following log when this happens:
```
│ BadRequestError: request aborted                                                                                                                                                                                                           
│     at IncomingMessage.onAborted (/apollo/node_modules/raw-body/index.js:231:10)                                                                                                                                                           
│     at IncomingMessage.emit (events.js:315:20)                                                                                                                                                                                             
│     at abortIncoming (_http_server.js:561:9)                                                                                                                                                                                               
│     at socketOnClose (_http_server.js:554:3)                                                                                                                                                                                               
│     at Socket.emit (events.js:327:22)                                                                                                                                                                                                     
│     at TCP.<anonymous> (net.js:673:12)  
```
Which is an indication that the server is overloaded at the moment. An easy solution is to use the `read` kwarg in the retrier. 

### Why `read` and not `connect`?

Starting at the initial stack trace, the exception being raised is a `ConnectionError`. I (incorrectly) assumed this was covered by the connect case. A bit counterintuitively perhaps, the `read` kwarg catches `ProtocolError`: https://github.com/urllib3/urllib3/blob/37a67739ba9a7835886555744e9dabe3009e538a/src/urllib3/util/retry.py#L366-L370
Which I found to be aliased to `ConnectionError`: https://github.com/urllib3/urllib3/blob/9fbab29644bfc8068eb2082d0f25726c91813337/src/urllib3/exceptions.py#L84


## Changes
<!-- What does this PR change? -->
This change allows the Prefect Client to retry on `read` failure up to 5 times.



## Importance
<!-- Why is this PR important? -->
Intermittent errors in service availability should be tolerated reasonably.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)