### PR TITLE
Introduce output flag on deployment build and update default yaml name

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -24,7 +24,7 @@ Each deployment references a single flow (though that flow may, in turn, call an
 At a high level, you can think of a deployment as configuration for managing flows, whether you run them via the CLI, the UI, or the API.
 
 !!! warning "Deployments have changed since beta"
-    Deployments now rely on manifest files for describing your workflow in a portable way, and `deployment.yaml` files for specifying a deployment of your workflow.
+    Deployments now rely on manifest files for describing your workflow in a portable way, and deployment YAML files for specifying a deployment of your workflow.
 
     Deployments based on `Deployment` and `DeploymentSpec` are no longer supported.
 
@@ -55,7 +55,7 @@ To create a deployment you need:
 
 - Your flow code script and any supporting files.
 - A manifest file
-- A `deployment.yaml` file
+- A deployment YAML file
 
 Optionally, you may reference pre-configured storage and infrastructure blocks that define where flow code and results are stored and how your flow execution environment is configured.
 
@@ -86,7 +86,7 @@ Manifests are JSON descriptions of a workflow. The manifest lives alongside your
 
 The location of your manifest file is important. When building your deployment and uploading your flow files to storage, the manifest file serves as the root of the directory that is uploaded &mdash; everything in its directory and recursively down will be stored in the storage of your choosing. This ensures that your relative imports remain portable. Additionally, at runtime, your agent will always ensure that your workflow is imported and executed in the same directory as your manifest file.
 
-The default name format for manifests is `[flow-function-name]-manifest.json`, but you may rename the file as long as it is referenced correctly in the `deployment.yaml` file.
+The default name format for manifests is `[flow-function-name]-manifest.json`, but you may rename the file as long as it is referenced correctly in the deployment's YAML file.
 
 ```json
 {
@@ -110,11 +110,11 @@ The default name format for manifests is `[flow-function-name]-manifest.json`, b
 
 ## deployment.yaml
 
-A `deployment.yaml` file references the manifest for your flow, and configures additional settings needed to create a deployment on the server.
+A deployment's YAML file references the manifest for your flow, and configures additional settings needed to create a deployment on the server.
 
-As a single flow may have multiple deployments created for it, with different schedules, tags, and so on, a single flow definition may have multiple `deployment.yaml` files, each specifying different settings. The only requirement is that each deployment must have a unique name.
+As a single flow may have multiple deployments created for it, with different schedules, tags, and so on, a single flow definition may have multiple deployment YAML files, each specifying different settings. The only requirement is that each deployment must have a unique name.
 
-The default `deployment.yaml` filename may be edited as needed.
+The default `{flow-name}-deployment.yaml` filename may be edited as needed with the `--output` flag to `prefect deployment build`.
 
 ```yaml
 name: catfact
@@ -153,7 +153,7 @@ parameter_openapi_schema:
 ```
 
 !!! note "Editing deployment.yaml"
-    Note the big **DO NOT EDIT** comment in `deployment.yaml`: In practice, anything above this block can be freely edited _before_ running `prefect deployment apply` to create the deployment on the API. 
+    Note the big **DO NOT EDIT** comment in your deployment's YAML: In practice, anything above this block can be freely edited _before_ running `prefect deployment apply` to create the deployment on the API. 
     
     That said, we recommend editing most of these fields in the Prefect UI for convenience.
 
@@ -198,16 +198,16 @@ You may specify additional options to specify storage and infrastructure for the
 
 When you run this command, Prefect: 
 
-- Creates the the manifest and `deployment.yaml` files for your deployment based on your flow code and options.
+- Creates the the manifest and `catfacts_flow-deployment.yaml` files for your deployment based on your flow code and options.
 - Uploads your flow files to the configured storage location (local by default).
 
 ### Create deployment in API
 
-When you've configured the manifest and `deployment.yaml` for a deployment, you can create the deployment on the API. Run the following Prefect CLI command.
+When you've configured the manifest and `catfacts_flow-deployment.yaml` for a deployment, you can create the deployment on the API. Run the following Prefect CLI command.
 
 <div class="terminal">
 ```bash
-$ prefect deployment apply `deployment.yaml`
+$ prefect deployment apply `catfacts_flow-deployment.yaml`
 ```
 </div>
 
@@ -215,7 +215,7 @@ For example:
 
 <div class="terminal">
 ```bash
-$ prefect deployment apply ./catfact-deployment.yaml
+$ prefect deployment apply ./catfacts_flow-deployment.yaml
 Successfully loaded 'catfact'
 Deployment '76a9f1ac-4d8c-4a92-8869-615bec502685' successfully created.
 ```

--- a/docs/tutorials/deployments.md
+++ b/docs/tutorials/deployments.md
@@ -76,8 +76,8 @@ Like previous flow examples, this is still a script that you have to run locally
 
 In the rest of this tutorial, you'll turn this into a deployment that can create flow runs. You'll create the deployment by doing the following: 
 
-- Creating deployment manifest and `deployment.yaml` file that specify your flow details and deployment settings.
-- Applying the `deployment.yaml` settings to create a deployment on the server.
+- Creating deployment manifest and deployment YAML file that specify your flow details and deployment settings.
+- Applying the deployment YAML settings to create a deployment on the server.
 - Inspecting the deployment with the CLI and Prefect UI.
 - Starting an ad hoc flow run based on the deployment.
 
@@ -106,9 +106,9 @@ def leonardo_dicapriflow(name: str):
 
 To create a deployment from an existing flow script, there are just a few steps:
 
-1. Use the `prefect deployment build` Prefect CLI command to build a deployment manifest and `deployment.yaml` file. These describe the files and settings needed to create your deployment.
-1. If you needed to add customizations to the manifest or `deployment.yaml` file, you would do so now. 
-1. Use the `prefect deployment apply` Prefect CLI command to create the deployment on the API based on the settings in the deployment manifest and `deployment.yaml`.
+1. Use the `prefect deployment build` Prefect CLI command to build a deployment manifest and a deployment YAML file. These describe the files and settings needed to create your deployment.
+1. If you needed to add customizations to the manifest or the deployment YAML file, you would do so now. 
+1. Use the `prefect deployment apply` Prefect CLI command to create the deployment on the API based on the settings in the deployment manifest and deployment YAML.
 
 What you need for the first step, building the deployment artifacts, is:
 
@@ -133,14 +133,14 @@ What did we do here? Let's break down the command:
 
 Note that you may specify multiple tags by providing a `-t tag` parameter for each tag you want applied to the deployment.
 
-The command outputs two files: `leonardo_dicapriflow-manifest.json` contains workflow-specific information such as the code location, the name of the entrypoint flow, and flow parameters. `deployment.yaml` contains details about the deployment for this flow.
+The command outputs two files: `leonardo_dicapriflow-manifest.json` contains workflow-specific information such as the code location, the name of the entrypoint flow, and flow parameters. `leonardo_dicapriflow-deployment.yaml` contains details about the deployment for this flow.
 
 <div class="terminal">
 ```bash
 Found flow 'leonardo_dicapriflow'
 Manifest created at
 '/Users/terry/test/testflows/leo_flow/leonardo_dicapriflow-manifest.json'.
-Deployment YAML created at '/Users/terry/test/testflows/leo_flow/deployment.yaml'.
+Deployment YAML created at '/Users/terry/test/testflows/leo_flow/leonardo_dicapriflow-deployment.yaml'.
 ```
 </div>
 
@@ -148,7 +148,7 @@ Deployment YAML created at '/Users/terry/test/testflows/leo_flow/deployment.yaml
 
 Note that our flow needs a `name` parameter, but we didn't specify one when building the deployment files.
 
-Open the `deployment.yaml` file and add the parameter as `parameters: {'name':'Leo'}`:
+Open the `leonardo_dicapriflow-deployment.yaml` file and add the parameter as `parameters: {'name':'Leo'}`:
 
 ```yaml hl_lines="9"
 ###
@@ -232,13 +232,13 @@ To review, we have three files that make up the artifacts for this particular de
 
 - The flow code in `leo_flow.py`
 - The manifest `leonardo_dicapriflow-manifest.json`
-- The deployment settings `deployment.yaml`
+- The deployment settings `leonardo_dicapriflow-deployment.yaml`
 
-Now use the `prefect deployment apply` command to create the deployment on the Prefect Orion server, specifying the name of the `deployment.yaml` file.
+Now use the `prefect deployment apply` command to create the deployment on the Prefect Orion server, specifying the name of the `leonardo_dicapriflow-deployment.yaml` file.
 
 <div class="terminal">
 ```bash
-$ prefect deployment apply deployment.yaml
+$ prefect deployment apply leonardo_dicapriflow-deployment.yaml
 Successfully loaded 'leo-deployment'
 Deployment '3d2f55a2-46df-4857-ab6f-6cc80ce9cf9c' successfully created.
 ```


### PR DESCRIPTION
A common request we immediately received was for unique deployment YAML names (to better anticipate multi-flow deployments) and an optional output flag to customize the name. 

The students at PACC in San Jose all universally requested this today so it would be cool to have them get such a tight turnaround on their feedback (if possible / reasonable)!