### PR TITLE
fix raising error in __init__.py for snowflake task

### DIFF
--- a/src/prefect/tasks/snowflake/__init__.py
+++ b/src/prefect/tasks/snowflake/__init__.py
@@ -8,7 +8,7 @@ try:
         SnowflakeQuery,
         SnowflakeQueriesFromFile,
     )
-except ImportError:
+except ImportError as err:
     raise ImportError(
         'Using `prefect.tasks.snowflake` requires Prefect to be installed with the "snowflake" extra.'
     ) from err


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Importing SnowflakeQuery fails when Prefect was not installed with the "snowflake" extra but with wrong exception.




## Changes
Fix missing 'as err' so the right exceptions is raised instead of python's syntax exception




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)