### PR TITLE
Allow prefect client to retry for HTTP targets

### DIFF
--- a/changes/pr5824.yaml
+++ b/changes/pr5824.yaml
@@ -1,5 +1,0 @@
-fix:
-  - 'Allow the Prefect Client to retry connections for HTTP targets - [#5824](https://github.com/PrefectHQ/prefect/pull/5824)'
-
-contributor:
-  - '[Jason Bertman](https://github.com/jbertman)'

--- a/changes/pr5824.yaml
+++ b/changes/pr5824.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Allow the Prefect Client to retry connections for HTTP targets - [#5824](https://github.com/PrefectHQ/prefect/pull/5824)'
+
+contributor:
+  - '[Jason Bertman](https://github.com/jbertman)'

--- a/changes/pr5825.yaml
+++ b/changes/pr5825.yaml
@@ -1,0 +1,5 @@
+fix:
+  - 'Allow the Prefect Client to retry connections for HTTP targets - [#5825](https://github.com/PrefectHQ/prefect/pull/5825)'
+
+contributor:
+  - '[Jason Bertman](https://github.com/jbertman)'

--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -629,6 +629,7 @@ class Client:
             allowed_methods=["DELETE", "GET", "POST"],  # type: ignore
         )
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+        session.mount("http://", requests.adapters.HTTPAdapter(max_retries=retries))
         response = self._send_request(
             session=session, method=method, url=url, params=params, headers=headers
         )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -265,10 +265,9 @@ def test_client_requests_use_retries(monkeypatch):
     )
     HTTPAdapter.assert_called_with(max_retries=Retry())
     assert HTTPAdapter.call_count == 2
-    Session().mount.assert_has_calls([
-        call("https://", HTTPAdapter()),
-        call("http://", HTTPAdapter())
-    ])
+    Session().mount.assert_has_calls(
+        [call("https://", HTTPAdapter()), call("http://", HTTPAdapter())]
+    )
 
 
 def test_client_posts_to_api_server(patch_post):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from pathlib import Path
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import marshmallow
 import pendulum
@@ -263,8 +263,12 @@ def test_client_requests_use_retries(monkeypatch):
         status_forcelist=[500, 502, 503, 504],
         allowed_methods=["DELETE", "GET", "POST"],  # type: ignore
     )
-    HTTPAdapter.assert_called_once_with(max_retries=Retry())
-    Session().mount.assert_called_once_with("https://", HTTPAdapter())
+    HTTPAdapter.assert_called_with(max_retries=Retry())
+    assert HTTPAdapter.call_count == 2
+    Session().mount.assert_has_calls([
+        call("https://", HTTPAdapter()),
+        call("http://", HTTPAdapter())
+    ])
 
 
 def test_client_posts_to_api_server(patch_post):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR allows the prefect client to retry for HTTP targets. The reasoning leading up to this change can be found on https://github.com/PrefectHQ/prefect/pull/5600




## Changes
<!-- What does this PR change? -->
This change mounts the HTTPAdapter containing retry to logic to HTTP prefixes alongside HTTPS prefixes. Session mounts are keyed by prefix, this change did not cause any ill-effects in testing.



## Importance
<!-- Why is this PR important? -->
Communications taking place internal to a cluster or in other configurations that use HTTP by default do not get the retry logic that applies to all Prefect Client communications. This includes state updates. For example, if a single state update is missed in Kubernetes executions, the entire flow fails. This PR corrects that by applying the retry logic to all HTTP communication.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)