### PR TITLE
Swap order of "current" and "proposed" behavior in enhancement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
@@ -28,15 +28,15 @@ body:
 
   - type: textarea
     attributes:
-      label: Describe the proposed behavior
-      description: A clear and concise description of what new feature or behavior you would like to see
-    validations:
-      required: true
-
-  - type: textarea
-    attributes:
       label: Describe the current behavior
       description: A clear and concise description of what Prefect currently does
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
+      label: Describe the proposed behavior
+      description: A clear and concise description of what new feature or behavior you would like to see
     validations:
       required: true
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Every time I open an enhancement request I want to explain how things currently work and what's wrong with that before proposing a solution. If users do not have a clear story of the current behavior, a feature request does not make much sense. Currently, our issue template prompts for your proposed change _then_ prompts for current behavior. This pull request swaps the order of these fields. This should make issues easier to read and write.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
