### PR TITLE
Makes block schema creation idempotent

### DIFF
--- a/src/prefect/orion/api/block_schemas.py
+++ b/src/prefect/orion/api/block_schemas.py
@@ -8,14 +8,12 @@ import sqlalchemy as sa
 from fastapi import Body, Depends, HTTPException, Path, Response, status
 from fastapi.responses import Response
 
+from prefect.blocks.core import Block
 from prefect.orion import models, schemas
 from prefect.orion.api import dependencies
 from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.models.block_schemas import (
-    MissingBlockTypeException,
-    calculate_block_schema_checksum,
-)
+from prefect.orion.models.block_schemas import MissingBlockTypeException
 from prefect.orion.utilities.server import OrionRouter
 
 router = OrionRouter(prefix="/block_schemas", tags=["Block schemas"])
@@ -44,7 +42,7 @@ async def create_block_schema(
             detail="Block schemas for protected block types cannot be created.",
         )
 
-    block_schema_checksum = calculate_block_schema_checksum(block_schema)
+    block_schema_checksum = Block._calculate_schema_checksum(block_schema.fields)
     existing_block_schema = await models.block_schemas.read_block_schema_by_checksum(
         session=session, checksum=block_schema_checksum
     )

--- a/src/prefect/orion/models/block_schemas.py
+++ b/src/prefect/orion/models/block_schemas.py
@@ -49,9 +49,18 @@ async def create_block_schema(
         exclude={"block_type", "id", "created", "updated"},
     )
     definitions = definitions or insert_values["fields"].pop("definitions", None)
-    insert_values["checksum"] = Block._calculate_schema_checksum(
-        insert_values["fields"]
+    checksum = Block._calculate_schema_checksum(insert_values["fields"])
+
+    # Check for existing block schema based on calculated checksum
+    existing_block_schema = await read_block_schema_by_checksum(
+        session=session, checksum=checksum
     )
+    # Return existing block schema if it exists. Allows block schema creation to be called multiple
+    # times for the same schema without errors.
+    if existing_block_schema:
+        return existing_block_schema
+
+    insert_values["checksum"] = checksum
 
     block_schema_references: Dict = insert_values["fields"].pop(
         "block_schema_references", {}

--- a/src/prefect/orion/models/block_schemas.py
+++ b/src/prefect/orion/models/block_schemas.py
@@ -23,6 +23,14 @@ class MissingBlockTypeException(Exception):
     """Raised when the block type corresponding to a block schema cannot be found"""
 
 
+def calculate_block_schema_checksum(
+    block_schema: Union[BlockSchema, BlockSchemaCreate]
+):
+    block_schema_fields = copy(block_schema.fields)
+    block_schema_fields.pop("definitions", None)
+    return Block._calculate_schema_checksum(block_schema_fields)
+
+
 @inject_db
 async def create_block_schema(
     session: sa.orm.Session,
@@ -49,7 +57,7 @@ async def create_block_schema(
         exclude={"block_type", "id", "created", "updated"},
     )
     definitions = definitions or insert_values["fields"].pop("definitions", None)
-    checksum = Block._calculate_schema_checksum(insert_values["fields"])
+    checksum = calculate_block_schema_checksum(block_schema)
 
     # Check for existing block schema based on calculated checksum
     existing_block_schema = await read_block_schema_by_checksum(

--- a/tests/orion/api/test_block_schemas.py
+++ b/tests/orion/api/test_block_schemas.py
@@ -125,7 +125,7 @@ class TestCreateBlockSchema:
         )
         assert str(block_schema.id) == block_schema_id
 
-    async def test_create_block_schema_with_existing_checksum_fails(
+    async def test_create_block_schema_is_idempotent(
         self, session, client, block_type_x
     ):
         response_1 = await client.post(
@@ -142,7 +142,7 @@ class TestCreateBlockSchema:
                 json_compatible=True
             ),
         )
-        assert response_2.status_code == 201
+        assert response_2.status_code == 200
         assert response_1.json() == response_2.json()
 
     async def test_create_block_schema_for_system_block_type_fails(

--- a/tests/orion/api/test_block_schemas.py
+++ b/tests/orion/api/test_block_schemas.py
@@ -128,22 +128,22 @@ class TestCreateBlockSchema:
     async def test_create_block_schema_with_existing_checksum_fails(
         self, session, client, block_type_x
     ):
-        response = await client.post(
+        response_1 = await client.post(
             "/block_schemas/",
             json=BlockSchemaCreate(fields={}, block_type_id=block_type_x.id).dict(
                 json_compatible=True
             ),
         )
-        assert response.status_code == 201
+        assert response_1.status_code == 201
 
-        response = await client.post(
+        response_2 = await client.post(
             "/block_schemas/",
             json=BlockSchemaCreate(fields={}, block_type_id=block_type_x.id).dict(
                 json_compatible=True
             ),
         )
-        assert response.status_code == 409
-        assert "Identical block schema already exists." in response.json()["detail"]
+        assert response_2.status_code == 201
+        assert response_1.json() == response_2.json()
 
     async def test_create_block_schema_for_system_block_type_fails(
         self, client, system_block_type


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Makes block schema creation idempotent. If a block schema with the checksum calculated during creation already exists, then the existing block schema is returned instead of returning an error. This is to account for issues identified in #6265  caused by differences in block schema checksum calculation between the Python client and Orion server.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- Updated and added tests to verify that block schema creation called multiple times returns the same block schema and does not cause errors.
- Tested locally with an Orion server running code from main and a Python client running 2.0.3 with mismatched checksum calculation logic.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
