### PR TITLE
Add single_user_name to Databricks NewCluster

### DIFF
--- a/changes/pr5903.yaml
+++ b/changes/pr5903.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Add single_user_name to Databricks NewCluster - [#5903](https://github.com/PrefectHQ/prefect/pull/5903)"
+
+contributor:
+  - "[Cat Zhang](https://github.com/juscat)"

--- a/src/prefect/tasks/databricks/models.py
+++ b/src/prefect/tasks/databricks/models.py
@@ -84,6 +84,7 @@ class NewCluster(BaseModel):
     instance_pool_id: Optional[str] = None
     policy_id: Optional[str] = None
     data_security_mode: Optional[str] = None
+    single_user_name: Optional[str] = None
 
 
 class NotebookTask(BaseModel):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Related to data_security_mode (added https://github.com/PrefectHQ/prefect/pull/5778), single_user_name is an arg supported in newer versions of the Cluster API https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/resources/cluster.


## Changes
<!-- What does this PR change? -->
Adds an optional key to Databricks NewCluster.



## Importance
When creating Databricks cluster with security_mode=SINGLE_USER, the single_user_name must be supplied.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)