### PR TITLE
Change the issue type to Prefect 2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/3. orion.md
+++ b/.github/ISSUE_TEMPLATE/3. orion.md
@@ -1,8 +1,7 @@
 ---
 name: Prefect 2.0
 about: "Report a bug or request a feature for Prefect 2.0"
-title: 'Orion: '
-labels: orion
+labels: v2
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/3. orion.md
+++ b/.github/ISSUE_TEMPLATE/3. orion.md
@@ -1,6 +1,6 @@
 ---
-name: Orion Preview
-about: "Report a bug or request a feature for the Prefect Orion technical preview"
+name: Prefect 2.0
+about: "Report a bug or request a feature for Prefect 2.0"
 title: 'Orion: '
 labels: orion
 assignees: ''


### PR DESCRIPTION
To reflect that Orion is no longer in technical preview but instead in a beta stage.

Not sure if the title prefix should stay "Orion: " - there may be some automations that rely on it