### PR TITLE
Avoid croniter infinite loop

### DIFF
--- a/changes/PR5957.yaml
+++ b/changes/PR5957.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - task
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fix bug with infinite loop when parsing DST cron schedules - [#5957](https://github.com/PrefectHQ/prefect/pull/5957)"
+

--- a/src/prefect/schedules/clocks.py
+++ b/src/prefect/schedules/clocks.py
@@ -331,7 +331,7 @@ class CronClock(Clock):
                 # that starts after this date. This brute force avoids
                 # croniter issues like the Santiago DST boundary
                 if stuck_count == 3:
-                    cron = croniter(self.cron, next_date, day_or=self.day_or)
+                    cron = croniter(self.cron, next_date, day_or=self.day_or)  # type: ignore
                     next_date = pendulum.instance(cron.get_next(datetime))
                     break
 

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -652,7 +652,7 @@ class TestCronClockDaylightSavingsTime:
         if serialize:
             c = ClockSchema().load(ClockSchema().dump(c))
         next_4 = islice(c.events(after=dt), 4)
-        # constant 9am start
+        # no infinite loop on the 4th
         assert [t.start_time.in_tz("America/Santiago").day for t in next_4] == [
             28,
             4,

--- a/tests/schedules/test_clocks.py
+++ b/tests/schedules/test_clocks.py
@@ -640,6 +640,26 @@ class TestCronClockDaylightSavingsTime:
         ]
         assert [t.start_time.in_tz("UTC").hour for t in next_4] == [13, 13, 14, 14]
 
+    @pytest.mark.parametrize("serialize", [True, False])
+    def test_cron_clock_santiago(self, serialize):
+        """
+        On 9/4/2022, at 12am, America/Santiago switches clocks back an hour.
+
+        Croniter gets stuck in an infinite loop at midnight
+        """
+        dt = pendulum.datetime(2022, 8, 21, 10, tz="America/Santiago")
+        c = clocks.CronClock("0 0 * * 0", dt)
+        if serialize:
+            c = ClockSchema().load(ClockSchema().dump(c))
+        next_4 = islice(c.events(after=dt), 4)
+        # constant 9am start
+        assert [t.start_time.in_tz("America/Santiago").day for t in next_4] == [
+            28,
+            4,
+            11,
+            18,
+        ]
+
 
 class TestDatesClock:
     def test_create_dates_clock_one_date(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
We thought we had identified all the weird DST issues with croniter, but a user recently stumbled across a new one. A simplified demo:

```python
import pendulum
from croniter import croniter
from datetime import datetime

cron = croniter('0 0 * * 0', pendulum.datetime(2022, 8, 21, tz='America/Santiago'))
for i in range(10):
    print(cron.next(datetime))
```
Which results in
```
2022-08-28 00:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
2022-09-03 23:00:00-04:00
```

To avoid this (and others potentially lurking), this adds a check to see if we're stuck in a date loop when evaluating cron. If so, we exit the loop by creating a new cron instance that begins yielding immediately AFTER the date question. 

## Changes
<!-- What does this PR change? -->
Fixes a bug where certain DST conditions put schedules into an infinite loop



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)