### PR TITLE
Fix defect in serialization of GE results in LocalResult

### DIFF
--- a/changes/pr5724.yaml
+++ b/changes/pr5724.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix defect in serialization of GE results in LocalResult - [#5724](https://github.com/PrefectHQ/prefect/pull/5724)"
+
+contributor:
+  - "[David McGuire](https://github.com/dmcguire81)"

--- a/src/prefect/tasks/great_expectations/checkpoints.py
+++ b/src/prefect/tasks/great_expectations/checkpoints.py
@@ -11,6 +11,7 @@ Prefect flow.
 from typing import Optional
 
 import great_expectations as ge
+from great_expectations.core import RunIdentifier
 from great_expectations.checkpoint import Checkpoint
 from packaging import version
 
@@ -266,7 +267,7 @@ class RunGreatExpectationsValidation(Task):
             ge_checkpoint = ge_checkpoint or context.get_checkpoint(checkpoint_name)
             results = ge_checkpoint.run(
                 evaluation_parameters=evaluation_parameters,
-                run_id={"run_name": run_name or prefect.context.get("task_slug")},
+                run_id=RunIdentifier(run_name or prefect.context.get("task_slug")),
                 **checkpoint_kwargs,
             )
         else:
@@ -281,7 +282,7 @@ class RunGreatExpectationsValidation(Task):
             results = context.run_validation_operator(
                 validation_operator,
                 assets_to_validate=assets_to_validate,
-                run_id={"run_name": run_name or prefect.context.get("task_slug")},
+                run_id=RunIdentifier(run_name or prefect.context.get("task_slug")),
                 evaluation_parameters=evaluation_parameters,
             )
 

--- a/tests/tasks/great_expectations/.gitignore
+++ b/tests/tasks/great_expectations/.gitignore
@@ -1,0 +1,2 @@
+v2_api/expectations/.ge_store_backend_id
+v3_api/expectations/.ge_store_backend_id

--- a/tests/tasks/great_expectations/test_great_expectations_validation.py
+++ b/tests/tasks/great_expectations/test_great_expectations_validation.py
@@ -225,6 +225,12 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is ValidationOperatorResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "validation_operator_config" in serializable_results
+        assert "evaluation_parameters" in serializable_results
+        assert "success" in serializable_results
 
     def test_suite_name_with_batch_kwargs(self):
         task = RunGreatExpectationsValidation(
@@ -238,6 +244,12 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is ValidationOperatorResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "validation_operator_config" in serializable_results
+        assert "evaluation_parameters" in serializable_results
+        assert "success" in serializable_results
 
     def test_v2_checkpoint_api(self):
         task = RunGreatExpectationsValidation(
@@ -246,6 +258,12 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is ValidationOperatorResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "validation_operator_config" in serializable_results
+        assert "evaluation_parameters" in serializable_results
+        assert "success" in serializable_results
 
     def test_v3_checkpoint_api_pass(self):
         task = RunGreatExpectationsValidation(
@@ -254,6 +272,11 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is CheckpointResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "checkpoint_config" in serializable_results
+        assert "success" in serializable_results
 
     def test_v3_checkpoint_api_fail(self):
         task = RunGreatExpectationsValidation(
@@ -270,6 +293,11 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is CheckpointResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "checkpoint_config" in serializable_results
+        assert "success" in serializable_results
 
     def test_v3_with_runtime_data_frame(
         self, in_memory_runtime_batch_request, in_memory_data_context
@@ -288,3 +316,8 @@ class TestInitialization:
         )
         results = task.run()
         assert type(results) is CheckpointResult
+        serializable_results = repr(results)
+        assert "run_id" in serializable_results
+        assert "run_results" in serializable_results
+        assert "checkpoint_config" in serializable_results
+        assert "success" in serializable_results


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Addresses defect documented in #5570.


## Changes
<!-- What does this PR change? -->

Replaces a `RunIdentifier` supplied as a `dict` with the actual class, which serializes correctly. Unfortunately, `great-expectations` does not make it easy on anyone trying to leverage their API, as many key classes serialize to *look* like instances of `dict`, e.g.:

```python
>>> from great_expectations.core import RunIdentifier
>>> run_identifier = RunIdentifier("foo")
>>> str(run_identifier)
'{\n  "run_time": "2022-04-27T23:09:25.216846+00:00",\n  "run_name": "foo"\n}'
```

## Importance
Serialization is currently broken for both `LocalResult` and `S3Result` (that I've tested). This means the following functionality *does not work*:
* Running `prefect[ge]` in the `LocalAgent`, since `LocalResult` is implied in that context, and there is no (obvious) way to override it
* Caching `prefect[ge]` results in the cloud with `S3Result` (and, likely, any other `Result` subclasses)

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] ~~updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~