### PR TITLE
Remove pickle5 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ kubernetes >= 24.2.0
 packaging >= 21.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2
-pickle5 >= 0.0.11; python_version < '3.8'
 pydantic >= 1.8.2
 python-slugify >= 5.0
 pytz >= 2021.1


### PR DESCRIPTION
This was necessary for ray which has been moved out of the core library

cc @ahuang11 may need to be added to `prefect-ray`
@Sahiler  this should be updated in conda-forge as well