### PR TITLE
Fix `FlowRunView` task run queries when all task runs are cached

### DIFF
--- a/changes/6572.yaml
+++ b/changes/6572.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix `FlowRunView` task run queries when all task runs are cached - [#6572](https://github.com/PrefectHQ/prefect/pull/6572)"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Closes bug reported in https://prefecthq.slack.com/archives/C028BPL85C3/p1661452093250219 where if all of the task runs are cached an error is thrown when retrieving cache runs

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 880, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/usr/local/lib/python3.9/site-packages/prefect/utilities/executors.py", line 468, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/redacted.py", line 122, in redacted
    tasks = view.get_all_task_runs()
  File "/usr/local/lib/python3.9/site-packages/prefect/backend/flow_run.py", line 739, in get_all_task_runs
    task_run_data = TaskRunView._query_for_task_runs(
  File "/usr/local/lib/python3.9/site-packages/prefect/backend/task_run.py", line 367, in _query_for_task_runs
    raise ValueError(
ValueError: No task runs found while querying for task runs where ....
```

This is easily fixed by toggling the `error_on_empty` bool.
Includes a change that excludes of cached task runs from the `load_static_tasks` query.
Includes a fix that prevents duplicate task runs from being returned when the object is shared by multiple threads.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
from prefect.backend import FlowRunView

view = FlowRunView.from_flow_run_id("030ee8ba-3e2c-439f-96c4-44c0ef2ad618")

# Calling repeatedly does not fail
view.get_all_task_runs()
view.get_all_task_runs()  # Previously would fail here
view.get_all_task_runs()

# Getting the latest is fine
view.get_latest()

# Getting the latest and making a query for static tasks is fine
view.get_latest(load_static_tasks=True)

# Instantiating a new instance with static loading works still
view = FlowRunView.from_flow_run_id("030ee8ba-3e2c-439f-96c4-44c0ef2ad618", load_static_tasks=True)
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
