### PR TITLE
Update iterable detection to exclude strings and bytes

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -638,17 +638,19 @@ class Task(Generic[P, R]):
             >>> my_flow()
             [6, 7, 8]
 
-            Use unmapped to treat an iterable arg as static
+            Use `unmapped` to treat an iterable argument as static
             >>> from prefect import unmapped
             >>>
             >>> @task
-            >>> def my_task(n, static_str):
-            >>>     print(f'{n} - {static_str}')
+            >>> def add_n_to_items(items, n):
+            >>>     return [item + n for item in items]
             >>>
             >>> @flow
             >>> def my_flow():
-            >>>     my_task.map([1, 2, 3], unmapped("Hello!"))
-
+            >>>     return add_n_to_items.map(unmapped([10, 20]), n=[1, 2, 3])
+            >>>
+            >>> my_flow()
+            [[11, 21], [12, 22], [13, 23]]
         """
 
         from prefect.engine import enter_task_run_engine

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -579,38 +579,42 @@ class Task(Generic[P, R]):
             >>> def my_task(x):
             >>>     return x + 1
 
-            Run a map in a flow
+            Create mapped tasks
 
             >>> from prefect import flow
             >>> @flow
             >>> def my_flow():
             >>>     my_task.map([1, 2, 3])
 
-            Wait for mapping to finish
+            Wait for all mapped tasks to finish
 
             >>> @flow
             >>> def my_flow():
             >>>     futures = my_task.map([1, 2, 3])
             >>>     for future in futures:
             >>>         future.wait()
+            >>>     # Now all of the mapped tasks have finished
+            >>>     my_task(10)
 
-            Use the result from a map in a flow
+            Use the result from mapped tasks in a flow
 
             >>> @flow
             >>> def my_flow():
             >>>     futures = my_task.map([1, 2, 3])
             >>>     for future in futures:
-            >>>         future.result()
+            >>>         print(future.result())
             >>> my_flow()
-            [2, 3, 4]
+            2
+            3
+            4
 
             Enforce ordering between tasks that do not exchange data
             >>> @task
-            >>> def task_1():
+            >>> def task_1(x):
             >>>     pass
             >>>
             >>> @task
-            >>> def task_2():
+            >>> def task_2(y):
             >>>     pass
             >>>
             >>> @flow
@@ -620,25 +624,21 @@ class Task(Generic[P, R]):
             >>>     # task 2 will wait for task_1 to complete
             >>>     y = task_2.map([1, 2, 3], wait_for=[x])
 
-            Use static arguments
+            Use a non-iterable input as a constant across mapped tasks
             >>> @task
-            >>> def add_y(x, y):
-            >>>    return x + y
+            >>> def display(prefix, item):
+            >>>    print(prefix, item)
             >>>
             >>> @flow
             >>> def my_flow():
-            >>>     futures = add_something.map([1, 2, 3], 5)
-            >>>
-            >>>     # collect results
-            >>>     result = []
-            >>>     for future in futures:
-            >>>         result.append(future.result())
-            >>>     return result
+            >>>     display.map("Check it out: ", [1, 2, 3])
             >>>
             >>> my_flow()
-            [6, 7, 8]
+            Check it out: 1
+            Check it out: 2
+            Check it out: 3
 
-            Use `unmapped` to treat an iterable argument as static
+            Use `unmapped` to treat an iterable argument as a constant
             >>> from prefect import unmapped
             >>>
             >>> @task

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -126,12 +126,19 @@ T = TypeVar("T")
 
 
 def isiterable(obj: Any) -> bool:
+    """
+    Return a boolean indicating if an object is iterable.
+
+    Excludes types that are iterable but typically used as singletons:
+    - str
+    - bytes
+    """
     try:
         iter(obj)
     except TypeError:
         return False
     else:
-        return True
+        return not isinstance(obj, (str, bytes))
 
 
 def ensure_iterable(obj: Union[T, Iterable[T]]) -> Iterable[T]:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2013,15 +2013,41 @@ class TestTaskMap:
         futures = await my_flow()
         assert [future.result() for future in futures] == [3, 3, 3]
 
-    async def test_unmapped_value(self):
+    @pytest.mark.parametrize("explicit", [True, False])
+    async def test_unmapped_int(self, explicit):
         @flow
         def my_flow():
             numbers = [1, 2, 3]
-            other = unmapped(5)
+            other = unmapped(5) if explicit else 5
             return TestTaskMap.add_together.map(numbers, other)
 
         futures = my_flow()
         assert [future.result() for future in futures] == [6, 7, 8]
+
+    @pytest.mark.parametrize("explicit", [True, False])
+    async def test_unmapped_str(self, explicit):
+        @flow
+        def my_flow():
+            letters = ["a", "b", "c"]
+            other = unmapped("test") if explicit else "test"
+            return TestTaskMap.add_together.map(letters, other)
+
+        futures = my_flow()
+        assert [future.result() for future in futures] == ["atest", "btest", "ctest"]
+
+    async def test_unmapped_iterable(self):
+        @flow
+        def my_flow():
+            numbers = [[], [], []]
+            others = [4, 5, 6, 7]  # Different length!
+            return TestTaskMap.add_together.map(numbers, unmapped(others))
+
+        futures = my_flow()
+        assert [future.result() for future in futures] == [
+            [4, 5, 6, 7],
+            [4, 5, 6, 7],
+            [4, 5, 6, 7],
+        ]
 
     async def test_with_default_kwargs(self):
         @task

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -413,10 +413,10 @@ class TestRemoveKeys:
 
 
 class TestIsIterable:
-    @pytest.mark.parametrize("obj", [[1, 2, 3], (1, 2, 3), "hello"])
+    @pytest.mark.parametrize("obj", [[1, 2, 3], (1, 2, 3)])
     def test_is_iterable(self, obj):
         assert isiterable(obj)
 
-    @pytest.mark.parametrize("obj", [5, Exception(), True])
+    @pytest.mark.parametrize("obj", [5, Exception(), True, "hello", bytes()])
     def test_not_iterable(self, obj):
         assert not isiterable(obj)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Updates our `isiterable` check to treat `str` and `bytes` as non-iterable types. Our usage of `isiterable` is to detect if a parameter should be mapped over or not. These objects are singletons that happen to be iterable and should not require an explicit `unmapped` during mapped calls. Passing a string to a mapped call and expecting it to be treated as a constant is a very common pattern.

I've also updated the `Task.map` documentation to clarify this while simplifying and fixing some examples.

I noticed this in https://github.com/PrefectHQ/prefect/pull/6579.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
@task
def display(prefix, item):
   print(prefix, item)

@flow
def my_flow():
    # Previously, this would throw a mapping length mismatch error
    display.map("Check it out: ", [1, 2, 3])

my_flow()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
