### PR TITLE
BugFix: duplicating work queue deprecated toast message

### DIFF
--- a/orion-ui/src/pages/WorkQueue.vue
+++ b/orion-ui/src/pages/WorkQueue.vue
@@ -68,8 +68,8 @@
     router.push(routes.workQueues())
   }
 
-  watch(workQueue, () => {
-    if (workQueue.value?.deprecated) {
+  watch(() => workQueue.value?.deprecated, value => {
+    if (value) {
       showToast(localization.info.deprecatedWorkQueue, 'default', { dismissible: false, timeout: false })
     }
   })


### PR DESCRIPTION
because the watcher that triggers the persistent deprecated toast watches all of `workqueue`, any change (like pausing) will create additional toast messages. The fix was just to narrow the scope of what is watched

before: 
https://user-images.githubusercontent.com/6098901/186240647-58c9f4c0-4a8b-4a1f-af6d-d94a95d48c89.mov

after:
https://user-images.githubusercontent.com/6098901/186240671-fae75650-f0b5-44af-9793-08b012afd193.mov

you might notice that "work queue active/paused" toasts are stacked on top, that is a separate bug logged [here](https://github.com/PrefectHQ/orion-design/issues/527)
