### PR TITLE
GitHub-based deployments

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -165,6 +165,9 @@ class Block(BaseModel, ABC):
         super().__init__(*args, **kwargs)
         self.block_initialization()
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
     def block_initialization(self) -> None:
         pass
 

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -283,6 +283,11 @@ async def apply(
                         f"Successfully uploaded {file_count} files to {deployment.location}",
                         style="green",
                     )
+            else:
+                app.console.print(
+                    f"Deployment storage {deployment.storage} does not have upload capabilities; no files uploaded.",
+                    style="red",
+                )
 
         deployment_id = await deployment.apply()
         app.console.print(
@@ -580,6 +585,11 @@ async def build(
                     f"Successfully uploaded {file_count} files to {deployment.location}",
                     style="green",
                 )
+        else:
+            app.console.print(
+                f"Deployment storage {deployment.storage} does not have upload capabilities; no files uploaded.  Pass --skip-upload to suppress this warning.",
+                style="green",
+            )
 
     deployment_loc = output_file or f"{obj_name}-deployment.yaml"
     await deployment.to_yaml(deployment_loc)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -273,12 +273,16 @@ async def apply(
             exit_with_error(f"'{path!s}' did not conform to deployment spec: {exc!r}")
 
         if upload:
-            file_count = await deployment.upload_to_storage()
-            if file_count:
-                app.console.print(
-                    f"Successfully uploaded {file_count} files to {deployment.location}",
-                    style="green",
-                )
+            if (
+                deployment.storage
+                and "put-directory" in deployment.storage.get_block_capabilities()
+            ):
+                file_count = await deployment.upload_to_storage()
+                if file_count:
+                    app.console.print(
+                        f"Successfully uploaded {file_count} files to {deployment.location}",
+                        style="green",
+                    )
 
         deployment_id = await deployment.apply()
         app.console.print(
@@ -548,12 +552,16 @@ async def build(
         )
 
     if not skip_upload:
-        file_count = await deployment.upload_to_storage()
-        if file_count:
-            app.console.print(
-                f"Successfully uploaded {file_count} files to {deployment.location}",
-                style="green",
-            )
+        if (
+            deployment.storage
+            and "put-directory" in deployment.storage.get_block_capabilities()
+        ):
+            file_count = await deployment.upload_to_storage()
+            if file_count:
+                app.console.print(
+                    f"Successfully uploaded {file_count} files to {deployment.location}",
+                    style="green",
+                )
 
     deployment_loc = output_file or f"{obj_name}-deployment.yaml"
     await deployment.to_yaml(deployment_loc)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -394,7 +394,7 @@ async def build(
         None,
         "--storage-block",
         "-sb",
-        help="The slug of a remote storage block. Use the syntax: 'block_type/block_name', where block_type must be one of 'remote-file-system', 's3', 'gcs', 'azure', 'smb'",
+        help="The slug of a remote storage block. Use the syntax: 'block_type/block_name', where block_type must be one of 'github', 's3', 'gcs', 'azure', 'smb'",
     ),
     skip_upload: bool = typer.Option(
         False,

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -319,9 +319,9 @@ class Deployment(BaseModel):
             block = value
 
         capabilities = block.get_block_capabilities()
-        if "get-directory" not in capabilities and "put-directory" not in capabilities:
+        if "get-directory" not in capabilities:
             raise ValueError(
-                "Remote Storage block must have both 'get-directory' and 'put-directory' capabilities."
+                "Remote Storage block must have 'get-directory' capabilities."
             )
         return block
 

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -571,7 +571,11 @@ class Deployment(BaseModel):
             deployment.path = str(Path(".").absolute())
 
         if not skip_upload:
-            await deployment.upload_to_storage()
+            if (
+                deployment.storage
+                and "put-directory" in deployment.storage.get_block_capabilities()
+            ):
+                await deployment.upload_to_storage()
 
         if output:
             await deployment.to_yaml(output)

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -269,3 +269,9 @@ class MappingMissingIterable(PrefectException):
     """
     Raised when attempting to call Task.map with all static arguments
     """
+
+
+class BlockMissingCapabilities(PrefectException):
+    """
+    Raised when a block does not have required capabilities for a given operation.
+    """

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -267,7 +267,6 @@ class TestDeploymentBuild:
                 path=path,
             )
             assert d.path == path
->>>>>>> main
 
     async def test_build_from_flow_sets_description_and_version_if_not_set(
         self, flow_function

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -229,6 +229,17 @@ class TestDeploymentBuild:
         assert d.name == "foo"
         assert d.path is not None
 
+    async def test_build_from_flow_gracefully_handles_readonly_storage(
+        self, flow_function
+    ):
+        storage = GitHub(repository="prefect")
+        d = await Deployment.build_from_flow(
+            flow=flow_function, name="foo", storage=storage
+        )
+        assert d.flow_name == flow_function.name
+        assert d.name == "foo"
+        assert d.path is None
+
     async def test_build_from_flow_sets_description_and_version_if_not_set(
         self, flow_function
     ):

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -22,7 +22,7 @@ class TestDeploymentBasicInterface:
     async def test_that_storage_block_capabilities_are_validated(self):
         bad_storage = Process()
 
-        with pytest.raises(ValueError, match="capabilities"):
+        with pytest.raises(ValueError, match="'get-directory' capabilities"):
             Deployment(name="foo", storage=bad_storage)
 
     async def test_that_infrastructure_defaults_to_process(self):

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -6,7 +6,7 @@ from prefect.blocks.core import Block
 from prefect.deployments import Deployment
 from prefect.exceptions import BlockMissingCapabilities
 from prefect.filesystems import S3, GitHub, LocalFileSystem
-from prefect.infrastructure import Process
+from prefect.infrastructure import DockerContainer, Process
 
 
 class TestDeploymentBasicInterface:

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -127,15 +127,3 @@ class TestGitHub:
             mock.await_args[0][0]
             == f"git clone prefect -b 2.0.0 --depth 1 {expected_path}"
         )
-
-    async def test_get_directory_accepts_inputs(self, monkeypatch):
-        class p:
-            returncode = 0
-
-        mock = AsyncMock(return_value=p())
-        monkeypatch.setattr(prefect.filesystems, "run_process", mock)
-        g = GitHub(repository="prefect", reference="2.0.0")
-        await g.get_directory(from_path="prefect-aws", local_path="/my/tmp/place")
-
-        assert mock.await_count == 1
-        assert mock.await_args[0][0] == f"git clone prefect-aws /my/tmp/place"


### PR DESCRIPTION
This PR wires up `GitHub` remote storage so that it can be used with deployments seamlessly.   Specifically, users can now specify:
- a remote repository (currently required to be public, but we will expand support for private repos)
- a reference branch or tag of that repository
- and an optional subdirectory of that repository to use as a workflow deployment project structure

Closes #6585 

<!-- Include an overview here -->

### Example
We can actually illustrate this rather nicely off the current branch `github-deployments` that this PR is based on! 

Start by navigating to `tests/test-projects/nested-project` ([see its file structure here](https://github.com/PrefectHQ/prefect/tree/main/tests/test-projects/nested-project)).  We begin by creating a `GitHub` remote storage block:
```python
from prefect.filesystems import GitHub

g = GitHub(repository="https://github.com/PrefectHQ/prefect.git", reference="github-deployments")
g.save("example")
```
and then we proceed to create a corresponding deployment from the CLI for one of our test flows:
```bash
prefect deployment build ./implicit_relative.py:foobar \
 -n "GitHub Example" \
 -sb github/example \
 --path tests/test-projects/nested-project \
 --apply

prefect deployment run 'foobar/GitHub Example'

# this next command can be run from within *any* directory
prefect agent start -q default
...
17:53:46.052 | INFO    | Flow run 'intrepid-newt' - Finished in state Completed()
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
