### PR TITLE
Add support for prereleases to `generate-lower-bounds`

### DIFF
--- a/scripts/generate-lower-bounds.py
+++ b/scripts/generate-lower-bounds.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-This helper script compiles all of our lower version bounds on all base dependencies 
-from our `requirements.txt` file into a new file which is printed to stdout.  In this 
-new requirements file all dependencies are pinned to their lowest allowed versions.  
+This helper script compiles all of our lower version bounds on all base dependencies
+from our `requirements.txt` file into a new file which is printed to stdout.  In this
+new requirements file all dependencies are pinned to their lowest allowed versions.
 We use this new requirements file to test that we still support all of our
 specified versions.
 
@@ -36,7 +36,10 @@ LOWER_BOUND_RE = re.compile(
     .*                  # Ignore any non-lower bound version specifications
     (?:>=|==|~=)        # Begin parsing a version with a lower bound like equality
     \s*                 # Allow arbitrary whitespace between the equality and version
-    ([\d*\.?]+)         # Capture versions of arbitrary length X.Y.Z...
+    (
+        [\d*\.?]+       # Capture versions of arbitrary length X.Y.Z...
+        (\w+\d*)?      # Capture following alpha/beta/rc designations
+    )
     """,
     re.VERBOSE,
 )

--- a/tests/scripts/test_generate_lower_bounds.py
+++ b/tests/scripts/test_generate_lower_bounds.py
@@ -53,6 +53,23 @@ def test_generate_lower_bounds_robust_to_versions_with_dots(
 
 
 @pytest.mark.parametrize(
+    "min_version",
+    [
+        "10.0a1",
+        "10.0alpha",
+        "10.0a2",
+        "10.0b20",
+        "10.0rc1",
+    ],
+)
+def test_generate_lower_bounds_robust_to_versions_with_prerelease_designation(
+    generate_lower_bounds, min_version
+):
+    results = list(generate_lower_bounds([f"x >= {min_version}"]))
+    assert results == [f"x=={min_version}"]
+
+
+@pytest.mark.parametrize(
     "input",
     ["x <= 11", "x <=11"],
 )


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

Fixes bug found in https://github.com/PrefectHQ/prefect/pull/6540 where `generate-lower-bounds.py` fails to retain prerelease labels.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

If `aiosqlite` is modified to be `a0`, you can see the generated requirements retain the label

```
❯ ./scripts/generate-lower-bounds.py requirements.txt                         
aiofiles==0.7.0
aiohttp==3.8.1
aiosqlite==0.17.0a0
```

Unit test coverage was added for edge cases and other prerelease labels.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
