### PR TITLE
Allow the DB interface class to be modified

### DIFF
--- a/src/prefect/orion/database/dependencies.py
+++ b/src/prefect/orion/database/dependencies.py
@@ -29,6 +29,7 @@ MODELS_DEPENDENCIES = {
     "database_config": None,
     "query_components": None,
     "orm": None,
+    "interface_class": None,
 }
 
 
@@ -44,6 +45,7 @@ def provide_database_interface() -> OrionDBInterface:
     database_config = MODELS_DEPENDENCIES.get("database_config")
     query_components = MODELS_DEPENDENCIES.get("query_components")
     orm = MODELS_DEPENDENCIES.get("orm")
+    interface_class = MODELS_DEPENDENCIES.get("interface_class")
     dialect = get_dialect(connection_url)
 
     if database_config is None:
@@ -83,7 +85,10 @@ def provide_database_interface() -> OrionDBInterface:
 
         MODELS_DEPENDENCIES["orm"] = orm
 
-    return OrionDBInterface(
+    if interface_class is None:
+        interface_class = OrionDBInterface
+
+    return interface_class(
         database_config=database_config,
         query_components=query_components,
         orm=orm,
@@ -179,10 +184,29 @@ def temporary_orm_config(tmp_orm_config: BaseORMConfiguration):
 
 
 @contextmanager
+def temporary_interface_class(tmp_interface_class: BaseORMConfiguration):
+    """
+    Temporarily override the Orion interface class When the context is closed,
+    the existing interface will be restored.
+
+    Args:
+        tmp_interface_class: Orion interface class to inject.
+
+    """
+    starting_interface_class = MODELS_DEPENDENCIES["interface_class"]
+    try:
+        MODELS_DEPENDENCIES["interface_class"] = tmp_interface_class
+        yield
+    finally:
+        MODELS_DEPENDENCIES["interface_class"] = starting_interface_class
+
+
+@contextmanager
 def temporary_database_interface(
     tmp_database_config: BaseDatabaseConfiguration = None,
     tmp_queries: BaseQueryComponents = None,
     tmp_orm_config: BaseORMConfiguration = None,
+    tmp_interface_class: type = None,
 ):
     """
     Temporarily override the Orion database interface.
@@ -198,6 +222,7 @@ def temporary_database_interface(
         tmp_database_config: An optional Orion database configuration to inject.
         tmp_orm_config: An optional Orion ORM configuration to inject.
         tmp_queries: Optional Orion query components to inject.
+        tmp_interface_class: Optional OrionDB interface class to inject
 
     """
     with ExitStack() as stack:
@@ -206,6 +231,9 @@ def temporary_database_interface(
         )
         stack.enter_context(temporary_query_components(tmp_queries=tmp_queries))
         stack.enter_context(temporary_orm_config(tmp_orm_config=tmp_orm_config))
+        stack.enter_context(
+            temporary_interface_class(tmp_interface_class=tmp_interface_class)
+        )
         yield
 
 
@@ -222,3 +250,8 @@ def set_query_components(query_components: BaseQueryComponents):
 def set_orm_config(orm_config: BaseORMConfiguration):
     """Set Orion orm configuration."""
     MODELS_DEPENDENCIES["orm"] = orm_config
+
+
+def set_interface_class(interface_class: type):
+    """Set Orion interface class."""
+    MODELS_DEPENDENCIES["interface_class"] = interface_class

--- a/src/prefect/orion/database/interface.py
+++ b/src/prefect/orion/database/interface.py
@@ -16,6 +16,7 @@ class DBSingleton(type):
 
     def __call__(cls, *args, **kwargs):
         unique_key = (
+            cls.__name__,
             kwargs["database_config"]._unique_key(),
             kwargs["query_components"]._unique_key(),
             kwargs["orm"]._unique_key(),

--- a/tests/orion/database/test_dependencies.py
+++ b/tests/orion/database/test_dependencies.py
@@ -11,6 +11,7 @@ from prefect.orion.database.configurations import (
     BaseDatabaseConfiguration,
 )
 from prefect.orion.database.dependencies import inject_db
+from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.database.orm_models import (
     AioSqliteORMConfiguration,
     AsyncPostgresORMConfiguration,
@@ -180,3 +181,14 @@ async def test_inject_db(db):
             return 1
 
     assert inspect.iscoroutinefunction(Returner().return_1)
+
+
+async def test_inject_interface_class():
+    class TestInterface(OrionDBInterface):
+        @property
+        def new_property(self):
+            return 42
+
+    with dependencies.temporary_interface_class(TestInterface):
+        db = dependencies.provide_database_interface()
+        assert isinstance(db, TestInterface)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Currently, the database permits dependency injection in a variety of ways -- the ORM config, customizable queries, and the database's own configuration. One thing that can't be changed is the parent interface itself, which is always an `OrionDBInterface`.  

The `OrionDBInterface` re-exposes many of its component attributes as properties or methods, which provides convenient access (e.g. `db.json_arr_agg` instead of `db.queries.json_arr_agg`, a more difficult-to-discover access point. However, this means that if dependency injection is used to add a new query, it can not be accessed in the same way. By allowing the `OrionDBInterface` class itself to be injected, developers adding new queries and properties specific to their use case can  modify the parent interface as well.


<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
