### PR TITLE
Update RemoteFileSystem.put_directory to correctly handle `local_path` and to have better cross-OS support.

### DIFF
--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 import prefect
 from prefect.filesystems import GitHub, LocalFileSystem, RemoteFileSystem
 from prefect.testing.utilities import AsyncMock
+
+TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
 
 
 class TestLocalFileSystem:
@@ -89,6 +92,39 @@ class TestRemoteFileSystem:
         assert fs._resolve_path(base) == base + "/"
         assert fs._resolve_path(f"{base}/subdir") == f"{base}/subdir"
         assert fs._resolve_path("subdirectory") == f"{base}/subdirectory"
+
+    async def test_put_directory_flat(self):
+        fs = RemoteFileSystem(basepath="memory://flat")
+        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "flat-project"))
+        copied_files = set(fs.filesystem.glob("/flat/**"))
+        assert copied_files == {
+            "/flat/__pycache__",
+            "/flat/__pycache__/explicit_relative.cpython-39.pyc",
+            "/flat/__pycache__/implicit_relative.cpython-39.pyc",
+            "/flat/__pycache__/shared_libs.cpython-39.pyc",
+            "/flat/explicit_relative.py",
+            "/flat/implicit_relative.py",
+            "/flat/shared_libs.py",
+        }
+
+    async def test_put_directory_tree(self):
+        fs = RemoteFileSystem(basepath="memory://tree")
+        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "tree-project"))
+        copied_files = set(fs.filesystem.glob("/tree/**"))
+        assert copied_files == {
+            "/tree/imports",
+            "/tree/imports/__pycache__",
+            "/tree/imports/__pycache__/explicit_relative.cpython-39.pyc",
+            "/tree/imports/__pycache__/implicit_relative.cpython-39.pyc",
+            "/tree/imports/explicit_relative.py",
+            "/tree/imports/implicit_relative.py",
+            "/tree/shared_libs",
+            "/tree/shared_libs/__pycache__",
+            "/tree/shared_libs/__pycache__/bar.cpython-39.pyc",
+            "/tree/shared_libs/__pycache__/foo.cpython-39.pyc",
+            "/tree/shared_libs/bar.py",
+            "/tree/shared_libs/foo.py",
+        }
 
 
 class TestGitHub:


### PR DESCRIPTION
This makes a couple adjustments to `RemoteFileSystem.put_directory`:

- Updates `put_directory` to use `local_path` when generating the list of files to copy.
- Updates the way the remote file name is created to use `os.path.join` for better cross-OS support.

### Example
This example will create a memory-based RemoteFileSystem, copy in files from a path and then use `fsspec` to list the stored files.

```
import anyio
import functools
import sys

from prefect.filesystems import RemoteFileSystem


if __name__ == "__main__":
    fs = RemoteFileSystem(basepath="memory://root")
    partial = functools.partial(fs.put_directory, sys.argv[1])
    anyio.run(partial)
    print(fs.filesystem.glob("/root/**"))
```

Closes #6603 
Closes #6580 
Closes #6276

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.