### PR TITLE
Use a singleton diagnostics logger for `Client`

### DIFF
--- a/src/prefect/client/client.py
+++ b/src/prefect/client/client.py
@@ -95,6 +95,8 @@ class Client:
             `prefect auth` CLI
     """
 
+    logger = create_diagnostic_logger("client.diagnostics")
+
     def __init__(
         self,
         api_server: str = None,
@@ -102,7 +104,6 @@ class Client:
         tenant_id: str = None,
     ):
         self._attached_headers = {}  # type: Dict[str, str]
-        self.logger = create_diagnostic_logger("Diagnostics")
 
         # Hard-code the auth filepath location
         self._auth_file = Path(prefect.context.config.home_dir).absolute() / "auth.toml"


### PR DESCRIPTION
Each client "creates" a new logger which includes attaching handlers. Since Python loggers are singletons behind the scenes, this results in attaching duplicate handlers to the logger. Messages will then be duplicated per number of clients. Since task runs each have their own client, this can result in many log messages.

To resolve this, we define `logger` as a class variable instead of instance variable. The logger will be created once at import-time.

Closes https://github.com/PrefectHQ/prefect/issues/6831 