### PR TITLE
Add type that enforces timezone-aware datetimes

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -36,7 +36,7 @@ from prefect.filesystems import WritableFileSystem
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.core import FlowRun, TaskRun
 from prefect.orion.schemas.states import State
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.task_runners import BaseTaskRunner
 from prefect.utilities.importtools import load_script_as_module
@@ -102,7 +102,7 @@ class PrefectObjectRegistry(ContextModel):
         capture_failures: If set, failures during __init__ will be silenced and tracked.
     """
 
-    start_time: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
+    start_time: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
 
     _instance_registry: Dict[Type[T], List[T]] = PrivateAttr(
         default_factory=lambda: defaultdict(list)
@@ -179,7 +179,7 @@ class RunContext(ContextModel):
         client: The Orion client instance being used for API communication
     """
 
-    start_time: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
+    start_time: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
     client: OrionClient
 
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -25,7 +25,6 @@ from typing import (
 
 import pendulum
 from anyio.abc import BlockingPortal, CancelScope
-from pendulum.datetime import DateTime
 from pydantic import BaseModel, Field, PrivateAttr
 
 import prefect.logging
@@ -37,6 +36,7 @@ from prefect.filesystems import WritableFileSystem
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.core import FlowRun, TaskRun
 from prefect.orion.schemas.states import State
+from prefect.orion.utilities.schemas import datetime_tz
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.task_runners import BaseTaskRunner
 from prefect.utilities.importtools import load_script_as_module
@@ -102,7 +102,7 @@ class PrefectObjectRegistry(ContextModel):
         capture_failures: If set, failures during __init__ will be silenced and tracked.
     """
 
-    start_time: DateTime = Field(default_factory=lambda: pendulum.now("UTC"))
+    start_time: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
 
     _instance_registry: Dict[Type[T], List[T]] = PrivateAttr(
         default_factory=lambda: defaultdict(list)
@@ -179,7 +179,7 @@ class RunContext(ContextModel):
         client: The Orion client instance being used for API communication
     """
 
-    start_time: DateTime = Field(default_factory=lambda: pendulum.now("UTC"))
+    start_time: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
     client: OrionClient
 
 

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -2,7 +2,6 @@
 Routes for interacting with Deployment objects.
 """
 
-import datetime
 from typing import List
 from uuid import UUID
 
@@ -16,6 +15,7 @@ import prefect.orion.schemas as schemas
 from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.exceptions import ObjectNotFoundError
+from prefect.orion.utilities.schemas import datetime_tz
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/deployments", tags=["Deployments"])
@@ -164,10 +164,8 @@ async def delete_deployment(
 @router.post("/{id}/schedule")
 async def schedule_deployment(
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
-    start_time: datetime.datetime = Body(
-        None, description="The earliest date to schedule"
-    ),
-    end_time: datetime.datetime = Body(None, description="The latest date to schedule"),
+    start_time: datetime_tz = Body(None, description="The earliest date to schedule"),
+    end_time: datetime_tz = Body(None, description="The latest date to schedule"),
     max_runs: int = Body(None, description="The maximum number of runs to schedule"),
     session: sa.orm.Session = Depends(dependencies.get_session),
 ) -> None:

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -15,7 +15,7 @@ import prefect.orion.schemas as schemas
 from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.exceptions import ObjectNotFoundError
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/deployments", tags=["Deployments"])
@@ -164,8 +164,8 @@ async def delete_deployment(
 @router.post("/{id}/schedule")
 async def schedule_deployment(
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
-    start_time: datetime_tz = Body(None, description="The earliest date to schedule"),
-    end_time: datetime_tz = Body(None, description="The latest date to schedule"),
+    start_time: DateTimeTZ = Body(None, description="The earliest date to schedule"),
+    end_time: DateTimeTZ = Body(None, description="The latest date to schedule"),
     max_runs: int = Body(None, description="The maximum number of runs to schedule"),
     session: sa.orm.Session = Depends(dependencies.get_session),
 ) -> None:

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -19,7 +19,7 @@ from prefect.orion.models.flow_runs import DependencyResult
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
 from prefect.orion.orchestration.rules import OrchestrationResult
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 
 logger = get_logger("orion.api")
@@ -91,8 +91,8 @@ async def count_flow_runs(
 
 @router.post("/history")
 async def flow_run_history(
-    history_start: datetime_tz = Body(..., description="The history's start time."),
-    history_end: datetime_tz = Body(..., description="The history's end time."),
+    history_start: DateTimeTZ = Body(..., description="The history's start time."),
+    history_end: DateTimeTZ = Body(..., description="The history's end time."),
     history_interval: datetime.timedelta = Body(
         ...,
         description="The size of each history interval, in seconds. Must be at least 1 second.",

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -19,6 +19,7 @@ from prefect.orion.models.flow_runs import DependencyResult
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
 from prefect.orion.orchestration.rules import OrchestrationResult
+from prefect.orion.utilities.schemas import datetime_tz
 from prefect.orion.utilities.server import OrionRouter
 
 logger = get_logger("orion.api")
@@ -90,10 +91,8 @@ async def count_flow_runs(
 
 @router.post("/history")
 async def flow_run_history(
-    history_start: datetime.datetime = Body(
-        ..., description="The history's start time."
-    ),
-    history_end: datetime.datetime = Body(..., description="The history's end time."),
+    history_start: datetime_tz = Body(..., description="The history's start time."),
+    history_end: datetime_tz = Body(..., description="The history's end time."),
     history_interval: datetime.timedelta = Body(
         ...,
         description="The size of each history interval, in seconds. Must be at least 1 second.",

--- a/src/prefect/orion/api/run_history.py
+++ b/src/prefect/orion/api/run_history.py
@@ -15,6 +15,7 @@ import prefect.orion.schemas as schemas
 from prefect.logging import get_logger
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
+from prefect.orion.utilities.schemas import datetime_tz
 
 logger = get_logger("orion.api")
 
@@ -24,8 +25,8 @@ async def run_history(
     session: sa.orm.Session,
     db: OrionDBInterface,
     run_type: Literal["flow_run", "task_run"],
-    history_start: datetime.datetime,
-    history_end: datetime.datetime,
+    history_start: datetime_tz,
+    history_end: datetime_tz,
     history_interval: datetime.timedelta,
     flows: schemas.filters.FlowFilter = None,
     flow_runs: schemas.filters.FlowRunFilter = None,

--- a/src/prefect/orion/api/run_history.py
+++ b/src/prefect/orion/api/run_history.py
@@ -15,7 +15,7 @@ import prefect.orion.schemas as schemas
 from prefect.logging import get_logger
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 
 logger = get_logger("orion.api")
 
@@ -25,8 +25,8 @@ async def run_history(
     session: sa.orm.Session,
     db: OrionDBInterface,
     run_type: Literal["flow_run", "task_run"],
-    history_start: datetime_tz,
-    history_end: datetime_tz,
+    history_start: DateTimeTZ,
+    history_end: DateTimeTZ,
     history_interval: datetime.timedelta,
     flows: schemas.filters.FlowFilter = None,
     flow_runs: schemas.filters.FlowRunFilter = None,

--- a/src/prefect/orion/api/task_runs.py
+++ b/src/prefect/orion/api/task_runs.py
@@ -17,7 +17,7 @@ from prefect.orion.api.run_history import run_history
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
 from prefect.orion.orchestration.rules import OrchestrationResult
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/task_runs", tags=["Task Runs"])
@@ -71,8 +71,8 @@ async def count_task_runs(
 
 @router.post("/history")
 async def task_run_history(
-    history_start: datetime_tz = Body(..., description="The history's start time."),
-    history_end: datetime_tz = Body(..., description="The history's end time."),
+    history_start: DateTimeTZ = Body(..., description="The history's start time."),
+    history_end: DateTimeTZ = Body(..., description="The history's end time."),
     history_interval: datetime.timedelta = Body(
         ...,
         description="The size of each history interval, in seconds. Must be at least 1 second.",

--- a/src/prefect/orion/api/task_runs.py
+++ b/src/prefect/orion/api/task_runs.py
@@ -17,6 +17,7 @@ from prefect.orion.api.run_history import run_history
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
 from prefect.orion.orchestration.rules import OrchestrationResult
+from prefect.orion.utilities.schemas import datetime_tz
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/task_runs", tags=["Task Runs"])
@@ -70,10 +71,8 @@ async def count_task_runs(
 
 @router.post("/history")
 async def task_run_history(
-    history_start: datetime.datetime = Body(
-        ..., description="The history's start time."
-    ),
-    history_end: datetime.datetime = Body(..., description="The history's end time."),
+    history_start: datetime_tz = Body(..., description="The history's start time."),
+    history_end: datetime_tz = Body(..., description="The history's end time."),
     history_interval: datetime.timedelta = Body(
         ...,
         description="The size of each history interval, in seconds. Must be at least 1 second.",

--- a/src/prefect/orion/api/ui/flow_runs.py
+++ b/src/prefect/orion/api/ui/flow_runs.py
@@ -11,7 +11,7 @@ import prefect.orion.schemas as schemas
 from prefect.logging import get_logger
 from prefect.orion import models
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
 from prefect.orion.utilities.server import OrionRouter
 
 logger = get_logger("orion.api.ui.flow_runs")
@@ -22,7 +22,7 @@ router = OrionRouter(prefix="/ui/flow_runs", tags=["Flow Runs", "UI"])
 class SimpleFlowRun(PrefectBaseModel):
     id: UUID = Field(..., description="The flow run id.")
     state_type: schemas.states.StateType = Field(..., description="The state type.")
-    timestamp: datetime.datetime = Field(
+    timestamp: datetime_tz = Field(
         ...,
         description="The start time of the run, or the expected start time "
         "if it hasn't run yet.",

--- a/src/prefect/orion/api/ui/flow_runs.py
+++ b/src/prefect/orion/api/ui/flow_runs.py
@@ -11,7 +11,7 @@ import prefect.orion.schemas as schemas
 from prefect.logging import get_logger
 from prefect.orion import models
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 
 logger = get_logger("orion.api.ui.flow_runs")
@@ -22,7 +22,7 @@ router = OrionRouter(prefix="/ui/flow_runs", tags=["Flow Runs", "UI"])
 class SimpleFlowRun(PrefectBaseModel):
     id: UUID = Field(..., description="The flow run id.")
     state_type: schemas.states.StateType = Field(..., description="The state type.")
-    timestamp: datetime_tz = Field(
+    timestamp: DateTimeTZ = Field(
         ...,
         description="The start time of the run, or the expected start time "
         "if it hasn't run yet.",

--- a/src/prefect/orion/api/ui/flow_runs.py
+++ b/src/prefect/orion/api/ui/flow_runs.py
@@ -11,7 +11,7 @@ import prefect.orion.schemas as schemas
 from prefect.logging import get_logger
 from prefect.orion import models
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 from prefect.orion.utilities.server import OrionRouter
 
 logger = get_logger("orion.api.ui.flow_runs")

--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -12,7 +12,7 @@ from fastapi import Body, Depends, HTTPException, Path, status
 import prefect.orion.api.dependencies as dependencies
 import prefect.orion.models as models
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import datetime_tz
+from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/work_queues", tags=["Work Queues"])
@@ -102,7 +102,7 @@ async def read_work_queue(
 async def read_work_queue_runs(
     work_queue_id: UUID = Path(..., description="The work queue id", alias="id"),
     limit: int = dependencies.LimitBody(),
-    scheduled_before: datetime_tz = Body(
+    scheduled_before: DateTimeTZ = Body(
         None,
         description="Only flow runs scheduled to start before this time will be returned. If not provided, defaults to now.",
     ),

--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -2,7 +2,6 @@
 Routes for interacting with work queue objects.
 """
 
-import datetime
 from typing import List, Optional
 from uuid import UUID
 
@@ -13,6 +12,7 @@ from fastapi import Body, Depends, HTTPException, Path, status
 import prefect.orion.api.dependencies as dependencies
 import prefect.orion.models as models
 import prefect.orion.schemas as schemas
+from prefect.orion.utilities.schemas import datetime_tz
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/work_queues", tags=["Work Queues"])
@@ -102,7 +102,7 @@ async def read_work_queue(
 async def read_work_queue_runs(
     work_queue_id: UUID = Path(..., description="The work queue id", alias="id"),
     limit: int = dependencies.LimitBody(),
-    scheduled_before: datetime.datetime = Body(
+    scheduled_before: datetime_tz = Body(
         None,
         description="Only flow runs scheduled to start before this time will be returned. If not provided, defaults to now.",
     ),

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -12,7 +12,7 @@ import prefect.orion.database
 import prefect.orion.schemas as schemas
 from prefect.exceptions import InvalidNameError
 from prefect.orion.utilities.names import generate_slug, obfuscate_string
-from prefect.orion.utilities.schemas import ORMBaseModel, PrefectBaseModel
+from prefect.orion.utilities.schemas import ORMBaseModel, PrefectBaseModel, datetime_tz
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
 
 INVALID_CHARACTERS = ["/", "%", "&", ">", "<"]
@@ -147,17 +147,17 @@ class FlowRun(ORMBaseModel):
         0, description="The number of times the flow run was executed."
     )
 
-    expected_start_time: datetime.datetime = Field(
+    expected_start_time: datetime_tz = Field(
         None,
         description="The flow run's expected start time.",
     )
 
-    next_scheduled_start_time: datetime.datetime = Field(
+    next_scheduled_start_time: datetime_tz = Field(
         None,
         description="The next time the flow run is scheduled to start.",
     )
-    start_time: datetime.datetime = Field(None, description="The actual start time.")
-    end_time: datetime.datetime = Field(None, description="The actual end time.")
+    start_time: datetime_tz = Field(None, description="The actual start time.")
+    end_time: datetime_tz = Field(None, description="The actual end time.")
     total_run_time: datetime.timedelta = Field(
         datetime.timedelta(0),
         description="Total run time. If the flow run was executed multiple times, the time of each run will be summed.",
@@ -261,7 +261,7 @@ class TaskRun(ORMBaseModel):
         None,
         description="An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.",
     )
-    cache_expiration: datetime.datetime = Field(
+    cache_expiration: datetime_tz = Field(
         None, description="Specifies when the cached state should expire."
     )
     task_version: str = Field(None, description="The version of the task being run.")
@@ -287,19 +287,19 @@ class TaskRun(ORMBaseModel):
         0, description="The number of times the task run has been executed."
     )
 
-    expected_start_time: datetime.datetime = Field(
+    expected_start_time: datetime_tz = Field(
         None,
         description="The task run's expected start time.",
     )
 
     # the next scheduled start time will be populated
     # whenever the run is in a scheduled state
-    next_scheduled_start_time: datetime.datetime = Field(
+    next_scheduled_start_time: datetime_tz = Field(
         None,
         description="The next time the task run is scheduled to start.",
     )
-    start_time: datetime.datetime = Field(None, description="The actual start time.")
-    end_time: datetime.datetime = Field(None, description="The actual end time.")
+    start_time: datetime_tz = Field(None, description="The actual start time.")
+    end_time: datetime_tz = Field(None, description="The actual end time.")
     total_run_time: datetime.timedelta = Field(
         datetime.timedelta(0),
         description="Total run time. If the task run was executed multiple times, the time of each run will be summed.",
@@ -594,7 +594,7 @@ class Log(ORMBaseModel):
     name: str = Field(..., description="The logger name.")
     level: int = Field(..., description="The log level.")
     message: str = Field(..., description="The log message.")
-    timestamp: datetime.datetime = Field(..., description="The log timestamp.")
+    timestamp: datetime_tz = Field(..., description="The log timestamp.")
     flow_run_id: UUID = Field(
         ..., description="The flow run ID associated with the log."
     )
@@ -738,7 +738,7 @@ class Agent(ORMBaseModel):
     work_queue_id: UUID = Field(
         ..., description="The work queue with which the agent is associated."
     )
-    last_activity_time: Optional[datetime.datetime] = Field(
+    last_activity_time: Optional[datetime_tz] = Field(
         None, description="The last time this agent polled for work."
     )
 

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -12,7 +12,7 @@ import prefect.orion.database
 import prefect.orion.schemas as schemas
 from prefect.exceptions import InvalidNameError
 from prefect.orion.utilities.names import generate_slug, obfuscate_string
-from prefect.orion.utilities.schemas import ORMBaseModel, PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import ORMBaseModel, PrefectBaseModel, DateTimeTZ
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
 
 INVALID_CHARACTERS = ["/", "%", "&", ">", "<"]
@@ -147,17 +147,17 @@ class FlowRun(ORMBaseModel):
         0, description="The number of times the flow run was executed."
     )
 
-    expected_start_time: datetime_tz = Field(
+    expected_start_time: DateTimeTZ = Field(
         None,
         description="The flow run's expected start time.",
     )
 
-    next_scheduled_start_time: datetime_tz = Field(
+    next_scheduled_start_time: DateTimeTZ = Field(
         None,
         description="The next time the flow run is scheduled to start.",
     )
-    start_time: datetime_tz = Field(None, description="The actual start time.")
-    end_time: datetime_tz = Field(None, description="The actual end time.")
+    start_time: DateTimeTZ = Field(None, description="The actual start time.")
+    end_time: DateTimeTZ = Field(None, description="The actual end time.")
     total_run_time: datetime.timedelta = Field(
         datetime.timedelta(0),
         description="Total run time. If the flow run was executed multiple times, the time of each run will be summed.",
@@ -261,7 +261,7 @@ class TaskRun(ORMBaseModel):
         None,
         description="An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.",
     )
-    cache_expiration: datetime_tz = Field(
+    cache_expiration: DateTimeTZ = Field(
         None, description="Specifies when the cached state should expire."
     )
     task_version: str = Field(None, description="The version of the task being run.")
@@ -287,19 +287,19 @@ class TaskRun(ORMBaseModel):
         0, description="The number of times the task run has been executed."
     )
 
-    expected_start_time: datetime_tz = Field(
+    expected_start_time: DateTimeTZ = Field(
         None,
         description="The task run's expected start time.",
     )
 
     # the next scheduled start time will be populated
     # whenever the run is in a scheduled state
-    next_scheduled_start_time: datetime_tz = Field(
+    next_scheduled_start_time: DateTimeTZ = Field(
         None,
         description="The next time the task run is scheduled to start.",
     )
-    start_time: datetime_tz = Field(None, description="The actual start time.")
-    end_time: datetime_tz = Field(None, description="The actual end time.")
+    start_time: DateTimeTZ = Field(None, description="The actual start time.")
+    end_time: DateTimeTZ = Field(None, description="The actual end time.")
     total_run_time: datetime.timedelta = Field(
         datetime.timedelta(0),
         description="Total run time. If the task run was executed multiple times, the time of each run will be summed.",
@@ -594,7 +594,7 @@ class Log(ORMBaseModel):
     name: str = Field(..., description="The logger name.")
     level: int = Field(..., description="The log level.")
     message: str = Field(..., description="The log message.")
-    timestamp: datetime_tz = Field(..., description="The log timestamp.")
+    timestamp: DateTimeTZ = Field(..., description="The log timestamp.")
     flow_run_id: UUID = Field(
         ..., description="The flow run ID associated with the log."
     )
@@ -738,7 +738,7 @@ class Agent(ORMBaseModel):
     work_queue_id: UUID = Field(
         ..., description="The work queue with which the agent is associated."
     )
-    last_activity_time: Optional[datetime_tz] = Field(
+    last_activity_time: Optional[DateTimeTZ] = Field(
         None, description="The last time this agent polled for work."
     )
 

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -12,7 +12,7 @@ import prefect.orion.database
 import prefect.orion.schemas as schemas
 from prefect.exceptions import InvalidNameError
 from prefect.orion.utilities.names import generate_slug, obfuscate_string
-from prefect.orion.utilities.schemas import ORMBaseModel, PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, ORMBaseModel, PrefectBaseModel
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
 
 INVALID_CHARACTERS = ["/", "%", "&", ">", "<"]

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -12,7 +12,7 @@ from pydantic import Field
 from sqlalchemy.sql.elements import BooleanClauseList
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -4,7 +4,6 @@ Schemas that define Orion filtering operations.
 Each filter schema includes logic for transforming itself into a SQL `where` clause.
 """
 
-import datetime
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
@@ -13,7 +12,7 @@ from pydantic import Field
 from sqlalchemy.sql.elements import BooleanClauseList
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:
@@ -298,10 +297,10 @@ class FlowRunFilterFlowVersion(PrefectFilterBaseModel):
 class FlowRunFilterStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.start_time`."""
 
-    before_: datetime.datetime = Field(
+    before_: datetime_tz = Field(
         None, description="Only include flow runs starting at or before this time"
     )
-    after_: datetime.datetime = Field(
+    after_: datetime_tz = Field(
         None, description="Only include flow runs starting at or after this time"
     )
     is_null_: bool = Field(
@@ -326,11 +325,11 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
 class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.expected_start_time`."""
 
-    before_: datetime.datetime = Field(
+    before_: datetime_tz = Field(
         None,
         description="Only include flow runs scheduled to start at or before this time",
     )
-    after_: datetime.datetime = Field(
+    after_: datetime_tz = Field(
         None,
         description="Only include flow runs scheduled to start at or after this time",
     )
@@ -347,11 +346,11 @@ class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
 class FlowRunFilterNextScheduledStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.next_scheduled_start_time`."""
 
-    before_: datetime.datetime = Field(
+    before_: datetime_tz = Field(
         None,
         description="Only include flow runs with a next_scheduled_start_time or before this time",
     )
-    after_: datetime.datetime = Field(
+    after_: datetime_tz = Field(
         None,
         description="Only include flow runs with a next_scheduled_start_time at or after this time",
     )
@@ -573,10 +572,10 @@ class TaskRunFilterSubFlowRuns(PrefectFilterBaseModel):
 class TaskRunFilterStartTime(PrefectFilterBaseModel):
     """Filter by `TaskRun.start_time`."""
 
-    before_: datetime.datetime = Field(
+    before_: datetime_tz = Field(
         None, description="Only include task runs starting at or before this time"
     )
-    after_: datetime.datetime = Field(
+    after_: datetime_tz = Field(
         None, description="Only include task runs starting at or after this time"
     )
     is_null_: bool = Field(
@@ -793,10 +792,10 @@ class LogFilterLevel(PrefectFilterBaseModel):
 class LogFilterTimestamp(PrefectFilterBaseModel):
     """Filter by `Log.timestamp`."""
 
-    before_: datetime.datetime = Field(
+    before_: datetime_tz = Field(
         None, description="Only include logs with a timestamp at or before this time"
     )
-    after_: datetime.datetime = Field(
+    after_: datetime_tz = Field(
         None, description="Only include logs with a timestamp at or after this time"
     )
 

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -12,7 +12,7 @@ from pydantic import Field
 from sqlalchemy.sql.elements import BooleanClauseList
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:
@@ -297,10 +297,10 @@ class FlowRunFilterFlowVersion(PrefectFilterBaseModel):
 class FlowRunFilterStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.start_time`."""
 
-    before_: datetime_tz = Field(
+    before_: DateTimeTZ = Field(
         None, description="Only include flow runs starting at or before this time"
     )
-    after_: datetime_tz = Field(
+    after_: DateTimeTZ = Field(
         None, description="Only include flow runs starting at or after this time"
     )
     is_null_: bool = Field(
@@ -325,11 +325,11 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
 class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.expected_start_time`."""
 
-    before_: datetime_tz = Field(
+    before_: DateTimeTZ = Field(
         None,
         description="Only include flow runs scheduled to start at or before this time",
     )
-    after_: datetime_tz = Field(
+    after_: DateTimeTZ = Field(
         None,
         description="Only include flow runs scheduled to start at or after this time",
     )
@@ -346,11 +346,11 @@ class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
 class FlowRunFilterNextScheduledStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.next_scheduled_start_time`."""
 
-    before_: datetime_tz = Field(
+    before_: DateTimeTZ = Field(
         None,
         description="Only include flow runs with a next_scheduled_start_time or before this time",
     )
-    after_: datetime_tz = Field(
+    after_: DateTimeTZ = Field(
         None,
         description="Only include flow runs with a next_scheduled_start_time at or after this time",
     )
@@ -572,10 +572,10 @@ class TaskRunFilterSubFlowRuns(PrefectFilterBaseModel):
 class TaskRunFilterStartTime(PrefectFilterBaseModel):
     """Filter by `TaskRun.start_time`."""
 
-    before_: datetime_tz = Field(
+    before_: DateTimeTZ = Field(
         None, description="Only include task runs starting at or before this time"
     )
-    after_: datetime_tz = Field(
+    after_: DateTimeTZ = Field(
         None, description="Only include task runs starting at or after this time"
     )
     is_null_: bool = Field(
@@ -792,10 +792,10 @@ class LogFilterLevel(PrefectFilterBaseModel):
 class LogFilterTimestamp(PrefectFilterBaseModel):
     """Filter by `Log.timestamp`."""
 
-    before_: datetime_tz = Field(
+    before_: DateTimeTZ = Field(
         None, description="Only include logs with a timestamp at or before this time"
     )
-    after_: datetime_tz = Field(
+    after_: DateTimeTZ = Field(
         None, description="Only include logs with a timestamp at or after this time"
     )
 

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from typing_extensions import Literal
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
 from prefect.utilities.collections import AutoEnum
 
 
@@ -92,12 +92,10 @@ class HistoryResponseState(PrefectBaseModel):
 class HistoryResponse(PrefectBaseModel):
     """Represents a history of aggregation states over an interval"""
 
-    interval_start: datetime.datetime = Field(
+    interval_start: datetime_tz = Field(
         ..., description="The start date of the interval."
     )
-    interval_end: datetime.datetime = Field(
-        ..., description="The end date of the interval."
-    )
+    interval_end: datetime_tz = Field(..., description="The end date of the interval.")
     states: List[HistoryResponseState] = Field(
         ..., description="A list of state histories during the interval."
     )

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from typing_extensions import Literal
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
 from prefect.utilities.collections import AutoEnum
 
 
@@ -92,10 +92,10 @@ class HistoryResponseState(PrefectBaseModel):
 class HistoryResponse(PrefectBaseModel):
     """Represents a history of aggregation states over an interval"""
 
-    interval_start: datetime_tz = Field(
+    interval_start: DateTimeTZ = Field(
         ..., description="The start date of the interval."
     )
-    interval_end: datetime_tz = Field(..., description="The end date of the interval.")
+    interval_end: DateTimeTZ = Field(..., description="The end date of the interval.")
     states: List[HistoryResponseState] = Field(
         ..., description="A list of state histories during the interval."
     )

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from typing_extensions import Literal
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 from prefect.utilities.collections import AutoEnum
 
 

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -13,7 +13,7 @@ import pytz
 from croniter import croniter
 from pydantic import Field, validator
 
-from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
 
 MAX_ITERATIONS = 10000
 
@@ -62,7 +62,7 @@ class IntervalSchedule(PrefectBaseModel):
         exclude_none = True
 
     interval: datetime.timedelta
-    anchor_date: datetime_tz = None
+    anchor_date: DateTimeTZ = None
     timezone: str = Field(None, example="America/New_York")
 
     @validator("interval")

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -13,7 +13,7 @@ import pytz
 from croniter import croniter
 from pydantic import Field, validator
 
-from prefect.orion.utilities.schemas import PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 
 MAX_ITERATIONS = 10000
 

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -13,7 +13,7 @@ import pytz
 from croniter import croniter
 from pydantic import Field, validator
 
-from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.orion.utilities.schemas import PrefectBaseModel, datetime_tz
 
 MAX_ITERATIONS = 10000
 
@@ -62,7 +62,7 @@ class IntervalSchedule(PrefectBaseModel):
         exclude_none = True
 
     interval: datetime.timedelta
-    anchor_date: datetime.datetime = None
+    anchor_date: datetime_tz = None
     timezone: str = Field(None, example="America/New_York")
 
     @validator("interval")

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -12,7 +12,7 @@ import pendulum
 from pydantic import Field, root_validator, validator
 
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.utilities.schemas import IDBaseModel, PrefectBaseModel, datetime_tz
+from prefect.orion.utilities.schemas import IDBaseModel, PrefectBaseModel, DateTimeTZ
 from prefect.utilities.collections import AutoEnum
 
 R = TypeVar("R")
@@ -43,9 +43,9 @@ class StateDetails(PrefectBaseModel):
     task_run_id: UUID = None
     # for task runs that represent subflows, the subflow's run ID
     child_flow_run_id: UUID = None
-    scheduled_time: datetime_tz = None
+    scheduled_time: DateTimeTZ = None
     cache_key: str = None
-    cache_expiration: datetime_tz = None
+    cache_expiration: DateTimeTZ = None
 
 
 class State(IDBaseModel, Generic[R]):
@@ -56,7 +56,7 @@ class State(IDBaseModel, Generic[R]):
 
     type: StateType
     name: str = None
-    timestamp: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
+    timestamp: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
     message: str = Field(None, example="Run started")
     data: DataDocument[R] = Field(None)
     state_details: StateDetails = Field(default_factory=StateDetails)

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -12,7 +12,7 @@ import pendulum
 from pydantic import Field, root_validator, validator
 
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.utilities.schemas import IDBaseModel, PrefectBaseModel
+from prefect.orion.utilities.schemas import IDBaseModel, PrefectBaseModel, datetime_tz
 from prefect.utilities.collections import AutoEnum
 
 R = TypeVar("R")
@@ -43,9 +43,9 @@ class StateDetails(PrefectBaseModel):
     task_run_id: UUID = None
     # for task runs that represent subflows, the subflow's run ID
     child_flow_run_id: UUID = None
-    scheduled_time: datetime.datetime = None
+    scheduled_time: datetime_tz = None
     cache_key: str = None
-    cache_expiration: datetime.datetime = None
+    cache_expiration: datetime_tz = None
 
 
 class State(IDBaseModel, Generic[R]):
@@ -56,7 +56,7 @@ class State(IDBaseModel, Generic[R]):
 
     type: StateType
     name: str = None
-    timestamp: datetime.datetime = Field(default_factory=lambda: pendulum.now("UTC"))
+    timestamp: datetime_tz = Field(default_factory=lambda: pendulum.now("UTC"))
     message: str = Field(None, example="Run started")
     data: DataDocument[R] = Field(None)
     state_details: StateDetails = Field(default_factory=StateDetails)

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -12,7 +12,7 @@ import pendulum
 from pydantic import Field, root_validator, validator
 
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.utilities.schemas import IDBaseModel, PrefectBaseModel, DateTimeTZ
+from prefect.orion.utilities.schemas import DateTimeTZ, IDBaseModel, PrefectBaseModel
 from prefect.utilities.collections import AutoEnum
 
 R = TypeVar("R")

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -16,7 +16,7 @@ from pydantic.json import custom_pydantic_encoder
 T = TypeVar("T")
 
 
-class datetime_tz(pendulum.DateTime):
+class DateTimeTZ(pendulum.DateTime):
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
@@ -320,8 +320,8 @@ class ORMBaseModel(IDBaseModel):
     class Config:
         orm_mode = True
 
-    created: datetime_tz = Field(None, repr=False)
-    updated: datetime_tz = Field(None, repr=False)
+    created: DateTimeTZ = Field(None, repr=False)
+    updated: DateTimeTZ = Field(None, repr=False)
 
     def _reset_fields(self) -> Set[str]:
         return super()._reset_fields().union({"created", "updated"})

--- a/tests/orion/utilities/test_schemas.py
+++ b/tests/orion/utilities/test_schemas.py
@@ -6,10 +6,10 @@ import pydantic
 import pytest
 
 from prefect.orion.utilities.schemas import (
+    DateTimeTZ,
     IDBaseModel,
     ORMBaseModel,
     PrefectBaseModel,
-    DateTimeTZ,
     pydantic_subclass,
 )
 from prefect.testing.utilities import assert_does_not_warn

--- a/tests/orion/utilities/test_schemas.py
+++ b/tests/orion/utilities/test_schemas.py
@@ -9,6 +9,7 @@ from prefect.orion.utilities.schemas import (
     IDBaseModel,
     ORMBaseModel,
     PrefectBaseModel,
+    datetime_tz,
     pydantic_subclass,
 )
 from prefect.testing.utilities import assert_does_not_warn
@@ -269,3 +270,32 @@ class TestEqualityExcludedFields:
         # if the PBM is the RH operand, the equality check fails
         # because the Pydantic logic of using every field is applied
         assert Y(val=1) != X(val=1)
+
+
+class TestDatetimeTZ:
+    class Model(pydantic.BaseModel):
+        dt: datetime.datetime
+        dtp: pendulum.DateTime
+        dttz: datetime_tz
+
+    async def test_tz_adds_timezone(self):
+        model = self.Model(
+            dt=datetime.datetime(2022, 1, 1),
+            dtp=datetime.datetime(2022, 1, 1),
+            dttz=datetime.datetime(2022, 1, 1),
+        )
+
+        assert model.dt.tzinfo is None
+        assert model.dtp.tzinfo is None
+        assert model.dttz.tzinfo.name == "UTC"
+
+    async def test_tz_is_pydantic_object(self):
+        model = self.Model(
+            dt=datetime.datetime(2022, 1, 1),
+            dtp=datetime.datetime(2022, 1, 1),
+            dttz=datetime.datetime(2022, 1, 1),
+        )
+        assert not isinstance(model.dt, pendulum.DateTime)
+        # typing as pendulum datetime doesn't result in pendulum datetime
+        assert not isinstance(model.dtp, pendulum.DateTime)
+        assert isinstance(model.dttz, pendulum.DateTime)

--- a/tests/orion/utilities/test_schemas.py
+++ b/tests/orion/utilities/test_schemas.py
@@ -9,7 +9,7 @@ from prefect.orion.utilities.schemas import (
     IDBaseModel,
     ORMBaseModel,
     PrefectBaseModel,
-    datetime_tz,
+    DateTimeTZ,
     pydantic_subclass,
 )
 from prefect.testing.utilities import assert_does_not_warn
@@ -276,7 +276,7 @@ class TestDatetimeTZ:
     class Model(pydantic.BaseModel):
         dt: datetime.datetime
         dtp: pendulum.DateTime
-        dttz: datetime_tz
+        dttz: DateTimeTZ
 
     async def test_tz_adds_timezone(self):
         model = self.Model(


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

This PR introduces a new Pydantic-validated type `DateTimeTZ` that always converts its input to a Pendulum timezone-aware datetime. 

This is a drop-in replacement for anywhere we currently type inputs as `datetime.datetime` or `pendulum.DateTime`, following up from https://github.com/PrefectHQ/orion/pull/2469, in which care was taken to ensure that models were serialized with tz-aware datetimes. 

Note that it actually **doesn't** work to type a field as `pendulum.DateTime`; pydantic will not coerce native or timezone-naive datetimes to Pendulum types. This new type achieves this with a custom pydantic validator, which means that all API-facing inputs will be guaranteed to be timezone-aware. The class is defined [here](https://github.com/PrefectHQ/prefect/pull/6142/files#diff-95fcbac7a05664ca639da44401dac5293d2f0eb54bb08638416863edfe915ce2R19-R33) and Pydantic docs on custom-validated types are [here](https://pydantic-docs.helpmanual.io/usage/types/#custom-data-types).

cc @chrisguidry 

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by someobdy with limited knowledge of the feature that you are submitting


**Happy engineering!**
