### PR TITLE
Add flow run name and tag support to `create_flow_run_from_deployment`

### DIFF
--- a/src/prefect/client.py
+++ b/src/prefect/client.py
@@ -514,6 +514,8 @@ class OrionClient:
         parameters: Dict[str, Any] = None,
         context: dict = None,
         state: schemas.states.State = None,
+        name: str = None,
+        tags: Iterable[str] = None,
     ) -> schemas.core.FlowRun:
         """
         Create a flow run for a deployment.
@@ -535,11 +537,14 @@ class OrionClient:
         parameters = parameters or {}
         context = context or {}
         state = state or Scheduled()
+        tags = tags or []
 
         flow_run_create = schemas.actions.DeploymentFlowRunCreate(
             parameters=parameters,
             context=context,
             state=state,
+            tags=tags,
+            name=name,
         )
 
         response = await self._client.post(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -863,6 +863,21 @@ async def test_create_flow_run_from_deployment(orion_client, deployment):
     )
 
 
+async def test_create_flow_run_from_deployment_with_options(orion_client, deployment):
+    flow_run = await orion_client.create_flow_run_from_deployment(
+        deployment.id,
+        name="test-run-name",
+        tags={"foo", "bar"},
+        state=Pending(message="test"),
+        parameters={"foo": "bar"},
+    )
+    assert flow_run.name == "test-run-name"
+    assert set(flow_run.tags) == {"foo", "bar"}.union(deployment.tags)
+    assert flow_run.state.type == StateType.PENDING
+    assert flow_run.state.message == "test"
+    assert flow_run.parameters == {"foo": "bar"}
+
+
 async def test_update_flow_run(orion_client):
     @flow
     def foo():


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/6214

These are already supported by the API but were excluded from the client implementation.