### PR TITLE
Refactor client into new namespaces

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -2,13 +2,11 @@
 Command line interface for interacting with Prefect Cloud
 """
 import re
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable
 
-import anyio
 import httpx
 import readchar
 import typer
-from fastapi import status
 from rich.live import Live
 from rich.table import Table
 
@@ -17,7 +15,7 @@ import prefect.settings
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
-from prefect.exceptions import PrefectException
+from prefect.client.cloud import CloudUnauthorizedError, get_cloud_client
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
@@ -65,94 +63,6 @@ def get_current_workspace(workspaces):
         r".*accounts/.{36}/workspaces/(.{36})\Z", PREFECT_API_URL.value()
     ).groups()[0]
     return workspace_handles_by_id[current_workspace_id]
-
-
-def get_cloud_client(
-    host: str = None,
-    api_key: str = None,
-    httpx_settings: dict = None,
-    infer_cloud_url: bool = False,
-) -> "CloudClient":
-    if httpx_settings is not None:
-        httpx_settings = httpx_settings.copy()
-
-    if infer_cloud_url is False:
-        host = host or PREFECT_CLOUD_URL.value()
-    else:
-        configured_url = prefect.settings.PREFECT_API_URL.value()
-        host = re.sub(r"accounts/.{36}/workspaces/.{36}\Z", "", configured_url)
-
-    return CloudClient(
-        host=host,
-        api_key=api_key or PREFECT_API_KEY.value(),
-        httpx_settings=httpx_settings,
-    )
-
-
-class CloudUnauthorizedError(PrefectException):
-    """
-    Raised when the CloudClient receives a 401 or 403 from the Cloud API.
-    """
-
-
-class CloudClient:
-    def __init__(
-        self,
-        host: str,
-        api_key: str,
-        httpx_settings: dict = None,
-    ) -> None:
-
-        httpx_settings = httpx_settings or dict()
-        httpx_settings.setdefault("headers", dict())
-        httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
-
-        httpx_settings.setdefault("base_url", host)
-        self._client = httpx.AsyncClient(**httpx_settings)
-
-    async def api_healthcheck(self):
-        """
-        Attempts to connect to the Cloud API and raises the encountered exception if not
-        successful.
-
-        If successful, returns `None`.
-        """
-        with anyio.fail_after(10):
-            await self.read_workspaces()
-
-    async def read_workspaces(self) -> List[Dict]:
-        return await self.get("/me/workspaces")
-
-    async def __aenter__(self):
-        await self._client.__aenter__()
-        return self
-
-    async def __aexit__(self, *exc_info):
-        return await self._client.__aexit__(*exc_info)
-
-    def __enter__(self):
-        raise RuntimeError(
-            "The `CloudClient` must be entered with an async context. Use 'async "
-            "with CloudClient(...)' not 'with CloudClient(...)'"
-        )
-
-    def __exit__(self, *_):
-        assert False, "This should never be called but must be defined for __enter__"
-
-    async def get(self, route, **kwargs):
-        try:
-            res = await self._client.get(route, **kwargs)
-            res.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code in (
-                status.HTTP_401_UNAUTHORIZED,
-                status.HTTP_403_FORBIDDEN,
-            ):
-                raise CloudUnauthorizedError
-            else:
-                raise exc
-
-        return res.json()
 
 
 def build_table(selected_idx: int, workspaces: Iterable[str]) -> Table:

--- a/src/prefect/client/__init__.py
+++ b/src/prefect/client/__init__.py
@@ -1,0 +1,21 @@
+"""
+Asynchronous client implementation for communicating with the [Orion REST API](/api-ref/rest-api/).
+
+Explore the client by communicating with an in-memory webserver - no setup required:
+
+<div class="termy">
+```
+$ # start python REPL with native await functionality
+$ python -m asyncio
+>>> from prefect.client import get_client
+>>> async with get_client() as client:
+...     response = await client.hello()
+...     print(response.json())
+👋
+```
+</div>
+"""
+from prefect.client.orion import get_client, OrionClient
+from prefect.client.cloud import get_cloud_client, CloudClient
+
+__all__ = ["get_client", "OrionClient", "get_cloud_client", "CloudClient"]

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -1,0 +1,181 @@
+import copy
+import sys
+import threading
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from typing import ContextManager, Dict, Tuple, Type
+
+import anyio
+import httpx
+from asgi_lifespan import LifespanManager
+from fastapi import FastAPI, status
+from httpx import HTTPStatusError, Response
+from typing_extensions import Self
+
+from prefect.exceptions import PrefectHTTPStatusError
+
+# Datastores for lifespan management, keys should be a tuple of thread and app identities.
+APP_LIFESPANS: Dict[Tuple[int, int], LifespanManager] = {}
+APP_LIFESPANS_REF_COUNTS: Dict[Tuple[int, int], int] = {}
+# Blocks concurrent access to the above dicts per thread. The index should be the thread identity.
+APP_LIFESPANS_LOCKS: Dict[int, anyio.Lock] = defaultdict(anyio.Lock)
+
+
+@asynccontextmanager
+async def app_lifespan_context(app: FastAPI) -> ContextManager[None]:
+    """
+    A context manager that calls startup/shutdown hooks for the given application.
+
+    Lifespan contexts are cached per application to avoid calling the lifespan hooks
+    more than once if the context is entered in nested code. A no-op context will be
+    returned if the context for the given application is already being managed.
+
+    This manager is robust to concurrent access within the event loop. For example,
+    if you have concurrent contexts for the same application, it is guaranteed that
+    startup hooks will be called before their context starts and shutdown hooks will
+    only be called after their context exits.
+
+    A reference count is used to support nested use of clients without running
+    lifespan hooks excessively. The first client context entered will create and enter
+    a lifespan context. Each subsequent client will increment a reference count but will
+    not create a new lifespan context. When each client context exits, the reference
+    count is decremented. When the last client context exits, the lifespan will be
+    closed.
+
+    In simple nested cases, the first client context will be the one to exit the
+    lifespan. However, if client contexts are entered concurrently they may not exit
+    in a consistent order. If the first client context was responsible for closing
+    the lifespan, it would have to wait until all other client contexts to exit to
+    avoid firing shutdown hooks while the application is in use. Waiting for the other
+    clients to exit can introduce deadlocks, so, instead, the first client will exit
+    without closing the lifespan context and reference counts will be used to ensure
+    the lifespan is closed once all of the clients are done.
+    """
+    # TODO: A deadlock has been observed during multithreaded use of clients while this
+    #       lifespan context is being used. This has only been reproduced on Python 3.7
+    #       and while we hope to discourage using multiple event loops in threads, this
+    #       bug may emerge again.
+    #       See https://github.com/PrefectHQ/orion/pull/1696
+    thread_id = threading.get_ident()
+
+    # The id of the application is used instead of the hash so each application instance
+    # is managed independently even if they share the same settings. We include the
+    # thread id since applications are managed separately per thread.
+    key = (thread_id, id(app))
+
+    # On exception, this will be populated with exception details
+    exc_info = (None, None, None)
+
+    # Get a lock unique to this thread since anyio locks are not threadsafe
+    lock = APP_LIFESPANS_LOCKS[thread_id]
+
+    async with lock:
+        if key in APP_LIFESPANS:
+            # The lifespan is already being managed, just increment the reference count
+            APP_LIFESPANS_REF_COUNTS[key] += 1
+        else:
+            # Create a new lifespan manager
+            APP_LIFESPANS[key] = context = LifespanManager(
+                app, startup_timeout=30, shutdown_timeout=30
+            )
+            APP_LIFESPANS_REF_COUNTS[key] = 1
+
+            # Ensure we enter the context before releasing the lock so startup hooks
+            # are complete before another client can be used
+            await context.__aenter__()
+
+    try:
+        yield
+    except BaseException:
+        exc_info = sys.exc_info()
+        raise
+    finally:
+        # If we do not shield against anyio cancellation, the lock will return
+        # immediately and the code in its context will not run, leaving the lifespan
+        # open
+        with anyio.CancelScope(shield=True):
+            async with lock:
+                # After the consumer exits the context, decrement the reference count
+                APP_LIFESPANS_REF_COUNTS[key] -= 1
+
+                # If this the last context to exit, close the lifespan
+                if APP_LIFESPANS_REF_COUNTS[key] <= 0:
+                    APP_LIFESPANS_REF_COUNTS.pop(key)
+                    context = APP_LIFESPANS.pop(key)
+                    await context.__aexit__(*exc_info)
+
+
+class PrefectResponse(httpx.Response):
+    """
+    A Prefect wrapper for the `httpx.Response` class.
+
+    Provides more informative error messages.
+    """
+
+    def raise_for_status(self) -> None:
+        """
+        Raise an exception if the response contains an HTTPStatusError.
+
+        The `PrefectHTTPStatusError` contains useful additional information that
+        is not contained in the `HTTPStatusError`.
+        """
+        try:
+            return super().raise_for_status()
+        except HTTPStatusError as exc:
+            raise PrefectHTTPStatusError.from_httpx_error(exc) from exc.__cause__
+
+    @classmethod
+    def from_httpx_response(cls: Type[Self], response: httpx.Response) -> Self:
+        """
+        Create a `PrefectReponse` from an `httpx.Response`.
+
+        By changing the `__class__` attribute of the Response, we change the method
+        resolution order to look for methods defined in PrefectResponse, while leaving
+        everything else about the original Response instance intact.
+        """
+        new_response = copy.copy(response)
+        new_response.__class__ = cls
+        return new_response
+
+
+class PrefectHttpxClient(httpx.AsyncClient):
+    """
+    A Prefect wrapper for the async httpx client with support for CloudFlare-style
+    rate limiting.
+
+    Additionally, this client will always call `raise_for_status` on responses.
+
+    For more details on rate limit headers, see:
+    - https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Rate-Limiting-from-UI
+    """
+
+    RETRY_MAX = 5
+
+    async def send(self, *args, **kwargs) -> Response:
+        retry_count = 0
+        response = PrefectResponse.from_httpx_response(
+            await super().send(*args, **kwargs)
+        )
+        while (
+            response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+            and retry_count < self.RETRY_MAX
+        ):
+            retry_count += 1
+
+            # Respect the "Retry-After" header, falling back to an exponential back-off
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                retry_seconds = float(retry_after)
+            else:
+                retry_seconds = 2**retry_count
+
+            await anyio.sleep(retry_seconds)
+            response = await super().send(*args, **kwargs)
+
+        # Always raise bad responses
+        # NOTE: We may want to remove this and handle responses per route in the
+        #       `OrionClient`
+
+        response.raise_for_status()
+
+        return response

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -1,0 +1,99 @@
+import re
+from typing import Dict, List
+
+import anyio
+import httpx
+from fastapi import status
+
+import prefect.context
+import prefect.settings
+from prefect.exceptions import PrefectException
+from prefect.settings import PREFECT_API_KEY, PREFECT_CLOUD_URL
+
+
+def get_cloud_client(
+    host: str = None,
+    api_key: str = None,
+    httpx_settings: dict = None,
+    infer_cloud_url: bool = False,
+) -> "CloudClient":
+    if httpx_settings is not None:
+        httpx_settings = httpx_settings.copy()
+
+    if infer_cloud_url is False:
+        host = host or PREFECT_CLOUD_URL.value()
+    else:
+        configured_url = prefect.settings.PREFECT_API_URL.value()
+        host = re.sub(r"accounts/.{36}/workspaces/.{36}\Z", "", configured_url)
+
+    return CloudClient(
+        host=host,
+        api_key=api_key or PREFECT_API_KEY.value(),
+        httpx_settings=httpx_settings,
+    )
+
+
+class CloudUnauthorizedError(PrefectException):
+    """
+    Raised when the CloudClient receives a 401 or 403 from the Cloud API.
+    """
+
+
+class CloudClient:
+    def __init__(
+        self,
+        host: str,
+        api_key: str,
+        httpx_settings: dict = None,
+    ) -> None:
+
+        httpx_settings = httpx_settings or dict()
+        httpx_settings.setdefault("headers", dict())
+        httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
+
+        httpx_settings.setdefault("base_url", host)
+        self._client = httpx.AsyncClient(**httpx_settings)
+
+    async def api_healthcheck(self):
+        """
+        Attempts to connect to the Cloud API and raises the encountered exception if not
+        successful.
+
+        If successful, returns `None`.
+        """
+        with anyio.fail_after(10):
+            await self.read_workspaces()
+
+    async def read_workspaces(self) -> List[Dict]:
+        return await self.get("/me/workspaces")
+
+    async def __aenter__(self):
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return await self._client.__aexit__(*exc_info)
+
+    def __enter__(self):
+        raise RuntimeError(
+            "The `CloudClient` must be entered with an async context. Use 'async "
+            "with CloudClient(...)' not 'with CloudClient(...)'"
+        )
+
+    def __exit__(self, *_):
+        assert False, "This should never be called but must be defined for __enter__"
+
+    async def get(self, route, **kwargs):
+        try:
+            res = await self._client.get(route, **kwargs)
+            res.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (
+                status.HTTP_401_UNAUTHORIZED,
+                status.HTTP_403_FORBIDDEN,
+            ):
+                raise CloudUnauthorizedError
+            else:
+                raise exc
+
+        return res.json()

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -1,40 +1,8 @@
-"""
-Asynchronous client implementation for communicating with the [Orion REST API](/api-ref/rest-api/).
-
-Explore the client by communicating with an in-memory webserver - no setup required:
-
-<div class="termy">
-```
-$ # start python REPL with native await functionality
-$ python -m asyncio
->>> from prefect.client import get_client
->>> async with get_client() as client:
-...     response = await client.hello()
-...     print(response.json())
-👋
-```
-</div>
-"""
-import copy
 import datetime
-import sys
-import threading
 import warnings
-from collections import defaultdict
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ContextManager,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 from uuid import UUID
 
 import anyio
@@ -43,14 +11,11 @@ import pendulum
 import pydantic
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI, status
-from httpx import HTTPStatusError, Response
-from typing_extensions import Self
 
 import prefect
 import prefect.exceptions
 import prefect.orion.schemas as schemas
 import prefect.settings
-from prefect.exceptions import PrefectHTTPStatusError
 from prefect.logging import get_logger
 from prefect.orion.api.server import ORION_API_VERSION, create_app
 from prefect.orion.orchestration.rules import OrchestrationResult
@@ -76,6 +41,8 @@ from prefect.utilities.asyncutils import asyncnullcontext
 if TYPE_CHECKING:
     from prefect.flows import Flow
     from prefect.tasks import Task
+
+from prefect.client.base import PrefectHttpxClient, app_lifespan_context
 
 
 def inject_client(fn):
@@ -112,173 +79,6 @@ def get_client(httpx_settings: dict = None) -> "OrionClient":
         api_key=PREFECT_API_KEY.value(),
         httpx_settings=httpx_settings,
     )
-
-
-# Datastores for lifespan management, keys should be a tuple of thread and app identities.
-APP_LIFESPANS: Dict[Tuple[int, int], LifespanManager] = {}
-APP_LIFESPANS_REF_COUNTS: Dict[Tuple[int, int], int] = {}
-# Blocks concurrent access to the above dicts per thread. The index should be the thread identity.
-APP_LIFESPANS_LOCKS: Dict[int, anyio.Lock] = defaultdict(anyio.Lock)
-
-
-@asynccontextmanager
-async def app_lifespan_context(app: FastAPI) -> ContextManager[None]:
-    """
-    A context manager that calls startup/shutdown hooks for the given application.
-
-    Lifespan contexts are cached per application to avoid calling the lifespan hooks
-    more than once if the context is entered in nested code. A no-op context will be
-    returned if the context for the given application is already being managed.
-
-    This manager is robust to concurrent access within the event loop. For example,
-    if you have concurrent contexts for the same application, it is guaranteed that
-    startup hooks will be called before their context starts and shutdown hooks will
-    only be called after their context exits.
-
-    A reference count is used to support nested use of clients without running
-    lifespan hooks excessively. The first client context entered will create and enter
-    a lifespan context. Each subsequent client will increment a reference count but will
-    not create a new lifespan context. When each client context exits, the reference
-    count is decremented. When the last client context exits, the lifespan will be
-    closed.
-
-    In simple nested cases, the first client context will be the one to exit the
-    lifespan. However, if client contexts are entered concurrently they may not exit
-    in a consistent order. If the first client context was responsible for closing
-    the lifespan, it would have to wait until all other client contexts to exit to
-    avoid firing shutdown hooks while the application is in use. Waiting for the other
-    clients to exit can introduce deadlocks, so, instead, the first client will exit
-    without closing the lifespan context and reference counts will be used to ensure
-    the lifespan is closed once all of the clients are done.
-    """
-    # TODO: A deadlock has been observed during multithreaded use of clients while this
-    #       lifespan context is being used. This has only been reproduced on Python 3.7
-    #       and while we hope to discourage using multiple event loops in threads, this
-    #       bug may emerge again.
-    #       See https://github.com/PrefectHQ/orion/pull/1696
-    thread_id = threading.get_ident()
-
-    # The id of the application is used instead of the hash so each application instance
-    # is managed independently even if they share the same settings. We include the
-    # thread id since applications are managed separately per thread.
-    key = (thread_id, id(app))
-
-    # On exception, this will be populated with exception details
-    exc_info = (None, None, None)
-
-    # Get a lock unique to this thread since anyio locks are not threadsafe
-    lock = APP_LIFESPANS_LOCKS[thread_id]
-
-    async with lock:
-        if key in APP_LIFESPANS:
-            # The lifespan is already being managed, just increment the reference count
-            APP_LIFESPANS_REF_COUNTS[key] += 1
-        else:
-            # Create a new lifespan manager
-            APP_LIFESPANS[key] = context = LifespanManager(
-                app, startup_timeout=30, shutdown_timeout=30
-            )
-            APP_LIFESPANS_REF_COUNTS[key] = 1
-
-            # Ensure we enter the context before releasing the lock so startup hooks
-            # are complete before another client can be used
-            await context.__aenter__()
-
-    try:
-        yield
-    except BaseException:
-        exc_info = sys.exc_info()
-        raise
-    finally:
-        # If we do not shield against anyio cancellation, the lock will return
-        # immediately and the code in its context will not run, leaving the lifespan
-        # open
-        with anyio.CancelScope(shield=True):
-            async with lock:
-                # After the consumer exits the context, decrement the reference count
-                APP_LIFESPANS_REF_COUNTS[key] -= 1
-
-                # If this the last context to exit, close the lifespan
-                if APP_LIFESPANS_REF_COUNTS[key] <= 0:
-                    APP_LIFESPANS_REF_COUNTS.pop(key)
-                    context = APP_LIFESPANS.pop(key)
-                    await context.__aexit__(*exc_info)
-
-
-class PrefectResponse(httpx.Response):
-    """
-    A Prefect wrapper for the `httpx.Response` class.
-
-    Provides more informative error messages.
-    """
-
-    def raise_for_status(self) -> None:
-        """
-        Raise an exception if the response contains an HTTPStatusError.
-
-        The `PrefectHTTPStatusError` contains useful additional information that
-        is not contained in the `HTTPStatusError`.
-        """
-        try:
-            return super().raise_for_status()
-        except HTTPStatusError as exc:
-            raise PrefectHTTPStatusError.from_httpx_error(exc) from exc.__cause__
-
-    @classmethod
-    def from_httpx_response(cls: Type[Self], response: httpx.Response) -> Self:
-        """
-        Create a `PrefectReponse` from an `httpx.Response`.
-
-        By changing the `__class__` attribute of the Response, we change the method
-        resolution order to look for methods defined in PrefectResponse, while leaving
-        everything else about the original Response instance intact.
-        """
-        new_response = copy.copy(response)
-        new_response.__class__ = cls
-        return new_response
-
-
-class PrefectHttpxClient(httpx.AsyncClient):
-    """
-    A Prefect wrapper for the async httpx client with support for CloudFlare-style
-    rate limiting.
-
-    Additionally, this client will always call `raise_for_status` on responses.
-
-    For more details on rate limit headers, see:
-    - https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Rate-Limiting-from-UI
-    """
-
-    RETRY_MAX = 5
-
-    async def send(self, *args, **kwargs) -> Response:
-        retry_count = 0
-        response = PrefectResponse.from_httpx_response(
-            await super().send(*args, **kwargs)
-        )
-        while (
-            response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-            and retry_count < self.RETRY_MAX
-        ):
-            retry_count += 1
-
-            # Respect the "Retry-After" header, falling back to an exponential back-off
-            retry_after = response.headers.get("Retry-After")
-            if retry_after:
-                retry_seconds = float(retry_after)
-            else:
-                retry_seconds = 2**retry_count
-
-            await anyio.sleep(retry_seconds)
-            response = await super().send(*args, **kwargs)
-
-        # Always raise bad responses
-        # NOTE: We may want to remove this and handle responses per route in the
-        #       `OrionClient`
-
-        response.raise_for_status()
-
-        return response
 
 
 class OrionClient:

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -13,7 +13,8 @@ import yaml
 from pydantic import BaseModel, Field, parse_obj_as, validator
 
 from prefect.blocks.core import Block
-from prefect.client import OrionClient, get_client, inject_client
+from prefect.client import OrionClient, get_client
+from prefect.client.orion import inject_client
 from prefect.context import PrefectObjectRegistry
 from prefect.exceptions import BlockMissingCapabilities, ObjectNotFound
 from prefect.filesystems import LocalFileSystem

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -29,7 +29,8 @@ from typing_extensions import Literal
 
 import prefect
 import prefect.context
-from prefect.client import OrionClient, get_client, inject_client
+from prefect.client import OrionClient, get_client
+from prefect.client.orion import inject_client
 from prefect.context import (
     FlowRunContext,
     PrefectObjectRegistry,

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -22,7 +22,8 @@ from uuid import UUID
 
 import anyio
 
-from prefect.client import OrionClient, inject_client
+from prefect.client import OrionClient
+from prefect.client.orion import inject_client
 from prefect.orion.schemas.states import State
 from prefect.utilities.asyncutils import (
     A,

--- a/src/prefect/packaging/file.py
+++ b/src/prefect/packaging/file.py
@@ -4,7 +4,8 @@ from pydantic import Field
 from typing_extensions import Literal
 
 from prefect.blocks.core import Block
-from prefect.client import OrionClient, inject_client
+from prefect.client import OrionClient
+from prefect.client.orion import inject_client
 from prefect.filesystems import LocalFileSystem, ReadableFileSystem, WritableFileSystem
 from prefect.flows import Flow
 from prefect.packaging.base import PackageManifest, Packager, Serializer

--- a/src/prefect/packaging/orion.py
+++ b/src/prefect/packaging/orion.py
@@ -4,7 +4,8 @@ from pydantic import Field
 from typing_extensions import Literal
 
 from prefect.blocks.system import JSON
-from prefect.client import OrionClient, inject_client
+from prefect.client import OrionClient
+from prefect.client.orion import inject_client
 from prefect.flows import Flow
 from prefect.packaging.base import PackageManifest, Packager, Serializer
 from prefect.packaging.serializers import SourceSerializer

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -3,7 +3,8 @@ import uuid
 import pydantic
 
 from prefect.blocks.core import Block
-from prefect.client import OrionClient, inject_client
+from prefect.client import OrionClient
+from prefect.client.orion import inject_client
 from prefect.filesystems import WritableFileSystem
 from prefect.orion.schemas.data import DataDocument
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -5,7 +5,8 @@ import anyio
 import httpx
 from typing_extensions import TypeGuard
 
-from prefect.client import OrionClient, inject_client
+from prefect.client import OrionClient
+from prefect.client.orion import inject_client
 from prefect.futures import resolve_futures_to_states
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.states import Completed, Crashed, StateType

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -64,7 +64,7 @@ def mock_select_workspace(workspaces):
 
 def test_invalid_login(monkeypatch):
     monkeypatch.setattr(
-        "prefect.cli.cloud.get_cloud_client", get_unauthorized_mock_cloud_client
+        "prefect.client.cloud.get_cloud_client", get_unauthorized_mock_cloud_client
     )
 
     invoke_and_assert(

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -1,0 +1,155 @@
+from unittest.mock import call
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient, HTTPStatusError, Request, Response
+
+from prefect.client.base import PrefectHttpxClient
+from prefect.testing.utilities import AsyncMock
+
+
+class TestPrefectHttpxClient:
+    async def test_prefect_httpx_client_retries_429s(self, monkeypatch):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+        client = PrefectHttpxClient()
+        retry_response = Response(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            headers={"Retry-After": "0"},
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+        success_response = Response(
+            status.HTTP_200_OK,
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+        base_client_send.side_effect = [
+            retry_response,
+            retry_response,
+            retry_response,
+            success_response,
+        ]
+        response = await client.post(
+            url="fake.url/fake/route", data={"evenmorefake": "data"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert base_client_send.call_count == 4
+
+    async def test_prefect_httpx_client_retries_429s_up_to_five_times(
+        self, monkeypatch
+    ):
+        client = PrefectHttpxClient()
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        retry_response = Response(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            headers={"Retry-After": "0"},
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        # Return more than 6 retry responses
+        base_client_send.side_effect = [retry_response] * 7
+
+        with pytest.raises(HTTPStatusError, match="429"):
+            await client.post(
+                url="fake.url/fake/route",
+                data={"evenmorefake": "data"},
+            )
+
+        # 5 retries + 1 first attempt
+        assert base_client_send.call_count == 6
+
+    async def test_prefect_httpx_client_respects_retry_header(
+        self, monkeypatch, mock_anyio_sleep
+    ):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxClient()
+        retry_response = Response(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            headers={"Retry-After": "5"},
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        success_response = Response(
+            status.HTTP_200_OK,
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        base_client_send.side_effect = [
+            retry_response,
+            success_response,
+        ]
+
+        with mock_anyio_sleep.assert_sleeps_for(5):
+            response = await client.post(
+                url="fake.url/fake/route", data={"evenmorefake": "data"}
+            )
+        assert response.status_code == status.HTTP_200_OK
+
+    async def test_prefect_httpx_client_falls_back_to_exponential_backoff(
+        self, mock_anyio_sleep, monkeypatch
+    ):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxClient()
+        retry_response = Response(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        success_response = Response(
+            status.HTTP_200_OK,
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        base_client_send.side_effect = [
+            retry_response,
+            retry_response,
+            retry_response,
+            success_response,
+        ]
+
+        with mock_anyio_sleep.assert_sleeps_for(2 + 4 + 8):
+            response = await client.post(
+                url="fake.url/fake/route", data={"evenmorefake": "data"}
+            )
+        assert response.status_code == status.HTTP_200_OK
+        mock_anyio_sleep.assert_has_awaits([call(2), call(4), call(8)])
+
+    async def test_prefect_httpx_client_respects_retry_header_per_response(
+        self, mock_anyio_sleep, monkeypatch
+    ):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxClient()
+
+        def make_retry_response(retry_after):
+            return Response(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                headers={"Retry-After": str(retry_after)},
+                request=Request("a test request", "fake.url/fake/route"),
+            )
+
+        success_response = Response(
+            status.HTTP_200_OK,
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        base_client_send.side_effect = [
+            make_retry_response(5),
+            make_retry_response(0),
+            make_retry_response(10),
+            make_retry_response(2.0),
+            success_response,
+        ]
+
+        with mock_anyio_sleep.assert_sleeps_for(5 + 10 + 2):
+            response = await client.post(
+                url="fake.url/fake/route", data={"evenmorefake": "data"}
+            )
+        assert response.status_code == status.HTTP_200_OK
+        mock_anyio_sleep.assert_has_awaits([call(5), call(0), call(10), call(2.0)])

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1,7 +1,7 @@
 import random
 import threading
 from datetime import timedelta
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import anyio
@@ -10,12 +10,11 @@ import pendulum
 import pytest
 from fastapi import Depends, FastAPI, status
 from fastapi.security import HTTPBearer
-from httpx import AsyncClient, HTTPStatusError, Request, Response
 
 import prefect.context
 import prefect.exceptions
 from prefect import flow, tags
-from prefect.client import OrionClient, PrefectHttpxClient, get_client
+from prefect.client import OrionClient, get_client
 from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
 from prefect.orion.orchestration.rules import OrchestrationResult
@@ -29,153 +28,6 @@ from prefect.settings import (
 )
 from prefect.tasks import task
 from prefect.testing.utilities import AsyncMock, exceptions_equal
-
-
-class TestPrefectHttpxClient:
-    async def test_prefect_httpx_client_retries_429s(self, monkeypatch):
-        base_client_send = AsyncMock()
-        monkeypatch.setattr(AsyncClient, "send", base_client_send)
-        client = PrefectHttpxClient()
-        retry_response = Response(
-            status.HTTP_429_TOO_MANY_REQUESTS,
-            headers={"Retry-After": "0"},
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-        success_response = Response(
-            status.HTTP_200_OK,
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-        base_client_send.side_effect = [
-            retry_response,
-            retry_response,
-            retry_response,
-            success_response,
-        ]
-        response = await client.post(
-            url="fake.url/fake/route", data={"evenmorefake": "data"}
-        )
-        assert response.status_code == status.HTTP_200_OK
-        assert base_client_send.call_count == 4
-
-    async def test_prefect_httpx_client_retries_429s_up_to_five_times(
-        self, monkeypatch
-    ):
-        client = PrefectHttpxClient()
-        base_client_send = AsyncMock()
-        monkeypatch.setattr(AsyncClient, "send", base_client_send)
-
-        retry_response = Response(
-            status.HTTP_429_TOO_MANY_REQUESTS,
-            headers={"Retry-After": "0"},
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        # Return more than 6 retry responses
-        base_client_send.side_effect = [retry_response] * 7
-
-        with pytest.raises(HTTPStatusError, match="429"):
-            await client.post(
-                url="fake.url/fake/route",
-                data={"evenmorefake": "data"},
-            )
-
-        # 5 retries + 1 first attempt
-        assert base_client_send.call_count == 6
-
-    async def test_prefect_httpx_client_respects_retry_header(
-        self, monkeypatch, mock_anyio_sleep
-    ):
-        base_client_send = AsyncMock()
-        monkeypatch.setattr(AsyncClient, "send", base_client_send)
-
-        client = PrefectHttpxClient()
-        retry_response = Response(
-            status.HTTP_429_TOO_MANY_REQUESTS,
-            headers={"Retry-After": "5"},
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        success_response = Response(
-            status.HTTP_200_OK,
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        base_client_send.side_effect = [
-            retry_response,
-            success_response,
-        ]
-
-        with mock_anyio_sleep.assert_sleeps_for(5):
-            response = await client.post(
-                url="fake.url/fake/route", data={"evenmorefake": "data"}
-            )
-        assert response.status_code == status.HTTP_200_OK
-
-    async def test_prefect_httpx_client_falls_back_to_exponential_backoff(
-        self, mock_anyio_sleep, monkeypatch
-    ):
-        base_client_send = AsyncMock()
-        monkeypatch.setattr(AsyncClient, "send", base_client_send)
-
-        client = PrefectHttpxClient()
-        retry_response = Response(
-            status.HTTP_429_TOO_MANY_REQUESTS,
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        success_response = Response(
-            status.HTTP_200_OK,
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        base_client_send.side_effect = [
-            retry_response,
-            retry_response,
-            retry_response,
-            success_response,
-        ]
-
-        with mock_anyio_sleep.assert_sleeps_for(2 + 4 + 8):
-            response = await client.post(
-                url="fake.url/fake/route", data={"evenmorefake": "data"}
-            )
-        assert response.status_code == status.HTTP_200_OK
-        mock_anyio_sleep.assert_has_awaits([call(2), call(4), call(8)])
-
-    async def test_prefect_httpx_client_respects_retry_header_per_response(
-        self, mock_anyio_sleep, monkeypatch
-    ):
-        base_client_send = AsyncMock()
-        monkeypatch.setattr(AsyncClient, "send", base_client_send)
-
-        client = PrefectHttpxClient()
-
-        def make_retry_response(retry_after):
-            return Response(
-                status.HTTP_429_TOO_MANY_REQUESTS,
-                headers={"Retry-After": str(retry_after)},
-                request=Request("a test request", "fake.url/fake/route"),
-            )
-
-        success_response = Response(
-            status.HTTP_200_OK,
-            request=Request("a test request", "fake.url/fake/route"),
-        )
-
-        base_client_send.side_effect = [
-            make_retry_response(5),
-            make_retry_response(0),
-            make_retry_response(10),
-            make_retry_response(2.0),
-            success_response,
-        ]
-
-        with mock_anyio_sleep.assert_sleeps_for(5 + 10 + 2):
-            response = await client.post(
-                url="fake.url/fake/route", data={"evenmorefake": "data"}
-            )
-        assert response.status_code == status.HTTP_200_OK
-        mock_anyio_sleep.assert_has_awaits([call(5), call(0), call(10), call(2.0)])
 
 
 class TestGetClient:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

In preparation for client-side schemas, introduces a `prefect.client` namespace.

- Moves `CloudClient` from `prefect.cli.cloud` to `prefect.client.cloud`
- Moves `PrefectHttpxClient`, `PrefectResponse`, and similar to `prefect.client.base`
- Moves `OrionClient` to `prefect.client.orion`

Imports of `prefect.client.get_client` and `prefect.client.OrionClient` are backwards compatible. Other objects previously in the module are not available without specifying `prefect.client.base` or `prefect.client.orion`.

No changes in behavior have been made.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
client
├── __init__.py
├── base.py
├── cloud.py
└── orion.py
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
