### PR TITLE
Improve performance of flow run serialization for `/flow_runs/filter` endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ httpx >= 0.22
 importlib_metadata >= 4.4; python_version < '3.10'
 jsonpatch >= 1.32
 kubernetes >= 24.2.0
+orjson >= 3.7
 packaging >= 21.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -9,6 +9,7 @@ from functools import partial
 from typing import Any, Dict, List, Set, Type, TypeVar
 from uuid import UUID, uuid4
 
+import orjson
 import pendulum
 import pydantic
 from packaging.version import Version
@@ -113,6 +114,15 @@ def pydantic_subclass(
     return new_cls
 
 
+def orjson_dumps(v: Any, *, default: Any) -> str:
+    """
+    Utility for dumping a value to JSON using orjson.
+
+    orjson.dumps returns bytes, to match standard json.dumps we need to decode.
+    """
+    return orjson.dumps(v, default=default).decode()
+
+
 class PrefectBaseModel(BaseModel):
     """A base pydantic.BaseModel for all Prefect schemas and pydantic models.
 
@@ -140,6 +150,10 @@ class PrefectBaseModel(BaseModel):
             copy_on_model_validation = "none"
         else:
             copy_on_model_validation = False
+
+        # Use orjson for serialization
+        json_loads = orjson.loads
+        json_dumps = orjson_dumps
 
     @classmethod
     def subclass(

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import uuid4
 
 import pendulum
@@ -301,6 +302,8 @@ class TestReadFlowRuns:
         response = await client.post("/flow_runs/filter")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 3
+        # return type should be correct
+        assert pydantic.parse_obj_as(List[schemas.core.FlowRun], response.json())
 
     async def test_read_flow_runs_applies_flow_filter(self, flow, flow_runs, client):
         flow_run_filter = dict(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

In testing we noticed performance issues when using jsonable_encoder with large, nested data structures. FlowRun.parameters is often such a structure.

Not only can it be slow, but FastAPI does not run the call in a worker thread, so it blocks the main event loop.
We also now use `orjson` by default for our pydantic model serialization. In testing, this approach resulted in a 75% reduction in CPU time needed to process problematic flow runs.

See [issue](https://github.com/PrefectHQ/nebula/issues/1301) for more info.


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
