### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Happy engineering!
 Share an example of the change in action.
 
 A code blurb is best. Changes to features should include an example that is executable by a new user.
-If changing documentation, a link to a preview of the page or a screenshot is great.
+If changing documentation, a link to a preview of the page is great.
  -->
 
 ### Checklist
@@ -25,4 +25,5 @@ If changing documentation, a link to a preview of the page or a screenshot is gr
 - [ ] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
 - [ ] This pull request includes tests or only affects documentation.
-- [ ] This pull request includes a `bug`, `feature`, `enhancement`, or `maintenance` label categorizing the change.
+- [ ] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
+  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,28 @@
-<!-- Make sure that your title neatly summarizes the proposed changes -->
+<!-- 
+Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:
 
-### Summary
-<!-- Provide a short overview of the change and the value it adds -->
+- Make sure that your title neatly summarizes the proposed changes.
+- Provide a short overview of the change and the value it adds.
+- Share an example to help us understand the change in user experience.
+- Confirm that you've done common tasks so we can give a timely review.
 
-### Steps Taken to QA Changes
-<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
-
-### Checklist
-<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-
+Happy engineering!
 -->
 
-This pull request is:
+<!-- Include an overview here -->
 
-- [ ] A documentation / typographical error fix
-	- No tests or issue needed
-- [ ] A short code fix
-	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
-        - If no issue exists, please create a bug report issue 
-	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
-- [ ] A new feature implementation
-	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
-        - If no issue exists, please create a feature enhancement issue 
-	- Please include tests
-    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting
+### Example
+<!-- 
+Share an example of the change in action.
 
+A code blurb is best. Changes to features should include an example that is executable by a new user.
+If changing documentation, a link to a preview of the page or a screenshot is great.
+ -->
 
-**Happy engineering!**
+### Checklist
+<!-- These boxes may be checked after opening the pull request. -->
+
+- [ ] This pull request references any related issue by including "closes `<link to issue>`"
+	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
+- [ ] This pull request includes tests or only affects documentation.
+- [ ] This pull request includes a `bug`, `feature`, `enhancement`, or `maintenance` label categorizing the change.


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This updates the pull request template with a few changes:

- The checklist is now written to be applicable to all pull request types

GitHub includes a "X of Y tasks" message when viewing pull requests. This is helpful for determining if a pull request has completed our requirements for merging. The existing checklist is a nice way to split pull requests into categories, but results in this task list never being completed. Ideally, GitHub will extend pull request templates to be selectable via UI as with issue templates and we can include a specific checklist for each type, but for now, we need the template to be generic.

- "QA steps" has been renamed to "Example"

Often, changes are confirmed with existing or new unit tests. Sometimes, it is not clear what it means to provide QA steps. Instead, I've reframed this section as an "Example". This is a more generalized section that should be applicable to most pull requests. I'm hoping that users that don't understand what _we_ are looking for in QA are able to provide an example of what their change looks like which we can use for QA. This will also help us understand contributions effects on user experience separately from performing QA.

- Added a checklist item for including a label

Until we have automation that syncs labels from a linked issue to the pull request, we'll want to request that the label is added before the pull request is merged. The last release was missing a lot of pull request labels. Hopefully this will help us move towards consistently labeling for changelog generation.

- The "Summary" section does not have a header anymore

This simplifies `gh pr create` workflows where pull requests are generated from commit messages. I could be convinced to retain the header if it provides significant value to others.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page or a screenshot is great.
 -->

I used this template for this pull request! I've also synced this to a test repository so you can preview it at: https://github.com/madkinsz/prefect-gh-test/compare/main...test?expand=1

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.

### Future work

_Note this is not part of the template but may be a nice optional section in the... future ;)_

- Once documentation builds are going again, I'd like to include an example of how to link to it in the "Example" comment.
- I'm not sure if users will be able to include the label on their pull requests. We may want to investigate granting that permission or make it clear that we will add the label for them. As mentioned in the overview, this may be removable following the addition of automation.
- We may want to update our Contributing guidelines to include a section on Reviewing explaining the purpose of the checklist and labels.


