### PR TITLE
Add labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+# any PR to this branch gets the v1 label (note **/* syntax doesn't appear to work)
+v1:
+- '*'
+- src/**/*
+- tests/**/*
+- docs/**/*
+- examples/**/*
+- .github/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Labeler
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ github.token }}"


### PR DESCRIPTION
Followup from #6138. This combines @cicdw and @madkinsz suggestions by reusing our existing* labeler action to apply the `v1` label anytime a PR is opened in this branch.

Going forward, all PRs that use the 1.x branch as a base should have the `v1` label applied for easy triage.

\*the action doesn't already exist in _this_ branch, natch