### PR TITLE
Deprecate slack webhook

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ filterwarnings =
     ignore:`DeploymentSpec` has been replaced by `Deployment`:DeprecationWarning
     # This warning is raised on Windows by Python internals
     ignore:the imp module is deprecated:DeprecationWarning
+    ignore:The `SlackWebhook` has moved:DeprecationWarning
 
 [isort]
 skip = __init__.py

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -53,4 +54,12 @@ class SlackWebhook(NotificationBlock):
 
     @sync_compatible
     async def notify(self, body: str, subject: Optional[str] = None):
+        warnings.warn(
+            "The `SlackWebhook` has moved to `prefect-slack`. Install from the "
+            "command line with `pip install prefect-slack` and import with "
+            "`from prefect_slack import SlackWebhook`. "
+            "The `SlackWebhook` you are using will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         await self._async_webhook_client.send(text=body)


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Deprecate SlackWebhook in favor of https://github.com/PrefectHQ/prefect-slack/blob/main/prefect_slack/credentials.py#L39

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/15331990/183730255-4e4329b0-09c8-48ef-b393-7b14c1f99d13.png">
```
from prefect.blocks.notifications import SlackWebhook
await SlackWebhook(url=url).notify("testing...")
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
