### PR TITLE
Fix manifest only flag

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -450,7 +450,7 @@ async def build(
         style="green",
     )
     if manifest_only:
-        typer.Exit(0)
+        raise typer.Exit(0)
 
     ## process storage and move files around
     if storage_block:

--- a/tests/cli/test_deployment_build.py
+++ b/tests/cli/test_deployment_build.py
@@ -1,3 +1,4 @@
+import glob
 import shutil
 from pathlib import Path
 
@@ -48,3 +49,22 @@ class TestManifestGeneration:
             expected_code=0,
             temp_dir=str(cwd),
         )
+        res = glob.glob(f"{cwd}/**/**", recursive=True)
+        assert len({p for p in res if p.endswith("-manifest.json")}) == 1
+        assert len({p for p in res if p.endswith("-deployment.yaml")}) == 0
+
+    def test_manifest_only_creation_does_not_require_name(self, cwd):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                f"{cwd}/flows/hello.py:my_flow",
+                "--manifest-only",
+            ],
+            expected_output_contains=["Manifest created"],
+            expected_code=0,
+            temp_dir=str(cwd),
+        )
+        res = glob.glob(f"{cwd}/**/**", recursive=True)
+        assert len({p for p in res if p.endswith("-manifest.json")}) == 1
+        assert len({p for p in res if p.endswith("-deployment.yaml")}) == 0


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
The manifest only flag should not cause any file uploads to occur and should only generate the flow's JSON manifest.  There was a missing `raise` that preventing the CLI from short circuiting in the right place.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
Tests + confirmed locally.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
