### PR TITLE
Use `named` paramstyle for sqlite

### DIFF
--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -210,7 +210,7 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             # use `named` paramstyle for sqlite instead of `qmark` in very rare
             # circumstances, we've seen aiosqlite pass parameters in the wrong
             # order; by using named parameters we avoid this issue
-            # see e.g. https://github.com/PrefectHQ/prefect/pull/6645
+            # see https://github.com/PrefectHQ/prefect/pull/6702
             kwargs["paramstyle"] = "named"
 
             # ensure a long-lasting pool is used with in-memory databases

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,6 +207,8 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
+            kwargs["paramstyle"] = "named"
+
             # ensure a long-lasting pool is used with in-memory databases
             # because they disappear when the last connection closes
             if ":memory:" in self.connection_url:

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,6 +207,10 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
+            # use `named` paramstyle for sqlite instead of `qmark` in very rare
+            # circumstances, we've seen aiosqlite pass parameters in the wrong
+            # order; by using named parameters we avoid this issue
+            # see e.g. https://github.com/PrefectHQ/prefect/pull/6645
             kwargs["paramstyle"] = "named"
 
             # ensure a long-lasting pool is used with in-memory databases

--- a/src/prefect/orion/utilities/database.py
+++ b/src/prefect/orion/utilities/database.py
@@ -539,7 +539,15 @@ def _json_has_any_key_sqlite(element, compiler, **kwargs):
     return compiler.process(
         sa.select(1)
         .select_from(json_each)
-        .where(sa.literal_column("json_each.value").in_(element.values))
+        .where(
+            sa.literal_column("json_each.value").in_(
+                # manually set the bindparam key because the default will
+                # include the `.` from the literal column name and sqlite params
+                # must be alphanumeric. `unique=True` automatically suffixes the bindparam
+                # if there are overlaps.
+                sa.bindparam(key="json_each_values", value=element.values, unique=True)
+            )
+        )
         .exists(),
         **kwargs,
     )

--- a/tests/orion/utilities/test_database.py
+++ b/tests/orion/utilities/test_database.py
@@ -338,6 +338,29 @@ class TestJSON:
         )
         assert await self.get_ids(session, query) == ids
 
+    async def test_multiple_json_has_any(self, session):
+        """
+        SQLAlchemy's default bindparam has a `.` in it, which SQLite rejects. We
+        create a custom bindparam name with `unique=True` to avoid confusion;
+        this tests that multiple json_has_any_key clauses can be used in the
+        same query.
+        """
+        query = (
+            sa.select(SQLJSONModel)
+            .where(
+                sa.or_(
+                    sa.and_(
+                        json_has_any_key(SQLJSONModel.data, ["a"]),
+                        json_has_any_key(SQLJSONModel.data, ["b"]),
+                    ),
+                    json_has_any_key(SQLJSONModel.data, ["c"]),
+                    json_has_any_key(SQLJSONModel.data, ["d"]),
+                ),
+            )
+            .order_by(SQLJSONModel.id)
+        )
+        assert await self.get_ids(session, query) == [3, 4, 5, 6]
+
     @pytest.mark.parametrize(
         "keys,ids",
         [


### PR DESCRIPTION
In https://github.com/PrefectHQ/prefect/pull/6645 we found a bizarre edge case where SQLite passed parameters to the compiled query in the wrong order. This happened at the lowest level of the DBApi -- even `compile()`-ing the statement in SqlAlchemy rendered everything correctly. We were unable to identify the source of the issue (something with nested CTEs and subqueries, presumably) and resolved it with a SQLite-specific code branch that materialized a heavily-parameterized query rather than leaving it as a CTE.

To resolve this properly, this PR changes the SQLite `paramstyle` from `qmark` to `named`. This has the effect of changing 
```
SELECT *
FROM my_table
WHERE x = ? and y = ?
```
to 
```
SELECT *
FROM my_table
WHERE x = :x and y = :y
```

This removes any ambiguity with how parameters are ordered, as they are passed by name (like kwargs). 

We tried this briefly in #6645 but it caused unit test failures. The cause of those failures was SQLalchemy's automatic naming of bindparams based on the column being bound. In our `json_has_any_key` function, we work with a virtual SQLite column called `json_each.value`; when we compare that to a value called, say, `x`, SQLAlchemy automatically names the bound parameter `json_each.value_x`. This creates errors because SQLite doesn't allow `.` in bound parameter names - they must be alphanumeric. Therefore, this PR manually sets the `bindparam` name for these `json_each.value` clauses, which is essentially the same thing SQLAlchemy is doing automatically except that we don't include a `.` in the key. 

Once the `json_each` bindparam names are fixed, all tests pass with this paramstyle AND we can remove the sqlite-specific code path for querying block documents. 