### PR TITLE
Simplify the nested block document query

### DIFF
--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -210,7 +210,7 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             # use `named` paramstyle for sqlite instead of `qmark` in very rare
             # circumstances, we've seen aiosqlite pass parameters in the wrong
             # order; by using named parameters we avoid this issue
-            # see e.g. https://github.com/PrefectHQ/prefect/pull/6645
+            # see https://github.com/PrefectHQ/prefect/pull/6702
             kwargs["paramstyle"] = "named"
 
             # ensure a long-lasting pool is used with in-memory databases

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,6 +207,8 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
+            kwargs["paramstyle"] = "named"
+
             # ensure a long-lasting pool is used with in-memory databases
             # because they disappear when the last connection closes
             if ":memory:" in self.connection_url:

--- a/src/prefect/orion/database/configurations.py
+++ b/src/prefect/orion/database/configurations.py
@@ -207,6 +207,10 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             if self.timeout is not None:
                 kwargs["connect_args"] = dict(timeout=self.timeout)
 
+            # use `named` paramstyle for sqlite instead of `qmark` in very rare
+            # circumstances, we've seen aiosqlite pass parameters in the wrong
+            # order; by using named parameters we avoid this issue
+            # see e.g. https://github.com/PrefectHQ/prefect/pull/6645
             kwargs["paramstyle"] = "named"
 
             # ensure a long-lasting pool is used with in-memory databases

--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -1,6 +1,6 @@
 import datetime
 from abc import ABC, abstractmethod, abstractproperty
-from typing import TYPE_CHECKING, Hashable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Hashable, List, Tuple
 
 import pendulum
 import sqlalchemy as sa
@@ -126,128 +126,6 @@ class BaseQueryComponents(ABC):
             include_defaults=False,
         )
         await session.execute(stmt)
-
-    async def read_block_documents(
-        self,
-        session: sa.orm.Session,
-        db: "OrionDBInterface",
-        block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
-        block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
-        block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
-        include_secrets: bool = False,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-    ):
-
-        # if no filter is provided, one is created that excludes anonymous blocks
-        if block_document_filter is None:
-            block_document_filter = schemas.filters.BlockDocumentFilter(
-                is_anonymous=schemas.filters.BlockDocumentFilterIsAnonymous(eq_=False)
-            )
-
-        # --- Query for Parent Block Documents
-        # begin by building a query for only those block documents that are selected
-        # by the provided filters
-        filtered_block_documents_query = sa.select(db.BlockDocument.id).where(
-            block_document_filter.as_sql_filter(db)
-        )
-
-        if block_type_filter is not None:
-            block_type_exists_clause = sa.select(db.BlockType).where(
-                db.BlockType.id == db.BlockDocument.block_type_id,
-                block_type_filter.as_sql_filter(db),
-            )
-            filtered_block_documents_query = filtered_block_documents_query.where(
-                block_type_exists_clause.exists()
-            )
-
-        if block_schema_filter is not None:
-            block_schema_exists_clause = sa.select(db.BlockSchema).where(
-                db.BlockSchema.id == db.BlockDocument.block_schema_id,
-                block_schema_filter.as_sql_filter(db),
-            )
-            filtered_block_documents_query = filtered_block_documents_query.where(
-                block_schema_exists_clause.exists()
-            )
-
-        if offset is not None:
-            filtered_block_documents_query = filtered_block_documents_query.offset(
-                offset
-            )
-
-        if limit is not None:
-            filtered_block_documents_query = filtered_block_documents_query.limit(limit)
-
-        filtered_block_documents_query = filtered_block_documents_query.cte(
-            "filtered_block_documents"
-        )
-
-        # --- Query for Referenced Block Documents
-        # next build a recursive query for (potentially nested) block documents
-        # that reference the filtered block documents
-        block_document_references_query = (
-            sa.select(db.BlockDocumentReference)
-            .filter(
-                db.BlockDocumentReference.parent_block_document_id.in_(
-                    sa.select(filtered_block_documents_query.c.id)
-                )
-            )
-            .cte("block_document_references", recursive=True)
-        )
-        block_document_references_join = sa.select(db.BlockDocumentReference).join(
-            block_document_references_query,
-            db.BlockDocumentReference.parent_block_document_id
-            == block_document_references_query.c.reference_block_document_id,
-        )
-        recursive_block_document_references_cte = (
-            block_document_references_query.union_all(block_document_references_join)
-        )
-
-        # --- Final Query for All Block Documents
-        # build a query that unions:
-        # - the filtered block documents
-        # - with any block documents that are discovered as (potentially nested) references
-        all_block_documents_query = sa.union_all(
-            # first select the parent block
-            sa.select(
-                [
-                    db.BlockDocument,
-                    sa.null().label("reference_name"),
-                    sa.null().label("reference_parent_block_document_id"),
-                ]
-            )
-            .select_from(db.BlockDocument)
-            .where(
-                db.BlockDocument.id.in_(sa.select(filtered_block_documents_query.c.id))
-            ),
-            #
-            # then select any referenced blocks
-            sa.select(
-                [
-                    db.BlockDocument,
-                    recursive_block_document_references_cte.c.name,
-                    recursive_block_document_references_cte.c.parent_block_document_id,
-                ]
-            )
-            .select_from(db.BlockDocument)
-            .join(
-                recursive_block_document_references_cte,
-                db.BlockDocument.id
-                == recursive_block_document_references_cte.c.reference_block_document_id,
-            ),
-        ).cte("all_block_documents_query")
-
-        # the final union query needs to be `aliased` for proper ORM unpacking
-        # and also be sorted
-        return (
-            sa.select(
-                sa.orm.aliased(db.BlockDocument, all_block_documents_query),
-                all_block_documents_query.c.reference_name,
-                all_block_documents_query.c.reference_parent_block_document_id,
-            )
-            .select_from(all_block_documents_query)
-            .order_by(all_block_documents_query.c.name)
-        )
 
 
 class AsyncPostgresQueryComponents(BaseQueryComponents):

--- a/src/prefect/orion/utilities/database.py
+++ b/src/prefect/orion/utilities/database.py
@@ -539,7 +539,15 @@ def _json_has_any_key_sqlite(element, compiler, **kwargs):
     return compiler.process(
         sa.select(1)
         .select_from(json_each)
-        .where(sa.literal_column("json_each.value").in_(element.values))
+        .where(
+            sa.literal_column("json_each.value").in_(
+                # manually set the bindparam key because the default will
+                # include the `.` from the literal column name and sqlite params
+                # must be alphanumeric. `unique=True` automatically suffixes the bindparam
+                # if there are overlaps.
+                sa.bindparam(key="json_each_values", value=element.values, unique=True)
+            )
+        )
         .exists(),
         **kwargs,
     )

--- a/tests/orion/utilities/test_database.py
+++ b/tests/orion/utilities/test_database.py
@@ -338,6 +338,29 @@ class TestJSON:
         )
         assert await self.get_ids(session, query) == ids
 
+    async def test_multiple_json_has_any(self, session):
+        """
+        SQLAlchemy's default bindparam has a `.` in it, which SQLite rejects. We
+        create a custom bindparam name with `unique=True` to avoid confusion;
+        this tests that multiple json_has_any_key clauses can be used in the
+        same query.
+        """
+        query = (
+            sa.select(SQLJSONModel)
+            .where(
+                sa.or_(
+                    sa.and_(
+                        json_has_any_key(SQLJSONModel.data, ["a"]),
+                        json_has_any_key(SQLJSONModel.data, ["b"]),
+                    ),
+                    json_has_any_key(SQLJSONModel.data, ["c"]),
+                    json_has_any_key(SQLJSONModel.data, ["d"]),
+                ),
+            )
+            .order_by(SQLJSONModel.id)
+        )
+        assert await self.get_ids(session, query) == [3, 4, 5, 6]
+
     @pytest.mark.parametrize(
         "keys,ids",
         [


### PR DESCRIPTION
In #6645 we refactored the block document query for significant performance gains, but noted an unfortunate need to create a slightly different implementation for sqlite.

In #6702 we unified the sqlite and postgres implementations of this query.

#6645 was motivated by replacing a slow `OR` condition with `UNION`; in this PR we restructure the query to remove that UNION entirely and cut the query complexity by about half.

In the original query, we began by using the provided filters to load all _parent_ block document ids, then used a recursive CTE to find all _referenced_ block documents, including potentially nested ones. We then queried the block document table, using the information in those two queries to know which documents to load. It is because we were using those two disjoint queries that we needed an `OR` or `UNION` statement at all.

In this query, we modify the recursive CTE so that instead of initializing it with any reference blocks contained in the parent documents, we initialize it with the parent block documents themselves. This means that after the recursive query finishes, it contains not only the IDs of any nested references, but the parent document IDs as well! This eliminates the need for the `OR` / `UNION` entirely: all the IDs we need are in the recursive output and we can do an efficient inner join to the block document table to load all the information we need.

The net result of #6702 and this PR is that we no longer need to relegate this query to the `QueryComponents` as it no longer relies on any db-specific implementations, and we're able to remove #6645's `UNION` entirely.