### PR TITLE
Create a local 1.x branch before we check if the commit exists in it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
           name: 1.x branch check
           command: |
             apk add git
-            git checkout 1.x
+            git branch 1.x origin/1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -412,7 +412,7 @@ jobs:
           name: 1.x branch check
           command: |
             apk add git
-            git checkout 1.x
+            git branch 1.x origin/1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -461,7 +461,7 @@ jobs:
           name: 1.x branch check
           command: |
             apk add git
-            git checkout 1.x
+            git branch 1.x origin/1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -532,7 +532,7 @@ jobs:
           # commit is not on 1.x.
           name: 1.x branch check
           command: |
-            git checkout 1.x
+            git branch 1.x origin/1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,9 +342,10 @@ jobs:
       - checkout
       - run:
           # since this job is kicked off on *any* tag, we want to bail if this commit is not on 1.x
-          name: Master branch check
+          name: 1.x branch check
           command: |
             apk add git
+            git checkout 1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -408,9 +409,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Master branch check
+          name: 1.x branch check
           command: |
             apk add git
+            git checkout 1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -456,9 +458,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Master branch check
+          name: 1.x branch check
           command: |
             apk add git
+            git checkout 1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1
@@ -527,8 +530,9 @@ jobs:
       - run:
           # since this job is kicked off on *any* tag (that matches the version pattern), we want to bail if this
           # commit is not on 1.x.
-          name: Master branch check
+          name: 1.x branch check
           command: |
+            git checkout 1.x
             if [[ $(git branch --contains $CIRCLE_SHA1 --points-at 1.x | grep 1.x | wc -l) -ne 1 ]]; then
               echo "commit $CIRCLE_SHA1 is not a member of the 1.x branch"
               exit 1


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
Attempts to fix our CircleCI commit check now that the default branch is "main." Previously, we cloned the repo and tested if a commit was in the "master" branch. Now, we need to check if the commit is in the "1.x" branch, but because that isn't the default branch, we need to create it locally before we check the commit.

Fixes #6190 

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
I manually ran the git commands in our CircleCI config locally until I could reproduce the error (I had to clone a fresh copy of `prefect`, which finally reproduced the issue). Then I ran the command `git branch 1.x origin/1.x` and verified that the error did not occur.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
