### PR TITLE
Add error message if `get_run_logger` receives context of unknown type

### DIFF
--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -73,6 +73,11 @@ def get_run_logger(context: "RunContext" = None, **kwargs: str) -> logging.Logge
             flow_run_context = context
         elif isinstance(context, prefect.context.TaskRunContext):
             task_run_context = context
+        else:
+            raise TypeError(
+                f"Received unexpected type {type(context).__name__!r} for context. "
+                "Expected one of 'None', 'FlowRunContext', or 'TaskRunContext'."
+            )
 
     # Determine if this is a task or flow run logger
     if task_run_context:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -909,6 +909,11 @@ def test_run_logger_fails_outside_context():
         get_run_logger()
 
 
+async def test_run_logger_with_explicit_context_of_invalid_type():
+    with pytest.raises(TypeError, match="Received unexpected type 'str' for context."):
+        get_run_logger("my man!")
+
+
 async def test_run_logger_with_explicit_context(
     orion_client, flow_run, local_filesystem
 ):


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

Throw a type error instead of falling through to a "no context available" error if `get_run_logger` is called with an invalid context type. This should help narrow the cause of errors like the following where we can see the function is called with a value.

```python
Traceback (most recent call last):
  File "/root/venv/lib/python3.8/site-packages/prefect_dask/task_runners.py", line 236, in wait
    return await future.result(timeout=timeout)
  File "/root/venv/lib/python3.8/site-packages/distributed/client.py", line 294, in _result
    raise exc.with_traceback(tb)
  File "/root/venv/lib/python3.8/site-packages/prefect/engine.py", line 959, in begin_task_run
    get_run_logger(flow_run_context).debug(
  File "/root/venv/lib/python3.8/site-packages/prefect/logging/loggers.py", line 91, in get_run_logger
    raise RuntimeError("There is no active flow or task run context.")
RuntimeError: There is no active flow or task run context.
```

From https://github.com/PrefectHQ/prefect/issues/6086#issuecomment-1213240222

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

Added unit test.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
