### PR TITLE
Use Github Action's cache for image layer caches.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           outputs: type=docker,dest=/tmp/image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test docker image
         run: |
@@ -158,6 +160,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           outputs: type=docker,dest=/tmp/image-conda.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test docker image
         run: |


### PR DESCRIPTION
This should improve the runtime of our release process by using cached image
layers between runs.  Note, though, that the biggest benefits here come from
optimizing the order of the Dockerfile to maximize layer reuse.  This is
something we can work on over time.

Reference for the cache directives: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
