### PR TITLE
Update agent to prevent crash when infrastructure errors after submission

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -207,9 +207,8 @@ class OrionAgent:
                 await self.task_group.start(infrastructure.run)
                 self.logger.info(f"Completed submission of flow run '{flow_run.id}'")
             except Exception as exc:
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to submit flow run '{flow_run.id}' to infrastructure.",
-                    exc_info=True,
                 )
                 await self._propose_failed_state(flow_run, exc)
 

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -207,8 +207,9 @@ class OrionAgent:
                 await self.task_group.start(infrastructure.run)
                 self.logger.info(f"Completed submission of flow run '{flow_run.id}'")
             except Exception as exc:
-                self.logger.exception(
+                self.logger.error(
                     f"Failed to submit flow run '{flow_run.id}' to infrastructure.",
+                    exc_info=True,
                 )
                 await self._propose_failed_state(flow_run, exc)
 


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

~Builds on the simple change in #6453 — this can supersede that pull request entirely if desired.~

Requires #6610 as it uses the agent test refactor there.

### Summary
<!-- Provide a short overview of the change and the value it adds -->

Running infrastructure is a two step process:
- Submission: infrastructure is created for the flow run
- Monitoring: the infrastructure is watched for success/failure

AnyIO's `TaskStatus` is used to report the completion of submission
allowing a caller to use `task_group.start` to await submission without
blocking on monitoring. If an error occurs during submission, the
agent captures it and marks the flow run as failed. However, if an
error occured during monitoring, the agent does not capture this
exception. Instead, it is raised in the agent's task group which
can cause the agent and any other concurrent tasks to fail.

A single flow run should not be able to crash the agent. To resolve
this, the agent is updated to capture exceptions during the
monitoring phase as well. In contrast to submission, we do not mark
the flow run as failed as this could be unrelated to execution of
the flow itself. The error and traceback are logged.

Prevents an exception in #6446 from crashing the agent. Does not address the cause of that exception.

### Future work

- Consider changing the reported state for flow runs that fail to submit to CRASHED.
- Consider using the exit code of the infrastructure to report CRASHED flow runs that fail to report their own failure.
- Consider separate `start` and `watch` interfaces for the `InfrastructureBlock` which would simplify this handling and allow us to resume watching jobs on agent restart.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
