### PR TITLE
Docs: Simplify pytest example

### DIFF
--- a/docs/tutorials/testing.md
+++ b/docs/tutorials/testing.md
@@ -45,6 +45,6 @@ def prefect_test_fixture():
     with prefect_test_harness():
         yield
 
-def test_my_favorite_function(prefect_test_fixture):
+def test_my_favorite_function():
     assert my_favorite_function().result() == 42
 ```


### PR DESCRIPTION
## Summary
Autouse fixtures don't need to be imported

## Changes
Slight simplification of the pytest example in the testing section

## Importance
Not terribly important, but may give best practices for folks who don't know `pytest` too well

## Checklist
This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)