### PR TITLE
Update Docker container name collision log to `INFO` level for clarity

### DIFF
--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -412,8 +412,9 @@ class DockerContainer(Infrastructure):
                 container = docker_client.containers.create(name=name, **kwargs)
             except APIError as exc:
                 if "Conflict" in str(exc) and "container name" in str(exc):
-                    self.logger.debug(
-                        f"Docker container name already exists; adding identifier..."
+                    self.logger.info(
+                        f"Docker container name {display_name} already exists; "
+                        "retrying..."
                     )
                     index += 1
                     name = f"{original_name}-{index}"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Addresses confusion in https://github.com/PrefectHQ/prefect/issues/6652#issuecomment-1233243902

Previously, the default logs would make it appear as though multiple containers had been created for a single run.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
import anyio
from prefect.infrastructure import DockerContainer
from prefect.logging.configuration import setup_logging

setup_logging()

container = DockerContainer(command=["echo", "hello!"], name="test")
anyio.run(container.run)
anyio.run(container.run)
```
```
13:27:32.455 | INFO    | prefect.infrastructure.docker-container - Creating Docker container 'foo'...
13:27:32.765 | INFO    | prefect.infrastructure.docker-container - Docker container 'foo' has status 'exited'
hello!
13:27:32.799 | INFO    | prefect.infrastructure.docker-container - Creating Docker container 'foo'...
13:27:32.815 | INFO    | prefect.infrastructure.docker-container - Docker container name 'foo' already exists; retrying...
13:27:32.815 | INFO    | prefect.infrastructure.docker-container - Creating Docker container 'foo-1'...
13:27:33.103 | INFO    | prefect.infrastructure.docker-container - Docker container 'foo-1' has status 'exited'
hello!
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
