### PR TITLE
Docs: deprecation notice for Slack webhook tutorial

### DIFF
--- a/docs/core/advanced_tutorials/slack-notifications.md
+++ b/docs/core/advanced_tutorials/slack-notifications.md
@@ -6,6 +6,20 @@ sidebarDepth: 1
 
 ![slack-banner](https://uploads-ssl.webflow.com/5ba446b0e783e26d5a2f2382/5bc4f20bd534b99be66f24aa_slack.png){.viz-md}
 
+::: warning Deprecation warning
+
+Note that this tutorial is outdated and will be removed in a future release.
+
+For Slack notifications, we recommend:
+
+- [Automations](/orchestration/ui/automations.html)
+- [SlackTask](/api/latest/tasks/notifications.html#slacktask)
+- [Notifications and State Handlers](/core/concepts/notifications.html)
+
+You'll find an excellent tutorial demonstrating [How to send Slack notifications using the SlackTask](https://discourse.prefect.io/t/how-to-send-slack-notifications-using-the-slacktask/497) in the [Prefect Community Discourse](https://discourse.prefect.io/).
+
+:::
+
 Prefect lets you easily setup callback hooks to get notified when certain state changes occur within your flows or for a given task.
 This can be as simple as:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Adds a deprecation notice for the [Slack Notifications tutorial](https://deploy-preview-5786--prefect-docs.netlify.app/core/advanced_tutorials/slack-notifications.html), which is out of date and also slightly dodgy with the "secret URL" business.

## Changes
Rather than removing the tutorial entirely, added a deprecation notice at the top of the page with links to more current solutions.

Deprecation notice gives us a chance to redirect users who may have bookmarked this page, be following from a third party link, or find via search. If there's a true issue with removing, this gives users a chance to create an issue or raise a concern.

## Importance
Better experience for users who want to use Slack notifications.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

~~- [ ] adds new tests (if appropriate)~~
~~- [ ] adds a change file in the `changes/` directory (if appropriate)~~
~~- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)~~