### PR TITLE
Update crash detection to ignore abort signals

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1319,6 +1319,9 @@ async def report_flow_run_crashes(flow_run: FlowRun, client: OrionClient):
     """
     try:
         yield
+    except Abort:
+        # Do not capture aborts as crashes
+        raise
     except BaseException as exc:
         state = exception_to_crashed_state(exc)
         logger = flow_run_logger(flow_run)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Abort signals from the API were being incorrectly treated as crashes. Consequently, a flow run would be forced into a crashed state while running somewhere else.

Closes https://github.com/PrefectHQ/prefect/issues/6725

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Create a deployment with a short interval schedule and multiple agents with high prefetch seconds. Multiple agents will attempt to start the flow runs, resulting in some of them aborting. These should not be marked as crashes.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
