### PR TITLE
Fixed example for prefect deployment inspect

### DIFF
--- a/docs/tutorials/deployments.md
+++ b/docs/tutorials/deployments.md
@@ -265,7 +265,7 @@ Use `prefect deployment inspect` to display details for a specific deployment.
 
 <div class='terminal'>
 ```bash
-$ prefect deployment inspect 'leonardo_dicapriflow/leo-deployment'
+$ prefect deployment inspect leonardo_dicapriflow/leo-deployment
 {
     'id': '3d2f55a2-46df-4857-ab6f-6cc80ce9cf9c',
     'created': '2022-07-27T00:50:09.624876+00:00',


### PR DESCRIPTION

### Summary
The example of running `prefect deployment inspect` contained single quotes around the deployment name.
However, these quotes are encoded as %27 in the GET request to the API, which in returns a 404.

>"GET /deployments/name/%27leonardo_dicapriflow/leo-deployment%27 HTTP/1.1" 404 Not Found

Removing the quotes solves this issue. I'm running prefect on windows, could the behavior differ using another OS?


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- No tests or issue needed
