### PR TITLE
Check if from_path and local_path are the same in LocalFileSystem.get…

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -123,10 +123,19 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         Defaults to copying the entire contents of the block's basepath to the current working directory.
         """
         if from_path is None:
-            from_path = Path(self.basepath).expanduser()
+            from_path = Path(self.basepath).expanduser().resolve()
+        else:
+            from_path = Path(from_path).resolve()
 
         if local_path is None:
-            local_path = Path(".").absolute()
+            local_path = Path(".").resolve()
+        else:
+            local_path = Path(local_path).resolve()
+
+        if from_path == local_path:
+            # If the paths are the same there is no need to copy
+            # and we avoid shutil.copytree raising an error
+            return
 
         if sys.version_info < (3, 8):
             shutil.copytree(from_path, local_path)

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -45,7 +45,6 @@ class TestLocalFileSystem:
         await fs.get_directory(".", ".")
         
 
-
 class TestRemoteFileSystem:
     def test_must_contain_scheme(self):
         with pytest.raises(ValueError, match="must start with a scheme"):

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -39,6 +39,11 @@ class TestLocalFileSystem:
         assert fs._resolve_path(tmp_path) == tmp_path
         assert fs._resolve_path(tmp_path / "subdirectory") == tmp_path / "subdirectory"
         assert fs._resolve_path("subdirectory") == tmp_path / "subdirectory"
+    
+    async def test_get_directory_duplicate_directory(self, tmp_path):
+        fs = LocalFileSystem(basepath=str(tmp_path))
+        await fs.get_directory(".", ".")
+        
 
 
 class TestRemoteFileSystem:

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -39,11 +39,11 @@ class TestLocalFileSystem:
         assert fs._resolve_path(tmp_path) == tmp_path
         assert fs._resolve_path(tmp_path / "subdirectory") == tmp_path / "subdirectory"
         assert fs._resolve_path("subdirectory") == tmp_path / "subdirectory"
-    
+
     async def test_get_directory_duplicate_directory(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
         await fs.get_directory(".", ".")
-        
+
 
 class TestRemoteFileSystem:
     def test_must_contain_scheme(self):


### PR DESCRIPTION

Fixes #6652 

Check if the resolved `from_path` and `local_path` are the same, if yes, do not copy anything.

### Example
```py
get_directory(".", ".") # no longer throws an error
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
