### PR TITLE
Fix saving blocks' fields with aliases

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -350,12 +350,10 @@ class Block(BaseModel, ABC):
         # create references to those saved block documents.
         for key in data_keys:
             field_value = getattr(self, key)
-
             if (
                 isinstance(field_value, Block)
                 and field_value._block_document_id is not None
             ):
-                # save using alias
                 block_document_data[key] = {
                     "$ref": {"block_document_id": field_value._block_document_id}
                 }

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -338,17 +338,24 @@ class Block(BaseModel, ABC):
                 "No block type ID provided, either as an argument or on the block."
             )
 
-        data_keys = self.schema()["properties"].keys()
-        block_document_data = self.dict(include=data_keys)
+        # The keys passed to `include` must NOT be aliases, else some items will be missed
+        # i.e. must do `self.schema_` vs `self.schema` to get a `schema_ = Field(alias="schema")`
+        # reported from https://github.com/PrefectHQ/prefect-dbt/issues/54
+        data_keys = self.schema(by_alias=False)["properties"].keys()
+
+        # `block_document_data`` must return the aliased version for it to show in the UI
+        block_document_data = self.dict(by_alias=True, include=data_keys)
 
         # Iterate through and find blocks that already have saved block documents to
         # create references to those saved block documents.
         for key in data_keys:
             field_value = getattr(self, key)
+
             if (
                 isinstance(field_value, Block)
                 and field_value._block_document_id is not None
             ):
+                # save using alias
                 block_document_data[key] = {
                     "$ref": {"block_document_id": field_value._block_document_id}
                 }

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1284,7 +1284,7 @@ class TestSaveBlock:
 
         assert loaded_inner_block == updated_inner_block
 
-    async def test_update_block_with_secrets(self, InnerBlock):
+    async def test_update_block_with_secrets(self):
         class HasSomethingToHide(Block):
             something_to_hide: SecretStr
 
@@ -1301,6 +1301,24 @@ class TestSaveBlock:
             loaded_shifty_block.something_to_hide.get_secret_value()
             == "a birthday present"
         )
+
+    async def test_block_with_alias(self):
+        class AliasBlock(Block):
+            type: str
+            schema_: str = Field(alias="schema")
+            real_name: str = Field(alias="an_alias")
+            threads: int = 4
+
+        alias_block = AliasBlock(
+            type="snowflake", schema="a_schema", an_alias="my_real_name", threads=8
+        )
+        await alias_block.save(name="my-aliased-block")
+
+        loaded_alias_block = await AliasBlock.load("my-aliased-block")
+        assert loaded_alias_block.type == "snowflake"
+        assert loaded_alias_block.schema_ == "a_schema"
+        assert loaded_alias_block.real_name == "my_real_name"
+        assert loaded_alias_block.threads == 8
 
 
 class TestToBlockType:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect-dbt/issues/54

Previously, when users tried saving a block with a field that was aliased in code, it would not save the aliased field.

A block that fits the description:
https://github.com/PrefectHQ/prefect-dbt/blob/main/prefect_dbt/cli/configs/base.py#L84

Another block:
https://github.com/PrefectHQ/prefect-snowflake/blob/main/prefect_snowflake/database.py#L43

This PR fixes this issue by properly setting `by_alias` in their respective places.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Modified example from the issue above:
```
from prefect import flow
from prefect_dbt.cli.configs.base import TargetConfigs

@flow
def test_flow():
    myconfig = TargetConfigs(schema="abc", type="snowflake")
    myconfig.save("testconfiguration", True)
    loaded_myconfig = myconfig.load("testconfiguration")
    return loaded_myconfig

assert test_flow().schema_ == "abc"
```
![image](https://user-images.githubusercontent.com/15331990/189245189-4179e5a4-e9d1-4edc-95a8-c383f677053d.png)

Then, I tried creating the block on the UI, also works:
![image](https://user-images.githubusercontent.com/15331990/189245694-370fdd1a-96c8-449d-8af5-d596b8bc76c5.png)
![image](https://user-images.githubusercontent.com/15331990/189245709-3d1321cb-3a1b-4f51-902a-b25c76e96109.png)



Also:
```
from prefect.blocks.core import Block
from pydantic import Field

class AliasBlock(Block):
    type: str
    schema_: str = Field(alias="schema")
    real_name: str = Field(alias="an_alias")
    threads: int = 4

alias_block = AliasBlock(
    type="snowflake",
    schema="a_schema",
    an_alias="something_real",
    threads=8
)

await alias_block.save(name="my_aliased_block")

loaded_alias_block = await AliasBlock.load("my-aliased-block")
assert loaded_alias_block.type == "snowflake"
assert loaded_alias_block.schema_ == "a_schema"
assert loaded_alias_block.real_name == "something_real"
assert loaded_alias_block.threads == 8
```
![image](https://user-images.githubusercontent.com/15331990/189244924-33630aa8-98cf-451d-8fc7-6c714071a17a.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
