### PR TITLE
Update Docker container runs to be robust to container removal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ filterwarnings =
     ignore:`DeploymentSpec` has been replaced by `Deployment`:DeprecationWarning
     # This warning is raised on Windows by Python internals
     ignore:the imp module is deprecated:DeprecationWarning
+    # Dockerpy is behind on this one 
+    ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [isort]
 skip = __init__.py

--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -36,7 +36,25 @@ def mock_docker_client(monkeypatch):
     fake_container = docker.models.containers.Container()
     fake_container.client = MagicMock(name="Container.client")
     fake_container.collection = MagicMock(name="Container.collection")
-    attrs = {"Id": "fake-id", "Name": "fake-name", "State": "exited"}
+    attrs = (
+        {
+            "Id": "fake-id",
+            "Name": "fake-name",
+            "State": {
+                "Status": "exited",
+                "Running": False,
+                "Paused": False,
+                "Restarting": False,
+                "OOMKilled": False,
+                "Dead": True,
+                "Pid": 0,
+                "ExitCode": 0,
+                "Error": "",
+                "StartedAt": "2022-08-31T18:01:32.645851548Z",
+                "FinishedAt": "2022-08-31T18:01:32.657076632Z",
+            },
+        },
+    )
     fake_container.collection.get().attrs = attrs
     fake_container.attrs = attrs
 

--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -573,6 +573,18 @@ async def test_container_result(docker: "DockerClient"):
 
 
 @pytest.mark.service("docker")
+async def test_container_auto_remove(docker: "DockerClient"):
+    from docker.errors import NotFound
+
+    result = await DockerContainer(command=["echo", "hello"], auto_remove=True).run()
+    assert bool(result)
+    assert result.status_code == 0
+    assert result.identifier
+    with pytest.raises(NotFound):
+        docker.containers.get(result.identifier)
+
+
+@pytest.mark.service("docker")
 async def test_container_metadata(docker: "DockerClient"):
     result = await DockerContainer(
         command=["echo", "hello"],

--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -36,25 +36,23 @@ def mock_docker_client(monkeypatch):
     fake_container = docker.models.containers.Container()
     fake_container.client = MagicMock(name="Container.client")
     fake_container.collection = MagicMock(name="Container.collection")
-    attrs = (
-        {
-            "Id": "fake-id",
-            "Name": "fake-name",
-            "State": {
-                "Status": "exited",
-                "Running": False,
-                "Paused": False,
-                "Restarting": False,
-                "OOMKilled": False,
-                "Dead": True,
-                "Pid": 0,
-                "ExitCode": 0,
-                "Error": "",
-                "StartedAt": "2022-08-31T18:01:32.645851548Z",
-                "FinishedAt": "2022-08-31T18:01:32.657076632Z",
-            },
+    attrs = {
+        "Id": "fake-id",
+        "Name": "fake-name",
+        "State": {
+            "Status": "exited",
+            "Running": False,
+            "Paused": False,
+            "Restarting": False,
+            "OOMKilled": False,
+            "Dead": True,
+            "Pid": 0,
+            "ExitCode": 0,
+            "Error": "",
+            "StartedAt": "2022-08-31T18:01:32.645851548Z",
+            "FinishedAt": "2022-08-31T18:01:32.657076632Z",
         },
-    )
+    }
     fake_container.collection.get().attrs = attrs
     fake_container.attrs = attrs
 


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/6648

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

If a container was removed while streaming logs, we threw an exception instead of returning the correct result. This  pull request updates our container watching implementation to repeatedly yield the latest container metadata it has seen so a wrapper can catch any `NotFound` errors and still produce a `DockerContainerResult`.

I imagine there are some edge cases here where we end up with a version of the container metadata that does not contain the exit code, but we can tackle those in a later as they'd require more redesign of how we stream logs. For example, the call to `wait()` could be fully decoupled from the log streaming calls  by running them in separate worker threads.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

As described in the linked issue, the following would fail as the container was removed before a final status could be retrieved:
 
```python
from prefect.infrastructure import DockerContainer
from prefect.logging.configuration import setup_logging

setup_logging()

DockerContainer(command=["echo", "hello!"], auto_remove=True).run()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
