### PR TITLE
Add libffi-dev to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.vcs-ref=${GIT_SHA}
 LABEL org.label-schema.build-date=${BUILD_DATE}
 
 RUN apt update && \
-    apt install -y gcc git tini build-essential && \
+    apt install -y gcc git tini build-essential libffi-dev && \
     mkdir /root/.prefect/ && \
     pip install "pip==20.2.4" && \
     pip install --no-cache-dir git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION}#egg=prefect[${EXTRAS}] && \


### PR DESCRIPTION
Required to build grpcio on Python 3.10 slim which failed during the release of 1.2.2.

We'll need to publish the 1.2.2 image for 3.10 manually.