### PR TITLE
Update blocks to dispatch instance creation using slugs

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -174,6 +174,13 @@ class Block(BaseModel, ABC):
     def __str__(self) -> str:
         return self.__repr__()
 
+    def __repr_args__(self):
+        repr_args = super().__repr_args__()
+        data_keys = self.schema()["properties"].keys()
+        return [
+            (key, value) for key, value in repr_args if key is None or key in data_keys
+        ]
+
     def block_initialization(self) -> None:
         pass
 

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -185,7 +185,6 @@ class TestAPICompatibility:
             "x": "**********",
             "y": "**********",
             "z": "z",
-            "block_type_slug": SecretBlock.get_block_type_slug(),
         }
 
         json_blockdoc_with_secrets = json.loads(blockdoc.json(include_secrets=True))
@@ -193,7 +192,6 @@ class TestAPICompatibility:
             "x": "x",
             "y": "y",
             "z": "z",
-            "block_type_slug": SecretBlock.get_block_type_slug(),
         }
 
     def test_create_nested_api_block_with_secret_values_are_obfuscated_by_default(self):
@@ -219,24 +217,20 @@ class TestAPICompatibility:
         assert json_blockdoc["data"] == {
             "a": "**********",
             "b": "b",
+            # The child includes the type slug because it is not a block document
             "child": {
                 "a": "**********",
                 "b": "b",
-                "block_type_slug": Child.get_block_type_slug(),
+                "block_type_slug": "child",
             },
-            "block_type_slug": Parent.get_block_type_slug(),
         }
 
         json_blockdoc_with_secrets = json.loads(blockdoc.json(include_secrets=True))
         assert json_blockdoc_with_secrets["data"] == {
             "a": "a",
             "b": "b",
-            "child": {
-                "a": "a",
-                "b": "b",
-                "block_type_slug": Child.get_block_type_slug(),
-            },
-            "block_type_slug": Parent.get_block_type_slug(),
+            # The child includes the type slug because it is not a block document
+            "child": {"a": "a", "b": "b", "block_type_slug": "child"},
         }
 
     def test_registering_blocks_with_capabilities(self):

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1749,8 +1749,9 @@ class TestTypeDispatch:
     def test_block_type_slug_respects_include(self):
         assert "block_type_slug" not in AChildBlock().dict(include={"a"})
 
-    def test_block_type_slug_excluded_from_document(self):
-        document = AChildBlock()._to_block_document()
+    async def test_block_type_slug_excluded_from_document(self, orion_client):
+        await AChildBlock.register_type_and_schema(client=orion_client)
+        document = AChildBlock()._to_block_document(name="foo")
         assert "block_type_slug" not in document.data
 
     def test_base_parse_works_for_base_instance(self):

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1810,3 +1810,10 @@ class TestTypeDispatch:
     async def test_created_block_can_be_saved(self):
         block = BaseBlock.parse_obj(AChildBlock().dict())
         assert await block.save("test")
+
+    async def test_created_block_can_be_saved_then_loaded(self):
+        block = BaseBlock.parse_obj(AChildBlock().dict())
+        await block.save("test")
+        new_block = await block.load("test")
+        assert block == new_block
+        assert new_block.__fields_set__

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1797,3 +1797,16 @@ class TestTypeDispatch:
 
         model = ParentModel(block=BChildBlock().dict())
         assert type(model.block) == BChildBlock
+
+    def test_created_block_has_pydantic_attributes(self):
+        block = BaseBlock.parse_obj(AChildBlock().dict())
+        assert block.__fields_set__
+
+    def test_created_block_can_be_copied(self):
+        block = BaseBlock.parse_obj(AChildBlock().dict())
+        block_copy = block.copy()
+        assert block == block_copy
+
+    async def test_created_block_can_be_saved(self):
+        block = BaseBlock.parse_obj(AChildBlock().dict())
+        assert await block.save("test")

--- a/tests/infrastructure/test_submission.py
+++ b/tests/infrastructure/test_submission.py
@@ -51,7 +51,7 @@ class MockInfrastructure(Infrastructure):
     async def run(self, task_status=None):
         if task_status:
             task_status.started()
-        self._run(self.dict())
+        self._run(self.dict(exclude={"block_type_slug"}))
 
     def preview(self):
         return self.json()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This pull request allows model fields to be defined as generic or base block types which means that a model can consume a block without enumerating all known types. This is essential for allowing models to be configured with blocks that are defined outside the core library.

For example, this should allow us to change the `Deployment.infrastructure` field to be `Infrastructure` instead of `Union[Process, DockerContainer, KubernetesJob]`.

This is implemented by adding `block_type_slug` to the `dict()` and `json()` outputs of a block. This field is not included in the block document. During class instantiation, a hook in `__new__` will determine if the block type slug is present and look up a type in the registry. If the block type slug is not present, `__new__` is called normally. This follows the pattern established in `prefect.utilities.pydantic.add_type_dispatch` with custom handling for blocks.

To ensure this new data is hidden from users unless working with raw data, the Block's Pydantic `__repr_args__` is updated to only display data keys. This may also hide private attributes from the repr.

Note this pull request does not allow block model fields to be defined as an abstract block type. The API does not know how to handle abstract block types yet as their schemas are not registered. We will need to solve that separately before this is useful more broadly. This basically means if the type defining the field is a `Block` instead of another type of `BaseModel` the type defining the field will not be able to be registered. This was noted in #6478 and is blocking https://github.com/PrefectHQ/prefect-aws/pull/68.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Given the following types

```python
from prefect.blocks.core import Block
from pydantic import BaseModel

class BaseBlock(Block):
    base: int = 0

class AChildBlock(BaseBlock):
    a: int = 1

    def hi(self):
       print("hi", self.a)

class BChildBlock(BaseBlock):
    b: int = 2

    def hi(self):
       print("hi", self.b)

class ParentModel(BaseModel):
    block: BaseBlock
```

If you instantiated the `ParentModel` with a child type's data e.g.

```python
model = ParentModel(block=AChildBlock().dict())
```

The model would load it as the base block type

```python
type(model.block)  # BaseBlock
```

Data from the child block may be silently dropped, throw an error, or included depending on the base's config. If you attempt to call a method that should be implement on the child, it will fail

```python
model.block.hi()  # Attribute error (or with abstract bases, a not implemented error)
```

With the changes here, `.dict()` on a `Block` type will now include the `block_type_slug` string. When a new instance of a `Block` is created, we will check for the slug and look up the block type implementation in our type registry:

```python
data = AChildBlock().dict()  # {'base': 0, 'a': 1, 'block_type_slug': 'achildblock'}
model = ParentModel(block=data)
model.block  # AChildBlock(base=0, a=1)
model.hi()  # hi 1
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `bug`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
