### PR TITLE
add boto_kwargs to S3List

### DIFF
--- a/changes/issue5907.yaml
+++ b/changes/issue5907.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "add boto_kwargs to S3List - [#5907](https://github.com/PrefectHQ/prefect/pull/5907)"
+
+contributor:
+  - "[Nico Neumann](https://github.com/neumann-nico)"

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -184,12 +184,19 @@ class S3List(Task):
 
     Args:
         - bucket (str, optional): the name of the S3 Bucket to list the files of.
+        - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, bucket: str = None, **kwargs):
+    def __init__(self, bucket: str = None, boto_kwargs: dict = None, **kwargs):
         self.bucket = bucket
+
+        if boto_kwargs is None:
+            self.boto_kwargs = {}
+        else:
+            self.boto_kwargs = boto_kwargs
+
         super().__init__(**kwargs)
 
     @defaults_from_attrs("bucket")
@@ -231,7 +238,7 @@ class S3List(Task):
         if bucket is None:
             raise ValueError("A bucket name must be provided.")
 
-        s3_client = get_boto_client("s3", credentials=credentials)
+        s3_client = get_boto_client("s3", credentials=credentials, **self.boto_kwargs)
 
         config = {"PageSize": page_size, "MaxItems": max_items}
         paginator = s3_client.get_paginator("list_objects_v2")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Currently only `S3Upload` and `S3Download` support the `boto_kwargs` parameter. This PR adds support for `S3List`.


## Changes
<!-- What does this PR change? -->
Allows to provide boto keyword arguments to the initializer of `S3List`. 

## Importance
<!-- Why is this PR important? -->
The `boto_kwargs` parameter should be provided for all S3 classes to allow e.g. changing of the `endpoint_url`.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)