### PR TITLE
Add `empirical_policy` to flow run update route

### DIFF
--- a/src/prefect/client.py
+++ b/src/prefect/client.py
@@ -624,15 +624,21 @@ class OrionClient:
         parameters: Optional[dict] = None,
         name: Optional[str] = None,
         tags: Optional[Iterable[str]] = None,
-    ) -> None:
+        empirical_policy: Optional[schemas.core.FlowRunPolicy] = None,
+    ) -> httpx.Response:
         """
         Update a flow run's details.
 
         Args:
-            flow_run_id: the run ID to update
-            flow_version: a new version string for the flow run
-            parameters: a dictionary of updated parameter values for the run
-            name: a new name for the flow run
+            flow_run_id: The identifier for the flow run to update.
+            flow_version: A new version string for the flow run.
+            parameters: A dictionary of parameter values for the flow run. This will not
+                be merged with any existing parameters.
+            name: A new name for the flow run.
+            empirical_policy: A new flow run orchestration policy. This will not be
+                merged with any existing policy.
+            tags: An iterable of new tags for the flow run. These will not be merged with
+                any existing tags.
 
         Returns:
             an `httpx.Response` object from the PATCH request
@@ -646,6 +652,8 @@ class OrionClient:
             params["name"] = name
         if tags is not None:
             params["tags"] = tags
+        if empirical_policy is not None:
+            params["empirical_policy"] = empirical_policy
 
         flow_run_data = schemas.actions.FlowRunUpdate(**params)
 

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -110,7 +110,13 @@ class DeploymentUpdate(
 class FlowRunUpdate(
     schemas.core.FlowRun.subclass(
         name="FlowRunUpdate",
-        include_fields=["flow_version", "parameters", "name", "tags"],
+        include_fields=[
+            "flow_version",
+            "parameters",
+            "name",
+            "tags",
+            "empirical_policy",
+        ],
     )
 ):
     """Data used by the Orion API to update a flow run."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -908,12 +908,20 @@ async def test_update_flow_run(orion_client):
         parameters={"foo": "bar"},
         name="test",
         tags=["hello", "world"],
+        empirical_policy=schemas.core.FlowRunPolicy(
+            max_retries=1,
+            retry_delay_seconds=2,
+        ),
     )
     updated_flow_run = await orion_client.read_flow_run(flow_run.id)
     assert updated_flow_run.flow_version == "foo"
     assert updated_flow_run.parameters == {"foo": "bar"}
     assert updated_flow_run.name == "test"
     assert updated_flow_run.tags == ["hello", "world"]
+    assert updated_flow_run.empirical_policy == schemas.core.FlowRunPolicy(
+        max_retries=1,
+        retry_delay_seconds=2,
+    )
 
 
 async def test_update_flow_run_overrides_tags(orion_client):


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

This will facilitate updating orchestration rules discovered from flow-level annotations for deployment flow runs.

Related to #6485 
See usage in https://github.com/PrefectHQ/prefect/pull/6489

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
