### PR TITLE
Only load flow if necessary

### DIFF
--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -73,6 +73,7 @@ async def test_tolerates_majority_errors():
     assert workload.await_count == 6
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_quits_after_3_consecutive_errors(capsys: pytest.CaptureFixture):
     workload = AsyncMock(
         side_effect=[


### PR DESCRIPTION
I believe this may resolve the weird bug @znicholasbrown is seeing by avoiding a redundant load.  My theory is that objects loaded with our utility have non-standard attributes making this code path brittle.

I unfortunately don't have time to write a test for this right now, so if anyone else wants to take over this PR or I can follow up later (assuming it closes the issue).
