### PR TITLE
Disable debug mode on stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          debug-only: true
-          enable-statistics: true
           stale-issue-message: "This issue is stale because it has been open 30 days with no activity. To keep this issue open remove stale label or comment."
           close-issue-message: "This issue was closed because it has been stale for 7 days with no activity. If this issue is important or you have more to add feel free to re-open it."
           stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. To keep this pull request open remove stale label or comment."


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

The stale action has been running for a few days now. It only has 30 operations it can do, but the [logs](https://github.com/PrefectHQ/prefect/runs/8262229857?check_suite_focus=true) show it doing what I'd expect.Alternatively we could look at increasing the number of operations it's allowed to perform and let it be in debug mode for longer. But I think it's configured pretty well as it is and it's unable to do a lot of damage with only 30 operation per-day.