### PR TITLE
Add base class and async compatibility to DockerRegistry

### DIFF
--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -3,6 +3,7 @@ import re
 import sys
 import urllib.parse
 import warnings
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import packaging.version
@@ -16,7 +17,7 @@ from prefect.blocks.core import Block, SecretStr
 from prefect.docker import get_prefect_image_name
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.settings import PREFECT_API_URL
-from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.importtools import lazy_import
 
@@ -40,45 +41,29 @@ class ImagePullPolicy(AutoEnum):
     NEVER = AutoEnum.auto()
 
 
-class DockerRegistry(Block):
-    """
-    Connects to a Docker registry.
-
-    Requires a Docker Engine to be connectable. Login information is persisted to disk
-    at the Docker default location.
-
-    Attributes:
-        username: The username to log into the registry with.
-        password: The password to log into the registry with.
-        registry_url: The URL to the registry. Generally, "http" or "https" can be
-            omitted.
-        reauth: If already logged into the registry, should login be performed again?
-            This setting defaults to `True` to support common token authentication
-            patterns such as ECR.
-    """
-
+class BaseDockerLogin(Block, ABC):
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2IfXXfMq66mrzJBDFFCHTp/344dda583986d2d0db361c92dd650693/Moby-logo.webp?h=250"
-    _block_type_name = "Docker Registry"
     _block_schema_capabilities = ["docker-login"]
 
-    username: str
-    password: SecretStr
-    registry_url: str
-    reauth: bool = True
+    @abstractmethod
+    async def login() -> None:
+        """
+        Log in with `docker login`, persisting credentials.
+        """
 
-    def login(self):
-        client = self._get_client()
+    def _login(self, username, password, registry_url, reauth):
+        client = self._get_docker_client()
 
         return client.login(
-            username=self.username,
-            password=self.password.get_secret_value(),
-            registry=self.registry_url,
+            username=username,
+            password=password,
+            registry=registry_url,
             # See https://github.com/docker/docker-py/issues/2256 for information on
             # the default value for reauth.
-            reauth=self.reauth,
+            reauth=reauth,
         )
 
-    def _get_client(self):
+    def _get_docker_client(self):
         try:
 
             with warnings.catch_warnings():
@@ -96,6 +81,39 @@ class DockerRegistry(Block):
             raise RuntimeError(f"Could not connect to Docker.") from exc
 
         return docker_client
+
+
+class DockerRegistry(BaseDockerLogin):
+    """
+    Connects to a Docker registry.
+
+    Requires a Docker Engine to be connectable. Login information is persisted to disk
+    at the Docker default location.
+
+    Attributes:
+        username: The username to log into the registry with.
+        password: The password to log into the registry with.
+        registry_url: The URL to the registry. Generally, "http" or "https" can be
+            omitted.
+        reauth: If already logged into the registry, should login be performed again?
+            This setting defaults to `True` to support common token authentication
+            patterns such as ECR.
+    """
+
+    username: str
+    password: SecretStr
+    registry_url: str
+    reauth: bool = True
+
+    @sync_compatible
+    async def login(self):
+        return await run_sync_in_worker_thread(
+            self._login,
+            self.username,
+            self.password.get_secret_value(),
+            self.registry_url,
+            self.reauth,
+        )
 
 
 class DockerContainerResult(InfrastructureResult):

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -99,6 +99,7 @@ class DockerRegistry(BaseDockerLogin):
             This setting defaults to `True` to support common token authentication
             patterns such as ECR.
     """
+
     _block_type_name = "Docker Registry"
     username: str
     password: SecretStr

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -99,7 +99,7 @@ class DockerRegistry(BaseDockerLogin):
             This setting defaults to `True` to support common token authentication
             patterns such as ECR.
     """
-
+    _block_type_name = "Docker Registry"
     username: str
     password: SecretStr
     registry_url: str


### PR DESCRIPTION
Follow up to #6303 

- Adds a base class. This will allow the ECR registry at https://github.com/PrefectHQ/prefect-aws/pull/68 to inherit shared logic and configuration
- Updates `login` to be async. Block methods should be async first.