### PR TITLE
 Improve sanitization of labels for Kubernetes Jobs

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -445,17 +445,12 @@ class KubernetesJob(Infrastructure):
         Slugify text for use as a label key.
 
         Keys are composed of an optional prefix and name, separated by a slash (/).
-        The name segment is required and must be 63 characters or less, beginning
-        and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-),
-        underscores (_), dots (.), and alphanumerics between.
 
-        The prefix is optional. If specified, the prefix must be a DNS subdomain:
-        a series of DNS labels separated by dots (.),
-        not longer than 253 characters in total, followed by a slash (/).
+        Keeps only alphanumeric characters, dashes, underscores, and periods.
+        Limits the length of the label prefix to 253 characters.
+        Limits the length of the label name to 63 characters.
 
-        Limits the total length of label text to below 63 characters, which is
-        the limit for e.g. label names that follow RFC 1123 (hostnames) and
-        RFC 1035 (domain names).
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 
         Args:
             key: The label key
@@ -493,10 +488,7 @@ class KubernetesJob(Infrastructure):
         Slugify text for use as a label value.
 
         Keeps only alphanumeric characters, dashes, underscores, and periods.
-
-        Limits the total length of label text to below 63 characters, which is
-        the limit for e.g. label names that follow RFC 1123 (hostnames) and
-        RFC 1035 (domain names).
+        Limits the total length of label text to below 63 characters.
 
         See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -466,17 +466,26 @@ class KubernetesJob(Infrastructure):
 
         # TODO: Note that the name must start and end with an alphanumeric character
         #       but that is not enforced here
-        name_slug = slugify(
-            name,
-            max_length=63,
-            regex_pattern=r"[^a-zA-Z0-9-_.]+",
+
+        name_slug = (
+            slugify(
+                name,
+                max_length=63,
+                regex_pattern=r"[^a-zA-Z0-9-_.]+",
+            )
+            or name
         )
+        # Fallback to the original if we end up with an empty slug, this will allow
+        # Kubernetes to throw the validation error
 
         if prefix:
-            prefix_slug = slugify(
-                prefix,
-                max_length=253,
-                regex_pattern=r"[^a-zA-Z0-9-\.]+",
+            prefix_slug = (
+                slugify(
+                    prefix,
+                    max_length=253,
+                    regex_pattern=r"[^a-zA-Z0-9-\.]+",
+                )
+                or prefix
             )
 
             return f"{prefix_slug}/{name_slug}"
@@ -500,11 +509,17 @@ class KubernetesJob(Infrastructure):
         """
         # TODO: Note that the text must start and end with an alphanumeric character
         #       but that is not enforced here
-        slug = slugify(
-            value,
-            max_length=63,
-            regex_pattern=r"[^a-zA-Z0-9-_\.]+",
+        slug = (
+            slugify(
+                value,
+                max_length=63,
+                regex_pattern=r"[^a-zA-Z0-9-_\.]+",
+            )
+            or value
         )
+        # Fallback to the original if we end up with an empty slug, this will allow
+        # Kubernetes to throw the validation error
+
         return slug
 
     def _get_environment_variables(self):

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -230,6 +230,10 @@ async def test_uses_labels_setting(
         ("a" * 300, "a" * 63),
         # Truncation of the prefix and name together
         ("a" * 300 + "/" + "b" * 100, "a" * 253 + "/" + "b" * 63),
+        # All invalid passes through
+        ("$@*^$@", "$@*^$@"),
+        # All invalid passes through for prefix
+        ("$@*^$@/name", "$@*^$@/name"),
     ],
 )
 async def test_sanitizes_user_label_keys(
@@ -263,6 +267,8 @@ async def test_sanitizes_user_label_keys(
         ),
         # Truncation
         ("a" * 100, "a" * 63),
+        # All invalid passes through
+        ("$@*^$@", "$@*^$@"),
     ],
 )
 async def test_sanitizes_user_label_values(


### PR DESCRIPTION
Previously, we were not sanitizing the key at all and there was no test coverage for this.

Here, I separate handling of keys and values and sanitize both. Additionally, there's now a fallback if the slugified content is empty to the original content which will let Kubernetes throw an informative error about the bad label.

## Future work

- Consider throwing a local error when slugification results in empty content
- Add checks/enforcement of starting and ending with alphanumeric characters