### PR TITLE
Fix flow visualization when tasks are mapped lambdas (#5656)

### DIFF
--- a/changes/pr5662.yaml
+++ b/changes/pr5662.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Fixes graphviz syntax error when visualizing a flow with a task which is a mapped lambda. [#5662](https://github.com/PrefectHQ/prefect/pull/5662)'
+
+contributor:
+  - '[Ben Ayers-Glassey](https://github.com/bayersglassey-zesty/)'

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1363,7 +1363,12 @@ class Flow:
         for t in self.tasks:
             is_mapped = any(edge.mapped for edge in self.edges_to(t))
             shape = "box" if is_mapped else "ellipse"
-            name = "{} <map>".format(t.name) if is_mapped else t.name
+
+            # Wrapping the string in graphviz.escape tells Graphviz to quote it, even if it
+            # looks like an "HTML-like label" or contains backslashes.
+            # See: https://github.com/PrefectHQ/prefect/issues/5656
+            name = graphviz.escape("{} <map>".format(t.name) if is_mapped else t.name)
+
             if is_mapped and flow_state:
                 assert isinstance(flow_state.result, dict)
                 if flow_state.result[t].is_mapped():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1369,6 +1369,17 @@ class TestFlowVisualize:
         assert "label=x style=dashed" in graph.source
         assert "label=y style=dashed" in graph.source
 
+    def test_viz_can_handle_mapped_lambdas(self):
+        # See: https://github.com/PrefectHQ/prefect/issues/5656
+        ipython = MagicMock(
+            get_ipython=lambda: MagicMock(config=dict(IPKernelApp=True))
+        )
+        with patch.dict("sys.modules", IPython=ipython):
+            with Flow(name="test") as f:
+                res = AddTask(name="<lambda>").map(x=Task(name="a_list_task"), y=8)
+            graph = f.visualize()
+        assert 'label="<lambda> <map>" shape=box' in graph.source
+
     def test_viz_can_handle_skipped_mapped_tasks(self):
         ipython = MagicMock(
             get_ipython=lambda: MagicMock(config=dict(IPKernelApp=True))


### PR DESCRIPTION
## Summary

See: https://github.com/PrefectHQ/prefect/issues/5656
In short, this PR fixes an issue where a mapped lambda, e.g. `task(lambda x: x + 1).map([1, 2, 3])`, causes `graphviz.Digraph.render` (called by `Flow.visualize`) to generate DOT syntax with the label unquoted, e.g. `[label=<lambda> <map>]`, because it assumes that a string enclosed in angle brackets should contain valid HTML; and the resulting syntax is incorrect, so the `dot` command correctly rejects it, leading to an error.

Quick way to check whether the changes in PR fix the issue or not:
```python
from prefect import task, Flow
with Flow('test') as flow:
    xs = task(lambda x: x + 1).map([1, 2, 3])
flow.visualize()
```

...after this PR, that does not result in an error.


## Changes

In Flow.visualize, we now wrap node labels with `graphviz.quoting.nohtml`, which tells graphviz to quote the labels even if they look vaguely HTML-like, e.g. `'<lambda> <map>'`.


## Importance

Mapped lambdas are something new users will likely play with, e.g. if they follow this page: https://docs.prefect.io/core/concepts/mapping.html
```python
numbers = [1, 2, 3]
map_fn = task(lambda x: x + 1)
reduce_fn = task(lambda x: sum(x))

with Flow('Map Reduce') as flow:
    mapped_result = map_fn.map(numbers)
    reduced_result = reduce_fn(mapped_result)
```

...in this case, without the fix in this PR, calling `flow.visualize()` (which a new user may reasonably be expected to do) will fail.


## Checklist

This PR:

- [X] adds new tests (if appropriate)
- [X] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)

Note: I assume this small fix does not require a change file or updated docstrings. Please let me know if that is not the case.