### PR TITLE
Makes the agent's inner loop more robust in the face of environmental failures

### DIFF
--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -1,10 +1,13 @@
 """
 Command line interface for working with agent services
 """
-from typing import List
+import traceback
+from collections import deque
+from typing import Callable, Coroutine, Deque, List, Optional
 from uuid import UUID
 
 import anyio
+import httpx
 import typer
 
 from prefect.agent import OrionAgent
@@ -14,6 +17,7 @@ from prefect.cli.root import app
 from prefect.client import get_client
 from prefect.exceptions import ObjectAlreadyExists
 from prefect.settings import PREFECT_AGENT_QUERY_INTERVAL, PREFECT_API_URL
+from prefect.utilities.collections import distinct
 
 agent_app = PrefectTyper(
     name="agent", help="Commands for starting and interacting with agent processes."
@@ -64,7 +68,7 @@ async def start(
         try:
             work_queue_id = UUID(work_queue)
             work_queue_name = None
-        except:
+        except (TypeError, ValueError):
             work_queue_id = None
             work_queue_name = work_queue
     elif tags:
@@ -97,15 +101,82 @@ async def start(
         if not hide_welcome:
             app.console.print(ascii_name)
             app.console.print(
-                f"Agent started! Looking for work from queue '{work_queue_name or work_queue_id}'..."
+                "Agent started! Looking for work from "
+                f"queue '{work_queue_name or work_queue_id}'..."
             )
 
-        while True:
-            try:
-                await agent.get_and_submit_flow_runs()
-            except KeyboardInterrupt:
-                break
-
-            await anyio.sleep(PREFECT_AGENT_QUERY_INTERVAL.value())
+        await critical_service_loop(
+            agent.get_and_submit_flow_runs,
+            PREFECT_AGENT_QUERY_INTERVAL.value(),
+        )
 
     app.console.print("Agent stopped!")
+
+
+async def critical_service_loop(
+    workload: Callable[..., Coroutine],
+    interval: float,
+    memory: int = 20,
+):
+    """
+    Runs the the given `workload` function on the specified `interval`, while being
+    forgiving of intermittent issues like temporary HTTP errors.  If more failures than
+    successes occur, prints a summary of recently seen errors, then returns.
+
+    Args:
+        `workload`: the function to call
+        `interval`: how frequently to call it
+        `memory`: how many successes/failures to remember when deciding whether to exit
+    """
+
+    track_record: Deque[int] = deque(maxlen=memory)
+    exceptions: Deque[Optional[Exception]] = deque(maxlen=track_record.maxlen)
+
+    while True:
+        try:
+            await workload()
+
+            track_record.append(1)
+            exceptions.append(None)
+        except httpx.TransportError as exc:
+            # httpx.TransportError is the base class for any kind of communications
+            # error, like timeouts, connection failures, etc.  This does _not_ cover
+            # routine HTTP error codes (even 5xx errors like 502/503) so this
+            # handler should not be attempting to cover cases where the Orion server
+            # or Prefect Cloud is having an outage (which will be covered by the
+            # exception clause below)
+            track_record.append(-1)
+            exceptions.append(exc)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (502, 503):
+                # 502/503 indicate a potential outage of the Orion server or Prefect
+                # Cloud, which is likely to be temporary and transient.  Don't quit
+                # over these unless it is prolonged.
+                track_record.append(-1)
+                exceptions.append(exc)
+            else:
+                raise
+        except KeyboardInterrupt:
+            return
+
+        # If the last result was a failure, see if it's time to cut our losses because
+        # we're failing more often than we're succeeding
+        if track_record[-1] < 0 and sum(track_record) < 0:
+            # We've failed more than we've succeeded, the writing is on the wall.  Let's
+            # explain what we've seen.
+            losses = abs(sum(w for w in track_record if w < 0))
+            app.console.print(
+                f"\nFailed {losses} of the last {len(track_record)} attempts.  "
+                "Please check your environment and configuration."
+            )
+
+            app.console.print("Examples of recent errors:\n")
+
+            for exception in distinct(reversed(exceptions), key=lambda e: type(e)):
+                if not exception:
+                    continue
+                app.console.print("\n".join(traceback.format_exception(exception)))
+                app.console.print()
+            return
+
+        await anyio.sleep(interval)

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -13,6 +13,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Generator,
     Generic,
     Hashable,
     Iterable,
@@ -340,12 +341,12 @@ def remove_nested_keys(keys_to_remove: List[Hashable], obj):
     `key_to_remove`. Return `obj` unchanged if not a dictionary.
 
     Args:
-        keys_to_remove: A list of keys to remove from obj
-        obj: The object to remove keys from.
+        keys_to_remove: A list of keys to remove from obj obj: The object to remove keys
+        from.
 
     Returns:
-        `obj` without keys matching an entry in `keys_to_remove` if `obj` is a dictionary.
-        `obj` if `obj` is not a dictionary.
+        `obj` without keys matching an entry in `keys_to_remove` if `obj` is a
+        dictionary. `obj` if `obj` is not a dictionary.
     """
     if not isinstance(obj, dict):
         return obj
@@ -354,3 +355,15 @@ def remove_nested_keys(keys_to_remove: List[Hashable], obj):
         for key, value in obj.items()
         if key not in keys_to_remove
     }
+
+
+def distinct(
+    iterable: Iterable[T],
+    key: Callable[[T], Any] = (lambda i: i),
+) -> Generator[T, None, None]:
+    seen: Set = set()
+    for item in iterable:
+        if key(item) in seen:
+            continue
+        seen.add(key(item))
+        yield item

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -1,0 +1,94 @@
+import traceback
+from collections import deque
+from typing import Callable, Coroutine, Deque, Optional
+
+import anyio
+import httpx
+
+from prefect.utilities.collections import distinct
+
+
+async def critical_service_loop(
+    workload: Callable[..., Coroutine],
+    interval: float,
+    memory: int = 10,
+    consecutive: int = 3,
+    printer: Callable[..., None] = print,
+):
+    """
+    Runs the the given `workload` function on the specified `interval`, while being
+    forgiving of intermittent issues like temporary HTTP errors.  If more than a certain
+    number of `consecutive` errors occur, print a summary of up to `memory` recent
+    exceptions to `printer`, then exit.
+
+    Args:
+        `workload`: the function to call
+        `interval`: how frequently to call it
+        `memory`: how many recent errors to remember
+        `consecutive`: how many consecutive errors must we see before we exit
+        `printer`: a `print`-like function where errors will be reported
+    """
+
+    track_record: Deque[Optional[Exception]] = deque(maxlen=memory)
+
+    while True:
+        try:
+            await workload()
+
+            track_record.append(None)
+        except httpx.TransportError as exc:
+            # httpx.TransportError is the base class for any kind of communications
+            # error, like timeouts, connection failures, etc.  This does _not_ cover
+            # routine HTTP error codes (even 5xx errors like 502/503) so this
+            # handler should not be attempting to cover cases where the Orion server
+            # or Prefect Cloud is having an outage (which will be covered by the
+            # exception clause below)
+            track_record.append(exc)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (502, 503):
+                # 502/503 indicate a potential outage of the Orion server or Prefect
+                # Cloud, which is likely to be temporary and transient.  Don't quit
+                # over these unless it is prolonged.
+                track_record.append(exc)
+            else:
+                raise
+        except KeyboardInterrupt:
+            return
+
+        # Decide whether to exit now based on recent history.
+        #
+        # Given some typical background error rate of, say, 1%, we may still observe
+        # quite a few errors in our recent samples, but this is not necessarily a cause
+        # for concern.
+        #
+        # Imagine two distributions that could reflect our situation at any time: the
+        # everything-is-fine distribution of errors, and the everything-is-on-fire
+        # distribution of errors. We are trying to determine which of those two worlds
+        # we are currently experiencing.  We compare the likelihood that we'd draw N
+        # consecutive errors from each.  In the everything-is-fine distribution, that
+        # would be a very low-probability occurrance, but in the everything-is-on-fire
+        # distribution, that is a high-probability occurrance.
+        #
+        # Remarkably, we only need to look back for a small number of consecutive
+        # errors to have reasonable confidence that this is indeed an anomaly.
+        # @anticorrelator and @chrisguidry estimated that we should only need to look
+        # back for 3 consectutive errors.
+        most_recent = list(reversed(track_record))
+        if len(most_recent) > consecutive and all(most_recent[:consecutive]):
+            # We've failed enough times to be sure something is wrong, the writing is
+            # on the wall.  Let's explain what we've seen and exit.
+            printer(
+                f"\nFailed the last {consecutive} attempts.  "
+                "Please check your environment and configuration."
+            )
+
+            printer("Examples of recent errors:\n")
+
+            for exception in distinct(most_recent, key=lambda e: type(e)):
+                if not exception:
+                    continue
+                printer("\n".join(traceback.format_exception(exception)))
+                printer()
+            return
+
+        await anyio.sleep(interval)

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -87,7 +87,7 @@ async def critical_service_loop(
             for exception in distinct(most_recent, key=lambda e: type(e)):
                 if not exception:
                     continue
-                printer("\n".join(traceback.format_exception(exception)))
+                printer("\n".join(traceback.format_exception_only(exception)))
                 printer()
             return
 

--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -1,0 +1,96 @@
+from unittest import mock
+
+import httpx
+import pytest
+
+from prefect.utilities.services import critical_service_loop
+
+
+async def test_critical_service_loop_operates_normally():
+    workload = mock.AsyncMock(
+        side_effect=[
+            None,
+            None,
+            None,
+            None,
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+
+    await critical_service_loop(workload, 0.0)
+
+    assert workload.await_count == 6
+
+
+async def test_tolerates_single_intermittent_error():
+    workload = mock.AsyncMock(
+        side_effect=[
+            None,
+            httpx.ConnectError("woops"),
+            None,
+            None,
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+
+    await critical_service_loop(workload, 0.0)
+
+    assert workload.await_count == 6
+
+
+async def test_tolerates_two_consecutive_errors():
+    workload = mock.AsyncMock(
+        side_effect=[
+            None,
+            httpx.ConnectError("woops"),
+            httpx.TimeoutException("oofta"),
+            None,
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+
+    await critical_service_loop(workload, 0.0)
+
+    assert workload.await_count == 6
+
+
+async def test_tolerates_majority_errors():
+    workload = mock.AsyncMock(
+        side_effect=[
+            httpx.ConnectError("woops"),
+            None,
+            httpx.TimeoutException("oofta"),
+            httpx.TimeoutException("boo"),
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+
+    await critical_service_loop(workload, 0.0)
+
+    assert workload.await_count == 6
+
+
+async def test_quits_after_3_consecutive_errors(capsys: pytest.CaptureFixture):
+    workload = mock.AsyncMock(
+        side_effect=[
+            None,
+            httpx.TimeoutException("oofta"),
+            httpx.TimeoutException("boo"),
+            httpx.ConnectError("woops"),
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+
+    await critical_service_loop(workload, 0.0, consecutive=3)
+
+    assert workload.await_count == 4
+    result = capsys.readouterr()
+    assert "Failed the last 3 attempts" in result.out
+    assert "Examples of recent errors" in result.out
+    assert "httpx.ConnectError: woops" in result.out
+    assert "httpx.TimeoutException: boo" in result.out

--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -1,13 +1,12 @@
-from unittest import mock
-
 import httpx
 import pytest
 
+from prefect.testing.utilities import AsyncMock
 from prefect.utilities.services import critical_service_loop
 
 
 async def test_critical_service_loop_operates_normally():
-    workload = mock.AsyncMock(
+    workload = AsyncMock(
         side_effect=[
             None,
             None,
@@ -24,7 +23,7 @@ async def test_critical_service_loop_operates_normally():
 
 
 async def test_tolerates_single_intermittent_error():
-    workload = mock.AsyncMock(
+    workload = AsyncMock(
         side_effect=[
             None,
             httpx.ConnectError("woops"),
@@ -41,7 +40,7 @@ async def test_tolerates_single_intermittent_error():
 
 
 async def test_tolerates_two_consecutive_errors():
-    workload = mock.AsyncMock(
+    workload = AsyncMock(
         side_effect=[
             None,
             httpx.ConnectError("woops"),
@@ -58,7 +57,7 @@ async def test_tolerates_two_consecutive_errors():
 
 
 async def test_tolerates_majority_errors():
-    workload = mock.AsyncMock(
+    workload = AsyncMock(
         side_effect=[
             httpx.ConnectError("woops"),
             None,
@@ -75,7 +74,7 @@ async def test_tolerates_majority_errors():
 
 
 async def test_quits_after_3_consecutive_errors(capsys: pytest.CaptureFixture):
-    workload = mock.AsyncMock(
+    workload = AsyncMock(
         side_effect=[
             None,
             httpx.TimeoutException("oofta"),


### PR DESCRIPTION
### Summary
This takes the approach of remembering the recent track record for a service,
so that momentary blips won't cause it to exit prematurely, but an ongoing
series of problems that might indicate a deeper issue (network, server, or cloud
outage) will.

Big thanks to @anticorrelator for help with the statistical underpinning here, it turned out very simple.  Math is real!

### Steps Taken to QA Changes

(none yet, this is a draft)

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by someobdy with limited knowledge of the feature that you are submitting


**Happy engineering!**
