### PR TITLE
Coerce any floating point extrema (`NaN`, `-Infinity`, `Infinity`) in JSON objects to `None` for the DB

### DIFF
--- a/src/prefect/orion/utilities/database.py
+++ b/src/prefect/orion/utilities/database.py
@@ -54,15 +54,15 @@ def _generate_uuid_sqlite(element, compiler, **kwargs):
 
     return """
     (
-        lower(hex(randomblob(4))) 
-        || '-' 
-        || lower(hex(randomblob(2))) 
-        || '-4' 
-        || substr(lower(hex(randomblob(2))),2) 
-        || '-' 
-        || substr('89ab',abs(random()) % 4 + 1, 1) 
-        || substr(lower(hex(randomblob(2))),2) 
-        || '-' 
+        lower(hex(randomblob(4)))
+        || '-'
+        || lower(hex(randomblob(2)))
+        || '-4'
+        || substr(lower(hex(randomblob(2))),2)
+        || '-'
+        || substr('89ab',abs(random()) % 4 + 1, 1)
+        || substr(lower(hex(randomblob(2))),2)
+        || '-'
         || lower(hex(randomblob(6)))
     )
     """
@@ -179,6 +179,24 @@ class JSON(TypeDecorator):
             return dialect.type_descriptor(sqlite.JSON(none_as_null=True))
         else:
             return dialect.type_descriptor(sa.JSON(none_as_null=True))
+
+    def process_bind_param(self, value, dialect):
+        """Prepares the given value to be used as a JSON field in a parameter binding"""
+        if not value:
+            return value
+
+        # PostgreSQL does not support the floating point extrema values `NaN`,
+        # `-Infinity`, or `Infinity`
+        # https://www.postgresql.org/docs/current/datatype-json.html#JSON-TYPE-MAPPING-TABLE
+        #
+        # SQLite supports storing and retrieving full JSON values that include
+        # `NaN`, `-Infinity`, or `Infinity`, but any query that requires SQLite to parse
+        # the value (like `json_extract`) will fail.
+        #
+        # Replace any `NaN`, `-Infinity`, or `Infinity` values with `None` in the
+        # returned value.  See more about `parse_constant` at
+        # https://docs.python.org/3/library/json.html#json.load.
+        return json.loads(json.dumps(value), parse_constant=lambda c: None)
 
 
 class Pydantic(TypeDecorator):


### PR DESCRIPTION
PostgreSQL [explicitly does not support these values](https://www.postgresql.org/docs/current/datatype-json.html#JSON-TYPE-MAPPING-TABLE), and while SQLite supports saving and reading full JSON documents containing these values, any attempt to parse them in SQLite (like to use them with JSON operators) will fail.

This change follows the Javascript convention, which is to coerce these values to `null`, which should have good standards compatibility with the frontend and other non-Python clients.  The JSON spec does not comment on what to do with these values, but [MDN says they are prohibited](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON#numbers).

This was observed in our Prefect Cloud 2.0 environment: https://github.com/PrefectHQ/nebula/issues/1157 as errors like:

```
<class 'asyncpg.exceptions.InvalidTextRepresentationError'>: invalid input syntax for type json
[DETAIL] Token "NaN" is invalid
```