### PR TITLE
Add `DockerRegistry` block for `DockerContainer` to pull images from registries with authentication

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -96,7 +96,6 @@ R = TypeVar("R")
 EngineReturnType = Literal["future", "state", "result"]
 
 
-UNTRACKABLE_TYPES = {bool, type(None), type(...), type(NotImplemented)}
 engine_logger = get_logger("engine")
 
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -96,6 +96,7 @@ R = TypeVar("R")
 EngineReturnType = Literal["future", "state", "result"]
 
 
+UNTRACKABLE_TYPES = {bool, type(None), type(...), type(NotImplemented)}
 engine_logger = get_logger("engine")
 
 

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -54,7 +54,7 @@ class DockerRegistry(Block):
             omitted.
         reauth: If already logged into the registry, should login be performed again?
             This setting defaults to `True` to support common token authentication
-            patterns such as ECS.
+            patterns such as ECR.
     """
 
     _block_type_name = "Docker Registry"
@@ -72,7 +72,9 @@ class DockerRegistry(Block):
             username=self.username,
             password=self.password.get_secret_value(),
             registry=self.registry_url,
-            reauth=True,
+            # See https://github.com/docker/docker-py/issues/2256 for information on
+            # the default value for reauth.
+            reauth=self.reauth,
         )
 
     def _get_client(self):

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -58,7 +58,7 @@ class DockerRegistry(Block):
     """
 
     _block_type_name = "Docker Registry"
-    _block_schema_capabilities = ["login"]
+    _block_schema_capabilities = ["docker-login"]
 
     username: str
     password: SecretStr

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -56,7 +56,8 @@ class DockerRegistry(Block):
             This setting defaults to `True` to support common token authentication
             patterns such as ECR.
     """
-_logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2IfXXfMq66mrzJBDFFCHTp/344dda583986d2d0db361c92dd650693/Moby-logo.webp?h=250"
+
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2IfXXfMq66mrzJBDFFCHTp/344dda583986d2d0db361c92dd650693/Moby-logo.webp?h=250"
     _block_type_name = "Docker Registry"
     _block_schema_capabilities = ["docker-login"]
 

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -12,6 +12,7 @@ from slugify import slugify
 from typing_extensions import Literal
 
 import prefect
+from prefect.blocks.core import Block, SecretStr
 from prefect.docker import get_prefect_image_name
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.settings import PREFECT_API_URL
@@ -37,6 +38,61 @@ class ImagePullPolicy(AutoEnum):
     IF_NOT_PRESENT = AutoEnum.auto()
     ALWAYS = AutoEnum.auto()
     NEVER = AutoEnum.auto()
+
+
+class DockerRegistry(Block):
+    """
+    Connects to a Docker registry.
+
+    Requires a Docker Engine to be connectable. Login information is persisted to disk
+    at the Docker default location.
+
+    Attributes:
+        username: The username to log into the registry with.
+        password: The password to log into the registry with.
+        registry_url: The URL to the registry. Generally, "http" or "https" can be
+            omitted.
+        reauth: If already logged into the registry, should login be performed again?
+            This setting defaults to `True` to support common token authentication
+            patterns such as ECS.
+    """
+
+    _block_type_name = "Docker Registry"
+    _block_schema_capabilities = ["login"]
+
+    username: str
+    password: SecretStr
+    registry_url: str
+    reauth: bool = True
+
+    def login(self):
+        client = self._get_client()
+
+        return client.login(
+            username=self.username,
+            password=self.password.get_secret_value(),
+            registry=self.registry_url,
+            reauth=True,
+        )
+
+    def _get_client(self):
+        try:
+
+            with warnings.catch_warnings():
+                # Silence warnings due to use of deprecated methods within dockerpy
+                # See https://github.com/docker/docker-py/pull/2931
+                warnings.filterwarnings(
+                    "ignore",
+                    message="distutils Version classes are deprecated.*",
+                    category=DeprecationWarning,
+                )
+
+                docker_client = docker.from_env()
+
+        except docker.errors.DockerException as exc:
+            raise RuntimeError(f"Could not connect to Docker.") from exc
+
+        return docker_client
 
 
 class DockerContainerResult(InfrastructureResult):
@@ -86,6 +142,7 @@ class DockerContainer(Infrastructure):
 
     image: str = Field(default_factory=get_prefect_image_name)
     image_pull_policy: ImagePullPolicy = None
+    image_registry: Optional[DockerRegistry] = None
     networks: List[str] = Field(default_factory=list)
     network_mode: str = None
     auto_remove: bool = False
@@ -280,6 +337,8 @@ class DockerContainer(Infrastructure):
         Pull the image we're going to use to create the container.
         """
         image, tag = self._get_image_and_tag()
+        if self.image_registry:
+            self.image_registry.login()
         return docker_client.images.pull(image, tag)
 
     def _create_container(self, docker_client: "DockerClient", **kwargs) -> "Container":

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -56,7 +56,7 @@ class DockerRegistry(Block):
             This setting defaults to `True` to support common token authentication
             patterns such as ECR.
     """
-
+_logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2IfXXfMq66mrzJBDFFCHTp/344dda583986d2d0db361c92dd650693/Moby-logo.webp?h=250"
     _block_type_name = "Docker Registry"
     _block_schema_capabilities = ["docker-login"]
 


### PR DESCRIPTION
- Adds a `DockerRegistry` block with a `login` capability.
- Adds an `image_registry` setting to the `DockerContainer` infrastructure block allowing login to a registry before image pull.

Addresses https://github.com/PrefectHQ/prefect/issues/6230 — I do not think it is fair to close this since a separate implementation with ECR token refresh support will be required.

