### PR TITLE
Prevent non-UUID slugs from raising errors on the BlockDocuments APIs.

### DIFF
--- a/src/prefect/orion/api/block_documents.py
+++ b/src/prefect/orion/api/block_documents.py
@@ -5,16 +5,7 @@ from typing import List, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import (
-    Body,
-    Depends,
-    HTTPException,
-    Path,
-    Query,
-    Response,
-    responses,
-    status,
-)
+from fastapi import Body, Depends, HTTPException, Path, Query, Response, status
 
 from prefect.orion import models, schemas
 from prefect.orion.api import dependencies
@@ -74,7 +65,7 @@ async def read_block_documents(
     return result
 
 
-@router.get("/{id}")
+@router.get("/{id:uuid}")
 async def read_block_document_by_id(
     block_document_id: UUID = Path(
         ..., description="The block document id", alias="id"
@@ -90,15 +81,15 @@ async def read_block_document_by_id(
         include_secrets=include_secrets,
     )
     if not block_document:
-        return responses.JSONResponse(
-            status_code=404, content={"message": "Block document not found"}
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Block document not found")
     return block_document
 
 
-@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_block_document(
-    block_document_id: str = Path(..., description="The block document id", alias="id"),
+    block_document_id: UUID = Path(
+        ..., description="The block document id", alias="id"
+    ),
     session: sa.orm.Session = Depends(dependencies.get_session),
 ):
     result = await models.block_documents.delete_block_document(
@@ -110,10 +101,12 @@ async def delete_block_document(
         )
 
 
-@router.patch("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.patch("/{id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
 async def update_block_document_data(
     block_document: schemas.actions.BlockDocumentUpdate,
-    block_document_id: str = Path(..., description="The block document id", alias="id"),
+    block_document_id: UUID = Path(
+        ..., description="The block document id", alias="id"
+    ),
     session: sa.orm.Session = Depends(dependencies.get_session),
 ):
     try:


### PR DESCRIPTION
### Summary

In Prefect Cloud, we observed some errors when clients would send requests for
`.../block_documents/null`, which should really be handled at the routing layer
with 404s when the path UUIDs can't be parsed.

Note that this is just correcting the server-side issue, but does not attempt
to diagnose the client-side issue at this time.  Also, this does not attempt
to go through every route in Orion that includes UUIDs in its path.

### Steps Taken to QA Changes

Additional regression tests added for this symptom, and no other tests were modified.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
