### PR TITLE
Make artifacts optional in `StartFlowRun`

### DIFF
--- a/changes/pr5795.yaml
+++ b/changes/pr5795.yaml
@@ -1,2 +1,2 @@
-fix:
+enhancement:
   - "Make artifacts optional in StartFlowRun - [#5795](https://github.com/PrefectHQ/prefect/pull/5795)"

--- a/changes/pr5795.yaml
+++ b/changes/pr5795.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Make artifacts optional in StartFlowRun - [#5795](https://github.com/PrefectHQ/prefect/pull/5795)"

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -313,7 +313,7 @@ class StartFlowRun(Task):
             for; if not provided, defaults to now
         - poll_interval (timedelta): the time to wait between each check if the flow is finished.
                 Has to be >= 3 seconds. Used only if `wait=True`. Defaults to 10 seconds.
-        - create_artifact_link (bool, optional): whether to create a link artifact
+        - create_link_artifact (bool, optional): whether to create a link artifact
             to the child flow run page.  Defaults to `True`.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
@@ -329,7 +329,7 @@ class StartFlowRun(Task):
         run_name: str = None,
         scheduled_start_time: datetime.datetime = None,
         poll_interval: timedelta = timedelta(seconds=10),
-        create_artifact_link: bool = True,
+        create_link_artifact: bool = True,
         **kwargs: Any,
     ):
         self.flow_name = flow_name
@@ -358,6 +358,7 @@ class StartFlowRun(Task):
                 f"(poll_interval == {poll_interval.total_seconds()} seconds)!"
             )
         self.poll_interval = poll_interval
+        self.create_link_artifact = create_link_artifact
         if flow_name:
             kwargs.setdefault("name", f"Flow {flow_name}")
         super().__init__(**kwargs)
@@ -475,7 +476,7 @@ class StartFlowRun(Task):
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id)
-        if self.create_artifact_link:
+        if self.create_link_artifact:
             create_link_artifact(urlparse(run_link).path)
         self.logger.info(f"Flow Run: {run_link}")
 

--- a/src/prefect/tasks/prefect/flow_run.py
+++ b/src/prefect/tasks/prefect/flow_run.py
@@ -313,6 +313,8 @@ class StartFlowRun(Task):
             for; if not provided, defaults to now
         - poll_interval (timedelta): the time to wait between each check if the flow is finished.
                 Has to be >= 3 seconds. Used only if `wait=True`. Defaults to 10 seconds.
+        - create_artifact_link (bool, optional): whether to create a link artifact
+            to the child flow run page.  Defaults to `True`.
         - **kwargs (dict, optional): additional keyword arguments to pass to the Task constructor
     """
 
@@ -327,6 +329,7 @@ class StartFlowRun(Task):
         run_name: str = None,
         scheduled_start_time: datetime.datetime = None,
         poll_interval: timedelta = timedelta(seconds=10),
+        create_artifact_link: bool = True,
         **kwargs: Any,
     ):
         self.flow_name = flow_name
@@ -472,7 +475,8 @@ class StartFlowRun(Task):
 
         self.logger.debug(f"Creating link artifact for Flow Run {flow_run_id}.")
         run_link = client.get_cloud_url("flow-run", flow_run_id)
-        create_link_artifact(urlparse(run_link).path)
+        if self.create_artifact_link:
+            create_link_artifact(urlparse(run_link).path)
         self.logger.info(f"Flow Run: {run_link}")
 
         if not self.wait:


### PR DESCRIPTION
## Summary
Artifact creation is not always necessary and may cause issues when used with mapped tasks.


## Changes
Adds a bool flag




## Importance
Discussion on [Slack](https://linen.prefect.io/t/419667/We-are-seeing-errors-when-trying-to-register-artifacts-in-ou)


This PR:
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)