### PR TITLE
add policy_id to NewCluster; autoscale is optional

### DIFF
--- a/changes/pr0000.yaml
+++ b/changes/pr0000.yaml
@@ -1,5 +1,5 @@
 fix:
-  - "Added correct Databricks API params (autoscale, policy_id) - [Databricks API](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsCreate)"
+  - "Corrected Databricks new cluster API params: autoscale and policy_id - [#5681](https://github.com/PrefectHQ/prefect/pull/5681)"
 
 contributor:
   - "[Mahmoud Lababidi](https://github.com/lababidi)"

--- a/changes/pr0000.yaml
+++ b/changes/pr0000.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Added correct Databricks API params (autoscale, policy_id) - [Databricks API](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsCreate)"
+
+contributor:
+  - "[Mahmoud Lababidi](https://github.com/lababidi)"

--- a/src/prefect/tasks/databricks/models.py
+++ b/src/prefect/tasks/databricks/models.py
@@ -67,10 +67,10 @@ class InitScriptInfo(BaseModel):
 
 
 class NewCluster(BaseModel):
-    autoscale: AutoScale
     spark_version: str
     node_type_id: str
     spark_conf: Dict = Field(default_factory=dict)
+    autoscale: Optional[AutoScale] = None
     num_workers: Optional[int] = None
     aws_attributes: Optional[AwsAttributes] = None
     driver_node_type_id: Optional[str] = None

--- a/src/prefect/tasks/databricks/models.py
+++ b/src/prefect/tasks/databricks/models.py
@@ -82,6 +82,7 @@ class NewCluster(BaseModel):
     enable_elastic_disk: Optional[bool] = None
     driver_instance_pool_id: Optional[str] = None
     instance_pool_id: Optional[str] = None
+    policy_id: Optional[str] = None
 
 
 class NotebookTask(BaseModel):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Added an additional missing Parameter from the Databricks API for `policy_id`

Adjusted the `autoscale` parameter to accept none/optional since it's an optional value in Databricks API

[https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsCreate](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsCreate)
## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->
adding a policy id is critical to Databricks tasks and making autoscale not required is the right thing to do





## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)