### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,6 +563,7 @@ workflows:
       - test_37
       - test_38
       - test_39
+      - test_310
       - test_lower_prefect
       - test_vanilla_prefect
       - test_task_library

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           command: pytest tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
 
   # ----------------------------------
-  # Run unit tests in Python 3.7-3.9
+  # Run unit tests in Python 3.7-3.10
   # ----------------------------------
 
   test_37:
@@ -258,7 +258,7 @@ jobs:
 
   test_39:
     docker:
-      - image: python:3.9.0
+      - image: python:3.9
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PW
@@ -280,6 +280,38 @@ jobs:
       - run:
           name: Install Prefect
           # All extras cannot be tested because they do not support 3.9 yet, until then
+          # we will just guarantee that we pass the core test suite
+          # See https://github.com/PrefectHQ/prefect/pull/3441#issuecomment-708419324
+          command: pip install ".[test]"
+
+      - run:
+          name: Run tests
+          command: pytest tests --ignore=tests/tasks -vvrfEsx --numprocesses 4 --dist=loadfile
+
+  test_310:
+    docker:
+      - image: python:3.10
+        auth:
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PW
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install zsh for tests
+          command: apt-get update && apt-get install -y zsh
+
+      - run:
+          name: Install graphviz
+          command: apt-get update && apt-get install -y graphviz
+
+      - run:
+          name: Upgrade pip
+          command: pip install "pip==20.2.4"
+
+      - run:
+          name: Install Prefect
+          # All extras cannot be tested because they do not support 3.10 yet, until then
           # we will just guarantee that we pass the core test suite
           # See https://github.com/PrefectHQ/prefect/pull/3441#issuecomment-708419324
           command: pip install ".[test]"
@@ -407,7 +439,7 @@ jobs:
           command: |
             docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
             docker push prefecthq/prefect:master
-            
+
   build_core_docker_image:
     docker:
       - image: docker
@@ -463,7 +495,7 @@ jobs:
                 command: |
                   docker login --username  $DOCKER_HUB_USER --password $DOCKER_HUB_PW
                   docker push prefecthq/prefect:core
-                  
+
   promote_server_artifacts:
     docker:
       - image: docker
@@ -576,6 +608,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+      - build_docker_image:
+          python_version: '3.10'
+          extras: 'all_orchestration_extras'
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - release_to_pypi:
           filters:
             branches:
@@ -584,6 +624,14 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - build_core_docker_image:
           python_version: '3.9'
+          tag_latest: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+      - build_core_docker_image:
+          python_version: '3.10'
           tag_latest: true
           filters:
             branches:
@@ -623,6 +671,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^1.0rc[0-9]$/
+      - build_docker_image:
+          python_version: '3.10'
+          extras: 'all_orchestration_extras'
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^1.0rc[0-9]$/
       - release_to_pypi:
           filters:
             branches:
@@ -631,6 +687,13 @@ workflows:
               only: /^1.0rc[0-9]$/
       - build_core_docker_image:
           python_version: '3.9'
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^1.0rc[0-9]$/
+      - build_core_docker_image:
+          python_version: '3.10'
           filters:
             branches:
               ignore: /.*/

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
       fail-fast: false
 
     steps:

--- a/changes/pr5770.yaml
+++ b/changes/pr5770.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add Python 3.10 support - [#5770](https://github.com/PrefectHQ/prefect/pull/5770)"
+
+contributor:
+  - "[Nico Neumann](https://github.com/neumann-nico)"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 black
 graphviz >= 0.8
 jinja2 >= 2.0, < 4.0
-mypy >= 0.600, < 0.813
 Pygments >= 2.2, < 3.0

--- a/docs/core/development/tests.md
+++ b/docs/core/development/tests.md
@@ -76,7 +76,7 @@ The `--sw` flag will exit `pytest` the first time it encounters an error; subseq
 
 CI will run automatically against any PR you open. Please run your tests locally first to avoid "debugging in CI", as this takes up resources that could be used by other contributors.
 
-In CI, Prefect's unit tests are run against Python 3.7, 3.8, and 3.9. A separate "formatting" CI job is also run. Since formatting errors are common in PRs, we have found this to be a useful early-warning during development.
+In CI, Prefect's unit tests are run against Python 3.7, 3.8, 3.9 and 3.10. A separate "formatting" CI job is also run. Since formatting errors are common in PRs, we have found this to be a useful early-warning during development.
 
 ## Documentation
 

--- a/docs/orchestration/flow_config/docker.md
+++ b/docs/orchestration/flow_config/docker.md
@@ -58,19 +58,21 @@ Every release of Prefect comes with a few built-in images. These images are all
 named [prefecthq/prefect](https://hub.docker.com/r/prefecthq/prefect), but have
 a few different tag options:
 
-| Tag              |     Prefect Version      | Python Version |
-| ---------------- | :----------------------: | -------------: |
-| latest           | most recent PyPi version |            3.7 |
-| master           |       master build       |            3.7 |
-| latest-python3.9 | most recent PyPi version |            3.9 |
-| latest-python3.8 | most recent PyPi version |            3.8 |
-| latest-python3.7 | most recent PyPi version |            3.7 |
-| X.Y.Z            |          X.Y.Z           |            3.7 |
-| X.Y.Z-python3.9  |          X.Y.Z           |            3.9 |
-| X.Y.Z-python3.8  |          X.Y.Z           |            3.8 |
-| X.Y.Z-python3.7  |          X.Y.Z           |            3.7 |
-| core             | most recent PyPi version |            3.8 |
-| core-X.Y.Z       |          X.Y.Z           |            3.8 |
+| Tag               |     Prefect Version      | Python Version  |
+| ----------------  | :----------------------: | -------------:  |
+| latest            | most recent PyPi version |            3.7  |
+| master            |       master build       |            3.7  |
+| latest-python3.10 | most recent PyPi version |            3.10 |
+| latest-python3.9  | most recent PyPi version |            3.9  |
+| latest-python3.8  | most recent PyPi version |            3.8  |
+| latest-python3.7  | most recent PyPi version |            3.7  |
+| X.Y.Z             |          X.Y.Z           |            3.7  |
+| X.Y.Z-python3.10  |          X.Y.Z           |            3.10 |
+| X.Y.Z-python3.9   |          X.Y.Z           |            3.9  |
+| X.Y.Z-python3.8   |          X.Y.Z           |            3.8  |
+| X.Y.Z-python3.7   |          X.Y.Z           |            3.7  |
+| core              | most recent PyPi version |            3.8  |
+| core-X.Y.Z        |          X.Y.Z           |            3.8  |
 
 The images can be broken into a few categories:
 

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Monitoring",
     ],


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR adds support for Python 3.10

I had a look at those Python 3.9 PRs:
https://github.com/PrefectHQ/prefect/pull/3441
https://github.com/PrefectHQ/prefect/pull/4896

## Changes
<!-- What does this PR change? -->
Changes setup.py and CI to inlcude Python 3.10



## Importance
<!-- Why is this PR important? -->
Python 3.10 is the latest stable version of Python so it would be great to include it :)



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)