### PR TITLE
Add helpful defaults and messages when creating deployments

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ Agents and work queues give you control over where and how flow runs are execute
 * Added a Server Message Block (SMB) file system block in https://github.com/PrefectHQ/prefect/pull/6344 - Special thanks to @darrida for this contribution!
 * Removed explicit type validation from some API routes in https://github.com/PrefectHQ/prefect/pull/6448
 * Improved robustness of streaming output from subprocesses in https://github.com/PrefectHQ/prefect/pull/6445
+* Added a default work queue ("default") when creating new deployments from the Python client or CLI in https://github.com/PrefectHQ/prefect/pull/6458
 
 ### New Collections
 - [prefect-monday](https://prefecthq.github.io/prefect-monday/)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -273,6 +273,22 @@ async def apply(
             style="green",
         )
 
+        if deployment.work_queue_name is not None:
+            app.console.print(
+                "\nTo execute flow runs from this deployment, start an agent "
+                f"that pulls work from the the {deployment.work_queue_name!r} work queue:"
+            )
+            app.console.print(
+                f"$ prefect agent start -q {deployment.work_queue_name!r}", style="blue"
+            )
+        else:
+            app.console.print(
+                "\nThis deployment does not specify a work queue name, which means agents "
+                "will not be able to pick up its runs. To add a work queue, "
+                "edit the deployment spec and re-run this command, or visit the deployment in the UI.",
+                style="red",
+            )
+
 
 @deployment_app.command()
 async def delete(

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -105,7 +105,8 @@ class Deployment(BaseModel):
         name: A name for the deployment (required).
         version: An optional version for the deployment; defaults to the flow's version
         description: An optional description of the deployment; defaults to the flow's description
-        tags: An optional list of tags to associate with this deployment; note that tags are used only for organizational purposes. For delegating work to agents, see `work_queue_name`.
+        tags: An optional list of tags to associate with this deployment; note that tags are
+            used only for organizational purposes. For delegating work to agents, see `work_queue_name`.
         schedule: A schedule to run this deployment on, once registered
         work_queue_name: The work queue that will handle this deployment's runs
         flow_name: The name of the flow this deployment encapsulates
@@ -233,7 +234,7 @@ class Deployment(BaseModel):
     schedule: schemas.schedules.SCHEDULE_TYPES = None
     flow_name: str = Field(None, description="The name of the flow.")
     work_queue_name: Optional[str] = Field(
-        None,
+        "default",
         description="The work queue for the deployment.",
         yaml_comment="The work queue that will handle this deployment's runs",
     )

--- a/tests/cli/test_deployment_build.py
+++ b/tests/cli/test_deployment_build.py
@@ -37,6 +37,31 @@ class TestInputValidation:
             expected_code=1,
         )
 
+    def test_work_queue_name_is_populated_as_default(self, patch_import, tmp_path):
+        d = Deployment(
+            name="TEST",
+            flow_name="fn",
+            version="server",
+        )
+        assert d.apply()
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_code=0,
+            temp_dir=tmp_path,
+        )
+
+        deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        assert deployment.work_queue_name == "default"
+
     def test_server_side_settings_are_used_if_present(self, patch_import, tmp_path):
         d = Deployment(
             name="TEST",

--- a/tests/cli/test_deployment_cli.py
+++ b/tests/cli/test_deployment_cli.py
@@ -5,6 +5,11 @@ from prefect.deployments import Deployment
 from prefect.testing.cli import invoke_and_assert
 
 
+@flow
+def my_flow():
+    pass
+
+
 @pytest.fixture
 def dep_path():
     return "./dog.py"
@@ -38,13 +43,6 @@ class TestInputValidation:
         )
 
     def test_work_queue_name_is_populated_as_default(self, patch_import, tmp_path):
-        d = Deployment(
-            name="TEST",
-            flow_name="fn",
-            version="server",
-        )
-        assert d.apply()
-
         invoke_and_assert(
             [
                 "deployment",
@@ -115,3 +113,80 @@ class TestInputValidation:
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
         assert deployment.version == "CLI-version"
+
+
+class TestOutputMessages:
+    def test_message_with_work_queue_name(self, patch_import, tmp_path):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_code=0,
+            temp_dir=tmp_path,
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=[
+                (
+                    "To execute flow runs from this deployment, start an agent "
+                    "that pulls work from the the 'default' work queue:"
+                ),
+                "$ prefect agent start -q 'default'",
+            ],
+        )
+
+    def test_message_with_work_queue_name_from_python_build(
+        self, patch_import, tmp_path
+    ):
+        d = Deployment.build_from_flow(
+            flow=my_flow,
+            name="TEST",
+            flow_name="my_flow",
+            output=str(tmp_path / "test.yaml"),
+            work_queue_name="prod",
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=[
+                (
+                    "To execute flow runs from this deployment, start an agent "
+                    f"that pulls work from the the {d.work_queue_name!r} work queue:"
+                ),
+                f"$ prefect agent start -q {d.work_queue_name!r}",
+            ],
+        )
+
+    def test_message_with_missing_work_queue_name(self, patch_import, tmp_path):
+        d = Deployment.build_from_flow(
+            flow=my_flow,
+            name="TEST",
+            flow_name="my_flow",
+            output=str(tmp_path / "test.yaml"),
+            work_queue_name=None,
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=(
+                "This deployment does not specify a work queue name, which means agents "
+                "will not be able to pick up its runs. To add a work queue, "
+                "edit the deployment spec and re-run this command, or visit the deployment in the UI.",
+            ),
+        )

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -177,4 +177,4 @@ class TestYAML:
         comment_index = contents.index(
             "# The work queue that will handle this deployment's runs\n"
         )
-        assert contents[comment_index + 1] == "work_queue_name: null\n"
+        assert contents[comment_index + 1] == "work_queue_name: default\n"

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -15,6 +15,10 @@ class TestDeploymentBasicInterface:
         d = Deployment(name="foo")
         assert isinstance(d.infrastructure, Process)
 
+    async def test_default_work_queue_name(self):
+        d = Deployment(name="foo")
+        assert d.work_queue_name == "default"
+
 
 class TestDeploymentLoad:
     async def test_deployment_load_hydrates_with_server_settings(


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Adds a default work queue ("default") to client-side Deployments (no server-side changes)
- Adds helpful messages after `apply`-ing a deployment to start a work queue OR that no work queue was provided

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

cc @anna-geller 
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
