### PR TITLE
Change Directory into Prefect to Streamline Copy Paste

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -18,6 +18,7 @@ First, you'll need to download the source code and install an editable version o
 ```bash
 # Clone the repository and switch to the 'orion' branch
 git clone https://github.com/PrefectHQ/prefect.git
+cd prefect
 git checkout orion
 # Install the package with development dependencies
 pip install -e ".[dev]"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Change directory into prefect repository to allow copy paste install for contributing.

Previously, developers were unable to copy all commands and run, due to missing change directory.

## Changes
<!-- What does this PR change? -->
Contribution documentation



## Importance
<!-- Why is this PR important? -->
When reading the wiki, developers will likely copy paste all commands to have a simplified paste and install process. Currently, this does not work as the install checkout and subsequent commands are not in the prefect repo




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ x] adds new tests (if appropriate)
- [x ] adds a change file in the `changes/` directory (if appropriate)
- [ x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)