### PR TITLE
Storage upload updates

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -262,12 +262,6 @@ class OrionAgent:
         await self.client.__aenter__()
         await self.task_group.__aenter__()
 
-        # Convert the passed default infrastructure to an id
-        if self.default_infrastructure and not self.default_infrastructure_document_id:
-            self.default_infrastructure_document_id = (
-                await self.default_infrastructure._save(is_anonymous=True)
-            )
-
     async def shutdown(self, *exc_info):
         self.started = False
         await self.task_group.__aexit__(*exc_info)

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -155,13 +155,19 @@ class OrionAgent:
     async def get_infrastructure(self, flow_run: FlowRun) -> Infrastructure:
         deployment = await self.client.read_deployment(flow_run.deployment_id)
 
+        # overrides only apply when configuring known infra blocks
+        if not deployment.infrastructure_document_id:
+            if self.default_infrastructure:
+                return self.default_infrastructure
+            else:
+                infra_document = await self.client.read_block_document(
+                    self.default_infrastructure_document_id
+                )
+                return Block._from_block_document(infra_document)
+
         ## get infra
-        infrastructure_document_id = (
-            deployment.infrastructure_document_id
-            or self.default_infrastructure_document_id
-        )
         infra_document = await self.client.read_block_document(
-            infrastructure_document_id
+            deployment.infrastructure_document_id
         )
 
         # this piece of logic applies any overrides that may have been set on the deployment;

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -168,6 +168,9 @@ class Deployment(BaseModel):
             "schedule",
             "infra_overrides",
         ]
+
+        # if infrastructure is baked as a pre-saved block, then
+        # editing its fields will not update anything
         if self.infrastructure._block_document_id:
             return editable_fields
         else:

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -398,10 +398,7 @@ class Deployment(BaseModel):
         deployment_path = None
         file_count = None
         if storage_block:
-            template = await Block.load(storage_block)
-            self.storage = template.copy(
-                exclude={"_block_document_id", "_block_document_name", "_is_anonymous"}
-            )
+            self.storage = await Block.load(storage_block)
 
             # upload current directory to storage location
             file_count = await self.storage.put_directory(


### PR DESCRIPTION
This PR tidies up some issues with blocks related to deployments:
- stops redundantly saving storage blocks as anonymous blocks
- stops saving default infra blocks on agents as anonymous blocks
- exposes a `--skip-upload` flag on `build` to avoid remote storage uploads (related to https://github.com/PrefectHQ/prefect/issues/6376 but does not take it that far yet)

Example usage:
```
prefect deployment build ./flows/example.py:main --name "Example" -sb s3/dev --skip-upload
# user is now responsible for performing the file upload
prefect deployment apply main-deployment.yaml
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
