### PR TITLE
chore: Included githubactions in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     timezone: America/New_York
   open-pull-requests-limit: 10
   rebase-strategy: disabled
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule: 
+   interval: weekly
+  open-pull-requests-limit: 10
+  rebase-strategy: disabled


### PR DESCRIPTION
This should help with keeping the GitHub actions updated on new releases. This will also help with keeping it secure.

Dependabot helps in keeping the supply chain secure https://docs.github.com/en/code-security/dependabot

GitHub actions up to date https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool
Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
