### PR TITLE
Add support for specifying schedules via deployment CLI

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -166,8 +166,9 @@ class Deployment(BaseModel):
         else:
             return editable_fields + ["infrastructure"]
 
-    def to_yaml(self, path: Path) -> None:
-        yaml_dict = self.yaml_dict()
+    @sync_compatible
+    async def to_yaml(self, path: Path) -> None:
+        yaml_dict = self._yaml_dict()
         schema = self.schema()
 
         with open(path, "w") as f:
@@ -353,21 +354,6 @@ class Deployment(BaseModel):
 
         self.path = deployment_path
         return file_count
-
-    @sync_compatible
-    async def to_yaml(self, output: str):
-        """
-        Compiles the current deployment into a YAML file at the location specified by `output`.
-        """
-        with open(output, "w") as f:
-            f.write(self.header)
-            yaml.dump(self._editable_fields_dict(), f, sort_keys=False)
-            do_not_edit_msg = " DO NOT EDIT BELOW THIS LINE "
-            msg_length = len(do_not_edit_msg)
-            f.write(
-                f"###{' ' * msg_length}###\n###{do_not_edit_msg}###\n###{' ' * msg_length}###\n"
-            )
-            yaml.dump(self._immutable_fields_dict(), f, sort_keys=False)
 
     @sync_compatible
     async def apply(self) -> UUID:

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -55,6 +55,12 @@ class IntervalSchedule(PrefectBaseModel):
     will adjust for DST boundaries so that the clock-hour remains constant. This
     means that a daily schedule that always fires at 9am will observe DST and
     continue to fire at 9am in the local time zone.
+
+    Args:
+        interval (datetime.timedelta): an interval to schedule on
+        anchor_date (DateTimeTZ, optional): an anchor date to schedule increments against;
+            if not provided, the current timestamp will be used
+        timezone (str, optional): a valid timezone string
     """
 
     class Config:
@@ -327,6 +333,10 @@ class RRuleSchedule(PrefectBaseModel):
     to the initial timezone provided. A 9am daily schedule with a daylight saving
     time-aware start date will maintain a local 9am time through DST boundaries;
     a 9am daily schedule with a UTC start date will maintain a 9am UTC time.
+
+    Args:
+        rrule (str): a valid RRule string
+        timezone (str, optional): a valid timezone string
     """
 
     class Config:


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
This PR:
- fixes issues with `main` that were caused by a bad merge resolution (sorry everyone!)
- extends the `deployment build` CLI to support 3 schedule types: cron, interval and rrule

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
Tested by specifying three different schedules for a deployment locally, over specifying multiple schedules, and not specifying any schedule at all.  That's how I discovered the issues with `main` :D 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
