### PR TITLE
Switch the name of the active profile on rename if in use

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -1,6 +1,7 @@
 """
 Command line interface for working with profiles.
 """
+import os
 import textwrap
 from typing import Optional
 
@@ -250,6 +251,17 @@ def rename(name: str, new_name: str):
 
     profiles.add_profile(profiles[name].copy(update={"name": new_name}))
     profiles.remove_profile(name)
+
+    # Switch the active profile to the new name if provided
+    context_profile = prefect.context.get_settings_context().profile
+    if profiles.active_name == name:
+        profiles.set_active(new_name)
+    if os.environ.get("PREFECT_PROFILE") == name:
+        app.console.print(
+            f"You have set your current profile to {name!r} with the "
+            "PREFECT_PROFILE environment variable. You must update this variable to "
+            f"{new_name!r} to continue using the profile."
+        )
 
     prefect.settings.save_profiles(profiles)
     exit_with_success(f"Renamed profile {name!r} to {new_name!r}.")

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -252,7 +252,7 @@ def rename(name: str, new_name: str):
     profiles.add_profile(profiles[name].copy(update={"name": new_name}))
     profiles.remove_profile(name)
 
-    # Switch the active profile to the new name if provided
+    # If the active profile was renamed switch the active profile to the new name.
     context_profile = prefect.context.get_settings_context().profile
     if profiles.active_name == name:
         profiles.set_active(new_name)

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -455,6 +455,77 @@ def test_rename_profile_unknown_name():
     )
 
 
+def test_rename_profile_renames_profile():
+    save_profiles(
+        ProfilesCollection(
+            profiles=[
+                Profile(name="foo", settings={PREFECT_API_KEY: "foo"}),
+            ],
+            active=None,
+        )
+    )
+
+    invoke_and_assert(
+        ["profile", "rename", "foo", "bar"],
+        expected_output="Renamed profile 'foo' to 'bar'.",
+        expected_code=0,
+    )
+
+    profiles = load_profiles()
+    assert "foo" not in profiles, "The original profile should not exist anymore"
+    assert profiles["bar"].settings == {
+        PREFECT_API_KEY: "foo"
+    }, "Settings should be retained"
+
+
+def test_rename_profile_changes_active_profile():
+    save_profiles(
+        ProfilesCollection(
+            profiles=[
+                Profile(name="foo", settings={PREFECT_API_KEY: "foo"}),
+            ],
+            active="foo",
+        )
+    )
+
+    invoke_and_assert(
+        ["profile", "rename", "foo", "bar"],
+        expected_output="Renamed profile 'foo' to 'bar'.",
+        expected_code=0,
+    )
+
+    profiles = load_profiles()
+    assert profiles.active_name == "bar"
+
+
+def test_rename_profile_warns_on_environment_variable_active_profile(monkeypatch):
+    save_profiles(
+        ProfilesCollection(
+            profiles=[
+                Profile(name="foo", settings={PREFECT_API_KEY: "foo"}),
+            ],
+            active=None,
+        )
+    )
+
+    monkeypatch.setenv("PREFECT_PROFILE", "foo")
+
+    invoke_and_assert(
+        ["profile", "rename", "foo", "bar"],
+        expected_output_contains=(
+            "You have set your current profile to 'foo' with the PREFECT_PROFILE "
+            "environment variable. You must update this variable to 'bar' "
+            "to continue using the profile."
+        ),
+        expected_code=0,
+    )
+
+    profiles = load_profiles()
+    assert (
+        profiles.active_name != "foo"
+    ), "The active profile should not be updated in the file"
+
+
 def test_inspect_profile_unknown_name():
     invoke_and_assert(
         ["profile", "inspect", "foo"],

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -476,6 +476,7 @@ def test_rename_profile_renames_profile():
     assert profiles["bar"].settings == {
         PREFECT_API_KEY: "foo"
     }, "Settings should be retained"
+    assert profiles.active_name != "bar", "The active profile should not be changed"
 
 
 def test_rename_profile_changes_active_profile():


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/6110 by changing the active profile in the profiles file if it is the one that was renamed. Includes a warning if you've renamed an active profile set by environment variable.