### PR TITLE
Fix substitution in release notes generation

### DIFF
--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -94,7 +94,8 @@ def generate_release_notes(
 
     # Strip contributors from individual entries
     release_notes = ENTRY_REGEX.sub(
-        lambda match: f"- {match[0]} — {match[2]}", release_notes
+        lambda match: f"- {match.group(1)} — {match.group(3)}",
+        release_notes,
     )
 
     print(release_notes)


### PR DESCRIPTION
It turns out `match[0]` is the full match string and you need to start at `1` for groups.

Fixes entry generation from

`- * Task runner documentation fixes and clarifications by @tpdorsey in https://github.com/PrefectHQ/prefect/pull/6733 — tpdorsey`

to

`- Task runner documentation fixes and clarifications — https://github.com/PrefectHQ/prefect/pull/6733`