### PR TITLE
Fix Docker builds for complex Python dependencies

### DIFF
--- a/changes/issue5860.yaml
+++ b/changes/issue5860.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Fixes issue where complex Python dependencies would break Docker storage builds - [#5860](https://github.com/PrefectHQ/prefect/issues/5860)"
+
+contributor:
+  - "[Bryan \"Beege\" Berry](https://github.com/TheBeege)"

--- a/src/prefect/storage/docker.py
+++ b/src/prefect/storage/docker.py
@@ -445,7 +445,7 @@ class Docker(Storage):
         pip_installs = "RUN pip install "
         if self.python_dependencies:
             for dependency in self.python_dependencies:
-                pip_installs += "{} ".format(dependency)
+                pip_installs += "'{}' ".format(dependency)
 
         # Write all install-time commands that should be run in the image
         installation_commands = ""

--- a/tests/storage/test_docker_storage.py
+++ b/tests/storage/test_docker_storage.py
@@ -693,6 +693,30 @@ def test_create_dockerfile_with_weird_flow_name():
             )
 
 
+def test_create_dockerfile_with_complex_python_dependencies():
+    with tempfile.TemporaryDirectory() as tempdir_outside:
+
+        with open(os.path.join(tempdir_outside, "test"), "w+") as t:
+            t.write("asdf")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+
+            storage = Docker(
+                registry_url="test1",
+                base_image="test3",
+                python_dependencies=["lib[flavor]<2.0.0,>=1.1.1", "other-lib"],
+            )
+            dpath = storage.create_dockerfile_object(directory=tempdir)
+
+            with open(dpath, "r") as dockerfile:
+                output = dockerfile.read()
+
+            assert (
+                "RUN pip install 'lib[flavor]<2.0.0,>=1.1.1' 'other-lib' 'wheel'"
+                in output
+            )
+
+
 def test_create_dockerfile_with_weird_flow_name_custom_prefect_dir(tmpdir):
 
     with open(os.path.join(tmpdir, "test"), "w+") as t:


### PR DESCRIPTION
## Summary
Docker storage currently produces a pip install statement simply listing the dependencies as entered. For more complex dependency definitions, such as those with square brackets and various version constraints, the Docker build fails. This fixes the issue.

Addresses #5860 




## Changes
This PR just quotes the Python dependencies in the resulting Dockerfile's `RUN` directive.




## Importance
Users can't automatically build Docker storage for flows that use complex Python dependency definitions.




## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)