### PR TITLE
Relative paths

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -334,7 +334,7 @@ class Infra(str, Enum):
 
 @deployment_app.command()
 async def build(
-    path: str = typer.Argument(
+    entrypoint: str = typer.Argument(
         ...,
         help="The path to a flow entrypoint, in the form of `./path/to/file.py:flow_func_name`",
     ),
@@ -398,6 +398,11 @@ async def build(
         "--rrule",
         help="An RRule that will be used to set an RRuleSchedule on the deployment.",
     ),
+    path: str = typer.Option(
+        None,
+        "--path",
+        help="An optional path to specify a subdirectory of remote storage to upload to.",
+    ),
     output: str = typer.Option(
         None,
         "--output",
@@ -433,15 +438,15 @@ async def build(
 
     # validate flow
     try:
-        fpath, obj_name = path.rsplit(":", 1)
+        fpath, obj_name = entrypoint.rsplit(":", 1)
     except ValueError as exc:
         if str(exc) == "not enough values to unpack (expected 2, got 1)":
-            missing_flow_name_msg = f"Your flow path must include the name of the function that is the entrypoint to your flow.\nTry {path}:<flow_name> for your flow path."
+            missing_flow_name_msg = f"Your flow entrypoint must include the name of the function that is the entrypoint to your flow.\nTry {entrypoint}:<flow_name>"
             exit_with_error(missing_flow_name_msg)
         else:
             raise exc
     try:
-        flow = prefect.utilities.importtools.import_object(path)
+        flow = prefect.utilities.importtools.import_object(entrypoint)
         if isinstance(flow, Flow):
             app.console.print(f"Found flow {flow.name!r}", style="green")
         else:
@@ -480,6 +485,17 @@ async def build(
     elif rrule:
         schedule = RRuleSchedule(rrule=rrule)
 
+    # parse storage_block
+    if storage_block:
+        block_type, block_name, *block_path = storage_block.split("/")
+        if block_path and path:
+            exit_with_error(
+                "Must provide a `path` explicitly or provide one on the storage block specification, but not both."
+            )
+        elif not path:
+            path = "/".join(block_path)
+        storage_block = f"{block_type}/{block_name}"
+
     # set up deployment object
     deployment = Deployment(name=name, flow_name=flow.name)
     await deployment.load()  # load server-side settings, if any
@@ -489,6 +505,7 @@ async def build(
         f"{Path(fpath).absolute().relative_to(Path('.').absolute())}:{obj_name}"
     )
     updates = dict(
+        path=path,
         parameter_openapi_schema=flow_parameter_schema,
         entrypoint=entrypoint,
         description=deployment.description or flow.description,
@@ -510,8 +527,15 @@ async def build(
 
     file_count = await deployment.upload_to_storage(storage_block)
     if file_count:
+        location = (
+            deployment.storage.basepath + "/"
+            if not deployment.storage.basepath.endswith("/")
+            else ""
+        )
+        if path:
+            location += path
         app.console.print(
-            f"Successfully uploaded {file_count} files to {deployment.storage.basepath}",
+            f"Successfully uploaded {file_count} files to {location}",
             style="green",
         )
     deployment_loc = output_file or f"{obj_name}-deployment.yaml"

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -378,13 +378,17 @@ class Deployment(BaseModel):
             )
 
             # upload current directory to storage location
-            file_count = await self.storage.put_directory(ignore_file=ignore_file)
+            file_count = await self.storage.put_directory(
+                ignore_file=ignore_file, to_path=self.path
+            )
         elif not self.storage:
             # default storage, no need to move anything around
             self.storage = None
             deployment_path = str(Path(".").absolute())
         else:
-            file_count = await self.storage.put_directory(ignore_file=".prefectignore")
+            file_count = await self.storage.put_directory(
+                ignore_file=ignore_file, to_path=self.path
+            )
 
         # persists storage now in case it contains secret values
         if self.storage and not self.storage._block_document_id:

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -51,17 +51,13 @@ async def load_flow_from_flow_run(
             storage_block = LocalFileSystem(basepath=basepath)
 
         sys.path.insert(0, ".")
-        # TODO: append deployment.path
-        await storage_block.get_directory(from_path=None, local_path=".")
+        await storage_block.get_directory(from_path=deployment.path, local_path=".")
 
     flow_run_logger(flow_run).debug(
         f"Loading flow for deployment {deployment.name!r}..."
     )
 
-    if deployment.path:
-        import_path = Path(deployment.path) / deployment.entrypoint
-    else:
-        import_path = deployment.entrypoint
+    import_path = deployment.entrypoint
 
     # for backwards compat
     if deployment.manifest_path:
@@ -384,7 +380,7 @@ class Deployment(BaseModel):
         elif not self.storage:
             # default storage, no need to move anything around
             self.storage = None
-            deployment_path = str(Path(".").absolute())
+            self.path = str(Path(".").absolute())
         else:
             file_count = await self.storage.put_directory(
                 ignore_file=ignore_file, to_path=self.path
@@ -394,7 +390,6 @@ class Deployment(BaseModel):
         if self.storage and not self.storage._block_document_id:
             await self.storage._save(is_anonymous=True)
 
-        self.path = deployment_path
         return file_count
 
     @sync_compatible

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -253,6 +253,8 @@ class RemoteFileSystem(ReadableFileSystem, WritableFileSystem):
         """
         if from_path is None:
             from_path = str(self.basepath)
+        else:
+            from_path = self._resolve_path(from_path)
 
         if local_path is None:
             local_path = Path(".").absolute()

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -273,6 +273,8 @@ class RemoteFileSystem(ReadableFileSystem, WritableFileSystem):
         """
         if to_path is None:
             to_path = str(self.basepath)
+        else:
+            to_path = self._resolve_path(to_path)
 
         if local_path is None:
             local_path = "."

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -73,9 +73,9 @@ class LocalFileSystem(ReadableFileSystem, WritableFileSystem):
             path = basepath / path
         else:
             path = path.resolve()
-            if not basepath in path.parents:
+            if not basepath in path.parents and (basepath != path):
                 raise ValueError(
-                    f"Attempted to write to path {path} outside of the base path {basepath}."
+                    f"Provided path {path} is outside of the base path {basepath}."
                 )
 
         return path

--- a/tests/cli/test_deployment_cli.py
+++ b/tests/cli/test_deployment_cli.py
@@ -29,8 +29,8 @@ class TestInputValidation:
         invoke_and_assert(
             ["deployment", "build", dep_path, "-n", "dog-deployment"],
             expected_output_contains=[
-                "Your flow path must include the name of the function that is the entrypoint to your flow.",
-                f"Try {dep_path}:<flow_name> for your flow path.",
+                "Your flow entrypoint must include the name of the function that is the entrypoint to your flow.",
+                f"Try {dep_path}:<flow_name>",
             ],
             expected_code=1,
         )

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -28,6 +28,13 @@ class TestLocalFileSystem:
         with pytest.raises(ValueError, match="not a file"):
             await fs.read_path(tmp_path / "folder")
 
+    async def test_resolve_path(self, tmp_path):
+        fs = LocalFileSystem(basepath=str(tmp_path))
+
+        assert fs._resolve_path(tmp_path) == tmp_path
+        assert fs._resolve_path(tmp_path / "subdirectory") == tmp_path / "subdirectory"
+        assert fs._resolve_path("subdirectory") == tmp_path / "subdirectory"
+
 
 class TestRemoteFileSystem:
     def test_must_contain_scheme(self):
@@ -72,3 +79,11 @@ class TestRemoteFileSystem:
         fs = RemoteFileSystem(basepath="memory://root")
         with pytest.raises(FileNotFoundError):
             await fs.read_path("foo/bar")
+
+    async def test_resolve_path(self):
+        base = "memory://root"
+        fs = RemoteFileSystem(basepath=base)
+
+        assert fs._resolve_path(base) == base + "/"
+        assert fs._resolve_path(f"{base}/subdir") == f"{base}/subdir"
+        assert fs._resolve_path("subdirectory") == f"{base}/subdirectory"


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
This PR exposes the ability for users to specify relative subpaths when working with remote storage for deployments; in particular users can now do one of the following mutually exclusive things:
- provide a `--path` that specifies a relative path within remote storage to upload to / retrieve from
- specify such path with syntactic sugar of the form `--storage-block s3/dev/subdirectory/path` 

Closes https://github.com/PrefectHQ/prefect/issues/6320

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
Tested locally, still need to do more extensive QA before we can merge.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
