### PR TITLE
use json() instead of dict()

### DIFF
--- a/changes/pr5727.yaml
+++ b/changes/pr5727.yaml
@@ -1,5 +1,0 @@
-fix:
-  - "use json instead of dict for DatabricksSubmitMultitaskRun - [#5727](https://github.com/PrefectHQ/prefect/pull/5727)"
-
-contributor:
-  - "[Robert Phamle](https://github.com/rphamle)"

--- a/changes/pr5727.yaml
+++ b/changes/pr5727.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "use json instead of dict for DatabricksSubmitMultitaskRun - [#5727](https://github.com/PrefectHQ/prefect/pull/5727)"
+
+contributor:
+  - "[Robert Phamle](https://github.com/rphamle)"

--- a/changes/pr5728.yaml
+++ b/changes/pr5728.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "use json instead of dict for DatabricksSubmitMultitaskRun - [#5728](https://github.com/PrefectHQ/prefect/pull/5728)"
+
+contributor:
+  - "[Robert Phamle](https://github.com/rphamle)"

--- a/src/prefect/tasks/databricks/databricks_submitjob.py
+++ b/src/prefect/tasks/databricks/databricks_submitjob.py
@@ -1071,7 +1071,7 @@ class DatabricksSubmitMultitaskRun(Task):
                 timeout_seconds=timeout_seconds,
                 idempotency_token=idempotency_token,
                 access_control_list=[
-                    entry.dict() for entry in access_control_list or []
+                    entry.json() for entry in access_control_list or []
                 ],
             )
         )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Use `BaseModel.json()` instead of `BaseModel.dict()` in order to appropriately convert `List[AccessControlRequest]` to JSON.

## Changes
<!-- What does this PR change? -->
The `AccessControlRequest` model uses a `__root__` attribute, which does not lend itself well to using `BaseModel.dict()` when converting to JSON. We need to use `BaseModel.json()`.

Example with `dict()`:
```
{'__root__': {'user_name': 'test@email.com',
  'permission_level': <CanManage.CAN_MANAGE: 'CAN_MANAGE'>}}
```

Example with `json()`: 
```
'{"user_name": "test@email.com", "permission_level": "CAN_MANAGE"}'
```




## Importance
<!-- Why is this PR important? -->
`access_control_list` is not passed correctly to Databricks for the `DatabricksSubmitMultitaskRun` API unless this is fixed.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)