### PR TITLE
Add inference of Docker network mode for 'host' and 'none' networks

### DIFF
--- a/changes/pr5748.yaml
+++ b/changes/pr5748.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - 'Add inference of Docker network mode for "host" and "none" networks - [#5748](https://github.com/PrefectHQ/prefect/pull/5748)'

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -449,7 +449,7 @@ class DockerAgent(Agent):
 
             # Ensure that we change the network mode from bridge to host/none if using
             # the special predefined network names
-            if network == "host" or network == "none":
+            if network in ("host", "none"):
                 host_config.setdefault("network_mode", network)
 
         labels = {

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -442,9 +442,16 @@ class DockerAgent(Agent):
         # is connected to the default `bridge` network.
         # The rest of the networks are connected after creation.
         if self.networks:
+            network = self.networks[0]
             networking_config = self.docker_client.create_networking_config(
-                {self.networks[0]: self.docker_client.create_endpoint_config()}
+                {network: self.docker_client.create_endpoint_config()}
             )
+
+            # Ensure that we change the network mode from bridge to host/none if using
+            # the special predefined network names
+            if network == "host" or network == "none":
+                host_config.setdefault("network_mode", network)
+
         labels = {
             "io.prefect.flow-name": flow_run.flow.name,
             "io.prefect.flow-id": flow_run.flow.id,

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -15,6 +15,7 @@ from prefect.utilities.importtools import import_object
 if TYPE_CHECKING:
     import dask
     from distributed import Future, Event
+    from dask.delayed import Delayed
     import concurrent.futures
 
 
@@ -626,7 +627,7 @@ class LocalDaskExecutor(Executor):
 
     def submit(
         self, fn: Callable, *args: Any, extra_context: dict = None, **kwargs: Any
-    ) -> "dask.delayed":
+    ) -> "Delayed":
         """
         Submit a function to the executor for execution. Returns a `dask.delayed` object.
 
@@ -648,7 +649,7 @@ class LocalDaskExecutor(Executor):
         key = _make_task_key(**(extra_context or {}))
         if key is not None:
             extra_kwargs["dask_key_name"] = key
-        return dask.delayed(fn, pure=False)(*args, **kwargs, **extra_kwargs)
+        return dask.delayed(fn, pure=False)(*args, **kwargs, **extra_kwargs)  # type: ignore
 
     def wait(self, futures: Any) -> Any:
         """

--- a/src/prefect/executors/dask.py
+++ b/src/prefect/executors/dask.py
@@ -13,7 +13,6 @@ from prefect.executors.base import Executor
 from prefect.utilities.importtools import import_object
 
 if TYPE_CHECKING:
-    import dask
     from distributed import Future, Event
     from dask.delayed import Delayed
     import concurrent.futures


### PR DESCRIPTION
This brings our behavior in-line with the Docker CLI which will
change the network mode on created containers to 'host' or 'none'
respectively if the special network names 'host' or 'none' are used.

These networks appear to be immutably defined by Docker.

'host' networking is still not expected to work on non-Linux systems,
see the Docker documentation for more information.

Closes https://github.com/PrefectHQ/prefect/issues/4840
Closes https://github.com/PrefectHQ/prefect/issues/2638
