### PR TITLE
no_args_is_help as default

### DIFF
--- a/src/prefect/cli/base.py
+++ b/src/prefect/cli/base.py
@@ -73,6 +73,17 @@ class PrefectTyper(typer.Typer):
     Wraps commands created by `Typer` to support async functions and handle errors.
     """
 
+    def add_typer(
+        self,
+        typer_instance: "PrefectTyper",
+        *args,
+        no_args_is_help: bool = True,
+        **kwargs,
+    ) -> None:
+        return super().add_typer(
+            typer_instance, *args, no_args_is_help=no_args_is_help, **kwargs
+        )
+
     def command(self, *args, **kwargs):
         command_decorator = super().command(*args, **kwargs)
 

--- a/src/prefect/cli/base.py
+++ b/src/prefect/cli/base.py
@@ -80,6 +80,9 @@ class PrefectTyper(typer.Typer):
         no_args_is_help: bool = True,
         **kwargs,
     ) -> None:
+        """
+        This will cause help to be default command for all sub apps unless specifically stated otherwise, opposite of before.
+        """
         return super().add_typer(
             typer_instance, *args, no_args_is_help=no_args_is_help, **kwargs
         )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
I added no_args_is_help as default to cli wrapper



## Changes
<!-- What does this PR change? -->
It forces me from having to type `prefect x y z --help` 80 times a day :man_dancing: 



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)