### PR TITLE
Restricts blocks in suite tests to only blocks in prefect module

### DIFF
--- a/tests/blocks/test_block_standards.py
+++ b/tests/blocks/test_block_standards.py
@@ -3,12 +3,19 @@ import pytest
 from prefect.blocks.core import Block
 from prefect.testing.standard_test_suites import BlockStandardTestSuite
 from prefect.utilities.dispatch import get_registry_for_type
+from prefect.utilities.importtools import to_qualified_name
 
 block_registry = get_registry_for_type(Block) or {}
 
+blocks_under_test = [
+    block
+    for block in block_registry.values()
+    if to_qualified_name(block).startswith("prefect.")
+]
+
 
 @pytest.mark.parametrize(
-    "block", sorted(block_registry.values(), key=lambda x: x.get_block_type_slug())
+    "block", sorted(blocks_under_test, key=lambda x: x.get_block_type_slug())
 )
 class TestAllBlocksAdhereToStandards(BlockStandardTestSuite):
     @pytest.fixture

--- a/tests/blocks/test_checksum_consistency.py
+++ b/tests/blocks/test_checksum_consistency.py
@@ -12,13 +12,21 @@ import pytest
 
 from prefect.blocks.core import Block
 from prefect.utilities.dispatch import get_registry_for_type
+from prefect.utilities.importtools import to_qualified_name
 
 with open(str(Path(__file__).parent) + "/checksums.json", "r") as f:
     standard_checksum = json.load(f)
 block_registry = get_registry_for_type(Block) or {}
 
+blocks_under_test = [
+    (block_key, block)
+    for block_key, block in block_registry.items()
+    if to_qualified_name(block).startswith("prefect.")
+]
+blocks_under_test = sorted(blocks_under_test, key=lambda x: x[1].get_block_type_slug())
 
-@pytest.mark.parametrize("block_key,block", block_registry.items())
+
+@pytest.mark.parametrize("block_key,block", blocks_under_test)
 def test_checksums_are_consistent(block_key, block):
     assert block._calculate_schema_checksum() == standard_checksum.get(
         block_key


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Restricts blocks used in suite tests to only the blocks in the prefect module. This way, any blocks that are installed in the same virtual environment will not cause failures in the prefect test suite.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
