### PR TITLE
Add list of public modules to infrastructure/__init__.py

### DIFF
--- a/src/prefect/infrastructure/__init__.py
+++ b/src/prefect/infrastructure/__init__.py
@@ -9,3 +9,19 @@ from prefect.infrastructure.kubernetes import (
     KubernetesRestartPolicy,
 )
 from prefect.infrastructure.process import Process, ProcessResult
+
+# Declare API
+__all__ = [
+    "DockerContainer",
+    "DockerContainerResult",
+    "Infrastructure",
+    "InfrastructureResult",
+    "KubernetesClusterConfig",
+    "KubernetesImagePullPolicy",
+    "KubernetesJob",
+    "KubernetesJobResult",
+    "KubernetesManifest",
+    "KubernetesRestartPolicy",
+    "Process",
+    "ProcessResult",
+]


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
Adds the `__all__` attribute to `infrastructure/__init__.py` to denote which modules are public. Fixes issue #6144 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix 
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
