### PR TITLE
Update work-queue CLI to accept both IDs and names

### DIFF
--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -80,7 +80,7 @@ async def create(
         except ObjectAlreadyExists:
             exit_with_error(f"Work queue with name: {name!r} already exists.")
 
-    tags_message = f"tags - {tags}\n" if tags else ""
+    tags_message = f"tags - {', '.join(sorted(tags))}\n" if tags else ""
 
     output_msg = dedent(
         f"""

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -2,7 +2,7 @@
 Command line interface for working with work queues.
 """
 from textwrap import dedent
-from typing import List
+from typing import List, Union
 from uuid import UUID
 
 import pendulum
@@ -16,23 +16,56 @@ from prefect.cli.root import app
 from prefect.client import get_client
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 
-work_app = PrefectTyper(name="work-queue", help="Commands for work queue CRUD.")
+work_app = PrefectTyper(
+    name="work-queue", help="Commands for working with work queues."
+)
 app.add_typer(work_app, aliases=["work-queues"])
+
+
+async def _get_work_queue_id_from_name_or_id(name_or_id: Union[UUID, str]):
+    """
+    For backwards-compatibility, the main argument of the work queue CLI can be
+    either a name (preferred) or an ID (legacy behavior).
+    """
+
+    if not name_or_id:
+        # hint that we prefer names
+        exit_with_error("Provide a work queue name.")
+
+    # try parsing as ID
+    try:
+        return UUID(name_or_id)
+
+    # parse as string
+    except (AttributeError, ValueError):
+        async with get_client() as client:
+            try:
+                work_queue = await client.read_work_queue_by_name(name=name_or_id)
+                return work_queue.id
+            except ObjectNotFound:
+                exit_with_error(f"No work queue named {name_or_id!r} found.")
 
 
 @work_app.command()
 async def create(
     name: str = typer.Argument(..., help="The unique name to assign this work queue"),
-    tags: List[str] = typer.Option(
-        None, "-t", "--tag", help="One or more optional tags"
-    ),
     limit: int = typer.Option(
         None, "-l", "--limit", help="The concurrency limit to set on the queue."
+    ),
+    tags: List[str] = typer.Option(
+        None, "-t", "--tag", help="DEPRECATED: One or more optional tags"
     ),
 ):
     """
     Create a work queue.
     """
+    if tags:
+        app.console.print(
+            "Supplying `tags` for work queues is deprecated. This work "
+            "queue will use legacy tag-matching behavior.",
+            style="red",
+        )
+
     async with get_client() as client:
         try:
             result = await client.create_work_queue(
@@ -47,111 +80,126 @@ async def create(
         except ObjectAlreadyExists:
             exit_with_error(f"Work queue with name: {name!r} already exists.")
 
+    tags_message = f"tags - {tags}\n" if tags else ""
+
     output_msg = dedent(
         f"""
         Created work queue with properties:
             name - {name!r}
-            uuid - {result.id}
-            tags - {tags or None}
+            id - {result.id}
             concurrency limit - {limit}
+            {tags_message}
+        Start an agent to pick up flow runs from the work queue:
+            prefect agent start -q '{result.name}'
 
-        Start an agent to pick up flows from the created work queue:
-            prefect agent start '{result.id}'
-
-        Inspect the created work queue:
-            prefect work-queue inspect '{result.id}'
+        Inspect the work queue:
+            prefect work-queue inspect '{result.name}'
         """
     )
-    app.console.print(output_msg)
+    exit_with_success(output_msg)
 
 
 @work_app.command()
 async def set_concurrency_limit(
-    id: UUID = typer.Argument(..., help="The id of the work queue"),
+    name: str = typer.Argument(..., help="The name or ID of the work queue"),
     limit: int = typer.Argument(..., help="The concurrency limit to set on the queue."),
 ):
     """
     Set a concurrency limit on a work queue.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
+
     async with get_client() as client:
         try:
             await client.update_work_queue(
-                id=id,
+                id=queue_id,
                 concurrency_limit=limit,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
-    exit_with_success(f"Concurrency limit of {limit} set on work queue {id}")
+    exit_with_success(
+        f"Concurrency limit of {limit} set on work queue {name or queue_id!r}"
+    )
 
 
 @work_app.command()
 async def clear_concurrency_limit(
-    id: UUID = typer.Argument(..., help="The id of the work queue to clear"),
+    name: str = typer.Argument(..., help="The name or ID of the work queue to clear"),
 ):
     """
     Clear any concurrency limits from a work queue.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
     async with get_client() as client:
         try:
             await client.update_work_queue(
-                id=id,
+                id=queue_id,
                 concurrency_limit=None,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
-    exit_with_success(f"Concurrency limits removed on work queue {id}")
+    exit_with_success(f"Concurrency limits removed on work queue {name or queue_id!r}")
 
 
 @work_app.command()
 async def pause(
-    id: UUID = typer.Argument(..., help="The ID of the work queue to pause."),
+    name: str = typer.Argument(..., help="The name or ID of the work queue to pause"),
 ):
     """
     Pause a work queue.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
+
     async with get_client() as client:
         try:
             await client.update_work_queue(
-                id=id,
+                id=queue_id,
                 is_paused=True,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
-    exit_with_success(f"Paused work queue {id}")
+    exit_with_success(f"Paused work queue {name or queue_id!r}")
 
 
 @work_app.command()
 async def resume(
-    id: UUID = typer.Argument(..., help="The ID of the work queue to resume."),
+    name: str = typer.Argument(..., help="The name or ID of the work queue to resume"),
 ):
     """
     Resume a paused work queue.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
+
     async with get_client() as client:
         try:
             await client.update_work_queue(
-                id=id,
+                id=queue_id,
                 is_paused=False,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
-    exit_with_success(f"Resumed work queue {id}")
+    exit_with_success(f"Resumed work queue {name or queue_id!r}")
 
 
 @work_app.command()
-async def inspect(id: UUID):
+async def inspect(
+    name: str = typer.Argument(
+        None, help="The name or ID of the work queue to inspect"
+    ),
+):
     """
     Inspect a work queue by ID.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
     async with get_client() as client:
         try:
-            result = await client.read_work_queue(id=id)
+            result = await client.read_work_queue(id=queue_id)
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
     app.console.print(Pretty(result))
 
@@ -168,11 +216,11 @@ async def ls(
     table = Table(
         title="Work Queues", caption="(**) denotes a paused queue", caption_style="red"
     )
-    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
     table.add_column("Name", style="green", no_wrap=True)
+    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
     table.add_column("Concurrency Limit", style="blue", no_wrap=True)
     if verbose:
-        table.add_column("Filter", style="magenta", no_wrap=True)
+        table.add_column("Filter (Deprecated)", style="magenta", no_wrap=True)
 
     async with get_client() as client:
         queues = await client.read_work_queues()
@@ -182,13 +230,13 @@ async def ls(
     for queue in sorted(queues, key=sort_by_created_key):
 
         row = [
-            str(queue.id),
             f"{queue.name} [red](**)" if queue.is_paused else queue.name,
+            str(queue.id),
             f"[red]{queue.concurrency_limit}"
             if queue.concurrency_limit
             else "[blue]None",
         ]
-        if verbose:
+        if verbose and queue.filter is not None:
             row.append(queue.filter.json())
         table.add_row(*row)
 
@@ -197,7 +245,9 @@ async def ls(
 
 @work_app.command()
 async def preview(
-    id: UUID = typer.Argument(..., help="The id of the work queue"),
+    name: str = typer.Argument(
+        None, help="The name or ID of the work queue to preview"
+    ),
     hours: int = typer.Option(
         None,
         "-h",
@@ -208,6 +258,8 @@ async def preview(
     """
     Preview a work queue.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
+
     table = Table(caption="(**) denotes a late run", caption_style="red")
     table.add_column(
         "Scheduled Start Time", justify="left", style="yellow", no_wrap=True
@@ -220,10 +272,10 @@ async def preview(
     async with get_client() as client:
         try:
             runs = await client.get_runs_in_work_queue(
-                id, limit=10, scheduled_before=window
+                queue_id, limit=10, scheduled_before=window
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
     now = pendulum.now("utc")
     sort_by_created_key = lambda r: now - r.created
@@ -248,14 +300,17 @@ async def preview(
 
 
 @work_app.command()
-async def delete(id: UUID):
+async def delete(
+    name: str = typer.Argument(..., help="The name or ID of the work queue to delete"),
+):
     """
     Delete a work queue by ID.
     """
+    queue_id = await _get_work_queue_id_from_name_or_id(name_or_id=name)
     async with get_client() as client:
         try:
-            await client.delete_work_queue_by_id(id=id)
+            await client.delete_work_queue_by_id(id=queue_id)
         except ObjectNotFound:
-            exit_with_error(f"No work queue found with id {id}")
+            exit_with_error(f"No work queue found: {name or queue_id!r}")
 
-    exit_with_success(f"Deleted work queue {id}")
+    exit_with_success(f"Deleted work queue {name or queue_id!r}")

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -116,11 +116,9 @@ async def set_concurrency_limit(
                 concurrency_limit=limit,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
-    exit_with_success(
-        f"Concurrency limit of {limit} set on work queue {name or queue_id!r}"
-    )
+    exit_with_success(f"Concurrency limit of {limit} set on work queue {name!r}")
 
 
 @work_app.command()
@@ -138,9 +136,9 @@ async def clear_concurrency_limit(
                 concurrency_limit=None,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
-    exit_with_success(f"Concurrency limits removed on work queue {name or queue_id!r}")
+    exit_with_success(f"Concurrency limits removed on work queue {name!r}")
 
 
 @work_app.command()
@@ -159,9 +157,9 @@ async def pause(
                 is_paused=True,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
-    exit_with_success(f"Paused work queue {name or queue_id!r}")
+    exit_with_success(f"Paused work queue {name!r}")
 
 
 @work_app.command()
@@ -180,9 +178,9 @@ async def resume(
                 is_paused=False,
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
-    exit_with_success(f"Resumed work queue {name or queue_id!r}")
+    exit_with_success(f"Resumed work queue {name!r}")
 
 
 @work_app.command()
@@ -199,7 +197,7 @@ async def inspect(
         try:
             result = await client.read_work_queue(id=queue_id)
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
     app.console.print(Pretty(result))
 
@@ -275,7 +273,7 @@ async def preview(
                 queue_id, limit=10, scheduled_before=window
             )
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
     now = pendulum.now("utc")
     sort_by_created_key = lambda r: now - r.created
@@ -311,6 +309,6 @@ async def delete(
         try:
             await client.delete_work_queue_by_id(id=queue_id)
         except ObjectNotFound:
-            exit_with_error(f"No work queue found: {name or queue_id!r}")
+            exit_with_error(f"No work queue found: {name!r}")
 
-    exit_with_success(f"Deleted work queue {name or queue_id!r}")
+    exit_with_success(f"Deleted work queue {name!r}")

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -1,0 +1,158 @@
+import pytest
+
+import prefect.exceptions
+from prefect.testing.cli import invoke_and_assert
+from prefect.utilities.asyncutils import sync_compatible
+
+
+@sync_compatible
+async def read_queue(orion_client, name):
+    return await orion_client.read_work_queue_by_name(name)
+
+
+def test_create_work_queue():
+    invoke_and_assert(
+        command="work-queue create q-name",
+        expected_output_contains=[
+            "Created work queue with properties:",
+            "name - 'q-name'",
+        ],
+        expected_code=0,
+    )
+
+
+def test_create_work_queue_with_limit():
+    invoke_and_assert(
+        command="work-queue create q-name -l 3",
+        expected_output_contains=[
+            "Created work queue with properties:",
+            "concurrency limit - 3",
+        ],
+        expected_code=0,
+    )
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_create_work_queue_with_tags():
+    invoke_and_assert(
+        command="work-queue create q-name -t blue -t red",
+        expected_output_contains=[
+            "Supplying `tags` for work queues is deprecated",
+            "tags - ['blue', 'red']",
+        ],
+        expected_code=0,
+    )
+
+
+def test_set_concurrency_limit(orion_client, work_queue):
+    assert work_queue.concurrency_limit is None
+    invoke_and_assert(
+        command=f"work-queue set-concurrency-limit {work_queue.name} 5",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.concurrency_limit == 5
+
+
+def test_set_concurrency_limit_by_id(orion_client, work_queue):
+    assert work_queue.concurrency_limit is None
+    invoke_and_assert(
+        command=f"work-queue set-concurrency-limit {work_queue.id} 5",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.concurrency_limit == 5
+
+
+def test_clear_concurrency_limit(orion_client, work_queue):
+    invoke_and_assert(command=f"work-queue set-concurrency-limit {work_queue.name} 5")
+    invoke_and_assert(
+        command=f"work-queue clear-concurrency-limit {work_queue.name}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.concurrency_limit is None
+
+
+def test_clear_concurrency_limit_by_id(orion_client, work_queue):
+    invoke_and_assert(command=f"work-queue set-concurrency-limit {work_queue.name} 5")
+    invoke_and_assert(
+        command=f"work-queue clear-concurrency-limit {work_queue.id}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.concurrency_limit is None
+
+
+def test_pause(orion_client, work_queue):
+    assert not work_queue.is_paused
+    invoke_and_assert(
+        command=f"work-queue pause {work_queue.name}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.is_paused
+
+
+def test_pause_by_id(orion_client, work_queue):
+    assert not work_queue.is_paused
+    invoke_and_assert(
+        command=f"work-queue pause {work_queue.id}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert q.is_paused
+
+
+def test_resume(orion_client, work_queue):
+    invoke_and_assert(command=f"work-queue pause {work_queue.name}")
+    invoke_and_assert(
+        command=f"work-queue resume {work_queue.name}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert not q.is_paused
+
+
+def test_resume_by_id(orion_client, work_queue):
+    invoke_and_assert(command=f"work-queue pause {work_queue.name}")
+    invoke_and_assert(
+        command=f"work-queue resume {work_queue.id}",
+        expected_code=0,
+    )
+    q = read_queue(orion_client, work_queue.name)
+    assert not q.is_paused
+
+
+def test_inspect(work_queue):
+    invoke_and_assert(
+        command=f"work-queue inspect {work_queue.name}",
+        expected_output_contains=[f"id='{work_queue.id}'", f"name={work_queue.name!r}"],
+        expected_code=0,
+    )
+
+
+def test_inspect_by_id(work_queue):
+    invoke_and_assert(
+        command=f"work-queue inspect {work_queue.id}",
+        expected_output_contains=[f"id='{work_queue.id}'", f"name={work_queue.name!r}"],
+        expected_code=0,
+    )
+
+
+def test_delete(orion_client, work_queue):
+    invoke_and_assert(
+        command=f"work-queue delete {work_queue.name}",
+        expected_code=0,
+    )
+    with pytest.raises(prefect.exceptions.ObjectNotFound):
+        read_queue(orion_client, work_queue.name)
+
+
+def test_delete_by_id(orion_client, work_queue):
+    invoke_and_assert(
+        command=f"work-queue delete {work_queue.id}",
+        expected_code=0,
+    )
+    with pytest.raises(prefect.exceptions.ObjectNotFound):
+        read_queue(orion_client, work_queue.name)

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -38,7 +38,7 @@ def test_create_work_queue_with_tags():
         command="work-queue create q-name -t blue -t red",
         expected_output_contains=[
             "Supplying `tags` for work queues is deprecated",
-            "tags - ['blue', 'red']",
+            "tags - blue, red",
         ],
         expected_code=0,
     )

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -227,6 +227,19 @@ async def deployment(
 
 
 @pytest.fixture
+async def work_queue(session):
+    work_queue = await models.work_queues.create_work_queue(
+        session=session,
+        work_queue=schemas.core.WorkQueue(
+            name="wq-1",
+            description="All about my work queue",
+        ),
+    )
+    await session.commit()
+    return work_queue
+
+
+@pytest.fixture
 async def block_type_x(session):
     # Ignore warnings caused by block reuse in fixtuer
     warnings.filterwarnings("ignore", category=UserWarning)

--- a/tests/orion/api/test_work_queues.py
+++ b/tests/orion/api/test_work_queues.py
@@ -10,19 +10,6 @@ from prefect.orion import models, schemas
 from prefect.orion.schemas.actions import WorkQueueCreate, WorkQueueUpdate
 
 
-@pytest.fixture
-async def work_queue(session):
-    work_queue = await models.work_queues.create_work_queue(
-        session=session,
-        work_queue=schemas.core.WorkQueue(
-            name="wq-1",
-            description="All about my work queue",
-        ),
-    )
-    await session.commit()
-    return work_queue
-
-
 class TestCreateWorkQueue:
     async def test_create_work_queue(
         self,


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

Recent changes to work queues have advanced work queue names as the primary user-facing identifier, instead of UUIDs. This aligns with work-queues being more lightweight, automatically generated objects. This PR updates the `prefect work-queue` CLI with similar behavior. It now accepts either an ID or a name for operating on work queues, which is a significant UX improvement:

Old:
```console
prefect work-queue set-concurrency-limit 45362125-0a31-4897-b8a4-9319264f2713 5
prefect work-queue inspect 45362125-0a31-4897-b8a4-9319264f2713
```
New:
```console
prefect work-queue set-concurrency-limit my-queue 5
prefect work-queue inspect my-queue
```
Note this change is not breaking (old commands still work). This PR also adds tests for both the name and ID versions of this subcommand 