### PR TITLE
Add sync compatibility to `run` for all infrastructure types

### DIFF
--- a/src/prefect/infrastructure/base.py
+++ b/src/prefect/infrastructure/base.py
@@ -51,9 +51,10 @@ class Infrastructure(Block, abc.ABC):
         identifier for the infrastructure.
 
         The call will then monitor the created infrastructure, returning a result at
-        the end containing a status code indicating if the infrastructure exited cleanly\
+        the end containing a status code indicating if the infrastructure exited cleanly
         or encountered an error.
         """
+        # Note: implementations should include `sync_compatible`
 
     @abc.abstractmethod
     def preview(self) -> str:

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -229,6 +229,7 @@ class DockerContainer(Infrastructure):
 
         return volumes
 
+    @sync_compatible
     async def run(
         self,
         task_status: Optional[TaskStatus] = None,

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -12,7 +12,7 @@ from typing_extensions import Literal
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 from prefect.docker import get_prefect_image_name
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
-from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.hashing import stable_hash
 from prefect.utilities.importtools import lazy_import
 from prefect.utilities.pydantic import JsonPatch
@@ -206,6 +206,7 @@ class KubernetesJob(Infrastructure):
         with open(filename, "r", encoding="utf-8") as f:
             return JsonPatch(yaml.load(f, yaml.SafeLoader))
 
+    @sync_compatible
     async def run(
         self,
         task_status: Optional[TaskStatus] = None,

--- a/src/prefect/infrastructure/process.py
+++ b/src/prefect/infrastructure/process.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from typing_extensions import Literal
 
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
+from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import run_process
 
 
@@ -52,6 +53,7 @@ class Process(Infrastructure):
         description="If set, output will be streamed from the process to local standard output.",
     )
 
+    @sync_compatible
     async def run(
         self,
         task_status: TaskStatus = None,

--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -60,27 +60,25 @@ def mock_docker_client(monkeypatch):
         ("flow9.-foo_bar^x", "flow9.-foo_bar-x"),
     ],
 )
-async def test_name_cast_to_valid_container_name(
+def test_name_cast_to_valid_container_name(
     mock_docker_client, requested_name, container_name
 ):
 
-    await DockerContainer(name=requested_name).run()
+    DockerContainer(name=requested_name).run()
     mock_docker_client.containers.create.assert_called_once()
     call_name = mock_docker_client.containers.create.call_args[1].get("name")
     assert call_name == container_name
 
 
-async def test_container_name_falls_back_to_null(mock_docker_client):
-    await DockerContainer(name="--__....").run()
+def test_container_name_falls_back_to_null(mock_docker_client):
+    DockerContainer(name="--__....").run()
     mock_docker_client.containers.create.assert_called_once()
     call_name = mock_docker_client.containers.create.call_args[1].get("name")
     assert call_name is None
 
 
 @pytest.mark.parametrize("collision_count", (0, 1, 5))
-async def test_container_name_includes_index_on_conflict(
-    mock_docker_client, collision_count
-):
+def test_container_name_includes_index_on_conflict(mock_docker_client, collision_count):
     import docker.errors
 
     if collision_count:
@@ -100,7 +98,7 @@ async def test_container_name_includes_index_on_conflict(
 
     mock_docker_client.containers.create.side_effect = fail_if_name_exists
 
-    await DockerContainer(name="test-name").run()
+    DockerContainer(name="test-name").run()
 
     assert mock_docker_client.containers.create.call_count == collision_count + 1
     call_name = mock_docker_client.containers.create.call_args[1].get("name")
@@ -110,7 +108,7 @@ async def test_container_name_includes_index_on_conflict(
     assert call_name == expected_name
 
 
-async def test_container_creation_failure_reraises_if_not_name_conflict(
+def test_container_creation_failure_reraises_if_not_name_conflict(
     mock_docker_client,
 ):
     import docker.errors
@@ -120,18 +118,18 @@ async def test_container_creation_failure_reraises_if_not_name_conflict(
     )
 
     with pytest.raises(docker.errors.APIError, match="test error"):
-        await DockerContainer().run()
+        DockerContainer().run()
 
 
-async def test_uses_image_setting(mock_docker_client):
-    await DockerContainer(image="foo").run()
+def test_uses_image_setting(mock_docker_client):
+    DockerContainer(image="foo").run()
     mock_docker_client.containers.create.assert_called_once()
     call_image = mock_docker_client.containers.create.call_args[1].get("image")
     assert call_image == "foo"
 
 
-async def test_uses_volumes_setting(mock_docker_client):
-    await DockerContainer(volumes=["a:b", "c:d"]).run()
+def test_uses_volumes_setting(mock_docker_client):
+    DockerContainer(volumes=["a:b", "c:d"]).run()
     mock_docker_client.containers.create.assert_called_once()
     call_volumes = mock_docker_client.containers.create.call_args[1].get("volumes")
     assert "a:b" in call_volumes
@@ -139,8 +137,8 @@ async def test_uses_volumes_setting(mock_docker_client):
 
 
 @pytest.mark.parametrize("networks", [[], ["a"], ["a", "b"]])
-async def test_uses_network_setting(mock_docker_client, networks):
-    await DockerContainer(networks=networks).run()
+def test_uses_network_setting(mock_docker_client, networks):
+    DockerContainer(networks=networks).run()
     mock_docker_client.containers.create.assert_called_once()
     call_network = mock_docker_client.containers.create.call_args[1].get("network")
 
@@ -162,31 +160,31 @@ async def test_uses_network_setting(mock_docker_client, networks):
         )
 
 
-async def test_uses_label_setting(
+def test_uses_label_setting(
     mock_docker_client,
 ):
 
-    await DockerContainer(labels={"foo": "FOO", "bar": "BAR"}).run()
+    DockerContainer(labels={"foo": "FOO", "bar": "BAR"}).run()
     mock_docker_client.containers.create.assert_called_once()
     call_labels = mock_docker_client.containers.create.call_args[1].get("labels")
     assert call_labels == {**CONTAINER_LABELS, "foo": "FOO", "bar": "BAR"}
 
 
-async def test_uses_network_mode_setting(
+def test_uses_network_mode_setting(
     mock_docker_client,
 ):
 
-    await DockerContainer(network_mode="bridge").run()
+    DockerContainer(network_mode="bridge").run()
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
     assert network_mode == "bridge"
 
 
-async def test_uses_env_setting(
+def test_uses_env_setting(
     mock_docker_client,
 ):
 
-    await DockerContainer(env={"foo": "FOO", "bar": "BAR"}).run()
+    DockerContainer(env={"foo": "FOO", "bar": "BAR"}).run()
     mock_docker_client.containers.create.assert_called_once()
     call_env = mock_docker_client.containers.create.call_args[1].get("environment")
     assert call_env == {
@@ -196,11 +194,11 @@ async def test_uses_env_setting(
     }
 
 
-async def test_uses_image_registry_setting(
+def test_uses_image_registry_setting(
     mock_docker_client,
 ):
 
-    await DockerContainer(
+    DockerContainer(
         image_registry=DockerRegistry(
             username="foo", password="bar", registry_url="example.test"
         ),
@@ -237,21 +235,21 @@ async def test_uses_image_registry_setting_after_save(
 
 
 @pytest.mark.parametrize("localhost", ["localhost", "127.0.0.1"])
-async def test_network_mode_defaults_to_host_if_using_localhost_api_on_linux(
+def test_network_mode_defaults_to_host_if_using_localhost_api_on_linux(
     mock_docker_client, localhost, monkeypatch
 ):
     monkeypatch.setattr("sys.platform", "linux")
 
-    await DockerContainer(env=dict(PREFECT_API_URL=f"http://{localhost}/test")).run()
+    DockerContainer(env=dict(PREFECT_API_URL=f"http://{localhost}/test")).run()
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
     assert network_mode == "host"
 
 
-async def test_network_mode_defaults_to_none_if_using_networks(mock_docker_client):
+def test_network_mode_defaults_to_none_if_using_networks(mock_docker_client):
     # Despite using localhost for the API, we will set the network mode to `None`
     # because `networks` and `network_mode` cannot both be set.
-    await DockerContainer(
+    DockerContainer(
         env=dict(PREFECT_API_URL="http://localhost/test"),
         networks=["test"],
     ).run()
@@ -260,27 +258,25 @@ async def test_network_mode_defaults_to_none_if_using_networks(mock_docker_clien
     assert network_mode is None
 
 
-async def test_network_mode_defaults_to_none_if_using_nonlocal_api(mock_docker_client):
+def test_network_mode_defaults_to_none_if_using_nonlocal_api(mock_docker_client):
 
-    await DockerContainer(env=dict(PREFECT_API_URL="http://foo/test")).run()
+    DockerContainer(env=dict(PREFECT_API_URL="http://foo/test")).run()
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
     assert network_mode is None
 
 
-async def test_network_mode_defaults_to_none_if_not_on_linux(
-    mock_docker_client, monkeypatch
-):
+def test_network_mode_defaults_to_none_if_not_on_linux(mock_docker_client, monkeypatch):
     monkeypatch.setattr("sys.platform", "darwin")
 
-    await DockerContainer(env=dict(PREFECT_API_URL="http://localhost/test")).run()
+    DockerContainer(env=dict(PREFECT_API_URL="http://localhost/test")).run()
 
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
     assert network_mode is None
 
 
-async def test_network_mode_defaults_to_none_if_api_url_cannot_be_parsed(
+def test_network_mode_defaults_to_none_if_api_url_cannot_be_parsed(
     mock_docker_client, monkeypatch
 ):
     monkeypatch.setattr("sys.platform", "darwin")
@@ -292,7 +288,7 @@ async def test_network_mode_defaults_to_none_if_api_url_cannot_be_parsed(
     )
 
     with pytest.warns(UserWarning, match="Failed to parse host"):
-        await DockerContainer(env=dict(PREFECT_API_URL="foo")).run()
+        DockerContainer(env=dict(PREFECT_API_URL="foo")).run()
 
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
@@ -300,11 +296,11 @@ async def test_network_mode_defaults_to_none_if_api_url_cannot_be_parsed(
 
 
 @pytest.mark.usefixtures("use_hosted_orion")
-async def test_replaces_localhost_api_with_dockerhost_when_not_using_host_network(
+def test_replaces_localhost_api_with_dockerhost_when_not_using_host_network(
     mock_docker_client, hosted_orion_api
 ):
 
-    await DockerContainer(
+    DockerContainer(
         network_mode="bridge",
     ).run()
     mock_docker_client.containers.create.assert_called_once()
@@ -316,7 +312,7 @@ async def test_replaces_localhost_api_with_dockerhost_when_not_using_host_networ
 
 
 @pytest.mark.usefixtures("use_hosted_orion")
-async def test_does_not_replace_localhost_api_when_using_host_network(
+def test_does_not_replace_localhost_api_when_using_host_network(
     mock_docker_client,
     hosted_orion_api,
     monkeypatch,
@@ -324,7 +320,7 @@ async def test_does_not_replace_localhost_api_when_using_host_network(
     # We will warn if setting 'host' network mode on non-linux platforms
     monkeypatch.setattr("sys.platform", "linux")
 
-    await DockerContainer(
+    DockerContainer(
         network_mode="host",
     ).run()
     mock_docker_client.containers.create.assert_called_once()
@@ -334,7 +330,7 @@ async def test_does_not_replace_localhost_api_when_using_host_network(
 
 
 @pytest.mark.usefixtures("use_hosted_orion")
-async def test_warns_at_runtime_when_using_host_network_mode_on_non_linux_platform(
+def test_warns_at_runtime_when_using_host_network_mode_on_non_linux_platform(
     mock_docker_client,
     monkeypatch,
 ):
@@ -349,26 +345,26 @@ async def test_warns_at_runtime_when_using_host_network_mode_on_non_linux_platfo
         UserWarning,
         match="'host' network mode is not supported on platform 'darwin'",
     ):
-        await runner.run()
+        runner.run()
 
     mock_docker_client.containers.create.assert_called_once()
     network_mode = mock_docker_client.containers.create.call_args[1].get("network_mode")
     assert network_mode == "host", "The setting is passed to dockerpy still"
 
 
-async def test_does_not_override_user_provided_api_host(
+def test_does_not_override_user_provided_api_host(
     mock_docker_client,
 ):
-    await DockerContainer(env={"PREFECT_API_URL": "http://localhost/api"}).run()
+    DockerContainer(env={"PREFECT_API_URL": "http://localhost/api"}).run()
     mock_docker_client.containers.create.assert_called_once()
     call_env = mock_docker_client.containers.create.call_args[1].get("environment")
     assert call_env.get("PREFECT_API_URL") == "http://localhost/api"
 
 
-async def test_adds_docker_host_gateway_on_linux(mock_docker_client, monkeypatch):
+def test_adds_docker_host_gateway_on_linux(mock_docker_client, monkeypatch):
     monkeypatch.setattr("sys.platform", "linux")
 
-    await DockerContainer().run()
+    DockerContainer().run()
 
     mock_docker_client.containers.create.assert_called_once()
     call_extra_hosts = mock_docker_client.containers.create.call_args[1].get(
@@ -377,99 +373,95 @@ async def test_adds_docker_host_gateway_on_linux(mock_docker_client, monkeypatch
     assert call_extra_hosts == {"host.docker.internal": "host-gateway"}
 
 
-async def test_default_image_pull_policy_pulls_image_with_latest_tag(
+def test_default_image_pull_policy_pulls_image_with_latest_tag(
     mock_docker_client,
 ):
-    await DockerContainer(image="prefect:latest").run()
+    DockerContainer(image="prefect:latest").run()
     mock_docker_client.images.pull.assert_called_once()
     mock_docker_client.images.pull.assert_called_with("prefect", "latest")
 
 
-async def test_default_image_pull_policy_pulls_image_with_no_tag(
+def test_default_image_pull_policy_pulls_image_with_no_tag(
     mock_docker_client,
 ):
-    await DockerContainer(image="prefect").run()
+    DockerContainer(image="prefect").run()
     mock_docker_client.images.pull.assert_called_once()
     mock_docker_client.images.pull.assert_called_with("prefect", None)
 
 
-async def test_default_image_pull_policy_pulls_image_with_tag_other_than_latest_if_not_present(
+def test_default_image_pull_policy_pulls_image_with_tag_other_than_latest_if_not_present(
     mock_docker_client,
 ):
     from docker.errors import ImageNotFound
 
     mock_docker_client.images.get.side_effect = ImageNotFound("No way, bub")
 
-    await DockerContainer(image="prefect:omega").run()
+    DockerContainer(image="prefect:omega").run()
     mock_docker_client.images.pull.assert_called_once()
     mock_docker_client.images.pull.assert_called_with("prefect", "omega")
 
 
-async def test_default_image_pull_policy_does_not_pull_image_with_tag_other_than_latest_if_present(
+def test_default_image_pull_policy_does_not_pull_image_with_tag_other_than_latest_if_present(
     mock_docker_client,
 ):
     from docker.models.images import Image
 
     mock_docker_client.images.get.return_value = Image()
 
-    await DockerContainer(image="prefect:omega").run()
+    DockerContainer(image="prefect:omega").run()
     mock_docker_client.images.pull.assert_not_called()
 
 
-async def test_image_pull_policy_always_pulls(
+def test_image_pull_policy_always_pulls(
     mock_docker_client,
 ):
-    await DockerContainer(
-        image="prefect", image_pull_policy=ImagePullPolicy.ALWAYS
-    ).run()
+    DockerContainer(image="prefect", image_pull_policy=ImagePullPolicy.ALWAYS).run()
     mock_docker_client.images.get.assert_not_called()
     mock_docker_client.images.pull.assert_called_once()
     mock_docker_client.images.pull.assert_called_with("prefect", None)
 
 
-async def test_image_pull_policy_never_does_not_pull(
+def test_image_pull_policy_never_does_not_pull(
     mock_docker_client,
 ):
-    await DockerContainer(
-        image="prefect", image_pull_policy=ImagePullPolicy.NEVER
-    ).run()
+    DockerContainer(image="prefect", image_pull_policy=ImagePullPolicy.NEVER).run()
     mock_docker_client.images.pull.assert_not_called()
 
 
-async def test_image_pull_policy_if_not_present_pulls_image_if_not_present(
+def test_image_pull_policy_if_not_present_pulls_image_if_not_present(
     mock_docker_client,
 ):
     from docker.errors import ImageNotFound
 
     mock_docker_client.images.get.side_effect = ImageNotFound("No way, bub")
 
-    await DockerContainer(
+    DockerContainer(
         image="prefect", image_pull_policy=ImagePullPolicy.IF_NOT_PRESENT
     ).run()
     mock_docker_client.images.pull.assert_called_once()
     mock_docker_client.images.pull.assert_called_with("prefect", None)
 
 
-async def test_image_pull_policy_if_not_present_does_not_pull_image_if_present(
+def test_image_pull_policy_if_not_present_does_not_pull_image_if_present(
     mock_docker_client,
 ):
     from docker.models.images import Image
 
     mock_docker_client.images.get.return_value = Image()
 
-    await DockerContainer(
+    DockerContainer(
         image="prefect", image_pull_policy=ImagePullPolicy.IF_NOT_PRESENT
     ).run()
     mock_docker_client.images.pull.assert_not_called()
 
 
 @pytest.mark.parametrize("platform", ["win32", "darwin"])
-async def test_does_not_add_docker_host_gateway_on_other_platforms(
+def test_does_not_add_docker_host_gateway_on_other_platforms(
     mock_docker_client, monkeypatch, platform
 ):
     monkeypatch.setattr("sys.platform", platform)
 
-    await DockerContainer().run()
+    DockerContainer().run()
 
     mock_docker_client.containers.create.assert_called_once()
     call_extra_hosts = mock_docker_client.containers.create.call_args[1].get(
@@ -488,7 +480,7 @@ async def test_does_not_add_docker_host_gateway_on_other_platforms(
     ],
 )
 @pytest.mark.usefixtures("use_hosted_orion")
-async def test_warns_if_docker_version_does_not_support_host_gateway_on_linux(
+def test_warns_if_docker_version_does_not_support_host_gateway_on_linux(
     mock_docker_client,
     explicit_api_url,
     monkeypatch,
@@ -504,7 +496,7 @@ async def test_warns_if_docker_version_does_not_support_host_gateway_on_linux(
             f"feature is not supported on Docker Engine v19.1.1"
         ),
     ):
-        await DockerContainer(
+        DockerContainer(
             env={"PREFECT_API_URL": explicit_api_url} if explicit_api_url else {}
         ).run()
 
@@ -515,7 +507,7 @@ async def test_warns_if_docker_version_does_not_support_host_gateway_on_linux(
     assert not call_extra_hosts
 
 
-async def test_does_not_warn_about_gateway_if_user_has_provided_nonlocal_api_url(
+def test_does_not_warn_about_gateway_if_user_has_provided_nonlocal_api_url(
     mock_docker_client,
     monkeypatch,
 ):
@@ -523,9 +515,7 @@ async def test_does_not_warn_about_gateway_if_user_has_provided_nonlocal_api_url
     mock_docker_client.version.return_value = {"Version": "19.1.1"}
 
     with assert_does_not_warn():
-        await DockerContainer(
-            env={"PREFECT_API_URL": "http://my-domain.test/api"}
-        ).run()
+        DockerContainer(env={"PREFECT_API_URL": "http://my-domain.test/api"}).run()
 
     mock_docker_client.containers.create.assert_called_once()
     call_extra_hosts = mock_docker_client.containers.create.call_args[1].get(
@@ -534,9 +524,9 @@ async def test_does_not_warn_about_gateway_if_user_has_provided_nonlocal_api_url
     assert not call_extra_hosts
 
 
-async def test_task_status_receives_container_id(mock_docker_client):
+def test_task_status_receives_container_id(mock_docker_client):
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
-    result = await DockerContainer(command=["echo", "hello"], stream_output=False).run(
+    result = DockerContainer(command=["echo", "hello"], stream_output=False).run(
         task_status=fake_status
     )
     fake_status.started.assert_called_once_with(result.identifier)
@@ -544,7 +534,7 @@ async def test_task_status_receives_container_id(mock_docker_client):
 
 @pytest.mark.usefixtures("use_hosted_orion")
 @pytest.mark.parametrize("platform", ["win32", "darwin"])
-async def test_does_not_warn_about_gateway_if_not_using_linux(
+def test_does_not_warn_about_gateway_if_not_using_linux(
     mock_docker_client,
     platform,
     monkeypatch,
@@ -553,7 +543,7 @@ async def test_does_not_warn_about_gateway_if_not_using_linux(
     mock_docker_client.version.return_value = {"Version": "19.1.1"}
 
     with assert_does_not_warn():
-        await DockerContainer().run()
+        DockerContainer().run()
 
     mock_docker_client.containers.create.assert_called_once()
     call_extra_hosts = mock_docker_client.containers.create.call_args[1].get(
@@ -563,8 +553,8 @@ async def test_does_not_warn_about_gateway_if_not_using_linux(
 
 
 @pytest.mark.service("docker")
-async def test_container_result(docker: "DockerClient"):
-    result = await DockerContainer(command=["echo", "hello"]).run()
+def test_container_result(docker: "DockerClient"):
+    result = DockerContainer(command=["echo", "hello"]).run()
     assert bool(result)
     assert result.status_code == 0
     assert result.identifier
@@ -573,8 +563,8 @@ async def test_container_result(docker: "DockerClient"):
 
 
 @pytest.mark.service("docker")
-async def test_container_metadata(docker: "DockerClient"):
-    result = await DockerContainer(
+def test_container_metadata(docker: "DockerClient"):
+    result = DockerContainer(
         command=["echo", "hello"],
         name="test-name",
         labels={"test.foo": "a", "test.bar": "b"},
@@ -590,17 +580,27 @@ async def test_container_metadata(docker: "DockerClient"):
 
 
 @pytest.mark.service("docker")
-async def test_container_name_collision(docker: "DockerClient"):
+def test_container_name_collision(docker: "DockerClient"):
     # Generate a unique base name to avoid collissions with existing images
     base_name = uuid.uuid4().hex
 
     container = DockerContainer(
         command=["echo", "hello"], name=base_name, auto_remove=False
     )
-    result = await container.run()
+    result = container.run()
     created_container: "Container" = docker.containers.get(result.identifier)
     assert created_container.name == base_name
 
-    result = await container.run()
+    result = container.run()
     created_container: "Container" = docker.containers.get(result.identifier)
     assert created_container.name == base_name + "-1"
+
+
+@pytest.mark.service("docker")
+async def test_container_result_async(docker: "DockerClient"):
+    result = await DockerContainer(command=["echo", "hello"]).run()
+    assert bool(result)
+    assert result.status_code == 0
+    assert result.identifier
+    container = docker.containers.get(result.identifier)
+    assert container is not None

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -5,6 +5,7 @@ from typing import Dict
 from unittest import mock
 from unittest.mock import MagicMock
 
+import anyio
 import anyio.abc
 import kubernetes
 import kubernetes as k8s
@@ -117,7 +118,7 @@ def test_building_a_job_is_idempotent():
     assert first_time == second_time
 
 
-async def test_creates_job_by_building_a_manifest(
+def test_creates_job_by_building_a_manifest(
     mock_k8s_batch_client,
     mock_k8s_client,
     mock_watch,
@@ -127,7 +128,7 @@ async def test_creates_job_by_building_a_manifest(
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
     k8s_job = KubernetesJob(command=["echo", "hello"])
     expected_manifest = k8s_job.build_job()
-    await k8s_job.run(fake_status)
+    k8s_job.run(fake_status)
     mock_k8s_client.read_namespaced_pod_status.assert_called_once()
 
     mock_k8s_batch_client.create_namespaced_job.assert_called_with(
@@ -138,14 +139,26 @@ async def test_creates_job_by_building_a_manifest(
     fake_status.started.assert_called_once()
 
 
-async def test_task_status_receives_job_name(
+def test_task_status_receives_job_name(
     mock_k8s_batch_client,
     mock_k8s_client,
     mock_watch,
 ):
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
-    result = await KubernetesJob(command=["echo", "hello"]).run(task_status=fake_status)
+    result = KubernetesJob(command=["echo", "hello"]).run(task_status=fake_status)
     fake_status.started.assert_called_once_with(result.identifier)
+
+
+async def test_task_group_start_returns_job_name(
+    mock_k8s_batch_client,
+    mock_k8s_client,
+    mock_watch,
+):
+    async with anyio.create_task_group() as tg:
+        status_result = await tg.start(
+            KubernetesJob(command=["echo", "hello"], name="test").run
+        )
+        assert status_result == "mock-k8s-v1-job"
 
 
 @pytest.mark.parametrize(
@@ -160,7 +173,7 @@ async def test_task_status_receives_job_name(
         ("infra9.-foo_bar^x", "infra9-foo-bar-x"),
     ],
 )
-async def test_job_name_creates_valid_name(
+def test_job_name_creates_valid_name(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
@@ -169,7 +182,7 @@ async def test_job_name_creates_valid_name(
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
-    await KubernetesJob(name=job_name, command=["echo", "hello"]).run(fake_status)
+    KubernetesJob(name=job_name, command=["echo", "hello"]).run(fake_status)
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     call_name = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "generateName"
@@ -177,14 +190,14 @@ async def test_job_name_creates_valid_name(
     assert call_name == clean_name
 
 
-async def test_uses_image_setting(
+def test_uses_image_setting(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"], image="foo").run(MagicMock())
+    KubernetesJob(command=["echo", "hello"], image="foo").run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     image = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["spec"][
         "template"
@@ -192,16 +205,16 @@ async def test_uses_image_setting(
     assert image == "foo"
 
 
-async def test_uses_labels_setting(
+def test_uses_labels_setting(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(
-        command=["echo", "hello"], labels={"foo": "foo", "bar": "bar"}
-    ).run(MagicMock())
+    KubernetesJob(command=["echo", "hello"], labels={"foo": "foo", "bar": "bar"}).run(
+        MagicMock()
+    )
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     labels = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "labels"
@@ -236,7 +249,7 @@ async def test_uses_labels_setting(
         ("$@*^$@/name", "$@*^$@/name"),
     ],
 )
-async def test_sanitizes_user_label_keys(
+def test_sanitizes_user_label_keys(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
@@ -245,9 +258,7 @@ async def test_sanitizes_user_label_keys(
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"], labels={given: "foo"}).run(
-        MagicMock()
-    )
+    KubernetesJob(command=["echo", "hello"], labels={given: "foo"}).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     labels = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "labels"
@@ -271,7 +282,7 @@ async def test_sanitizes_user_label_keys(
         ("$@*^$@", "$@*^$@"),
     ],
 )
-async def test_sanitizes_user_label_values(
+def test_sanitizes_user_label_values(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
@@ -280,9 +291,7 @@ async def test_sanitizes_user_label_values(
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"], labels={"foo": given}).run(
-        MagicMock()
-    )
+    KubernetesJob(command=["echo", "hello"], labels={"foo": given}).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     labels = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "labels"
@@ -290,14 +299,14 @@ async def test_sanitizes_user_label_values(
     assert labels["foo"] == expected
 
 
-async def test_uses_namespace_setting(
+def test_uses_namespace_setting(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"], namespace="foo").run(MagicMock())
+    KubernetesJob(command=["echo", "hello"], namespace="foo").run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     namespace = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "namespace"
@@ -305,14 +314,14 @@ async def test_uses_namespace_setting(
     assert namespace == "foo"
 
 
-async def test_uses_service_account_name_setting(
+def test_uses_service_account_name_setting(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"], service_account_name="foo").run(
+    KubernetesJob(command=["echo", "hello"], service_account_name="foo").run(
         MagicMock()
     )
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
@@ -322,14 +331,14 @@ async def test_uses_service_account_name_setting(
     assert service_account_name == "foo"
 
 
-async def test_defaults_to_unspecified_image_pull_policy(
+def test_defaults_to_unspecified_image_pull_policy(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"]).run(MagicMock())
+    KubernetesJob(command=["echo", "hello"]).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     call_image_pull_policy = mock_k8s_batch_client.create_namespaced_job.call_args[0][
         1
@@ -337,14 +346,14 @@ async def test_defaults_to_unspecified_image_pull_policy(
     assert call_image_pull_policy is None
 
 
-async def test_uses_specified_image_pull_policy(
+def test_uses_specified_image_pull_policy(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(
+    KubernetesJob(
         command=["echo", "hello"],
         image_pull_policy=KubernetesImagePullPolicy.IF_NOT_PRESENT,
     ).run(MagicMock())
@@ -355,14 +364,14 @@ async def test_uses_specified_image_pull_policy(
     assert call_image_pull_policy == "IfNotPresent"
 
 
-async def test_defaults_to_unspecified_restart_policy(
+def test_defaults_to_unspecified_restart_policy(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    await KubernetesJob(command=["echo", "hello"]).run(MagicMock())
+    KubernetesJob(command=["echo", "hello"]).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     call_restart_policy = mock_k8s_batch_client.create_namespaced_job.call_args[0][1][
         "spec"
@@ -370,16 +379,16 @@ async def test_defaults_to_unspecified_restart_policy(
     assert call_restart_policy is None
 
 
-async def test_no_raise_on_submission_with_hosted_api(
+def test_no_raise_on_submission_with_hosted_api(
     mock_cluster_config,
     mock_k8s_batch_client,
     mock_k8s_client,
     use_hosted_orion,
 ):
-    await KubernetesJob(command=["echo", "hello"]).run(MagicMock())
+    KubernetesJob(command=["echo", "hello"]).run(MagicMock())
 
 
-async def test_defaults_to_incluster_config(
+def test_defaults_to_incluster_config(
     mock_k8s_client,
     mock_watch,
     mock_cluster_config,
@@ -388,13 +397,13 @@ async def test_defaults_to_incluster_config(
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
 
-    await KubernetesJob(command=["echo", "hello"]).run(fake_status)
+    KubernetesJob(command=["echo", "hello"]).run(fake_status)
 
     mock_cluster_config.load_incluster_config.assert_called_once()
     assert not mock_cluster_config.load_kube_config.called
 
 
-async def test_uses_cluster_config_if_not_in_cluster(
+def test_uses_cluster_config_if_not_in_cluster(
     mock_k8s_client,
     mock_watch,
     mock_cluster_config,
@@ -405,12 +414,12 @@ async def test_uses_cluster_config_if_not_in_cluster(
 
     mock_cluster_config.load_incluster_config.side_effect = ConfigException()
 
-    await KubernetesJob(command=["echo", "hello"]).run(fake_status)
+    KubernetesJob(command=["echo", "hello"]).run(fake_status)
 
     mock_cluster_config.load_kube_config.assert_called_once()
 
 
-async def test_allows_configurable_timeouts_for_pod_and_job_watches(
+def test_allows_configurable_timeouts_for_pod_and_job_watches(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
@@ -419,7 +428,7 @@ async def test_allows_configurable_timeouts_for_pod_and_job_watches(
         side_effect=_mock_pods_stream_that_returns_running_pod
     )
 
-    await KubernetesJob(
+    KubernetesJob(
         command=["echo", "hello"],
         pod_watch_timeout_seconds=42,
         job_watch_timeout_seconds=24,
@@ -443,7 +452,7 @@ async def test_allows_configurable_timeouts_for_pod_and_job_watches(
     )
 
 
-async def test_watches_the_right_namespace(
+def test_watches_the_right_namespace(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
@@ -452,7 +461,7 @@ async def test_watches_the_right_namespace(
         side_effect=_mock_pods_stream_that_returns_running_pod
     )
 
-    await KubernetesJob(command=["echo", "hello"], namespace="my-awesome-flows").run(
+    KubernetesJob(command=["echo", "hello"], namespace="my-awesome-flows").run(
         MagicMock()
     )
 

--- a/tests/infrastructure/test_process.py
+++ b/tests/infrastructure/test_process.py
@@ -18,10 +18,8 @@ def mock_open_process(monkeypatch):
 
 
 @pytest.mark.parametrize("stream_output", [True, False])
-async def test_process_stream_output(capsys, stream_output):
-    assert await Process(
-        stream_output=stream_output, command=["echo", "hello world"]
-    ).run()
+def test_process_stream_output(capsys, stream_output):
+    assert Process(stream_output=stream_output, command=["echo", "hello world"]).run()
 
     out, err = capsys.readouterr()
 
@@ -35,8 +33,8 @@ async def test_process_stream_output(capsys, stream_output):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="stderr redirect does not work on Windows"
 )
-async def test_process_streams_stderr(capsys):
-    assert await Process(
+def test_process_streams_stderr(capsys):
+    assert Process(
         command=["bash", "-c", ">&2 echo hello world"], stream_output=True
     ).run()
 
@@ -49,21 +47,21 @@ async def test_process_streams_stderr(capsys):
     sys.platform == "win32", reason="bash calls are not working on Windows"
 )
 @pytest.mark.parametrize("exit_code", [0, 1, 2])
-async def test_process_returns_exit_code(exit_code):
-    result = await Process(command=["bash", "-c", f"exit {exit_code}"]).run()
+def test_process_returns_exit_code(exit_code):
+    result = Process(command=["bash", "-c", f"exit {exit_code}"]).run()
     assert result.status_code == exit_code
     assert bool(result) is (exit_code == 0)
 
 
-async def test_process_runs_command(tmp_path):
+def test_process_runs_command(tmp_path):
     # Perform a side-effect to demonstrate the command is run
-    assert await Process(command=["touch", str(tmp_path / "canary")]).run()
+    assert Process(command=["touch", str(tmp_path / "canary")]).run()
     assert (tmp_path / "canary").exists()
 
 
-async def test_process_environment_variables(monkeypatch, mock_open_process):
+def test_process_environment_variables(monkeypatch, mock_open_process):
     monkeypatch.setenv("MYVAR", "VALUE")
-    await Process(command=["echo", "hello"], stream_output=False).run()
+    Process(command=["echo", "hello"], stream_output=False).run()
     mock_open_process.assert_awaited_once()
     env = mock_open_process.call_args[1].get("env")
     assert env == {**os.environ, **Process._base_environment(), "MYVAR": "VALUE"}
@@ -72,9 +70,9 @@ async def test_process_environment_variables(monkeypatch, mock_open_process):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="bash calls are not working on Windows"
 )
-async def test_process_includes_current_env_vars(monkeypatch, capsys):
+def test_process_includes_current_env_vars(monkeypatch, capsys):
     monkeypatch.setenv("MYVAR", "VALUE-A")
-    assert await Process(command=["bash", "-c", "echo $MYVAR"]).run()
+    assert Process(command=["bash", "-c", "echo $MYVAR"]).run()
     out, _ = capsys.readouterr()
     assert "VALUE-A" in out
 
@@ -82,23 +80,23 @@ async def test_process_includes_current_env_vars(monkeypatch, capsys):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="bash calls are not working on Windows"
 )
-async def test_process_env_override_current_env_vars(monkeypatch, capsys):
+def test_process_env_override_current_env_vars(monkeypatch, capsys):
     monkeypatch.setenv("MYVAR", "VALUE-A")
-    assert await Process(
+    assert Process(
         command=["bash", "-c", "echo $MYVAR"], env={"MYVAR": "VALUE-B"}
     ).run()
     out, _ = capsys.readouterr()
     assert "VALUE-B" in out
 
 
-async def test_process_created_then_marked_as_started(mock_open_process):
+def test_process_created_then_marked_as_started(mock_open_process):
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
     # By raising an exception when started is called we can assert the process
     # is opened before this time
     fake_status.started.side_effect = RuntimeError("Started called!")
 
     with pytest.raises(RuntimeError, match="Started called!"):
-        await Process(command=["echo", "hello"], stream_output=False).run(
+        Process(command=["echo", "hello"], stream_output=False).run(
             task_status=fake_status
         )
 
@@ -106,9 +104,14 @@ async def test_process_created_then_marked_as_started(mock_open_process):
     mock_open_process.assert_awaited_once()
 
 
-async def test_task_status_receives_pid():
+async def test_process_can_be_run_async():
+    result = await Process(command=["echo", "hello"], stream_output=False).run()
+    assert result
+
+
+def test_task_status_receives_pid():
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
-    result = await Process(command=["echo", "hello"], stream_output=False).run(
+    result = Process(command=["echo", "hello"], stream_output=False).run(
         task_status=fake_status
     )
     fake_status.started.assert_called_once_with(int(result.identifier))


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This is particularly helpful for testing infrastructure, but is also relevant for the many cases in which a user may want to run commands in infrastructure from sync flows or tasks.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Previously the following would not run the process as it returned a coroutine

```python
from prefect import flow
from prefect.infrastructure import Process

@flow
def foo():
    process = Process(command=["echo", "hello!"])
    process.run()

foo()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
