### PR TITLE
Preserve schedules set via the API in building deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ site/
 
 # UI artifacts
 src/prefect/orion/ui/*
-orion-ui/node_modules
+**/node_modules
 
 # Databases
 *.db

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -511,10 +511,12 @@ async def build(
             infrastructure = Process()
 
     description = getdoc(flow)
+    schedule = None
     async with get_client() as client:
         try:
             deployment = await client.read_deployment_by_name(f"{flow.name}/{name}")
             description = deployment.description
+            schedule = deployment.schedule
         except ObjectNotFound:
             pass
 
@@ -523,6 +525,7 @@ async def build(
         description=description,
         tags=tags or [],
         flow_name=flow.name,
+        schedule=schedule,
         parameter_openapi_schema=manifest.parameter_openapi_schema,
         manifest_path=manifest_loc,
         storage=storage,

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -379,8 +379,8 @@ class DeploymentYAML(BaseModel):
             "name",
             "description",
             "tags",
-            "schedule",
             "parameters",
+            "schedule",
             "infrastructure",
         ]
         return editable_fields


### PR DESCRIPTION
This PR ensures that schedules set via API / UI on a deployment are preserved when building deployments from the CLI.  This behavior mirrors the current behavior with deployment `description`.