### PR TITLE
Add type hints to state predicates

### DIFF
--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -191,28 +191,28 @@ class State(IDBaseModel, Generic[R]):
                 state_details.scheduled_time = pendulum.now("utc")
         return values
 
-    def is_scheduled(self):
+    def is_scheduled(self) -> bool:
         return self.type == StateType.SCHEDULED
 
-    def is_pending(self):
+    def is_pending(self) -> bool:
         return self.type == StateType.PENDING
 
-    def is_running(self):
+    def is_running(self) -> bool:
         return self.type == StateType.RUNNING
 
-    def is_completed(self):
+    def is_completed(self) -> bool:
         return self.type == StateType.COMPLETED
 
-    def is_failed(self):
+    def is_failed(self) -> bool:
         return self.type == StateType.FAILED
 
-    def is_crashed(self):
+    def is_crashed(self) -> bool:
         return self.type == StateType.CRASHED
 
-    def is_cancelled(self):
+    def is_cancelled(self) -> bool:
         return self.type == StateType.CANCELLED
 
-    def is_final(self):
+    def is_final(self) -> bool:
         return self.type in TERMINAL_STATES
 
     def copy(self, *, update: dict = None, reset_fields: bool = False, **kwargs):


### PR DESCRIPTION
Mypy complains that calls like `state.is_completed()` are untyped in a typed context. 
This PR should fix that.

Closes #6562 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
