### PR TITLE
add unmapped example to `Task.map` docstring

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -638,6 +638,17 @@ class Task(Generic[P, R]):
             >>> my_flow()
             [6, 7, 8]
 
+            Use unmapped to treat an iterable arg as static
+            >>> from prefect import unmapped
+            >>>
+            >>> @task
+            >>> def my_task(n, static_str):
+            >>>     print(f'{n} - {static_str}')
+            >>>
+            >>> @flow
+            >>> def my_flow():
+            >>>     my_task.map([1, 2, 3], unmapped("Hello!"))
+
         """
 
         from prefect.engine import enter_task_run_engine


### PR DESCRIPTION
After running into `prefect.exceptions.MappingLengthMismatch` when I passed a `str` arg to `Task.map` and it was treated as an iterable, I wasn't sure that `unmapped` was implemented yet - there was no example I could find of unmapped being used on an arg passed to `Task.map`

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### example to add
```python
from prefect import unmapped


@task
def my_task(n, static_str):
    print(f'{n} - {static_str}')


@flow
def my_flow():
    my_task.map([1, 2, 3], unmapped("Hello!"))
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
