### PR TITLE
Remove default arguments; components are not optional

### DIFF
--- a/src/prefect/orion/database/interface.py
+++ b/src/prefect/orion/database/interface.py
@@ -40,9 +40,9 @@ class OrionDBInterface(metaclass=DBSingleton):
 
     def __init__(
         self,
-        database_config: BaseDatabaseConfiguration = None,
-        query_components: BaseQueryComponents = None,
-        orm: BaseORMConfiguration = None,
+        database_config: BaseDatabaseConfiguration,
+        query_components: BaseQueryComponents,
+        orm: BaseORMConfiguration,
     ):
 
         self.database_config = database_config


### PR DESCRIPTION
Minor simplification -- AFAICT these arguments are not optional and in fact `provide_database_interface` errors if any of them are not provided. However, the possibility that they are `None` really upsets mypy in other codebases.