### PR TITLE
initial pass at teams block

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ packaging >= 21.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2
 pydantic >= 1.8.2, != 1.9.1
+pymsteams==0.2.1
 python-slugify >= 5.0
 pytz >= 2021.1
 pyyaml >= 5.4.1

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import cloudpickle
 
 from prefect import flow
-from prefect.blocks.notifications import SlackWebhook
+from prefect.blocks.notifications import MSTeamsWebhook, SlackWebhook
 from prefect.testing.utilities import AsyncMock
 
 
@@ -52,3 +52,53 @@ class TestSlackWebhook:
         pickled = cloudpickle.dumps(block)
         unpickled = cloudpickle.loads(pickled)
         assert isinstance(unpickled, SlackWebhook)
+
+
+class TestMSTeamsWebhook:
+    async def test_notify_async(self, monkeypatch):
+        async_webhook_client_mock = AsyncMock()
+        async_webhook_client_constructor_mock = MagicMock(
+            return_value=async_webhook_client_mock
+        )
+        monkeypatch.setattr(
+            "pymsteams.async_connectorcard",
+            async_webhook_client_constructor_mock,
+        )
+
+        url = "http://example.com/teams"
+        block = MSTeamsWebhook(url=url)
+        await block.notify("test")
+
+        async_webhook_client_constructor_mock.assert_called_once_with(
+            block.url.get_secret_value()
+        )
+        async_webhook_client_mock.text.assert_called_once_with("test")
+        async_webhook_client_mock.send.assert_called_once_with()
+
+    def test_notify_sync(self, monkeypatch):
+        async_webhook_client_mock = AsyncMock()
+        async_webhook_client_constructor_mock = MagicMock(
+            return_value=async_webhook_client_mock
+        )
+        monkeypatch.setattr(
+            "pymsteams.async_connectorcard",
+            async_webhook_client_constructor_mock,
+        )
+
+        @flow
+        def test_flow():
+            url = "http://example.com/teams"
+            block = MSTeamsWebhook(url=url)
+            block.notify("test")
+
+        test_flow()
+        url = "http://example.com/teams"
+        async_webhook_client_constructor_mock.assert_called_once_with(url)
+        async_webhook_client_mock.text.assert_called_once_with("test")
+        async_webhook_client_mock.send.assert_called_once_with()
+
+    def test_is_picklable(self):
+        block = MSTeamsWebhook(url="http://example.com/teams")
+        pickled = cloudpickle.dumps(block)
+        unpickled = cloudpickle.loads(pickled)
+        assert isinstance(unpickled, MSTeamsWebhook)


### PR DESCRIPTION
### Summary

Keeping this as a draft for now for a few reasons:
- We might want to factor out the webhook based blocks into either a webhook block class, or split slack and teams out into their own collections.
- I'm hitting an error related to a line in my notify method being non async in the pymsteams library. Will debug further soon.

### Steps Taken to QA Changes
Tested with @rpeden's teams account.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [ ] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
