### PR TITLE
Update `status:needs-triage` to `status:triage`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_general_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_general_bug_report.yaml
@@ -1,6 +1,6 @@
 name: Report a bug
 description: Errors and regression reports with complete reproducing test cases and/or stack traces.
-labels: ["status:needs-triage", "bug"]
+labels: ["status:triage", "bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_ui_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/2_ui_bug_report.yaml
@@ -1,6 +1,6 @@
 name: Report a bug with the Prefect UI
 description: Errors and display issues with the Prefect web interface.
-labels: ["status:needs-triage", "ui", "bug"]
+labels: ["status:triage", "ui", "bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
@@ -1,6 +1,6 @@
 name: Propose a feature enhancement
 description: Propose a new feature or an enhancement to an existing feature.
-labels: ["status:needs-triage", "enhancement"]
+labels: ["status:triage", "enhancement"]
 body:
   - type: checkboxes
     id: checks


### PR DESCRIPTION
We already have a `needs:` category and this label is otherwise verbose.

Existing labels can be updated after merge.