### PR TITLE
Update labeler to work for external contributions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: Labeler
 
-on: [pull_request]
+on: [pull_request_target]
 
 permissions:
   contents: read


### PR DESCRIPTION
See brief discussion at https://prefecthq.slack.com/archives/CH84XHRB4/p1661455833761669

The labeler does not have permissions to run on external contexts since it requires GitHub credentials.