### PR TITLE
Add pipe support for EdgeAnnotation.

### DIFF
--- a/changes/pr5674.yml
+++ b/changes/pr5674.yml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add pipe support for EdgeAnnotation - [#5674](https://github.com/PrefectHQ/prefect/pull/5674)"
+
+contributor:
+  - "[Karthikeyan Singaravelan](https://github.com/tirkarthi)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -30,6 +30,7 @@ import prefect.triggers
 from prefect.utilities import logging
 from prefect.utilities.notifications import callback_factory
 from prefect.utilities.edges import EdgeAnnotation
+from prefect.utilities.tasks import as_task
 
 if TYPE_CHECKING:
     from prefect.core.flow import Flow
@@ -950,7 +951,11 @@ class Task(metaclass=TaskMetaclass):
         """
         if "self" in kwargs:
             raise ValueError('You cannot use the keyword argument "self" in .pipe.')
-        return _prefect_task(_prefect_self, **kwargs)
+
+        if inspect.isclass(_prefect_task) and issubclass(_prefect_task, EdgeAnnotation):
+            return as_task(_prefect_task(_prefect_self, **kwargs))
+        else:
+            return _prefect_task(_prefect_self, **kwargs)
 
     # Serialization ------------------------------------------------------------
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -8,6 +8,7 @@ import warnings
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
+    cast,
     Any,
     Callable,
     Dict,
@@ -936,7 +937,9 @@ class Task(metaclass=TaskMetaclass):
             return_annotation = Any
         return return_annotation
 
-    def pipe(_prefect_self, _prefect_task: "Task", **kwargs: Any) -> "Task":
+    def pipe(
+        _prefect_self, _prefect_task: Union[Type[EdgeAnnotation], "Task"], **kwargs: Any
+    ) -> "Task":
         """
         "Pipes" the result of this task through another task. ``some_task().pipe(other_task)`` is
         equivalent to ``other_task(some_task())``, but can result in more readable code when used in a
@@ -955,7 +958,9 @@ class Task(metaclass=TaskMetaclass):
         if inspect.isclass(_prefect_task) and issubclass(_prefect_task, EdgeAnnotation):
             return as_task(_prefect_task(_prefect_self, **kwargs))
         else:
-            return _prefect_task(_prefect_self, **kwargs)
+            # cast as Task to pass mypy since Union is used in signature and mypy doesn't
+            # infer this block to always return Task.
+            return cast("Task", _prefect_task(_prefect_self, **kwargs))
 
     # Serialization ------------------------------------------------------------
 

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -8,7 +8,6 @@ import warnings
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
-    cast,
     Any,
     Callable,
     Dict,
@@ -955,12 +954,11 @@ class Task(metaclass=TaskMetaclass):
         if "self" in kwargs:
             raise ValueError('You cannot use the keyword argument "self" in .pipe.')
 
-        if inspect.isclass(_prefect_task) and issubclass(_prefect_task, EdgeAnnotation):
-            return as_task(_prefect_task(_prefect_self, **kwargs))
+        if inspect.isclass(_prefect_task) and issubclass(_prefect_task, EdgeAnnotation):  # type: ignore
+            return as_task(_prefect_task(_prefect_self))
         else:
-            # cast as Task to pass mypy since Union is used in signature and mypy doesn't
-            # infer this block to always return Task.
-            return cast("Task", _prefect_task(_prefect_self, **kwargs))
+            # mypy<0.900 doesn't infer type as Task due to Union type
+            return _prefect_task(_prefect_self, **kwargs)  # type: ignore
 
     # Serialization ------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Add pipe support for EdgeAnnotation.

## Changes

Handle `EdgeAnnotation` in `pipe` to return `Task` instead of `EdgeAnnotation` for subsequent chaining.

## Importance

Fixes #5665

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)