### PR TITLE
Allow Orion UI to run on Windows

### DIFF
--- a/src/prefect/orion/api/server.py
+++ b/src/prefect/orion/api/server.py
@@ -3,6 +3,7 @@ Defines the Orion FastAPI app.
 """
 
 import asyncio
+import mimetypes
 import os
 import warnings
 from functools import partial
@@ -200,6 +201,11 @@ def create_orion_api(
 
 def create_ui_app(ephemeral: bool) -> FastAPI:
     ui_app = FastAPI(title=UI_TITLE)
+
+    if os.name == "nt":
+        # Windows defaults to text/plain for .js files
+        mimetypes.init()
+        mimetypes.add_type("application/javascript", ".js")
 
     @ui_app.get("/ui-settings")
     def ui_settings():


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Windows defaults to the mimetype text/plain for .js files, leading to the Orion UI loading a blank page, with the following in the JavaScript console:
"Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec."

This can be mitigated by changing the mimetype in the Windows registry, but that seems a bit invasive for such a minor fix.

## Changes
This PR overrides the mime type for .js files if os.name == "nt", allowing the UI to load.



## Importance
<!-- Why is this PR important? -->

While it's still not possible to develop the UI on Windows (all the commands in dev that run `subprocess.check_output(['npm', ...])` fail due to not checking the path by default), this at least allows the final product to run on a Windows desktop/server.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->
(I'm assuming I need to check these even if I haven't done anything, as it wasn't appropriate?)
This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)