### PR TITLE
Use event instead of sleep, second attempt

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -328,6 +328,7 @@ class ConcurrentTaskRunner(BaseTaskRunner):
         """
         Block until the run result has been populated.
         """
+        result = None  # result in case of timeout
         with anyio.move_on_after(timeout):
             await self._events[run_key].wait()
             # I would like to use pop to avoid a memory leak here but wait() seems to

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -322,7 +322,7 @@ class ConcurrentTaskRunner(BaseTaskRunner):
         except BaseException as exc:
             self._results[run_key] = exception_to_crashed_state(exc)
         finally:
-            self._events[run_key].set() # raise event
+            self._events[run_key].set()  # raise event
 
     async def _get_run_result(self, run_key: str, timeout: float = None):
         """
@@ -334,8 +334,8 @@ class ConcurrentTaskRunner(BaseTaskRunner):
             # I would like to use pop to avoid a memory leak here but wait() seems to
             # be called twice sometimes? Not cleaning up task_run results is going to be
             # a problem for flows with lots of tasks or large results
-            #self._events.pop(run_key)
-            #result = self._results.pop(run_key)
+            # self._events.pop(run_key)
+            # result = self._results.pop(run_key)
             result = self._results[run_key]
         return result
 

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -82,7 +82,13 @@ async def test_run_sync_in_interruptible_worker_thread():
 
     assert await run_sync_in_interruptible_worker_thread(foo, 1, y=2) == 6
 
-
+# During testing cancelling the worker thread by raising a exeption sometimes
+# causes pytest to catch the exception from the worker thread.  It seems
+# there is some kind of race condition going on between teardown of the test
+# as a whole and the cancellation of the thread.  Because unhandled thread
+# exeptions are normally silently ignored and we want this exception to
+# happen in the first place we'll tell pytest to ignore this as well
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 async def test_run_sync_in_interruptible_worker_thread_does_not_hide_exceptions():
     def foo():
         raise ValueError("test")
@@ -90,7 +96,8 @@ async def test_run_sync_in_interruptible_worker_thread_does_not_hide_exceptions(
     with pytest.raises(ValueError, match="test"):
         await run_sync_in_interruptible_worker_thread(foo)
 
-
+# See the test above for the explanation
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 async def test_run_sync_in_interruptible_worker_thread_does_not_hide_base_exceptions():
     class LikeKeyboardInterrupt(BaseException):
         """Like a keyboard interrupt but not for real"""


### PR DESCRIPTION
Replace the use of anyio.sleep(0) with wait()ing on anyio.Event()s

### Summary
In a multithreaded environment the use of polling with anyio.sleep(0) in the main thread causes that thread to claim the GIL on every possible opportunity, thus taking time away from the other threads.
Even when only the main thread is running the use of polling is just a waste of CPU-resources and energy.

This PR is a suggestion as I believe that this PR uncovered some bugs in either the tests of Prefect itself that would need fixing first. (see below)

(See #6004 for the original PR)

### Steps Taken to QA Changes
The tests in tests/test_task_runners.py and tests/utilities/test_asyncutils.py all pass, the latter with a bit of help.

Manual tests with some of my production use cases saw more than 95% reduction in user CPU time.

However, some tests in tests/test_tasks.py fail. After quite a bit of digging it seems that in those failing test the wait() method on the ConcurrentTaskRunner instance is called from a different thread ("ThreadPoolExecutor-%d_%d") than the thread that called
submit() ("MainThread"). This causes an error "Non-thread-safe operation invoked on an event loop other than the current one" from python3.10/asyncio/base_events.py.
As the docstring of _run_and_store_result mentions that it expects to be called from the main thread I believe this to be an error in either pytest or Prefect itself. I hope someone more knowledgeable can explain what is going on here.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
