### PR TITLE
Allow the repo to be null in serialized `Git` storage schema

### DIFF
--- a/src/prefect/serialization/storage.py
+++ b/src/prefect/serialization/storage.py
@@ -157,7 +157,7 @@ class GitSchema(BaseStorageSchema):
         object_class = Git
 
     flow_path = fields.String(allow_none=False)
-    repo = fields.String(allow_none=False)
+    repo = fields.String(allow_none=True)
     repo_host = fields.String(allow_none=False)
     flow_name = fields.String(allow_none=True)
     git_token_secret_name = fields.String(allow_none=True)


### PR DESCRIPTION
Follow-up to https://github.com/PrefectHQ/prefect/pull/5033 updating the marshmallow `GitSchema` schema to match the changes to the `Git` storage object.

Closes #4882 

