### PR TITLE
Allow custom job name from passed job template

### DIFF
--- a/changes/pr5819.yaml
+++ b/changes/pr5819.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow custom job name from passed job template - [#5819](https://github.com/PrefectHQ/prefect/pull/5819)"

--- a/docs/orchestration/agents/kubernetes.md
+++ b/docs/orchestration/agents/kubernetes.md
@@ -139,6 +139,8 @@ configured per-flow (on the
 `run_config`), or on the Agent as a default for flows that don't provide their
 own template.
 
+As an example, providing a custom job template will allow you to customize the Kubernetes Job name prefix from `prefect-job` to something more descriptive for each flow and its associated workload. The prefix is specified in the job template's `metadata.name` field.
+
 For reference, the default template packaged with Prefect can be found
 [here](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/agent/kubernetes/job_template.yaml).
 

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -479,7 +479,8 @@ class KubernetesAgent(Agent):
 
         identifier = uuid.uuid4().hex[:8]
 
-        job_name = f"prefect-job-{identifier}"
+        job_name = _get_or_create(job, "metadata.name", "prefect-job")
+        job_name = f"{job_name}-{identifier}"
 
         # Populate job metadata for identification
         k8s_labels = {

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -480,6 +480,8 @@ class KubernetesAgent(Agent):
         identifier = uuid.uuid4().hex[:8]
 
         job_name = _get_or_create(job, "metadata.name", "prefect-job")
+        # 63 max length - 9 identifier - 6 pod identifier
+        job_name = job_name[:48]
         job_name = f"{job_name}-{identifier}"
 
         # Populate job metadata for identification

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -898,6 +898,14 @@ class TestK8sAgentRunConfig:
         job = self.agent.generate_job_spec(flow_run)
         assert job["metadata"]["labels"]["TEST"] == "VALUE"
 
+    def test_generate_job_spec_uses_job_template_name_provided_in_run_config(self):
+        template = self.read_default_template()
+        template.setdefault("metadata", {})["name"] = "custom-job-name"
+
+        flow_run = self.build_flow_run(KubernetesRun(job_template=template))
+        job = self.agent.generate_job_spec(flow_run)
+        assert re.match(r"custom-job-name-[a-f0-9]{8}", job["metadata"]["name"])
+
     def test_generate_job_spec_uses_job_template_path_provided_in_run_config(
         self, tmpdir, monkeypatch
     ):

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -906,6 +906,14 @@ class TestK8sAgentRunConfig:
         job = self.agent.generate_job_spec(flow_run)
         assert re.match(r"custom-job-name-[a-f0-9]{8}", job["metadata"]["name"])
 
+    def test_generate_job_spec_truncates_job_template_name_provided_in_run_config(self):
+        template = self.read_default_template()
+        template.setdefault("metadata", {})["name"] = "custom-job-name-that-has-a-lot-of-characters-and-will-truncate"
+
+        flow_run = self.build_flow_run(KubernetesRun(job_template=template))
+        job = self.agent.generate_job_spec(flow_run)
+        assert re.match(r"custom-job-name-that-has-a-lot-of-characters-and-[a-f0-9]{8}", job["metadata"]["name"])
+
     def test_generate_job_spec_uses_job_template_path_provided_in_run_config(
         self, tmpdir, monkeypatch
     ):

--- a/tests/agent/test_k8s_agent.py
+++ b/tests/agent/test_k8s_agent.py
@@ -908,11 +908,16 @@ class TestK8sAgentRunConfig:
 
     def test_generate_job_spec_truncates_job_template_name_provided_in_run_config(self):
         template = self.read_default_template()
-        template.setdefault("metadata", {})["name"] = "custom-job-name-that-has-a-lot-of-characters-and-will-truncate"
+        template.setdefault("metadata", {})[
+            "name"
+        ] = "custom-job-name-that-has-a-lot-of-characters-and-will-truncate"
 
         flow_run = self.build_flow_run(KubernetesRun(job_template=template))
         job = self.agent.generate_job_spec(flow_run)
-        assert re.match(r"custom-job-name-that-has-a-lot-of-characters-and-[a-f0-9]{8}", job["metadata"]["name"])
+        assert re.match(
+            r"custom-job-name-that-has-a-lot-of-characters-and-[a-f0-9]{8}",
+            job["metadata"]["name"],
+        )
 
     def test_generate_job_spec_uses_job_template_path_provided_in_run_config(
         self, tmpdir, monkeypatch


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This allows custom job name prefix using the job template passed to the KubernetesAgent.



## Changes
<!-- What does this PR change? -->
The current code in `KubernetesAgent.generate_job_spec` forces a job name prefix of `prefect-job`. This change  means that the job template's `metadata.name` (if it exists) will be used as the job name prefix. If not, it will fall back to `prefect-job`



## Importance
<!-- Why is this PR important? -->
This PR allows users to name jobs so that they may be more easily identifiable.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)