### PR TITLE
Feature: Block type page

### DIFF
--- a/orion-ui/package-lock.json
+++ b/orion-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prefecthq/miter-design": "0.1.34",
-        "@prefecthq/orion-design": "1.0.67",
+        "@prefecthq/orion-design": "1.0.68",
         "@prefecthq/prefect-design": "1.0.34",
         "@prefecthq/vue-compositions": "0.1.40",
         "@types/lodash.debounce": "4.0.7",
@@ -199,12 +199,12 @@
       }
     },
     "node_modules/@prefecthq/orion-design": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.67.tgz",
-      "integrity": "sha512-oCmz/ElqYf0/SLO9YXDUDz7YbDV7s9M6RANwvNFqgtESVmuG33N6iOmK9pqQK0q77a/yrHsNjcGy3200M0Ba0g==",
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.68.tgz",
+      "integrity": "sha512-e9aWaN5q+9kV9v5bUpp2uXdizhLNmFsbCvj3e967AFPkGMHqff2pnLklMAGcYKiOcnjngRXqDUwHPNZ7orUMBw==",
       "dependencies": {
         "@prefecthq/radar": "0.0.17",
-        "@prefecthq/vue-charts": "0.0.17",
+        "@prefecthq/vue-charts": "0.0.18",
         "@prefecthq/vue-compositions": "0.1.40",
         "axios": "0.27.2",
         "cronstrue": "^2.11.0",
@@ -320,9 +320,9 @@
       }
     },
     "node_modules/@prefecthq/vue-charts": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.0.17.tgz",
-      "integrity": "sha512-3TnbH1miq2Y9l2zjLfrHbc8Bab+iPa6sKQSnreyDWPuv59/TuSeXe8fhEM1fH54gpC1V0DBK2cxHvL4GaUA5XA==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.0.18.tgz",
+      "integrity": "sha512-9CMJmxM5pjhOAFhQk7UVPSHCI92/fQGK2fr/JwEffaHiI5vArTb9bT4OaqFzr+YDJMWYBxuRP1EWpOME9pcIPA==",
       "dependencies": {
         "d3": "7.4.4",
         "lodash.debounce": "4.0.8"
@@ -5055,12 +5055,12 @@
       "requires": {}
     },
     "@prefecthq/orion-design": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.67.tgz",
-      "integrity": "sha512-oCmz/ElqYf0/SLO9YXDUDz7YbDV7s9M6RANwvNFqgtESVmuG33N6iOmK9pqQK0q77a/yrHsNjcGy3200M0Ba0g==",
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.68.tgz",
+      "integrity": "sha512-e9aWaN5q+9kV9v5bUpp2uXdizhLNmFsbCvj3e967AFPkGMHqff2pnLklMAGcYKiOcnjngRXqDUwHPNZ7orUMBw==",
       "requires": {
         "@prefecthq/radar": "0.0.17",
-        "@prefecthq/vue-charts": "0.0.17",
+        "@prefecthq/vue-charts": "0.0.18",
         "@prefecthq/vue-compositions": "0.1.40",
         "axios": "0.27.2",
         "cronstrue": "^2.11.0",
@@ -5153,9 +5153,9 @@
       }
     },
     "@prefecthq/vue-charts": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.0.17.tgz",
-      "integrity": "sha512-3TnbH1miq2Y9l2zjLfrHbc8Bab+iPa6sKQSnreyDWPuv59/TuSeXe8fhEM1fH54gpC1V0DBK2cxHvL4GaUA5XA==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.0.18.tgz",
+      "integrity": "sha512-9CMJmxM5pjhOAFhQk7UVPSHCI92/fQGK2fr/JwEffaHiI5vArTb9bT4OaqFzr+YDJMWYBxuRP1EWpOME9pcIPA==",
       "requires": {
         "d3": "7.4.4",
         "lodash.debounce": "4.0.8"

--- a/orion-ui/package.json
+++ b/orion-ui/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@prefecthq/miter-design": "0.1.34",
-    "@prefecthq/orion-design": "1.0.67",
+    "@prefecthq/orion-design": "1.0.68",
     "@prefecthq/prefect-design": "1.0.34",
     "@prefecthq/vue-compositions": "0.1.40",
     "@types/lodash.debounce": "4.0.7",

--- a/orion-ui/src/App.vue
+++ b/orion-ui/src/App.vue
@@ -26,6 +26,7 @@
 <script lang="ts" setup>
   import {
     blockCapabilitiesApiKey,
+    blockCatalogViewRouteKey,
     blockCatalogCreateRouteKey,
     blockCatalogRouteKey,
     blockDocumentsApiKey,
@@ -88,6 +89,7 @@
 
   provide(canKey, can)
 
+  provide(blockCatalogViewRouteKey, routes.blocksCatalogView)
   provide(blockCatalogCreateRouteKey, routes.blocksCatalogCreate)
   provide(blockCatalogRouteKey, routes.blocksCatalog)
   provide(blockEditRouteKey, routes.blockEdit)

--- a/orion-ui/src/pages/BlocksCatalogView.vue
+++ b/orion-ui/src/pages/BlocksCatalogView.vue
@@ -1,0 +1,28 @@
+<template>
+  <p-layout-default v-if="blockType" class="blocks-catalog-view">
+    <template #header>
+      <PageHeadingBlocksCatalogView :block-type="blockType" />
+    </template>
+
+    <BlockTypeCard :block-type="blockType" />
+  </p-layout-default>
+</template>
+
+<script lang="ts" setup>
+  import { PageHeadingBlocksCatalogView, BlockTypeCard } from '@prefecthq/orion-design'
+  import { useRouteParam, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { blockTypesApi } from '@/services/blockTypesApi'
+
+  const blockTypeSlugParam = useRouteParam('blockTypeSlug')
+  const blockTypeSubscriptionArgs = computed<Parameters<typeof blockTypesApi.getBlockTypeBySlug> | null>(() => {
+    if (!blockTypeSlugParam.value) {
+      return null
+    }
+
+    return [blockTypeSlugParam.value]
+  })
+
+  const blockTypeSubscription = useSubscriptionWithDependencies(blockTypesApi.getBlockTypeBySlug, blockTypeSubscriptionArgs)
+  const blockType = computed(() => blockTypeSubscription.response)
+</script>

--- a/orion-ui/src/router/index.ts
+++ b/orion-ui/src/router/index.ts
@@ -104,6 +104,11 @@ const routeRecords: AppRouteRecord[] = [
         component: (): RouteComponent => import('@/pages/BlocksCatalog.vue'),
       },
       {
+        name: 'blocks.view',
+        path: 'catalog/:blockTypeSlug',
+        component: (): RouteComponent => import('@/pages/BlocksCatalogView.vue'),
+      },
+      {
         name: 'blocks.create',
         path: 'catalog/:blockTypeSlug/create',
         component: (): RouteComponent => import('@/pages/BlocksCatalogCreate.vue'),

--- a/orion-ui/src/router/routes.ts
+++ b/orion-ui/src/router/routes.ts
@@ -20,6 +20,7 @@ export const routes = {
   workQueues: () => ({ name: 'work-queues' }) as const,
   blocks: () => ({ name: 'blocks' }) as const,
   blocksCatalog: () => ({ name: 'blocks.catalog' }) as const,
+  blocksCatalogView: (blockTypeSlug: string) => ({ name: 'blocks.view', params: { blockTypeSlug } }) as const,
   blocksCatalogCreate: (blockTypeSlug: string) => ({ name: 'blocks.create', params: { blockTypeSlug } }) as const,
   block: (blockDocumentId: string) => ({ name: 'block', params: { blockDocumentId } }) as const,
   blockEdit: (blockDocumentId: string) => ({ name: 'block.edit', params: { blockDocumentId } }) as const,


### PR DESCRIPTION
# Description
Adds a page for viewing block types. This is useful because there are long descriptions and code examples that are not visible when viewing the list of block types. 

<img width="1466" alt="image" src="https://user-images.githubusercontent.com/6200442/182654828-6eff5f4e-1121-486d-ade4-e140cf2fbb23.png">

Implementation for https://github.com/PrefectHQ/orion-design/pull/443