### PR TITLE
Fix pickle errors when using mismatched versions of Prefect and S3Result

### DIFF
--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -55,6 +55,9 @@ class S3Result(Result):
         return state
 
     def __setstate__(self, state: dict) -> None:
+        # Ensure pickles are backwards compatible
+        state.setdefault("boto3_kwargs", {})
+        state.setdefault("upload_options", {})
         self.__dict__.update(state)
 
     def write(self, value_: Any, **kwargs: Any) -> Result:


### PR DESCRIPTION
When pickling an `S3Result` with an old version of Prefect and unpickling with a new version, the new attribute will be missing.

See https://prefect-community.slack.com/archives/CL09KU1K7/p1657211370977639