### PR TITLE
Add PR, Issue, and New Feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -28,7 +28,7 @@ Your bug report should include the following features:
 
 1. a **succinct description of the problem** - typically a line or two at most
 
-2. **succinct, dependency-free code which reproduces the problem**, otherwise known as a [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example.
+2. **succinct code example which reproduces the problem**, otherwise known as a [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example.
 
 3. **complete stack traces for all errors - please avoid screenshots, use formatted text inside issues**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: "
 
-**FOR ALL USERS - PLEASE READ THIS PARAGRAPH AS IT HELPS US TO DO OUR WORK MORE EFFICIENTLY:**
+**PLEASE READ THIS PARAGRAPH - this helps us identify the root cause and fix the issue:**
 
 The **VAST MAJORITY** of bugs reported are in fact
 **USAGE QUESTIONS, NOT BUGS** for APIs that can take some practice to familiarize with,

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -55,7 +55,7 @@ Provide your [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/
     attributes:
       label: Error
       description: "
-Provide the complete text of any errors received **including the complete stack trace**.
+Provide the full exception tracebacks.
 If the message is a warning, run your program with the ``-Werror`` flag:   ``python -Werror myprogram.py``
 "
       placeholder: "# Copy complete stack trace and error message here, including SQL log output if applicable."

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -12,7 +12,7 @@ body:
 **PLEASE READ THIS PARAGRAPH - this helps us identify the root cause and fix the issue:**
 
 Many bug reports are often
-**USAGE QUESTIONS, NOT BUGS** for APIs that can take some practice to familiarize with,
+**USAGE QUESTIONS, NOT BUGS** - for those, please report your question via our [Community Slack](https://www.prefect.io/slack/) or [Discourse](https://discourse.prefect.io/). We'll then investigate the issue and open a bug report when necessary.
 and which are also tailored towards high quality relational designs that
 beginners are sometimes less familiar with.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -14,7 +14,6 @@ body:
 Many bug reports are often
 **USAGE QUESTIONS, NOT BUGS** - for those, please report your question via our [Community Slack](https://www.prefect.io/slack/) or [Discourse](https://discourse.prefect.io/). We'll then investigate the issue and open a bug report when necessary.
 and which are also tailored towards high quality relational designs that
-beginners are sometimes less familiar with.
 
 TODO
 "

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -54,13 +54,13 @@ Provide your [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/
       label: Error
       description: "
 Provide the full exception tracebacks.
-If the message is a warning, run your program with the ``-Werror`` flag:   ``python -Werror myprogram.py``
+If the message is a warning, run your program with the ``-Werror`` flag:   ``python -Werror myflow.py``
 "
-      placeholder: "# Copy complete stack trace and error message here, including SQL log output if applicable."
+      placeholder: "# Copy complete stack trace and error message here, including log output if applicable."
       value: "\
 ```
 
-# Copy complete stack trace and error message here, including SQL log output if applicable.
+# Copy complete stack trace and error message here, including log output if applicable.
 
 ```
 "

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,105 @@
+# docs https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Create a bug report
+description: Errors and regression reports with complete reproducing test cases and/or stack traces.
+labels: [requires triage]
+body:
+  - type: markdown
+    attributes:
+      value: "
+
+**FOR ALL USERS - PLEASE READ THIS PARAGRAPH AS IT IS HELPS US TO DO OUR WORK MORE EFFICIENTLY:**
+
+The **VAST MAJORITY** of bugs reported are in fact
+**USAGE QUESTIONS, NOT BUGS** for APIs that can take some practice to familiarize with,
+and which are also tailored towards high quality relational designs that
+beginners are sometimes less familiar with.
+
+If you are relatively new to SQLAlchemy, and even if not but the issue is uncertain, PLEASE START A NEW
+[DISCUSSION](https://github.com/sqlalchemy/sqlalchemy/discussions/new?category=Usage-Questions) INSTEAD, so that we can
+help with your issue.   If you are relatively new to
+SQLAlchemy, there is an approximately **90% chance your issue is not a bug and will be converted to a
+discussion in any case**.
+If your issue is actually a bug, we will open a new bug report with what we need.
+
+[START A NEW USAGE QUESTIONS DISCUSSION HERE](https://github.com/sqlalchemy/sqlalchemy/discussions/new?category=Usage-Questions)
+
+"
+  - type: markdown
+    attributes:
+      value: "
+
+**GUIDELINES FOR REPORTING BUGS**
+
+If you are new to SQLAlchemy bug reports, please review our many examples
+of [well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=is%3Aissue+label%3A%22great+mcve%22).   Each of these reports include the following features:
+
+1. a **succinct description of the problem** - typically a line or two at most
+
+2. **succinct, dependency-free code which reproduces the problem**, otherwise known as a [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example.
+
+3. **complete stack traces for all errors - please avoid screenshots, use formatted text inside issues**
+
+4. Other things as applicable:   **SQL log output**, **database backend and DBAPI driver**,
+   **operating system**, **comparative performance timings** for performance issues.
+"
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: "
+Provide your [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example here.
+If you need help creating one, you can model yours after the MCV code shared in one of our previous
+[well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=is%3Aissue+label%3A%22great+mcve%22)"
+      placeholder: "# Insert code here"
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Error
+      description: "
+Provide the complete text of any errors received **including the complete stack trace**.
+If the message is a warning, run your program with the ``-Werror`` flag:   ``python -Werror myprogram.py``
+"
+      placeholder: "# Copy complete stack trace and error message here, including SQL log output if applicable."
+      value: "\
+```
+
+# Copy complete stack trace and error message here, including SQL log output if applicable.
+
+```
+"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Versions
+      value: |
+        - OS:
+        - Python:
+        - SQLAlchemy:
+        - Database:
+        - DBAPI (eg: psycopg, cx_oracle, mysqlclient):
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "**Have a nice day!**"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,7 +32,7 @@ Your bug report should include the following features:
 
 3. **complete stack traces for errors - please avoid screenshots, and use formatted text inside issues**
 
-4. Other things as applicable: **operating system**, **comparative performance timings** for performance issues.
+4. Additional details that may help us reproduce your issue, including your operating system, the output of the `prefect version` command, or benchmarks for performance issues.
 "
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,7 +13,6 @@ body:
 
 Many bug reports are often
 **USAGE QUESTIONS, NOT BUGS** - for those, please report your question via our [Community Slack](https://www.prefect.io/slack/) or [Discourse](https://discourse.prefect.io/). We'll then investigate the issue and open a bug report when necessary.
-and which are also tailored towards high quality relational designs that
 
 TODO
 "

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,22 +9,14 @@ body:
     attributes:
       value: "
 
-**FOR ALL USERS - PLEASE READ THIS PARAGRAPH AS IT IS HELPS US TO DO OUR WORK MORE EFFICIENTLY:**
+**FOR ALL USERS - PLEASE READ THIS PARAGRAPH AS IT HELPS US TO DO OUR WORK MORE EFFICIENTLY:**
 
 The **VAST MAJORITY** of bugs reported are in fact
 **USAGE QUESTIONS, NOT BUGS** for APIs that can take some practice to familiarize with,
 and which are also tailored towards high quality relational designs that
 beginners are sometimes less familiar with.
 
-If you are relatively new to SQLAlchemy, and even if not but the issue is uncertain, PLEASE START A NEW
-[DISCUSSION](https://github.com/sqlalchemy/sqlalchemy/discussions/new?category=Usage-Questions) INSTEAD, so that we can
-help with your issue.   If you are relatively new to
-SQLAlchemy, there is an approximately **90% chance your issue is not a bug and will be converted to a
-discussion in any case**.
-If your issue is actually a bug, we will open a new bug report with what we need.
-
-[START A NEW USAGE QUESTIONS DISCUSSION HERE](https://github.com/sqlalchemy/sqlalchemy/discussions/new?category=Usage-Questions)
-
+TODO
 "
   - type: markdown
     attributes:
@@ -32,8 +24,7 @@ If your issue is actually a bug, we will open a new bug report with what we need
 
 **GUIDELINES FOR REPORTING BUGS**
 
-If you are new to SQLAlchemy bug reports, please review our many examples
-of [well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=is%3Aissue+label%3A%22great+mcve%22).   Each of these reports include the following features:
+Your bug report should include the following features:
 
 1. a **succinct description of the problem** - typically a line or two at most
 
@@ -41,8 +32,7 @@ of [well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=
 
 3. **complete stack traces for all errors - please avoid screenshots, use formatted text inside issues**
 
-4. Other things as applicable:   **SQL log output**, **database backend and DBAPI driver**,
-   **operating system**, **comparative performance timings** for performance issues.
+4. Other things as applicable: **operating system**, **comparative performance timings** for performance issues.
 "
   - type: textarea
     attributes:
@@ -56,8 +46,6 @@ of [well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=
       label: To Reproduce
       description: "
 Provide your [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example here.
-If you need help creating one, you can model yours after the MCV code shared in one of our previous
-[well written bug reports](https://github.com/sqlalchemy/sqlalchemy/issues?q=is%3Aissue+label%3A%22great+mcve%22)"
       placeholder: "# Insert code here"
       render: python
     validations:
@@ -87,9 +75,7 @@ If the message is a warning, run your program with the ``-Werror`` flag:   ``pyt
       value: |
         - OS:
         - Python:
-        - SQLAlchemy:
-        - Database:
-        - DBAPI (eg: psycopg, cx_oracle, mysqlclient):
+        - Prefect:
     validations:
       required: true
 
@@ -102,4 +88,4 @@ If the message is a warning, run your program with the ``-Werror`` flag:   ``pyt
 
   - type: markdown
     attributes:
-      value: "**Have a nice day!**"
+      value: "**Happy engineering!**"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,7 @@ body:
 
 **PLEASE READ THIS PARAGRAPH - this helps us identify the root cause and fix the issue:**
 
-The **VAST MAJORITY** of bugs reported are in fact
+Many bug reports are often
 **USAGE QUESTIONS, NOT BUGS** for APIs that can take some practice to familiarize with,
 and which are also tailored towards high quality relational designs that
 beginners are sometimes less familiar with.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,7 +30,7 @@ Your bug report should include the following features:
 
 2. **succinct code example which reproduces the problem**, otherwise known as a [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example.
 
-3. **complete stack traces for all errors - please avoid screenshots, use formatted text inside issues**
+3. **complete stack traces for errors - please avoid screenshots, and use formatted text inside issues**
 
 4. Other things as applicable: **operating system**, **comparative performance timings** for performance issues.
 "

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     attributes:
       label: Additional context
-      description: Add any other context about the use case here.
+      description: Provide additional context about the use case here.
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
@@ -22,7 +22,7 @@ body:
   - type: textarea
     attributes:
       label: Example Use
-      description: Provide a clear example of what the use would look like 
+      description: Provide an example of how end users could leverage that functionality
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
@@ -24,7 +24,7 @@ body:
       label: Example Use
       description: Provide an example of how end users could leverage that functionality
     validations:
-      required: true
+      required: false
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yaml
@@ -1,0 +1,38 @@
+# docs https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Propose a feature enhancement
+description: Propose a new feature or an enhancement for Prefect
+labels: [requires triage]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the proposed behavior
+      description: A clear and concise description of what new feature or behavior you would like to see
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the current behavior
+      description: A clear and concise description of what Prefect currently does
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Example Use
+      description: Provide a clear example of what the use would look like 
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the use case here.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "**Happy engineering!**"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- Provide a general summary of your proposed changes in the Title field above -->
+
+### Description
+<!-- Describe your changes in detail -->
+
+### Checklist
+<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
+
+-->
+
+This pull request is:
+
+- [ ] A documentation / typographical error fix
+	- Good to go, no issue or tests are needed
+- [ ] A short code fix
+	- please include the issue number, and create an issue if none exists, which
+	  must include a complete example of the issue.  one line code fixes without an
+	  issue and demonstration will not be accepted.
+	- Please include: `Fixes: #<issue number>` in the commit message
+	- please include tests.   one line code fixes without tests will not be accepted.
+- [ ] A new feature implementation
+	- please include the issue number, and create an issue if none exists, which must
+	  include a complete example of how the feature would look.
+	- Please include: `Fixes: #<issue number>` in the commit message
+	- please include tests.
+
+**Have a nice day!**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,7 @@
 <!-- Make sure that your title neatly summarizes the proposed changes -->
 
 ### Summary
-<!-- Provide a short overview of the changes -->
-
-### Value Added by Changes
-<!-- Describe where and how the changes add value -->
-
-### Description of Changes
-<!-- Describe the changes in detail -->
+<!-- Provide a short overview of the changes and its importance -->
 
 ### Steps Taken to QA Changes
 <!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,16 @@
-<!-- Provide a general summary of your proposed changes in the Title field above -->
+<!-- Make sure that your title neatly summarizes the proposed changes -->
 
-### Description
-<!-- Describe your changes in detail -->
+### Summary
+<!-- Provide a short overview of the changes -->
+
+### Value Added by Changes
+<!-- Describe where and how the changes add value -->
+
+### Description of Changes
+<!-- Describe the changes in detail -->
+
+### Steps Taken to QA Changes
+<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
 
 ### Checklist
 <!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
@@ -11,17 +20,16 @@
 This pull request is:
 
 - [ ] A documentation / typographical error fix
-	- Good to go, no issue or tests are needed
+	- No tests or issue needed
 - [ ] A short code fix
-	- please include the issue number, and create an issue if none exists, which
-	  must include a complete example of the issue.  one line code fixes without an
-	  issue and demonstration will not be accepted.
-	- Please include: `Fixes: #<issue number>` in the commit message
-	- please include tests.   one line code fixes without tests will not be accepted.
+	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
+        - If no issue exists, please create a bug-fix issue 
+	- Please include tests. One line code fixes without tests will not be accepted.
 - [ ] A new feature implementation
-	- please include the issue number, and create an issue if none exists, which must
-	  include a complete example of how the feature would look.
-	- Please include: `Fixes: #<issue number>` in the commit message
-	- please include tests.
+	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
+        - If no issue exists, please create a feature-enhancement issue 
+	- Please include tests
+    - Please make sure that your QA steps are both thorough and easy to reproduce by someobdy with limited knowledge of the feature that you are submitting
 
-**Have a nice day!**
+
+**Happy engineering!**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,11 +23,11 @@ This pull request is:
 	- No tests or issue needed
 - [ ] A short code fix
 	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
-        - If no issue exists, please create a bug-fix issue 
+        - If no issue exists, please create a bug report issue 
 	- Please include tests. One line code fixes without tests will not be accepted.
 - [ ] A new feature implementation
 	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
-        - If no issue exists, please create a feature-enhancement issue 
+        - If no issue exists, please create a feature enhancement issue 
 	- Please include tests
     - Please make sure that your QA steps are both thorough and easy to reproduce by someobdy with limited knowledge of the feature that you are submitting
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ This pull request is:
 - [ ] A short code fix
 	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
         - If no issue exists, please create a bug report issue 
-	- Please include tests. One line code fixes without tests will not be accepted.
+	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
 - [ ] A new feature implementation
 	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
         - If no issue exists, please create a feature enhancement issue 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Make sure that your title neatly summarizes the proposed changes -->
 
 ### Summary
-<!-- Provide a short overview of the changes and its importance -->
+<!-- Provide a short overview of the change and the value it adds -->
 
 ### Steps Taken to QA Changes
 <!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->


### PR DESCRIPTION
This pull request creates new templates for PRs and Issues. It is **heavily** inspired by the SQLAlchemy templates. I'll be working with @anna-geller to figure out wording and links on the bug report text.

I'm not certain if there's a way to preview the YAML results beforehand, so any input there would be helpful. I also don't know which tags we want to add as defaults to our issues. 

Seeking feedback on whether anything feels too verbose, hostile, or like we're asking too much. 

[Previous 1.x Pull Request Template](https://github.com/PrefectHQ/prefect/blob/1.x/.github/PULL_REQUEST_TEMPLATE.md)
[Previous 1.x Bug Report Template](https://github.com/PrefectHQ/prefect/blob/1.x/.github/ISSUE_TEMPLATE/1.%20bug_report.md)
[Previous 1.x Feature Enhancement Template](https://github.com/PrefectHQ/prefect/blob/1.x/.github/ISSUE_TEMPLATE/2.%20enhance-a-feature.md)

[SQLAlchemy PR Template](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/pull_request_template.md)
[SQLAlchemy Bug Report Template](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml)
[SQLAlchemy New Usecase Template](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/ISSUE_TEMPLATE/use_case.yaml)
