### PR TITLE
Validate positional-only arguments in task signature.

### DIFF
--- a/changes/pr5789.yaml
+++ b/changes/pr5789.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Raise error when positional-only parameters are present in function signature - [#5789](https://github.com/PrefectHQ/prefect/pull/5789)"
+
+contributor:
+  - "[Karthikeyan Singaravelan](https://github.com/tirkarthi)"

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -659,6 +659,18 @@ class Task(metaclass=TaskMetaclass):
             - Task: a new Task instance
         """
         new = self.copy(**(task_args or {}))
+
+        positional_args = [
+            name
+            for name, parameter in inspect.signature(new).parameters.items()
+            if parameter.kind == inspect.Parameter.POSITIONAL_ONLY
+        ]
+        if positional_args:
+            raise TypeError(
+                "Prefect passes arguments to task as keyword arguments. "
+                f"Positional-Only arguments found : {positional_args}"
+            )
+
         new.bind(
             *args, mapped=mapped, upstream_tasks=upstream_tasks, flow=flow, **kwargs
         )

--- a/src/prefect/core/task.py
+++ b/src/prefect/core/task.py
@@ -312,6 +312,7 @@ class Task(metaclass=TaskMetaclass):
     Raises:
         - TypeError: if `tags` is of type `str`
         - TypeError: if `timeout` is not of type `int`
+        - TypeError: if positional-only parameters are present in task's signature
     """
 
     def __init__(
@@ -348,6 +349,18 @@ class Task(metaclass=TaskMetaclass):
 
         self.name = name or type(self).__name__
         self.slug = slug
+
+        positional_args = [
+            name
+            for name, parameter in self.__signature__.parameters.items()
+            if parameter.kind == inspect.Parameter.POSITIONAL_ONLY
+        ]
+        if positional_args:
+            raise TypeError(
+                "Found positional-only parameters in the function signature for "
+                f"task {self.name}: {positional_args}. Prefect passes arguments "
+                "using keywords and does not support positional-only parameters."
+            )
 
         self.logger = logging.get_logger(self.name)
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1978,22 +1978,17 @@ class TestSerializedHash:
 
     @pytest.mark.skipif(
         sys.version_info < (3, 8),
-        reason="Positional-Only arguments are only supported in Python 3.8+",
+        reason="Positional-Only parameters are only supported in Python 3.8+",
     )
     def test_task_positional_only_arguments(self, tmpdir):
         contents = textwrap.dedent(
             """
-        from prefect import task, Flow
+        from prefect import task
 
         @task
         def dummy_task(a, b, /):
             pass
 
-        with Flow("example-flow") as flow:
-            dummy_task()
-
-        if __name__ == "__main__":
-            flow.run()
         """
         )
         script = tmpdir.join("flow.py")
@@ -2001,8 +1996,8 @@ class TestSerializedHash:
 
         result = subprocess.run([sys.executable, str(script)], capture_output=True)
         error_message = (
-            "TypeError: Prefect passes arguments to task as keyword arguments. "
-            "Positional-Only arguments found : ['a', 'b']"
+            "Found positional-only parameters in the function signature for task dummy_task: ['a', 'b']. "
+            "Prefect passes arguments using keywords and does not support positional-only parameters."
         )
 
         assert result.returncode == 1

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -4,6 +4,7 @@ import json
 import os
 import platform
 import random
+import re
 import sys
 import tempfile
 import time
@@ -1991,17 +1992,14 @@ class TestSerializedHash:
 
         """
         )
-        script = tmpdir.join("flow.py")
-        script.write_text(contents, encoding="utf-8")
 
-        result = subprocess.run([sys.executable, str(script)], capture_output=True)
         error_message = (
             "Found positional-only parameters in the function signature for task dummy_task: ['a', 'b']. "
             "Prefect passes arguments using keywords and does not support positional-only parameters."
         )
 
-        assert result.returncode == 1
-        assert error_message in result.stderr.decode()
+        with pytest.raises(TypeError, match=re.escape(error_message)):
+            exec(contents)
 
     def test_task_order_is_deterministic(self):
         def my_fake_task(foo):


### PR DESCRIPTION
## Summary

Validate positional-only arguments in task signature before bind to raise `TypeError` instead of exception during task run

## Changes

Provide better error message to positional only arguments

## Importance

Closes https://github.com/PrefectHQ/prefect/issues/5522 with better error message




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)