### PR TITLE
feat: allow to the endpoint url to boto3

### DIFF
--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -74,7 +74,5 @@ To see the IDs of available storage configurations, use the `prefect storage ls`
 
 `prefect storage reset-default` resets the default storage option to temporary local storage.
 
-### S3 compatible storage
-When need there is the option to use a S3 compatible storage like minio or Scaleway.
-To get this working you would need to provide the endpoint url when creating the storage via the CLI.
-Usually the endpoint url looks something like this ```https://bucketname.s3.nl-ams.scw.cloud```.
+### S3 Endpoint URL
+When using an S3 compatible storage solution, like minio or Scaleway, or a VPC endpoint for S3, specify the endpoint URL when setting up storage via the CLI. An endpoint URL is not necessary when using AWS S3 directly.

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -52,7 +52,7 @@ Found the following storage types:
 3) Local Storage
     Store data in a run's local file system
 4) S3 Storage
-    Store data in an AWS S3 bucket
+    Store data in S3 compatible storage
 5) Temporary Local Storage
     Store data in a temporary directory in a run's local file system
 Select a storage type to create:
@@ -73,3 +73,8 @@ Updated default storage!
 To see the IDs of available storage configurations, use the `prefect storage ls` command.
 
 `prefect storage reset-default` resets the default storage option to temporary local storage.
+
+### S3 compatible storage
+When need there is the option to use a S3 compatible storage like minio or Scaleway.
+To get this working you would need to provide the endpoint url when creating the storage via the CLI.
+Usually the endpoint url looks something like this ```https://bucketname.s3.nl-ams.scw.cloud```.

--- a/src/prefect/blocks/storage.py
+++ b/src/prefect/blocks/storage.py
@@ -156,6 +156,7 @@ class S3StorageBlock(StorageBlock):
     aws_session_token: Optional[str] = None
     profile_name: Optional[str] = None
     region_name: Optional[str] = None
+    endpoint_url: Optional[str] = None
 
     def block_initialization(self):
         import boto3
@@ -177,12 +178,12 @@ class S3StorageBlock(StorageBlock):
         return await run_sync_in_worker_thread(self._read_sync, key)
 
     def _write_sync(self, key: str, data: bytes) -> None:
-        s3_client = self.aws_session.client("s3")
+        s3_client = self.aws_session.client("s3", endpoint_url=self.endpoint_url)
         with io.BytesIO(data) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=self.bucket, Key=key)
 
     def _read_sync(self, key: str) -> bytes:
-        s3_client = self.aws_session.client("s3")
+        s3_client = self.aws_session.client("s3", endpoint_url=self.endpoint_url)
         with io.BytesIO() as stream:
             s3_client.download_fileobj(Bucket=self.bucket, Key=key, Fileobj=stream)
             stream.seek(0)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This allow to use S3 compatible storage like minio or Scaleway.


## Changes
We added the optional parameter endpoint_url for creating S3 storage.


## Importance
This allows any S3 compatible object storage to be used (not just AWS).

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [X] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)