### PR TITLE
Fix: Add ignore_files and skip upload if dir

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -282,7 +282,10 @@ class RemoteFileSystem(ReadableFileSystem, WritableFileSystem):
                 fpath = to_path + f
             else:
                 fpath = to_path + "/" + f
-            self.filesystem.put_file(f, fpath, overwrite=True)
+            if Path(f).is_dir():
+                pass
+            else:
+                self.filesystem.put_file(f, fpath, overwrite=True)
             counter += 1
         return counter
 
@@ -550,15 +553,18 @@ class Azure(ReadableFileSystem, WritableFileSystem):
         )
 
     async def put_directory(
-        self, local_path: Optional[str] = None, to_path: Optional[str] = None
+        self,
+        local_path: Optional[str] = None,
+        to_path: Optional[str] = None,
+        ignore_file: Optional[str] = None,
     ) -> int:
         """
-        Uploads a directory from a given local path to a remote direcotry.
+        Uploads a directory from a given local path to a remote directory.
 
         Defaults to uploading the entire contents of the current working directory to the block's basepath.
         """
         return await self.filesystem.put_directory(
-            local_path=local_path, to_path=to_path
+            local_path=local_path, to_path=to_path, ignore_file=ignore_file
         )
 
     async def read_path(self, path: str) -> bytes:


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
- Adds `ignore_files` on Azure block
- Skips upload if a file is a directory rather than file, otherwise Azure upload gets stuck

### Steps Taken to QA Changes
- created a block
- created a deployment with Azure and Process


This pull request is:

- [X] A short code fix

**Happy engineering!**
