### PR TITLE
Set `format` of JsonPatch schema to `rfc6902`

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -67,11 +67,11 @@ class KubernetesJob(Infrastructure):
     # shortcuts for the most common user-serviceable settings
     image: str = Field(default_factory=get_prefect_image_name)
     namespace: str = "default"
-    service_account_name: str = None
+    service_account_name: Optional[str] = None
     image_pull_policy: Optional[KubernetesImagePullPolicy] = None
 
     # connection to a cluster
-    cluster_config: KubernetesClusterConfig = None
+    cluster_config: Optional[KubernetesClusterConfig] = None
 
     # settings allowing full customization of the Job
     job: KubernetesManifest = Field(

--- a/src/prefect/utilities/pydantic.py
+++ b/src/prefect/utilities/pydantic.py
@@ -229,4 +229,13 @@ class PartialModel(Generic[M]):
 class JsonPatch(JsonPatchBase):
     @classmethod
     def __modify_schema__(cls, field_schema):
-        field_schema.update(type="string", format="json-string")
+        field_schema.update(
+            {
+                "type": "array",
+                "format": "rfc6902",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+            }
+        )

--- a/tests/utilities/test_pydantic.py
+++ b/tests/utilities/test_pydantic.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 
 from prefect.utilities.dispatch import register_type
 from prefect.utilities.pydantic import (
+    JsonPatch,
     PartialModel,
     add_cloudpickle_reduction,
     add_type_dispatch,
@@ -299,3 +300,24 @@ class TestTypeDispatchField:
             @add_type_dispatch
             class Base(pydantic.BaseModel):
                 type: int
+
+
+class TestJsonPatch:
+    class PatchModel(pydantic.BaseModel):
+        class Config:
+            arbitrary_types_allowed = True
+
+        patch: JsonPatch = pydantic.Field(default_factory=lambda: JsonPatch([]))
+
+    def test_json_schema(self):
+        schema = TestJsonPatch.PatchModel().schema()
+
+        assert schema["properties"]["patch"] == {
+            "title": "Patch",
+            "type": "array",
+            "format": "rfc6902",
+            "items": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+        }


### PR DESCRIPTION
In issue #6079 we found that the `customizations` OpenAPI schema was being output as `string` and this caused the UI to display the field as a simple text input.

This PR changes the schema to be an `array` with `object` children. This makes sense because JSON Patch is an array of JSON objects. This also sets the `format` to `rfc6902` so that further validation can be performed per the RFC spec. The schema for JSON Patch is now:

```
"customizations": {
    "title": "Customizations",
    "type": "array",
    "format": "rfc6902",
    "items": {
        "type": "object",
        "additionalProperties": {
            "type": "string"
        }
    }
}
```