### PR TITLE
Add Toloka tasks

### DIFF
--- a/changes/pr5865.yaml
+++ b/changes/pr5865.yaml
@@ -1,0 +1,6 @@
+feature:
+  - "Adds tasks for Toloka API.
+    - [#5865](https://github.com/PrefectHQ/prefect/pull/5865)"
+
+contributor:
+  - "[Vladislav Moiseev](https://github.com/vlad-mois)"

--- a/docs/outline.toml
+++ b/docs/outline.toml
@@ -803,3 +803,18 @@ classes = ["HightouchRunSync"]
 title = "SFTP Tasks"
 module = "prefect.tasks.sftp.sftp"
 classes = ["SftpDownload", "SftpUpload"]
+
+[pages.tasks.toloka]
+title = "Toloka Tasks"
+module = "prefect.tasks.toloka"
+functions = ["create_project",
+             "create_exam_pool",
+             "create_pool",
+             "create_tasks",
+             "open_pool",
+             "open_exam_pool",
+             "wait_pool",
+             "get_assignments",
+             "get_assignments_df",
+             "accept_assignment",
+             "reject_assignment"]

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,8 @@ extras = {
 
 if sys.version_info < (3, 6):
     extras["dev"].remove("black")
+
+if sys.version_info < (3, 7):
     del extras["toloka"]
 
 extras["all_extras"] = sum(extras.values(), [])

--- a/setup.py
+++ b/setup.py
@@ -103,11 +103,13 @@ extras = {
     "neo4j": ["py2neo >= 2021.2.3"],
     "transform": ["transform >= 1.0.12"],
     "sftp": ["paramiko >= 2.10.4"],
+    "toloka": ["toloka-kit >= 0.1.25", "pandas >= 1.1.0", "requests >= 2.25"],
 }
 
 
 if sys.version_info < (3, 6):
     extras["dev"].remove("black")
+    del extras["toloka"]
 
 extras["all_extras"] = sum(extras.values(), [])
 

--- a/src/prefect/tasks/toloka/__init__.py
+++ b/src/prefect/tasks/toloka/__init__.py
@@ -1,0 +1,12 @@
+"""
+This module contains a collection of tasks for interacting with Toloka API.
+
+All Toloka related tasks can be authenticated using the `TOLOKA_TOKEN` Prefect Secret that should contain Toloka API OAuth token. See [Third Party Authentication](../../../orchestration/recipes/third_party_auth.html) for more information.
+"""
+try:
+    from .helpers import *
+    from .operations import *
+except ImportError as err:
+    raise ImportError(
+        'Using `prefect.tasks.tasks` requires Prefect to be installed with the "toloka" extra.'
+    ) from err

--- a/src/prefect/tasks/toloka/helpers.py
+++ b/src/prefect/tasks/toloka/helpers.py
@@ -1,0 +1,22 @@
+__all__ = [
+    'download_json',
+]
+
+import requests
+from prefect import task
+from typing import Any
+
+
+@task
+def download_json(url: str) -> Any:
+    """
+    Task to download and parse JSON data stored at given url.
+    Args:
+        - url (str): URL to download.
+
+    Returns:
+        - Any: the content at this url, being parsed from JSON.
+    """
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.json()

--- a/src/prefect/tasks/toloka/operations.py
+++ b/src/prefect/tasks/toloka/operations.py
@@ -1,0 +1,511 @@
+__all__ = [
+    'create_project',
+    'create_exam_pool',
+    'create_pool',
+    'create_tasks',
+    'open_pool',
+    'open_exam_pool',
+    'wait_pool',
+    'get_assignments',
+    'get_assignments_df',
+    'accept_assignment',
+    'reject_assignment',
+]
+
+import logging
+import http
+import pandas as pd
+import time
+from datetime import datetime, timedelta
+from enum import Enum, unique
+from typing import Dict, List, Optional, Union
+
+from prefect import task
+
+from toloka.client import Assignment, Pool, Project, TolokaClient, Training
+from toloka.client import Task as TolokaTask
+from toloka.client.analytics_request import CompletionPercentagePoolAnalytics
+from toloka.client.assignment import GetAssignmentsTsvParameters
+from toloka.client.batch_create_results import TaskBatchCreateResult
+from toloka.client.exceptions import IncorrectActionsApiError
+
+from .utils import extract_id, structure_from_conf, with_logger, with_toloka_client
+
+
+@task
+@with_toloka_client
+def create_project(
+    obj: Union[Project, Dict, str, bytes],
+    *,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Project:
+    """
+    Task to create a Toloka `Project` object from given config.
+
+    Args:
+        - obj (Project, Dict, str, bytes): Either a `Project` object itself or a config to make a `Project`.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Project: Toloka project object with id assigned.
+
+    Example:
+        >>> project_conf = {...}  # May also be configured toloka.client.Project object.
+        >>> project = create_project(project_conf)
+        ...
+    """
+    obj = structure_from_conf(obj, Project)
+    return toloka_client.create_project(obj)
+
+
+@task
+@with_toloka_client
+def create_exam_pool(
+    obj: Union[Training, Dict, str, bytes],
+    *,
+    project_id: Union[Project, Dict, str, None] = None,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Training:
+    """
+    Task to create a Toloka `Training` pool object from given config.
+
+    Args:
+        - obj (Training, Dict, str, bytes): Either a `Training` object itself or a config to make a `Training`.
+        - project_id (Project, Dict, str, optional): Project ID to assign a training pool to.
+            May pass either an object, config or project_id value.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Training: Toloka training pool object with id assigned.
+
+    Example:
+        >>> project = create_project({...})
+        >>> exam = create_exam_pool({...}, project_id=project)
+        ...
+    """
+    obj = structure_from_conf(obj, Training)
+    if project_id is not None:
+        obj.project_id = extract_id(project_id, Project)
+    return toloka_client.create_training(obj)
+
+
+@task
+@with_toloka_client
+def create_pool(
+    obj: Union[Pool, Dict, str, bytes],
+    *,
+    project_id: Union[Project, Dict, str, None] = None,
+    exam_pool_id: Union[Training, Dict, str, None] = None,
+    expiration: Union[datetime, timedelta, None] = None,
+    reward_per_assignment: Optional[float] = None,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Pool:
+    """
+    Task to create a Toloka `Pool` object from given config.
+
+    Args:
+        - obj (Pool, Dict, str, bytes): Either a `Pool` object itself or a config to make a `Pool`.
+        - project_id (Project, Dict, str, optional): Project ID to assign a pool to.
+            May pass either an object, config or project_id value.
+        - exam_pool_id (Training, Dict, str, optional): Related training pool ID.
+            May pass either an object, config or pool_id value.
+        - expiration (datetime, timedelta, optional): Expiration setting. May pass any of:
+            `None` if this setting if already present;
+            `datetime` object to set exact datetime;
+            `timedelta` to set expiration related to the current time.
+        - reward_per_assignment (float, optional): Allow to redefine reward per assignment.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Pool: Toloka pool object with id assigned.
+
+    Example:
+        >>> project = create_project({...})
+        >>> exam = create_exam_pool({...}, project_id=project)
+        >>> pool = create_pool({...}, project_id=project, exam_pool_id=exam)
+        ...
+    """
+    obj = structure_from_conf(obj, Pool)
+    if project_id is not None:
+        obj.project_id = extract_id(project_id, Project)
+    if exam_pool_id:
+        if obj.quality_control.training_requirement is None:
+            raise ValueError('pool.quality_control.training_requirement should be set before exam_pool assignment')
+        obj.quality_control.training_requirement.training_pool_id = extract_id(exam_pool_id, Training)
+    if expiration:
+        obj.will_expire = datetime.utcnow() + expiration if isinstance(expiration, timedelta) else expiration
+    if reward_per_assignment:
+        obj.reward_per_assignment = reward_per_assignment
+    return toloka_client.create_pool(obj)
+
+
+@task
+@with_toloka_client
+def create_tasks(
+    tasks: List[Union[TolokaTask, Dict]],
+    *,
+    pool_id: Union[Pool, Training, Dict, str, None] = None,
+    allow_defaults: bool = False,
+    open_pool: bool = False,
+    skip_invalid_items: bool = False,
+    toloka_client: Optional[TolokaClient] = None,
+) -> TaskBatchCreateResult:
+    """
+    Task to create a list of tasks for a given pool.
+
+    Args:
+        - tasks (List[Union[TolokaTask, Dict]]): List of either a `toloka.client.Task` objects
+            or task conofigurations.
+        - pool_id (Pool, Training, Dict, str, optional): Allow to set tasks pool ID
+            if it's not present in tasks themselves.
+            May be either a `Pool` or `Training` object or config or a pool_id value.
+        - allow_defaults (bool, optional): Allow to use the overlap that is set in the pool parameters.
+        - open_pool (bool, optional): Open the pool immediately after creating a task suite, if the pool is closed.
+        - skip_invalid_items (bool, optional): Allow to skip invalid tasks.
+            You can handle them using resulting TaskBatchCreateResult object.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - TaskBatchCreateResult: Result object.
+
+    Example:
+        >>> tasks = [{'input_values': ...}, {'input_values': ...}, {'input_values': ...}]
+        >>> create_tasks(tasks,
+        ...              pool_id='some-pool_id-123',
+        ...              open_pool=True,
+        ...              allow_defaults=True)
+        ...
+    """
+    tasks = [structure_from_conf(task, TolokaTask) for task in tasks]
+    if pool_id is not None:
+        try:
+            pool_id = extract_id(pool_id, Pool)
+        except Exception:
+            pool_id = extract_id(pool_id, Training)
+        for task in tasks:
+            task.pool_id = pool_id
+    kwargs = {'allow_defaults': allow_defaults, 'open_pool': open_pool, 'skip_invalid_items': skip_invalid_items}
+    return toloka_client.create_tasks(tasks, **kwargs)
+
+
+@task
+@with_toloka_client
+def open_pool(
+    obj: Union[Pool, Dict, str],
+    *,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Pool:
+    """
+    Task to open given Toloka pool.
+
+    Args:
+        - obj (Pool, Dict, str): Pool id or `Pool` object of it's config.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Pool: Opened pool object.
+
+    Example:
+        >>> pool = create_pool({...})
+        >>> _tasks_creation = create_tasks([...], pool=pool)
+        >>> open_pool(pool, upstream_tasks=[_tasks_creation])
+        ...
+    """
+    pool_id = extract_id(obj, Pool)
+    return toloka_client.open_pool(pool_id)
+
+
+@task
+@with_toloka_client
+def open_exam_pool(
+    obj: Union[Training, str],
+    *,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Pool:
+    """
+    Task to open given training pool.
+
+    Args:
+        - obj (Training, Dict, str): Training pool_id or `Training` object of it's config.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Training: Opened training (exam) pool object.
+
+    Example:
+        >>> exam = create_training({...})
+        >>> _exam_tasks_creation = create_tasks([...], pool=exam)
+        >>> open_exam_pool(exam, upstream_tasks=[_exam_tasks_creation])
+        ...
+    """
+    pool_id = extract_id(obj, Training)
+    return toloka_client.open_training(pool_id)
+
+
+@task
+@with_toloka_client
+@with_logger
+def wait_pool(
+    pool_id: Union[Pool, Dict, str],
+    period: timedelta = timedelta(seconds=60),
+    *,
+    open_pool: bool = False,
+    logger: logging.Logger,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Pool:
+    """
+    Task to wait given Toloka pool until close.
+
+    Args:
+        - pool_id (Pool, Dict, str): Either a `Pool` object or it's config or a pool ID value.
+        - period (timedelta): Interval between checks. One minute by default.
+        - open_pool (bool, optional): Allow to open pool at start if it's closed. False by default.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Pool: Toloka pool object.
+
+    Example:
+        >>> pool = create_pool({...})
+        >>> _tasks_creation = create_tasks([...], pool=pool)
+        >>> wait_pool(pool, open_pool=True, upstream_tasks=[_tasks_creation])
+        ...
+    """
+    pool_id = extract_id(pool_id, Pool)
+    pool = toloka_client.get_pool(pool_id)
+    if pool.is_closed() and open_pool:
+        pool = toloka_client.open_pool(pool_id)
+
+    while pool.is_open():
+        op = toloka_client.get_analytics([CompletionPercentagePoolAnalytics(subject_id=pool_id)])
+        percentage = toloka_client.wait_operation(op).details['value'][0]['result']['value']
+        logger.info(f'Pool {pool_id} - {percentage}%')
+
+        time.sleep(period.total_seconds())
+        pool = toloka_client.get_pool(pool_id)
+
+    return pool
+
+
+@task
+@with_toloka_client
+def get_assignments(
+    pool_id: Union[Pool, Dict, str],
+    status: Union[str, List[str], Assignment.Status, List[Assignment.Status], None] = None,
+    *,
+    toloka_client: Optional[TolokaClient] = None,
+    **kwargs
+) -> List[Assignment]:
+    """
+    Task to get all assignments of selected status from Toloka pool.
+
+    Args:
+        - pool_id (Pool, Dict, str): Either a `Pool` object or it's config or a pool ID value.
+        - status (str, List[str], optional): A status or a list of statuses to get.
+            All statuses (None) by default.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+        - **kwargs: Other args presented in `toloka.client.search_requests.AssignmentSearchRequest`.
+
+    Returns:
+        - List[Assignment]: Get assignments result.
+
+    Example:
+        >>> pool = create_pool({...})
+        >>> _tasks_creation = create_tasks([...], pool=pool)
+        >>> _waiting = wait_pool(pool, open_pool=True, upstream_tasks=[_tasks_creation])
+        >>> results = get_assignments(pool, status=['SUBMITTED'], upstream_tasks=[_waiting])
+        ...
+    """
+    pool_id = extract_id(pool_id, Pool)
+    return list(toloka_client.get_assignments(pool_id=pool_id, status=status, **kwargs))
+
+
+@task
+@with_toloka_client
+def get_assignments_df(
+    pool_id: Union[Pool, Dict, str],
+    status: Union[str, List[str], Assignment.Status, List[Assignment.Status], None] = None,
+    *,
+    toloka_client: Optional[TolokaClient] = None,
+    start_time_from: Optional[datetime] = None,
+    start_time_to: Optional[datetime] = None,
+    exclude_banned: bool = False,
+    field: Optional[List[GetAssignmentsTsvParameters.Field]] = None,
+) -> pd.DataFrame:
+    """
+    Task to get pool assignments of selected statuses in Pandas `DataFrame` format useful for aggregation.
+
+    Args:
+        - pool_id (Pool, Dict, str): Either a `Pool` object or it's config or a pool ID value.
+        - status (str, List[str], optional): A status or a list of statuses to get.
+            All statuses (None) by default.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+        - start_time_from (str, optional): Upload assignments submitted after the specified date and time.
+        - start_time_to (str, optional): Upload assignments submitted before the specified date and time.
+        - exclude_banned (bool, optional): Exclude answers from banned performers,
+            even if assignments in suitable status "ACCEPTED".
+        - field (List[GetAssignmentsTsvParameters.Field], optional): Select some additional fields.
+            You can find possible values in the `toloka.client.assignment.GetAssignmentsTsvParameters.Field` enum.
+
+    Returns:
+        - DataFrame: `pd.DataFrame` with selected assignments.
+            Note that nested paths are presented with a ":" sign.
+
+    Example:
+        >>> pool = create_pool({...})
+        >>> _tasks_creation = create_tasks([...], pool=pool)
+        >>> _waiting = wait_pool(pool, open_pool=True, upstream_tasks=[_tasks_creation])
+        >>> df = get_assignments_df(pool, status=['SUBMITTED'], upstream_tasks=[_waiting])
+        ...
+    """
+    pool_id = extract_id(pool_id, Pool)
+    if not status:
+        status = []
+    elif isinstance(status, (str, Assignment.Status)):
+        status = [status]
+    kwargs = {'start_time_from': start_time_from,
+              'start_time_to': start_time_to,
+              'exclude_banned': exclude_banned,
+              'field': field}
+    return toloka_client.get_assignments_df(
+        pool_id=pool_id,
+        status=status,
+        **{key: value for key, value in kwargs.items() if value is not None}
+    )
+
+
+@unique
+class _PatchAssignmentMethod(Enum):
+    ACCEPT_ASSIGNMENT = 'accept_assignment'
+    REJECT_ASSIGNMENT = 'reject_assignment'
+
+
+def _patch_assignment(
+    method_name: _PatchAssignmentMethod,
+    assignment_id: Union[Assignment, Dict, str],
+    public_comment: str,
+    fail_if_already_set: bool,
+    logger: logging.Logger,
+    toloka_client: Optional[TolokaClient],
+) -> Union[Assignment, Dict, str]:
+    """Function to either accept or reject assignment with given comment."""
+    assignment_id = extract_id(assignment_id, Assignment)
+    method = getattr(toloka_client, method_name.value)
+    try:
+        method(assignment_id, public_comment=public_comment)
+    except IncorrectActionsApiError as exc:
+        logger.warning('Can\'t %s %s: %s', method_name.value, assignment_id, exc)
+        if fail_if_already_set or exc.status_code != http.client.CONFLICT.value:
+            raise
+    return assignment_id
+
+
+@task
+@with_toloka_client
+@with_logger
+def accept_assignment(
+    assignment_id: Union[Assignment, Dict, str],
+    public_comment: str,
+    fail_if_already_set: bool = False,
+    *,
+    logger: logging.Logger,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Union[Assignment, Dict, str]:
+    """
+    Task to accept given assignment by given ID.
+    Use `accept_assignment.map` to process multiple assignments. Pass public_comment with `unmapped` wrapper in this case.
+
+    Args:
+        - assignment_id (Assignment, Dict, str): Either an `Assignment` object or it's config or an assignment ID value.
+        - public_comment (str): Public comment.
+        - fail_if_already_set (bool, optional): Fail if the assignment has already been accepted (in the UI for example).
+            Skip by default.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Union[Assignment, Dict, str]: The same assignment_id, that was given.
+
+    Example:
+        >>> aggregated = do_some_aggregation(assignments)
+        >>> to_accept = some_filter_to_accept(aggregated)
+        >>> accept_assignment.map(to_accept, unmapped('Well done!'))
+        ...
+    """
+    return _patch_assignment(_PatchAssignmentMethod.ACCEPT_ASSIGNMENT,
+                             assignment_id,
+                             public_comment,
+                             fail_if_already_set,
+                             logger,
+                             toloka_client)
+
+
+@task
+@with_toloka_client
+@with_logger
+def reject_assignment(
+    assignment_id: Union[Assignment, Dict, str],
+    public_comment: str,
+    fail_if_already_set: bool = False,
+    *,
+    logger: logging.Logger,
+    toloka_client: Optional[TolokaClient] = None,
+) -> Union[Assignment, Dict, str]:
+    """
+    Task to reject given assignment by given ID.
+    Use `reject_assignment.map` to process multiple assignments. Pass public_comment with `unmapped` wrapper in this case.
+
+    Args:
+        - assignment_id (Assignment, Dict, str): Either an `Assignment` object or it's config or an assignment ID value.
+        - public_comment (str): Public comment.
+        - fail_if_already_set (bool, optional): Fail if the assignment has already been rejected (in the UI for example).
+            Skip by default.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env (str, optional): Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
+
+    Returns:
+        - Union[Assignment, Dict, str]: The same assignment_id, that was given.
+
+    Example:
+        >>> aggregated = do_some_aggregation(assignments)
+        >>> to_reject = some_filter_to_reject(aggregated)
+        >>> reject_assignment.map(to_reject, unmapped('Incorrect answer'))
+        ...
+    """
+    return _patch_assignment(_PatchAssignmentMethod.REJECT_ASSIGNMENT,
+                             assignment_id,
+                             public_comment,
+                             fail_if_already_set,
+                             logger,
+                             toloka_client)

--- a/src/prefect/tasks/toloka/operations.py
+++ b/src/prefect/tasks/toloka/operations.py
@@ -43,11 +43,9 @@ def create_project(
     Task to create a Toloka `Project` object from given config.
 
     Args:
-        - obj (Project, Dict, str, bytes): Either a `Project` object itself or a config to make a `Project`.
-        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
-            Default: "TOLOKA_TOKEN".
-        - env (str, optional): Allow to use non-default Toloka environment.
-            Default: "PRODUCTION".
+        - obj: Either a `Project` object itself or a config to make a `Project`.
+        - secret_name: Allow to use non-default secret for Toloka token. Default: "TOLOKA_TOKEN".
+        - env: Allow to use non-default Toloka environment. Default: "PRODUCTION".
 
     Returns:
         - Project: Toloka project object with id assigned.

--- a/src/prefect/tasks/toloka/operations.py
+++ b/src/prefect/tasks/toloka/operations.py
@@ -44,8 +44,10 @@ def create_project(
 
     Args:
         - obj: Either a `Project` object itself or a config to make a `Project`.
-        - secret_name: Allow to use non-default secret for Toloka token. Default: "TOLOKA_TOKEN".
-        - env: Allow to use non-default Toloka environment. Default: "PRODUCTION".
+        - secret_name: Allow to use non-default secret for Toloka token.
+            Default: "TOLOKA_TOKEN".
+        - env: Allow to use non-default Toloka environment.
+            Default: "PRODUCTION".
 
     Returns:
         - Project: Toloka project object with id assigned.

--- a/src/prefect/tasks/toloka/operations.py
+++ b/src/prefect/tasks/toloka/operations.py
@@ -43,10 +43,11 @@ def create_project(
     Task to create a Toloka `Project` object from given config.
 
     Args:
-        - obj: Either a `Project` object itself or a config to make a `Project`.
-        - secret_name: Allow to use non-default secret for Toloka token.
+        - obj (Project, Dict, str, bytes): Either a `Project` object itself
+            or a config to make a `Project`.
+        - secret_name (str, optional): Allow to use non-default secret for Toloka token.
             Default: "TOLOKA_TOKEN".
-        - env: Allow to use non-default Toloka environment.
+        - env (str, optional): Allow to use non-default Toloka environment.
             Default: "PRODUCTION".
 
     Returns:
@@ -73,7 +74,8 @@ def create_exam_pool(
     Task to create a Toloka `Training` pool object from given config.
 
     Args:
-        - obj (Training, Dict, str, bytes): Either a `Training` object itself or a config to make a `Training`.
+        - obj (Training, Dict, str, bytes): Either a `Training` object itself
+            or a config to make a `Training`.
         - project_id (Project, Dict, str, optional): Project ID to assign a training pool to.
             May pass either an object, config or project_id value.
         - secret_name (str, optional): Allow to use non-default secret for Toloka token.
@@ -139,10 +141,14 @@ def create_pool(
         obj.project_id = extract_id(project_id, Project)
     if exam_pool_id:
         if obj.quality_control.training_requirement is None:
-            raise ValueError('pool.quality_control.training_requirement should be set before exam_pool assignment')
+            raise ValueError(
+                'pool.quality_control.training_requirement should be set before exam_pool assignment')
         obj.quality_control.training_requirement.training_pool_id = extract_id(exam_pool_id, Training)
     if expiration:
-        obj.will_expire = datetime.utcnow() + expiration if isinstance(expiration, timedelta) else expiration
+        if isinstance(expiration, timedelta):
+            obj.will_expire = datetime.utcnow() + expiration
+        else:
+            obj.will_expire = expiration
     if reward_per_assignment:
         obj.reward_per_assignment = reward_per_assignment
     return toloka_client.create_pool(obj)
@@ -169,7 +175,7 @@ def create_tasks(
             if it's not present in tasks themselves.
             May be either a `Pool` or `Training` object or config or a pool_id value.
         - allow_defaults (bool, optional): Allow to use the overlap that is set in the pool parameters.
-        - open_pool (bool, optional): Open the pool immediately after creating a task suite, if the pool is closed.
+        - open_pool (bool, optional): Open the pool immediately after creating a task suite, if closed.
         - skip_invalid_items (bool, optional): Allow to skip invalid tasks.
             You can handle them using resulting TaskBatchCreateResult object.
         - secret_name (str, optional): Allow to use non-default secret for Toloka token.
@@ -196,7 +202,9 @@ def create_tasks(
             pool_id = extract_id(pool_id, Training)
         for task in tasks:
             task.pool_id = pool_id
-    kwargs = {'allow_defaults': allow_defaults, 'open_pool': open_pool, 'skip_invalid_items': skip_invalid_items}
+    kwargs = {'allow_defaults': allow_defaults,
+              'open_pool': open_pool,
+              'skip_invalid_items': skip_invalid_items}
     return toloka_client.create_tasks(tasks, **kwargs)
 
 
@@ -357,7 +365,8 @@ def get_assignments_df(
     field: Optional[List[GetAssignmentsTsvParameters.Field]] = None,
 ) -> pd.DataFrame:
     """
-    Task to get pool assignments of selected statuses in Pandas `DataFrame` format useful for aggregation.
+    Task to get pool assignments of selected statuses
+    in Pandas `DataFrame` format useful for aggregation.
 
     Args:
         - pool_id (Pool, Dict, str): Either a `Pool` object or it's config or a pool ID value.
@@ -367,12 +376,13 @@ def get_assignments_df(
             Default: "TOLOKA_TOKEN".
         - env (str, optional): Allow to use non-default Toloka environment.
             Default: "PRODUCTION".
-        - start_time_from (str, optional): Upload assignments submitted after the specified date and time.
-        - start_time_to (str, optional): Upload assignments submitted before the specified date and time.
+        - start_time_from (str, optional): Upload assignments submitted after the specified datetime.
+        - start_time_to (str, optional): Upload assignments submitted before the specified datetime.
         - exclude_banned (bool, optional): Exclude answers from banned performers,
             even if assignments in suitable status "ACCEPTED".
         - field (List[GetAssignmentsTsvParameters.Field], optional): Select some additional fields.
-            You can find possible values in the `toloka.client.assignment.GetAssignmentsTsvParameters.Field` enum.
+            You can find possible values in the
+            `toloka.client.assignment.GetAssignmentsTsvParameters.Field` enum.
 
     Returns:
         - DataFrame: `pd.DataFrame` with selected assignments.
@@ -440,13 +450,15 @@ def accept_assignment(
 ) -> Union[Assignment, Dict, str]:
     """
     Task to accept given assignment by given ID.
-    Use `accept_assignment.map` to process multiple assignments. Pass public_comment with `unmapped` wrapper in this case.
+    Use `accept_assignment.map` to process multiple assignments.
+    Pass public_comment with `unmapped` wrapper in this case.
 
     Args:
-        - assignment_id (Assignment, Dict, str): Either an `Assignment` object or it's config or an assignment ID value.
+        - assignment_id (Assignment, Dict, str): Either an `Assignment` object
+            or it's config or an assignment ID value.
         - public_comment (str): Public comment.
-        - fail_if_already_set (bool, optional): Fail if the assignment has already been accepted (in the UI for example).
-            Skip by default.
+        - fail_if_already_set (bool, optional): Fail if the assignment has already been accepted
+            (in the UI for example). Skip by default.
         - secret_name (str, optional): Allow to use non-default secret for Toloka token.
             Default: "TOLOKA_TOKEN".
         - env (str, optional): Allow to use non-default Toloka environment.
@@ -482,13 +494,15 @@ def reject_assignment(
 ) -> Union[Assignment, Dict, str]:
     """
     Task to reject given assignment by given ID.
-    Use `reject_assignment.map` to process multiple assignments. Pass public_comment with `unmapped` wrapper in this case.
+    Use `reject_assignment.map` to process multiple assignments.
+    Pass public_comment with `unmapped` wrapper in this case.
 
     Args:
-        - assignment_id (Assignment, Dict, str): Either an `Assignment` object or it's config or an assignment ID value.
+        - assignment_id (Assignment, Dict, str): Either an `Assignment` object
+            or it's config or an assignment ID value.
         - public_comment (str): Public comment.
-        - fail_if_already_set (bool, optional): Fail if the assignment has already been rejected (in the UI for example).
-            Skip by default.
+        - fail_if_already_set (bool, optional): Fail if the assignment has already been rejected
+            (in the UI for example). Skip by default.
         - secret_name (str, optional): Allow to use non-default secret for Toloka token.
             Default: "TOLOKA_TOKEN".
         - env (str, optional): Allow to use non-default Toloka environment.

--- a/src/prefect/tasks/toloka/utils.py
+++ b/src/prefect/tasks/toloka/utils.py
@@ -1,0 +1,166 @@
+import inspect
+import json
+import pickle
+from decimal import Decimal
+from functools import partial, wraps
+from typing import Any, Callable, Iterable, Type
+
+from prefect.client import Secret
+
+from toloka.client import TolokaClient, add_headers
+import toloka.client as _toloka_client_lib  # To avoid `structure` pickling errors.
+
+
+def with_updated_signature(
+    func: Callable,
+    wrapper: Callable,
+    add_wrapper_args: Iterable[str] = (),
+    remove_func_args: Iterable[str] = (),
+) -> Callable:
+    """
+    Prefect tasks relate on function signature,
+    so we need to change it since we use some args-changing wrappers.
+
+    Args:
+        - func (Callable): Initial function to get signature from.
+        - wrapper (Callable): Wrapper to take body from.
+        - add_wrapper_args (Iterable, optional): Wrapper's args to put in the final signature.
+        - remove_func_args (Iterable, optional): Func's args to remove from the final signature.
+
+    Returns:
+        - Callable: initial wrapper with modified signature.
+    """
+
+    remove_func_args = set(remove_func_args)
+
+    signature_func = inspect.signature(func)
+    parameters_keep = [
+        param
+        for param in signature_func.parameters.values()
+        if param.name not in remove_func_args and param.kind != inspect.Parameter.VAR_KEYWORD
+    ]
+
+    parameters_wrapper = inspect.signature(wrapper).parameters
+    parameters_add = [parameters_wrapper[arg_name] for arg_name in add_wrapper_args]
+
+    last_param = next(reversed(signature_func.parameters.values()), inspect.Parameter)
+    if last_param.kind == inspect.Parameter.VAR_KEYWORD:
+        parameters_add.append(last_param)
+
+    res = wraps(func)(wrapper)
+    res.__signature__ = signature_func.replace(parameters=parameters_keep + parameters_add)
+
+    return res
+
+
+def with_logger(func: Callable) -> Callable:
+    """
+    Decorator, that allows function to use Prefect logger instance.
+    Enrich function signature with keyword-only argument "logger".
+    Use it to write logs from Prefect task.
+
+    Args:
+        - func (Callable): Function that takes `logger` argument.
+
+    Returns:
+        - Callable: a wrapper with Prefect logger passed.
+
+    Example:
+        >>> @task
+        ... def some_task():
+        ...     return 123
+        ...
+        >>> @task
+        ... @with_logger
+        ... def task_with_logger(arg, logger):
+        ...     logger.warning('arg value: %s', arg)
+        ...
+        >>> with Flow('some-flow') as flow:
+        ...     res = some_task()
+        ...     task_with_logger(res)
+        ...
+    """
+
+    def _wrapper(*args, **kwargs) -> Any:
+        import prefect
+        return partial(func, logger=prefect.context.get('logger'))(*args, **kwargs)
+
+    return with_updated_signature(func, _wrapper, remove_func_args={'logger'})
+
+
+_json_loads = partial(json.loads, parse_float=Decimal)
+
+
+def structure_from_conf(obj: Any, cl: Type) -> object:
+    if isinstance(obj, cl):
+        return obj
+    if isinstance(obj, bytes):
+        try:
+            return pickle.loads(obj)
+        except Exception:
+            pass
+        obj = obj.decode()
+    if isinstance(obj, str):
+        obj = _json_loads(obj)
+    return _toloka_client_lib.structure(obj, cl)
+
+
+def extract_id(obj: Any, cl: Type) -> str:
+    if isinstance(obj, str):
+        try:
+            obj = _json_loads(obj)
+        except Exception:
+            return obj
+        if isinstance(obj, int):
+            return str(obj)
+    res = structure_from_conf(obj, cl).id
+    if res is None:
+        raise ValueError(f'Got id=None from: {obj}')
+    return res
+
+
+DEFAULT_TOLOKA_SECRET_NAME = 'TOLOKA_TOKEN'
+DEFAULT_TOLOKA_ENV = 'PRODUCTION'
+
+
+def with_toloka_client(func: Callable) -> Callable:
+    """
+    Decorator that allows function to pass `secret_name` and `env` args
+    and operate with `toloka_client` instance.
+
+    Args:
+        - func (Callable): function, that operate with `toloka_client` argument.
+
+    Returns:
+        - Callable: the wrapper, that takes optional `secret_name` and `env` arguments
+            and operates with default `toloka_token` if they are not passed.
+
+    Example:
+        >>> @with_toloka_client
+        ... def some_func(toloka_client: TolokaClient):
+        ...     toloka_client.create_project(...)
+        ...
+        >>> some_func()  # Use default toloka_client created using TOLOKA_TOKEN secret.
+        >>> some_func(secret_name='OTHER_ACCOUNT_SECRET')  # Allow to pass other secret.
+        ...
+    """
+
+    def _wrapper(
+        *args,
+        __func: Callable,
+        secret_name: str = DEFAULT_TOLOKA_SECRET_NAME,
+        env: str = DEFAULT_TOLOKA_ENV,
+        **kwargs
+    ) -> Any:
+        token = Secret(secret_name).get()
+        toloka_client = TolokaClient(token, env)
+        # TODO: Remove after toloka-kit==0.1.24 release.
+        toloka_client.retryer_factory = partial(toloka_client.retryer_factory, status_list=(408, 429, 500, 503))
+        return partial(add_headers('prefect')(__func), toloka_client=toloka_client)(*args, **kwargs)
+
+    return with_updated_signature(
+        func,
+        partial(_wrapper, __func=func),
+        remove_func_args=('toloka_client',),
+        add_wrapper_args=('secret_name', 'env'),
+    )

--- a/src/prefect/tasks/toloka/utils.py
+++ b/src/prefect/tasks/toloka/utils.py
@@ -50,9 +50,6 @@ def with_updated_signature(
     res = wraps(func)(wrapper)
     res.__special_wrapped__ = res.__wrapped__
     del res.__wrapped__
-    if isinstance(res, partial):
-        res.__special_func__ = res.func
-        del res.func
     res.__signature__ = signature_func.replace(parameters=parameters_keep + parameters_add)
 
     return res

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,5 @@ pytest-xdist >= 2.0
 flaky >= 3.0
 responses >= 0.14.0
 PyJWT >= 2.3.0
+freezegun >= 1.0.0
+requests_mock >= 1.0.0

--- a/tests/tasks/toloka/test_client.py
+++ b/tests/tasks/toloka/test_client.py
@@ -1,0 +1,60 @@
+import inspect
+import prefect
+import pytest
+import requests_mock
+from prefect.tasks.toloka.utils import (
+    DEFAULT_TOLOKA_ENV,
+    DEFAULT_TOLOKA_SECRET_NAME,
+    with_toloka_client,
+)
+from toloka.client import TolokaClient
+from unittest.mock import Mock
+
+
+DEFAULT_TOKEN = 'some-token'
+
+OTHER_SECRET_NAME = 'OTHER_SECRET'
+OTHER_TOKEN = 'some-other-token'
+OTHER_ENV = 'SANDBOX'
+
+
+@pytest.fixture
+def secrets_mock():
+    secrets = {DEFAULT_TOLOKA_SECRET_NAME: DEFAULT_TOKEN,
+               OTHER_SECRET_NAME: OTHER_TOKEN}
+    with prefect.context(secrets=secrets):
+        yield
+
+
+class TestWithTolokaClient:
+    def test_signature(self, secrets_mock):
+        @with_toloka_client
+        def some_func(arg1, arg2, toloka_client):
+            ...
+
+        params = set(inspect.signature(some_func).parameters)
+        assert {'arg1', 'arg2', 'secret_name', 'env'} == params, params
+
+    def test_new_toloka_client(self, secrets_mock):
+        @with_toloka_client
+        def some_func(expected_token, expected_env, toloka_client=None):
+            assert expected_token == toloka_client.token
+            assert TolokaClient.Environment[expected_env].value == toloka_client.url
+
+        some_func(DEFAULT_TOKEN, DEFAULT_TOLOKA_ENV)
+        some_func(OTHER_TOKEN, OTHER_ENV, secret_name=OTHER_SECRET_NAME, env=OTHER_ENV)
+
+
+def test_add_headers(secrets_mock):
+    @with_toloka_client
+    def make_request(toloka_client):
+        return toloka_client.get_pool('123')
+
+    with requests_mock.Mocker(real_http=False) as mocker:
+        mocker.get(requests_mock.ANY, content=b'...')
+        with pytest.raises(Exception, match='Expecting value'):
+            make_request()
+
+        assert mocker.called
+        headers = mocker.request_history[0].headers
+        assert 'prefect' == headers['X-Caller-Context'], headers

--- a/tests/tasks/toloka/test_client.py
+++ b/tests/tasks/toloka/test_client.py
@@ -8,7 +8,6 @@ from prefect.tasks.toloka.utils import (
     with_toloka_client,
 )
 from toloka.client import TolokaClient
-from unittest.mock import Mock
 
 
 DEFAULT_TOKEN = 'some-token'

--- a/tests/tasks/toloka/test_docstrings.py
+++ b/tests/tasks/toloka/test_docstrings.py
@@ -18,7 +18,7 @@ def test_all_arguments_documented(task_name):
     non_documented = []
     for arg, param in inspect.signature(task).parameters.items():
         if param.kind == inspect.Parameter.VAR_KEYWORD:
-            pattern = '^\\s+- \*\*kwargs[ :].+'
+            pattern = '^\\s+- \*\*kwargs[ :].+'  # noqa
         else:
             pattern = f'^\\s+- {arg} .+'
         if not re.search(pattern, args_doc, flags=re.MULTILINE):

--- a/tests/tasks/toloka/test_docstrings.py
+++ b/tests/tasks/toloka/test_docstrings.py
@@ -1,0 +1,27 @@
+import inspect
+import pytest
+import re
+from prefect.core import Task
+from prefect.tasks.toloka import operations as tlk
+
+
+TASKS = {name: getattr(tlk, name)
+         for name in dir(tlk)
+         if isinstance(getattr(tlk, name), Task)}
+
+
+@pytest.mark.parametrize('task_name', list(TASKS))
+def test_all_arguments_documented(task_name):
+    task = TASKS[task_name]
+    args_doc = task.__doc__.split('    Args:\n')[1]
+
+    non_documented = []
+    for arg, param in inspect.signature(task).parameters.items():
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            pattern = '^\\s+- \*\*kwargs[ :].+'
+        else:
+            pattern = f'^\\s+- {arg} .+'
+        if not re.search(pattern, args_doc, flags=re.MULTILINE):
+            non_documented.append(arg)
+    if non_documented:
+        raise ValueError(f'Task {task_name} has undocummented args: {non_documented}')

--- a/tests/tasks/toloka/test_helpers.py
+++ b/tests/tasks/toloka/test_helpers.py
@@ -1,0 +1,23 @@
+import functools
+import json
+import pytest
+import requests_mock
+from prefect.tasks.toloka.helpers import download_json
+
+
+URL = 'https://some.url'
+CONTENT = {'key': ['value', 'значение', '価値']}
+
+
+_json_dump = functools.partial(json.dumps, ensure_ascii=False)
+
+
+@pytest.fixture
+def mocked_url():
+    with requests_mock.Mocker(real_http=False) as mock:
+        mock.get(URL, content=_json_dump(CONTENT).encode())
+        yield URL
+
+
+def test_download_json(mocked_url):
+    assert CONTENT == download_json.run(mocked_url)

--- a/tests/tasks/toloka/test_import.py
+++ b/tests/tasks/toloka/test_import.py
@@ -1,0 +1,2 @@
+def test_import():
+    import prefect.tasks.toloka

--- a/tests/tasks/toloka/test_import.py
+++ b/tests/tasks/toloka/test_import.py
@@ -1,2 +1,2 @@
 def test_import():
-    import prefect.tasks.toloka
+    import prefect.tasks.toloka  # noqa

--- a/tests/tasks/toloka/test_operations.py
+++ b/tests/tasks/toloka/test_operations.py
@@ -1,0 +1,235 @@
+import pandas as pd
+import prefect
+import pytest
+import pytz
+from freezegun import freeze_time
+from functools import partial
+from datetime import datetime, timedelta
+from prefect.tasks.toloka.operations import (
+    create_exam_pool,
+    create_pool,
+    create_project,
+    create_tasks,
+    get_assignments,
+    get_assignments_df,
+    open_exam_pool,
+    open_pool,
+    wait_pool,
+)
+from prefect.tasks.toloka.utils import DEFAULT_TOLOKA_SECRET_NAME, structure_from_conf
+from toloka.client import Assignment, Pool, Project, TolokaClient, Training
+from toloka.client import Task as TolokaTask
+from toloka.client.assignment import GetAssignmentsTsvParameters
+from toloka.client.batch_create_results import TaskBatchCreateResult
+from toloka.client.quality_control import QualityControl
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def secrets_mock():
+    with prefect.context(secrets={DEFAULT_TOLOKA_SECRET_NAME: 'some-token'}):
+        yield
+
+
+PROJECT_ID = 'some-project-id'
+POOL_ID = 'some-pool-id'
+TRAINING_ID = 'some-training-id'
+
+
+@pytest.fixture
+def project_mock():
+    return Project(id=PROJECT_ID)
+
+
+@pytest.fixture
+def pool_mock():
+    return Pool(id=POOL_ID)
+
+
+@pytest.fixture
+def training_mock():
+    return Training(id=TRAINING_ID)
+
+
+@pytest.fixture
+def tasks_mock():
+    return [TolokaTask(input_values={}, id=str(index)) for index in range(3)]
+
+
+@pytest.fixture
+def tasks_creation_result(tasks_mock):
+    return TaskBatchCreateResult(items=tasks_mock)
+
+
+@pytest.fixture
+def assignments_mock():
+    return [Assignment(id=f'assignment-{index}') for index in range(3)]
+
+
+@pytest.fixture
+def assignments_df_mock():
+    return pd.DataFrame.from_records([{'ASSIGNMENT:assignment_id': f'assignment-{index}'}
+                                      for index in range(3)])
+
+
+@pytest.fixture
+def toloka_client_mock(
+    secrets_mock,
+    pool_mock,
+    training_mock,
+    tasks_creation_result,
+    assignments_mock,
+    assignments_df_mock,
+):
+    client = Mock()
+    client.create_project = partial(structure_from_conf, cl=Project)
+    client.create_pool = partial(structure_from_conf, cl=Pool)
+    client.create_training = partial(structure_from_conf, cl=Training)
+    client.create_tasks = Mock(return_value=tasks_creation_result)
+    client.open_pool = Mock(return_value=pool_mock)
+    client.open_training = Mock(return_value=training_mock)
+    client.get_assignments = Mock(return_value=iter(assignments_mock))
+    client.get_assignments_df = Mock(return_value=assignments_df_mock)
+    with patch('prefect.tasks.toloka.utils.TolokaClient', Mock(return_value=client)):
+        yield client
+
+
+def test_create_project(toloka_client_mock, project_mock):
+    assert project_mock == create_project.run(project_mock.unstructure())
+
+
+class TestCreateExamPool:
+    def test_create_exam_pool(self, toloka_client_mock, training_mock):
+        res = create_exam_pool.run(training_mock.unstructure())
+        assert training_mock == res
+
+    def test_create_exam_pool_with_project(self, toloka_client_mock, training_mock, project_mock):
+        res = create_exam_pool.run(training_mock.unstructure(), project_id=project_mock)
+        assert project_mock.id == res.project_id
+        res.project_id = None
+        assert training_mock == res
+
+
+class TestCreatePool:
+    def test_create_pool(self, toloka_client_mock, pool_mock):
+        res = create_pool.run(pool_mock.unstructure())
+        assert pool_mock == res
+
+    def test_create_pool_with_project(self, toloka_client_mock, pool_mock, project_mock):
+        res = create_pool.run(pool_mock.unstructure(), project_id=project_mock)
+        assert project_mock.id == res.project_id
+        res.project_id = None
+        assert pool_mock == res
+
+    def test_create_pool_with_exam(self, toloka_client_mock, pool_mock, project_mock, training_mock):
+        training_requirement = QualityControl.TrainingRequirement(training_passing_skill_value=90)
+        pool_mock.quality_control = QualityControl(training_requirement=training_requirement)
+        res = create_pool.run(pool_mock.unstructure(), project_id=project_mock, exam_pool_id=training_mock)
+        assert training_mock.id == res.quality_control.training_requirement.training_pool_id
+        res.quality_control.training_requirement.training_pool_id = None
+        res.project_id = None
+        assert pool_mock == res
+
+    def test_create_pool_with_exam_error(self, toloka_client_mock, pool_mock, project_mock, training_mock):
+        pool_mock.quality_control = QualityControl()
+        with pytest.raises(ValueError, match='pool.quality_control.training_requirement'):
+            create_pool.run(pool_mock.unstructure(), project_id=project_mock, exam_pool_id=training_mock)
+
+    def test_create_pool_with_expiration_exact(self, toloka_client_mock, pool_mock):
+        dt = datetime(2022, 1, 1, tzinfo=pytz.UTC)
+        res = create_pool.run(pool_mock.unstructure(), expiration=dt)
+        assert dt == res.will_expire
+
+    def test_create_pool_with_expiration_relative(self, toloka_client_mock, pool_mock):
+        with freeze_time(datetime(2022, 1, 1, tzinfo=pytz.UTC)):
+            res = create_pool.run(pool_mock.unstructure(), expiration=timedelta(days=31))
+        assert datetime(2022, 2, 1, tzinfo=pytz.UTC) == res.will_expire.replace(tzinfo=pytz.UTC)
+
+    def test_create_pool_with_reward(self, toloka_client_mock, pool_mock):
+        reward = 0.05
+        res = create_pool.run(pool_mock.unstructure(), reward_per_assignment=reward)
+        assert reward == res.reward_per_assignment
+        res.reward_per_assignment = None
+        assert pool_mock == res
+
+
+class TestCreateTasks:
+    def test_create_tasks(self, toloka_client_mock, tasks_mock, tasks_creation_result):
+        kwargs = {'allow_defaults': True, 'open_pool': True, 'skip_invalid_items': False}
+        assert tasks_creation_result == create_tasks.run(
+            [task.unstructure() for task in tasks_mock],
+            **kwargs
+        )
+        toloka_client_mock.create_tasks.assert_called()
+        call = toloka_client_mock.create_tasks.mock_calls[0]
+        assert (tasks_mock,) == call[1], call[1]
+        assert kwargs == call[2], call[2]
+
+    def test_create_tasks_with_pool(self, toloka_client_mock, tasks_mock, tasks_creation_result, pool_mock):
+        assert tasks_creation_result == create_tasks.run(
+            [task.unstructure() for task in tasks_mock],
+            pool_id=pool_mock,
+        )
+        call = toloka_client_mock.create_tasks.mock_calls[0]
+        assert all(task.pool_id == pool_mock.id for task in call[1][0])
+
+    def test_create_tasks_with_exam_pool(self, toloka_client_mock, tasks_mock, tasks_creation_result, training_mock):
+        assert tasks_creation_result == create_tasks.run(
+            [task.unstructure() for task in tasks_mock],
+            pool_id=training_mock,
+        )
+        call = toloka_client_mock.create_tasks.mock_calls[0]
+        assert all(task.pool_id == training_mock.id for task in call[1][0])
+
+
+class TestOpenPool:
+    def test_open_pool(self, toloka_client_mock, pool_mock):
+        assert pool_mock == open_pool.run(pool_mock)
+
+    def test_open_pool_by_id(self, toloka_client_mock, pool_mock):
+        assert pool_mock == open_pool.run(pool_mock.id)
+
+
+class TestOpenExamPool:
+    def test_open_exam_pool(self, toloka_client_mock, training_mock):
+        assert training_mock == open_exam_pool.run(training_mock)
+
+    def test_open_exam_pool_by_id(self, toloka_client_mock, training_mock):
+        assert training_mock == open_exam_pool.run(training_mock.id)
+
+
+class TestGetAssignments:
+    def test_get_assignments_by_pool_object(self, toloka_client_mock, pool_mock, assignments_mock):
+        assert assignments_mock == get_assignments.run(pool_mock)
+        assert pool_mock.id == toloka_client_mock.get_assignments.mock_calls[0][2]['pool_id']
+
+    def test_get_assignments_by_pool_id(self, toloka_client_mock, pool_mock, assignments_mock):
+        assert assignments_mock == get_assignments.run(pool_mock.id)
+
+    def test_get_assignments_with_status(self, toloka_client_mock, pool_mock, assignments_mock):
+        assert assignments_mock == get_assignments.run(pool_mock.id, ['ACCEPTED'])
+        assert ['ACCEPTED'] == toloka_client_mock.get_assignments.mock_calls[0][2]['status']
+
+
+class TestGetAssignmentsDf:
+    def test_get_assignments_df_by_pool_object(self, toloka_client_mock, pool_mock, assignments_df_mock):
+        assert assignments_df_mock.equals(get_assignments_df.run(pool_mock))
+        assert pool_mock.id == toloka_client_mock.get_assignments_df.mock_calls[0][2]['pool_id']
+        assert [] == toloka_client_mock.get_assignments_df.mock_calls[0][2]['status']
+        assert 'field' not in toloka_client_mock.get_assignments_df.mock_calls[0][2]
+
+    def test_get_assignments_df_by_pool_id(self, toloka_client_mock, pool_mock, assignments_df_mock):
+        assert assignments_df_mock.equals(get_assignments_df.run(pool_mock.id))
+
+    def test_get_assignments_df_with_status(self, toloka_client_mock, pool_mock, assignments_df_mock):
+        assert assignments_df_mock.equals(get_assignments_df.run(pool_mock.id, 'APPROVED'))
+        assert ['APPROVED'] == toloka_client_mock.get_assignments_df.mock_calls[0][2]['status']
+
+    def test_get_assignments_df_with_kwargs(self, toloka_client_mock, pool_mock, assignments_df_mock):
+        kwargs = {'status': ['APPROVED'],
+                  'start_time_from': datetime(2022, 1, 1),
+                  'start_time_to': datetime(2022, 2, 1),
+                  'exclude_banned': True,
+                  'field': GetAssignmentsTsvParameters.Field.ASSIGNMENT_ID}
+        assert assignments_df_mock.equals(get_assignments_df.run(pool_mock.id, **kwargs))
+        assert {'pool_id': pool_mock.id, **kwargs} == toloka_client_mock.get_assignments_df.mock_calls[0][2]

--- a/tests/tasks/toloka/test_utils.py
+++ b/tests/tasks/toloka/test_utils.py
@@ -1,0 +1,68 @@
+import inspect
+import pickle
+import pytest
+from prefect.tasks.toloka.utils import extract_id, structure_from_conf, with_logger
+from toloka.client import Pool
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def pool():
+    return Pool(id='some_pool_id',
+                project_id='some_project_id',
+                type=Pool.Type.TRAINING)
+
+
+class TestStructureFromConf:
+    def test_object_given(self, pool):
+        assert pool == structure_from_conf(pool, Pool)
+
+    def test_dict_given(self, pool):
+        assert pool == structure_from_conf(pool.unstructure(), Pool)
+
+    def test_json_given(self, pool):
+        assert pool == structure_from_conf(pool.to_json(), Pool)
+
+    def test_pickle_given(self, pool):
+        assert pool == structure_from_conf(pickle.dumps(pool), Pool)
+
+
+class TestExtractId:
+    def test_object_given(self, pool):
+        assert pool.id == extract_id(pool, Pool)
+
+    def test_dict_given(self, pool):
+        assert pool.id == extract_id(pool.unstructure(), Pool)
+
+    def test_json_given(self, pool):
+        assert pool.id == extract_id(pool.to_json(), Pool)
+
+    def test_id_given(self, pool):
+        assert pool.id == extract_id(pool.id, Pool)
+
+    def test_int_given(self):
+        assert '123' == extract_id('123', Pool)
+
+    def test_null_id_given(self, pool):
+        pool.id = None
+        with pytest.raises(ValueError, match='Got id=None'):
+            extract_id(pool, Pool)
+
+
+@patch('prefect.context')
+def test_with_logger(context_mock, pool):
+    logger_mock = Mock()
+    context_get_mock = Mock(return_value=logger_mock)
+    context_mock.get = context_get_mock
+
+    @with_logger
+    def some_func(arg, logger):
+        logger.info(arg)
+
+    func_params = inspect.signature(some_func).parameters
+    assert {'arg': inspect.Parameter('arg', inspect.Parameter.POSITIONAL_OR_KEYWORD)} == func_params
+
+    some_func('info-arg')
+
+    assert 1 == len(logger_mock.mock_calls), logger_mock.mock_calls
+    assert ('info-arg',) == logger_mock.mock_calls[0][1]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
This PR adds new `toloka` tasks to create crowdsourcing projects using Toloka.ai

## Importance
Human-in-the-loop processes may be quite sophisticated and are usually better implemented as DAGs. Prefect is very handy for orchestration of such projects. With this tasks users can operate with crowdsourcing via Toloka and Prefect.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)