### PR TITLE
Backend changes for work queues operating on name, not tags

### DIFF
--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -294,6 +294,7 @@ async def create_flow_run_from_deployment(
         infrastructure_document_id=(
             flow_run.infrastructure_document_id or deployment.infrastructure_document_id
         ),
+        work_queue_name=deployment.work_queue_name,
     )
 
     if not flow_run.state:
@@ -306,7 +307,8 @@ async def create_flow_run_from_deployment(
     return model
 
 
-@router.get("/{id}/work_queue_check")
+# DEPRECATED
+@router.get("/{id}/work_queue_check", deprecated=True)
 async def work_queue_check_for_deployment(
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
     session: AsyncSession = Depends(dependencies.get_session),

--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -5,7 +5,6 @@ Routes for interacting with work queue objects.
 from typing import List, Optional
 from uuid import UUID
 
-import pendulum
 import sqlalchemy as sa
 from fastapi import Body, Depends, HTTPException, Path, status
 
@@ -104,7 +103,7 @@ async def read_work_queue_runs(
     limit: int = dependencies.LimitBody(),
     scheduled_before: DateTimeTZ = Body(
         None,
-        description="Only flow runs scheduled to start before this time will be returned. If not provided, defaults to now.",
+        description="Only flow runs scheduled to start before this time will be returned.",
     ),
     agent_id: Optional[UUID] = Body(
         None,
@@ -115,8 +114,6 @@ async def read_work_queue_runs(
     """
     Get flow runs from the work queue.
     """
-    scheduled_before = scheduled_before or pendulum.now("UTC")
-
     flow_runs = await models.work_queues.get_runs_in_work_queue(
         session=session,
         work_queue_id=work_queue_id,

--- a/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add work queue name to runs
+SQLite: `575634b7acd4`
+Postgres: `77eb737fc759`
+
 ## Add more fields to deployments
 
 SQLite: `296e2665785f`

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_08_07_134410_77eb737fc759_add_work_queue_name_to_runs.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_08_07_134410_77eb737fc759_add_work_queue_name_to_runs.py
@@ -1,0 +1,58 @@
+"""Add work queue name to runs
+
+Revision ID: 77eb737fc759
+Revises: 60e428f92a75
+Create Date: 2022-08-07 13:44:10.238362
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "77eb737fc759"
+down_revision = "60e428f92a75"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("work_queue_name", sa.String(), nullable=True))
+        batch_op.create_index(
+            batch_op.f("ix_deployment__work_queue_name"),
+            ["work_queue_name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("work_queue_name", sa.String(), nullable=True))
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__work_queue_name"),
+            ["work_queue_name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.alter_column("filter", nullable=True, server_default=None)
+
+
+def downgrade():
+
+    op.execute(
+        """
+        UPDATE work_queue
+        SET filter = '{}'
+        WHERE filter IS NULL;
+        """
+    )
+
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.alter_column("filter", nullable=False, server_default=sa.text("'{}'"))
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_flow_run__work_queue_name"))
+        batch_op.drop_column("work_queue_name")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        # batch_op.drop_index(batch_op.f("ix_deployment__work_queue_name"))
+        batch_op.drop_column("work_queue_name")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_08_07_134138_575634b7acd4_add_work_queue_name_to_runs.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_08_07_134138_575634b7acd4_add_work_queue_name_to_runs.py
@@ -1,0 +1,58 @@
+"""Add work queue name to runs
+
+Revision ID: 575634b7acd4
+Revises: 296e2665785f
+Create Date: 2022-08-07 13:41:38.128173
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "575634b7acd4"
+down_revision = "296e2665785f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("work_queue_name", sa.String(), nullable=True))
+        batch_op.create_index(
+            batch_op.f("ix_deployment__work_queue_name"),
+            ["work_queue_name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("work_queue_name", sa.String(), nullable=True))
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__work_queue_name"),
+            ["work_queue_name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.alter_column("filter", nullable=True, server_default=None)
+
+
+def downgrade():
+
+    op.execute(
+        """
+        UPDATE work_queue
+        SET filter = '{}'
+        WHERE filter IS NULL;
+        """
+    )
+
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.alter_column("filter", nullable=False, server_default=sa.text("'{}'"))
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_flow_run__work_queue_name"))
+        batch_op.drop_column("work_queue_name")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_deployment__work_queue_name"))
+        batch_op.drop_column("work_queue_name")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -352,6 +352,7 @@ class ORMFlowRun(ORMRun):
             UUID(), sa.ForeignKey("deployment.id", ondelete="set null"), index=True
         )
 
+    work_queue_name = sa.Column(sa.String, index=True)
     flow_version = sa.Column(sa.String, index=True)
     parameters = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     idempotency_key = sa.Column(sa.String)
@@ -658,6 +659,7 @@ class ORMDeployment:
     version = sa.Column(sa.String, nullable=True)
     description = sa.Column(sa.Text(), nullable=True)
     manifest_path = sa.Column(sa.String, nullable=True)
+    work_queue_name = sa.Column(sa.String, nullable=True, index=True)
     infra_overrides = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     path = sa.Column(sa.String, nullable=True)
     entrypoint = sa.Column(sa.String, nullable=True)
@@ -929,9 +931,9 @@ class ORMWorkQueue:
 
     filter = sa.Column(
         Pydantic(schemas.core.QueueFilter),
-        server_default="{}",
-        default=dict,
-        nullable=False,
+        server_default=None,
+        default=None,
+        nullable=True,
     )
     description = sa.Column(sa.String, nullable=False, default="", server_default="")
     is_paused = sa.Column(sa.Boolean, nullable=False, server_default="0", default=False)

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -11,7 +11,7 @@ import pendulum
 import sqlalchemy as sa
 from sqlalchemy import delete, or_, select
 
-import prefect.orion.schemas as schemas
+from prefect.orion import models, schemas
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.exceptions import ObjectNotFoundError
@@ -79,6 +79,7 @@ async def create_deployment(
                         "tags",
                         "parameters",
                         "updated",
+                        "work_queue_name",
                         "storage_document_id",
                         "infrastructure_document_id",
                         "manifest_path",
@@ -105,6 +106,11 @@ async def create_deployment(
     )
     result = await session.execute(query)
     model = result.scalar()
+
+    if model.work_queue_name:
+        await models.work_queues._ensure_work_queue_exists(
+            session=session, name=model.work_queue_name, db=db
+        )
 
     # because this could upsert a different schedule, delete any runs from the old
     # deployment
@@ -147,6 +153,12 @@ async def update_deployment(
     await _delete_auto_scheduled_runs(
         session=session, deployment_id=deployment_id, db=db
     )
+
+    # create work queue if it doesn't exist
+    if update_data.get("work_queue_name"):
+        await models.work_queues._ensure_work_queue_exists(
+            session=session, name=update_data["work_queue_name"], db=db
+        )
 
     return result.rowcount > 0
 
@@ -440,6 +452,7 @@ async def _generate_scheduled_flow_runs(
                 "id": uuid4(),
                 "flow_id": deployment.flow_id,
                 "deployment_id": deployment_id,
+                "work_queue_name": deployment.work_queue_name,
                 "parameters": deployment.parameters,
                 "infrastructure_document_id": deployment.infrastructure_document_id,
                 "idempotency_key": f"scheduled {deployment.id} {date}",

--- a/src/prefect/orion/models/work_queues.py
+++ b/src/prefect/orion/models/work_queues.py
@@ -15,6 +15,7 @@ import prefect.orion.schemas as schemas
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.exceptions import ObjectNotFoundError
+from prefect.orion.schemas.states import StateType
 
 
 @inject_db
@@ -172,7 +173,7 @@ async def delete_work_queue(
 async def get_runs_in_work_queue(
     session: sa.orm.Session,
     work_queue_id: UUID,
-    scheduled_before: datetime.datetime,
+    scheduled_before: datetime.datetime = None,
     limit: int = None,
 ):
     """
@@ -188,6 +189,7 @@ async def get_runs_in_work_queue(
             concurrency limit, it will be ignored.
 
     """
+
     work_queue = await read_work_queue(session=session, work_queue_id=work_queue_id)
     if not work_queue:
         raise ObjectNotFoundError(f"Work queue with id {work_queue_id} not found.")
@@ -195,37 +197,70 @@ async def get_runs_in_work_queue(
     if work_queue.is_paused:
         return []
 
-    # ensure the filter object is fully hydrated
-    # SQLAlchemy caching logic can result in a dict type instead
-    # of the full pydantic model
-    work_queue_filter = parse_obj_as(schemas.core.QueueFilter, work_queue.filter)
+    # handle legacy work queues that use tag-based filters
+    if work_queue.filter is not None:
+        # ensure the filter object is fully hydrated
+        # SQLAlchemy caching logic can result in a dict type instead
+        # of the full pydantic model
+        work_queue_filter = parse_obj_as(schemas.core.QueueFilter, work_queue.filter)
+        flow_run_filter = dict(
+            tags=dict(all_=work_queue_filter.tags),
+            deployment_id=dict(any_=work_queue_filter.deployment_ids, is_null_=False),
+        )
+
+    # new work queues are entirely name-based
+    else:
+        flow_run_filter = dict(work_queue_name=dict(any_=[work_queue.name]))
 
     # if the work queue has a concurrency limit, check how many runs are currently
     # executing and compare that count to the concurrency limit
     if work_queue.concurrency_limit is not None:
         # Note this does not guarantee race conditions wont be hit
-        concurrent_count = await models.flow_runs.count_flow_runs(
+        running_frs = await models.flow_runs.count_flow_runs(
             session=session,
-            flow_run_filter=work_queue_filter.get_executing_flow_run_filter(),
+            flow_run_filter=schemas.filters.FlowRunFilter(
+                **flow_run_filter,
+                state=dict(type=dict(any_=[StateType.PENDING, StateType.RUNNING])),
+            ),
         )
 
         # compute the available concurrency slots
-        open_concurrency_slots = max(0, work_queue.concurrency_limit - concurrent_count)
+        open_concurrency_slots = max(0, work_queue.concurrency_limit - running_frs)
 
         # if a limit override was given, ensure we return no more
         # than that limit
         if limit is not None:
-            open_concurrency_slots = min(open_concurrency_slots, limit)
-    else:
-        # otherwise, the amount of flow runs to return is only controlled
-        # by the limit given
-        open_concurrency_slots = limit
+            limit = min(open_concurrency_slots, limit)
+        else:
+            limit = open_concurrency_slots
 
     return await models.flow_runs.read_flow_runs(
         session=session,
-        flow_run_filter=work_queue_filter.get_scheduled_flow_run_filter(
-            scheduled_before=scheduled_before
+        flow_run_filter=schemas.filters.FlowRunFilter(
+            **flow_run_filter,
+            state=dict(type=dict(any_=[StateType.SCHEDULED])),
+            next_scheduled_start_time=dict(before_=scheduled_before),
         ),
-        limit=open_concurrency_slots,
+        limit=limit,
         sort=schemas.sorting.FlowRunSort.NEXT_SCHEDULED_START_TIME_ASC,
     )
+
+
+@inject_db
+async def _ensure_work_queue_exists(
+    session: sa.orm.Session, name: str, db: OrionDBInterface
+):
+    """
+    Checks if a work queue exists and creates it if it does not.
+
+    Useful when working with deployments, agents, and flow runs that automatically create work queues.
+    """
+    # read work queue
+    work_queue = await models.work_queues.read_work_queue_by_name(
+        session=session, name=name
+    )
+    if not work_queue:
+        await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(name=name),
+        )

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -61,6 +61,7 @@ class DeploymentCreate(
             "flow_id",
             "schedule",
             "is_schedule_active",
+            "work_queue_name",
             "description",
             "tags",
             "parameters",
@@ -88,6 +89,7 @@ class DeploymentUpdate(
             "schedule",
             "is_schedule_active",
             "description",
+            "work_queue_name",
             "tags",
             "manifest_path",
             "path",
@@ -352,11 +354,12 @@ class WorkQueueCreate(
     schemas.core.WorkQueue.subclass(
         "WorkQueueCreate",
         include_fields=[
-            "filter",
             "name",
             "description",
             "is_paused",
             "concurrency_limit",
+            # filters are deprecated
+            "filter",
         ],
     )
 ):
@@ -370,11 +373,11 @@ class WorkQueueUpdate(
     schemas.core.WorkQueue.subclass(
         "WorkQueueUpdate",
         include_fields=[
-            "filter",
-            "name",
             "description",
             "is_paused",
             "concurrency_limit",
+            # filters are deprecated
+            "filter",
         ],
     )
 ):
@@ -382,8 +385,6 @@ class WorkQueueUpdate(
 
     class Config:
         extra = "forbid"
-
-    name: Optional[str] = Field(None, description="The name of the work queue.")
 
 
 class FlowRunNotificationPolicyCreate(

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -358,7 +358,7 @@ class WorkQueueCreate(
             "description",
             "is_paused",
             "concurrency_limit",
-            # filters are deprecated
+            # DEPRECATED: filters are deprecated
             "filter",
         ],
     )
@@ -376,8 +376,10 @@ class WorkQueueUpdate(
             "description",
             "is_paused",
             "concurrency_limit",
-            # filters are deprecated
+            # DEPRECATED: filters are deprecated
             "filter",
+            # DEPRECATED: names should not be updated, left for compat
+            "name",
         ],
     )
 ):

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -378,8 +378,6 @@ class WorkQueueUpdate(
             "concurrency_limit",
             # DEPRECATED: filters are deprecated
             "filter",
-            # DEPRECATED: names should not be updated, left for compat
-            "name",
         ],
     )
 ):
@@ -387,6 +385,11 @@ class WorkQueueUpdate(
 
     class Config:
         extra = "forbid"
+
+    # DEPRECATED: names should not be updated, left here only for backwards-compatibility
+    name: Optional[str] = Field(
+        None, description="The name of the work queue.", deprecated=True
+    )
 
 
 class FlowRunNotificationPolicyCreate(

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -108,6 +108,9 @@ class FlowRun(ORMBaseModel):
         None,
         description="The id of the deployment associated with this flow run, if available.",
     )
+    work_queue_name: str = Field(
+        None, description="The work queue that handled this flow run."
+    )
     flow_version: str = Field(
         None,
         description="The version of the flow executed in this flow run.",
@@ -352,7 +355,10 @@ class Deployment(ORMBaseModel):
         description="A list of tags for the deployment",
         example=["tag-1", "tag-2"],
     )
-
+    work_queue_name: Optional[str] = Field(
+        None,
+        description="The work queue for the deployment. If no work queue is set, work will not be scheduled.",
+    )
     parameter_openapi_schema: Dict[str, Any] = Field(
         None,
         description="The parameter schema of the flow, including defaults.",
@@ -630,69 +636,10 @@ class QueueFilter(PrefectBaseModel):
         description="Only include flow runs from these deployments in the work queue.",
     )
 
-    def get_flow_run_filter(self) -> "schemas.filters.FlowRunFilter":
-        """
-        Construct a flow run filter for the work queue's flow runs.
-        """
-        return schemas.filters.FlowRunFilter(
-            tags=schemas.filters.FlowRunFilterTags(all_=self.tags),
-            deployment_id=schemas.filters.FlowRunFilterDeploymentId(
-                any_=self.deployment_ids,
-                is_null_=False,
-            ),
-        )
-
-    def get_scheduled_flow_run_filter(
-        self, scheduled_before: datetime.datetime
-    ) -> "schemas.filters.FlowRunFilter":
-        """
-        Construct a flow run filter for the work queue's SCHEDULED flow runs.
-
-        Args:
-            scheduled_before: Create a FlowRunFilter that excludes runs scheduled before this date.
-
-        Returns:
-            Flow run filter that can be used to query the work queue for scheduled runs.
-        """
-        return self.get_flow_run_filter().copy(
-            update={
-                "state": schemas.filters.FlowRunFilterState(
-                    type=schemas.filters.FlowRunFilterStateType(
-                        any_=[
-                            schemas.states.StateType.SCHEDULED,
-                        ]
-                    )
-                ),
-                "next_scheduled_start_time": schemas.filters.FlowRunFilterNextScheduledStartTime(
-                    before_=scheduled_before
-                ),
-            }
-        )
-
-    def get_executing_flow_run_filter(self) -> "schemas.filters.FlowRunFilter":
-        """
-        Construct a flow run filter for the work queue's PENDING or RUNNING flow runs.
-        """
-        return self.get_flow_run_filter().copy(
-            update={
-                "state": schemas.filters.FlowRunFilterState(
-                    type=schemas.filters.FlowRunFilterStateType(
-                        any_=[
-                            schemas.states.StateType.PENDING,
-                            schemas.states.StateType.RUNNING,
-                        ]
-                    )
-                )
-            }
-        )
-
 
 class WorkQueue(ORMBaseModel):
     """An ORM representation of a work queue"""
 
-    filter: QueueFilter = Field(
-        default_factory=QueueFilter, description="Filter criteria for the work queue."
-    )
     name: str = Field(..., description="The name of the work queue.")
     description: Optional[str] = Field(
         "", description="An optional description for the work queue."
@@ -702,6 +649,11 @@ class WorkQueue(ORMBaseModel):
     )
     concurrency_limit: Optional[int] = Field(
         None, description="An optional concurrency limit for the work queue."
+    )
+    filter: Optional[QueueFilter] = Field(
+        None,
+        description="Deprecated field: Filter criteria for the work queue.",
+        deprecated=True,
     )
 
     @validator("name", check_fields=False)

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -241,6 +241,31 @@ class FlowRunFilterDeploymentId(PrefectOperatorFilterBaseModel):
         return filters
 
 
+class FlowRunFilterWorkQueueName(PrefectOperatorFilterBaseModel):
+    """Filter by `FlowRun.work_queue_name`."""
+
+    any_: List[str] = Field(
+        None,
+        description="A list of work queue names to include",
+        example=["work_queue_1", "work_queue_2"],
+    )
+    is_null_: bool = Field(
+        None, description="If true, only include flow runs without work queue names"
+    )
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.FlowRun.work_queue_name.in_(self.any_))
+        if self.is_null_ is not None:
+            filters.append(
+                db.FlowRun.work_queue_name == None
+                if self.is_null_
+                else db.FlowRun.work_queue_name != None
+            )
+        return filters
+
+
 class FlowRunFilterStateType(PrefectFilterBaseModel):
     """Filter by `FlowRun.state_type`."""
 
@@ -402,6 +427,9 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
     deployment_id: Optional[FlowRunFilterDeploymentId] = Field(
         None, description="Filter criteria for `FlowRun.deployment_id`"
     )
+    work_queue_name: Optional[FlowRunFilterWorkQueueName] = Field(
+        None, description="Filter criteria for `FlowRun.work_queue_name"
+    )
     state: Optional[FlowRunFilterState] = Field(
         None, description="Filter criteria for `FlowRun.state`"
     )
@@ -432,6 +460,8 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.tags.as_sql_filter(db))
         if self.deployment_id is not None:
             filters.append(self.deployment_id.as_sql_filter(db))
+        if self.work_queue_name is not None:
+            filters.append(self.work_queue_name.as_sql_filter(db))
         if self.flow_version is not None:
             filters.append(self.flow_version.as_sql_filter(db))
         if self.state is not None:
@@ -678,6 +708,22 @@ class DeploymentFilterName(PrefectFilterBaseModel):
         return filters
 
 
+class DeploymentFilterWorkQueueName(PrefectFilterBaseModel):
+    """Filter by `Deployment.work_queue_name`."""
+
+    any_: List[str] = Field(
+        None,
+        description="A list of work queue names to include",
+        example=["work_queue_1", "work_queue_2"],
+    )
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.Deployment.work_queue_name.in_(self.any_))
+        return filters
+
+
 class DeploymentFilterIsScheduleActive(PrefectFilterBaseModel):
     """Filter by `Deployment.is_schedule_active`."""
 
@@ -733,6 +779,9 @@ class DeploymentFilter(PrefectOperatorFilterBaseModel):
     tags: Optional[DeploymentFilterTags] = Field(
         None, description="Filter criteria for `Deployment.tags`"
     )
+    work_queue_name: Optional[DeploymentFilterWorkQueueName] = Field(
+        None, description="Filter criteria for `Deployment.work_queue_name`"
+    )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
@@ -745,6 +794,8 @@ class DeploymentFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.is_schedule_active.as_sql_filter(db))
         if self.tags is not None:
             filters.append(self.tags.as_sql_filter(db))
+        if self.work_queue_name is not None:
+            filters.append(self.work_queue_name.as_sql_filter(db))
 
         return filters
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -219,6 +219,7 @@ async def deployment(
             path="./subdir",
             entrypoint="/file.py:flow",
             infrastructure_document_id=infrastructure_document_id,
+            work_queue_name="wq",
         ),
     )
     await session.commit()

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -101,6 +101,15 @@ class TestCreateDeployment:
         assert deployment.infrastructure_document_id == infrastructure_document_id
         assert deployment.storage_document_id == storage_document_id
 
+    async def test_default_work_queue_name_is_none(self, session, client, flow):
+
+        data = DeploymentCreate(
+            name="My Deployment", manifest_path="", flow_id=flow.id
+        ).dict(json_compatible=True)
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["work_queue_name"] == None
+
     async def test_create_deployment_respects_flow_id_name_uniqueness(
         self,
         session,
@@ -836,6 +845,18 @@ class TestCreateFlowRunFromDeployment:
         assert response.json()["infrastructure_document_id"] == str(
             deployment.infrastructure_document_id
         )
+        assert response.json()["work_queue_name"] == "wq"
+
+    async def test_create_flow_run_from_deployment_uses_work_queue_name(
+        self, deployment, client, session
+    ):
+        await client.patch(
+            f"deployments/{deployment.id}", json=dict(work_queue_name="wq-test")
+        )
+        response = await client.post(
+            f"deployments/{deployment.id}/create_flow_run", json={}
+        )
+        assert response.json()["work_queue_name"] == "wq-test"
 
     async def test_create_flow_run_from_deployment_override_params(
         self, deployment, client

--- a/tests/orion/models/deprecated/test_work_queues.py
+++ b/tests/orion/models/deprecated/test_work_queues.py
@@ -1,0 +1,743 @@
+"""Tests deprecated tag-based matching systems for work queues"""
+from uuid import uuid4
+
+import pendulum
+import pytest
+
+from prefect.orion import models, schemas
+from prefect.orion.exceptions import ObjectNotFoundError
+from prefect.orion.models.deployments import check_work_queues_for_deployment
+
+
+@pytest.fixture
+async def work_queue(session):
+    work_queue = await models.work_queues.create_work_queue(
+        session=session,
+        work_queue=schemas.core.WorkQueue(
+            name="My WorkQueue",
+            description="All about my work queue",
+            # filters for all runs
+            filter=schemas.core.QueueFilter(),
+        ),
+    )
+    await session.commit()
+    return work_queue
+
+
+class TestCreateWorkQueue:
+    async def test_create_work_queue_succeeds(self, session):
+        work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name="My WorkQueue", filter=schemas.core.QueueFilter()
+            ),
+        )
+        assert work_queue.name == "My WorkQueue"
+        assert work_queue.filter is not None
+
+
+class TestUpdateWorkQueue:
+    async def test_update_work_queue(self, session, work_queue):
+        result = await models.work_queues.update_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            work_queue=schemas.actions.WorkQueueUpdate(
+                filter=schemas.core.QueueFilter(tags=["updated", "tags"])
+            ),
+        )
+        assert result
+
+        updated_queue = await models.work_queues.read_work_queue(
+            session=session, work_queue_id=work_queue.id
+        )
+        assert updated_queue.id == work_queue.id
+        assert updated_queue.filter.tags == ["updated", "tags"]
+
+
+class TestGetRunsInWorkQueue:
+    @pytest.fixture
+    async def tb12_work_queue(self, session):
+        work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name="TB12",
+                description="The GOAT",
+                filter=schemas.core.QueueFilter(tags=["tb12"]),
+            ),
+        )
+        await session.commit()
+        return work_queue
+
+    @pytest.fixture
+    async def flow_run_1_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_2_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_3_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_4_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_5_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_6_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    async def flow_run_7_id(self):
+        return uuid4()
+
+    @pytest.fixture(autouse=True)
+    async def flow_runs(
+        self,
+        session,
+        deployment,
+        infrastructure_document_id,
+        flow_run_1_id,
+        flow_run_2_id,
+        flow_run_3_id,
+        flow_run_4_id,
+        flow_run_5_id,
+        flow_run_6_id,
+        flow_run_7_id,
+    ):
+
+        # flow run 1 is in a SCHEDULED state 5 seconds ago
+        flow_run_1 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_1_id,
+                flow_id=deployment.flow_id,
+                deployment_id=deployment.id,
+                flow_version="0.1",
+                infrastructure_document_id=infrastructure_document_id,
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_1.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(seconds=1)
+                ),
+            ),
+        )
+
+        # flow run 2 is in a SCHEDULED state 1 minute ago with tags ["tb12", "goat"]
+        flow_run_2 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_2_id,
+                flow_id=deployment.flow_id,
+                deployment_id=deployment.id,
+                flow_version="0.1",
+                tags=["tb12", "goat"],
+                next_scheduled_start_time=pendulum.now("UTC").subtract(minutes=1),
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_2.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(minutes=1),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(minutes=1)
+                ),
+            ),
+        )
+
+        # flow run 3 is in a PENDING state with tags ["tb12", "goat"]
+        flow_run_3 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_3_id,
+                flow_id=deployment.flow_id,
+                deployment_id=deployment.id,
+                flow_version="0.1",
+                tags=["tb12", "goat"],
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_3.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(seconds=1)
+                ),
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_3.id,
+            state=schemas.states.Pending(),
+        )
+
+        # flow run 4 is in a RUNNING state with no tags
+        flow_run_4 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_4_id,
+                flow_id=deployment.flow_id,
+                deployment_id=deployment.id,
+                flow_version="0.1",
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_4.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(seconds=1)
+                ),
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_4.id,
+            state=schemas.states.Pending(),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_4.id,
+            state=schemas.states.Running(),
+        )
+
+        # flow run 5 is in a SCHEDULED state 1 year in the future
+        flow_run_5 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_5_id,
+                flow_id=deployment.flow_id,
+                deployment_id=deployment.id,
+                flow_version="0.1",
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_5.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(scheduled_time=pendulum.now("UTC").add(years=1)),
+            ),
+        )
+
+        # flow run 6 is in a SCHEDULED state 5 seconds ago but has no
+        # deployment_id, it should never be returned by the queue
+        flow_run_6 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_6_id,
+                flow_id=deployment.flow_id,
+                flow_version="0.1",
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_6.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(seconds=1)
+                ),
+            ),
+        )
+
+        # flow run 7 is in a RUNNING state but has no
+        # deployment_id, it should never be returned by the queue
+        # or count against concurrency limits
+        flow_run_7 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                id=flow_run_7_id,
+                flow_id=deployment.flow_id,
+                flow_version="0.1",
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_7.id,
+            state=schemas.states.State(
+                type=schemas.states.StateType.SCHEDULED,
+                timestamp=pendulum.now("UTC").subtract(seconds=5),
+                state_details=dict(
+                    scheduled_time=pendulum.now("UTC").subtract(seconds=1)
+                ),
+            ),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_7.id,
+            state=schemas.states.Pending(),
+        )
+        await models.flow_runs.set_flow_run_state(
+            session=session,
+            flow_run_id=flow_run_7.id,
+            state=schemas.states.Running(),
+        )
+        await session.commit()
+
+    async def test_get_runs_in_work_queue_returns_scheduled_runs(
+        self,
+        session,
+        work_queue,
+        flow_run_1_id,
+        flow_run_2_id,
+    ):
+        # should only return SCHEDULED runs before NOW with
+        # a deployment_id
+        runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        )
+        assert {run.id for run in runs} == {flow_run_1_id, flow_run_2_id}
+
+        # should respect limit param
+        limited_runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+            limit=1,
+        )
+        # flow run 2 is scheduled to start before flow run 1
+        assert {run.id for run in limited_runs} == {flow_run_2_id}
+
+        # should respect scheduled before param
+        # (turns out pendulum does not actually let you go back far enough but you get the idea)
+        runs_from_babylon = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC").subtract(years=2000),
+            limit=1,
+        )
+        assert len(runs_from_babylon) == 0
+
+    async def test_get_runs_in_work_queue_filters_on_tags(
+        self,
+        session,
+        tb12_work_queue,
+        flow_run_2_id,
+    ):
+        # should only return SCHEDULED runs before NOW with
+        # a deployment_id and tags ["tb12"]
+        runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=tb12_work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        )
+        assert {run.id for run in runs} == {flow_run_2_id}
+
+    async def test_get_runs_in_work_queue_filters_on_deployment_ids(
+        self,
+        session,
+        deployment,
+        flow_run_1_id,
+        flow_run_2_id,
+    ):
+        # should only return SCHEDULED runs before NOW with
+        # the correct deployment_id
+        deployment_work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name=f"Work Queue for Deployment {deployment.name}",
+                filter=schemas.core.QueueFilter(
+                    deployment_ids=[deployment.id, uuid4()]
+                ),
+            ),
+        )
+        runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=deployment_work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        )
+        assert {run.id for run in runs} == {flow_run_1_id, flow_run_2_id}
+
+        bad_deployment_work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name=f"Work Queue for Deployment that doesnt exist",
+                filter=schemas.core.QueueFilter(deployment_ids=[uuid4()]),
+            ),
+        )
+        assert (
+            await models.work_queues.get_runs_in_work_queue(
+                session=session,
+                work_queue_id=bad_deployment_work_queue.id,
+                scheduled_before=pendulum.now("UTC"),
+            )
+        ) == []
+
+    async def test_get_runs_in_work_queue_uses_union_of_filter_criteria(self, session):
+        # tags "tb12" will match but the deployment ids should not match any flow runs
+        conflicting_filter_work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name=f"Work Queue for Deployment that doesnt exist",
+                filter=schemas.core.QueueFilter(
+                    deployment_ids=[uuid4()], tags=["tb12"]
+                ),
+            ),
+        )
+        assert (
+            await models.work_queues.get_runs_in_work_queue(
+                session=session,
+                work_queue_id=conflicting_filter_work_queue.id,
+                scheduled_before=pendulum.now("UTC"),
+            )
+        ) == []
+
+    async def test_get_runs_in_work_queue_respects_concurrency_limit(
+        self,
+        session,
+        work_queue,
+        flow_run_1_id,
+        flow_run_2_id,
+    ):
+        runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        )
+        assert {run.id for run in runs} == {flow_run_1_id, flow_run_2_id}
+
+        # add a concurrency limit
+        await models.work_queues.update_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            work_queue=schemas.actions.WorkQueueUpdate(concurrency_limit=2),
+        )
+        # since there is one PENDING and one RUNNING flow run, no runs
+        # should be returned
+        assert (
+            await models.work_queues.get_runs_in_work_queue(
+                session=session,
+                work_queue_id=work_queue.id,
+                scheduled_before=pendulum.now("UTC"),
+            )
+        ) == []
+
+        # since there is one PENDING and one RUNNING flow run, no runs
+        # should be returned, even if a larger limit has been provided
+        assert (
+            await models.work_queues.get_runs_in_work_queue(
+                session=session,
+                work_queue_id=work_queue.id,
+                scheduled_before=pendulum.now("UTC"),
+                limit=9001,
+            )
+        ) == []
+
+        # increase the concurrency limit
+        await models.work_queues.update_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            work_queue=schemas.actions.WorkQueueUpdate(concurrency_limit=3),
+        )
+        # since there is one PENDING and one RUNNING flow run, one
+        # flow run should be returned
+        runs = await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        )
+        assert {run.id for run in runs} == {flow_run_2_id}
+
+    async def test_get_runs_in_work_queue_respects_concurrency_limit_of_0(
+        self,
+        session,
+        work_queue,
+    ):
+        # set concurrency limit to 0
+        await models.work_queues.update_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            work_queue=schemas.actions.WorkQueueUpdate(concurrency_limit=0),
+        )
+
+        await models.work_queues.get_runs_in_work_queue(
+            session=session,
+            work_queue_id=work_queue.id,
+            scheduled_before=pendulum.now("UTC"),
+        ) == []
+
+    async def test_get_runs_in_work_queue_raises_object_not_found_error(self, session):
+        with pytest.raises(ObjectNotFoundError):
+            await models.work_queues.get_runs_in_work_queue(
+                session=session,
+                work_queue_id=uuid4(),
+                scheduled_before=pendulum.now("UTC"),
+            )
+
+
+class TestCheckWorkQueuesForDeployment:
+    async def setup_work_queues_and_deployment(
+        self, session, flow, flow_function, tags=[]
+    ):
+        """
+        Create combinations of work queues, and a deployment to make sure that query is working correctly.
+
+        Returns the ID of the deployment that was created and a random ID that was provided to work queues
+        for testing purposes.
+        """
+        deployment = (
+            await models.deployments.create_deployment(
+                session=session,
+                deployment=schemas.core.Deployment(
+                    name="My Deployment",
+                    manifest_path="file.json",
+                    flow_id=flow.id,
+                    tags=tags,
+                ),
+            ),
+        )
+        match_id = deployment[0].id
+        miss_id = uuid4()
+
+        tags = [  # "a" and "b" are matches and "y" and "z" are misses
+            [],
+            ["a"],
+            ["z"],
+            ["a", "b"],
+            ["a", "z"],
+            ["y", "z"],
+        ]
+
+        deployments = [
+            [],
+            [match_id],
+            [miss_id],
+            [match_id, miss_id],
+        ]
+
+        # Generate all combinations of work queues
+        for t in tags:
+            for d in deployments:
+
+                await models.work_queues.create_work_queue(
+                    session=session,
+                    work_queue=schemas.core.WorkQueue(
+                        name=f"{t}:{d}",
+                        filter=schemas.core.QueueFilter(tags=t, deployment_ids=d),
+                    ),
+                )
+
+        # return the two IDs needed to compare results
+        return match_id, miss_id
+
+    async def assert_queues_found(self, session, deployment_id, desired_queues):
+        queues = await check_work_queues_for_deployment(
+            session=session, deployment_id=deployment_id
+        )
+        actual_queue_attrs = [[q.filter.tags, q.filter.deployment_ids] for q in queues]
+
+        for q in desired_queues:
+            assert q in actual_queue_attrs
+
+    async def test_object_not_found_error_raised(self, session):
+        with pytest.raises(ObjectNotFoundError):
+            await check_work_queues_for_deployment(
+                session=session, deployment_id=uuid4()
+            )
+
+    # NO TAG DEPLOYMENTS with no-tag queues
+    async def test_no_tag_picks_up_no_filter_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function
+        )
+        match_q = [[[], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_no_tag_picks_up_no_tags_no_runners_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function
+        )
+        match_q = [
+            [[], [match_id]],
+            [[], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_no_tag_picks_up_no_tags_no_id_with_runners_match(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function
+        )
+        match_q = [
+            [[], []],
+            [[], []],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_no_tag_picks_up_no_tags_with_id_and_runners_match(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function
+        )
+        match_q = [
+            [[], [match_id]],
+            [[], [match_id, miss_id]],
+            [[], [match_id]],
+            [[], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_no_tag_picks_up_only_number_of_expected_queues(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function
+        )
+
+        actual_queues = await check_work_queues_for_deployment(
+            session=session, deployment_id=match_id
+        )
+
+        assert len(actual_queues) == 3
+
+    # ONE TAG DEPLOYMENTS with no-tag queues
+    async def test_one_tag_picks_up_no_filter_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a"]
+        )
+        match_q = [[[], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_one_tag_picks_up_no_tags_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a"]
+        )
+        match_q = [
+            [[], [match_id]],
+            [[], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    # ONE TAG DEPLOYMENTS with one-tag queues
+    async def test_one_tag_picks_up_one_tag_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a"]
+        )
+        match_q = [[["a"], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_one_tag_picks_up_one_tag_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a"]
+        )
+        match_q = [
+            [["a"], [match_id]],
+            [["a"], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_one_tag_picks_up_only_number_of_expected_queues(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a"]
+        )
+
+        actual_queues = await check_work_queues_for_deployment(
+            session=session, deployment_id=match_id
+        )
+
+        assert len(actual_queues) == 6
+
+    # TWO TAG DEPLOYMENTS with no-tag queues
+    async def test_two_tag_picks_up_no_filter_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [[[], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_two_tag_picks_up_no_tags_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [
+            [[], [match_id]],
+            [[], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    # TWO TAG DEPLOYMENTS with one-tag queues
+    async def test_two_tag_picks_up_one_tag_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [[["a"], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_two_tag_picks_up_one_tag_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [
+            [["a"], [match_id]],
+            [["a"], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    # TWO TAG DEPLOYMENTS with two-tag queues
+    async def test_two_tag_picks_up_two_tag_q(self, session, flow, flow_function):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [[["a", "b"], []]]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_two_tag_picks_up_two_tag_with_id_match_q(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+        match_q = [
+            [["a", "b"], [match_id]],
+            [["a", "b"], [match_id, miss_id]],
+        ]
+        await self.assert_queues_found(session, match_id, match_q)
+
+    async def test_two_tag_picks_up_only_number_of_expected_queues(
+        self, session, flow, flow_function
+    ):
+        match_id, miss_id = await self.setup_work_queues_and_deployment(
+            session=session, flow=flow, flow_function=flow_function, tags=["a", "b"]
+        )
+
+        actual_queues = await check_work_queues_for_deployment(
+            session=session, deployment_id=match_id
+        )
+
+        assert len(actual_queues) == 9


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary

Implements the backend changes described in the [raft design doc](https://www.notion.so/prefect/Improving-Run-Work-Queue-Affinity-5a61f9ef96e6495d8605a43327591311), namely:
- work queues operate strictly by name, not by matching tags. Deployments (and flow runs) are explicitly linked to a single work queue
- as a convenience, work queues are automatically created whenever deployments (or agents) reference them. This means users do not need to interact with work queues explicitly unless they want to use work-queue specific features like pausing and concurrency
- backwards-compatibility is maintained. If `work_queue.filter is not None`, it is considered a "legacy" work queue and uses tag-based matching. Conversely, if `work_queue.filter is None` then it is a "new" work queue and tag matching is not used.
- deployment.yaml uses a default value of `work_queue_name=null`


Note: this work was originally contained in #6317 but I'm trying to split the PR into smaller sections


<!-- Provide a short overview of the change and the value it adds -->

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

See @anna-geller work in #6317

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
