### PR TITLE
bump readchar to >=3.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pydantic >= 1.8.2
 python-slugify >= 5.0
 pytz >= 2021.1
 pyyaml >= 5.4.1
-readchar >= 3.0.5
+readchar >= 3.0.6
 rich >= 11.0
 slack-sdk>=3.15.1
 sqlalchemy[asyncio] >= 1.4.20, != 1.4.33


### PR DESCRIPTION
readchar released a new version, that finally fixes support for arrow-keys on windows. As this featrue is usefull to this project I recomend requiring that version.