### PR TITLE
Use `copy_model_fields` utility for action schemas

### DIFF
--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -246,7 +246,7 @@ async def set_flow_run_state(
             session=session,
             flow_run_id=flow_run_id,
             # convert to a full State object
-            state=schemas.states.State.parse_obj(state),
+            state=schemas.states.State.parse_obj(state.dict()),
             force=force,
             flow_policy=flow_policy,
         )

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -246,7 +246,7 @@ async def set_flow_run_state(
             session=session,
             flow_run_id=flow_run_id,
             # convert to a full State object
-            state=schemas.states.State.parse_obj(state.dict()),
+            state=schemas.states.State.parse_obj(state),
             force=force,
             flow_policy=flow_policy,
         )

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -61,21 +61,26 @@ class DeploymentCreate(PrefectBaseModel):
     """Data used by the Orion API to create a deployment."""
 
     name: str = FieldFrom(schemas.core.Deployment)
-    version: Optional[str] = FieldFrom(schemas.core.Deployment)
-    description: str = FieldFrom(schemas.core.Deployment)
     flow_id: UUID = FieldFrom(schemas.core.Deployment)
-    schedule: schemas.schedules.SCHEDULE_TYPES = FieldFrom(schemas.core.Deployment)
     is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
-    infra_overrides: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
     parameters: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
     tags: List[str] = FieldFrom(schemas.core.Deployment)
+
+    manifest_path: Optional[str] = FieldFrom(schemas.core.Deployment)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
-    parameter_openapi_schema: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
-    path: str = FieldFrom(schemas.core.Deployment)
-    entrypoint: str = FieldFrom(schemas.core.Deployment)
-    manifest_path: str = FieldFrom(schemas.core.Deployment)
     storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
+    schedule: Optional[schemas.schedules.SCHEDULE_TYPES] = FieldFrom(
+        schemas.core.Deployment
+    )
+    description: Optional[str] = FieldFrom(schemas.core.Deployment)
+    parameter_openapi_schema: Optional[Dict[str, Any]] = FieldFrom(
+        schemas.core.Deployment
+    )
+    path: Optional[str] = FieldFrom(schemas.core.Deployment)
+    version: Optional[str] = FieldFrom(schemas.core.Deployment)
+    entrypoint: Optional[str] = FieldFrom(schemas.core.Deployment)
+    infra_overrides: Optional[Dict[str, Any]] = FieldFrom(schemas.core.Deployment)
 
     class Config:
         extra = "forbid"
@@ -184,7 +189,7 @@ class FlowRunCreate(PrefectBaseModel):
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
     empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
-    idempotency_key: str = FieldFrom(schemas.core.FlowRun)
+    idempotency_key: Optional[str] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
@@ -205,7 +210,7 @@ class DeploymentFlowRunCreate(PrefectBaseModel):
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
     empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
-    idempotency_key: str = FieldFrom(schemas.core.FlowRun)
+    idempotency_key: Optional[str] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
@@ -293,7 +298,6 @@ class BlockDocumentCreate(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    # validators
     _validate_name_format = validator("name", allow_reuse=True)(
         validate_block_document_name
     )

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -143,7 +143,9 @@ class StateCreate(ActionBaseModel):
     # DEPRECATED
 
     timestamp: Optional[schemas.core.DateTimeTZ] = Field(
-        default=None, repr=False, ignored=True
+        default=None,
+        repr=False,
+        ignored=True,
     )
     id: Optional[UUID] = Field(default=None, repr=False, ignored=True)
 

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -2,13 +2,13 @@
 Reduced schemas for accepting API actions.
 """
 import re
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import Field, validator
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.orion.utilities.schemas import From, PrefectBaseModel, copy_model_fields
 
 LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
 
@@ -31,135 +31,105 @@ def validate_block_document_name(value):
     return value
 
 
-class FlowCreate(
-    schemas.core.Flow.subclass(
-        name="FlowCreate",
-        include_fields=["name", "tags"],
-    )
-):
+@copy_model_fields
+class FlowCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow."""
 
+    name: str = From(schemas.core.Flow)
+    tags: List[str] = From(schemas.core.Flow)
+
     class Config:
         extra = "forbid"
 
 
-class FlowUpdate(
-    schemas.core.Flow.subclass(name="FlowUpdate", include_fields=["tags"])
-):
+@copy_model_fields
+class FlowUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow."""
 
+    tags: List[str] = From(schemas.core.Flow)
+
     class Config:
         extra = "forbid"
 
 
-class DeploymentCreate(
-    schemas.core.Deployment.subclass(
-        name="DeploymentCreate",
-        include_fields=[
-            "name",
-            "version",
-            "flow_id",
-            "schedule",
-            "is_schedule_active",
-            "work_queue_name",
-            "description",
-            "tags",
-            "parameters",
-            "manifest_path",
-            "parameter_openapi_schema",
-            "storage_document_id",
-            "path",
-            "entrypoint",
-            "infrastructure_document_id",
-            "infra_overrides",
-        ],
-    )
-):
+@copy_model_fields
+class DeploymentCreate(PrefectBaseModel):
     """Data used by the Orion API to create a deployment."""
 
+    name: str = From(schemas.core.Deployment)
+    version: Optional[str] = From(schemas.core.Deployment)
+    description: str = From(schemas.core.Deployment)
+    flow_id: UUID = From(schemas.core.Deployment)
+    schedule: schemas.schedules.SCHEDULE_TYPES = From(schemas.core.Deployment)
+    is_schedule_active: bool = From(schemas.core.Deployment)
+    infra_overrides: Dict[str, Any] = From(schemas.core.Deployment)
+    parameters: Dict[str, Any] = From(schemas.core.Deployment)
+    tags: List[str] = From(schemas.core.Deployment)
+    work_queue_name: Optional[str] = From(schemas.core.Deployment)
+    parameter_openapi_schema: Dict[str, Any] = From(schemas.core.Deployment)
+    path: str = From(schemas.core.Deployment)
+    entrypoint: str = From(schemas.core.Deployment)
+    manifest_path: str = From(schemas.core.Deployment)
+    storage_document_id: Optional[UUID] = From(schemas.core.Deployment)
+    infrastructure_document_id: Optional[UUID] = From(schemas.core.Deployment)
+
     class Config:
         extra = "forbid"
 
 
-class DeploymentUpdate(
-    schemas.core.Deployment.subclass(
-        name="DeploymentUpdate",
-        include_fields=[
-            "version",
-            "schedule",
-            "is_schedule_active",
-            "description",
-            "work_queue_name",
-            "tags",
-            "manifest_path",
-            "path",
-            "entrypoint",
-            "parameters",
-            "storage_document_id",
-            "infrastructure_document_id",
-            "infra_overrides",
-        ],
-    )
-):
+@copy_model_fields
+class DeploymentUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a deployment."""
 
+    version: Optional[str] = From(schemas.core.Deployment)
+    description: str = From(schemas.core.Deployment)
+    schedule: schemas.schedules.SCHEDULE_TYPES = From(schemas.core.Deployment)
+    is_schedule_active: bool = From(schemas.core.Deployment)
+    infra_overrides: Dict[str, Any] = From(schemas.core.Deployment)
+    parameters: Dict[str, Any] = From(schemas.core.Deployment)
+    tags: List[str] = From(schemas.core.Deployment)
+    work_queue_name: Optional[str] = From(schemas.core.Deployment)
+    path: str = From(schemas.core.Deployment)
+    entrypoint: str = From(schemas.core.Deployment)
+    manifest_path: str = From(schemas.core.Deployment)
+    storage_document_id: Optional[UUID] = From(schemas.core.Deployment)
+    infrastructure_document_id: Optional[UUID] = From(schemas.core.Deployment)
+
     class Config:
         extra = "forbid"
 
 
-class FlowRunUpdate(
-    schemas.core.FlowRun.subclass(
-        name="FlowRunUpdate",
-        include_fields=[
-            "flow_version",
-            "parameters",
-            "name",
-            "tags",
-            "empirical_policy",
-        ],
-    )
-):
+@copy_model_fields
+class FlowRunUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow run."""
 
+    name: str = From(schemas.core.FlowRun)
+    flow_version: str = From(schemas.core.FlowRun)
+    parameters: dict = From(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
+    tags: List[str] = From(schemas.core.FlowRun)
+
     class Config:
         extra = "forbid"
 
 
-class StateCreate(
-    schemas.states.State.subclass(
-        name="StateCreate",
-        include_fields=[
-            "type",
-            "name",
-            "message",
-            "data",
-            "state_details",
-        ],
-    )
-):
+@copy_model_fields
+class StateCreate(PrefectBaseModel):
     """Data used by the Orion API to create a new state."""
 
+    type: schemas.states.StateType = From(schemas.states.State)
+    name: str = From(schemas.states.State)
+    timestamp: schemas.core.DateTimeTZ = From(schemas.states.State)
+    message: str = From(schemas.states.State)
+    data: schemas.data.DataDocument = From(schemas.states.State)
+    state_details: schemas.states.StateDetails = From(schemas.states.State)
+
     class Config:
-        extra = "forbid"
+        extra = "ignore"
 
 
-class TaskRunCreate(
-    schemas.core.TaskRun.subclass(
-        name="TaskRunCreate",
-        include_fields=[
-            "name",
-            "flow_run_id",
-            "task_key",
-            "dynamic_key",
-            "cache_key",
-            "cache_expiration",
-            "task_version",
-            "empirical_policy",
-            "tags",
-            "task_inputs",
-        ],
-    )
-):
+@copy_model_fields
+class TaskRunCreate(PrefectBaseModel):
     """Data used by the Orion API to create a task run"""
 
     # TaskRunCreate states must be provided as StateCreate objects
@@ -167,25 +137,29 @@ class TaskRunCreate(
         default=None, description="The state of the task run to create"
     )
 
-
-class FlowRunCreate(
-    schemas.core.FlowRun.subclass(
-        name="FlowRunCreate",
-        include_fields=[
-            "name",
-            "flow_id",
-            "deployment_id",
-            "flow_version",
-            "parameters",
-            "context",
-            "tags",
-            "idempotency_key",
-            "parent_task_run_id",
-            "empirical_policy",
-            "infrastructure_document_id",
+    name: str = From(schemas.core.TaskRun)
+    flow_run_id: UUID = From(schemas.core.TaskRun)
+    task_key: str = From(schemas.core.TaskRun)
+    dynamic_key: str = From(schemas.core.TaskRun)
+    cache_key: str = From(schemas.core.TaskRun)
+    cache_expiration: schemas.core.DateTimeTZ = From(schemas.core.TaskRun)
+    task_version: str = From(schemas.core.TaskRun)
+    empirical_policy: schemas.core.TaskRunPolicy = From(schemas.core.TaskRun)
+    tags: List[str] = From(schemas.core.TaskRun)
+    task_inputs: Dict[
+        str,
+        List[
+            Union[
+                schemas.core.TaskRunResult,
+                schemas.core.Parameter,
+                schemas.core.Constant,
+            ]
         ],
-    )
-):
+    ] = From(schemas.core.TaskRun)
+
+
+@copy_model_fields
+class FlowRunCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow run."""
 
     class Config:
@@ -196,21 +170,21 @@ class FlowRunCreate(
         default=None, description="The state of the flow run to create"
     )
 
+    name: str = From(schemas.core.FlowRun)
+    flow_id: UUID = From(schemas.core.FlowRun)
+    deployment_id: UUID = From(schemas.core.FlowRun)
+    flow_version: str = From(schemas.core.FlowRun)
+    parameters: dict = From(schemas.core.FlowRun)
+    context: dict = From(schemas.core.FlowRun)
+    parent_task_run_id: UUID = From(schemas.core.FlowRun)
+    infrastructure_document_id: Optional[UUID] = From(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
+    tags: List[str] = From(schemas.core.FlowRun)
+    idempotency_key: str = From(schemas.core.FlowRun)
 
-class DeploymentFlowRunCreate(
-    schemas.core.FlowRun.subclass(
-        name="FlowRunCreate",
-        include_fields=[
-            "name",
-            "parameters",
-            "context",
-            "tags",
-            "idempotency_key",
-            "empirical_policy",
-            "infrastructure_document_id",
-        ],
-    )
-):
+
+@copy_model_fields
+class DeploymentFlowRunCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow run from a deployment."""
 
     class Config:
@@ -221,45 +195,47 @@ class DeploymentFlowRunCreate(
         default=None, description="The state of the flow run to create"
     )
 
+    name: Optional[str] = From(schemas.core.FlowRun)
+    parameters: dict = From(schemas.core.FlowRun)
+    context: dict = From(schemas.core.FlowRun)
+    infrastructure_document_id: Optional[UUID] = From(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
+    tags: List[str] = From(schemas.core.FlowRun)
+    idempotency_key: str = From(schemas.core.FlowRun)
 
-class SavedSearchCreate(
-    schemas.core.SavedSearch.subclass(
-        name="SavedSearchCreate",
-        include_fields=["name", "filters"],
-    )
-):
+
+@copy_model_fields
+class SavedSearchCreate(PrefectBaseModel):
     """Data used by the Orion API to create a saved search."""
 
+    name: str = From(schemas.core.SavedSearch)
+    filters: List[schemas.core.SavedSearchFilter] = From(schemas.core.SavedSearch)
+
     class Config:
         extra = "forbid"
 
 
-class ConcurrencyLimitCreate(
-    schemas.core.ConcurrencyLimit.subclass(
-        name="ConcurrencyLimitCreate",
-        include_fields=["tag", "concurrency_limit"],
-    )
-):
+@copy_model_fields
+class ConcurrencyLimitCreate(PrefectBaseModel):
     """Data used by the Orion API to create a concurrency limit."""
 
+    tag: str = From(schemas.core.ConcurrencyLimit)
+    concurrency_limit: int = From(schemas.core.ConcurrencyLimit)
+
     class Config:
         extra = "forbid"
 
 
-class BlockTypeCreate(
-    schemas.core.BlockType.subclass(
-        name="BlockTypeCreate",
-        include_fields=[
-            "name",
-            "slug",
-            "logo_url",
-            "documentation_url",
-            "description",
-            "code_example",
-        ],
-    )
-):
+@copy_model_fields
+class BlockTypeCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block type."""
+
+    name: str = From(schemas.core.BlockType)
+    slug: str = From(schemas.core.BlockType)
+    logo_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
+    documentation_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
+    description: Optional[str] = From(schemas.core.BlockType)
+    code_example: Optional[str] = From(schemas.core.BlockType)
 
     class Config:
         extra = "forbid"
@@ -270,43 +246,41 @@ class BlockTypeCreate(
     )
 
 
+@copy_model_fields
 class BlockTypeUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a block type."""
 
     class Config:
         extra = "forbid"
 
-    logo_url: Optional[str] = None
-    documentation_url: Optional[str] = None
-    description: Optional[str] = None
-    code_example: Optional[str] = None
+    logo_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
+    documentation_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
+    description: Optional[str] = From(schemas.core.BlockType)
+    code_example: Optional[str] = From(schemas.core.BlockType)
 
 
-class BlockSchemaCreate(
-    schemas.core.BlockSchema.subclass(
-        name="BlockSchemaCreate",
-        include_fields=["fields", "capabilities", "block_type_id", "version"],
-    )
-):
+@copy_model_fields
+class BlockSchemaCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block schema."""
+
+    fields: dict = From(schemas.core.BlockSchema)
+    block_type_id: Optional[UUID] = From(schemas.core.BlockSchema)
+    capabilities: List[str] = From(schemas.core.BlockSchema)
+    version: str = From(schemas.core.BlockSchema)
 
     class Config:
         extra = "forbid"
 
 
-class BlockDocumentCreate(
-    schemas.core.BlockDocument.subclass(
-        name="BlockDocumentCreate",
-        include_fields=[
-            "name",
-            "data",
-            "block_schema_id",
-            "block_type_id",
-            "is_anonymous",
-        ],
-    )
-):
+@copy_model_fields
+class BlockDocumentCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block document."""
+
+    name: Optional[str] = From(schemas.core.BlockDocument)
+    data: dict = From(schemas.core.BlockDocument)
+    block_schema_id: UUID = From(schemas.core.BlockDocument)
+    block_type_id: UUID = From(schemas.core.BlockDocument)
+    is_anonymous: bool = From(schemas.core.BlockDocument)
 
     class Config:
         extra = "forbid"
@@ -317,119 +291,113 @@ class BlockDocumentCreate(
     )
 
 
+@copy_model_fields
 class BlockDocumentUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a block document."""
 
+    data: dict = From(schemas.core.BlockDocument)
+
     class Config:
         extra = "forbid"
 
-    data: Optional[dict] = None
 
-
-class BlockDocumentReferenceCreate(
-    schemas.core.BlockDocumentReference.subclass(
-        name="BlockDocumentReferenceCreate",
-        include_fields=[
-            "id",
-            "name",
-            "parent_block_document_id",
-            "reference_block_document_id",
-        ],
-    )
-):
+@copy_model_fields
+class BlockDocumentReferenceCreate(PrefectBaseModel):
     """Data used to create block document reference."""
 
+    id: UUID = From(schemas.core.BlockDocumentReference)
+    parent_block_document_id: UUID = From(schemas.core.BlockDocumentReference)
+    reference_block_document_id: UUID = From(schemas.core.BlockDocumentReference)
+    name: str = From(schemas.core.BlockDocumentReference)
+
     class Config:
         extra = "forbid"
 
 
-class LogCreate(
-    schemas.core.Log.subclass(
-        name="LogCreate",
-        include_fields=[
-            "name",
-            "level",
-            "message",
-            "timestamp",
-            "flow_run_id",
-            "task_run_id",
-        ],
-    )
-):
+@copy_model_fields
+class LogCreate(PrefectBaseModel):
     """Data used by the Orion API to create a log."""
 
+    name: str = From(schemas.core.Log)
+    level: int = From(schemas.core.Log)
+    message: str = From(schemas.core.Log)
+    timestamp: schemas.core.DateTimeTZ = From(schemas.core.Log)
+    flow_run_id: UUID = From(schemas.core.Log)
+    task_run_id: Optional[UUID] = From(schemas.core.Log)
+
     class Config:
         extra = "forbid"
 
 
-class WorkQueueCreate(
-    schemas.core.WorkQueue.subclass(
-        "WorkQueueCreate",
-        include_fields=[
-            "name",
-            "description",
-            "is_paused",
-            "concurrency_limit",
-            # DEPRECATED: filters are deprecated
-            "filter",
-        ],
-    )
-):
+@copy_model_fields
+class WorkQueueCreate(PrefectBaseModel):
     """Data used by the Orion API to create a work queue."""
 
+    name: str = From(schemas.core.WorkQueue)
+    description: Optional[str] = From(schemas.core.WorkQueue)
+    is_paused: bool = From(schemas.core.WorkQueue)
+    concurrency_limit: Optional[int] = From(schemas.core.WorkQueue)
+
+    # DEPRECATED
+
+    filter: Optional[schemas.core.QueueFilter] = Field(
+        None,
+        description="Filter criteria for the work queue.",
+        deprecated=True,
+    )
+
     class Config:
         extra = "forbid"
 
 
-class WorkQueueUpdate(
-    schemas.core.WorkQueue.subclass(
-        "WorkQueueUpdate",
-        include_fields=[
-            "description",
-            "is_paused",
-            "concurrency_limit",
-            # DEPRECATED: filters are deprecated
-            "filter",
-        ],
-    )
-):
+@copy_model_fields
+class WorkQueueUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a work queue."""
 
-    class Config:
-        extra = "forbid"
+    description: Optional[str] = From(schemas.core.WorkQueue)
+    is_paused: bool = From(schemas.core.WorkQueue)
+    concurrency_limit: Optional[int] = From(schemas.core.WorkQueue)
 
-    # DEPRECATED: names should not be updated, left here only for backwards-compatibility
+    # DEPRECATED
+
+    filter: Optional[schemas.core.QueueFilter] = Field(
+        None,
+        description="Filter criteria for the work queue.",
+        deprecated=True,
+    )
+
+    # Names should not be updated, left here only for backwards-compatibility
     name: Optional[str] = Field(
         default=None, description="The name of the work queue.", deprecated=True
     )
 
+    class Config:
+        extra = "forbid"
 
-class FlowRunNotificationPolicyCreate(
-    schemas.core.FlowRunNotificationPolicy.subclass(
-        "FlowRunNotificationPolicyCreate",
-        include_fields=[
-            "is_active",
-            "state_names",
-            "tags",
-            "block_document_id",
-            "message_template",
-        ],
-    )
-):
+
+@copy_model_fields
+class FlowRunNotificationPolicyCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow run notification policy."""
+
+    is_active: bool = From(schemas.core.FlowRunNotificationPolicy)
+    state_names: List[str] = From(schemas.core.FlowRunNotificationPolicy)
+    tags: List[str] = From(schemas.core.FlowRunNotificationPolicy)
+    block_document_id: UUID = From(schemas.core.FlowRunNotificationPolicy)
+    message_template: str = From(schemas.core.FlowRunNotificationPolicy)
 
     class Config:
         extra = "forbid"
 
 
+@copy_model_fields
 class FlowRunNotificationPolicyUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow run notification policy."""
 
     class Config:
         extra = "forbid"
 
-    is_active: Optional[bool] = None
-    state_names: Optional[List[str]] = None
-    tags: Optional[List[str]] = None
-    block_document_id: Optional[UUID] = None
-    message_template: Optional[str] = None
+    is_active: Optional[bool] = From(schemas.core.FlowRunNotificationPolicy)
+    state_names: Optional[List[str]] = From(schemas.core.FlowRunNotificationPolicy)
+    tags: Optional[List[str]] = From(schemas.core.FlowRunNotificationPolicy)
+    block_document_id: Optional[UUID] = From(schemas.core.FlowRunNotificationPolicy)
+    message_template: Optional[str] = From(schemas.core.FlowRunNotificationPolicy)

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -91,16 +91,18 @@ class DeploymentUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a deployment."""
 
     version: Optional[str] = FieldFrom(schemas.core.Deployment)
-    description: str = FieldFrom(schemas.core.Deployment)
-    schedule: schemas.schedules.SCHEDULE_TYPES = FieldFrom(schemas.core.Deployment)
+    schedule: Optional[schemas.schedules.SCHEDULE_TYPES] = FieldFrom(
+        schemas.core.Deployment
+    )
+    description: Optional[str] = FieldFrom(schemas.core.Deployment)
     is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
-    infra_overrides: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
     parameters: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
     tags: List[str] = FieldFrom(schemas.core.Deployment)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
-    path: str = FieldFrom(schemas.core.Deployment)
-    entrypoint: str = FieldFrom(schemas.core.Deployment)
-    manifest_path: str = FieldFrom(schemas.core.Deployment)
+    path: Optional[str] = FieldFrom(schemas.core.Deployment)
+    infra_overrides: Optional[Dict[str, Any]] = FieldFrom(schemas.core.Deployment)
+    entrypoint: Optional[str] = FieldFrom(schemas.core.Deployment)
+    manifest_path: Optional[str] = FieldFrom(schemas.core.Deployment)
     storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
 
@@ -112,8 +114,8 @@ class DeploymentUpdate(PrefectBaseModel):
 class FlowRunUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow run."""
 
-    name: str = FieldFrom(schemas.core.FlowRun)
-    flow_version: str = FieldFrom(schemas.core.FlowRun)
+    name: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    flow_version: Optional[str] = FieldFrom(schemas.core.FlowRun)
     parameters: dict = FieldFrom(schemas.core.FlowRun)
     empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
@@ -127,10 +129,10 @@ class StateCreate(PrefectBaseModel):
     """Data used by the Orion API to create a new state."""
 
     type: schemas.states.StateType = FieldFrom(schemas.states.State)
-    name: str = FieldFrom(schemas.states.State)
+    name: Optional[str] = FieldFrom(schemas.states.State)
     timestamp: schemas.core.DateTimeTZ = FieldFrom(schemas.states.State)
-    message: str = FieldFrom(schemas.states.State)
-    data: schemas.data.DataDocument = FieldFrom(schemas.states.State)
+    message: Optional[str] = FieldFrom(schemas.states.State)
+    data: Optional[schemas.data.DataDocument] = FieldFrom(schemas.states.State)
     state_details: schemas.states.StateDetails = FieldFrom(schemas.states.State)
 
     class Config:
@@ -395,7 +397,7 @@ class FlowRunNotificationPolicyCreate(PrefectBaseModel):
     state_names: List[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
     tags: List[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
     block_document_id: UUID = FieldFrom(schemas.core.FlowRunNotificationPolicy)
-    message_template: str = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    message_template: Optional[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
 
     class Config:
         extra = "forbid"

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -8,7 +8,11 @@ from uuid import UUID
 from pydantic import Field, validator
 
 import prefect.orion.schemas as schemas
-from prefect.orion.utilities.schemas import From, PrefectBaseModel, copy_model_fields
+from prefect.orion.utilities.schemas import (
+    FieldFrom,
+    PrefectBaseModel,
+    copy_model_fields,
+)
 
 LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
 
@@ -35,8 +39,8 @@ def validate_block_document_name(value):
 class FlowCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow."""
 
-    name: str = From(schemas.core.Flow)
-    tags: List[str] = From(schemas.core.Flow)
+    name: str = FieldFrom(schemas.core.Flow)
+    tags: List[str] = FieldFrom(schemas.core.Flow)
 
     class Config:
         extra = "forbid"
@@ -46,7 +50,7 @@ class FlowCreate(PrefectBaseModel):
 class FlowUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow."""
 
-    tags: List[str] = From(schemas.core.Flow)
+    tags: List[str] = FieldFrom(schemas.core.Flow)
 
     class Config:
         extra = "forbid"
@@ -56,22 +60,22 @@ class FlowUpdate(PrefectBaseModel):
 class DeploymentCreate(PrefectBaseModel):
     """Data used by the Orion API to create a deployment."""
 
-    name: str = From(schemas.core.Deployment)
-    version: Optional[str] = From(schemas.core.Deployment)
-    description: str = From(schemas.core.Deployment)
-    flow_id: UUID = From(schemas.core.Deployment)
-    schedule: schemas.schedules.SCHEDULE_TYPES = From(schemas.core.Deployment)
-    is_schedule_active: bool = From(schemas.core.Deployment)
-    infra_overrides: Dict[str, Any] = From(schemas.core.Deployment)
-    parameters: Dict[str, Any] = From(schemas.core.Deployment)
-    tags: List[str] = From(schemas.core.Deployment)
-    work_queue_name: Optional[str] = From(schemas.core.Deployment)
-    parameter_openapi_schema: Dict[str, Any] = From(schemas.core.Deployment)
-    path: str = From(schemas.core.Deployment)
-    entrypoint: str = From(schemas.core.Deployment)
-    manifest_path: str = From(schemas.core.Deployment)
-    storage_document_id: Optional[UUID] = From(schemas.core.Deployment)
-    infrastructure_document_id: Optional[UUID] = From(schemas.core.Deployment)
+    name: str = FieldFrom(schemas.core.Deployment)
+    version: Optional[str] = FieldFrom(schemas.core.Deployment)
+    description: str = FieldFrom(schemas.core.Deployment)
+    flow_id: UUID = FieldFrom(schemas.core.Deployment)
+    schedule: schemas.schedules.SCHEDULE_TYPES = FieldFrom(schemas.core.Deployment)
+    is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
+    infra_overrides: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
+    parameters: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
+    tags: List[str] = FieldFrom(schemas.core.Deployment)
+    work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
+    parameter_openapi_schema: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
+    path: str = FieldFrom(schemas.core.Deployment)
+    entrypoint: str = FieldFrom(schemas.core.Deployment)
+    manifest_path: str = FieldFrom(schemas.core.Deployment)
+    storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
+    infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
 
     class Config:
         extra = "forbid"
@@ -81,19 +85,19 @@ class DeploymentCreate(PrefectBaseModel):
 class DeploymentUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a deployment."""
 
-    version: Optional[str] = From(schemas.core.Deployment)
-    description: str = From(schemas.core.Deployment)
-    schedule: schemas.schedules.SCHEDULE_TYPES = From(schemas.core.Deployment)
-    is_schedule_active: bool = From(schemas.core.Deployment)
-    infra_overrides: Dict[str, Any] = From(schemas.core.Deployment)
-    parameters: Dict[str, Any] = From(schemas.core.Deployment)
-    tags: List[str] = From(schemas.core.Deployment)
-    work_queue_name: Optional[str] = From(schemas.core.Deployment)
-    path: str = From(schemas.core.Deployment)
-    entrypoint: str = From(schemas.core.Deployment)
-    manifest_path: str = From(schemas.core.Deployment)
-    storage_document_id: Optional[UUID] = From(schemas.core.Deployment)
-    infrastructure_document_id: Optional[UUID] = From(schemas.core.Deployment)
+    version: Optional[str] = FieldFrom(schemas.core.Deployment)
+    description: str = FieldFrom(schemas.core.Deployment)
+    schedule: schemas.schedules.SCHEDULE_TYPES = FieldFrom(schemas.core.Deployment)
+    is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
+    infra_overrides: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
+    parameters: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
+    tags: List[str] = FieldFrom(schemas.core.Deployment)
+    work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
+    path: str = FieldFrom(schemas.core.Deployment)
+    entrypoint: str = FieldFrom(schemas.core.Deployment)
+    manifest_path: str = FieldFrom(schemas.core.Deployment)
+    storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
+    infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
 
     class Config:
         extra = "forbid"
@@ -103,11 +107,11 @@ class DeploymentUpdate(PrefectBaseModel):
 class FlowRunUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a flow run."""
 
-    name: str = From(schemas.core.FlowRun)
-    flow_version: str = From(schemas.core.FlowRun)
-    parameters: dict = From(schemas.core.FlowRun)
-    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
-    tags: List[str] = From(schemas.core.FlowRun)
+    name: str = FieldFrom(schemas.core.FlowRun)
+    flow_version: str = FieldFrom(schemas.core.FlowRun)
+    parameters: dict = FieldFrom(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
+    tags: List[str] = FieldFrom(schemas.core.FlowRun)
 
     class Config:
         extra = "forbid"
@@ -117,12 +121,12 @@ class FlowRunUpdate(PrefectBaseModel):
 class StateCreate(PrefectBaseModel):
     """Data used by the Orion API to create a new state."""
 
-    type: schemas.states.StateType = From(schemas.states.State)
-    name: str = From(schemas.states.State)
-    timestamp: schemas.core.DateTimeTZ = From(schemas.states.State)
-    message: str = From(schemas.states.State)
-    data: schemas.data.DataDocument = From(schemas.states.State)
-    state_details: schemas.states.StateDetails = From(schemas.states.State)
+    type: schemas.states.StateType = FieldFrom(schemas.states.State)
+    name: str = FieldFrom(schemas.states.State)
+    timestamp: schemas.core.DateTimeTZ = FieldFrom(schemas.states.State)
+    message: str = FieldFrom(schemas.states.State)
+    data: schemas.data.DataDocument = FieldFrom(schemas.states.State)
+    state_details: schemas.states.StateDetails = FieldFrom(schemas.states.State)
 
     class Config:
         extra = "ignore"
@@ -137,15 +141,15 @@ class TaskRunCreate(PrefectBaseModel):
         default=None, description="The state of the task run to create"
     )
 
-    name: str = From(schemas.core.TaskRun)
-    flow_run_id: UUID = From(schemas.core.TaskRun)
-    task_key: str = From(schemas.core.TaskRun)
-    dynamic_key: str = From(schemas.core.TaskRun)
-    cache_key: str = From(schemas.core.TaskRun)
-    cache_expiration: schemas.core.DateTimeTZ = From(schemas.core.TaskRun)
-    task_version: str = From(schemas.core.TaskRun)
-    empirical_policy: schemas.core.TaskRunPolicy = From(schemas.core.TaskRun)
-    tags: List[str] = From(schemas.core.TaskRun)
+    name: str = FieldFrom(schemas.core.TaskRun)
+    flow_run_id: UUID = FieldFrom(schemas.core.TaskRun)
+    task_key: str = FieldFrom(schemas.core.TaskRun)
+    dynamic_key: str = FieldFrom(schemas.core.TaskRun)
+    cache_key: str = FieldFrom(schemas.core.TaskRun)
+    cache_expiration: schemas.core.DateTimeTZ = FieldFrom(schemas.core.TaskRun)
+    task_version: str = FieldFrom(schemas.core.TaskRun)
+    empirical_policy: schemas.core.TaskRunPolicy = FieldFrom(schemas.core.TaskRun)
+    tags: List[str] = FieldFrom(schemas.core.TaskRun)
     task_inputs: Dict[
         str,
         List[
@@ -155,7 +159,7 @@ class TaskRunCreate(PrefectBaseModel):
                 schemas.core.Constant,
             ]
         ],
-    ] = From(schemas.core.TaskRun)
+    ] = FieldFrom(schemas.core.TaskRun)
 
 
 @copy_model_fields
@@ -170,17 +174,17 @@ class FlowRunCreate(PrefectBaseModel):
         default=None, description="The state of the flow run to create"
     )
 
-    name: str = From(schemas.core.FlowRun)
-    flow_id: UUID = From(schemas.core.FlowRun)
-    deployment_id: UUID = From(schemas.core.FlowRun)
-    flow_version: str = From(schemas.core.FlowRun)
-    parameters: dict = From(schemas.core.FlowRun)
-    context: dict = From(schemas.core.FlowRun)
-    parent_task_run_id: UUID = From(schemas.core.FlowRun)
-    infrastructure_document_id: Optional[UUID] = From(schemas.core.FlowRun)
-    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
-    tags: List[str] = From(schemas.core.FlowRun)
-    idempotency_key: str = From(schemas.core.FlowRun)
+    name: str = FieldFrom(schemas.core.FlowRun)
+    flow_id: UUID = FieldFrom(schemas.core.FlowRun)
+    deployment_id: UUID = FieldFrom(schemas.core.FlowRun)
+    flow_version: str = FieldFrom(schemas.core.FlowRun)
+    parameters: dict = FieldFrom(schemas.core.FlowRun)
+    context: dict = FieldFrom(schemas.core.FlowRun)
+    parent_task_run_id: UUID = FieldFrom(schemas.core.FlowRun)
+    infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
+    tags: List[str] = FieldFrom(schemas.core.FlowRun)
+    idempotency_key: str = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
@@ -195,21 +199,21 @@ class DeploymentFlowRunCreate(PrefectBaseModel):
         default=None, description="The state of the flow run to create"
     )
 
-    name: Optional[str] = From(schemas.core.FlowRun)
-    parameters: dict = From(schemas.core.FlowRun)
-    context: dict = From(schemas.core.FlowRun)
-    infrastructure_document_id: Optional[UUID] = From(schemas.core.FlowRun)
-    empirical_policy: schemas.core.FlowRunPolicy = From(schemas.core.FlowRun)
-    tags: List[str] = From(schemas.core.FlowRun)
-    idempotency_key: str = From(schemas.core.FlowRun)
+    name: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    parameters: dict = FieldFrom(schemas.core.FlowRun)
+    context: dict = FieldFrom(schemas.core.FlowRun)
+    infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
+    empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
+    tags: List[str] = FieldFrom(schemas.core.FlowRun)
+    idempotency_key: str = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
 class SavedSearchCreate(PrefectBaseModel):
     """Data used by the Orion API to create a saved search."""
 
-    name: str = From(schemas.core.SavedSearch)
-    filters: List[schemas.core.SavedSearchFilter] = From(schemas.core.SavedSearch)
+    name: str = FieldFrom(schemas.core.SavedSearch)
+    filters: List[schemas.core.SavedSearchFilter] = FieldFrom(schemas.core.SavedSearch)
 
     class Config:
         extra = "forbid"
@@ -219,8 +223,8 @@ class SavedSearchCreate(PrefectBaseModel):
 class ConcurrencyLimitCreate(PrefectBaseModel):
     """Data used by the Orion API to create a concurrency limit."""
 
-    tag: str = From(schemas.core.ConcurrencyLimit)
-    concurrency_limit: int = From(schemas.core.ConcurrencyLimit)
+    tag: str = FieldFrom(schemas.core.ConcurrencyLimit)
+    concurrency_limit: int = FieldFrom(schemas.core.ConcurrencyLimit)
 
     class Config:
         extra = "forbid"
@@ -230,12 +234,14 @@ class ConcurrencyLimitCreate(PrefectBaseModel):
 class BlockTypeCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block type."""
 
-    name: str = From(schemas.core.BlockType)
-    slug: str = From(schemas.core.BlockType)
-    logo_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
-    documentation_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
-    description: Optional[str] = From(schemas.core.BlockType)
-    code_example: Optional[str] = From(schemas.core.BlockType)
+    name: str = FieldFrom(schemas.core.BlockType)
+    slug: str = FieldFrom(schemas.core.BlockType)
+    logo_url: Optional[schemas.core.HttpUrl] = FieldFrom(schemas.core.BlockType)
+    documentation_url: Optional[schemas.core.HttpUrl] = FieldFrom(
+        schemas.core.BlockType
+    )
+    description: Optional[str] = FieldFrom(schemas.core.BlockType)
+    code_example: Optional[str] = FieldFrom(schemas.core.BlockType)
 
     class Config:
         extra = "forbid"
@@ -253,20 +259,22 @@ class BlockTypeUpdate(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    logo_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
-    documentation_url: Optional[schemas.core.HttpUrl] = From(schemas.core.BlockType)
-    description: Optional[str] = From(schemas.core.BlockType)
-    code_example: Optional[str] = From(schemas.core.BlockType)
+    logo_url: Optional[schemas.core.HttpUrl] = FieldFrom(schemas.core.BlockType)
+    documentation_url: Optional[schemas.core.HttpUrl] = FieldFrom(
+        schemas.core.BlockType
+    )
+    description: Optional[str] = FieldFrom(schemas.core.BlockType)
+    code_example: Optional[str] = FieldFrom(schemas.core.BlockType)
 
 
 @copy_model_fields
 class BlockSchemaCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block schema."""
 
-    fields: dict = From(schemas.core.BlockSchema)
-    block_type_id: Optional[UUID] = From(schemas.core.BlockSchema)
-    capabilities: List[str] = From(schemas.core.BlockSchema)
-    version: str = From(schemas.core.BlockSchema)
+    fields: dict = FieldFrom(schemas.core.BlockSchema)
+    block_type_id: Optional[UUID] = FieldFrom(schemas.core.BlockSchema)
+    capabilities: List[str] = FieldFrom(schemas.core.BlockSchema)
+    version: str = FieldFrom(schemas.core.BlockSchema)
 
     class Config:
         extra = "forbid"
@@ -276,11 +284,11 @@ class BlockSchemaCreate(PrefectBaseModel):
 class BlockDocumentCreate(PrefectBaseModel):
     """Data used by the Orion API to create a block document."""
 
-    name: Optional[str] = From(schemas.core.BlockDocument)
-    data: dict = From(schemas.core.BlockDocument)
-    block_schema_id: UUID = From(schemas.core.BlockDocument)
-    block_type_id: UUID = From(schemas.core.BlockDocument)
-    is_anonymous: bool = From(schemas.core.BlockDocument)
+    name: Optional[str] = FieldFrom(schemas.core.BlockDocument)
+    data: dict = FieldFrom(schemas.core.BlockDocument)
+    block_schema_id: UUID = FieldFrom(schemas.core.BlockDocument)
+    block_type_id: UUID = FieldFrom(schemas.core.BlockDocument)
+    is_anonymous: bool = FieldFrom(schemas.core.BlockDocument)
 
     class Config:
         extra = "forbid"
@@ -295,7 +303,7 @@ class BlockDocumentCreate(PrefectBaseModel):
 class BlockDocumentUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a block document."""
 
-    data: dict = From(schemas.core.BlockDocument)
+    data: dict = FieldFrom(schemas.core.BlockDocument)
 
     class Config:
         extra = "forbid"
@@ -305,10 +313,10 @@ class BlockDocumentUpdate(PrefectBaseModel):
 class BlockDocumentReferenceCreate(PrefectBaseModel):
     """Data used to create block document reference."""
 
-    id: UUID = From(schemas.core.BlockDocumentReference)
-    parent_block_document_id: UUID = From(schemas.core.BlockDocumentReference)
-    reference_block_document_id: UUID = From(schemas.core.BlockDocumentReference)
-    name: str = From(schemas.core.BlockDocumentReference)
+    id: UUID = FieldFrom(schemas.core.BlockDocumentReference)
+    parent_block_document_id: UUID = FieldFrom(schemas.core.BlockDocumentReference)
+    reference_block_document_id: UUID = FieldFrom(schemas.core.BlockDocumentReference)
+    name: str = FieldFrom(schemas.core.BlockDocumentReference)
 
     class Config:
         extra = "forbid"
@@ -318,12 +326,12 @@ class BlockDocumentReferenceCreate(PrefectBaseModel):
 class LogCreate(PrefectBaseModel):
     """Data used by the Orion API to create a log."""
 
-    name: str = From(schemas.core.Log)
-    level: int = From(schemas.core.Log)
-    message: str = From(schemas.core.Log)
-    timestamp: schemas.core.DateTimeTZ = From(schemas.core.Log)
-    flow_run_id: UUID = From(schemas.core.Log)
-    task_run_id: Optional[UUID] = From(schemas.core.Log)
+    name: str = FieldFrom(schemas.core.Log)
+    level: int = FieldFrom(schemas.core.Log)
+    message: str = FieldFrom(schemas.core.Log)
+    timestamp: schemas.core.DateTimeTZ = FieldFrom(schemas.core.Log)
+    flow_run_id: UUID = FieldFrom(schemas.core.Log)
+    task_run_id: Optional[UUID] = FieldFrom(schemas.core.Log)
 
     class Config:
         extra = "forbid"
@@ -333,10 +341,10 @@ class LogCreate(PrefectBaseModel):
 class WorkQueueCreate(PrefectBaseModel):
     """Data used by the Orion API to create a work queue."""
 
-    name: str = From(schemas.core.WorkQueue)
-    description: Optional[str] = From(schemas.core.WorkQueue)
-    is_paused: bool = From(schemas.core.WorkQueue)
-    concurrency_limit: Optional[int] = From(schemas.core.WorkQueue)
+    name: str = FieldFrom(schemas.core.WorkQueue)
+    description: Optional[str] = FieldFrom(schemas.core.WorkQueue)
+    is_paused: bool = FieldFrom(schemas.core.WorkQueue)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkQueue)
 
     # DEPRECATED
 
@@ -354,9 +362,9 @@ class WorkQueueCreate(PrefectBaseModel):
 class WorkQueueUpdate(PrefectBaseModel):
     """Data used by the Orion API to update a work queue."""
 
-    description: Optional[str] = From(schemas.core.WorkQueue)
-    is_paused: bool = From(schemas.core.WorkQueue)
-    concurrency_limit: Optional[int] = From(schemas.core.WorkQueue)
+    description: Optional[str] = FieldFrom(schemas.core.WorkQueue)
+    is_paused: bool = FieldFrom(schemas.core.WorkQueue)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkQueue)
 
     # DEPRECATED
 
@@ -379,11 +387,11 @@ class WorkQueueUpdate(PrefectBaseModel):
 class FlowRunNotificationPolicyCreate(PrefectBaseModel):
     """Data used by the Orion API to create a flow run notification policy."""
 
-    is_active: bool = From(schemas.core.FlowRunNotificationPolicy)
-    state_names: List[str] = From(schemas.core.FlowRunNotificationPolicy)
-    tags: List[str] = From(schemas.core.FlowRunNotificationPolicy)
-    block_document_id: UUID = From(schemas.core.FlowRunNotificationPolicy)
-    message_template: str = From(schemas.core.FlowRunNotificationPolicy)
+    is_active: bool = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    state_names: List[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    tags: List[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    block_document_id: UUID = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    message_template: str = FieldFrom(schemas.core.FlowRunNotificationPolicy)
 
     class Config:
         extra = "forbid"
@@ -396,8 +404,10 @@ class FlowRunNotificationPolicyUpdate(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    is_active: Optional[bool] = From(schemas.core.FlowRunNotificationPolicy)
-    state_names: Optional[List[str]] = From(schemas.core.FlowRunNotificationPolicy)
-    tags: Optional[List[str]] = From(schemas.core.FlowRunNotificationPolicy)
-    block_document_id: Optional[UUID] = From(schemas.core.FlowRunNotificationPolicy)
-    message_template: Optional[str] = From(schemas.core.FlowRunNotificationPolicy)
+    is_active: Optional[bool] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    state_names: Optional[List[str]] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    tags: Optional[List[str]] = FieldFrom(schemas.core.FlowRunNotificationPolicy)
+    block_document_id: Optional[UUID] = FieldFrom(
+        schemas.core.FlowRunNotificationPolicy
+    )
+    message_template: Optional[str] = FieldFrom(schemas.core.FlowRunNotificationPolicy)

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -341,7 +341,7 @@ class WorkQueueCreate(ActionBaseModel):
 
     filter: Optional[schemas.core.QueueFilter] = Field(
         None,
-        description="Filter criteria for the work queue.",
+        description="DEPRECATED: Filter criteria for the work queue.",
         deprecated=True,
     )
 
@@ -358,13 +358,13 @@ class WorkQueueUpdate(ActionBaseModel):
 
     filter: Optional[schemas.core.QueueFilter] = Field(
         None,
-        description="Filter criteria for the work queue.",
+        description="DEPRECATED: Filter criteria for the work queue.",
         deprecated=True,
     )
-
-    # Names should not be updated, left here only for backwards-compatibility
     name: Optional[str] = Field(
-        default=None, description="The name of the work queue.", deprecated=True
+        default=None,
+        description="DEPRECATED: The name of the work queue.",
+        deprecated=True,
     )
 
 

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -736,7 +736,7 @@ class WorkQueue(ORMBaseModel):
     )
     filter: Optional[QueueFilter] = Field(
         default=None,
-        description="Deprecated field: Filter criteria for the work queue.",
+        description="DEPRECATED: Filter criteria for the work queue.",
         deprecated=True,
     )
 

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -56,7 +56,7 @@ class State(IDBaseModel, Generic[R]):
         orm_mode = True
 
     type: StateType
-    name: str = None
+    name: Optional[str] = Field(default=None)
     timestamp: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
     message: Optional[str] = Field(default=None, example="Run started")
     data: Optional[DataDocument[R]] = Field(

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -172,7 +172,7 @@ class State(IDBaseModel, Generic[R]):
 
         # if `type` is not in `values` it means the `type` didn't pass its own
         # validation check and an error will be raised after this function is called
-        if v is None and "type" in values:
+        if v is None and values.get("type"):
             v = " ".join([v.capitalize() for v in values.get("type").value.split("_")])
         return v
 

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -351,15 +351,18 @@ class ORMBaseModel(IDBaseModel):
 
 
 @dataclass
-class _FromField:
+class _FieldFrom:
     """Container for holding the origin of a field's definition"""
 
     origin: Type[BaseModel]
 
 
-def From(origin: Type[BaseModel]) -> Any:
-    """Indicates that the given field is to be copied from another class"""
-    return _FromField(origin)
+def FieldFrom(origin: Type[BaseModel]) -> Any:
+    """
+    Indicates that the given field is to be copied from another class by
+    `copy_model_fields`.
+    """
+    return _FieldFrom(origin)
 
 
 def copy_model_fields(model_class: Type[B]) -> Type[B]:
@@ -392,7 +395,7 @@ def copy_model_fields(model_class: Type[B]) -> Type[B]:
 
     """
     for name, field in model_class.__fields__.items():
-        if not isinstance(field.default, _FromField):
+        if not isinstance(field.default, _FieldFrom):
             continue
 
         origin = field.default.origin

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -373,13 +373,13 @@ def copy_model_fields(model_class: Type[B]) -> Type[B]:
     those classes.  Note that you should still include the type hint for the field in
     order to make typing explicit.
 
-    Use this decorator and the corresponding `From` field to compose response and
+    Use this decorator and the corresponding `FieldFrom` to compose response and
     action schemas from other classes.
 
     Example:
 
         >>> from pydantic import BaseModel
-        >>> from prefect.orion.utilities.schemas import copy_model_fields, From
+        >>> from prefect.orion.utilities.schemas import copy_model_fields, FieldFrom
         >>>
         >>> class Parent(BaseModel):
         ...     name: str
@@ -387,7 +387,7 @@ def copy_model_fields(model_class: Type[B]) -> Type[B]:
         >>>
         >>> @copy_model_fields
         >>> class Derived(BaseModel):
-        ...     name: str = From(Parent)
+        ...     name: str = FieldFrom(Parent)
         ...     my_own: str
 
         In this example, `Derived` will have the fields `name`, and `my_own`, with the

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -588,8 +588,8 @@ class TestSetFlowRunState:
         assert run.state.type == states.StateType.RUNNING
         assert run.state.name == "Test State"
 
-    async def test_set_flow_run_errors_if_client_provides_timestamp(
-        self, flow_run, client
+    async def test_set_flow_run_state_ignores_client_provided_timestamp(
+        self, flow_run, client, session
     ):
         response = await client.post(
             f"/flow_runs/{flow_run.id}/set_state",
@@ -601,7 +601,9 @@ class TestSetFlowRunState:
                 )
             ),
         )
-        assert response.status_code == 422
+        assert response.status_code == status.HTTP_201_CREATED
+        state = schemas.states.State.parse_obj(response.json()["state"])
+        assert state.timestamp < pendulum.now(), "The timestamp should be overwritten"
 
     async def test_set_flow_run_state_force_skips_orchestration(
         self, flow_run, client, session

--- a/tests/orion/api/test_logs.py
+++ b/tests/orion/api/test_logs.py
@@ -67,7 +67,12 @@ class TestCreateLogs:
         assert len(logs) == 2
 
         for i, log in enumerate(logs):
-            assert LogCreate.from_orm(log).dict(json_compatible=True) == log_data[i]
+            assert (
+                Log.from_orm(log).dict(
+                    json_compatible=True, exclude={"created", "id", "updated"}
+                )
+                == log_data[i]
+            )
 
     async def test_create_logs_with_task_run_id_and_returns_number_created(
         self, session, client, flow_run_id, task_run_id, log_data
@@ -79,7 +84,12 @@ class TestCreateLogs:
         logs = await models.logs.read_logs(session=session, log_filter=log_filter)
         assert len(logs) == 1
 
-        assert LogCreate.from_orm(logs[0]).dict(json_compatible=True) == log_data[1]
+        assert (
+            Log.from_orm(logs[0]).dict(
+                json_compatible=True, exclude={"created", "id", "updated"}
+            )
+            == log_data[1]
+        )
 
     async def test_database_failure(
         self, client_without_exceptions, session, flow_run_id, task_run_id, log_data

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -310,7 +310,7 @@ class TestSetTaskRunState:
         assert run.state.name == "Test State"
         assert run.run_count == 1
 
-    async def test_set_task_run_errors_if_client_provides_timestamp(
+    async def test_set_task_run_ignores_client_provided_timestamp(
         self, flow_run, client
     ):
         response = await client.post(
@@ -323,7 +323,9 @@ class TestSetTaskRunState:
                 )
             ),
         )
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_201_CREATED
+        state = schemas.states.State.parse_obj(response.json()["state"])
+        assert state.timestamp < pendulum.now(), "The timestamp should be overwritten"
 
     async def test_failed_becomes_awaiting_retry(self, task_run, client, session):
         # set max retries to 1

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -69,7 +69,7 @@ class TestCreateTaskRun:
         assert str(task_run.id) == response.json()["id"]
         assert task_run.state.type == task_run_data.state.type
 
-    async def test_create_task_run_with_state_sets_timestamp_on_server(
+    async def test_create_task_run_with_state_ignores_client_provided_timestamp(
         self, flow_run, client, session
     ):
         response = await client.post(
@@ -79,8 +79,7 @@ class TestCreateTaskRun:
                 task_key="a",
                 state=schemas.actions.StateCreate(
                     type=schemas.states.StateType.COMPLETED,
-                    # This is no longer allowed
-                    # timestamp=pendulum.now().add(months=1),
+                    timestamp=pendulum.now().add(months=1),
                 ),
                 dynamic_key="0",
             ).dict(json_compatible=True),

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -57,7 +57,7 @@ class TestCreateTaskRun:
         task_run_data = schemas.actions.TaskRunCreate(
             flow_run_id=flow_run.id,
             task_key="task-key",
-            state=states.Running(),
+            state=schemas.actions.StateCreate(type=schemas.states.StateType.RUNNING),
             dynamic_key="0",
         )
         response = await client.post(
@@ -77,7 +77,11 @@ class TestCreateTaskRun:
             json=schemas.actions.TaskRunCreate(
                 flow_run_id=flow_run.id,
                 task_key="a",
-                state=states.Completed(timestamp=pendulum.now().add(months=1)),
+                state=schemas.actions.StateCreate(
+                    type=schemas.states.StateType.COMPLETED,
+                    # This is no longer allowed
+                    # timestamp=pendulum.now().add(months=1),
+                ),
                 dynamic_key="0",
             ).dict(json_compatible=True),
         )

--- a/tests/orion/models/deprecated/test_work_queues.py
+++ b/tests/orion/models/deprecated/test_work_queues.py
@@ -47,8 +47,10 @@ class TestUpdateWorkQueue:
         )
         assert result
 
-        updated_queue = await models.work_queues.read_work_queue(
-            session=session, work_queue_id=work_queue.id
+        updated_queue = schemas.core.WorkQueue.from_orm(
+            await models.work_queues.read_work_queue(
+                session=session, work_queue_id=work_queue.id
+            )
         )
         assert updated_queue.id == work_queue.id
         assert updated_queue.filter.tags == ["updated", "tags"]

--- a/tests/orion/models/test_logs.py
+++ b/tests/orion/models/test_logs.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 
 from prefect.orion import models
 from prefect.orion.schemas.actions import LogCreate
+from prefect.orion.schemas.core import Log
 from prefect.orion.schemas.filters import LogFilter
 from prefect.orion.schemas.sorting import LogSort
 
@@ -68,7 +69,10 @@ class TestCreateLogs:
         read_logs = result.scalars().unique().all()
 
         for i, log in enumerate(read_logs):
-            assert LogCreate.from_orm(log) == log_data[i]
+            assert (
+                Log.from_orm(log).dict(exclude={"created", "id", "updated"})
+                == log_data[i]
+            )
 
 
 class TestReadLogs:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Pulls the `copy_model_fields` utility from  https://github.com/PrefectHQ/nebula/commit/9874ae454ce6fa64ad22291fb906584be937b617 and uses it for our actions models instead of the `pydantic_subclass` utility. This means action types no longer violate the Liskov substitution principle in which we were claiming they were subclasses of the parent type but we were excluding fields. We no longer use the subclass utility and it could be removed but I think it may be useful still.

I discovered several cases of undesirable and confusing behavior from the old pattern. I've done my best to match the old behavior but in some cases it was wrong and needed to be changed. This includes one "breaking" change to the set state routes for flow runs and task runs: Previously, these routes would raise a 422 if the client provided a timestamp. Now, they will ignore the timestamp and set the state. This now matches the behavior of flow run and task run creation.

I renamed the associated `From` utility to `FieldFrom` as I think it makes its usage more intuitive. After this is merged, I can open a pull request to Nebula to use the utilities from the core library instead.

This utility will be useful in upcoming work on result persistence where we will need to introduce client-side copies of server-side models with extended capabilities.

Requires #6829 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
