### PR TITLE
Pluralize CLI commands

### DIFF
--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -1,6 +1,8 @@
 """
 Custom Prefect CLI types
 """
+from typing import List
+
 import typer
 import typer.core
 
@@ -47,21 +49,22 @@ class PrefectTyper(typer.Typer):
         typer_instance: "PrefectTyper",
         *args,
         no_args_is_help: bool = True,
-        pluralization_string: str = None,
+        aliases: List[str] = None,
         **kwargs,
     ) -> None:
         """
         This will cause help to be default command for all sub apps unless specifically stated otherwise, opposite of before.
         """
-        if pluralization_string is not None:
-            super().add_typer(
-                typer_instance,
-                *args,
-                name=pluralization_string,
-                no_args_is_help=no_args_is_help,
-                hidden=True,
-                **kwargs,
-            )
+        if aliases:
+            for alias in aliases:
+                super().add_typer(
+                    typer_instance,
+                    *args,
+                    name=alias,
+                    no_args_is_help=no_args_is_help,
+                    hidden=True,
+                    **kwargs,
+                )
 
         return super().add_typer(
             typer_instance, *args, no_args_is_help=no_args_is_help, **kwargs

--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -47,11 +47,22 @@ class PrefectTyper(typer.Typer):
         typer_instance: "PrefectTyper",
         *args,
         no_args_is_help: bool = True,
+        pluralization_string: str = None,
         **kwargs,
     ) -> None:
         """
         This will cause help to be default command for all sub apps unless specifically stated otherwise, opposite of before.
         """
+        if pluralization_string is not None:
+            super().add_typer(
+                typer_instance,
+                *args,
+                name=pluralization_string,
+                no_args_is_help=no_args_is_help,
+                hidden=True,
+                **kwargs,
+            )
+
         return super().add_typer(
             typer_instance, *args, no_args_is_help=no_args_is_help, **kwargs
         )

--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -21,8 +21,8 @@ from prefect.utilities.importtools import load_script_as_module
 
 blocks_app = PrefectTyper(name="block", help="Commands for working with blocks.")
 blocktypes_app = PrefectTyper(name="type", help="Commands for working with blocks.")
-app.add_typer(blocks_app)
-blocks_app.add_typer(blocktypes_app)
+app.add_typer(blocks_app, pluralization_string="blocks")
+blocks_app.add_typer(blocktypes_app, pluralization_string="types")
 
 
 async def _register_blocks_in_module(module: ModuleType) -> List[Type[Block]]:

--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -21,8 +21,8 @@ from prefect.utilities.importtools import load_script_as_module
 
 blocks_app = PrefectTyper(name="block", help="Commands for working with blocks.")
 blocktypes_app = PrefectTyper(name="type", help="Commands for working with blocks.")
-app.add_typer(blocks_app, pluralization_string="blocks")
-blocks_app.add_typer(blocktypes_app, pluralization_string="types")
+app.add_typer(blocks_app, aliases=["blocks"])
+blocks_app.add_typer(blocktypes_app, aliases=["types"])
 
 
 async def _register_blocks_in_module(module: ModuleType) -> List[Type[Block]]:

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -33,7 +33,7 @@ cloud_app = PrefectTyper(
 workspace_app = PrefectTyper(
     name="workspace", help="Commands for interacting with Prefect Cloud Workspaces"
 )
-cloud_app.add_typer(workspace_app, pluralization_string="workspaces")
+cloud_app.add_typer(workspace_app, aliases=["workspaces"])
 app.add_typer(cloud_app)
 
 

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -33,7 +33,7 @@ cloud_app = PrefectTyper(
 workspace_app = PrefectTyper(
     name="workspace", help="Commands for interacting with Prefect Cloud Workspaces"
 )
-cloud_app.add_typer(workspace_app)
+cloud_app.add_typer(workspace_app, pluralization_string="workspaces")
 app.add_typer(cloud_app)
 
 

--- a/src/prefect/cli/concurrency_limit.py
+++ b/src/prefect/cli/concurrency_limit.py
@@ -25,7 +25,7 @@ concurrency_limit_app = PrefectTyper(
     name="concurrency-limit",
     help="Commands for managing task-level concurrency limits.",
 )
-app.add_typer(concurrency_limit_app)
+app.add_typer(concurrency_limit_app, pluralization_string="concurrency_limits")
 
 
 @concurrency_limit_app.command()

--- a/src/prefect/cli/concurrency_limit.py
+++ b/src/prefect/cli/concurrency_limit.py
@@ -25,7 +25,7 @@ concurrency_limit_app = PrefectTyper(
     name="concurrency-limit",
     help="Commands for managing task-level concurrency limits.",
 )
-app.add_typer(concurrency_limit_app, pluralization_string="concurrency-limits")
+app.add_typer(concurrency_limit_app, aliases=["concurrency-limits"])
 
 
 @concurrency_limit_app.command()

--- a/src/prefect/cli/concurrency_limit.py
+++ b/src/prefect/cli/concurrency_limit.py
@@ -25,7 +25,7 @@ concurrency_limit_app = PrefectTyper(
     name="concurrency-limit",
     help="Commands for managing task-level concurrency limits.",
 )
-app.add_typer(concurrency_limit_app, pluralization_string="concurrency_limits")
+app.add_typer(concurrency_limit_app, pluralization_string="concurrency-limits")
 
 
 @concurrency_limit_app.command()

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -49,7 +49,7 @@ yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
 deployment_app = PrefectTyper(
     name="deployment", help="Commands for working with deployments."
 )
-app.add_typer(deployment_app, pluralization_string="deployments")
+app.add_typer(deployment_app, aliases=["deployments"])
 
 
 def assert_deployment_name_format(name: str) -> None:

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -49,7 +49,7 @@ yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
 deployment_app = PrefectTyper(
     name="deployment", help="Commands for working with deployments."
 )
-app.add_typer(deployment_app)
+app.add_typer(deployment_app, pluralization_string="deployments")
 
 
 def assert_deployment_name_format(name: str) -> None:

--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -10,7 +10,7 @@ from prefect.client import get_client
 from prefect.orion.schemas.sorting import FlowSort
 
 flow_app = PrefectTyper(name="flow", help="Commands for interacting with flows.")
-app.add_typer(flow_app, pluralization_string="flows")
+app.add_typer(flow_app, aliases=["flows"])
 
 
 @flow_app.command()

--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -10,7 +10,7 @@ from prefect.client import get_client
 from prefect.orion.schemas.sorting import FlowSort
 
 flow_app = PrefectTyper(name="flow", help="Commands for interacting with flows.")
-app.add_typer(flow_app)
+app.add_typer(flow_app, pluralization_string="flows")
 
 
 @flow_app.command()

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -23,7 +23,7 @@ from prefect.orion.schemas.states import StateType
 flow_run_app = PrefectTyper(
     name="flow-run", help="Commands for interacting with flow runs."
 )
-app.add_typer(flow_run_app, pluralization_string="flow-runs")
+app.add_typer(flow_run_app, aliases=["flow-runs"])
 
 
 @flow_run_app.command()

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -23,7 +23,7 @@ from prefect.orion.schemas.states import StateType
 flow_run_app = PrefectTyper(
     name="flow-run", help="Commands for interacting with flow runs."
 )
-app.add_typer(flow_run_app)
+app.add_typer(flow_run_app, pluralization_string="flow-runs")
 
 
 @flow_run_app.command()

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -23,7 +23,7 @@ from prefect.context import use_profile
 profile_app = PrefectTyper(
     name="profile", help="Commands for interacting with your Prefect profiles."
 )
-app.add_typer(profile_app)
+app.add_typer(profile_app, pluralization_string="profiles")
 
 
 @profile_app.command()

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -23,7 +23,7 @@ from prefect.context import use_profile
 profile_app = PrefectTyper(
     name="profile", help="Commands for interacting with your Prefect profiles."
 )
-app.add_typer(profile_app, pluralization_string="profiles")
+app.add_typer(profile_app, aliases=["profiles"])
 
 
 @profile_app.command()

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -17,7 +17,7 @@ from prefect.client import get_client
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 
 work_app = PrefectTyper(name="work-queue", help="Commands for work queue CRUD.")
-app.add_typer(work_app, pluralization_string="work-queues")
+app.add_typer(work_app, aliases=["work-queues"])
 
 
 @work_app.command()

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -17,7 +17,7 @@ from prefect.client import get_client
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 
 work_app = PrefectTyper(name="work-queue", help="Commands for work queue CRUD.")
-app.add_typer(work_app)
+app.add_typer(work_app, pluralization_string="work-queues")
 
 
 @work_app.command()

--- a/tests/cli/test_typer_utils.py
+++ b/tests/cli/test_typer_utils.py
@@ -1,0 +1,41 @@
+from prefect.cli._types import PrefectTyper
+from prefect.cli.root import app
+from prefect.testing.cli import invoke_and_assert
+
+
+class TestPrefectTyper:
+    singular_subcommand = PrefectTyper(name="singular-subcommand")
+    pluralized_subcommand = PrefectTyper(name="pluralized-subcommand")
+    app.add_typer(singular_subcommand)
+    app.add_typer(
+        pluralized_subcommand, pluralization_string="pluralized-subcommands"
+    )
+
+    def test_pluralized_subcommands_have_multiple_valid_invocations(self):
+        invoke_and_assert(["pluralized-subcommand", "--help"], expected_code=0)
+        invoke_and_assert(["pluralized-subcommands", "--help"], expected_code=0)
+
+    def test_unpluralized_subcommands_have_one_invocation(self):
+        invoke_and_assert(["singular-subcommand", "--help"], expected_code=0)
+        invoke_and_assert(["singular-subcommands", "--help"], expected_code=2)
+
+        app.add_typer(
+            self.singular_subcommand, pluralization_string="singular-subcommands"
+        )
+        invoke_and_assert(["singular-subcommands", "--help"], expected_code=0)
+
+    def test_registering_a_command_is_propogated_properly(self):
+        @self.pluralized_subcommand.command()
+        def exists():
+            print("hello")
+
+        invoke_and_assert(
+            ["pluralized-subcommand", "exists"],
+            expected_output_contains="hello",
+            expected_code=0,
+        )
+        invoke_and_assert(
+            ["pluralized-subcommands", "exists"],
+            expected_output_contains="hello",
+            expected_code=0,
+        )

--- a/tests/cli/test_typer_utils.py
+++ b/tests/cli/test_typer_utils.py
@@ -7,9 +7,7 @@ class TestPrefectTyper:
     singular_subcommand = PrefectTyper(name="singular-subcommand")
     pluralized_subcommand = PrefectTyper(name="pluralized-subcommand")
     app.add_typer(singular_subcommand)
-    app.add_typer(
-        pluralized_subcommand, pluralization_string="pluralized-subcommands"
-    )
+    app.add_typer(pluralized_subcommand, pluralization_string="pluralized-subcommands")
 
     def test_pluralized_subcommands_have_multiple_valid_invocations(self):
         invoke_and_assert(["pluralized-subcommand", "--help"], expected_code=0)

--- a/tests/cli/test_typer_utils.py
+++ b/tests/cli/test_typer_utils.py
@@ -7,7 +7,7 @@ class TestPrefectTyper:
     singular_subcommand = PrefectTyper(name="singular-subcommand")
     pluralized_subcommand = PrefectTyper(name="pluralized-subcommand")
     app.add_typer(singular_subcommand)
-    app.add_typer(pluralized_subcommand, pluralization_string="pluralized-subcommands")
+    app.add_typer(pluralized_subcommand, aliases=["pluralized-subcommands"])
 
     def test_pluralized_subcommands_have_multiple_valid_invocations(self):
         invoke_and_assert(["pluralized-subcommand", "--help"], expected_code=0)
@@ -17,12 +17,10 @@ class TestPrefectTyper:
         invoke_and_assert(["singular-subcommand", "--help"], expected_code=0)
         invoke_and_assert(["singular-subcommands", "--help"], expected_code=2)
 
-        app.add_typer(
-            self.singular_subcommand, pluralization_string="singular-subcommands"
-        )
+        app.add_typer(self.singular_subcommand, aliases=["singular-subcommands"])
         invoke_and_assert(["singular-subcommands", "--help"], expected_code=0)
 
-    def test_registering_a_command_is_propogated_properly(self):
+    def test_registering_a_command_is_propogated_to_parents(self):
         @self.pluralized_subcommand.command()
         def exists():
             print("hello")


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
In this PR we further extend our `Typer` wrappers to add the ability to add pluralized versions of our subcommands to our CLI. This implementation creates hidden (e.g. our documentation and help menus will only list the "singular" subcommands) alternate commands that we can specify when adding a subcomand to a `Typer` object via the `add_typer` method.

@cicdw suggested that we might want to consider a simple default pluralization scheme for each subcommand. This would reduce the maintenance overhead. One benefit to explicitly specifying pluralizations: in this PR I've purposefully omitted pluralizations for specific subcommands that make no sense, though I think that decision should ultimately be a product one.

Another interesting point is we could use the ability to explicitly specify alternate spellings for subcommands to handle various common typos if we wish (cc @chrisguidry).

Pluralized subcommands:
- `block`
- `concurrency-limit`
- `deployment`
- `flow`
- `flow-run`
- `profile`
- `work-queue`

Subcommands I've left unpluralized:
- `agent`
- `cloud`
- `config`
- `kubernetes`
- `orion`

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting
