### PR TITLE
Update flows.md

### DIFF
--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -75,7 +75,7 @@ The final state of the flow is determined by its return value.  The following ru
 
 - If an exception is raised directly in the flow function, the flow run is marked as failed.
 - If the flow does not return a value (or returns `None`), its state is determined by the states of all of the tasks and subflows within it. In particular, if _any_ task run or subflow run failed, then the final flow run state is marked as failed.
-- If a flow returns one or more task run futures or states, these runs are used as the _reference tasks_ for determining the final state of the run. If _any_ of the returned task runs fail, the flow run is marked as failed.
+- If a flow returns one or more [task run futures](/api-ref/prefect/futures/#prefect.futures.PrefectFuture) or states, these runs are used as the _reference tasks_ for determining the final state of the run. If _any_ of the returned task runs fail, the flow run is marked as failed.
 - If a flow returns a manually created state, it is used as the state of the final flow run. This allows for manual determination of final state.
 - If the flow run returns _any other object_, then it is marked as successfully completed.
 


### PR DESCRIPTION
Added link to give context to PrefectFuture

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Task run futures are introduced without any context and later in the page referred to simply as futures which is confusing.
Added a link to api-ref/prefect/futures/#prefect.futures.PrefectFuture



## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)