### PR TITLE
Fix empty return in S3List task

### DIFF
--- a/changes/pr6028.yaml
+++ b/changes/pr6028.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix empty file returning in s3list task - [#6028](https://github.com/PrefectHQ/prefect/pull/6028)"
+
+contributor:
+  - "[Dennis Hinnenkamp](https://github.com/mcfuhrt)"

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -270,6 +270,7 @@ class S3List(Task):
 
         files = []
         for page in filtered_results if filtered_results else results:
-            files.extend(obj["Key"] for obj in page.get("Contents", []))
+            if not page.get("Contents", []) is None:
+                files.extend(obj["Key"] for obj in page.get("Contents", []))
 
         return files


### PR DESCRIPTION
## Summary
If the S3List task does not return any files, the task automatically fails. Here it would be useful if instead an empty list is returned




## Changes
Check if files are return before adding them to the function return value




## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)