### PR TITLE
Ensure RemoteFileSystem.put_directory handles local_path and windows file structure

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,8 @@
 - Add the ability to specify relative sub-paths when working with remote storage for deployments — [#6518](https://github.com/PrefectHQ/prefect/pull/6518)
 - Prevent non-UUID slugs from raising errors on `/block_document` endpoints — [#6541](https://github.com/PrefectHQ/prefect/pull/6541)
 - Improve Docker image tag parsing to support the full Moby specification — [#6564](https://github.com/PrefectHQ/prefect/pull/6564)
+- Fix path issues with RemoteFileSystem and Windows — [#6620](https://github.com/PrefectHQ/prefect/pull/6620)
+- Fix a bug where `RemoteFileSystem.put_directory` did not respect `local_path` — [#6620](https://github.com/PrefectHQ/prefect/pull/6620)
 
 ### Fixes
 

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -320,14 +320,16 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
             with open(ignore_file, "r") as f:
                 ignore_patterns = f.readlines()
 
-            included_files = filter_files(local_path, ignore_patterns)
+            included_files = filter_files(
+                local_path, ignore_patterns, include_dirs=True
+            )
 
         counter = 0
         for f in glob.glob(os.path.join(local_path, "**"), recursive=True):
-            if ignore_file and f not in included_files:
+            relative_path = PurePath(f).relative_to(local_path).as_posix()
+            if included_files and relative_path not in included_files:
                 continue
 
-            relative_path = PurePath(f).relative_to(local_path).as_posix()
             if to_path.endswith("/"):
                 fpath = to_path + relative_path
             else:

--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -28,7 +28,7 @@ def set_default_ignore_file(path: str) -> bool:
 
 def filter_files(
     root: str = ".", ignore_patterns: list = None, include_dirs: bool = True
-) -> list:
+) -> set:
     """
     This function accepts a root directory path and a list of file patterns to ignore, and returns
     a list of files that excludes those that should be ignored.

--- a/tests/test-projects/flat-project/.prefectignore
+++ b/tests/test-projects/flat-project/.prefectignore
@@ -1,0 +1,2 @@
+.prefectignore
+__pycache__

--- a/tests/test-projects/tree-project/.prefectignore
+++ b/tests/test-projects/tree-project/.prefectignore
@@ -1,0 +1,2 @@
+.prefectignore
+__pycache__/

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -95,13 +95,15 @@ class TestRemoteFileSystem:
 
     async def test_put_directory_flat(self):
         fs = RemoteFileSystem(basepath="memory://flat")
-        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "flat-project"))
+        await fs.put_directory(
+            os.path.join(TEST_PROJECTS_DIR, "flat-project"),
+            ignore_file=os.path.join(
+                TEST_PROJECTS_DIR, "flat-project", ".prefectignore"
+            ),
+        )
         copied_files = set(fs.filesystem.glob("/flat/**"))
+
         assert copied_files == {
-            "/flat/__pycache__",
-            "/flat/__pycache__/explicit_relative.cpython-39.pyc",
-            "/flat/__pycache__/implicit_relative.cpython-39.pyc",
-            "/flat/__pycache__/shared_libs.cpython-39.pyc",
             "/flat/explicit_relative.py",
             "/flat/implicit_relative.py",
             "/flat/shared_libs.py",
@@ -109,19 +111,19 @@ class TestRemoteFileSystem:
 
     async def test_put_directory_tree(self):
         fs = RemoteFileSystem(basepath="memory://tree")
-        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "tree-project"))
+        await fs.put_directory(
+            os.path.join(TEST_PROJECTS_DIR, "tree-project"),
+            ignore_file=os.path.join(
+                TEST_PROJECTS_DIR, "tree-project", ".prefectignore"
+            ),
+        )
         copied_files = set(fs.filesystem.glob("/tree/**"))
+
         assert copied_files == {
             "/tree/imports",
-            "/tree/imports/__pycache__",
-            "/tree/imports/__pycache__/explicit_relative.cpython-39.pyc",
-            "/tree/imports/__pycache__/implicit_relative.cpython-39.pyc",
             "/tree/imports/explicit_relative.py",
             "/tree/imports/implicit_relative.py",
             "/tree/shared_libs",
-            "/tree/shared_libs/__pycache__",
-            "/tree/shared_libs/__pycache__/bar.cpython-39.pyc",
-            "/tree/shared_libs/__pycache__/foo.cpython-39.pyc",
             "/tree/shared_libs/bar.py",
             "/tree/shared_libs/foo.py",
         }

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 import prefect
 from prefect.filesystems import GitHub, LocalFileSystem, RemoteFileSystem
 from prefect.testing.utilities import AsyncMock
+
+TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
 
 
 class TestLocalFileSystem:
@@ -89,6 +92,39 @@ class TestRemoteFileSystem:
         assert fs._resolve_path(base) == base + "/"
         assert fs._resolve_path(f"{base}/subdir") == f"{base}/subdir"
         assert fs._resolve_path("subdirectory") == f"{base}/subdirectory"
+
+    async def test_put_directory_flat(self):
+        fs = RemoteFileSystem(basepath="memory://flat")
+        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "flat-project"))
+        copied_files = set(fs.filesystem.glob("/flat/**"))
+        assert copied_files == {
+            "/flat/__pycache__",
+            "/flat/__pycache__/explicit_relative.cpython-39.pyc",
+            "/flat/__pycache__/implicit_relative.cpython-39.pyc",
+            "/flat/__pycache__/shared_libs.cpython-39.pyc",
+            "/flat/explicit_relative.py",
+            "/flat/implicit_relative.py",
+            "/flat/shared_libs.py",
+        }
+
+    async def test_put_directory_tree(self):
+        fs = RemoteFileSystem(basepath="memory://tree")
+        await fs.put_directory(os.path.join(TEST_PROJECTS_DIR, "tree-project"))
+        copied_files = set(fs.filesystem.glob("/tree/**"))
+        assert copied_files == {
+            "/tree/imports",
+            "/tree/imports/__pycache__",
+            "/tree/imports/__pycache__/explicit_relative.cpython-39.pyc",
+            "/tree/imports/__pycache__/implicit_relative.cpython-39.pyc",
+            "/tree/imports/explicit_relative.py",
+            "/tree/imports/implicit_relative.py",
+            "/tree/shared_libs",
+            "/tree/shared_libs/__pycache__",
+            "/tree/shared_libs/__pycache__/bar.cpython-39.pyc",
+            "/tree/shared_libs/__pycache__/foo.cpython-39.pyc",
+            "/tree/shared_libs/bar.py",
+            "/tree/shared_libs/foo.py",
+        }
 
 
 class TestGitHub:


### PR DESCRIPTION
This makes a couple adjustments to `RemoteFileSystem.put_directory`:

- Updates `put_directory` to use `local_path` when generating the list of files to copy.
- Updates the way the remote file name is created to use `pathlib` for better cross-OS support.

### Example
This example will create a memory-based RemoteFileSystem, copy in files from a path and then use `fsspec` to list the stored files.

```python
import anyio
import functools
import sys

from prefect.filesystems import RemoteFileSystem


if __name__ == "__main__":
    fs = RemoteFileSystem(basepath="memory://root")
    partial = functools.partial(fs.put_directory, sys.argv[1])
    anyio.run(partial)
    print(fs.filesystem.glob("/root/**"))
```

I tested this both on the Mac and in Windows via Parallels.

Closes #6603 
Closes #6580 
Closes #6276

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.