### PR TITLE
Deployment upload flags

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -255,6 +255,11 @@ async def apply(
         ...,
         help="One or more paths to deployment YAML files.",
     ),
+    upload: bool = typer.Option(
+        False,
+        "--upload",
+        help="A flag that, when provided, uploads this deployment's files to remote storage.",
+    ),
 ):
     """
     Create or update a deployment from a YAML file.
@@ -266,6 +271,21 @@ async def apply(
             app.console.print(f"Successfully loaded {deployment.name!r}", style="green")
         except Exception as exc:
             exit_with_error(f"'{path!s}' did not conform to deployment spec: {exc!r}")
+
+        if upload:
+            file_count = await deployment.upload_to_storage()
+            if file_count and deployment.storage:
+                location = (
+                    deployment.storage.basepath + "/"
+                    if not deployment.storage.basepath.endswith("/")
+                    else ""
+                )
+                if deployment.path:
+                    location += deployment.path
+                app.console.print(
+                    f"Successfully uploaded {file_count} files to {location}",
+                    style="green",
+                )
 
         deployment_id = await deployment.apply()
         app.console.print(

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -274,16 +274,9 @@ async def apply(
 
         if upload:
             file_count = await deployment.upload_to_storage()
-            if file_count and deployment.storage:
-                location = (
-                    deployment.storage.basepath + "/"
-                    if not deployment.storage.basepath.endswith("/")
-                    else ""
-                )
-                if deployment.path:
-                    location += deployment.path
+            if file_count:
                 app.console.print(
-                    f"Successfully uploaded {file_count} files to {location}",
+                    f"Successfully uploaded {file_count} files to {deployment.location}",
                     style="green",
                 )
 
@@ -556,16 +549,9 @@ async def build(
 
     if not skip_upload:
         file_count = await deployment.upload_to_storage()
-        if file_count and deployment.storage:
-            location = (
-                deployment.storage.basepath + "/"
-                if not deployment.storage.basepath.endswith("/")
-                else ""
-            )
-            if path:
-                location += path
+        if file_count:
             app.console.print(
-                f"Successfully uploaded {file_count} files to {location}",
+                f"Successfully uploaded {file_count} files to {deployment.location}",
                 style="green",
             )
 

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -507,6 +507,7 @@ class Deployment(BaseModel):
         entry_path = Path(flow_file).absolute().relative_to(Path(".").absolute())
         deployment.entrypoint = f"{entry_path}:{flow.fn.__name__}"
         deployment.parameter_openapi_schema = parameter_schema(flow)
+
         if not deployment.version:
             deployment.version = flow.version
         if not deployment.description:

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -176,6 +176,25 @@ class Deployment(BaseModel):
         else:
             return editable_fields + ["infrastructure"]
 
+    @property
+    def location(self) -> str:
+        """
+        The 'location' that this deployment points to is given by `path` alone
+        in the case of no remote storage, and otherwise by `storage.basepath / path`.
+
+        The underlying flow entrypoint is interpreted relative to this location.
+        """
+        location = ""
+        if self.storage:
+            location = (
+                self.storage.basepath + "/"
+                if not self.storage.basepath.endswith("/")
+                else ""
+            )
+        if self.path:
+            location += self.path
+        return location
+
     @sync_compatible
     async def to_yaml(self, path: Path) -> None:
         yaml_dict = self._yaml_dict()

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -419,9 +419,12 @@ class Deployment(BaseModel):
         return file_count
 
     @sync_compatible
-    async def apply(self) -> UUID:
+    async def apply(self, upload: bool = False) -> UUID:
         """
         Registers this deployment with the API and returns the deployment's ID.
+
+        Args:
+            upload: if True, deployment files are automatically uploaded to remote storage
         """
         if not self.name or not self.flow_name:
             raise ValueError("Both a deployment name and flow name must be set.")
@@ -436,6 +439,9 @@ class Deployment(BaseModel):
                 infrastructure_document_id = await self.infrastructure._save(
                     is_anonymous=True,
                 )
+
+            if upload:
+                await self.upload_to_storage()
 
             # we assume storage was already saved
             storage_document_id = getattr(self.storage, "_block_document_id", None)

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -274,7 +274,7 @@ class Deployment(BaseModel):
     )
 
     @validator("infrastructure", pre=True)
-    def infrastructure_must_have_capabilities(cls, value):
+    def infrastructure_validation(cls, value):
         if isinstance(value, dict):
             block_type = lookup_type(Block, value.pop("_block_type_slug"))
             block = block_type(**value)
@@ -290,10 +290,13 @@ class Deployment(BaseModel):
         return block
 
     @validator("storage", pre=True)
-    def storage_must_have_capabilities(cls, value):
+    def storage_validation(cls, value):
         if isinstance(value, dict):
-            block_type = lookup_type(Block, value.pop("_block_type_slug"))
+            type_slug = value.pop("_block_type_slug")
+            block_type = lookup_type(Block, type_slug)
             block = block_type(**value)
+            if block._block_document_name:
+                block = Block.load(f"{type_slug}/{block._block_document_name}")
         elif value is None:
             return value
         else:

--- a/src/prefect/docker.py
+++ b/src/prefect/docker.py
@@ -139,7 +139,8 @@ def build_image(
 
     if not context:
         raise ValueError("context required to build an image")
-    if not context.exists():
+
+    if not Path(context).exists():
         raise ValueError(f"Context path {context} does not exist")
 
     image_id = None

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,9 +1,10 @@
 import pytest
+import yaml
 from pydantic.error_wrappers import ValidationError
 
 from prefect.blocks.core import Block
 from prefect.deployments import Deployment
-from prefect.filesystems import LocalFileSystem
+from prefect.filesystems import LocalFileSystem, S3
 from prefect.infrastructure import Process
 
 
@@ -259,6 +260,39 @@ class TestYAML:
         assert new_d.flow_name == "test"
         assert new_d.storage == storage
         assert new_d.infrastructure == infrastructure
+
+    async def test_deployment_yaml_roundtrip_handles_secret_values(self, tmp_path):
+        storage = S3(
+            bucket_path="unreal",
+            aws_access_key_id="fake",
+            aws_secret_access_key="faker",
+        )
+
+        # save so that secret values are persisted somewhere
+        await storage.save("test-me-with-secrets")
+        infrastructure = Process()
+
+        d = Deployment(
+            name="yaml",
+            flow_name="test",
+            storage=storage,
+            infrastructure=infrastructure,
+            tags=["A", "B"],
+        )
+        yaml_path = str(tmp_path / "dep.yaml")
+        await d.to_yaml(yaml_path)
+
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        # ensure secret values are hidden
+        assert set(data["storage"]["aws_access_key_id"]) == {"*"}
+        assert set(data["storage"]["aws_secret_access_key"]) == {"*"}
+
+        # ensure secret values are re-hydrated
+        new_d = await Deployment.load_from_yaml(yaml_path)
+        assert new_d.storage.aws_access_key_id.get_secret_value() == "fake"
+        assert new_d.storage.aws_secret_access_key.get_secret_value() == "faker"
 
     def test_yaml_comment_for_work_queue(self, tmp_path):
         d = Deployment(name="yaml", flow_name="test")

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -188,8 +188,11 @@ class TestDeploymentBuild:
         assert d.flow_name == flow_function.name
         assert d.name == "foo"
 
-    async def test_build_from_flow_sets_path(self, flow_function):
-        d = await Deployment.build_from_flow(flow=flow_function, name="foo")
+    @pytest.mark.parametrize("skip_upload", [True, False])
+    async def test_build_from_flow_sets_path(self, flow_function, skip_upload):
+        d = await Deployment.build_from_flow(
+            flow=flow_function, name="foo", skip_upload=skip_upload
+        )
         assert d.flow_name == flow_function.name
         assert d.name == "foo"
         assert d.path is not None

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -131,12 +131,6 @@ class TestDeploymentLoad:
 
 
 class TestDeploymentUpload:
-    async def test_uploading_with_no_storage_sets_path(self):
-        d = Deployment(name="foo", flow_name="bar")
-        assert d.path is None
-        await d.upload_to_storage()
-        assert d.path
-
     async def test_uploading_with_unsaved_storage_creates_anon_block(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
 
@@ -193,6 +187,12 @@ class TestDeploymentBuild:
         d = await Deployment.build_from_flow(flow=flow_function, name="foo")
         assert d.flow_name == flow_function.name
         assert d.name == "foo"
+
+    async def test_build_from_flow_sets_path(self, flow_function):
+        d = await Deployment.build_from_flow(flow=flow_function, name="foo")
+        assert d.flow_name == flow_function.name
+        assert d.name == "foo"
+        assert d.path is not None
 
     async def test_build_from_flow_sets_description_and_version_if_not_set(
         self, flow_function

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -4,7 +4,7 @@ from pydantic.error_wrappers import ValidationError
 
 from prefect.blocks.core import Block
 from prefect.deployments import Deployment
-from prefect.filesystems import LocalFileSystem, S3
+from prefect.filesystems import S3, LocalFileSystem
 from prefect.infrastructure import Process
 
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -33,6 +33,18 @@ class TestDeploymentBasicInterface:
         d = Deployment(name="foo")
         assert d.work_queue_name == "default"
 
+    async def test_location(self):
+        storage = S3(bucket_path="test-bucket")
+
+        d = Deployment(name="foo", storage=storage)
+        assert d.location == "s3://test-bucket/"
+
+        d = Deployment(name="foo", storage=storage, path="subdir")
+        assert d.location == "s3://test-bucket/subdir"
+
+        d = Deployment(name="foo", path="/full/path/to/flow/")
+        assert d.location == "/full/path/to/flow/"
+
 
 class TestDeploymentLoad:
     async def test_deployment_load_hydrates_with_server_settings(


### PR DESCRIPTION
<!-- Include an overview here -->
This PR makes some adjustments to deployment uploads to remote storage:
- calling `deployment.upload_to_storage` no longer adjusts attributes of the deployment object other than storage
- exposes `skip_upload` flag on `Deployment.build_from_flow` for feature parity with the CLI
- exposes new `upload` flags on both the `deployment.apply` method as well as the `apply` CLI

The `--skip-upload` / `--upload` combo addresses #6376 in a non-breaking way.

### Example

```
prefect deployment build ./flows/example.py:main -n "demo" -sb s3/dev --skip-upload
prefect deployment apply main-deployment.yaml --upload
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
