### PR TITLE
Handle database errors during state transition validation

### DIFF
--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -244,12 +244,15 @@ class FlowOrchestrationContext(OrchestrationContext):
                 await self._validate_proposed_state()
             except Exception:
                 # unset the run state in case it's been set
-                initial_orm_state = db.FlowRunState(
-                    flow_run_id=self.run.id,
-                    **self.initial_state.dict(shallow=True),
-                )
-                self.session.add(initial_orm_state)
-                self.run.set_state(initial_orm_state)
+                if self.initial_state is not None:
+                    initial_orm_state = db.FlowRunState(
+                        flow_run_id=self.run.id,
+                        **self.initial_state.dict(shallow=True),
+                    )
+                    self.session.add(initial_orm_state)
+                    self.run.set_state(initial_orm_state)
+                else:
+                    self.run.set_state(None)
                 continue
             return
 
@@ -372,12 +375,15 @@ class TaskOrchestrationContext(OrchestrationContext):
                 await self._validate_proposed_state()
             except Exception:
                 # unset the run state in case it's been set
-                initial_orm_state = db.TaskRunState(
-                    flow_run_id=self.run.id,
-                    **self.initial_state.dict(shallow=True),
-                )
-                self.session.add(initial_orm_state)
-                self.run.set_state(initial_orm_state)
+                if self.initial_state is not None:
+                    initial_orm_state = db.TaskRunState(
+                        task_run_id=self.run.id,
+                        **self.initial_state.dict(shallow=True),
+                    )
+                    self.session.add(initial_orm_state)
+                    self.run.set_state(initial_orm_state)
+                else:
+                    self.run.set_state(None)
                 continue
             return
 

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -181,19 +181,6 @@ class OrchestrationContext(PrefectBaseModel):
         safe_context = self.safe_copy()
         return safe_context.initial_state, safe_context.validated_state, safe_context
 
-    async def validate_proposed_state(self):
-        for validation_attempt in range(2):
-            try:
-                await self._validate_proposed_state()
-            except Exception:
-                self.run.set_state(None)  # unset the run state in case it's been set
-                continue
-            return
-
-        reason = "Error validating state"
-        self.response_status = SetStateStatus.ABORT
-        self.response_details = StateAbortDetails(reason=reason)
-
 
 class FlowOrchestrationContext(OrchestrationContext):
     """
@@ -235,7 +222,7 @@ class FlowOrchestrationContext(OrchestrationContext):
     run: Any = ...
 
     @inject_db
-    async def _validate_proposed_state(
+    async def validate_proposed_state(
         self,
         db: OrionDBInterface,
     ):
@@ -251,6 +238,30 @@ class FlowOrchestrationContext(OrchestrationContext):
         Returns:
             None
         """
+
+        for validation_attempt in range(2):
+            try:
+                await self._validate_proposed_state()
+            except Exception:
+                # unset the run state in case it's been set
+                initial_orm_state = db.FlowRunState(
+                    flow_run_id=self.run.id,
+                    **self.initial_state.dict(shallow=True),
+                )
+                self.session.add(initial_orm_state)
+                self.run.set_state(initial_orm_state)
+                continue
+            return
+
+        reason = "Error validating state"
+        self.response_status = SetStateStatus.ABORT
+        self.response_details = StateAbortDetails(reason=reason)
+
+    @inject_db
+    async def _validate_proposed_state(
+        self,
+        db: OrionDBInterface,
+    ):
         if self.proposed_state is not None:
             validated_orm_state = db.FlowRunState(
                 flow_run_id=self.run.id,
@@ -339,7 +350,7 @@ class TaskOrchestrationContext(OrchestrationContext):
     run: Any = ...
 
     @inject_db
-    async def _validate_proposed_state(
+    async def validate_proposed_state(
         self,
         db: OrionDBInterface,
     ):
@@ -356,6 +367,29 @@ class TaskOrchestrationContext(OrchestrationContext):
             None
         """
 
+        for validation_attempt in range(2):
+            try:
+                await self._validate_proposed_state()
+            except Exception:
+                # unset the run state in case it's been set
+                initial_orm_state = db.TaskRunState(
+                    flow_run_id=self.run.id,
+                    **self.initial_state.dict(shallow=True),
+                )
+                self.session.add(initial_orm_state)
+                self.run.set_state(initial_orm_state)
+                continue
+            return
+
+        reason = "Error validating state"
+        self.response_status = SetStateStatus.ABORT
+        self.response_details = StateAbortDetails(reason=reason)
+
+    @inject_db
+    async def _validate_proposed_state(
+        self,
+        db: OrionDBInterface,
+    ):
         if self.proposed_state is not None:
             validated_orm_state = db.TaskRunState(
                 task_run_id=self.run.id,

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -256,6 +256,7 @@ class FlowOrchestrationContext(OrchestrationContext):
                 continue
             return
 
+        self.proposed_state = None
         reason = "Error validating state"
         self.response_status = SetStateStatus.ABORT
         self.response_details = StateAbortDetails(reason=reason)
@@ -387,6 +388,7 @@ class TaskOrchestrationContext(OrchestrationContext):
                 continue
             return
 
+        self.proposed_state = None
         reason = "Error validating state"
         self.response_status = SetStateStatus.ABORT
         self.response_details = StateAbortDetails(reason=reason)

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -242,6 +242,7 @@ class FlowOrchestrationContext(OrchestrationContext):
         for validation_attempt in range(2):
             try:
                 await self._validate_proposed_state()
+                return
             except Exception:
                 # unset the run state in case it's been set
                 if self.initial_state is not None:
@@ -374,6 +375,7 @@ class TaskOrchestrationContext(OrchestrationContext):
         for validation_attempt in range(2):
             try:
                 await self._validate_proposed_state()
+                return
             except Exception:
                 # unset the run state in case it's been set
                 if self.initial_state is not None:

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -186,6 +186,7 @@ class OrchestrationContext(PrefectBaseModel):
             try:
                 await self._validate_proposed_state()
             except Exception:
+                self.run.set_state(None)  # unset the run state in case it's been set
                 continue
             return
 

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -260,7 +260,9 @@ class FlowOrchestrationContext(OrchestrationContext):
                 continue
             return
 
-        logger.error(f"Encountered errors during state validation: {validation_errors!r}")
+        logger.error(
+            f"Encountered errors during state validation: {validation_errors!r}"
+        )
         self.proposed_state = None
         reason = f"Error validating state: {validation_errors!r}"
         self.response_status = SetStateStatus.ABORT
@@ -395,7 +397,9 @@ class TaskOrchestrationContext(OrchestrationContext):
                 continue
             return
 
-        logger.error(f"Encountered errors during state validation: {validation_errors!r}")
+        logger.error(
+            f"Encountered errors during state validation: {validation_errors!r}"
+        )
         self.proposed_state = None
         reason = f"Error validating state: {validation_errors!r}"
         self.response_status = SetStateStatus.ABORT

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -1,7 +1,7 @@
 import contextlib
 import random
 from itertools import permutations, product
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pendulum
 import pytest

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -1,12 +1,12 @@
 import contextlib
 import random
 from itertools import product
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pendulum
 import pytest
 
-from prefect.orion import schemas
+from prefect.orion import models, schemas
 from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.orchestration.rules import (
     ALL_ORCHESTRATION_STATES,
@@ -14,6 +14,7 @@ from prefect.orion.orchestration.rules import (
     BaseUniversalTransform,
     OrchestrationContext,
     OrchestrationResult,
+    TaskOrchestrationContext,
 )
 from prefect.orion.schemas import states
 from prefect.orion.schemas.responses import (
@@ -22,6 +23,7 @@ from prefect.orion.schemas.responses import (
     StateRejectDetails,
     StateWaitDetails,
 )
+from prefect.testing.utilities import AsyncMock
 
 # Convert constant from set to list for deterministic ordering of tests
 ALL_ORCHESTRATION_STATES = list(

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -1,6 +1,6 @@
 import contextlib
 import random
-from itertools import product, permutations
+from itertools import permutations, product
 from unittest.mock import ANY, MagicMock
 
 import pendulum
@@ -1315,7 +1315,7 @@ class TestOrchestrationContext:
         ids=transition_names,
     )
     async def test_context_state_validation_encounters_multiple_exceptions(
-            self, session, run_type, intended_transition, initialize_orchestration
+        self, session, run_type, intended_transition, initialize_orchestration
     ):
         initial_state_type, proposed_state_type = intended_transition
         before_transition_hook = MagicMock()
@@ -1342,9 +1342,7 @@ class TestOrchestrationContext:
             RuntimeError("Something's wrong with the database!"),
             RuntimeError("Something's really wrong with the database..."),
         ]
-        object.__setattr__(
-            ctx.session, "flush", AsyncMock(side_effect=side_effects)
-        )
+        object.__setattr__(ctx.session, "flush", AsyncMock(side_effect=side_effects))
 
         async with contextlib.AsyncExitStack() as stack:
             mock_rule = MockRule(ctx, *intended_transition)
@@ -1352,9 +1350,7 @@ class TestOrchestrationContext:
             await ctx.validate_proposed_state()
 
         if ctx.initial_state is None:
-            assert (
-                ctx.run.state is None
-            ), "The run state should remain unchanged"
+            assert ctx.run.state is None, "The run state should remain unchanged"
         else:
             assert (
                 ctx.run.state.type == ctx.initial_state.type
@@ -1374,7 +1370,7 @@ class TestOrchestrationContext:
             ids=transition_names,
         )
         async def test_context_state_validation_encounters_intermittent_exception(
-                self, session, run_type, intended_transition, initialize_orchestration
+            self, session, run_type, intended_transition, initialize_orchestration
         ):
             initial_state_type, proposed_state_type = intended_transition
             before_transition_hook = MagicMock()
@@ -1385,16 +1381,22 @@ class TestOrchestrationContext:
                 FROM_STATES = ALL_ORCHESTRATION_STATES
                 TO_STATES = ALL_ORCHESTRATION_STATES
 
-                async def before_transition(self, initial_state, proposed_state, context):
+                async def before_transition(
+                    self, initial_state, proposed_state, context
+                ):
                     before_transition_hook(initial_state, proposed_state, context)
 
-                async def after_transition(self, initial_state, validated_state, context):
+                async def after_transition(
+                    self, initial_state, validated_state, context
+                ):
                     after_transition_hook(initial_state, validated_state, context)
 
                 async def cleanup(self, initial_state, validated_state, context):
                     cleanup_hook(initial_state, validated_state, context)
 
-            ctx = await initialize_orchestration(session, run_type, *intended_transition)
+            ctx = await initialize_orchestration(
+                session, run_type, *intended_transition
+            )
 
             # Bypass pydantic mutation protection, inject a one-time error
             working_flush = ctx.session.flush


### PR DESCRIPTION
Add error handling to the state validation step.

### Summary
We have observed intermittent and hard to reproduce database consistency errors where the validated state does not exist (when we believe it should). While at first we believed a race condition might be to blame, @madkinsz showed via a test that we could artificially recreate the error by invoking an exception during the state validation step. 

Here, on any failure to validate a proposed state, we will attempt to validate again a single time. If both attempts fail, we will abort the transition with an informative error. I don't believe it's desirable to defer the decision to retry the transition to the client, as this adds a significant amount of overhead to a failure we know exists on the backend.

We've both added tests to ensure the behavior on a database error, but also added a behavior test for unhandled errors during the `before_transition` hook, which currently documents possibly undesired behavior. We should address errors in the `before_transition` hook in a separate PR.

co-authored with @madkinsz 