### PR TITLE
Use `Flow` schema in `read_flow_by_name` instead of `Deployment`

### DIFF
--- a/src/prefect/client.py
+++ b/src/prefect/client.py
@@ -505,7 +505,7 @@ class OrionClient:
             a fully hydrated [Flow model][prefect.orion.schemas.core.Flow]
         """
         response = await self._client.get(f"/flows/name/{flow_name}")
-        return schemas.core.Deployment.parse_obj(response.json())
+        return schemas.core.Flow.parse_obj(response.json())
 
     async def create_flow_run_from_deployment(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -845,6 +845,17 @@ async def test_read_flows_with_filter(orion_client):
     assert {flow.id for flow in flows} == {flow_id_1, flow_id_2}
 
 
+async def test_read_flow_by_name(orion_client):
+    @flow(name="null-flow")
+    def do_nothing():
+        pass
+
+    flow_id = await orion_client.create_flow(do_nothing)
+    the_flow = await orion_client.read_flow_by_name("null-flow")
+
+    assert the_flow.id == flow_id
+
+
 async def test_create_flow_run_from_deployment(orion_client, deployment):
     flow_run = await orion_client.create_flow_run_from_deployment(deployment.id)
     # Deployment details attached


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
The Orion response in `read_flow_by_name` was being parsed as a `Deployment` instead of a `Flow` and that was causing a pydantic validation error. This updates the client to parse it with as `Flow`. Closes #6197 

### Steps Taken to QA Changes
- Created a unit test.
- Manually verified that I could retrieve a flow by name.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix
- [ ] A new feature implementation