### PR TITLE
S3Result upload options

### DIFF
--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -25,6 +25,7 @@ class S3Result(Result):
         - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client
             session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
             is initialized.
+        - upload_options (dict, optional): additional options for s3 client upload_fileobj() 'ExtraArgs' argument.
         - **kwargs (Any, optional): any additional `Result` initialization options
     """
 
@@ -85,7 +86,7 @@ class S3Result(Result):
                 stream,
                 Bucket=self.bucket,
                 Key=new.location,
-                ExtraArgs=self.upload_options
+                ExtraArgs=self.upload_options,
             )
         except ClientError as err:
             self.logger.error("Error uploading to S3: {}".format(err))

--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -29,10 +29,15 @@ class S3Result(Result):
     """
 
     def __init__(
-        self, bucket: str, boto3_kwargs: Dict[str, Any] = None, **kwargs: Any
+        self,
+        bucket: str,
+        boto3_kwargs: Dict[str, Any] = None,
+        upload_options: Dict[str, Any] = None,
+        **kwargs: Any,
     ) -> None:
         self.bucket = bucket
         self.boto3_kwargs = boto3_kwargs or {}
+        self.upload_options = upload_options or {}
         super().__init__(**kwargs)
 
     @property
@@ -76,7 +81,12 @@ class S3Result(Result):
         from botocore.exceptions import ClientError
 
         try:
-            self.client.upload_fileobj(stream, Bucket=self.bucket, Key=new.location)
+            self.client.upload_fileobj(
+                stream,
+                Bucket=self.bucket,
+                Key=new.location,
+                ExtraArgs=self.upload_options
+            )
         except ClientError as err:
             self.logger.error("Error uploading to S3: {}".format(err))
             raise err

--- a/tests/engine/results/test_s3_result.py
+++ b/tests/engine/results/test_s3_result.py
@@ -67,6 +67,22 @@ class TestS3Result:
         assert used_uri == new_result.location
         assert new_result.location.startswith("yes!/here.txt")
 
+    def test_s3_writes_with_upload_options(self, mock_boto3):
+        upload_options = {"ServerSideEncryption": "aws:kms"}
+
+        result = S3Result(
+            bucket="foo",
+            location="{thing}/here.txt",
+            upload_options=upload_options,
+        )
+
+        with prefect.context(thing="yes!"):
+            result.write("so-much-data", **prefect.context)
+
+        extra_args = mock_boto3.client.return_value.upload_fileobj.call_args[1]["ExtraArgs"]
+
+        assert extra_args == upload_options
+
     def test_s3_result_is_pickleable(self, mock_boto3):
         class NoPickle:
             def __getstate__(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Support  `ExtraArgs` when uploading results to S3




## Changes
Adds an `upload_options` parameter to the `S3Result` class to which gets passed to `ExtraArgs` in the boto3 upload_fileobj method




## Importance
Allow uploading of results to KMS encrypted S3 buckets




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)