### PR TITLE
Adding fs handling for gs scheme

### DIFF
--- a/changes/pr5705.yml
+++ b/changes/pr5705.yml
@@ -1,0 +1,2 @@
+feature:
+  - "Add 'gs' as acceptable schema filesystem - [#5705](https://github.com/PrefectHQ/prefect/pull/5705)"

--- a/src/prefect/utilities/filesystems.py
+++ b/src/prefect/utilities/filesystems.py
@@ -65,7 +65,7 @@ def read_bytes_from_path(path: str) -> bytes:
         import requests
 
         return requests.get(path).content
-    elif parsed.scheme in ["gcs","gs"]:
+    elif parsed.scheme in ["gcs", "gs"]:
         from prefect.utilities.gcp import get_storage_client
 
         client = get_storage_client()

--- a/src/prefect/utilities/filesystems.py
+++ b/src/prefect/utilities/filesystems.py
@@ -65,7 +65,7 @@ def read_bytes_from_path(path: str) -> bytes:
         import requests
 
         return requests.get(path).content
-    elif parsed.scheme == "gcs":
+    elif parsed.scheme in ["gcs","gs"]:
         from prefect.utilities.gcp import get_storage_client
 
         client = get_storage_client()

--- a/tests/utilities/test_filesystems.py
+++ b/tests/utilities/test_filesystems.py
@@ -69,13 +69,14 @@ class Test_read_bytes_from_path:
         assert requests_get.call_args[0] == (url,)
         assert res == b"testing"
 
-    def test_read_gcs(self, monkeypatch):
+    @pytest.mark.parametrize("scheme", ["gcs", "gs"])
+    def test_read_gcs(self, monkeypatch, scheme):
         pytest.importorskip("prefect.utilities.gcp")
         client = MagicMock()
         monkeypatch.setattr(
             "prefect.utilities.gcp.get_storage_client", MagicMock(return_value=client)
         )
-        res = read_bytes_from_path("gcs://mybucket/path/to/thing.yaml")
+        res = read_bytes_from_path(f"{scheme}://mybucket/path/to/thing.yaml")
         assert client.bucket.call_args[0] == ("mybucket",)
         bucket = client.bucket.return_value
         assert bucket.get_blob.call_args[0] == ("path/to/thing.yaml",)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary

Currently, doing something like:
```
prefect kubernetes agent start --job-template gs://blah/template.yml
```
as seen [here](https://docs.prefect.io/orchestration/agents/kubernetes.html#custom-job-template) will result in:
```
Unsupported file scheme gs://blah/template.yml
```

This is because our `if` condition looks for `gcs` as the scheme instead of `gs`. However, the convention is actually `gs`.

## Changes

It adds support for both `gs` and `gcs` and adds a corresponding test.


## Importance

There is no intuitive error if somebody uses the `gs` convention for Google Cloud Storage paths as opposed to `gcs`.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)