### PR TITLE
Modified changes under Kubernetes CLI options docs

### DIFF
--- a/docs/api/0.14.22/cli/agent.md
+++ b/docs/api/0.14.22/cli/agent.md
@@ -155,13 +155,13 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  install  Generate a deployment.yml file for a Kubernetes Agent
+  install  Generate a deployment.yml file for a Kubernetes agent
   start    Start a Kubernetes agent
 ```
 
 ### kubernetes install
 ```
-Generate a deployment.yml file for a Kubernetes Agent
+Generate a deployment.yml file for a Kubernetes agent
 
 Options:
   -t, --token TEXT               A Prefect Cloud API token with RUNNER scope.

--- a/docs/api/0.14.22/cli/agent.md
+++ b/docs/api/0.14.22/cli/agent.md
@@ -155,13 +155,13 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  install  Generate a supervisord.conf file for a Local agent
+  install  Generate a deployment.yml file for a Kubernetes Agent
   start    Start a Kubernetes agent
 ```
 
 ### kubernetes install
 ```
-Generate a supervisord.conf file for a Local agent
+Generate a deployment.yml file for a Kubernetes Agent
 
 Options:
   -t, --token TEXT               A Prefect Cloud API token with RUNNER scope.

--- a/docs/api/0.15.13/cli/agent.md
+++ b/docs/api/0.15.13/cli/agent.md
@@ -153,13 +153,13 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  install  Generate a supervisord.conf file for a Local agent
+  install  Generate a deployment.yml file for a Kubernetes Agent
   start    Start a Kubernetes agent
 ```
 
 ### kubernetes install
 ```
-Generate a supervisord.conf file for a Local agent
+Generate a deployment.yml file for a Kubernetes Agent
 
 Options:
   -k, --key TEXT                 A Prefect Cloud API key

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -326,7 +326,7 @@ def start(image_pull_secrets=None, **kwargs):
 )
 @click.option("--backend", "-b", help="Prefect backend to use for this agent.")
 def install(label, env, **kwargs):
-    """Generate a deployment.yml file for a Kubernetes Agent"""
+    """Generate a deployment.yml file for a Kubernetes agent"""
     from prefect.agent.kubernetes import KubernetesAgent
 
     deployment = KubernetesAgent.generate_deployment_yaml(

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -326,7 +326,7 @@ def start(image_pull_secrets=None, **kwargs):
 )
 @click.option("--backend", "-b", help="Prefect backend to use for this agent.")
 def install(label, env, **kwargs):
-    """Generate a supervisord.conf file for a Local agent"""
+    """Generate a deployment.yml file for a Kubernetes Agent"""
     from prefect.agent.kubernetes import KubernetesAgent
 
     deployment = KubernetesAgent.generate_deployment_yaml(


### PR DESCRIPTION


https://docs.prefect.io/api/latest/cli/agent.html#kubernetes
https://docs.prefect.io/api/latest/cli/agent.html#kubernetes-install

In the above mentioned links the documentation fix was supposed to be 
To change 

`Generate a supervisord.conf file for a Local agent`  to `Generate a deployment.yml file for a Kubernetes Agent`



## Changes
This documentation fix will now show correct instructions under kubernetes cli install options

