### PR TITLE
Fix issue with github storage running in non-empty directories

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -774,12 +774,14 @@ class GitHub(ReadableDeploymentStorage):
         if local_path is None:
             local_path = Path(".").absolute()
 
+        if not from_path:
+            from_path = ""
+
         # in this case, we clone to a temporary directory and move the subdirectory over
         tmp_dir = None
-        if from_path:
-            tmp_dir = tempfile.TemporaryDirectory(suffix="prefect")
-            path_to_move = str(Path(tmp_dir.name).joinpath(from_path))
-            cmd += f" {tmp_dir.name} && cp -R {path_to_move}/."
+        tmp_dir = tempfile.TemporaryDirectory(suffix="prefect")
+        path_to_move = str(Path(tmp_dir.name).joinpath(from_path))
+        cmd += f" {tmp_dir.name} && cp -R {path_to_move}/."
 
         cmd += f" {local_path}"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,6 +366,7 @@ class TestClientContextManager:
         assert startup.call_count == shutdown.call_count
         assert startup.call_count > 0
 
+    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.skipif(not_enough_open_files(), reason=not_enough_open_files.__doc__)
     async def test_client_context_lifespan_is_robust_to_mixed_concurrency(self):
         startup, shutdown = MagicMock(), MagicMock()

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -141,27 +141,22 @@ class TestGitHub:
         class p:
             returncode = 0
 
-        expected_path = Path(".").absolute()
         mock = AsyncMock(return_value=p())
         monkeypatch.setattr(prefect.filesystems, "run_process", mock)
         g = GitHub(repository="prefect")
         await g.get_directory()
 
         assert mock.await_count == 1
-        assert mock.await_args[0][0] == f"git clone prefect {expected_path}"
+        assert f"git clone prefect" in mock.await_args[0][0]
 
     async def test_reference_default(self, monkeypatch):
         class p:
             returncode = 0
 
-        expected_path = Path(".").absolute()
         mock = AsyncMock(return_value=p())
         monkeypatch.setattr(prefect.filesystems, "run_process", mock)
         g = GitHub(repository="prefect", reference="2.0.0")
         await g.get_directory()
 
         assert mock.await_count == 1
-        assert (
-            mock.await_args[0][0]
-            == f"git clone prefect -b 2.0.0 --depth 1 {expected_path}"
-        )
+        assert f"git clone prefect -b 2.0.0 --depth 1" in mock.await_args[0][0]


### PR DESCRIPTION
When running a deployment within a Docker image that has a non-empty working directory, GitHub storage would fail because `git clone` errors out if the directory is non-empty.  This PR adjusts the logic to `git clone` into a temporary directory (that will always be empty) and then recursively copy all files over into the present working directory.  This code path is the same as if a user had specified a subdirectory of their repository, so a nice side effect is a unified code path.

QA'ed live with @discdiver @WillRaphaelson and @khuyentran1401 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
