### PR TITLE
Fix collision with existing storage during deployment creation

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -65,6 +65,7 @@ from prefect.client import OrionClient, inject_client
 from prefect.exceptions import (
     MissingDeploymentError,
     MissingFlowError,
+    ObjectAlreadyExists,
     SpecValidationError,
     UnspecifiedDeploymentError,
     UnspecifiedFlowError,
@@ -277,11 +278,17 @@ class DeploymentSpec(PrefectBaseModel):
                 self.flow_storage._block_spec_version,
             )
 
-            self.flow_storage._block_id = await client.create_block(
-                self.flow_storage,
-                block_spec_id=block_spec.id,
-                name=f"{self.flow_name}-{self.name}",
-            )
+            block_name = f"{self.flow_name}-{self.name}-{self.flow.version}"
+            i = 0
+            while not self.flow_storage._block_id:
+                try:
+                    self.flow_storage._block_id = await client.create_block(
+                        self.flow_storage,
+                        block_spec_id=block_spec.id,
+                        name=f"{block_name}-{i}",
+                    )
+                except ObjectAlreadyExists:
+                    i += 1
 
         # Write the flow to storage
         storage_token = await self.flow_storage.write(flow_bytes)


### PR DESCRIPTION
When a storage block was attached directly to a deployment specification, deployment creation would register the block with the flow and deployment name. Since block names must be unique on the server, this means that deployment specifications with a storage block can only be created once. Subsequent attempts would fail with an `ObjectAlreadyExists` error. This resolves the issue by including the flow version to reduce the chance of collision and appending a numeric suffix until a collision no longer occurs.
