### PR TITLE
Fixs 1.x task library tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,9 @@ if sys.version_info < (3, 6):
 if sys.version_info < (3, 7):
     del extras["toloka"]
 
-extras["all_extras"] = sum(extras.values(), [])
+extras["all_extras"] = sum(
+    (extra for name, extra in extras.items() if name not in ["sodasql"]), []
+)
 
 # Extras for docker image builds to include for orchestration
 extras["all_orchestration_extras"] = sum(orchestration_extras.values(), [])

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,6 @@ extras["task_library_ci"] = [
     and not r.startswith("pyodbc")
     and not r.startswith("soda")
 ]
-print(extras["task_library_ci"])
 
 extras["base_library_ci"] = (
     extras["all_orchestration_extras"]

--- a/setup.py
+++ b/setup.py
@@ -114,15 +114,15 @@ if sys.version_info < (3, 6):
 if sys.version_info < (3, 7):
     del extras["toloka"]
 
-extras["all_extras"] = sum(
-    (extra for name, extra in extras.items() if name not in ["sodasql"]), []
-)
+extras["all_extras"] = sum(extras.values(), [])
 
 # Extras for docker image builds to include for orchestration
 extras["all_orchestration_extras"] = sum(orchestration_extras.values(), [])
 
 # CI extras to control dependencies for tests
-extras["task_library_ci"] = sum(extras.values(), [])
+extras["task_library_ci"] = sum(
+    (extra for name, extra in extras.items() if name not in ["sodasql"]), []
+)
 extras["task_library_ci"] = [
     r
     for r in extras["task_library_ci"]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras = {
     "databricks": ["pydantic >= 1.9.0"],
     "dropbox": ["dropbox ~= 9.0"],
     "firebolt": ["firebolt-sdk >= 0.2.1"],
-    "ge": ["great_expectations >= 0.13.8", "mistune < 2.0"],
+    "ge": ["great_expectations >= 0.13.8"],
     "gcp": [
         "google-cloud-bigquery >= 1.6.0",
     ]

--- a/setup.py
+++ b/setup.py
@@ -120,14 +120,15 @@ extras["all_extras"] = sum(extras.values(), [])
 extras["all_orchestration_extras"] = sum(orchestration_extras.values(), [])
 
 # CI extras to control dependencies for tests
-extras["task_library_ci"] = sum(
-    (extra for name, extra in extras.items() if name not in ["sodasql"]), []
-)
+extras["task_library_ci"] = sum(extras.values(), [])
 extras["task_library_ci"] = [
     r
     for r in extras["task_library_ci"]
-    if not r.startswith("dask_cloudprovider") and not r.startswith("pyodbc")
+    if not r.startswith("dask_cloudprovider")
+    and not r.startswith("pyodbc")
+    and not r.startswith("soda")
 ]
+print(extras["task_library_ci"])
 
 extras["base_library_ci"] = (
     extras["all_orchestration_extras"]

--- a/src/prefect/tasks/sodaspark/__init__.py
+++ b/src/prefect/tasks/sodaspark/__init__.py
@@ -1,6 +1,14 @@
 """
 This module contains a collection of tasks to run Data Quality tests using soda-spark library
 """
+from warnings import warn
+
+warn(
+    f"soda-spark has been deprecated. We cannot guarantee that the SodaSparkScan "
+    "task will continue to function properly.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 try:
     from prefect.tasks.sodaspark.sodaspark_tasks import SodaSparkScan

--- a/src/prefect/tasks/sodasql/__init__.py
+++ b/src/prefect/tasks/sodasql/__init__.py
@@ -1,6 +1,14 @@
 """
 This module contains a collection of tasks to run Data Quality tests using soda-sql library
 """
+from warnings import warn
+
+warn(
+    f"soda-sql has been deprecated. We cannot guarantee that the SodaSparkScan "
+    "task will continue to function properly.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 try:
     from prefect.tasks.sodasql.sodasql_tasks import SodaSQLScan


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Fixes the task library tasks by removing the soda sql tasks from the `task_library_ci`. `soda-sql` and `soda-spark` have  very restrictive dependency pins and have been deprecated. I added a deprecation warning reflecting that. We have no records of use for the soda tasks, so I don't expect issues from these changes.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- No tests or issue needed
- [x] A short code fix
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. One-line fixes without tests will not be accepted unless it's related to the documentation only.
- [ ] A new feature implementation
	- Please reference the related issue by including "closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure that your QA steps are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**
