### PR TITLE
Add handling for null states to `get_task_run_info`

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -6,16 +6,7 @@ import time
 import uuid
 import warnings
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, NamedTuple, Optional, Union
 from urllib.parse import urljoin, urlparse
 
 # if simplejson is installed, `requests` defaults to using it instead of json
@@ -30,11 +21,12 @@ import toml
 from slugify import slugify
 
 import prefect
+from prefect.engine.state import Pending
 from prefect.exceptions import (
     AuthorizationError,
     ClientError,
-    VersionLockMismatchSignal,
     ObjectNotFoundError,
+    VersionLockMismatchSignal,
 )
 from prefect.run_configs import RunConfig
 from prefect.utilities.graphql import (
@@ -1483,7 +1475,12 @@ class Client:
 
         task_run_info = result.data.get_or_create_task_run_info
 
-        state = prefect.engine.state.State.deserialize(task_run_info.serialized_state)
+        state = (
+            prefect.engine.state.State.deserialize(task_run_info.serialized_state)
+            if task_run_info.serialized_state
+            else Pending()
+        )
+
         return TaskRunInfoResult(
             id=task_run_info.id,
             task_id=task_id,

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1248,7 +1248,7 @@ class Client:
         state = (
             prefect.engine.state.State.deserialize(result.serialized_state)
             if result.serialized_state
-            else prefect.engine.state.Pending
+            else prefect.engine.state.Pending()
         )
 
         return FlowRunInfoResult(
@@ -1486,7 +1486,7 @@ class Client:
         state = (
             prefect.engine.state.State.deserialize(task_run_info.serialized_state)
             if task_run_info.serialized_state
-            else prefect.engine.state.Pending
+            else prefect.engine.state.Pending()
         )
 
         return TaskRunInfoResult(

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -1240,7 +1240,7 @@ class Client:
                 task_slug=tr.task.slug,
                 state=State.deserialize(tr.serialized_state)
                 if tr.serialized_state
-                else prefect.engine.state.Pending,
+                else prefect.engine.state.Pending(),
             )
             for tr in result.task_runs
         ]


### PR DESCRIPTION
Sometimes, the backend returns task run information before the
state has been populated in the database. This results in a null
state payload which throws an exception on deserialization.
Generally, it is safe to treat these null states as `Pending`.
