### PR TITLE
Add hyperlink on air traffic control in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ tags:
 
 ## Prefect coordinates dataflows
 
-Prefect is air traffic control for your data stack. Monitor, coordinate, and orchestrate dataflows between and across your applications. Build pipelines, deploy them anywhere, and configure them remotely. You might just love your workflows again.
+Prefect is [air traffic control for the modern data stack](https://www.prefect.io/guide/blog/the-global-coordination-plane#ATCfortheMDS). Monitor, coordinate, and orchestrate dataflows between and across your applications. Build pipelines, deploy them anywhere, and configure them remotely. You might just love your workflows again.
 
 ## Why Prefect?
 


### PR DESCRIPTION
To expand on why Prefect is air traffic control for the modern data stack