### PR TITLE
Add error when sync compatible methods are used incorrectly

### DIFF
--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -3,6 +3,7 @@ Utilities for interoperability with async functions and workers from various con
 """
 import ctypes
 import inspect
+import sys
 import threading
 import warnings
 from contextlib import asynccontextmanager
@@ -181,8 +182,20 @@ def sync_compatible(async_fn: T) -> T:
     @wraps(async_fn)
     def wrapper(*args, **kwargs):
         if in_async_main_thread():
-            # In the main async context; return the coro for them to await
-            return async_fn(*args, **kwargs)
+            caller_frame = sys._getframe(1)
+            caller_async = caller_frame.f_code.co_flags & inspect.CO_COROUTINE
+            if caller_async:
+                # In the main async context; return the coro for them to await
+                return async_fn(*args, **kwargs)
+            else:
+                # In the main thread but call was made from a sync method
+                raise RuntimeError(
+                    "A 'sync_compatible' method was called from a context that was "
+                    "previously async but is now sync. The sync call must be changed "
+                    "to run in a worker thread to support sending the coroutine for "
+                    f"{async_fn.__name__!r} to the main thread."
+                )
+
         elif in_async_worker_thread():
             # In a sync context but we can access the event loop thread; send the async
             # call to the parent

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -193,6 +193,20 @@ async def test_sync_compatible_call_from_async(fn):
     assert await fn(1, y=2) == 6
 
 
+async def test_sync_compatible_call_from_sync_in_async_thread():
+    # Here we are in the async main thread
+
+    def run_fn():
+        # Here we are back in a sync context but still in the async main thread
+        sync_compatible_fn(1, y=2)
+
+    with pytest.raises(
+        RuntimeError,
+        match="method was called from a context that was previously async but is now sync",
+    ):
+        run_fn()
+
+
 @pytest.mark.parametrize("fn", SYNC_COMPAT_TEST_CASES)
 async def test_sync_compatible_call_from_worker(fn):
     def run_fn():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Attempts to resolve a common confusion around `sync_compatible` calls. You cannot call a `sync_compatible` method from a synchronous function that was called by an asynchronous function. For example:

```python
async def foo():
    # Here the main thread is async
    bar()


def bar():
    # Here we are in an async thread but we are in a sync function
    # To support execution of `foobar`, we must be able to send it to an event loop
    # If we send it to the main thread where we are now, it will attempt to run it and wait for
    # it on the same thread resulting in a deadlock
    foobar()


@sync_compatible
async def foobar():
    pass


run_async_in_new_loop(foo)
```

The proper pattern is

```python
async def foo():
    # Here the main thread is async
    await run_sync_in_worker_thread(bar)


def bar():
    # Here we are in a worker thread. `sync_compatible` will send foobar
    # back to the main thread for completion. Since it is using `await` to wait
    # for the result of `bar`, the event loop has yielded and is free to execute
    # `foobar`.
    foobar()


@sync_compatible
async def foobar():
    pass


run_async_in_new_loop(foo)
```

There is likely a small performance hit from peaking at the frame of the caller to see if it is an async function. We attempt to minimize this by retrieving at a single frame instead of the full stack.

Instead of throwing an error, we could support execution of this case by creating a _new_ thread with a _new_ event loop and executing the given coroutine in it. However, this is a dangerous pattern and may cause more issues in the long run. For now, I'd like to continue discouraging patterns that attempt to run `sync_compatible` methods in a blocked event loop.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

The first snippet above would have previously returned a coroutine that could not be awaited. Now, instead, we raise an exception:

> RuntimeError: A 'sync_compatible' method was called from a context that was previously async but is not sync. The sync call must be changed to run in a worker thread to support sending the coroutine for 'foobar' to the main thread.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
