### PR TITLE
Add support for filtering on state name to `prefect flow-run ls`

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -47,18 +47,22 @@ async def ls(
     flow_name: List[str] = None,
     limit: int = 15,
     state_type: List[StateType] = None,
+    state_name: List[str] = None,
 ):
     """
     View recent flow runs or flow runs for specific flows
     """
+
+    state_filter = {}
+    if state_name:
+        state_filter["name"] = {"any_": state_name}
+    if state_type:
+        state_filter["type"] = {"any_": state_type}
+
     async with get_client() as client:
         flow_runs = await client.read_flow_runs(
             flow_filter=FlowFilter(name={"any_": flow_name}) if flow_name else None,
-            flow_run_filter=(
-                FlowRunFilter(state={"type": {"any_": state_type}})
-                if state_type
-                else None
-            ),
+            flow_run_filter=FlowRunFilter(state=state_filter) if state_filter else None,
             limit=limit,
             sort=FlowRunSort.EXPECTED_START_TIME_DESC,
         )

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import httpx
 import pendulum
+import typer
 from fastapi import status
 from rich.pretty import Pretty
 from rich.table import Table
@@ -44,10 +45,12 @@ async def inspect(id: UUID):
 
 @flow_run_app.command()
 async def ls(
-    flow_name: List[str] = None,
-    limit: int = 15,
-    state: List[str] = None,
-    state_type: List[StateType] = None,
+    flow_name: List[str] = typer.Option(None, help="Name of the Flow"),
+    limit: int = typer.Option(15, help="Maximum number of Flow Run's to list"),
+    state: List[str] = typer.Option(None, help="Name of the Flow Run's state"),
+    state_type: List[StateType] = typer.Option(
+        None, help="Type of the Flow Run's state"
+    ),
 ):
     """
     View recent flow runs or flow runs for specific flows

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -46,16 +46,16 @@ async def inspect(id: UUID):
 async def ls(
     flow_name: List[str] = None,
     limit: int = 15,
+    state: List[str] = None,
     state_type: List[StateType] = None,
-    state_name: List[str] = None,
 ):
     """
     View recent flow runs or flow runs for specific flows
     """
 
     state_filter = {}
-    if state_name:
-        state_filter["name"] = {"any_": state_name}
+    if state:
+        state_filter["name"] = {"any_": state}
     if state_type:
         state_filter["type"] = {"any_": state_type}
 

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -45,11 +45,11 @@ async def inspect(id: UUID):
 
 @flow_run_app.command()
 async def ls(
-    flow_name: List[str] = typer.Option(None, help="Name of the Flow"),
-    limit: int = typer.Option(15, help="Maximum number of Flow Run's to list"),
-    state: List[str] = typer.Option(None, help="Name of the Flow Run's state"),
+    flow_name: List[str] = typer.Option(None, help="Name of the flow"),
+    limit: int = typer.Option(15, help="Maximum number of flow run's to list"),
+    state: List[str] = typer.Option(None, help="Name of the flow run's state"),
     state_type: List[StateType] = typer.Option(
-        None, help="Type of the Flow Run's state"
+        None, help="Type of the flow run's state"
     ),
 ):
     """

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -46,7 +46,7 @@ async def inspect(id: UUID):
 @flow_run_app.command()
 async def ls(
     flow_name: List[str] = typer.Option(None, help="Name of the flow"),
-    limit: int = typer.Option(15, help="Maximum number of flow run's to list"),
+    limit: int = typer.Option(15, help="Maximum number of flow runs to list"),
     state: List[str] = typer.Option(None, help="Name of the flow run's state"),
     state_type: List[StateType] = typer.Option(
         None, help="Type of the flow run's state"

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -164,7 +164,7 @@ def test_ls_state_name_filter(
     late_flow_run,
 ):
     result = invoke_and_assert(
-        command=["flow-run", "ls", "--state-name", "Late"],
+        command=["flow-run", "ls", "--state", "Late"],
         expected_code=0,
     )
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -173,3 +173,30 @@ def test_ls_state_name_filter(
         expected=[late_flow_run],
         unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
     )
+
+
+def test_ls_limit(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--limit", "2"],
+        expected_code=0,
+    )
+
+    output = result.stdout.strip()
+
+    found_count = 0
+    for flow_run in [
+        scheduled_flow_run,
+        completed_flow_run,
+        running_flow_run,
+        late_flow_run,
+    ]:
+        id_start = str(flow_run.id)[:20]
+        if id_start in output:
+            found_count += 1
+
+    assert found_count == 2

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -3,8 +3,20 @@ from uuid import UUID
 import pytest
 
 import prefect.exceptions
+from prefect import flow
+from prefect.orion.schemas import states
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import sync_compatible
+
+
+@flow(name="hello")
+def hello_flow():
+    return "Hello!"
+
+
+@flow(name="goodbye")
+def goodbye_flow():
+    return "Goodbye"
 
 
 @sync_compatible
@@ -14,6 +26,51 @@ async def assert_flow_run_is_deleted(orion_client, flow_run_id: UUID):
     """
     with pytest.raises(prefect.exceptions.ObjectNotFound):
         await orion_client.read_flow_run(flow_run_id)
+
+
+def assert_flow_runs_in_result(result, expected, unexpected=None):
+    output = result.stdout.strip()
+
+    # When running in tests the output of the columns in the table are
+    # truncated, so this only asserts that the first 20 characters of each
+    # flow run's id is in the output.
+
+    for flow_run in expected:
+        id_start = str(flow_run.id)[:20]
+        assert id_start in output
+
+    if unexpected:
+        for flow_run in unexpected:
+            id_start = str(flow_run.id)[:20]
+            assert id_start not in output, f"{flow_run} should not be in the output"
+
+
+@pytest.fixture
+async def scheduled_flow_run(orion_client):
+    return await orion_client.create_flow_run(
+        name="scheduled_flow_run", flow=hello_flow, state=states.Scheduled()
+    )
+
+
+@pytest.fixture
+async def completed_flow_run(orion_client):
+    return await orion_client.create_flow_run(
+        name="completed_flow_run", flow=hello_flow, state=states.Completed()
+    )
+
+
+@pytest.fixture
+async def running_flow_run(orion_client):
+    return await orion_client.create_flow_run(
+        name="running_flow_run", flow=goodbye_flow, state=states.Running()
+    )
+
+
+@pytest.fixture
+async def late_flow_run(orion_client):
+    return await orion_client.create_flow_run(
+        name="late_flow_run", flow=goodbye_flow, state=states.Late()
+    )
 
 
 def test_delete_flow_run_fails_correctly():
@@ -33,3 +90,86 @@ def test_delete_flow_run_succeeds(orion_client, flow_run):
     )
 
     assert_flow_run_is_deleted(orion_client, flow_run.id)
+
+
+def test_ls_no_args(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls"],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        [
+            scheduled_flow_run,
+            completed_flow_run,
+            running_flow_run,
+            late_flow_run,
+        ],
+    )
+
+
+def test_ls_flow_name_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--flow-name", "goodbye"],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        expected=[running_flow_run, late_flow_run],
+        unexpected=[scheduled_flow_run, completed_flow_run],
+    )
+
+
+def test_ls_state_type_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=[
+            "flow-run",
+            "ls",
+            "--state-type",
+            "COMPLETED",
+            "--state-type",
+            "RUNNING",
+        ],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        expected=[running_flow_run, completed_flow_run],
+        unexpected=[scheduled_flow_run, late_flow_run],
+    )
+
+
+def test_ls_state_name_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--state-name", "Late"],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        expected=[late_flow_run],
+        unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
+    )


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
Adds a `--state` parameter to `prefect flow-run ls` to filter flow runs by the name of the state. Closes #6065 

### Steps Taken to QA Changes
- Unittests and manual verification

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
