### PR TITLE
Head off possible `PendingRollbackError`s from the `scheduler` and `flow-run-notifications` `LoopService`s.

### DIFF
--- a/src/prefect/orion/services/flow_run_notifications.py
+++ b/src/prefect/orion/services/flow_run_notifications.py
@@ -69,7 +69,6 @@ class FlowRunNotifications(LoopService):
         self,
         session: sa.orm.session,
         db: OrionDBInterface,
-        # notification: OrionDBInterface.Notification,
         notification,
     ):
         try:

--- a/src/prefect/orion/services/flow_run_notifications.py
+++ b/src/prefect/orion/services/flow_run_notifications.py
@@ -2,7 +2,6 @@
 A service that checks for flow run notifications and sends them.
 """
 import asyncio
-from typing import List
 
 import sqlalchemy as sa
 
@@ -21,8 +20,6 @@ class FlowRunNotifications(LoopService):
     actually sends the notification.
     """
 
-    batch_size: int = 10
-
     # check queue every 4 seconds
     # note: a tight loop is executed until the queue is exhausted
     loop_seconds: int = 4
@@ -34,9 +31,14 @@ class FlowRunNotifications(LoopService):
         async with session:
             async with session.begin():
                 while True:
+                    # Drain the queue one entry at a time, because if a database error
+                    # happens while sending a notification, we'll need to rollback the
+                    # transaction, which effectively re-queues any notifications that
+                    # we pulled here.  If we drain in batches larger than 1, we risk
+                    # double-sending notifications when a transient error occurs.
                     notifications = await db.get_flow_run_notifications_from_queue(
                         session=session,
-                        limit=self.batch_size,
+                        limit=1,
                     )
                     self.logger.debug(
                         f"Got {len(notifications)} notifications from queue."
@@ -46,59 +48,75 @@ class FlowRunNotifications(LoopService):
                     if not notifications:
                         break
 
-                    await self.send_flow_run_notifications(
-                        session=session, db=db, notifications=notifications
-                    )
+                    try:
+                        await self.send_flow_run_notification(
+                            session=session, db=db, notification=notifications[0]
+                        )
+                    finally:
+                        connection = await session.connection()
+                        if connection.invalidated:
+                            # If the connection was invalidated due to an error that
+                            # we handled in _send_flow_run_notification, we'll need to
+                            # rollback the session before we can proceed with more
+                            # iterations of the loop.  This may happen due to transient
+                            # database connection errors, but will _not_ happen due to
+                            # an calling a third-party service to send a notification.
+                            await session.rollback()
+                            assert not connection.invalidated
 
     @inject_db
-    async def send_flow_run_notifications(
-        self, session: sa.orm.session, db: OrionDBInterface, notifications: List
+    async def send_flow_run_notification(
+        self,
+        session: sa.orm.session,
+        db: OrionDBInterface,
+        # notification: OrionDBInterface.Notification,
+        notification,
     ):
-        for notification in notifications:
-            try:
-                orm_block_document = await session.get(
-                    db.BlockDocument, notification.block_document_id
-                )
-                if orm_block_document is None:
-                    self.logger.error(
-                        f"Missing block document {notification.block_document_id} "
-                        f"from policy {notification.flow_run_notification_policy_id}"
-                    )
-                    continue
-                block = Block._from_block_document(
-                    await schemas.core.BlockDocument.from_orm_model(
-                        session=session,
-                        orm_block_document=orm_block_document,
-                        include_secrets=True,
-                    )
-                )
-
-                message_template = (
-                    notification.flow_run_notification_policy_message_template
-                    or models.flow_run_notification_policies.DEFAULT_MESSAGE_TEMPLATE
-                )
-                message = message_template.format(
-                    **{
-                        k: notification[k]
-                        for k in schemas.core.FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS
-                    }
-                )
-                await block.notify(
-                    subject="Prefect flow run notification",
-                    body=message,
-                )
-
-                self.logger.debug(
-                    f"Successfully sent notification for flow run {notification.flow_run_id} "
+        try:
+            orm_block_document = await session.get(
+                db.BlockDocument, notification.block_document_id
+            )
+            if orm_block_document is None:
+                self.logger.error(
+                    f"Missing block document {notification.block_document_id} "
                     f"from policy {notification.flow_run_notification_policy_id}"
                 )
+                return
 
-            except Exception:
-                self.logger.error(
-                    f"Error sending notification for policy {notification.flow_run_notification_policy_id} "
-                    f"on flow run {notification.flow_run_id}",
-                    exc_info=True,
+            block = Block._from_block_document(
+                await schemas.core.BlockDocument.from_orm_model(
+                    session=session,
+                    orm_block_document=orm_block_document,
+                    include_secrets=True,
                 )
+            )
+
+            message_template = (
+                notification.flow_run_notification_policy_message_template
+                or models.flow_run_notification_policies.DEFAULT_MESSAGE_TEMPLATE
+            )
+            message = message_template.format(
+                **{
+                    k: notification[k]
+                    for k in schemas.core.FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS
+                }
+            )
+            await block.notify(
+                subject="Prefect flow run notification",
+                body=message,
+            )
+
+            self.logger.debug(
+                f"Successfully sent notification for flow run {notification.flow_run_id} "
+                f"from policy {notification.flow_run_notification_policy_id}"
+            )
+
+        except Exception:
+            self.logger.error(
+                f"Error sending notification for policy {notification.flow_run_notification_policy_id} "
+                f"on flow run {notification.flow_run_id}",
+                exc_info=True,
+            )
 
 
 if __name__ == "__main__":

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -23,6 +23,10 @@ from prefect.settings import (
 from prefect.utilities.collections import batched_iterable
 
 
+class TryAgain(Exception):
+    """Internal control-flow exception used to retry the Scheduler's main loop"""
+
+
 class Scheduler(LoopService):
     """
     A loop service that schedules flow runs from deployments.
@@ -61,7 +65,8 @@ class Scheduler(LoopService):
         - Generating the next set of flow runs based on each deployments schedule
         - Inserting all scheduled flow runs into the database
 
-        All inserted flow runs are committed to the database at the termination of the loop.
+        All inserted flow runs are committed to the database at the termination of the
+        loop.
         """
         now = pendulum.now("UTC")
         total_inserted_runs = 0
@@ -81,24 +86,12 @@ class Scheduler(LoopService):
                     deployment_ids = result.scalars().unique().all()
 
                     # collect runs across all deployments
-                    runs_to_insert = []
-                    for deployment_id in deployment_ids:
-                        # guard against erroneously configured schedules
-                        try:
-                            runs_to_insert.extend(
-                                await self._generate_scheduled_flow_runs(
-                                    session=session,
-                                    deployment_id=deployment_id,
-                                    start_time=now,
-                                    end_time=now + self.max_scheduled_time,
-                                    max_runs=self.max_runs,
-                                )
-                            )
-                        except Exception as exc:
-                            self.logger.error(
-                                f"Error scheduling deployment {deployment_id!r}.",
-                                exc_info=True,
-                            )
+                    try:
+                        runs_to_insert = await self._collect_flow_runs(
+                            session=session, deployment_ids=deployment_ids, now=now
+                        )
+                    except TryAgain:
+                        continue
 
                     # bulk insert the runs based on batch size setting
                     for batch in batched_iterable(
@@ -109,7 +102,7 @@ class Scheduler(LoopService):
                         )
                         total_inserted_runs += len(inserted_runs)
 
-                # if no deployments were found, exit the loop
+                # if this is the last page of deployments, exit the loop
                 if len(deployment_ids) < self.deployment_batch_size:
                     break
                 else:
@@ -134,6 +127,40 @@ class Scheduler(LoopService):
         )
         return query
 
+    async def _collect_flow_runs(
+        self,
+        session: sa.orm.Session,
+        deployment_ids: List[UUID],
+        now: pendulum.DateTime,
+    ) -> List[Dict]:
+        runs_to_insert = []
+        for deployment_id in deployment_ids:
+            # guard against erroneously configured schedules
+            try:
+                runs_to_insert.extend(
+                    await self._generate_scheduled_flow_runs(
+                        session=session,
+                        deployment_id=deployment_id,
+                        start_time=now,
+                        end_time=now + self.max_scheduled_time,
+                        max_runs=self.max_runs,
+                    )
+                )
+            except Exception:
+                self.logger.exception(
+                    f"Error scheduling deployment {deployment_id!r}.",
+                )
+            finally:
+                connection = await session.connection()
+                if connection.invalidated:
+                    # If the error we handled above was a database error that caused the
+                    # transaction to rollback and become invalidated, rollback this
+                    # session, break from this loop iteration, and have the main loop
+                    # in run_once start over
+                    await session.rollback()
+                    raise TryAgain()
+        return runs_to_insert
+
     @inject_db
     async def _generate_scheduled_flow_runs(
         self,
@@ -145,8 +172,8 @@ class Scheduler(LoopService):
         db: OrionDBInterface,
     ) -> List[Dict]:
         """
-        Given a `deployment_id` and schedule params, generates a list of flow run objects and
-        associated scheduled states that represent scheduled flow runs.
+        Given a `deployment_id` and schedule params, generates a list of flow run
+        objects and associated scheduled states that represent scheduled flow runs.
 
         Pass-through method for overrides.
         """
@@ -166,9 +193,9 @@ class Scheduler(LoopService):
         db: OrionDBInterface,
     ) -> List[UUID]:
         """
-        Given a list of flow runs to schedule, as generated by `_generate_scheduled_flow_runs`,
-        inserts them into the database. Note this is a separate method to facilitate batch
-        operations on many scheduled runs.
+        Given a list of flow runs to schedule, as generated by
+        `_generate_scheduled_flow_runs`, inserts them into the database. Note this is a
+        separate method to facilitate batch operations on many scheduled runs.
 
         Pass-through method for overrides.
         """

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -68,7 +68,6 @@ class Scheduler(LoopService):
         All inserted flow runs are committed to the database at the termination of the
         loop.
         """
-        now = pendulum.now("UTC")
         total_inserted_runs = 0
 
         session = await db.session()
@@ -88,7 +87,7 @@ class Scheduler(LoopService):
                     # collect runs across all deployments
                     try:
                         runs_to_insert = await self._collect_flow_runs(
-                            session=session, deployment_ids=deployment_ids, now=now
+                            session=session, deployment_ids=deployment_ids
                         )
                     except TryAgain:
                         continue
@@ -131,10 +130,10 @@ class Scheduler(LoopService):
         self,
         session: sa.orm.Session,
         deployment_ids: List[UUID],
-        now: pendulum.DateTime,
     ) -> List[Dict]:
         runs_to_insert = []
         for deployment_id in deployment_ids:
+            now = pendulum.now("UTC")
             # guard against erroneously configured schedules
             try:
                 runs_to_insert.extend(


### PR DESCRIPTION
The comments in the code tell the story in detail, but because this loop-service
handles Exceptions internally, it may sometimes handle transient DB errors that
require a rollback before proceeding with more work.

Part of PrefectHQ/nebula#1220