### PR TITLE
Allow extra arguments to Databricks NewCluster

### DIFF
--- a/changes/pr5948.yaml
+++ b/changes/pr5948.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow extra arguments to Databricks NewCluster - [#5948](https://github.com/PrefectHQ/prefect/pull/5948)"
+
+contributor:
+  - "[EmilRex](https://github.com/EmilRex)"

--- a/changes/pr5948.yaml
+++ b/changes/pr5948.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Allow extra arguments to Databricks NewCluster - [#5948](https://github.com/PrefectHQ/prefect/pull/5948)"
-
-contributor:
-  - "[EmilRex](https://github.com/EmilRex)"

--- a/changes/pr5949.yaml
+++ b/changes/pr5949.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Allow extra arguments to Databricks NewCluster - [#5949](https://github.com/PrefectHQ/prefect/pull/5949)"
+
+contributor:
+  - "[EmilRex](https://github.com/EmilRex)"

--- a/src/prefect/tasks/databricks/models.py
+++ b/src/prefect/tasks/databricks/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Extra, Field
 
 
 class TaskDependency(BaseModel):
@@ -66,7 +66,7 @@ class InitScriptInfo(BaseModel):
     S3: Optional[S3StorageInfo] = None
 
 
-class NewCluster(BaseModel):
+class NewCluster(BaseModel, extra=Extra.allow):
     spark_version: str
     node_type_id: str
     spark_conf: Dict = Field(default_factory=dict)

--- a/tests/tasks/databricks/test_databricks.py
+++ b/tests/tasks/databricks/test_databricks.py
@@ -672,3 +672,56 @@ class TestDatabricksSubmitMultitaskRun:
             )
             == expected_result
         )
+
+    def test_convert_dict_to_input_allow_extra(self):
+        expected_result = {
+            "tasks": [
+                JobTaskSettings(
+                    task_key="Match",
+                    description="Matches orders with user sessions",
+                    new_cluster=NewCluster(
+                        spark_version="7.3.x-scala2.12",
+                        node_type_id="i3.xlarge",
+                        spark_conf={"spark.speculation": True},
+                        aws_attributes=AwsAttributes(
+                            availability=AwsAvailability.SPOT, zone_id="us-west-2a"
+                        ),
+                        autoscale=AutoScale(min_workers=2, max_workers=16),
+                        amazing_new_feature=True,
+                    ),
+                    unsupported_argument="ignore_me",
+                    another_unsupported_argument="ignore_me",
+                ),
+            ],
+            "run_name": "A multitask job run",
+            "timeout_seconds": 86400,
+            "idempotency_token": "8f018174-4792-40d5-bcbc-3e6a527352c8",
+        }
+
+        assert (
+            DatabricksSubmitMultitaskRun.convert_dict_to_kwargs(
+                {
+                    "tasks": [
+                        {
+                            "task_key": "Match",
+                            "description": "Matches orders with user sessions",
+                            "new_cluster": {
+                                "spark_version": "7.3.x-scala2.12",
+                                "node_type_id": "i3.xlarge",
+                                "spark_conf": {"spark.speculation": True},
+                                "aws_attributes": {
+                                    "availability": "SPOT",
+                                    "zone_id": "us-west-2a",
+                                },
+                                "autoscale": {"min_workers": 2, "max_workers": 16},
+                                "amazing_new_feature": True
+                            },
+                        },
+                    ],
+                    "run_name": "A multitask job run",
+                    "timeout_seconds": 86400,
+                    "idempotency_token": "8f018174-4792-40d5-bcbc-3e6a527352c8",
+                }
+            )
+            == expected_result
+        )

--- a/tests/tasks/databricks/test_databricks.py
+++ b/tests/tasks/databricks/test_databricks.py
@@ -714,7 +714,7 @@ class TestDatabricksSubmitMultitaskRun:
                                     "zone_id": "us-west-2a",
                                 },
                                 "autoscale": {"min_workers": 2, "max_workers": 16},
-                                "amazing_new_feature": True
+                                "amazing_new_feature": True,
                             },
                         },
                     ],


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
Allows for extra arguments to the `NewCluster` model in the Databricks task library.

Fourth time's the charm! Replaces #5930, #5943, and #5948.



## Changes
<!-- What does this PR change? -->
The PR allows extra arguments in `NewCluster` to pass through pydantic validation. Notably, only the `NewCluster` model is affected and only entirely new fields are allowed. The change does not apply to any parent or child models.



## Importance
<!-- Why is this PR important? -->
This change will allow users to supply newly introduced Databricks cluster arguments without needing to wait for a Prefect release that includes them. The change was suggested by @desertaxle in #5903.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)