### PR TITLE
Fail login on invalid profile name

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -294,6 +294,7 @@ async def login(
         "Creating a profile for this Prefect Cloud login. Please specify a profile name: "
     )
 
+    cloud_profile_name = cloud_profile_name.strip()
     if cloud_profile_name == "":
         exit_with_error("Please provide a non-empty profile name.")
 

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -294,6 +294,9 @@ async def login(
         "Creating a profile for this Prefect Cloud login. Please specify a profile name: "
     )
 
+    if cloud_profile_name == "":
+        exit_with_error("Please provide a non-empty profile name.")
+
     if cloud_profile_name in profiles:
         exit_with_error(f"Profile {cloud_profile_name!r} already exists.")
 


### PR DESCRIPTION
Empty profile names will produce an invalid `profiles.toml` file, causing errors later on. This PR makes it so we'll simply fail if an empty profile name is provided.