### PR TITLE
Add `get_latest` to `TaskRunView`

### DIFF
--- a/docs/orchestration/flow-runs/task-runs.md
+++ b/docs/orchestration/flow-runs/task-runs.md
@@ -62,7 +62,7 @@ task_run = TaskRunView.from_task_run_id("c8751f34-9d5e-4ea7-aead-8b50978dabb7")
 :::warning Immutability
 `TaskRunView` objects are views of the backend `Task Run` at the time of the view's creation.
 They will not retrieve the newest information each time you access their properties.
-To get the newest data for a task run, use `task_run = task_run.get_latest()` which will return a new `TaskRunView` instance.
+To get the newest data for a task run, use `task_run = task_run.get_latest()`, which will return a new `TaskRunView` instance.
 :::
 
 #### Task run results

--- a/docs/orchestration/flow-runs/task-runs.md
+++ b/docs/orchestration/flow-runs/task-runs.md
@@ -59,6 +59,12 @@ task_run = TaskRunView.from_task_run_id("c8751f34-9d5e-4ea7-aead-8b50978dabb7")
 
 ::::
 
+:::warning Immutability
+`TaskRunView` objects are views of the backend `Task Run` at the time of the view's creation.
+They will not retrieve the newest information each time you access their properties.
+To get the newest data for a task run, use `task_run = task_run.get_latest()` which will return a new `TaskRunView` instance.
+:::
+
 #### Task run results
 
 Results from task runs are persisted to the location you've specified in the task's `result` attribute. The `Result` type allows you to store task results in many locations on your own infrastructure. See the [results documentation](/core/concepts/results.md) for more details on configuring results.
@@ -74,6 +80,13 @@ def foo():
 task_run = TaskRunView.from_task_slug("foo-1", flow_run_id="<id>")
 task_run.get_result()  # "foobar!"
 ```
+
+::: tip Result caching
+When a result is retrieved, it will be cached in the `TaskRunView`.
+This reduces the time to retrieve the result from storage in the future. 
+When you use `task_run.get_latest()`, the cached result is preserved.
+:::
+
 
 ##### Mapped task results
 

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -392,3 +392,17 @@ class TaskRunView:
             return NotImplemented
 
         return other.task_run_id == self.task_run_id and other.state == self.state
+
+    def get_latest(self) -> "TaskRunView":
+        """
+        Get the a new copy of this object with the latest data from the API. Cached
+        result objects will be passed to the new object.
+
+        This will not mutate the current object.
+
+        Returns:
+            A new instance of TaskRunView
+        """
+        latest_view = self.from_task_run_id(task_run_id=self.task_run_id)
+        latest_view._result = self._result
+        return latest_view

--- a/src/prefect/backend/task_run.py
+++ b/src/prefect/backend/task_run.py
@@ -401,7 +401,7 @@ class TaskRunView:
         This will not mutate the current object.
 
         Returns:
-            A new instance of TaskRunView
+            A new instance of `TaskRunView`.
         """
         latest_view = self.from_task_run_id(task_run_id=self.task_run_id)
         latest_view._result = self._result

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -3,6 +3,7 @@ Tests for `TaskRunView`
 """
 import time
 import pytest
+from copy import copy
 import sys
 import os
 from unittest.mock import MagicMock, call
@@ -405,3 +406,68 @@ def test_task_run_view_iter_mapped():
             ),
         ]
     )
+
+
+def test_task_run_view_get_latest_returns_new_instance(patch_posts):
+    patch_posts(
+        [
+            {"data": {"task_run": [TASK_RUN_DATA_1]}},
+            {"data": {"task_run": [TASK_RUN_DATA_2]}},
+        ]
+    )
+
+    task_run = TaskRunView.from_task_run_id("fake-id")
+    task_run_2 = task_run.get_latest()
+
+    # Assert we have not mutated the original flow run object
+    assert task_run.task_run_id == "id-1"
+    assert task_run.name == "name-1"
+    assert task_run.task_id == "task-id-1"
+    assert task_run.task_slug == "task-slug-1"
+    assert task_run.map_index == "map_index-1"
+    # This state is deserialized at initialization
+    assert task_run.state == Success(message="state-1")
+
+    # Assert the new object has the data returned by the query
+    # In reality, the task run id would be the same because that's how lookups are
+    # performed
+    assert task_run_2.task_run_id == "id-2"
+    assert task_run_2.name == "name-2"
+    assert task_run_2.task_id == "task-id-2"
+    assert task_run_2.task_slug == "task-slug-2"
+    assert task_run_2.map_index == "map_index-2"
+    # This state is deserialized at initialization
+    assert task_run_2.state == Success(message="state-2")
+
+
+def test_task_run_view_get_latest_retains_cached_results(patch_post, tmpdir):
+    result = LocalResult(dir=tmpdir).write("test-object!")
+
+    # Instantiate a very minimal task run view
+    task_run = TaskRunView(
+        task_run_id="test",
+        task_id=None,
+        task_slug=None,
+        name=None,
+        # Roundtrip serialize/deserialize to drop the value from the result
+        state=State.deserialize(Success(result=result).serialize()),
+        map_index=-1,
+        flow_run_id=None,
+    )
+
+    task_run_data = TASK_RUN_DATA_1.copy()
+    # Attach a state with a result to the API response
+    task_run_data["serialized_state"] = Success(result=result).serialize()
+
+    patch_post(
+        {"data": {"task_run": [task_run_data]}},
+    )
+
+    result = task_run.get_result()
+    task_run_2 = task_run.get_latest()
+
+    # Cached results are transfered
+    assert task_run_2._result is result
+
+    # Can be accessed
+    assert task_run_2.get_result() is result

--- a/tests/backend/test_task_run.py
+++ b/tests/backend/test_task_run.py
@@ -463,11 +463,11 @@ def test_task_run_view_get_latest_retains_cached_results(patch_post, tmpdir):
         {"data": {"task_run": [task_run_data]}},
     )
 
-    result = task_run.get_result()
+    result_value = task_run.get_result()
     task_run_2 = task_run.get_latest()
 
     # Cached results are transfered
-    assert task_run_2._result is result
+    assert task_run_2._result is result_value
 
     # Can be accessed
-    assert task_run_2.get_result() is result
+    assert task_run_2.get_result() is result_value


### PR DESCRIPTION
Addresses issue where task run results cannot be retrieved because stale views are being used by adding `TaskRunView.get_latest()` which retrieves the most recent metadata for a task run while preserving cached results.

See https://prefecthq.slack.com/archives/C028BPL85C3/p1662655107790269 (internal)