### PR TITLE
fix for secret.exists()

### DIFF
--- a/src/prefect/client/secrets.py
+++ b/src/prefect/client/secrets.py
@@ -103,7 +103,7 @@ class Secret:
         secrets = prefect.context.get("secrets", {})
         if self.name in secrets:
             return True
-        elif prefect.context.config.cloud.use_local_secrets is False:
+        elif prefect.config.backend == "cloud" and prefect.context.config.cloud.use_local_secrets is False:
             cloud_secrets = self.client.graphql("query{secret_names}").data.secret_names
             if self.name in cloud_secrets:
                 return True


### PR DESCRIPTION
## Summary
we should not fetch secrets from could if we work with `backend` server (not cloud one)


## Changes
<!-- What does this PR change? -->


## Importance
<!-- Why is this PR important? -->


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)