### PR TITLE
Add support for unmapped values to Task.map

### DIFF
--- a/docs/api-ref/prefect/utilities/annotations.md
+++ b/docs/api-ref/prefect/utilities/annotations.md
@@ -1,0 +1,8 @@
+---
+description: Prefect Python API utilities for annotation classes.
+tags:
+    - Python API
+    - annotations
+---
+
+::: prefect.utilities.annotations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
                 - 'prefect.cli.flow_run': api-ref/prefect/cli/flow_run.md
                 - 'prefect.cli.orion': api-ref/prefect/cli/orion.md
             - 'Utilities':
+                - 'prefect.utilities.annotations': api-ref/prefect/utilities/annotations.md
                 - 'prefect.utilities.asyncutils': api-ref/prefect/utilities/asyncutils.md
                 - 'prefect.utilities.processutils': api-ref/prefect/utilities/processutils.md
                 - 'prefect.utilities.callables': api-ref/prefect/utilities/callables.md

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -29,6 +29,7 @@ from prefect.context import tags
 from prefect.client import get_client
 from prefect.deployments import Deployment
 from prefect.manifests import Manifest
+from prefect.utilities.annotations import unmapped
 
 # Import modules that register types
 import prefect.serializers
@@ -59,7 +60,6 @@ PREFECT_1_ATTRIBUTES = [
     "prefect.mapped",
     "prefect.models",
     "prefect.resource_manager",
-    "prefect.unmapped",
 ]
 
 
@@ -103,4 +103,5 @@ __all__ = [
     "tags",
     "task",
     "Task",
+    "unmapped",
 ]

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -80,6 +80,7 @@ from prefect.task_runners import (
     TaskConcurrencyType,
 )
 from prefect.tasks import Task
+from prefect.utilities.annotations import unmapped
 from prefect.utilities.asyncutils import (
     gather,
     in_async_main_thread,
@@ -703,7 +704,11 @@ async def begin_task_map(
     # Resolve any futures / states that are in the parameters as we need to
     # validate the lengths of those values before proceeding.
     parameters.update(await resolve_inputs(parameters))
-    parameter_lengths = {key: len(val) for key, val in parameters.items()}
+    parameter_lengths = {
+        key: len(val)
+        for key, val in parameters.items()
+        if not isinstance(val, unmapped)
+    }
 
     lengths = set(parameter_lengths.values())
     if len(lengths) > 1:

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+class unmapped:
+    """A container that acts as an infinite array where all items are the same
+    value. Used for Task.map where there is a need to map over a single
+    value"""
+
+    def __init__(self, value: Any):
+        self.value = value
+
+    def __getitem__(self, _) -> Any:
+        return self.value

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -16,6 +16,7 @@ from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.states import State, StateType
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal, flaky_on_windows
+from prefect.utilities.annotations import unmapped
 from prefect.utilities.collections import quote
 
 
@@ -1871,3 +1872,13 @@ class TestTaskMap:
 
         futures = await my_flow()
         assert [future.result() for future in futures] == [3, 3, 3]
+
+    async def test_unmapped_value(self):
+        @flow
+        def my_flow():
+            numbers = [1, 2, 3]
+            other = unmapped(5)
+            return TestTaskMap.add_together.map(numbers, other)
+
+        futures = my_flow()
+        assert [future.result() for future in futures] == [6, 7, 8]

--- a/tests/utilities/test_annotations.py
+++ b/tests/utilities/test_annotations.py
@@ -1,0 +1,11 @@
+import random
+
+from prefect.utilities.annotations import unmapped
+
+
+class TestUnmapped:
+    def test_always_returns_same_value(self):
+        thing = unmapped("hello")
+
+        for _ in range(10):
+            assert thing[random.randint(0, 100)] == "hello"


### PR DESCRIPTION
In Issue #6106 it was called out that we didn't have an equivelant for `unmapped` from prefect 1. This adds support for `unmapped` to `Task.map` as it exists in Prefect 1.