### PR TITLE
Make Netlify deploy previews resilient on forks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ command = """
 pip install --upgrade pip \
 && pip install --upgrade --upgrade-strategy eager  -e ".[dev]" \
 && pip install git+https://${MKDOCS_INSIDERS_PAT}@github.com/PrefectHQ/mkdocs-material-insiders.git; \
-&& prefect dev build-docs  \
+prefect dev build-docs  \
 && mkdocs build --config-file mkdocs.insiders.yml \
 || mkdocs build --config-file mkdocs.insiders.yml \
 """

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,9 +11,10 @@ base = ""
 command = """
 pip install --upgrade pip \
 && pip install --upgrade --upgrade-strategy eager  -e ".[dev]" \
-&& pip install git+https://${MKDOCS_INSIDERS_PAT}@github.com/PrefectHQ/mkdocs-material-insiders.git \
+&& pip install git+https://${MKDOCS_INSIDERS_PAT}@github.com/PrefectHQ/mkdocs-material-insiders.git; \
 && prefect dev build-docs  \
-&& mkdocs build --config-file mkdocs.insiders.yml
+&& mkdocs build --config-file mkdocs.insiders.yml \
+|| mkdocs build --config-file mkdocs.insiders.yml \
 """
 publish = "site"
 


### PR DESCRIPTION
Currently every PR opened from a fork results in a Netlify notification asking to approve the deploy preview; because many of our open source PRs are documentation related, it is convenient to see these builds often.  Right now, we have sensitive environment variables for interacting with our MkDocs insiders repo so we don't want to use those for "untrusted" builds. 

This PR attempts to change our Netlify build command so that it first attempts to install our Insiders package, but if that fails it falls back to a standard MkDocs build (which should work).  We can then turn builds on for unknown authors that don't set sensitive environment variables.  This should hopefully let us see useful deploy previews at the cost of not knowing if our insider builds are failing (this should be readily apparent though).

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Let's see how the deploy previews go in practice!

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
