### PR TITLE
Fix error when = is present in parameter value

### DIFF
--- a/changes/pr5716.yaml
+++ b/changes/pr5716.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Fixes bug parsing a parameter that includes an equals ("=") sign [#5716](https://github.com/PrefectHQ/prefect/pull/5716)'
+
+contributor:
+  - '[oscarwyatt](https://github.com/oscarwyatt)'

--- a/src/prefect/cli/run.py
+++ b/src/prefect/cli/run.py
@@ -275,7 +275,7 @@ def load_json_key_values(
 
     for spec in cli_input:
         try:
-            key, value = spec.split("=")
+            key, _, value = spec.partition("=")
         except ValueError:
             raise TerminalError(
                 f"Invalid {display_name} option {spec!r}. Expected format 'key=value'."

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -226,6 +226,8 @@ def cloud_mocks(monkeypatch):
         ('"foo"', "foo"),
         ("0foo", "0foo"),  # auto-quote when starting with a number
         ('{"key": "value"}', {"key": "value"}),
+        ('{"key": "=value"}', {"key": "=value"}),
+        ('{"key": "foo=foo"}', {"key": "foo=foo"}),
     ],
 )
 def test_load_json_key_values(input, output):


### PR DESCRIPTION
## Summary
Fix error that arises when a (legitimate) equals sign is in a parameter value

## Changes
How keys and values are parsed in a CLI parameter

## Importance
In our use-case, we use [SMILES](https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system) strings 
to represent molecules. In this specification, an equals sign can represent a certain kind of bond. 
As is, passing a value with an equals sign causes an error

```
Invalid parameter option 'r-group-pattern='C=C'. Expected format 'key=value'.
```

This represents a huge problem for us and there is no easy obvious workaround.
This fixes that by only splitting on the first instance of an equals sign, where the parameter key and value are split.
I've checked that this works as expected included a test 

## Checklist


This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)