### PR TITLE
Fix handling of .prefectignore paths in Windows

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -326,14 +326,14 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         counter = 0
         for f in glob.glob(os.path.join(local_path, "**"), recursive=True):
-            relative_path = PurePath(f).relative_to(local_path).as_posix()
-            if included_files and relative_path not in included_files:
+            relative_path = PurePath(f).relative_to(local_path)
+            if included_files and str(relative_path) not in included_files:
                 continue
 
             if to_path.endswith("/"):
-                fpath = to_path + relative_path
+                fpath = to_path + relative_path.as_posix()
             else:
-                fpath = to_path + "/" + relative_path
+                fpath = to_path + "/" + relative_path.as_posix()
 
             if Path(f).is_dir():
                 pass


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

In #6620 we adjusted the way that `RemoteFileSystem.put_directory` handled paths to have better cross-OS support, but at the same time introduced a bug where if files where being ignored by `.prefectignore` we were comparing the `included_files` in POSIX format rather than Windows format and this caused any subdirectories to be ignored. This fixes that bug.

Closes #6678 

### Example

No real way to give an example, I tested this in Windows via Parallels by:

- Copying the `tree-project`, adding a flow to it and building a deployment from it. This initially showed it copying 4 files, but after this fix it shows the correct 12 files.
- I verified that the unittests added in #6620 were in fact failing in Windows as well. They pass with this change.

Output of successful `deployment build`:

```
C:\flows\tree-project> prefect deployment build main_python_files/w_wrapper_update_data.py:wrapper_data_update_function --name Capacity --storage-block remote-file-system/test --work-queue test
Found flow 'wrapper-data-update-function'
Successfully uploaded 12 files to memory://test/
Deployment YAML created at
'C:\flows\tree-project\wrapper_data_update_function-deployment.yaml'.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
