### PR TITLE
Update Kubernetes Job to use `args` instead of `command`

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -315,7 +315,7 @@ class KubernetesJob(Infrastructure):
             shortcuts.append(
                 {
                     "op": "add",
-                    "path": "/spec/template/spec/containers/0/command",
+                    "path": "/spec/template/spec/containers/0/args",
                     "value": self.command,
                 }
             )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Kubernetes uses `command` and `args` where Docker uses `entrypoint` and `command` respectively. By setting the infrastructure command in the `command` field of a Kubernetes container, we bypass any entrypoint configured on the container. By default, we should respect container entrypoints. This is particularly relevant for the Prefect base image which uses the entrypoint to install extra packages.

Closes #6551 

This may be a breaking change in some specific cases, i.e. the user is using a container that has an invalid entrypoint or an entrypoint that should be bypassed.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect.infrastructure import KubernetesJob

job = KubernetesJob(
    command=["pip", "show", "s3fs"],
    env={"EXTRA_PIP_PACKAGES": "s3fs"},
)

await job.run()
```
```
+pip install s3fs
Collecting s3fs
  Downloading s3fs-2022.7.1-py3-none-any.whl (27 kB)
Requirement already satisfied: fsspec==2022.7.1 in /usr/local/lib/python3.8/site-packages (from s3fs) (2022.7.1)
Collecting aiobotocore~=2.3.4
  Downloading aiobotocore-2.3.4-py3-none-any.whl (64 kB)
Requirement already satisfied: aiohttp in /usr/local/lib/python3.8/site-packages (from s3fs) (3.8.1)
Collecting botocore<1.24.22,>=1.24.21
  Downloading botocore-1.24.21-py3-none-any.whl (8.6 MB)
Collecting aioitertools>=0.5.1
  Downloading aioitertools-0.10.0-py3-none-any.whl (23 kB)
Collecting wrapt>=1.10.10
  Downloading wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (81 kB)
Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (1.3.0)
Requirement already satisfied: yarl<2.0,>=1.0 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (1.8.1)
Requirement already satisfied: charset-normalizer<3.0,>=2.0 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (2.1.0)
Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (22.1.0)
Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (4.0.2)
Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (6.0.2)
Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.8/site-packages (from aiohttp->s3fs) (1.2.0)
Requirement already satisfied: typing_extensions>=4.0 in /usr/local/lib/python3.8/site-packages (from aioitertools>=0.5.1->aiobotocore~=2.3.4->s3fs) (4.3.0)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /usr/local/lib/python3.8/site-packages (from botocore<1.24.22,>=1.24.21->aiobotocore~=2.3.4->s3fs) (2.8.2)
Requirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/local/lib/python3.8/site-packages (from botocore<1.24.22,>=1.24.21->aiobotocore~=2.3.4->s3fs) (1.26.11)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/local/lib/python3.8/site-packages (from botocore<1.24.22,>=1.24.21->aiobotocore~=2.3.4->s3fs) (1.0.1)
Requirement already satisfied: idna>=2.0 in /usr/local/lib/python3.8/site-packages (from yarl<2.0,>=1.0->aiohttp->s3fs) (3.3)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.8/site-packages (from python-dateutil<3.0.0,>=2.1->botocore<1.24.22,>=1.24.21->aiobotocore~=2.3.4->s3fs) (1.16.0)
Installing collected packages: wrapt, botocore, aioitertools, aiobotocore, s3fs
  Attempting uninstall: botocore
    Found existing installation: botocore 1.27.43
    Uninstalling botocore-1.27.43:
      Successfully uninstalled botocore-1.27.43
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
boto3 1.24.43 requires botocore<1.28.0,>=1.27.43, but you have botocore 1.24.21 which is incompatible.
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Successfully installed aiobotocore-2.3.4 aioitertools-0.10.0 botocore-1.24.21 s3fs-2022.7.1 wrapt-1.14.1
WARNING: You are using pip version 21.3.1; however, version 22.2.2 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
+pip show s3fs
Name: s3fs
Version: 2022.7.1
Summary: Convenient Filesystem interface over S3
Home-page: http://github.com/fsspec/s3fs/
Author:
Author-email:
License: BSD
Location: /usr/local/lib/python3.8/site-packages
Requires: aiobotocore, aiohttp, fsspec
Required-by:
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
