### PR TITLE
Fix DbtCloudRunJob task failing with nested input for additional_args

### DIFF
--- a/changes/issue5076.yaml
+++ b/changes/issue5076.yaml
@@ -1,0 +1,5 @@
+fix:
+  - fix DbtCloudRunJob task failing with nested input for additional_args [#5706](https://github.com/PrefectHQ/prefect/issues/5706)"
+
+contributor:
+  - "[Dominick Olivito](https://github.com/olivito)"

--- a/src/prefect/tasks/dbt/dbt_cloud_utils.py
+++ b/src/prefect/tasks/dbt/dbt_cloud_utils.py
@@ -104,7 +104,7 @@ def trigger_job_run(
             accountId=account_id, jobId=job_id, apiDomain=domain
         ),
         headers={"Authorization": f"Bearer {token}", **USER_AGENT_HEADER},
-        data=data,
+        json=data,
     )
 
     if trigger_request.status_code != 200:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This fixes an issue where calling DbtCloudRunJob with nested inputs for the optional parameter `additional_args`, the DBT API returns a 400 response "Bad Request".

See [#5706](https://github.com/PrefectHQ/prefect/issues/5706) for more details.

## Changes
<!-- What does this PR change? -->
This fixes the way that `additional_args` are passed to the [DBT Trigger Job Run API](https://docs.getdbt.com/dbt-cloud/api-v2#operation/triggerRun), using `json=` instead of `data=` to correct pass nested parameters.

## Importance
<!-- Why is this PR important? -->

This fix allows for calling the DbtCloudRunJob task with the `steps_override` nested argument (Array of string type) in `additional_args`.  

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate) -> I could not think of any particular unit/mock tests for this fix, but I'm open to suggestions.
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate) -> not applicable