### PR TITLE
Enable stale action to handle aging issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          debug-only: true
+          enable-statistics: true
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. To keep this issue open remove stale label or comment."
+          close-issue-message: "This issue was closed because it has been stale for 7 days with no activity. If this issue is important or you have more to add feel free to re-open it."
+          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. To keep this pull request open remove stale label or comment."
+          close-pr-message: "This pull request was closed because it has been stale for 7 days with no activity. If this pull request is important or you have more to add feel free to re-open it."
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-draft-pr: true
+          exempt-issue-labels: "status:backlog,status:in-progress,status:roadmap"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,6 @@ jobs:
           stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. To keep this pull request open remove stale label or comment."
           close-pr-message: "This pull request was closed because it has been stale for 7 days with no activity. If this pull request is important or you have more to add feel free to re-open it."
           days-before-stale: 30
-          days-before-close: 7
+          days-before-close: 14
           exempt-draft-pr: true
           exempt-issue-labels: "status:backlog,status:in-progress,status:roadmap"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This enables the [stale action](https://github.com/actions/stale), but sets it in debug mode so that we can look at the changes it would make if it were fully enabled. This way we can change the settings around till we're happy.

To see the debug output we'll have to set the `ACTIONS_STEP_DEBUG` secret in the repo to `true`.