### PR TITLE
Allow to send Slack blocks in SlackWebHook

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Dict, Optional, Sequence, Union
 
 from pydantic import Field, SecretStr
 
@@ -52,5 +52,10 @@ class SlackWebhook(NotificationBlock):
         self._async_webhook_client = AsyncWebhookClient(url=self.url.get_secret_value())
 
     @sync_compatible
-    async def notify(self, body: str, subject: Optional[str] = None):
-        await self._async_webhook_client.send(text=body)
+    async def notify(
+        self,
+        body: str,
+        subject: Optional[str] = None,
+        blocks: Optional[Sequence[Union[Dict[str, Any], Block]]] = None,
+    ):
+        await self._async_webhook_client.send(text=body, blocks=blocks)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -26,6 +26,35 @@ class TestSlackWebhook:
         )
         async_webhook_client_mock.send.assert_called_once_with(text="test")
 
+    async def test_notify_async_slack_blocks(self, monkeypatch):
+        async_webhook_client_mock = AsyncMock()
+        async_webhook_client_constructor_mock = MagicMock(
+            return_value=async_webhook_client_mock
+        )
+        monkeypatch.setattr(
+            "slack_sdk.webhook.async_client.AsyncWebhookClient",
+            async_webhook_client_constructor_mock,
+        )
+
+        block = SlackWebhook(url="http://example.com/slack")
+        slack_blocks = [
+            {
+                "type": "header",
+                "title": {"type": "plain_text", "text": "header title"},
+            }
+        ]
+        await block.notify(
+            "test",
+            blocks=slack_blocks,
+        )
+
+        async_webhook_client_constructor_mock.assert_called_once_with(
+            url=block.url.get_secret_value()
+        )
+        async_webhook_client_mock.send.assert_called_once_with(
+            text="test", blocks=slack_blocks
+        )
+
     def test_notify_sync(self, monkeypatch):
         async_webhook_client_mock = AsyncMock()
         async_webhook_client_constructor_mock = MagicMock(

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -24,7 +24,7 @@ class TestSlackWebhook:
         async_webhook_client_constructor_mock.assert_called_once_with(
             url=block.url.get_secret_value()
         )
-        async_webhook_client_mock.send.assert_called_once_with(text="test")
+        async_webhook_client_mock.send.assert_called_once_with(text="test", blocks=None)
 
     async def test_notify_async_slack_blocks(self, monkeypatch):
         async_webhook_client_mock = AsyncMock()


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
This PR adds the possibility to use Slack blocks in the SlackWebHook block. This allows e.g. to send images to Slack.

closes https://github.com/PrefectHQ/prefect/issues/6199

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

I tested the old functionality without the block and then the new functionality including the blocks. I setup Slack webhook and checked that I get the right response in my Slack channel.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
