### PR TITLE
Use the correct type annotations for PrefectBaseModel.subclass()

### DIFF
--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -31,12 +31,16 @@ class DateTimeTZ(pendulum.DateTime):
             raise ValueError("Unrecognized datetime.")
 
 
+B = TypeVar("B", bound=BaseModel)
+S = TypeVar("S", bound=BaseModel)
+
+
 def pydantic_subclass(
-    base: Type[BaseModel],
+    base: Type[B],
     name: str = None,
     include_fields: List[str] = None,
     exclude_fields: List[str] = None,
-) -> Type[BaseModel]:
+) -> Type[S]:
     """Creates a subclass of a Pydantic model that excludes certain fields.
     Pydantic models use the __fields__ attribute of their parent class to
     determine inherited fields, so to create a subclass without fields, we
@@ -141,7 +145,7 @@ class PrefectBaseModel(BaseModel):
         name: str = None,
         include_fields: List[str] = None,
         exclude_fields: List[str] = None,
-    ) -> Type[BaseModel]:
+    ) -> Type[S]:
         """Creates a subclass of this model containing only the specified fields.
 
         See `pydantic_subclass()`.

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -32,7 +32,6 @@ class DateTimeTZ(pendulum.DateTime):
 
 
 B = TypeVar("B", bound=BaseModel)
-S = TypeVar("S", bound=BaseModel)
 
 
 def pydantic_subclass(
@@ -40,7 +39,7 @@ def pydantic_subclass(
     name: str = None,
     include_fields: List[str] = None,
     exclude_fields: List[str] = None,
-) -> Type[S]:
+) -> Type[B]:
     """Creates a subclass of a Pydantic model that excludes certain fields.
     Pydantic models use the __fields__ attribute of their parent class to
     determine inherited fields, so to create a subclass without fields, we
@@ -141,11 +140,11 @@ class PrefectBaseModel(BaseModel):
 
     @classmethod
     def subclass(
-        cls,
+        cls: Type[B],
         name: str = None,
         include_fields: List[str] = None,
         exclude_fields: List[str] = None,
-    ) -> Type[S]:
+    ) -> Type[B]:
         """Creates a subclass of this model containing only the specified fields.
 
         See `pydantic_subclass()`.

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -6,7 +6,7 @@ import datetime
 import json
 import os
 from functools import partial
-from typing import Any, Dict, List, Set, TypeVar
+from typing import Any, Dict, List, Set, Type, TypeVar
 from uuid import UUID, uuid4
 
 import pendulum
@@ -32,11 +32,11 @@ class DateTimeTZ(pendulum.DateTime):
 
 
 def pydantic_subclass(
-    base: BaseModel,
+    base: Type[BaseModel],
     name: str = None,
     include_fields: List[str] = None,
     exclude_fields: List[str] = None,
-) -> BaseModel:
+) -> Type[BaseModel]:
     """Creates a subclass of a Pydantic model that excludes certain fields.
     Pydantic models use the __fields__ attribute of their parent class to
     determine inherited fields, so to create a subclass without fields, we
@@ -141,7 +141,7 @@ class PrefectBaseModel(BaseModel):
         name: str = None,
         include_fields: List[str] = None,
         exclude_fields: List[str] = None,
-    ) -> BaseModel:
+    ) -> Type[BaseModel]:
         """Creates a subclass of this model containing only the specified fields.
 
         See `pydantic_subclass()`.


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
The `PrefectBaseModel.subclass` method (and the underlying `pydantic_subclass` function) say they take _instances_ of `BaseModel` but they actually take _types_ derived from `BaseModel`.

<!-- Provide a short overview of the change and the value it adds -->

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
