### PR TITLE
Preserve task dependencies to futures passed as parameters in `.map`

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -55,7 +55,7 @@ from prefect.logging.loggers import (
     task_run_logger,
 )
 from prefect.orion.schemas import core
-from prefect.orion.schemas.core import FlowRun, TaskRun
+from prefect.orion.schemas.core import FlowRun, TaskRun, TaskRunInput
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.filters import FlowRunFilter
 from prefect.orion.schemas.responses import SetStateStatus
@@ -749,10 +749,16 @@ async def begin_task_map(
     task_runner: Optional[BaseTaskRunner],
 ) -> List[Union[PrefectFuture, Awaitable[PrefectFuture]]]:
     """Async entrypoint for task mapping"""
+    # We need to resolve some futures to map over their data, collect the upstream
+    # links beforehand to retain relationship tracking.
+    task_inputs = {
+        k: await collect_task_run_inputs(v, max_depth=0) for k, v in parameters.items()
+    }
 
-    # Resolve any futures / states that are in the parameters as we need to
-    # validate the lengths of those values before proceeding.
-    parameters.update(await resolve_inputs(parameters))
+    # Resolve the top-level parameters in order to get mappable data of a known length.
+    # Nested parameters will be resolved in each mapped child where their relationships
+    # will also be tracked.
+    parameters = await resolve_inputs(parameters, max_depth=1)
 
     iterable_parameters = {}
     static_parameters = {}
@@ -760,7 +766,7 @@ async def begin_task_map(
         if isinstance(val, unmapped):
             static_parameters[key] = val.value
         elif isiterable(val):
-            iterable_parameters[key] = val
+            iterable_parameters[key] = list(val)
         else:
             static_parameters[key] = val
 
@@ -795,15 +801,14 @@ async def begin_task_map(
                 wait_for=wait_for,
                 return_type=return_type,
                 task_runner=task_runner,
+                extra_task_inputs=task_inputs,
             )
         )
 
     return await gather(*task_runs)
 
 
-async def collect_task_run_inputs(
-    expr: Any,
-) -> Set[Union[core.TaskRunResult, core.Parameter, core.Constant]]:
+async def collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRunInput]:
     """
     This function recurses through an expression to generate a set of any discernable
     task run inputs it finds in the data structure. It produces a set of all inputs
@@ -835,6 +840,7 @@ async def collect_task_run_inputs(
         expr,
         visit_fn=add_futures_and_states_to_inputs,
         return_data=False,
+        max_depth=max_depth,
     )
 
     return inputs
@@ -847,13 +853,17 @@ async def get_task_call_return_value(
     wait_for: Optional[Iterable[PrefectFuture]],
     return_type: EngineReturnType,
     task_runner: Optional[BaseTaskRunner],
+    extra_task_inputs: Optional[Dict[str, Set[TaskRunInput]]] = None,
 ):
+    extra_task_inputs = extra_task_inputs or {}
+
     future = await create_task_run_future(
         task=task,
         flow_run_context=flow_run_context,
         parameters=parameters,
         wait_for=wait_for,
         task_runner=task_runner,
+        extra_task_inputs=extra_task_inputs,
     )
     if return_type == "future":
         return future
@@ -871,6 +881,7 @@ async def create_task_run_future(
     parameters: Dict[str, Any],
     wait_for: Optional[Iterable[PrefectFuture]],
     task_runner: Optional[BaseTaskRunner],
+    extra_task_inputs: Dict[str, Set[TaskRunInput]],
 ) -> PrefectFuture:
     # Default to the flow run's task runner
     task_runner = task_runner or flow_run_context.task_runner
@@ -899,6 +910,7 @@ async def create_task_run_future(
             parameters=parameters,
             wait_for=wait_for,
             task_runner=task_runner,
+            extra_task_inputs=extra_task_inputs,
         )
     )
 
@@ -921,6 +933,7 @@ async def create_task_run_then_submit(
     parameters: Dict[str, Any],
     wait_for: Optional[Iterable[PrefectFuture]],
     task_runner: BaseTaskRunner,
+    extra_task_inputs: Dict[str, Set[TaskRunInput]],
 ) -> None:
 
     task_run = await create_task_run(
@@ -930,6 +943,7 @@ async def create_task_run_then_submit(
         parameters=parameters,
         dynamic_key=task_run_dynamic_key,
         wait_for=wait_for,
+        extra_task_inputs=extra_task_inputs,
     )
 
     # Attach the task run to the future to support `get_state` operations
@@ -955,10 +969,15 @@ async def create_task_run(
     parameters: Dict[str, Any],
     dynamic_key: str,
     wait_for: Optional[Iterable[PrefectFuture]],
+    extra_task_inputs: Dict[str, Set[TaskRunInput]],
 ) -> TaskRun:
     task_inputs = {k: await collect_task_run_inputs(v) for k, v in parameters.items()}
     if wait_for:
         task_inputs["wait_for"] = await collect_task_run_inputs(wait_for)
+
+    # Join extra task inputs
+    for k, extras in extra_task_inputs.items():
+        task_inputs[k] = task_inputs[k].union(extras)
 
     logger = get_run_logger(flow_run_context)
 
@@ -1339,7 +1358,7 @@ async def report_flow_run_crashes(flow_run: FlowRun, client: OrionClient):
 
 
 async def resolve_inputs(
-    parameters: Dict[str, Any], return_data: bool = True
+    parameters: Dict[str, Any], return_data: bool = True, max_depth: int = -1
 ) -> Dict[str, Any]:
     """
     Resolve any `Quote`, `PrefectFuture`, or `State` types nested in parameters into
@@ -1377,6 +1396,7 @@ async def resolve_inputs(
         parameters,
         visit_fn=resolve_input,
         return_data=return_data,
+        max_depth=max_depth,
     )
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,9 @@
 import datetime
 import inspect
 import warnings
+from typing import Dict, List
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import anyio
 import pytest
@@ -15,6 +17,7 @@ from prefect.exceptions import (
     ReservedArgumentError,
 )
 from prefect.futures import PrefectFuture
+from prefect.orion import models
 from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.states import State, StateType
@@ -1947,6 +1950,195 @@ class TestTaskMap:
 
         futures = my_flow()
         assert [future.result() for future in futures] == [2, 3, 4]
+
+    @task
+    def echo(x):
+        return x
+
+    @task
+    def numbers():
+        return [1, 2, 3]
+
+    async def get_dependency_ids(self, session, flow_run_id) -> Dict[UUID, List[UUID]]:
+        graph = await models.flow_runs.read_task_run_dependencies(
+            session=session, flow_run_id=flow_run_id
+        )
+
+        return {x["id"]: [d.id for d in x["upstream_dependencies"]] for x in graph}
+
+    async def test_map_preserves_dependencies_between_futures_all_mapped_children(
+        self, session
+    ):
+        @flow
+        def my_flow():
+            """
+                    ┌─►add_together
+            numbers─┼─►add_together
+                    └─►add_together
+            """
+
+            numbers = TestTaskMap.numbers.submit()
+            return numbers, TestTaskMap.add_together.map(numbers, y=0)
+
+        numbers_future, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, numbers_future.state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [1, 2, 3]
+
+        assert dependency_ids[numbers_future.state_details.task_run_id] == []
+        assert all(
+            dependency_ids[a.state_details.task_run_id]
+            == [numbers_future.state_details.task_run_id]
+            for a in add_futures
+        )
+
+    async def test_map_preserves_dependencies_between_futures_all_mapped_children_multiple(
+        self, session
+    ):
+        @flow
+        def my_flow():
+            """
+            numbers1─┬►add_together
+                     ├►add_together
+            numbers2─┴►add_together
+            """
+
+            numbers1 = TestTaskMap.numbers.submit()
+            numbers2 = TestTaskMap.numbers.submit()
+            return (numbers1, numbers2), TestTaskMap.add_together.map(
+                numbers1, numbers2
+            )
+
+        numbers_futures, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, numbers_futures[0].state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [2, 4, 6]
+
+        assert all(
+            dependency_ids[n.state_details.task_run_id] == [] for n in numbers_futures
+        )
+        assert all(
+            set(dependency_ids[a.state_details.task_run_id])
+            == {n.state_details.task_run_id for n in numbers_futures}
+            and len(dependency_ids[a.state_details.task_run_id]) == 2
+            for a in add_futures
+        )
+
+    async def test_map_preserves_dependencies_between_futures_differing_parents(
+        self, session
+    ):
+        @flow
+        def my_flow():
+            """
+            x1─►add_together
+            x2─►add_together
+            """
+
+            x1 = TestTaskMap.echo.submit(1)
+            x2 = TestTaskMap.echo.submit(2)
+            return (x1, x2), TestTaskMap.add_together.map([x1, x2], y=0)
+
+        echo_futures, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, echo_futures[0].state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [1, 2]
+
+        assert all(
+            dependency_ids[e.state_details.task_run_id] == [] for e in echo_futures
+        )
+        assert all(
+            dependency_ids[a.state_details.task_run_id] == [e.state_details.task_run_id]
+            for a, e in zip(add_futures, echo_futures)
+        )
+
+    async def test_map_preserves_dependencies_between_futures_static_arg(self, session):
+        @flow
+        def my_flow():
+            """
+              ┌─►add_together
+            x─┼─►add_together
+              └─►add_together
+            """
+
+            x = TestTaskMap.echo.submit(1)
+            return x, TestTaskMap.add_together.map([1, 2, 3], y=x)
+
+        echo_future, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, echo_future.state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [2, 3, 4]
+
+        assert dependency_ids[echo_future.state_details.task_run_id] == []
+        assert all(
+            dependency_ids[a.state_details.task_run_id]
+            == [echo_future.state_details.task_run_id]
+            for a in add_futures
+        )
+
+    async def test_map_preserves_dependencies_between_futures_mixed_map(self, session):
+        @flow
+        def my_flow():
+            """
+            x─►add_together
+               add_together
+            """
+
+            x = TestTaskMap.echo.submit(1)
+            return x, TestTaskMap.add_together.map([x, 2], y=1)
+
+        echo_future, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, echo_future.state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [2, 3]
+
+        assert dependency_ids[echo_future.state_details.task_run_id] == []
+        assert dependency_ids[add_futures[0].state_details.task_run_id] == [
+            echo_future.state_details.task_run_id
+        ]
+        assert dependency_ids[add_futures[1].state_details.task_run_id] == []
+
+    async def test_map_preserves_dependencies_between_futures_deep_nesting(
+        self, session
+    ):
+        @flow
+        def my_flow():
+            """
+            x1─┬─►add_together
+            x2─┴─►add_together
+            """
+
+            x1 = TestTaskMap.echo.submit(1)
+            x2 = TestTaskMap.echo.submit(2)
+            return (x1, x2), TestTaskMap.add_together.map(
+                [[x1, x2], [x1, x2]], y=[[3], [4]]
+            )
+
+        echo_futures, add_futures = my_flow()
+        dependency_ids = await self.get_dependency_ids(
+            session, echo_futures[0].state_details.flow_run_id
+        )
+
+        assert [a.result() for a in add_futures] == [[1, 2, 3], [1, 2, 4]]
+
+        assert all(
+            dependency_ids[e.state_details.task_run_id] == [] for e in echo_futures
+        )
+        assert all(
+            set(dependency_ids[a.state_details.task_run_id])
+            == {e.state_details.task_run_id for e in echo_futures}
+            and len(dependency_ids[a.state_details.task_run_id]) == 2
+            for a in add_futures
+        )
 
     def test_map_can_take_flow_state_as_input(self):
         @flow


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Preserves relationships between a mapped task and its parameters if that parameter is a future, closes https://github.com/PrefectHQ/prefect/issues/6686.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python

from prefect import task, flow, get_run_logger


@task
def log_task(x: int):
    logger = get_run_logger()
    logger.info(x)


@task
def flat_numbers() -> list[int]:
    return [0, 1, 2, 3, 4]


@flow
def test_flow():
    x = flat_numbers.submit()
    log_task.map(x)
```

Will now correctly produce this graph:

![Screenshot 2022-09-03 at 3 44 34 pm](https://user-images.githubusercontent.com/67542061/188275743-fbc7fab6-023f-4ad1-a7d6-a7848aa50ba7.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
