### PR TITLE
Fix `auto_remove` docstring for DockerContainer

### DIFF
--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -139,6 +139,7 @@ class DockerContainer(Infrastructure):
 
     Attributes:
         auto_remove: If set, the container will be removed on completion. Otherwise,
+            the container will remain after exit for inspection.
         command: A list of strings specifying the command to run in the container to
             start the flow run. In most cases you should not override this.
         env: Environment variables to set for the container.
@@ -153,7 +154,6 @@ class DockerContainer(Infrastructure):
             used. If 'networks' is set, this cannot be set.
         networks: An optional list of strings specifying Docker networks to connect the
             container to.
-            the container will remain after exit for inspection.
         stream_output: If set, stream output from the container to local standard output.
         volumes: An optional list of volume mount strings in the format of
             "local_path:container_path".


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

The parameters in the docstring got moved around but the second line for `auto_remove` wasn't moved up, this fixes it.

Closes #6441 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
