### PR TITLE
Update tasks.md

### DIFF
--- a/docs/core/concepts/tasks.md
+++ b/docs/core/concepts/tasks.md
@@ -114,10 +114,10 @@ def add(x, y):
     return x + y
 
 with Flow('Flow With Constant') as flow:
-    add(1, 2)
+    output = add(1, 2)
 
 assert len(flow.tasks) == 1
-assert len(flow.constants) == 2
+assert len(flow.constants[output]) == 2
 ```
 
 Prefect will attempt to automatically turn Python objects into `Constants`, including collections (like `lists`, `tuples`, `sets`, and `dicts`). If the resulting constant is used directly as the input to a task, it is optimized out of the task graph and stored in the `flow.constants` dict. However, if the constant is mapped over, then it remains in the dependency graph.


### PR DESCRIPTION
## Summary
I noticed a small error in the documentation in one of the assertion statements in one of the examples [here](https://docs.prefect.io/core/concepts/tasks.html#constants)

## Changes
`flow.constants` returns a `defaultdict(dict)` with task references as keys, and a dictionary of constant names and their values as values. So task reference has to be used as key in the given assert statement.

## Importance
The mistake might confuse some people.


## Checklist
(Not applicable)

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)