### PR TITLE
Update for breaking pydantic API change

### DIFF
--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Set, Type, TypeVar
 from uuid import UUID, uuid4
 
 import pendulum
+import pydantic
 from pydantic import BaseModel, Field, SecretBytes, SecretStr
 from pydantic.json import custom_pydantic_encoder
 
@@ -136,7 +137,10 @@ class PrefectBaseModel(BaseModel):
         # which resets fields like `id`
         # https://github.com/samuelcolvin/pydantic/pull/2193
         # TODO: remove once this is the default in pydantic>=2.0
-        copy_on_model_validation = False
+        if pydantic.__version__ >= "1.9.2":
+            copy_on_model_validation = "none"
+        else:
+            copy_on_model_validation = False
 
     @classmethod
     def subclass(


### PR DESCRIPTION
A small patch to ensure that we are compatible with the latest release of Pydantic, which includes a breaking APi change. I'm switching the behavior on the Pydantic version here, in case users aren't ready to update their dependencies but I'm not sure what the right choice is.
