### PR TITLE
Resolve issue with python-based deployments having incorrect entrypoints

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -506,7 +506,8 @@ class Deployment(BaseModel):
         await deployment.load()
 
         # set a few attributes for this flow object
-        deployment.entrypoint = f"{Path(flow_file).absolute()}:{flow.fn.__name__}"
+        entry_path = Path(flow_file).absolute().relative_to(Path(".").absolute())
+        deployment.entrypoint = f"{entry_path}:{flow.fn.__name__}"
         deployment.parameter_openapi_schema = parameter_schema(flow)
         if not deployment.version:
             deployment.version = flow.version

--- a/tests/cli/test_deployment_cli.py
+++ b/tests/cli/test_deployment_cli.py
@@ -60,6 +60,24 @@ class TestInputValidation:
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
         assert deployment.work_queue_name == "default"
 
+    def test_entrypoint_is_saved_as_relative_path(self, patch_import, tmp_path):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_code=0,
+            temp_dir=tmp_path,
+        )
+
+        deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        assert deployment.entrypoint == "fake-path.py:fn"
+
     def test_server_side_settings_are_used_if_present(self, patch_import, tmp_path):
         d = Deployment(
             name="TEST",

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -211,6 +211,15 @@ class TestDeploymentBuild:
         assert d.description == flow_function.description
         assert d.version == flow_function.version
 
+    async def test_build_from_flow_sets_correct_entrypoint(self, flow_function):
+        """
+        Entrypoints are *always* relative to {storage.basepath / path}
+        """
+        d = await Deployment.build_from_flow(
+            flow=flow_function, name="foo", description="a", version="b"
+        )
+        d.entrypoint == "tests/fixtures/client.py:client_test_flow"
+
     async def test_build_from_flow_sets_provided_attrs(self, flow_function):
         d = await Deployment.build_from_flow(
             flow_function,


### PR DESCRIPTION
This PR resolves a critical issue with Deployments defined via Python; specifically, the `entrypoint` should _always_ be relative to `remote_storage.basepath / path` and was incorrectly being set as an absolute path on the local machine, resulting in failed deployment runs.

Closes #6482 
Closes #6463 
Closes #6469 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
