### PR TITLE
Airbyte does not return a 'schedule' key anymore for 'no schedule'

### DIFF
--- a/src/prefect/tasks/airbyte/airbyte.py
+++ b/src/prefect/tasks/airbyte/airbyte.py
@@ -178,7 +178,7 @@ class AirbyteConnectionTask(Task):
             response.raise_for_status()
 
             # check whether a schedule exists ...
-            schedule = response.json()["schedule"]
+            schedule = response.json().get("schedule")
             if schedule:
                 self.logger.warning("Found existing Connection schedule, removing ...")
 


### PR DESCRIPTION
As Airbyte does not always return a "schedule" key, this PR implements a soft-fail when the key is not present. As you can see, the fix is pretty simple.

This fixes the following stacktrace I've been having:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prefect/engine/task_runner.py", line 880, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/usr/local/lib/python3.8/site-packages/prefect/utilities/executors.py", line 468, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/usr/local/lib/python3.8/site-packages/prefect/utilities/tasks.py", line 456, in method
    return run_method(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/prefect/tasks/airbyte/airbyte.py", line 340, in run
    connection_status = self._get_connection_status(
  File "/usr/local/lib/python3.8/site-packages/prefect/tasks/airbyte/airbyte.py", line 181, in _get_connection_status
    schedule = response.json()["schedule"]
KeyError: 'schedule'
```