### PR TITLE
Automatically add v1 label to 1.x PRs

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,2 @@
+# Apply label "v1" if target branch is "1.x"
+'v1': ['1.x']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
-
-# don't only run when opened in case the branch is changed afterward
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   pr-labeler:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: PR Labeler
+
+# don't only run when opened in case the branch is changed afterward
+on: [pull_request]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
This action should automatically apply the existing `v1` label to any PR's targeting the `1.x` branch

(I tried proving this out in #6137 by changing the base branch to 1.x but the total lack of shared history terrified github and it forcibly closed the PR)