### PR TITLE
Adds test for parameter openapi schema

### DIFF
--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -78,6 +78,7 @@ async def create_deployment(
                         "description",
                         "tags",
                         "parameters",
+                        "parameter_openapi_schema",
                         "updated",
                         "work_queue_name",
                         "storage_document_id",

--- a/tests/orion/models/test_block_schemas.py
+++ b/tests/orion/models/test_block_schemas.py
@@ -885,7 +885,9 @@ class TestReadBlockSchemas:
             block_schemas_with_capabilities[0].id
         ]
 
-    @pytest.mark.flaky  # Order of block schema references sometimes doesn't match
+    @pytest.mark.flaky(
+        max_runs=3
+    )  # Order of block schema references sometimes doesn't match
     async def test_read_block_schema_with_union(
         self, session, block_type_x, block_type_y, block_type_z
     ):


### PR DESCRIPTION
This PR ensures that the Parameter OpenAPI schema is updated with each deployment creation; previously this update was not occurring, leading to the UI not displaying the correct information.

Closes https://github.com/PrefectHQ/prefect/issues/6563

<!-- Include an overview here -->

### Example
Take a flow defined as:
```python
from prefect import flow

@flow 
def my_flow(old: str):
    pass
```
and create a basic deployment for it (CLI or Python, doesn't matter).  Add an override for `old` in the UI.

Then update the flow:
```python
from prefect import flow

@flow 
def my_flow(old: str, new: bool = False):
    pass
```
and re-create a basic deployment for it.  Visit the UI - on `main`, the `new` parameter would not be displayed, but on this branch it will be.
