### PR TITLE
Agent version display

### DIFF
--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import typer
 
+import prefect
 from prefect.agent import OrionAgent
 from prefect.cli._types import PrefectTyper, SettingsOption
 from prefect.cli._utilities import exit_with_error
@@ -105,6 +106,9 @@ async def start(
         work_queues = [work_queue_name]
 
     if not hide_welcome:
+        app.console.print(
+            f"Starting agent running Prefect version {prefect.__version__}..."
+        )
         if api:
             app.console.print(f"Starting agent connected to {api}...")
         else:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -106,19 +106,20 @@ async def start(
         work_queues = [work_queue_name]
 
     if not hide_welcome:
-        app.console.print(
-            f"Starting agent running Prefect version {prefect.__version__}..."
-        )
         if api:
-            app.console.print(f"Starting agent connected to {api}...")
+            app.console.print(
+                f"Starting v{prefect.__version__} agent connected to {api}..."
+            )
         else:
-            app.console.print("Starting agent with ephemeral API...")
+            app.console.print(
+                f"Starting v{prefect.__version__} agent with ephemeral API..."
+            )
 
     async with OrionAgent(work_queues=work_queues) as agent:
         if not hide_welcome:
             app.console.print(ascii_name)
             app.console.print(
-                "Agent started! Looking for work from "
+                f"Agent started! Looking for work from "
                 f"queue(s): {', '.join(work_queues)}..."
             )
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -119,7 +119,7 @@ async def start(
         if not hide_welcome:
             app.console.print(ascii_name)
             app.console.print(
-                f"Agent started! Looking for work from "
+                "Agent started! Looking for work from "
                 f"queue(s): {', '.join(work_queues)}..."
             )
 


### PR DESCRIPTION
Minor change to display prefect version running on agents; accessing this information quickly and efficiently has come up a few times when debugging (**cc:** @dylanbhughes )