### PR TITLE
Adds versions to block schemas

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -1,6 +1,7 @@
 import hashlib
 import inspect
 import logging
+import sys
 import warnings
 from abc import ABC
 from textwrap import dedent
@@ -15,7 +16,12 @@ from slugify import slugify
 from typing_extensions import Self, get_args, get_origin
 
 import prefect
-from prefect.orion.schemas.core import BlockDocument, BlockSchema, BlockType
+from prefect.orion.schemas.core import (
+    DEFAULT_BLOCK_SCHEMA_VERSION,
+    BlockDocument,
+    BlockSchema,
+    BlockType,
+)
 from prefect.utilities.asyncutils import asyncnullcontext, sync_compatible
 from prefect.utilities.collections import remove_nested_keys
 from prefect.utilities.dispatch import lookup_type, register_base_type
@@ -175,6 +181,7 @@ class Block(BaseModel, ABC):
     _block_type_id: Optional[UUID] = None
     _block_schema_id: Optional[UUID] = None
     _block_schema_capabilities: Optional[List[str]] = None
+    _block_schema_version: Optional[str] = None
     _block_document_id: Optional[UUID] = None
     _block_document_name: Optional[str] = None
     _is_anonymous: Optional[bool] = None
@@ -206,6 +213,24 @@ class Block(BaseModel, ABC):
                 for c in getattr(base, "_block_schema_capabilities", []) or []
             }
         )
+
+    @classmethod
+    def _get_current_package_version(cls):
+        current_module = inspect.getmodule(cls)
+        if current_module:
+            top_level_module = sys.modules[
+                current_module.__name__.split(".")[0] or "__main__"
+            ]
+            try:
+                return str(top_level_module.__version__)
+            except AttributeError:
+                # Module does not have a __version__ attribute
+                pass
+        return DEFAULT_BLOCK_SCHEMA_VERSION
+
+    @classmethod
+    def get_block_schema_version(cls) -> str:
+        return cls._block_schema_version or cls._get_current_package_version()
 
     @classmethod
     def _to_block_schema_reference_dict(cls):
@@ -340,6 +365,7 @@ class Block(BaseModel, ABC):
             block_type_id=block_type_id or cls._block_type_id,
             block_type=cls._to_block_type(),
             capabilities=list(cls.get_block_capabilities()),
+            version=cls.get_block_schema_version(),
         )
 
     @classmethod

--- a/src/prefect/orion/api/block_schemas.py
+++ b/src/prefect/orion/api/block_schemas.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from fastapi import Body, Depends, HTTPException, Path, Query, Response, status
 from fastapi.responses import Response
 
 from prefect.blocks.core import Block
@@ -127,10 +127,14 @@ async def read_block_schema_by_checksum(
     block_schema_checksum: str = Path(
         ..., description="The block schema checksum", alias="checksum"
     ),
+    version: Optional[str] = Query(
+        None,
+        description="Version of block schema. If not provided the most recently created block schema with the matching checksum will be returned.",
+    ),
     session: sa.orm.Session = Depends(dependencies.get_session),
 ) -> schemas.core.BlockSchema:
     block_schema = await models.block_schemas.read_block_schema_by_checksum(
-        session=session, checksum=block_schema_checksum
+        session=session, checksum=block_schema_checksum, version=version
     )
     if not block_schema:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Block schema not found")

--- a/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add version to block schema
+SQLite: `e757138e954a`
+Postgres: `2d5e000696f1`
+
 # Add work queue name to runs
 SQLite: `575634b7acd4`
 Postgres: `77eb737fc759`

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_08_18_102804_2d5e000696f1_adds_block_schema_version.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_08_18_102804_2d5e000696f1_adds_block_schema_version.py
@@ -1,0 +1,43 @@
+"""Adds block schema version
+
+Revision ID: 2d5e000696f1
+Revises: 77eb737fc759
+Create Date: 2022-08-18 10:28:04.449256
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2d5e000696f1"
+down_revision = "77eb737fc759"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "block_schema",
+        sa.Column(
+            "version", sa.String(), server_default="non-versioned", nullable=False
+        ),
+    )
+    op.drop_index("ix_block_schema__capabilities", table_name="block_schema")
+    op.drop_index("uq_block_schema__checksum", table_name="block_schema")
+    op.create_index(
+        "uq_block_schema__checksum_version",
+        "block_schema",
+        ["checksum", "version"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("uq_block_schema__checksum_version", table_name="block_schema")
+    op.create_index(
+        "uq_block_schema__checksum", "block_schema", ["checksum"], unique=False
+    )
+    op.create_index(
+        "ix_block_schema__capabilities", "block_schema", ["capabilities"], unique=False
+    )
+    op.drop_column("block_schema", "version")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_08_18_102527_e757138e954a_adds_block_schema_version.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_08_18_102527_e757138e954a_adds_block_schema_version.py
@@ -1,0 +1,39 @@
+"""Adds block schema version
+
+Revision ID: e757138e954a
+Revises: 575634b7acd4
+Create Date: 2022-08-18 10:25:27.189680
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e757138e954a"
+down_revision = "575634b7acd4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("block_schema", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "version", sa.String(), server_default="non-versioned", nullable=False
+            )
+        )
+        batch_op.drop_index("uq_block_schema__checksum")
+        batch_op.create_index(
+            "uq_block_schema__checksum_version", ["checksum", "version"], unique=True
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")
+
+
+def downgrade():
+    with op.batch_alter_table("block_schema", schema=None) as batch_op:
+        batch_op.drop_index("uq_block_schema__checksum_version")
+        batch_op.create_index("uq_block_schema__checksum", ["checksum"], unique=False)
+        batch_op.drop_column("version")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -1270,7 +1270,7 @@ class BaseORMConfiguration(ABC):
     @property
     def block_schema_unique_upsert_columns(self):
         """Unique columns for upserting a BlockSchema"""
-        return [self.BlockSchema.checksum]
+        return [self.BlockSchema.checksum, self.BlockSchema.version]
 
     @property
     def flow_unique_upsert_columns(self):

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -770,6 +770,11 @@ class ORMBlockSchema:
     checksum = sa.Column(sa.String, nullable=False)
     fields = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     capabilities = sa.Column(JSON, server_default="[]", default=list, nullable=False)
+    version = sa.Column(
+        sa.String,
+        server_default=schemas.core.DEFAULT_BLOCK_SCHEMA_VERSION,
+        nullable=False,
+    )
 
     @declared_attr
     def block_type_id(cls):
@@ -788,8 +793,9 @@ class ORMBlockSchema:
     def __table_args__(cls):
         return (
             sa.Index(
-                "uq_block_schema__checksum",
+                "uq_block_schema__checksum_version",
                 "checksum",
+                "version",
                 unique=True,
             ),
             sa.Index("ix_block_schema__created", "created"),

--- a/src/prefect/orion/models/block_schemas.py
+++ b/src/prefect/orion/models/block_schemas.py
@@ -63,7 +63,7 @@ async def create_block_schema(
 
     # Check for existing block schema based on calculated checksum
     existing_block_schema = await read_block_schema_by_checksum(
-        session=session, checksum=checksum
+        session=session, checksum=checksum, version=block_schema.version
     )
     # Return existing block schema if it exists. Allows block schema creation to be called multiple
     # times for the same schema without errors.

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -273,7 +273,7 @@ class BlockTypeUpdate(PrefectBaseModel):
 class BlockSchemaCreate(
     schemas.core.BlockSchema.subclass(
         name="BlockSchemaCreate",
-        include_fields=["fields", "capabilities", "block_type_id"],
+        include_fields=["fields", "capabilities", "block_type_id", "version"],
     )
 ):
     """Data used by the Orion API to create a block schema."""

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -30,6 +30,8 @@ FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS = [
     "flow_run_state_message",
 ]
 
+DEFAULT_BLOCK_SCHEMA_VERSION = "non-versioned"
+
 
 def raise_on_invalid_name(name: str) -> None:
     """
@@ -443,24 +445,10 @@ class BlockSchema(ORMBaseModel):
         default_factory=list,
         description="A list of Block capabilities",
     )
-
-
-class BlockSchemaReference(ORMBaseModel):
-    """An ORM representation of a block schema reference."""
-
-    parent_block_schema_id: UUID = Field(
-        ..., description="ID of block schema the reference is nested within"
+    version: str = Field(
+        DEFAULT_BLOCK_SCHEMA_VERSION,
+        description="Human readable identifier for the block schema",
     )
-    parent_block_schema: Optional[BlockSchema] = Field(
-        None, description="The block schema the reference is nested within"
-    )
-    reference_block_schema_id: UUID = Field(
-        ..., description="ID of the nested block schema"
-    )
-    reference_block_schema: Optional[BlockSchema] = Field(
-        None, description="The nested block schema"
-    )
-    name: str = Field(..., description="The name that the reference is nested under")
 
 
 class BlockSchemaReference(ORMBaseModel):

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -1011,6 +1011,24 @@ class BlockSchemaFilterCapabilities(PrefectFilterBaseModel):
         return filters
 
 
+class BlockSchemaFilterVersion(PrefectFilterBaseModel):
+    """Filter by `BlockSchema.capabilities`"""
+
+    any_: List[str] = Field(
+        None,
+        example=["2.0.0", "2.1.0"],
+        description="A list of block schema versions.",
+    )
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        pass
+
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.BlockSchema.version.in_(self.any_))
+        return filters
+
+
 class BlockSchemaFilter(PrefectOperatorFilterBaseModel):
     """Filter BlockSchemas"""
 
@@ -1023,6 +1041,9 @@ class BlockSchemaFilter(PrefectOperatorFilterBaseModel):
     id: Optional[BlockSchemaFilterId] = Field(
         None, description="Filter criteria for `BlockSchema.id`"
     )
+    version: Optional[BlockSchemaFilterVersion] = Field(
+        None, description="Filter criteria for `BlockSchema.version`"
+    )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
@@ -1033,6 +1054,8 @@ class BlockSchemaFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.block_capabilities.as_sql_filter(db))
         if self.id is not None:
             filters.append(self.id.as_sql_filter(db))
+        if self.version is not None:
+            filters.append(self.version.as_sql_filter(db))
 
         return filters
 

--- a/tests/orion/api/test_block_schemas.py
+++ b/tests/orion/api/test_block_schemas.py
@@ -386,3 +386,15 @@ class TestReadBlockSchema:
         )
 
         assert block_schema_response.id == block_schema_1.id
+
+        # Read without version. Should return most recently created block schema.
+        response = await client.get(
+            f"/block_schemas/checksum/{block_schema_0.checksum}"
+        )
+        assert response.status_code == 200
+
+        block_schema_response = pydantic.parse_obj_as(
+            schemas.core.BlockSchema, response.json()
+        )
+
+        assert block_schema_response.id == block_schema_1.id

--- a/tests/orion/api/test_block_schemas.py
+++ b/tests/orion/api/test_block_schemas.py
@@ -7,6 +7,7 @@ import pytest
 from prefect.blocks.core import Block
 from prefect.orion import models, schemas
 from prefect.orion.schemas.actions import BlockSchemaCreate
+from prefect.orion.schemas.core import DEFAULT_BLOCK_SCHEMA_VERSION
 
 EMPTY_OBJECT_CHECKSUM = Block._calculate_schema_checksum({})
 
@@ -118,6 +119,7 @@ class TestCreateBlockSchema:
         )
         assert response.status_code == 201
         assert response.json()["checksum"] == EMPTY_OBJECT_CHECKSUM
+        assert response.json()["version"] == DEFAULT_BLOCK_SCHEMA_VERSION
         block_schema_id = response.json()["id"]
 
         block_schema = await models.block_schemas.read_block_schema(
@@ -125,9 +127,7 @@ class TestCreateBlockSchema:
         )
         assert str(block_schema.id) == block_schema_id
 
-    async def test_create_block_schema_is_idempotent(
-        self, session, client, block_type_x
-    ):
+    async def test_create_block_schema_is_idempotent(self, client, block_type_x):
         response_1 = await client.post(
             "/block_schemas/",
             json=BlockSchemaCreate(fields={}, block_type_id=block_type_x.id).dict(
@@ -159,6 +159,26 @@ class TestCreateBlockSchema:
             response.json()["detail"]
             == "Block schemas for protected block types cannot be created."
         )
+
+    async def test_create_block_schema_with_version(
+        self, session, client, block_type_x
+    ):
+        response = await client.post(
+            "/block_schemas/",
+            json=BlockSchemaCreate(
+                fields={}, block_type_id=block_type_x.id, version="1.0.0"
+            ).dict(json_compatible=True),
+        )
+        assert response.status_code == 201
+        assert response.json()["checksum"] == EMPTY_OBJECT_CHECKSUM
+        assert response.json()["version"] == "1.0.0"
+        block_schema_id = response.json()["id"]
+
+        block_schema = await models.block_schemas.read_block_schema(
+            session=session, block_schema_id=block_schema_id
+        )
+        assert str(block_schema.id) == block_schema_id
+        assert block_schema.version == "1.0.0"
 
 
 class TestDeleteBlockSchema:
@@ -321,3 +341,48 @@ class TestReadBlockSchema:
         )
         assert len(block_schemas) == 1
         assert block_schemas[0].id == block_schemas_with_capabilities[0].id
+
+    async def test_read_block_schema_by_checksum_with_version(
+        self, session, client, block_type_x
+    ):
+        # Create two block schemas with the same checksum, but different versions
+        block_schema_0 = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=schemas.actions.BlockSchemaCreate(
+                fields={}, block_type_id=block_type_x.id, version="1.0.1"
+            ),
+        )
+        await session.commit()
+        block_schema_1 = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=schemas.actions.BlockSchemaCreate(
+                fields={}, block_type_id=block_type_x.id, version="1.1.0"
+            ),
+        )
+        await session.commit()
+
+        assert block_schema_0.checksum == block_schema_1.checksum
+
+        # Read first version with version query parameter
+        response = await client.get(
+            f"/block_schemas/checksum/{block_schema_0.checksum}?version=1.0.1"
+        )
+        assert response.status_code == 200
+
+        block_schema_response = pydantic.parse_obj_as(
+            schemas.core.BlockSchema, response.json()
+        )
+
+        assert block_schema_response.id == block_schema_0.id
+
+        # Read second version with version query parameter
+        response = await client.get(
+            f"/block_schemas/checksum/{block_schema_1.checksum}?version=1.1.0"
+        )
+        assert response.status_code == 200
+
+        block_schema_response = pydantic.parse_obj_as(
+            schemas.core.BlockSchema, response.json()
+        )
+
+        assert block_schema_response.id == block_schema_1.id

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -624,6 +624,47 @@ class TestReadBlockSchemas:
         assert db_block_schema.fields == block_schema.fields
         assert db_block_schema.block_type_id == block_schema.block_type_id
 
+    async def test_read_block_schema_by_checksum_with_version(
+        self, session, client, block_type_x
+    ):
+        # Create two block schemas with the same checksum, but different versions
+        block_schema_0 = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=schemas.actions.BlockSchemaCreate(
+                fields={}, block_type_id=block_type_x.id, version="1.0.1"
+            ),
+        )
+
+        block_schema_1 = await models.block_schemas.create_block_schema(
+            session=session,
+            block_schema=schemas.actions.BlockSchemaCreate(
+                fields={}, block_type_id=block_type_x.id, version="1.1.0"
+            ),
+        )
+
+        assert block_schema_0.checksum == block_schema_1.checksum
+
+        # Read first version with version query parameter
+        read_block_schema = await models.block_schemas.read_block_schema_by_checksum(
+            session=session, checksum=block_schema_0.checksum, version="1.0.1"
+        )
+
+        assert read_block_schema.id == block_schema_0.id
+
+        # Read second version with version
+        read_block_schema = await models.block_schemas.read_block_schema_by_checksum(
+            session=session, checksum=block_schema_1.checksum, version="1.1.0"
+        )
+
+        assert read_block_schema.id == block_schema_1.id
+
+        # Read without version. Should return most recently created block schema.
+        read_block_schema = await models.block_schemas.read_block_schema_by_checksum(
+            session=session, checksum=block_schema_0.checksum
+        )
+
+        assert read_block_schema.id == block_schema_1.id
+
     async def test_read_block_schema_does_not_hardcode_references(
         self, session, db, block_type_x
     ):
@@ -684,6 +725,8 @@ class TestReadBlockSchemas:
             c: int
 
         class X(Block):
+            _block_schema_version = "1.1.0"
+
             y: Y
             z: Z
 
@@ -779,6 +822,31 @@ class TestReadBlockSchemas:
         assert len(db_block_schemas) == 2
         assert db_block_schemas[0].block_type_id == block_type_y.id
         assert db_block_schemas[1].block_type_id == block_type_x.id
+
+    async def test_read_all_block_schemas_with_block_type_and_version_filters(
+        self, session, nested_schemas
+    ):
+        A, X, Y, Z, block_type_x, block_type_y = nested_schemas
+
+        db_block_schemas = await models.block_schemas.read_block_schemas(
+            session=session,
+            block_schema_filter=schemas.filters.BlockSchemaFilter(
+                block_type_id=dict(any_=[block_type_x.id]),
+                version=dict(any_=[X._block_schema_version]),
+            ),
+        )
+
+        assert len(db_block_schemas) == 1
+        assert db_block_schemas[0].block_type_id == block_type_x.id
+
+        db_block_schemas = await models.block_schemas.read_block_schemas(
+            session=session,
+            block_schema_filter=schemas.filters.BlockSchemaFilter(
+                block_type_id=dict(any_=[block_type_x.id]), version=dict(any_=["1.1.1"])
+            ),
+        )
+
+        assert len(db_block_schemas) == 0
 
     async def test_read_block_schemas_with_capabilities_filter(
         self, session, block_schemas_with_capabilities


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Adds a `version` attribute to the block schema model. `BlockSchema.version` is a human readable string that is meant to help users differentiate between different block schemas that are associated with a given block type. This PR introduces `BlockSchema.version` in the API and backend, but additional work needs to be done to expose version strings to the user in the UI.

By default, the client will attempt to pull the version of the package that the block resides in to populate the block schema version. If the package version can not be determined, and no override has been provided, then the block schema will be given a version of `"non-versioned"`. Block schemas with a version of `"non-versioned"` operate the same as block schemas prior to versions being introduced. The block schema version can also be declared on the block definition with the `_block_schema_version` class variable.

As part of these changes, the unique constraint on the `block_schema` table is the combination of the `checksum` and `version` columns. As a result, multiple checksums can exist for a given version and multiple versions can exist for a given checksum. This allows us to be more resilient to differences in client/server versions, makes upgrade to blocks less disruptive, gives users more control during the creation of block documents, and allows for migration of block documents between block schemas in the future. 

Block schemas can now be filtered by version sting with the `block_schemas/filter` endpoint and the `block_schemas/checksum/{checksum}` endpoint gains an additional, optional query param `version` that can be used to specify a version for a block schema when multiple block schemas with the same checksum exist. If the `version` query param is not provided, the most recently created block schema with that checksum is returned. The query param is mainly used in the automatic registration step when saving a block document from the Python client.

#### Future Work
Two additional endpoints are necessary to expose versions via the UI:
- `block_schemas/version/{version}` for reading a block schema for a given version
- `block_types/versions` for reading all available block schema version for a block type

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
To verify old clients work with new endpoints:
- Clone this branch and install in editable mode in a venv 1
- In venv 1, run `prefect orion start`
- In venv 2, run `prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api`
- Run this script in venv 2:
```python
from prefect.blocks.system import JSON

json_block = JSON(value={"answer": 42})
json_block.save("life-the-universe-everything", overwrite=True)

loaded_block = JSON.load("life-the-universe-everything")
assert loaded_block.value == {"answer": 42}
print(loaded_block.value)
```
- The script should print `{"answer": 42}`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
