### PR TITLE
Update block CLI to match standard styling

### DIFF
--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -23,7 +23,7 @@ from prefect.utilities.importtools import load_script_as_module
 
 blocks_app = PrefectTyper(name="block", help="Commands for working with blocks.")
 blocktypes_app = PrefectTyper(
-    name="type", help="Commands for working with blocks types"
+    name="type", help="Commands for working with blocks types."
 )
 app.add_typer(blocks_app, aliases=["blocks"])
 blocks_app.add_typer(blocktypes_app, aliases=["types"])


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

- Clarifies the that the `prefect block register` command is related to types
- Updates description of `prefect block register` to display nicely during summary
- Updates the `prefect block type` subcommand to have the correct docstring
- Suggests available block types on missing create
- Updates capitalization to match our standard styling

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Before
```
❯ prefect block
                                                                                                      
 Usage: prefect block [OPTIONS] COMMAND [ARGS]...                                                     
                                                                                                      
 Commands for working with blocks.                                                                    
                                                                                                      
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────╮
│ create    Generate a link to the Prefect UI to create a Block.                                     │
│ delete    Delete a Block by slug or id.                                                            │
│ inspect   Displays Block details slug or id.                                                       │
│ ls        View all configured Blocks.                                                              │
│ register  Register blocks within a module or file to be available for configuration via the UI. If │
│           a block has already been registered, its registration will be updated to match the       │
│           block's current definition.                                                              │
│ type      Commands for working with blocks.                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

After:
```
❯ prefect block            
                                                                                                      
 Usage: prefect block [OPTIONS] COMMAND [ARGS]...                                                     
                                                                                                      
 Commands for working with blocks.                                                                    
                                                                                                      
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────╮
│ create          Generate a link to the Prefect UI to create a block.                               │
│ delete          Delete a configured block.                                                         │
│ inspect         Displays details about a configured block.                                         │
│ ls              View all configured blocks.                                                        │
│ register        Register blocks types within a module or file.                                     │
│ type            Commands for working with blocks types.                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
```


```
❯ prefect block create test
Block type 'test' not found!
Available block types: ecs-task, json, docker-registry, aws-credentials, kubernetes-job, process, secret, smb, string, 
docker-container, local-file-system, minio-credentials, slack-webhook, ecstask, gcs, s3-bucket, github, azure, 
remote-file-system, s3, date-time, kubernetes-cluster-config

```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->

## Future work

The `prefect block register` command seems to belong under the `type` sub-section.