### PR TITLE
Respect PREFECT__CLOUD__SEND_FLOW_RUN_LOGS

### DIFF
--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -586,7 +586,11 @@ class DockerAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 4. Non-overrideable required env vars
+        # 4. Allow disabling of sending flow run logs
+        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
+
+        # 5. Non-overrideable required env vars
         env.update(
             {
                 "PREFECT__BACKEND": config.backend,
@@ -598,7 +602,6 @@ class DockerAgent(Agent):
                     else ""
                 ),
                 "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,  # type: ignore
                 "PREFECT__CONTEXT__IMAGE": image,

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -588,7 +588,7 @@ class DockerAgent(Agent):
 
         # 4. Allow logs to be disabled by flow run settings but not enabled
         if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
-           env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
 
         # 5. Non-overrideable required env vars
         env.update(

--- a/src/prefect/agent/docker/agent.py
+++ b/src/prefect/agent/docker/agent.py
@@ -586,9 +586,9 @@ class DockerAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 4. Allow disabling of sending flow run logs
-        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
-            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
+        # 4. Allow logs to be disabled by flow run settings but not enabled
+        if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
+           env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
 
         # 5. Non-overrideable required env vars
         env.update(

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -515,7 +515,8 @@ class ECSAgent(Agent):
         env.update(self.env_vars)
         if run_config.env:
             env.update(run_config.env)
-        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+        # Allow logs to be disabled by flow run settings but not enabled
+        if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
             env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
         env.update(
             {

--- a/src/prefect/agent/ecs/agent.py
+++ b/src/prefect/agent/ecs/agent.py
@@ -515,6 +515,8 @@ class ECSAgent(Agent):
         env.update(self.env_vars)
         if run_config.env:
             env.update(run_config.env)
+        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
         env.update(
             {
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
@@ -523,7 +525,6 @@ class ECSAgent(Agent):
                 "PREFECT__CLOUD__API": config.cloud.api,
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
                 "PREFECT__CLOUD__API_KEY": self.flow_run_api_key or "",
                 "PREFECT__CLOUD__TENANT_ID": (
                     # Providing a tenant id is only necessary when authenticating

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -562,7 +562,8 @@ class KubernetesAgent(Agent):
         env.update(self.env_vars)
         if run_config.env:
             env.update(run_config.env)
-        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+        # Allow logs to be disabled by flow run settings but not enabled
+        if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
             env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
         env.update(
             {

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -562,6 +562,8 @@ class KubernetesAgent(Agent):
         env.update(self.env_vars)
         if run_config.env:
             env.update(run_config.env)
+        if "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
         env.update(
             {
                 "PREFECT__BACKEND": config.backend,
@@ -575,7 +577,6 @@ class KubernetesAgent(Agent):
                     else ""
                 ),
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,
                 "PREFECT__CONTEXT__IMAGE": image,

--- a/src/prefect/agent/kubernetes/agent.py
+++ b/src/prefect/agent/kubernetes/agent.py
@@ -562,7 +562,7 @@ class KubernetesAgent(Agent):
         env.update(self.env_vars)
         if run_config.env:
             env.update(run_config.env)
-        if "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
+        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
             env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
         env.update(
             {

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -201,8 +201,8 @@ class LocalAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 6. Allow disabling of sending flow run logs
-        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+        # 6. Allow logs to be disabled by flow run settings but not enabled
+        if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
             env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
 
         # 7. Non-overrideable required env vars

--- a/src/prefect/agent/local/agent.py
+++ b/src/prefect/agent/local/agent.py
@@ -201,7 +201,11 @@ class LocalAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 6. Non-overrideable required env vars
+        # 6. Allow disabling of sending flow run logs
+        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
+
+        # 7. Non-overrideable required env vars
         env.update(
             {
                 "PREFECT__BACKEND": config.backend,
@@ -217,7 +221,6 @@ class LocalAgent(Agent):
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,  # type: ignore
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
                 "PREFECT__ENGINE__FLOW_RUNNER__DEFAULT_CLASS": "prefect.engine.cloud.CloudFlowRunner",
             }
         )

--- a/src/prefect/agent/vertex/agent.py
+++ b/src/prefect/agent/vertex/agent.py
@@ -208,7 +208,11 @@ class VertexAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 4. Non-overrideable required env vars
+        # 4. Allow disabling of sending flow run logs
+        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+            env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
+
+        # 5. Non-overrideable required env vars
         env.update(
             {
                 "PREFECT__BACKEND": config.backend,
@@ -221,7 +225,6 @@ class VertexAgent(Agent):
                     else ""
                 ),
                 "PREFECT__CLOUD__AGENT__LABELS": str(self.labels),
-                "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": str(self.log_to_cloud).lower(),
                 "PREFECT__CONTEXT__FLOW_RUN_ID": flow_run.id,  # type: ignore
                 "PREFECT__CONTEXT__FLOW_ID": flow_run.flow.id,  # type: ignore
                 "PREFECT__CLOUD__USE_LOCAL_SECRETS": "false",

--- a/src/prefect/agent/vertex/agent.py
+++ b/src/prefect/agent/vertex/agent.py
@@ -208,8 +208,8 @@ class VertexAgent(Agent):
         if run_config is not None and run_config.env is not None:
             env.update(run_config.env)
 
-        # 4. Allow disabling of sending flow run logs
-        if env.get("PREFECT__CLOUD__SEND_FLOW_RUN_LOGS", "").lower() != "false":
+        # 4. Allow logs to be disabled by flow run settings but not enabled
+        if not self.log_to_cloud or "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS" not in env:
             env["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] = str(self.log_to_cloud).lower()
 
         # 5. Non-overrideable required env vars

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -223,7 +223,7 @@ def test_populate_env_vars_sets_log_to_cloud(flag, api, config_with_api_key):
 
 
 @pytest.mark.parametrize(
-    "no_cloud_logs,send_flow_run_logs,result",
+    "disabled_on_agent,enabled_by_run,expected",
     [
         # Ignore env var when --no-cloud-logs
         (True, "true", "false"),
@@ -234,12 +234,12 @@ def test_populate_env_vars_sets_log_to_cloud(flag, api, config_with_api_key):
     ],
 )
 def test_populate_env_vars_respect_send_flow_run_logs(
-    no_cloud_logs, send_flow_run_logs, result, api, config_with_api_key
+    disabled_on_agent, enabled_by_run, expected, api, config_with_api_key
 ):
-    agent = DockerAgent(labels=["42", "marvin"], no_cloud_logs=no_cloud_logs)
+    agent = DockerAgent(labels=["42", "marvin"], no_cloud_logs=disabled_on_agent)
 
     run = DockerRun(
-        env={"PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": send_flow_run_logs},
+        env={"PREFECT__CLOUD__SEND_FLOW_RUN_LOGS": enabled_by_run},
     )
 
     env_vars = agent.populate_env_vars(
@@ -254,7 +254,7 @@ def test_populate_env_vars_respect_send_flow_run_logs(
         "test-image",
         run_config=run,
     )
-    assert env_vars["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] == result
+    assert env_vars["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] == expected
 
 
 def test_populate_env_vars_from_run_config(api):

--- a/tests/agent/test_docker_agent.py
+++ b/tests/agent/test_docker_agent.py
@@ -233,7 +233,9 @@ def test_populate_env_vars_sets_log_to_cloud(flag, api, config_with_api_key):
         (False, "false", "false"),
     ],
 )
-def test_populate_env_vars_respect_send_flow_run_logs(no_cloud_logs, send_flow_run_logs, result, api, config_with_api_key):
+def test_populate_env_vars_respect_send_flow_run_logs(
+    no_cloud_logs, send_flow_run_logs, result, api, config_with_api_key
+):
     agent = DockerAgent(labels=["42", "marvin"], no_cloud_logs=no_cloud_logs)
 
     run = DockerRun(
@@ -241,14 +243,16 @@ def test_populate_env_vars_respect_send_flow_run_logs(no_cloud_logs, send_flow_r
     )
 
     env_vars = agent.populate_env_vars(
-        GraphQLResult({
-            "id": "id",
-            "name": "name",
-            "flow": {"id": "foo"},
-            "run_config": run.serialize()
-        }),
+        GraphQLResult(
+            {
+                "id": "id",
+                "name": "name",
+                "flow": {"id": "foo"},
+                "run_config": run.serialize(),
+            }
+        ),
         "test-image",
-        run_config=run
+        run_config=run,
     )
     assert env_vars["PREFECT__CLOUD__SEND_FLOW_RUN_LOGS"] == result
 

--- a/tests/agent/test_vertex_agent.py
+++ b/tests/agent/test_vertex_agent.py
@@ -250,6 +250,10 @@ class TestDeployFlow:
                                 "name": "PREFECT__LOGGING__LEVEL",
                                 "value": config.logging.level,
                             },
+                            {
+                                "name": "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS",
+                                "value": "true",
+                            },
                             {"name": "PREFECT__BACKEND", "value": config.backend},
                             {
                                 "name": "PREFECT__CLOUD__API",
@@ -258,10 +262,6 @@ class TestDeployFlow:
                             {"name": "PREFECT__CLOUD__API_KEY", "value": ""},
                             {"name": "PREFECT__CLOUD__TENANT_ID", "value": ""},
                             {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
-                            {
-                                "name": "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS",
-                                "value": "false",
-                            },
                             {
                                 "name": "PREFECT__CONTEXT__FLOW_RUN_ID",
                                 "value": "flow-run-id",

--- a/tests/agent/test_vertex_agent.py
+++ b/tests/agent/test_vertex_agent.py
@@ -260,7 +260,7 @@ class TestDeployFlow:
                             {"name": "PREFECT__CLOUD__AGENT__LABELS", "value": "[]"},
                             {
                                 "name": "PREFECT__CLOUD__SEND_FLOW_RUN_LOGS",
-                                "value": "true",
+                                "value": "false",
                             },
                             {
                                 "name": "PREFECT__CONTEXT__FLOW_RUN_ID",


### PR DESCRIPTION
The `PREFECT__CLOUD__SEND_FLOW_RUN_LOGS` environment variables is ignored when explicitly set. This change avoids overwriting it with a default value when set.

Closes #5521