### PR TITLE
fix: match DbtShellTask.run return type to ShellTask.run

### DIFF
--- a/src/prefect/tasks/dbt/dbt.py
+++ b/src/prefect/tasks/dbt/dbt.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, List, Optional, Union
 
 import yaml
 
@@ -114,7 +114,7 @@ class DbtShellTask(ShellTask):
         env: dict = None,
         helper_script: str = None,
         dbt_kwargs: dict = None,
-    ) -> str:
+    ) -> Optional[Union[str, List[str]]]:
         """
         If no profiles.yml file is found or if overwrite_profiles flag is set to True, this
         will first generate a profiles.yml file in the profiles_dir directory. Then run the dbt


### PR DESCRIPTION
When creating a DbtShellTask with `return_all=True` the return type of `run` is `List[str]` but this is not reflected in the return type.

This PR updates the return type to match the [return type of `run`](https://github.com/PrefectHQ/prefect/blob/de5bdcf/src/prefect/tasks/shell.py#L93) in the super class (ShellTask).

Signed-off-by: Oliver Mannion <125105+tekumara@users.noreply.github.com>
