### PR TITLE
Adds support for `BaseModel` fields in blocks

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -39,22 +39,22 @@ class InvalidBlockRegistration(Exception):
     """
 
 
-def _find_nested_reference_strings(obj):
+def _collect_nested_reference_strings(obj):
     found_reference_strings = []
     if isinstance(obj, dict):
         if obj.get("$ref"):
             found_reference_strings.append(obj.get("$ref"))
         for value in obj.values():
-            found_reference_strings.extend(_find_nested_reference_strings(value))
+            found_reference_strings.extend(_collect_nested_reference_strings(value))
     if isinstance(obj, list):
         for item in obj:
-            found_reference_strings.extend(_find_nested_reference_strings(item))
+            found_reference_strings.extend(_collect_nested_reference_strings(item))
     return found_reference_strings
 
 
 def _get_non_block_definitions(fields, definitions):
     non_block_definitions = {}
-    reference_strings = _find_nested_reference_strings(fields)
+    reference_strings = _collect_nested_reference_strings(fields)
     for reference_string in reference_strings:
         definition_key = reference_string.replace("#/definitions/", "")
         definition = definitions.get(definition_key)

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -39,8 +39,52 @@ class InvalidBlockRegistration(Exception):
     """
 
 
+def _find_nested_reference_strings(obj):
+    found_reference_strings = []
+    if isinstance(obj, dict):
+        if obj.get("$ref"):
+            found_reference_strings.append(obj.get("$ref"))
+        for value in obj.values():
+            found_reference_strings.extend(_find_nested_reference_strings(value))
+    if isinstance(obj, list):
+        for item in obj:
+            found_reference_strings.extend(_find_nested_reference_strings(item))
+    return found_reference_strings
+
+
+def _get_non_block_definitions(fields, definitions):
+    non_block_definitions = {}
+    reference_strings = _find_nested_reference_strings(fields)
+    for reference_string in reference_strings:
+        definition_key = reference_string.replace("#/definitions/", "")
+        definition = definitions.get(definition_key)
+        if definition and definition.get("block_type_slug") is None:
+            non_block_definitions = {
+                **non_block_definitions,
+                definition_key: definition,
+                **_get_non_block_definitions(definition, definitions),
+            }
+    return non_block_definitions
+
+
 @register_base_type
 class Block(BaseModel, ABC):
+    """
+    A base class for implementing a block that wraps an external service.
+
+    This class can be defined with an arbitrary set of fields and methods, and
+    couples business logic with data contained in an block document.
+    `_block_document_name`, `_block_document_id`, `_block_schema_id`, and
+    `_block_type_id` are reserved by Orion as Block metadata fields, but
+    otherwise a Block can implement arbitrary logic. Blocks can be instantiated
+    without populating these metadata fields, but can only be used interactively,
+    not with the Orion API.
+
+    Instead of the __init__ method, a block implementation allows the
+    definition of a `block_initialization` method that is called after
+    initialization.
+    """
+
     class Config:
         extra = "allow"
 
@@ -53,7 +97,10 @@ class Block(BaseModel, ABC):
             # Ensures args and code examples aren't included in the schema
             description = model.get_description()
             if description:
-                schema["description"] = model.get_description()
+                schema["description"] = description
+            else:
+                # Prevent the description of the base class from being included in the schema
+                schema.pop("description", None)
 
             # create a list of secret field names
             # secret fields include both top-level keys and dot-delimited nested secret keys
@@ -76,28 +123,21 @@ class Block(BaseModel, ABC):
                 if Block.is_block_class(field.type_):
                     refs[field.name] = field.type_._to_block_schema_reference_dict()
                 if get_origin(field.type_) is Union:
-                    refs[field.name] = []
                     for type_ in get_args(field.type_):
                         if Block.is_block_class(type_):
-                            refs[field.name].append(
-                                type_._to_block_schema_reference_dict()
-                            )
-
-    """
-    A base class for implementing a block that wraps an external service.
-
-    This class can be defined with an arbitrary set of fields and methods, and
-    couples business logic with data contained in an block document.
-    `_block_document_name`, `_block_document_id`, `_block_schema_id`, and
-    `_block_type_id` are reserved by Orion as Block metadata fields, but
-    otherwise a Block can implement arbitrary logic. Blocks can be instantiated
-    without populating these metadata fields, but can only be used interactively,
-    not with the Orion API.
-
-    Instead of the __init__ method, a block implementation allows the
-    definition of a `block_initialization` method that is called after
-    initialization.
-    """
+                            if isinstance(refs.get(field.name), list):
+                                refs[field.name].append(
+                                    type_._to_block_schema_reference_dict()
+                                )
+                            elif isinstance(refs.get(field.name), dict):
+                                refs[field.name] = [
+                                    refs[field.name],
+                                    type_._to_block_schema_reference_dict(),
+                                ]
+                            else:
+                                refs[
+                                    field.name
+                                ] = type_._to_block_schema_reference_dict()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -184,8 +224,18 @@ class Block(BaseModel, ABC):
             cls.schema() if block_schema_fields is None else block_schema_fields
         )
         fields_for_checksum = remove_nested_keys(
-            ["description", "definitions", "secret_fields"], block_schema_fields
+            ["description", "secret_fields"], block_schema_fields
         )
+        if fields_for_checksum.get("definitions"):
+            non_block_definitions = _get_non_block_definitions(
+                fields_for_checksum, fields_for_checksum["definitions"]
+            )
+            if non_block_definitions:
+                fields_for_checksum["definitions"] = non_block_definitions
+            else:
+                # Pop off definitions entirely instead of empty dict for consistency
+                # with the OpenAPI specification
+                fields_for_checksum.pop("definitions")
         checksum = hash_objects(fields_for_checksum, hash_algo=hashlib.sha256)
         if checksum is None:
             raise ValueError("Unable to compute checksum for block schema")

--- a/src/prefect/orion/models/block_schemas.py
+++ b/src/prefect/orion/models/block_schemas.py
@@ -10,7 +10,11 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy import delete, select
 
-from prefect.blocks.core import Block
+from prefect.blocks.core import (
+    Block,
+    _find_nested_reference_strings,
+    _get_non_block_definitions,
+)
 from prefect.orion import schemas
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
@@ -48,11 +52,28 @@ async def create_block_schema(
         exclude_unset=False,
         exclude={"block_type", "id", "created", "updated"},
     )
-    definitions = definitions or insert_values["fields"].pop("definitions", None)
-    insert_values["checksum"] = Block._calculate_schema_checksum(
-        insert_values["fields"]
-    )
+    definitions = definitions or insert_values["fields"].get("definitions", None)
+    fields_for_checksum = insert_values["fields"]
+    if definitions:
+        # Ensure definitions are available if this is a nested schema
+        # that is being registered
+        fields_for_checksum["definitions"] = definitions
+    insert_values["checksum"] = Block._calculate_schema_checksum(fields_for_checksum)
 
+    # Get non block definitions for saving to the DB.
+    non_block_definitions = _get_non_block_definitions(
+        insert_values["fields"], definitions
+    )
+    if non_block_definitions:
+        insert_values["fields"]["definitions"] = _get_non_block_definitions(
+            insert_values["fields"], definitions
+        )
+    else:
+        # Prevent storing definitions for blocks. Those are reconstructed on read.
+        insert_values["fields"].pop("definitions", None)
+
+    # Prevent saving block schema references in the block_schema table. They have
+    # they're own table.
     block_schema_references: Dict = insert_values["fields"].pop(
         "block_schema_references", {}
     )
@@ -141,11 +162,6 @@ async def _register_nested_block_schemas(
             )
             # Attempts to create block schema since it has not already been registered
             if reference_block_schema is None:
-                if definitions is None:
-                    raise ValueError(
-                        "Unable to create nested block schema due to missing definitions "
-                        "in root block schema fields"
-                    )
                 sub_block_schema_fields = _get_fields_for_child_schema(
                     definitions, base_fields, reference_name, reference_block_type
                 )
@@ -197,13 +213,14 @@ def _get_fields_for_child_schema(
                 definitions[definition_key]["block_type_slug"]
                 == reference_block_type.slug
             ):
-                # Once we've found the matching definition, we not longer
+                # Once we've found the matching definition, we no longer
                 # need to iterate
                 sub_block_schema_fields = potential_sub_block_schema_fields
                 break
     else:
         # When a block schema reference is a single block, we can use the
         # title to directly find the definition for that block schema.
+        _find_nested_reference_strings
         sub_block_schema_fields = definitions[
             spec_reference["$ref"].replace("#/definitions/", "")
         ]
@@ -338,8 +355,11 @@ def _construct_full_block_schema(
     definitions = _construct_block_schema_spec_definitions(
         root_block_schema, block_schemas_with_references
     )
-    if definitions:
-        root_block_schema.fields["definitions"] = definitions
+    if definitions or root_block_schema.fields.get("definitions"):
+        root_block_schema.fields["definitions"] = {
+            **root_block_schema.fields.get("definitions", {}),
+            **definitions,
+        }
     return root_block_schema
 
 

--- a/src/prefect/orion/models/block_schemas.py
+++ b/src/prefect/orion/models/block_schemas.py
@@ -191,7 +191,10 @@ async def _register_nested_block_schemas(
 
 
 def _get_fields_for_child_schema(
-    definitions: Dict, base_fields: Dict, reference_name: str, reference_block_type: BlockType
+    definitions: Dict,
+    base_fields: Dict,
+    reference_name: str,
+    reference_block_type: BlockType,
 ):
     """
     Returns the field definitions for a child schema. The fields definitions are pulled from the provided `definitions`
@@ -207,7 +210,9 @@ def _get_fields_for_child_schema(
     sub_block_schema_fields = None
     reference_strings = _collect_nested_reference_strings(spec_reference)
     if len(reference_strings) == 1:
-        sub_block_schema_fields = definitions.get(reference_strings[0].replace("#/definitions/", ""))
+        sub_block_schema_fields = definitions.get(
+            reference_strings[0].replace("#/definitions/", "")
+        )
     else:
         for reference_string in reference_strings:
             definition_key = reference_string.replace("#/definitions/", "")

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -1,13 +1,15 @@
 import warnings
-from typing import Union
+from typing import List, Union
 
 import pytest
 import sqlalchemy as sa
+from pydantic import BaseModel
 
 from prefect.blocks.core import Block
 from prefect.orion import models, schemas
 from prefect.orion.models.block_schemas import read_block_schema_by_checksum
 from prefect.orion.schemas.filters import BlockSchemaFilter
+from prefect.utilities.collections import AutoEnum
 
 EMPTY_OBJECT_CHECKSUM = Block._calculate_schema_checksum({})
 
@@ -822,6 +824,149 @@ class TestReadBlockSchemas:
 
         assert len(result) == 2
         assert [a_id, y_id] == [b.id for b in result]
+
+    async def test_read_block_with_non_block_object_attributes(self, session):
+        class NotABlock(BaseModel):
+            alias: str
+
+        class AlsoNotABlock(BaseModel):
+            pseudonym: str
+            child: NotABlock
+
+        class IsABlock(Block):
+            size: int
+            contents: AlsoNotABlock
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=IsABlock._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=IsABlock._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == IsABlock.schema()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+
+        assert read_block_schema.fields == IsABlock.schema()
+
+    async def test_read_block_with_enum_attribute(self, session):
+        class Fruit(AutoEnum):
+            APPLE = AutoEnum.auto()
+            BANANA = AutoEnum.auto()
+            ORANGE = AutoEnum.auto()
+
+        class IsABlock(Block):
+            size: int
+            contents: Fruit
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=IsABlock._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=IsABlock._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == IsABlock.schema()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+
+        assert read_block_schema.fields == IsABlock.schema()
+
+    async def test_read_block_with_non_block_union_attribute(self, session):
+        class NotABlock(BaseModel):
+            alias: str
+
+        class AlsoNotABlock(BaseModel):
+            pseudonym: str
+
+        class IsABlock(Block):
+            size: int
+            contents: Union[NotABlock, AlsoNotABlock]
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=IsABlock._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=IsABlock._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == IsABlock.schema()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+        assert read_block_schema.fields == IsABlock.schema()
+
+    async def test_read_block_with_both_block_and_non_block_attributes(self, session):
+        class NotABlock(BaseModel):
+            alias: str
+
+        class IsABlock(Block):
+            size: int
+
+        class IsAlsoABlock(Block):
+            size: float
+            contents: IsABlock
+            config: NotABlock
+
+        await models.block_types.create_block_type(
+            session=session, block_type=IsABlock._to_block_type()
+        )
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=IsAlsoABlock._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=IsAlsoABlock._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == IsAlsoABlock.schema()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+        assert read_block_schema.fields == IsAlsoABlock.schema()
+
+    async def test_read_block_schema_with_list_block_attribute(self, session):
+        class Child(Block):
+            age: float
+
+        class Parent(Block):
+            age: int
+            children: List[Child]
+
+        await models.block_types.create_block_type(
+            session=session, block_type=Child._to_block_type()
+        )
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=Parent._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=Parent._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == Parent.schema()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+        assert read_block_schema.fields == Parent.schema()
 
 
 class TestDeleteBlockSchema:

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -911,6 +911,31 @@ class TestReadBlockSchemas:
         )
         assert read_block_schema.fields == IsABlock.schema()
 
+    async def test_read_block_with_non_block_list_attribute(self, session):
+        class NotABlock(BaseModel):
+            alias: str
+
+        class IsABlock(Block):
+            size: int
+            contents: List[NotABlock]
+
+        block_type = await models.block_types.create_block_type(
+            session=session, block_type=IsABlock._to_block_type()
+        )
+
+        block_schema = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=IsABlock._to_block_schema(block_type_id=block_type.id),
+        )
+
+        assert block_schema.fields == IsABlock.schema()
+        assert block_schema.checksum == IsABlock._calculate_schema_checksum()
+
+        read_block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema.id
+        )
+        assert read_block_schema.fields == IsABlock.schema()
+
     async def test_read_block_with_both_block_and_non_block_attributes(self, session):
         class NotABlock(BaseModel):
             alias: str
@@ -974,6 +999,12 @@ class TestReadBlockSchemas:
 
         assert block_schema.fields == Parent.schema()
         assert block_schema.checksum == Parent._calculate_schema_checksum()
+        assert block_schema.fields["block_schema_references"] == {
+            "children": {
+                "block_type_slug": "child",
+                "block_schema_checksum": Child._calculate_schema_checksum(),
+            }
+        }
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -847,6 +847,7 @@ class TestReadBlockSchemas:
         )
 
         assert block_schema.fields == IsABlock.schema()
+        assert block_schema.checksum == IsABlock._calculate_schema_checksum()
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id
@@ -874,6 +875,7 @@ class TestReadBlockSchemas:
         )
 
         assert block_schema.fields == IsABlock.schema()
+        assert block_schema.checksum == IsABlock._calculate_schema_checksum()
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id
@@ -902,6 +904,8 @@ class TestReadBlockSchemas:
         )
 
         assert block_schema.fields == IsABlock.schema()
+        assert block_schema.checksum == IsABlock._calculate_schema_checksum()
+
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id
@@ -934,11 +938,17 @@ class TestReadBlockSchemas:
         )
 
         assert block_schema.fields == IsAlsoABlock.schema()
+        assert block_schema.checksum == IsAlsoABlock._calculate_schema_checksum()
 
-        read_block_schema = await models.block_schemas.read_block_schema(
+        read_parent_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id
         )
-        assert read_block_schema.fields == IsAlsoABlock.schema()
+        assert read_parent_block_schema.fields == IsAlsoABlock.schema()
+
+        read_child_block_schema = await models.block_schemas.read_block_schema_by_checksum(
+            session=session, checksum=IsABlock._calculate_schema_checksum()
+        )
+        assert read_child_block_schema.fields == IsABlock.schema()
 
     async def test_read_block_schema_with_list_block_attribute(self, session):
         class Child(Block):
@@ -962,6 +972,8 @@ class TestReadBlockSchemas:
         )
 
         assert block_schema.fields == Parent.schema()
+        assert block_schema.checksum == Parent._calculate_schema_checksum()
+
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -906,7 +906,6 @@ class TestReadBlockSchemas:
         assert block_schema.fields == IsABlock.schema()
         assert block_schema.checksum == IsABlock._calculate_schema_checksum()
 
-
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id
         )
@@ -945,8 +944,10 @@ class TestReadBlockSchemas:
         )
         assert read_parent_block_schema.fields == IsAlsoABlock.schema()
 
-        read_child_block_schema = await models.block_schemas.read_block_schema_by_checksum(
-            session=session, checksum=IsABlock._calculate_schema_checksum()
+        read_child_block_schema = (
+            await models.block_schemas.read_block_schema_by_checksum(
+                session=session, checksum=IsABlock._calculate_schema_checksum()
+            )
         )
         assert read_child_block_schema.fields == IsABlock.schema()
 
@@ -973,7 +974,6 @@ class TestReadBlockSchemas:
 
         assert block_schema.fields == Parent.schema()
         assert block_schema.checksum == Parent._calculate_schema_checksum()
-
 
         read_block_schema = await models.block_schemas.read_block_schema(
             session=session, block_schema_id=block_schema.id


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Adds the ability to embed `BaseModel` subclasses as fields within blocks. This fixes an issue with the `ImagePullPolicy` field on the `KubernetesJob` block not being saved in the block schema. To resolve, non-block definitions in the generated OpenAPI spec are saved in the `fields` column, while definitions for fields that are block continue to be stored in the `block_schema_references` table.

Note that an update to the blocks UI is still needed for `ImagePullPolicy` to render correctly. I've spoken with @pleek91 and should be addressed in an upcoming block UI refactor.

Closes https://github.com/PrefectHQ/prefect/issues/6163

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
The code snippet referenced in https://github.com/PrefectHQ/prefect/issues/6163 now runs successfully.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
