### PR TITLE
Add "cloud" to `prefect version` server type display

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -80,7 +80,11 @@ async def version():
 
     from prefect.orion.api.server import ORION_API_VERSION
     from prefect.orion.utilities.database import get_dialect
-    from prefect.settings import PREFECT_ORION_DATABASE_CONNECTION_URL
+    from prefect.settings import (
+        PREFECT_API_URL,
+        PREFECT_CLOUD_URL,
+        PREFECT_ORION_DATABASE_CONNECTION_URL,
+    )
 
     version_info = {
         "Version": prefect.__version__,
@@ -101,7 +105,15 @@ async def version():
     except Exception as exc:
         version_info["Server type"] = "<client error>"
     else:
-        version_info["Server type"] = "ephemeral" if is_ephemeral else "hosted"
+        version_info["Server type"] = (
+            "ephemeral"
+            if is_ephemeral
+            else (
+                "cloud"
+                if PREFECT_API_URL.value().startswith(PREFECT_CLOUD_URL.value())
+                else "hosted"
+            )
+        )
 
     # TODO: Consider adding an API route to retrieve this information?
     if is_ephemeral:

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -5,12 +5,6 @@ import pytest
 from prefect.settings import PREFECT_API_URL, PREFECT_CLOUD_URL, temporary_settings
 from prefect.testing.cli import invoke_and_assert
 
-# @pytest.fixture(autouse=True)
-# def temporary_profiles_path(tmp_path):
-#     path = tmp_path / "profiles.toml"
-#     with temporary_settings({PREFECT_PROFILES_PATH: path}):
-#         yield path
-
 
 def test_version_ephemeral_server_type():
     invoke_and_assert(

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from prefect.settings import PREFECT_API_URL, PREFECT_CLOUD_URL, temporary_settings
+from prefect.testing.cli import invoke_and_assert
+
+# @pytest.fixture(autouse=True)
+# def temporary_profiles_path(tmp_path):
+#     path = tmp_path / "profiles.toml"
+#     with temporary_settings({PREFECT_PROFILES_PATH: path}):
+#         yield path
+
+
+def test_version_ephemeral_server_type():
+    invoke_and_assert(
+        ["version"], expected_output_contains="Server type:         ephemeral"
+    )
+
+
+@pytest.mark.usefixtures("use_hosted_orion")
+def test_version_hosted_server_type():
+    invoke_and_assert(
+        ["version"], expected_output_contains="Server type:         hosted"
+    )
+
+
+def test_version_cloud_server_type():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: PREFECT_CLOUD_URL.value()
+            + "/accounts/<test>/workspaces/<test>"
+        }
+    ):
+        invoke_and_assert(
+            ["version"], expected_output_contains="Server type:         cloud"
+        )
+
+
+def test_version_client_error_server_type(monkeypatch):
+    monkeypatch.setattr("prefect.get_client", MagicMock(side_effect=ValueError))
+    invoke_and_assert(
+        ["version"], expected_output_contains="Server type:         <client error>"
+    )


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

Previously, "hosted" was displayed for self-hosted and Prefect Cloud offerings. This will help us distinguish user backends during issue triage.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

```
$ prefect --profile bar version 
Version:             2.1.1+24.gd7ba087cf.dirty
API version:         0.8.0
Python version:      3.8.3
Git commit:          d7ba087c
Built:               Mon, Aug 22, 2022 10:50 AM
OS/Arch:             darwin/x86_64
Profile:             bar
Server type:         cloud
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
