### PR TITLE
Refactor block documents queries for speed ⚡️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ profile_default/
 ipython_config.py
 *.ipynb_checkpoints/*
 
+# Profiling
+/prof
+
 # Environments
 .python-version
 .env

--- a/src/prefect/orion/api/block_documents.py
+++ b/src/prefect/orion/api/block_documents.py
@@ -43,6 +43,7 @@ async def create_block_document(
 async def read_block_documents(
     limit: int = dependencies.LimitBody(),
     block_documents: Optional[schemas.filters.BlockDocumentFilter] = None,
+    block_types: Optional[schemas.filters.BlockTypeFilter] = None,
     block_schemas: Optional[schemas.filters.BlockSchemaFilter] = None,
     include_secrets: bool = Body(
         False, description="Whether to include sensitive values in the block document."
@@ -56,6 +57,7 @@ async def read_block_documents(
     result = await models.block_documents.read_block_documents(
         session=session,
         block_document_filter=block_documents,
+        block_type_filter=block_types,
         block_schema_filter=block_schemas,
         include_secrets=include_secrets,
         offset=offset,

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,11 +207,6 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
-            # use `named` paramstyle because of edge cases where `qmark`
-            # results in params being sent in the wrong positional order
-            # https://github.com/PrefectHQ/prefect/pull/6645
-            kwargs["paramstyle"] = "named"
-
             # ensure a long-lasting pool is used with in-memory databases
             # because they disappear when the last connection closes
             if ":memory:" in self.connection_url:

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,6 +207,11 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
+            # use `named` paramstyle because of edge cases where `qmark`
+            # results in params being sent in the wrong positional order
+            # https://github.com/PrefectHQ/prefect/pull/6645
+            kwargs["paramstyle"] = "named"
+
             # ensure a long-lasting pool is used with in-memory databases
             # because they disappear when the last connection closes
             if ":memory:" in self.connection_url:

--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -1,6 +1,6 @@
 import datetime
 from abc import ABC, abstractmethod, abstractproperty
-from typing import TYPE_CHECKING, Hashable, List, Tuple
+from typing import TYPE_CHECKING, Hashable, List, Optional, Tuple
 
 import pendulum
 import sqlalchemy as sa
@@ -126,6 +126,134 @@ class BaseQueryComponents(ABC):
             include_defaults=False,
         )
         await session.execute(stmt)
+
+    async def read_block_documents(
+        self,
+        session: sa.orm.Session,
+        db: "OrionDBInterface",
+        block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
+        block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
+        block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
+        include_secrets: bool = False,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+    ):
+
+        # if no filter is provided, one is created that excludes anonymous blocks
+        if block_document_filter is None:
+            block_document_filter = schemas.filters.BlockDocumentFilter(
+                is_anonymous=schemas.filters.BlockDocumentFilterIsAnonymous(eq_=False)
+            )
+
+        # --- Query for Parent Block Documents
+        # begin by building a query for only those block documents that are selected
+        # by the provided filters
+        filtered_block_documents_query = sa.select(db.BlockDocument.id).where(
+            block_document_filter.as_sql_filter(db)
+        )
+
+        if block_type_filter is not None:
+            block_type_exists_clause = sa.select(db.BlockType).where(
+                db.BlockType.id == db.BlockDocument.block_type_id,
+                block_type_filter.as_sql_filter(db),
+            )
+            filtered_block_documents_query = filtered_block_documents_query.where(
+                block_type_exists_clause.exists()
+            )
+
+        if block_schema_filter is not None:
+            block_schema_exists_clause = sa.select(db.BlockSchema).where(
+                db.BlockSchema.id == db.BlockDocument.block_schema_id,
+                block_schema_filter.as_sql_filter(db),
+            )
+            filtered_block_documents_query = filtered_block_documents_query.where(
+                block_schema_exists_clause.exists()
+            )
+
+        if offset is not None:
+            filtered_block_documents_query = filtered_block_documents_query.offset(
+                offset
+            )
+
+        if limit is not None:
+            filtered_block_documents_query = filtered_block_documents_query.limit(limit)
+
+        # apply database-specific handling of the filtered parent block documents
+        filtered_block_document_ids = await self._handle_filtered_block_document_ids(
+            session=session,
+            filtered_block_documents_query=filtered_block_documents_query,
+        )
+
+        # --- Query for Referenced Block Documents
+        # next build a recursive query for (potentially nested) block documents
+        # that reference the filtered block documents
+        block_document_references_query = (
+            sa.select(db.BlockDocumentReference)
+            .filter(
+                db.BlockDocumentReference.parent_block_document_id.in_(
+                    filtered_block_document_ids
+                )
+            )
+            .cte("block_document_references", recursive=True)
+        )
+        block_document_references_join = sa.select(db.BlockDocumentReference).join(
+            block_document_references_query,
+            db.BlockDocumentReference.parent_block_document_id
+            == block_document_references_query.c.reference_block_document_id,
+        )
+        recursive_block_document_references_cte = (
+            block_document_references_query.union_all(block_document_references_join)
+        )
+
+        # --- Final Query for All Block Documents
+        # build a query that unions:
+        # - the filtered block documents
+        # - with any block documents that are discovered as (potentially nested) references
+        all_block_documents_query = sa.union_all(
+            # first select the parent block
+            sa.select(
+                [
+                    db.BlockDocument,
+                    sa.null().label("reference_name"),
+                    sa.null().label("reference_parent_block_document_id"),
+                ]
+            )
+            .select_from(db.BlockDocument)
+            .where(db.BlockDocument.id.in_(filtered_block_document_ids)),
+            #
+            # then select any referenced blocks
+            sa.select(
+                [
+                    db.BlockDocument,
+                    recursive_block_document_references_cte.c.name,
+                    recursive_block_document_references_cte.c.parent_block_document_id,
+                ]
+            )
+            .select_from(db.BlockDocument)
+            .join(
+                recursive_block_document_references_cte,
+                db.BlockDocument.id
+                == recursive_block_document_references_cte.c.reference_block_document_id,
+            ),
+        ).cte("all_block_documents_query")
+
+        # the final union query needs to be `aliased` for proper ORM unpacking
+        # and also be sorted
+        return (
+            sa.select(
+                sa.orm.aliased(db.BlockDocument, all_block_documents_query),
+                all_block_documents_query.c.reference_name,
+                all_block_documents_query.c.reference_parent_block_document_id,
+            )
+            .select_from(all_block_documents_query)
+            .order_by(all_block_documents_query.c.name)
+        )
+
+    async def _handle_filtered_block_document_ids(
+        self, session, filtered_block_documents_query
+    ):
+        """Apply database-specific processing to a filtered block document query"""
+        return filtered_block_documents_query
 
 
 class AsyncPostgresQueryComponents(BaseQueryComponents):
@@ -265,6 +393,15 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
 
         result = await session.execute(notification_details_stmt)
         return result.fetchall()
+
+    async def _handle_filtered_block_document_ids(
+        self, session, filtered_block_documents_query
+    ):
+        """
+        Transform the filtered block document query into a CTE and select its `id`
+        """
+        filtered_cte = filtered_block_documents_query.cte("filtered_block_documents")
+        return sa.select(filtered_cte.c.id)
 
 
 class AioSqliteQueryComponents(BaseQueryComponents):
@@ -437,3 +574,17 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         await session.execute(delete_stmt)
 
         return notifications
+
+    async def _handle_filtered_block_document_ids(
+        self, session, filtered_block_documents_query
+    ):
+        """
+        On SQLite, including the filtered block document parameters confuses the
+        compiler and it passes positional parameters in the wrong order (it is
+        unclear why; SQLalchemy manual compilation works great. Switching to
+        `named` paramstyle also works but fails elsewhere in the codebase). To
+        resolve this, we materialize the filtered id query into a literal set of
+        IDs rather than leaving it as a SQL select.
+        """
+        result = await session.execute(filtered_block_documents_query)
+        return result.scalars().all()

--- a/src/prefect/orion/models/block_documents.py
+++ b/src/prefect/orion/models/block_documents.py
@@ -367,7 +367,7 @@ async def read_block_documents(
         (await session.execute(all_block_documents_query)).unique().all()
     )
 
-    # find the "parent" block documents, which will have `None` in their last two columsn
+    # find the "parent" block documents, which will have `None` in their last two columns
     parent_block_document_ids = [
         b[0].id
         for b in block_documents_with_references

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -952,6 +952,19 @@ class BlockTypeFilterName(PrefectFilterBaseModel):
         return filters
 
 
+class BlockTypeFilterSlug(PrefectFilterBaseModel):
+    """Filter by `BlockType.slug`"""
+
+    any_: List[str] = Field(None, description=("A list of slugs to match"))
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.BlockType.slug.in_(self.any_))
+
+        return filters
+
+
 class BlockTypeFilter(PrefectFilterBaseModel):
     """Filter BlockTypes"""
 
@@ -959,11 +972,17 @@ class BlockTypeFilter(PrefectFilterBaseModel):
         None, description="Filter criteria for `BlockType.name`"
     )
 
+    slug: Optional[BlockTypeFilterSlug] = Field(
+        None, description="Filter criteria for `BlockType.slug`"
+    )
+
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
 
         if self.name is not None:
             filters.append(self.name.as_sql_filter(db))
+        if self.slug is not None:
+            filters.append(self.slug.as_sql_filter(db))
 
         return filters
 
@@ -1087,9 +1106,36 @@ class BlockDocumentFilterBlockTypeId(PrefectFilterBaseModel):
         return filters
 
 
+class BlockDocumentFilterId(PrefectFilterBaseModel):
+    """Filter by `BlockDocument.id`."""
+
+    any_: List[UUID] = Field(None, description="A list of block ids to include")
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.BlockDocument.id.in_(self.any_))
+        return filters
+
+
+class BlockDocumentFilterName(PrefectFilterBaseModel):
+    """Filter by `BlockDocument.name`."""
+
+    any_: List[str] = Field(None, description="A list of block names to include")
+
+    def _get_filter_list(self, db: "OrionDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.BlockDocument.name.in_(self.any_))
+        return filters
+
+
 class BlockDocumentFilter(PrefectOperatorFilterBaseModel):
     """Filter BlockDocuments. Only BlockDocuments matching all criteria will be returned"""
 
+    id: Optional[BlockDocumentFilterId] = Field(
+        None, description="Filter criteria for `BlockDocument.id`"
+    )
     is_anonymous: Optional[BlockDocumentFilterIsAnonymous] = Field(
         # default is to exclude anonymous blocks
         BlockDocumentFilterIsAnonymous(eq_=False),
@@ -1101,14 +1147,20 @@ class BlockDocumentFilter(PrefectOperatorFilterBaseModel):
     block_type_id: Optional[BlockDocumentFilterBlockTypeId] = Field(
         None, description="Filter criteria for `BlockDocument.block_type_id`"
     )
+    name: Optional[BlockDocumentFilterName] = Field(
+        None, description="Filter criteria for `BlockDocument.name`"
+    )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
+        if self.id is not None:
+            filters.append(self.id.as_sql_filter(db))
         if self.is_anonymous is not None:
             filters.append(self.is_anonymous.as_sql_filter(db))
         if self.block_type_id is not None:
             filters.append(self.block_type_id.as_sql_filter(db))
-
+        if self.name is not None:
+            filters.append(self.name.as_sql_filter(db))
         return filters
 
 

--- a/tests/orion/api/test_block_documents.py
+++ b/tests/orion/api/test_block_documents.py
@@ -578,6 +578,18 @@ class TestReadBlockDocuments:
             block_documents[4].id,
         ]
 
+    async def test_read_block_documents_filter_multiple(self, client, block_documents):
+        response = await client.post(
+            "/block_documents/filter",
+            json=dict(
+                block_types=dict(slug=dict(any_=["a", "b"])),
+                block_schemas=dict(block_capabilities=dict(all_=["fly"])),
+            ),
+        )
+        assert response.status_code == 200
+        docs = pydantic.parse_obj_as(List[schemas.core.BlockDocument], response.json())
+        assert [b.id for b in docs] == [block_documents[2].id, block_documents[4].id]
+
 
 class TestDeleteBlockDocument:
     async def test_delete_block(self, session, client, block_schemas):

--- a/tests/orion/api/test_block_documents.py
+++ b/tests/orion/api/test_block_documents.py
@@ -562,6 +562,22 @@ class TestReadBlockDocuments:
         assert len(swim_block_documents) == 1
         assert swim_block_documents[0].id == block_documents[6].id
 
+    async def test_read_block_documents_filter_types(self, client, block_documents):
+        response = await client.post(
+            "/block_documents/filter",
+            json=dict(block_types=dict(slug=dict(any_=["a", "b"]))),
+        )
+        assert response.status_code == 200
+        docs = pydantic.parse_obj_as(List[schemas.core.BlockDocument], response.json())
+        assert len(docs) == 3
+        assert len([d for d in docs if d.block_type.slug == "a"]) == 1
+        assert len([d for d in docs if d.block_type.slug == "b"]) == 2
+        assert [b.id for b in docs] == [
+            block_documents[1].id,
+            block_documents[2].id,
+            block_documents[4].id,
+        ]
+
 
 class TestDeleteBlockDocument:
     async def test_delete_block(self, session, client, block_schemas):

--- a/tests/orion/api/test_block_documents.py
+++ b/tests/orion/api/test_block_documents.py
@@ -429,7 +429,7 @@ class TestReadBlockDocuments:
         read_block_documents = pydantic.parse_obj_as(
             List[schemas.core.BlockDocument], response.json()
         )
-        # sorted by block type name, block document name
+        # sorted by block document name
         # anonymous blocks excluded by default
         assert [b.id for b in read_block_documents] == [
             b.id for b in block_documents if not b.is_anonymous
@@ -471,7 +471,7 @@ class TestReadBlockDocuments:
         read_block_documents = pydantic.parse_obj_as(
             List[schemas.core.BlockDocument], response.json()
         )
-        # sorted by block type name, block document name
+        # sorted by block document name
         assert [b.id for b in read_block_documents] == [
             b.id for b in block_documents if b.is_anonymous is is_anonymous
         ]
@@ -494,11 +494,11 @@ class TestReadBlockDocuments:
         read_block_documents = pydantic.parse_obj_as(
             List[schemas.core.BlockDocument], response.json()
         )
-        # sorted by block type name, block document name
+        # sorted by block document name
         assert [b.id for b in read_block_documents] == [b.id for b in block_documents]
 
     async def test_read_block_documents_limit_offset(self, client, block_documents):
-        # sorted by block type name, block document name
+        # sorted by block document name
         response = await client.post("/block_documents/filter", json=dict(limit=2))
         read_block_documents = pydantic.parse_obj_as(
             List[schemas.core.BlockDocument], response.json()

--- a/tests/orion/models/test_block_documents.py
+++ b/tests/orion/models/test_block_documents.py
@@ -809,7 +809,7 @@ class TestReadBlockDocuments:
             b.id for b in block_documents if not b.is_anonymous
         }
 
-        # sorted by block type name, block document name
+        # sorted by block document name
         assert [rb.id for rb in read_blocks] == [
             b.id for b in block_documents if not b.is_anonymous
         ]


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/nebula/issues/1492

@zangell44 noticed that block document queries are starting to take longer and longer in Prefect Cloud, even when querying for a nonexistent block document ID (see attached issue for detail, internal repo so re-summarizing here). Query complexity exploded into the hundreds of thousands, the culprit being an odd `seq scan` of the block document table, even though a block document ID was being provided.

When we looked closely, we identified that the blame lies with [this join condition](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/orion/models/block_documents.py#L148-L153):
```python
            sa.or_(
                db.BlockDocument.id == block_document_id,
                recursive_block_document_references_cte.c.parent_block_document_id.is_not(
                    None
                ),
            )
```
(note: this shows up as a where clause but is implicitly the join condition of an outer join specified immediately before)

The reason this is problematic is not the predicates, but the `OR`. In fact, both predicates should actually be instantaneous. However, many query planners opt for seq scans when evaluating `OR` conditions over multiple tables, and Postgres is no exception. This is why it was doing a seq scan even when a single, nonexistent ID was provided. 

In cases like this one, this resolution is straightforward: replace the `OR` condition with a `UNION` (or in our case, a `UNION ALL`). This lets the query planner take advantage of indexed lookups for each predicate, then trivially stitch the result together.

This change appears to work well and bring query times from hundreds of milliseconds down to the expected fraction of a millisecond. However, in implementing it I noticed that we form this query three different places: `read_block_document_by_id`, `read_block_document_by_name`, and `read_block_documents`. Therefore, I took the opportunity to refactor this code in the following ways:
- `read_block_document_by_id` and `read_block_document_by_name` are now just passthroughs to `read_block_documents`
- `read_block_documents` gains additional filter options to support those passthroughs: `block_type.slug`, `block_document.name`, and `block_document.id`.
- `read_block_documents` was making an additional DB query to load the ID's of block documents that met its filter criteria, then forming the "full" query from those materialized IDs; I refactored this so only a single DB query gets made.

Reviewed changes with @desertaxle and @zangell44 

Edit: see https://github.com/PrefectHQ/prefect/pull/6645#issuecomment-1234223411 for notes on implementation and a weird situation that prevented SQLite from being *quite* as efficient as we want (still makes two DB calls) but no longer suffers from the seq scan, so overall a big win.
### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
