### PR TITLE
Hide secret tails by default

### DIFF
--- a/src/prefect/orion/utilities/names.py
+++ b/src/prefect/orion/utilities/names.py
@@ -40,12 +40,12 @@ def generate_slug(n_words: int) -> str:
     return "-".join(words)
 
 
-def obfuscate_string(s: str) -> str:
+def obfuscate_string(s: str, show_tail=False) -> str:
     """
     Obfuscates a string by returning a new string of 8 characters. If the input
-    string is longer than 10 characters, then up to 4 of its final characters
-    will become final characters of the obfuscated string; all other characters
-    are "*".
+    string is longer than 10 characters and show_tail is True, then up to 4 of
+    its final characters will become final characters of the obfuscated string;
+    all other characters are "*".
 
     "abc"      -> "********"
     "abcdefgh" -> "********"
@@ -55,6 +55,6 @@ def obfuscate_string(s: str) -> str:
     result = OBFUSCATED_PREFIX + "*" * 4
     # take up to 4 characters, but only after the 10th character
     suffix = s[10:][-4:]
-    if suffix:
+    if suffix and show_tail:
         result = f"{result[:-len(suffix)]}{suffix}"
     return result

--- a/tests/orion/api/test_block_documents.py
+++ b/tests/orion/api/test_block_documents.py
@@ -1035,6 +1035,9 @@ class TestSecretBlockDocuments:
         assert block.data["y"] == obfuscate_string(Y)
         assert block.data["z"] == Z
 
+        # by default, no characters of secrets are shown
+        assert block.data["y"] == "*" * 8
+
     async def test_read_secret_block_document_by_id_obfuscates_results(
         self, client, secret_block_document
     ):

--- a/tests/orion/utilities/test_names.py
+++ b/tests/orion/utilities/test_names.py
@@ -20,4 +20,7 @@ from prefect.orion.utilities.names import obfuscate_string
     ],
 )
 def test_obfuscate_string(s, expected):
-    assert obfuscate_string(s) == expected
+    # default is not to reveal any characters
+    assert obfuscate_string(s) == obfuscate_string(s, show_tail=False) == "*" * 8
+    # show tail
+    assert obfuscate_string(s, show_tail=True) == expected


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

As a convenience, the API can send the last few characters of secrets to the UI. This has raised questions about whether the UI is receiving the entire secret and obfuscating it in the client (for clarity: it does not). In the future, we intend to make this behavior configurable (as some find it to be a useful convenience) but this PR disables it by default to avoid introducing unintended concern.

Closes #6707
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
