### PR TITLE
add data_security_mode

### DIFF
--- a/changes/pr5778.yaml
+++ b/changes/pr5778.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "add data_security_mode - [#5778](https://github.com/PrefectHQ/prefect/pull/5778)"
+
+contributor:
+  - "[Robert Phamle](https://github.com/rphamle)"

--- a/src/prefect/tasks/databricks/models.py
+++ b/src/prefect/tasks/databricks/models.py
@@ -83,6 +83,7 @@ class NewCluster(BaseModel):
     driver_instance_pool_id: Optional[str] = None
     instance_pool_id: Optional[str] = None
     policy_id: Optional[str] = None
+    data_security_mode: Optional[str] = None
 
 
 class NotebookTask(BaseModel):


### PR DESCRIPTION
## Summary
Adds an optional arg `data_security_mode` to Databricks cluster configuration.


## Changes
I am creating a Databricks cluster policy via Terraform and specifying a default `data_security_mode` in there ([docs](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/resources/cluster)), from which I get a `policy_id` arg that I am supplying to the Databricks API. However, I want the option to be able to override that from the Prefect/Databricks API. This PR will allow for that.


## Importance
Without this PR, I cannot override `data_security_mode` on a per-user basis.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)