### PR TITLE
Fix parsing of `PREFECT_TEST_MODE` in `PrefectBaseModel`

### DIFF
--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -138,7 +138,9 @@ class PrefectBaseModel(BaseModel):
     class Config:
         # extra attributes are forbidden in order to raise meaningful errors for
         # bad API payloads
-        if os.getenv("PREFECT_TEST_MODE"):
+        # We cannot load this setting through the normal pattern due to circular
+        # imports; instead just parse the value as a boolean directly
+        if pydantic.parse_obj_as(bool, os.getenv("PREFECT_TEST_MODE")):
             extra = "forbid"
         else:
             extra = "ignore"

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -139,8 +139,8 @@ class PrefectBaseModel(BaseModel):
         # extra attributes are forbidden in order to raise meaningful errors for
         # bad API payloads
         # We cannot load this setting through the normal pattern due to circular
-        # imports; instead just parse the value as a boolean directly
-        if pydantic.parse_obj_as(bool, os.getenv("PREFECT_TEST_MODE")):
+        # imports; instead just check if its a truthy setting directly
+        if os.getenv("PREFECT_TEST_MODE", "0").lower() in ["1", "true"]:
             extra = "forbid"
         else:
             extra = "ignore"

--- a/tests/orion/utilities/test_schemas.py
+++ b/tests/orion/utilities/test_schemas.py
@@ -23,7 +23,8 @@ from prefect.testing.utilities import assert_does_not_warn
 @contextmanager
 def reload_prefect_base_model(test_mode_value) -> Type[PrefectBaseModel]:
 
-    original = os.environ.get("PREFECT_TEST_MODE")
+    original_base_model = prefect.orion.utilities.schemas.PrefectBaseModel
+    original_environment = os.environ.get("PREFECT_TEST_MODE")
     if test_mode_value is not None:
         os.environ["PREFECT_TEST_MODE"] = test_mode_value
     else:
@@ -38,11 +39,13 @@ def reload_prefect_base_model(test_mode_value) -> Type[PrefectBaseModel]:
 
         yield PrefectBaseModel
     finally:
-        if original is None:
+        if original_environment is None:
             os.environ.pop("PREFECT_TEST_MODE")
         else:
-            os.environ["PREFECT_TEST_MODE"] = original
-        importlib.reload(prefect.orion.utilities.schemas)
+            os.environ["PREFECT_TEST_MODE"] = original_environment
+
+        # We must restore this type or `isinstance` checks will fail later
+        prefect.orion.utilities.schemas.PrefectBaseModel = original_base_model
 
 
 class TestExtraForbidden:

--- a/tests/orion/utilities/test_schemas.py
+++ b/tests/orion/utilities/test_schemas.py
@@ -22,7 +22,9 @@ class TestExtraForbidden:
         class Model(PrefectBaseModel):
             x: int
 
-        with pytest.raises(pydantic.ValidationError):
+        with pytest.raises(
+            pydantic.ValidationError, match="extra fields not permitted"
+        ):
             Model(x=1, y=2)
 
     @pytest.mark.parametrize("falsey_value", ["0", "False", "", None])
@@ -44,6 +46,26 @@ class TestExtraForbidden:
             x: int
 
         Model(x=1, y=2)
+
+    @pytest.mark.parametrize("truthy_value", ["1", "True", "true"])
+    def test_extra_attributes_are_not_allowed_with_truthy_test_mode(
+        self, monkeypatch, truthy_value
+    ):
+        monkeypatch.setenv("PREFECT_TEST_MODE", truthy_value)
+
+        # We must re-execute the module since the setting is configured at base model
+        # definition time
+        importlib.reload(prefect.orion.utilities.schemas)
+
+        from prefect.orion.utilities.schemas import PrefectBaseModel
+
+        class Model(PrefectBaseModel):
+            x: int
+
+        with pytest.raises(
+            pydantic.ValidationError, match="extra fields not permitted"
+        ):
+            Model(x=1, y=2)
 
 
 class TestPydanticSubclass:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

The `PrefectBaseModel` configures behavior when extra fields are provided to models as "forbid" or "ignore" depending on if we are in test mode. However, it just checked the truthiness of `os.getenv` which meant that if the variable was present with any non-empty value it would be treated as `True`. When we pass settings through from the main process to child processes or containers, we may want to set the variable to `"False"` which was then wrongly treated as `True`.

This pull request updates the parsing of the variable to check for truth-like values. I explored using `pydantic.parse_obj_as(bool, ...)` but its parsing was a bit more strict than I thought necessary. We want to avoid crashing here since it's on module import.


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Previously the following would fail:
```
❯ PREFECT_TEST_MODE="0" python -c "from prefect.orion.utilities.schemas import PrefectBaseModel; print(PrefectBaseModel(x=1))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for PrefectBaseModel
x
  extra fields not permitted (type=value_error.extra)
```

Now it succeeds.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
