### PR TITLE
Add No Ui Flag to Kubernetes Dev

### DIFF
--- a/src/prefect/cli/templates/kubernetes-dev.yaml
+++ b/src/prefect/cli/templates/kubernetes-dev.yaml
@@ -20,7 +20,7 @@ spec:
             - -c
             - >-
               pip install -e /opt/prefect/repo\[dev\] &&
-              prefect dev start
+              prefect dev start --no-ui
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 4200


### PR DESCRIPTION


<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
When creating a kubernetes manifest, the previous template did not include the no-ui option. This resulted
in the container crashing on load, as it does not have npm, which gets run as part of the UI standup process.

To overcome this, we launch orion without the UI in kube dev



## Changes
<!-- What does this PR change? -->
Fixes kubernetes dev manifest to not launch UI



## Importance
<!-- Why is this PR important? -->
Containers will fail on start
https://github.com/PrefectHQ/prefect/issues/5751


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ x] adds new tests (if appropriate)
- [x ] adds a change file in the `changes/` directory (if appropriate)
- [x ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)