### PR TITLE
Fix missing global settings by caching object instead of relying on contextvars

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -78,7 +78,7 @@ if not hasattr(sys, "frozen"):
     sys.meta_path = [Prefect1ImportInterceptor()] + sys.meta_path
 
 
-prefect.context.enter_root_settings_context()
+prefect.context.root_settings_context()
 prefect.context.initialize_object_registry()
 
 # The context needs updated references for flows and tasks

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -303,7 +303,7 @@ class SettingsContext(ContextModel):
     @classmethod
     def get(cls) -> "SettingsContext":
         # Return the global context instead of `None` if no context exists
-        return cls.__var__.get(GLOBAL_SETTINGS_CONTEXT)
+        return super().get() or GLOBAL_SETTINGS_CONTEXT
 
 
 def get_run_context() -> Union[FlowRunContext, TaskRunContext]:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -48,6 +48,11 @@ if TYPE_CHECKING:
     from prefect.flows import Flow
     from prefect.tasks import Task
 
+# Define the global settings context variable
+# This will be populated downstream but must be null here to facilitate loading the
+# default settings.
+GLOBAL_SETTINGS_CONTEXT = None
+
 
 class ContextModel(BaseModel):
     """
@@ -295,6 +300,11 @@ class SettingsContext(ContextModel):
 
         return return_value
 
+    @classmethod
+    def get(cls) -> "SettingsContext":
+        # Return the global context instead of `None` if no context exists
+        return cls.__var__.get(GLOBAL_SETTINGS_CONTEXT)
+
 
 def get_run_context() -> Union[FlowRunContext, TaskRunContext]:
     """
@@ -462,27 +472,15 @@ def use_profile(
         yield ctx
 
 
-GLOBAL_SETTINGS_CM: ContextManager[SettingsContext] = None
-
-
-def enter_root_settings_context():
+def root_settings_context():
     """
-    Enter the profile that will exist as the root context for the module.
+    Return the settings context that will exist as the root context for the module.
 
     The profile to use is determined with the following precedence
     - Command line via 'prefect --profile <name>'
     - Environment variable via 'PREFECT_PROFILE'
     - Profiles file via the 'active' key
-
-    This function is safe to call multiple times.
     """
-    # We set a global variable because otherwise the context object will be garbage
-    # collected which will call __exit__ as soon as this function scope ends.
-    global GLOBAL_SETTINGS_CM
-
-    if GLOBAL_SETTINGS_CM:
-        return  # A global context already has been entered
-
     profiles = prefect.settings.load_profiles()
     active_name = profiles.active_name
     profile_source = "in the profiles file"
@@ -507,15 +505,18 @@ def enter_root_settings_context():
         )
         active_name = "default"
 
-    GLOBAL_SETTINGS_CM = use_profile(
+    with use_profile(
         profiles[active_name],
         # Override environment variables if the profile was set by the CLI
         override_environment_variables=profile_source == "by command line argument",
-    )
+    ) as settings_context:
+        return settings_context
 
-    GLOBAL_SETTINGS_CM.__enter__()
+    # Note the above context is exited and the global settings context is used by
+    # an override in the `SettingsContext.get` method.
 
 
+GLOBAL_SETTINGS_CONTEXT: SettingsContext = root_settings_context()
 GLOBAL_OBJECT_REGISTRY: ContextManager[PrefectObjectRegistry] = None
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,9 +12,9 @@ from prefect.context import (
     FlowRunContext,
     SettingsContext,
     TaskRunContext,
-    enter_root_settings_context,
     get_run_context,
     get_settings_context,
+    root_settings_context,
     use_profile,
 )
 from prefect.exceptions import MissingContextError
@@ -268,17 +268,16 @@ class TestSettingsContext:
         save_profiles(ProfilesCollection(profiles=[profile]))
         return profile
 
-    def test_enter_global_profile_default(self, monkeypatch):
+    def test_root_settings_context_default(self, monkeypatch):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
-        enter_root_settings_context()
+        result = root_settings_context()
         use_profile.assert_called_once_with(
             Profile(name="default", settings={}, source=DEFAULT_PROFILES_PATH),
             override_environment_variables=False,
         )
         use_profile().__enter__.assert_called_once_with()
-        assert prefect.context.GLOBAL_SETTINGS_CM is not None
+        assert result is not None
 
     @pytest.mark.parametrize(
         "cli_command",
@@ -289,78 +288,63 @@ class TestSettingsContext:
             ["foobar", "--profile", "test"],
         ],
     )
-    def test_enter_global_profile_default_if_cli_args_do_not_match_format(
+    def test_root_settings_context_default_if_cli_args_do_not_match_format(
         self, monkeypatch, cli_command
     ):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
         monkeypatch.setattr("sys.argv", cli_command)
-        enter_root_settings_context()
+        result = root_settings_context()
         use_profile.assert_called_once_with(
             Profile(name="default", settings={}, source=DEFAULT_PROFILES_PATH),
             override_environment_variables=False,
         )
         use_profile().__enter__.assert_called_once_with()
-        assert prefect.context.GLOBAL_SETTINGS_CM is not None
+        assert result is not None
 
-    def test_enter_global_profile_respects_cli(self, monkeypatch, foo_profile):
+    def test_root_settings_context_respects_cli(self, monkeypatch, foo_profile):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
         monkeypatch.setattr("sys.argv", ["/prefect", "--profile", "foo"])
-        enter_root_settings_context()
+        result = root_settings_context()
         use_profile.assert_called_once_with(
             foo_profile,
             override_environment_variables=True,
         )
         use_profile().__enter__.assert_called_once_with()
-        assert prefect.context.GLOBAL_SETTINGS_CM is not None
+        assert result is not None
 
-    def test_enter_global_profile_respects_environment_variable(
+    def test_root_settings_context_respects_environment_variable(
         self, monkeypatch, foo_profile
     ):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
         monkeypatch.setenv("PREFECT_PROFILE", "foo")
-        enter_root_settings_context()
+        root_settings_context()
         use_profile.assert_called_once_with(
             foo_profile, override_environment_variables=False
         )
 
-    def test_enter_global_profile_missing_cli(self, monkeypatch, capsys):
+    def test_root_settings_context_missing_cli(self, monkeypatch, capsys):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
         monkeypatch.setattr("sys.argv", ["/prefect", "--profile", "bar"])
-        enter_root_settings_context()
+        root_settings_context()
         _, err = capsys.readouterr()
         assert (
             "profile 'bar' set by command line argument not found. The default profile will be used instead."
             in err
         )
 
-    def test_enter_global_profile_missing_environment_variables(
+    def test_root_settings_context_missing_environment_variables(
         self, monkeypatch, capsys
     ):
         use_profile = MagicMock()
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
         monkeypatch.setenv("PREFECT_PROFILE", "bar")
-        enter_root_settings_context()
+        root_settings_context()
         _, err = capsys.readouterr()
         assert (
             "profile 'bar' set by environment variable not found. The default profile will be used instead."
             in err
         )
-
-    def test_enter_global_profile_is_idempotent(self, monkeypatch):
-        use_profile = MagicMock()
-        monkeypatch.setattr("prefect.context.use_profile", use_profile)
-        monkeypatch.setattr("prefect.context.GLOBAL_SETTINGS_CM", None)
-        enter_root_settings_context()
-        enter_root_settings_context()
-        enter_root_settings_context()
-        use_profile.assert_called_once()
-        use_profile().__enter__.assert_called_once()


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

If a flow is called from a different thread than Prefect is imported from, the root settings context is missing. This is because the root settings context is accessed via context variable which is by definition thread independent. Additionally, if the flow was called from a different event loop than the one the module was imported from, the settings context would be missing. To address this, we no longer rely on the context variable. If the context variable does not detect any settings, we return a global variable where we have stashed a `SettingsContext` instance. We initialize this once on module import and it is accessible by all threads and event loops.

Initially, I thought we should just cache the settings context per thread or event loop and reinitialize it where necessary. See [this branch](https://github.com/PrefectHQ/prefect/compare/main...fix-global-settings) for implementation. This also solves the issue but I do not think it is clean or robust as we would need to inject this call everywhere settings are needed.

Closes https://github.com/PrefectHQ/prefect/issues/5847

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

The example in the linked issue was used to confirm functionality.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
