### PR TITLE
Prevent redundant transitions

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1169,11 +1169,22 @@ async def orchestrate_task_run(
         # Resolve futures in any non-data dependencies to ensure they are ready
         await resolve_inputs(wait_for, return_data=False)
     except UpstreamTaskError as upstream_exc:
-        return await propose_state(
-            client,
-            Pending(name="NotReady", message=str(upstream_exc)),
-            task_run_id=task_run.id,
-        )
+        if task_run.state.is_pending():
+            # if orchestrating a run already in a pending state, force orchestration to
+            # update the state name
+            return await propose_state(
+                client,
+                Pending(name="NotReady", message=str(upstream_exc)),
+                task_run_id=task_run.id,
+                force=True,
+            )
+        else:
+            return await propose_state(
+                client,
+                Pending(name="NotReady", message=str(upstream_exc)),
+                task_run_id=task_run.id,
+                force=False,
+            )
 
     # Generate the cache key to attach to proposed states
     cache_key = (
@@ -1412,6 +1423,7 @@ async def propose_state(
     client: OrionClient,
     state: State,
     backend_state_data: DataDocument = None,
+    force: bool = False,
     task_run_id: UUID = None,
     flow_run_id: UUID = None,
 ) -> State:
@@ -1461,11 +1473,11 @@ async def propose_state(
     # Attempt to set the state
     if task_run_id:
         response = await client.set_task_run_state(
-            task_run_id, state, backend_state_data=backend_state_data
+            task_run_id, state, backend_state_data=backend_state_data, force=force,
         )
     elif flow_run_id:
         response = await client.set_flow_run_state(
-            flow_run_id, state, backend_state_data=backend_state_data
+            flow_run_id, state, backend_state_data=backend_state_data, force=force,
         )
     else:
         raise ValueError(

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -35,7 +35,7 @@ class CoreFlowPolicy(BaseOrchestrationPolicy):
     def priority():
         return [
             PreventTransitionsFromTerminalStates,
-            PreventBackwardsTransitions,
+            PreventRedundantTransitions,
             WaitForScheduledTime,
             RetryFailedFlows,
         ]
@@ -51,7 +51,7 @@ class CoreTaskPolicy(BaseOrchestrationPolicy):
             CacheRetrieval,
             SecureTaskConcurrencySlots,  # retrieve cached states even if slots are full
             PreventTransitionsFromTerminalStates,
-            PreventBackwardsTransitions,
+            PreventRedundantTransitions,
             WaitForScheduledTime,
             RetryFailedTasks,
             RenameReruns,
@@ -445,5 +445,5 @@ class PreventRedundantTransitions(BaseOrchestrationRule):
             <= self.STATE_PROGRESS[initial_state_type]
         ):
             await self.abort_transition(
-                reason=f"This run cannot to the {proposed_state.type} state."
+                reason=f"This run cannot transition to the {proposed_state.type} state."
             )

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -445,5 +445,5 @@ class PreventRedundantTransitions(BaseOrchestrationRule):
             <= self.STATE_PROGRESS[initial_state_type]
         ):
             await self.abort_transition(
-                reason=f"This run cannot transition to the {proposed_state.type} state."
+                reason=f"This run cannot transition to the {proposed_state_type} state from the {initial_state_type}."
             )

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -413,6 +413,15 @@ class PreventTransitionsFromTerminalStates(BaseOrchestrationRule):
 
 
 class PreventRedundantTransitions(BaseOrchestrationRule):
+    """
+    Prevents redundant transitions.
+
+    Under normal operation, this rule prevents the "backwards" progress of a run. This
+    rule will also help prevent multiple agents from attempting to orchestrate a run by
+    preventing transitions into the same state type. If any of these disallowed
+    transitions are attempted, this rule will abort the transition.
+    """
+
     STATE_PROGRESS = {
         None: 0,
         StateType.SCHEDULED: 1,

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -445,5 +445,5 @@ class PreventRedundantTransitions(BaseOrchestrationRule):
             <= self.STATE_PROGRESS[initial_state_type]
         ):
             await self.abort_transition(
-                reason=f"This run cannot transition to the {proposed_state_type} state from the {initial_state_type}."
+                reason=f"This run cannot transition to the {proposed_state_type} state from the {initial_state_type} state."
             )

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -588,6 +588,32 @@ class TestSetFlowRunState:
         assert run.state.type == states.StateType.RUNNING
         assert run.state.name == "Test State"
 
+    @pytest.mark.parametrize("proposed_state", ["PENDING", "RUNNING"])
+    async def test_setting_flow_run_state_twice_aborts(
+        self, flow_run, client, session, proposed_state
+    ):
+        # A multi-agent environment may attempt to orchestrate a run more than once,
+        # this test ensures that a 2nd agent cannot re-propose a state that's already
+        # been set
+
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(state=dict(type=proposed_state, name="Test State")),
+        )
+        assert response.status_code == 201
+
+        api_response = OrchestrationResult.parse_obj(response.json())
+        assert api_response.status == responses.SetStateStatus.ACCEPT
+
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/set_state",
+            json=dict(state=dict(type="PENDING", name="Test State")),
+        )
+        assert response.status_code == 200
+
+        api_response = OrchestrationResult.parse_obj(response.json())
+        assert api_response.status == responses.SetStateStatus.ABORT
+
     async def test_set_flow_run_state_ignores_client_provided_timestamp(
         self, flow_run, client, session
     ):


### PR DESCRIPTION
Here we add a simple orchestration rule preventing redundant transitions. Among other things, this will prevent multiple Agents from orchestrating an active run in competing and inconsistent ways.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
