### PR TITLE
Sort by key when upstream and downstream slug are same for deterministic order.

### DIFF
--- a/changes/pr5785.yaml
+++ b/changes/pr5785.yaml
@@ -1,0 +1,7 @@
+# An example changelog entry
+#
+fix:
+  - "Make flow build deterministic when upstream and downstream slug are same - [#5785](https://github.com/PrefectHQ/prefect/pull/5785)"
+
+contributor:
+  - "[Karthikeyan Singaravelan](https://github.com/tirkarthi)"

--- a/src/prefect/serialization/flow.py
+++ b/src/prefect/serialization/flow.py
@@ -63,7 +63,7 @@ def get_edges(obj: prefect.Flow, context: dict) -> List:
     return list(
         sorted(
             edges,
-            key=lambda e: (e.upstream_task.slug, e.downstream_task.slug),
+            key=lambda e: (e.upstream_task.slug, e.downstream_task.slug, e.key or ""),
         )
     )
 

--- a/tests/serialization/test_flows.py
+++ b/tests/serialization/test_flows.py
@@ -41,6 +41,19 @@ def test_serialize_flow_sorts_nested_schemas():
     assert [task["slug"] for task in serialized["reference_tasks"]] == ["c-1", "d-1"]
 
 
+def test_serialize_flow_sorts_by_key():
+    @prefect.task()
+    def task1(p1, p2, p3, p4):
+        return p1, p2
+
+    with Flow("flow1") as flow:
+        param1 = Parameter("param1")
+        t1 = task1(param1, param1, param1, param1)
+
+    serialized = flow.serialize()
+    assert [edge["key"] for edge in serialized["edges"]] == ["p1", "p2", "p3", "p4"]
+
+
 def test_deserialize_flow():
     serialized = FlowSchema().dump(Flow(name="n"))
     deserialized = FlowSchema().load(serialized)


### PR DESCRIPTION
## Summary

As the parameter is used repeatedly multiple times the upstream and downstream slug can be same. Add `key` which can be used as additional field for sorting to ensure deterministic order for serialized output and also during register.

## Changes

Add `edge.key` as additional parameter for sorting. Use empty string when `None` so that `TypeError` is not raised.

## Importance

Closes https://github.com/PrefectHQ/prefect/issues/5776


## Checklist

The below test command for 100 runs will fail on randomly without patch.

```
# https://pypi.org/project/pytest-repeat/
pytest --count=100 -s -x tests/serialization/test_flows.py -k test_serialize_flow_sorts_by_key
```

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)