### PR TITLE
Update `Deployment.infrastructure` to accept types outside of the core library

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -6,7 +6,7 @@ import importlib
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 import yaml
@@ -18,7 +18,7 @@ from prefect.context import PrefectObjectRegistry
 from prefect.exceptions import BlockMissingCapabilities, ObjectNotFound
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import Flow
-from prefect.infrastructure import DockerContainer, KubernetesJob, Process
+from prefect.infrastructure import Infrastructure, Process
 from prefect.logging.loggers import flow_run_logger
 from prefect.orion import schemas
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
@@ -268,9 +268,7 @@ class Deployment(BaseModel):
         None,
         description="The path to the flow's manifest file, relative to the chosen storage.",
     )
-    infrastructure: Union[DockerContainer, KubernetesJob, Process] = Field(
-        default_factory=Process
-    )
+    infrastructure: Infrastructure = Field(default_factory=Process)
     infra_overrides: Dict[str, Any] = Field(
         default_factory=dict,
         description="Overrides to apply to the base infrastructure block at runtime.",

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -293,8 +293,10 @@ class Deployment(BaseModel):
     @validator("infrastructure", pre=True)
     def infrastructure_must_have_capabilities(cls, value):
         if isinstance(value, dict):
-            block_type = lookup_type(Block, value.pop("_block_type_slug"))
-            block = block_type(**value)
+            if "_block_type_slug" in value:
+                # Replace private attribute with public for dispatch
+                value["block_type_slug"] = value.pop("_block_type_slug")
+            block = Block(**value)
         elif value is None:
             return value
         else:

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -6,7 +6,7 @@ from prefect.blocks.core import Block
 from prefect.deployments import Deployment
 from prefect.exceptions import BlockMissingCapabilities
 from prefect.filesystems import S3, GitHub, LocalFileSystem
-from prefect.infrastructure import DockerContainer, Process
+from prefect.infrastructure import DockerContainer, Infrastructure, Process
 
 
 class TestDeploymentBasicInterface:
@@ -29,6 +29,19 @@ class TestDeploymentBasicInterface:
     async def test_that_infrastructure_defaults_to_process(self):
         d = Deployment(name="foo")
         assert isinstance(d.infrastructure, Process)
+
+    async def test_infrastructure_accepts_arbitrary_infra_types(self):
+        class CustomInfra(Infrastructure):
+            type = "CustomInfra"
+
+            def run(self):
+                return 42
+
+            def preview(self):
+                return "woof!"
+
+        d = Deployment(name="foo", infrastructure=CustomInfra())
+        assert isinstance(d.infrastructure, CustomInfra)
 
     async def test_default_work_queue_name(self):
         d = Deployment(name="foo")

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -43,6 +43,19 @@ class TestDeploymentBasicInterface:
         d = Deployment(name="foo", infrastructure=CustomInfra())
         assert isinstance(d.infrastructure, CustomInfra)
 
+    async def test_infrastructure_accepts_arbitrary_infra_types_as_dicts(self):
+        class CustomInfra(Infrastructure):
+            type = "CustomInfra"
+
+            def run(self):
+                return 42
+
+            def preview(self):
+                return "woof!"
+
+        d = Deployment(name="foo", infrastructure=CustomInfra().dict())
+        assert isinstance(d.infrastructure, CustomInfra)
+
     async def test_default_work_queue_name(self):
         d = Deployment(name="foo")
         assert d.work_queue_name == "default"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Updates deployment `infrastructure` field type to the `Infrastructure` base class instead of enumerating all types. This is required for the upcoming infrastructure blocks in collections e.g. `ECSTask` and `CloudRunJob`.

#6622 should allow us to do this without any issues.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
from prefect_aws.ecs import ECSTask

Deployment(name="foo", infrastructure=ECSTask(...))
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
