### PR TITLE
Add max concurrent submitted & running flow runs on local agent

### DIFF
--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -42,6 +42,8 @@ class LocalAgent(Agent):
             be set on each flow run that this agent submits for execution
         - max_polls (int, optional): maximum number of times the agent will poll Prefect Cloud
             for flow runs; defaults to infinite
+        - max_concurrent_runs (int, optional): maximum number of flow runs that will be submitted or
+            running at the same time on this agent.
         - agent_address (str, optional):  Address to serve internal api at. Currently this is
             just health checks for use by an orchestration layer. Leave blank for no api server
             (default).

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -163,6 +163,12 @@ def local():
     default=True,
     help="Add hostname to the LocalAgent's labels",
 )
+@click.option(
+    "--max-concurrent-flows",
+    default=None,
+    type=int,
+    help="Limit max number of concurrent flows submitted by agent",
+)
 def start(import_paths, **kwargs):
     """Start a local agent"""
     from prefect.agent.local import LocalAgent

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -123,7 +123,8 @@ def test_agent_start(name, import_path, extra_cmd, extra_kwargs, monkeypatch):
         (
             "--key TEST-KEY --api TEST-API --agent-config-id TEST-AGENT-CONFIG-ID "
             "--name TEST-NAME -l label1 -l label2 -e KEY1=VALUE1 -e KEY2=VALUE2 "
-            "-e KEY3=VALUE=WITH=EQUALS --max-polls 10 --agent-address 127.0.0.1:8080"
+            "-e KEY3=VALUE=WITH=EQUALS --max-polls 10 --agent-address 127.0.0.1:8080 "
+            "--max-concurrent-runs 4"
         ).split()
     )
     command.extend(["--log-level", "debug"])
@@ -143,6 +144,7 @@ def test_agent_start(name, import_path, extra_cmd, extra_kwargs, monkeypatch):
         "max_polls": 10,
         "agent_address": "127.0.0.1:8080",
         "no_cloud_logs": None,
+        "max_concurrent_runs": 4,
         **extra_kwargs,
     }
 


### PR DESCRIPTION
### Summary
Our use case is poorly served by having agents submit as many flows as they can. We limit the number that actually run concurrently on the agent but they are still running on the agent as far as prefect is concerned. This PR adds some checks so that the agent will leave flow runs in the scheduled state if the number that have been submitted on the agent but not finished grows greater than a configurable parameter.

### Steps Taken to QA Changes
Code has been tested manually. The agent can be tested by running it with the parameter set and then running flow runs and monitoring their status. Better testing can be looked into after we get some initial comments.

### Checklist
- [x] Closes https://github.com/PrefectHQ/prefect/issues/6231

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
