### PR TITLE
Fix Dask CI failures

### DIFF
--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -269,6 +269,7 @@ class DaskExecutor(Executor):
             - message (dict): Information about the event that the scheduler has sent
         """
         if op == "add":
+            print(message)
             for worker in message.get("workers", ()):
                 self.logger.debug("Worker %s added", worker)
         elif op == "remove":

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -268,8 +268,8 @@ class DaskExecutor(Executor):
             - op (str): Either "add" or "remove"
             - message (dict): Information about the event that the scheduler has sent
         """
+        print("on_worker_status_changed", op, message)
         if op == "add":
-            print(message)
             for worker in message.get("workers", ()):
                 self.logger.debug("Worker %s added", worker)
         elif op == "remove":

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -268,7 +268,6 @@ class DaskExecutor(Executor):
             - op (str): Either "add" or "remove"
             - message (dict): Information about the event that the scheduler has sent
         """
-        print("on_worker_status_changed", op, message)
         if op == "add":
             for worker in message.get("workers", ()):
                 self.logger.debug("Worker %s added", worker)
@@ -281,7 +280,6 @@ class DaskExecutor(Executor):
         from distributed.core import rpc
 
         try:
-            print("setting up dask events watch")
             scheduler_comm = rpc(
                 self.client.scheduler.address,  # type: ignore
                 connection_args=self.client.security.get_connection_args("client"),  # type: ignore
@@ -292,10 +290,8 @@ class DaskExecutor(Executor):
             comm = await asyncio.shield(scheduler_comm.live_comm())
             await comm.write({"op": "subscribe_worker_status"})
             _ = await comm.read()
-            print("starting to watch dask events")
             while True:
                 try:
-                    print("reading dask events")
                     msgs = await comm.read()
                 except OSError:
                     break

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -281,6 +281,7 @@ class DaskExecutor(Executor):
         from distributed.core import rpc
 
         try:
+            print("setting up dask events watch")
             scheduler_comm = rpc(
                 self.client.scheduler.address,  # type: ignore
                 connection_args=self.client.security.get_connection_args("client"),  # type: ignore
@@ -291,8 +292,10 @@ class DaskExecutor(Executor):
             comm = await asyncio.shield(scheduler_comm.live_comm())
             await comm.write({"op": "subscribe_worker_status"})
             _ = await comm.read()
+            print("starting to watch dask events")
             while True:
                 try:
+                    print("reading dask events")
                     msgs = await comm.read()
                 except OSError:
                     break

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -6,6 +6,7 @@ import tempfile
 import threading
 import time
 import uuid
+import re
 
 import cloudpickle
 import dask
@@ -484,10 +485,8 @@ class TestDaskExecutor:
                 while len(client.scheduler_info()["workers"]) > 1:
                     time.sleep(0.1)
 
-            time.sleep(0.5)
-
-        assert any("Worker %s added" == rec.msg for rec in caplog.records)
-        assert any("Worker %s removed" == rec.msg for rec in caplog.records)
+        assert any(re.match("Worker .+ added", rec.msg) for rec in caplog.records)
+        assert any(re.match("Worker .+ removed", rec.msg) for rec in caplog.records)
 
     @pytest.mark.parametrize("kind", ["external", "inproc"])
     @pytest.mark.flaky

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -469,7 +469,7 @@ class TestDaskExecutor:
             assert post._futures is None
             assert post._should_run_event is None
 
-    @pytest.mark.flaky
+    @pytest.mark.flaky()
     def test_executor_logs_worker_events(self, caplog):
         caplog.set_level(logging.DEBUG, logger="prefect")
         with distributed.Client(
@@ -483,6 +483,8 @@ class TestDaskExecutor:
                 client.cluster.scale(1)
                 while len(client.scheduler_info()["workers"]) > 1:
                     time.sleep(0.1)
+
+            time.sleep(0.5)
 
         assert any("Worker %s added" == rec.msg for rec in caplog.records)
         assert any("Worker %s removed" == rec.msg for rec in caplog.records)

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -478,7 +478,7 @@ class TestDaskExecutor:
         ) as client:
             executor = DaskExecutor(address=client.scheduler.address)
             with executor.start():
-                time.sleep(1)
+                time.sleep(0.1)
                 client.cluster.scale(4)
                 while len(client.scheduler_info()["workers"]) < 4:
                     time.sleep(0.1)

--- a/tests/executors/test_executors.py
+++ b/tests/executors/test_executors.py
@@ -478,6 +478,7 @@ class TestDaskExecutor:
         ) as client:
             executor = DaskExecutor(address=client.scheduler.address)
             with executor.start():
+                time.sleep(1)
                 client.cluster.scale(4)
                 while len(client.scheduler_info()["workers"]) < 4:
                     time.sleep(0.1)

--- a/tests/tasks/prefect/test_flow_run.py
+++ b/tests/tasks/prefect/test_flow_run.py
@@ -403,7 +403,7 @@ class TestGetTaskRunResult:
         # Ensure we aren't sleeping on already finished runs
         mock_sleep = MagicMock(
             side_effect=RuntimeError(
-                "Sleep should not be called for a fnished flow run."
+                "Sleep should not be called for a finished flow run."
             )
         )
         monkeypatch.setattr("prefect.tasks.prefect.flow_run.time.sleep", mock_sleep)


### PR DESCRIPTION
Adds sleep before running Dask cluster scale in test to allow Dask event listener to start up.