### PR TITLE
feat: add flag to hide welcome message

### DIFF
--- a/changes/pr5797.yaml
+++ b/changes/pr5797.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Add flag to prevent ASCII welcome message to be printed [5619](https://github.com/PrefectHQ/prefect/issues/5619)"
+  - "Add flag to prevent printing ASCII welcome message [5619](https://github.com/PrefectHQ/prefect/issues/5619)"
 
 contributor:
   - "[Jaakko Lappalainen](https://github.com/jkklapp)"

--- a/changes/pr5797.yaml
+++ b/changes/pr5797.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Add flag to prevent ASCII welcome message to be printed [5619](https://github.com/PrefectHQ/prefect/issues/5619)"
+
+contributor:
+  - "[Jaakko Lappalainen](https://github.com/jkklapp)"

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -583,7 +583,7 @@ def start(
     \b
         --detach, -d                Detached mode. Runs Server containers in the background
         --skip-pull                 Flag to skip pulling new images (if available)
-        --hide-welcome              Flag to hide the artful ASCII welcome message
+        --hide-welcome              Flag to hide the ASCII welcome message
     """
     # set external postgres flag if the user has provided `--postgres-url`
     if postgres_url is not None:

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -508,6 +508,12 @@ def config_cmd(
     is_flag=True,
     hidden=True,
 )
+@click.option(
+    "--hide-welcome",
+    help="Pass this flag to hide the ASCII welcome message",
+    is_flag=True,
+    hidden=True,
+)
 def start(
     version,
     ui_version,
@@ -530,6 +536,7 @@ def start(
     no_server_port,
     use_volume,
     volume_path,
+    hide_welcome
 ):
     """
     This command spins up all infrastructure and services for the Prefect Core server
@@ -576,6 +583,7 @@ def start(
     \b
         --detach, -d                Detached mode. Runs Server containers in the background
         --skip-pull                 Flag to skip pulling new images (if available)
+        --hide-welcome              Flag to hide the artful ASCII welcome message
     """
     # set external postgres flag if the user has provided `--postgres-url`
     if postgres_url is not None:
@@ -647,7 +655,8 @@ def start(
                     # Create a default tenant if no tenant exists
                     if not client.get_available_tenants():
                         client.create_tenant(name="default")
-                    print(ascii_welcome(ui_port=str(ui_port)))
+                    if not hide_welcome:
+                        print(ascii_welcome(ui_port=str(ui_port)))
                 except Exception:
                     time.sleep(0.5)
                     pass

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -536,7 +536,7 @@ def start(
     no_server_port,
     use_volume,
     volume_path,
-    hide_welcome
+    hide_welcome,
 ):
     """
     This command spins up all infrastructure and services for the Prefect Core server


### PR DESCRIPTION
## Summary
Add flag `--hide-welcome` to avoid printing the ascii welcome message

It should close #5619 


## Changes
Add the possibility to prevent ASCII welcome message




## Importance
Minor importance




## Checklist

This PR:

- [x] adds new tests
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)