### PR TITLE
Add toggle for block registration on application start

### DIFF
--- a/src/prefect/orion/api/server.py
+++ b/src/prefect/orion/api/server.py
@@ -272,6 +272,9 @@ def create_app(
 
     async def add_block_types():
         """Add all registered blocks to the database"""
+        if not prefect.settings.PREFECT_ORION_BLOCKS_REGISTER_ON_START:
+            return
+
         from prefect.blocks.core import Block
         from prefect.orion.database.dependencies import provide_database_interface
         from prefect.orion.models.block_schemas import create_block_schema

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -397,6 +397,18 @@ PREFECT_AGENT_PREFETCH_SECONDS = Setting(
     prefetched. Defaults to `10`.""",
 )
 
+PREFECT_ORION_BLOCKS_REGISTER_ON_START = Setting(
+    bool,
+    default=True,
+    description=textwrap.dedent(
+        """
+        If set, any block types that have been imported will be registered with the 
+        backend on application startup. If not set, block types must be manually 
+        registered.
+        """
+    ),
+)
+
 PREFECT_ORION_DATABASE_PASSWORD = Setting(
     str,
     default=None,

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -2,6 +2,7 @@ import asyncio
 
 from prefect.blocks import system
 from prefect.client import OrionClient
+from prefect.settings import PREFECT_ORION_BLOCKS_REGISTER_ON_START, temporary_settings
 from prefect.testing.cli import invoke_and_assert
 
 TEST_BLOCK_CODE = """\
@@ -163,30 +164,31 @@ def test_listing_blocks_after_saving_a_block():
 
 
 def test_listing_system_block_types():
-    expected_output = (
-        "Block Types",
-        "Slug",
-        "Description",
-        "slack",
-        "date-time",
-        "docker-container",
-        "gcs",
-        "json",
-        "kubernetes-cluster-config",
-        "kubernetes-job",
-        "local-file-system",
-        "process",
-        "remote-file-system",
-        "s3",
-        "secret",
-        "slack-webhook",
-    )
+    with temporary_settings({PREFECT_ORION_BLOCKS_REGISTER_ON_START: True}):
+        expected_output = (
+            "Block Types",
+            "Slug",
+            "Description",
+            "slack",
+            "date-time",
+            "docker-container",
+            "gcs",
+            "json",
+            "kubernetes-cluster-config",
+            "kubernetes-job",
+            "local-file-system",
+            "process",
+            "remote-file-system",
+            "s3",
+            "secret",
+            "slack-webhook",
+        )
 
-    invoke_and_assert(
-        ["block", "type", "ls"],
-        expected_code=0,
-        expected_output_contains=expected_output,
-    )
+        invoke_and_assert(
+            ["block", "type", "ls"],
+            expected_code=0,
+            expected_output_contains=expected_output,
+        )
 
 
 def test_inspecting_a_block():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from prefect.settings import (
     PREFECT_LOGGING_LEVEL,
     PREFECT_LOGGING_ORION_ENABLED,
     PREFECT_ORION_ANALYTICS_ENABLED,
+    PREFECT_ORION_BLOCKS_REGISTER_ON_START,
     PREFECT_ORION_DATABASE_CONNECTION_URL,
     PREFECT_ORION_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED,
     PREFECT_ORION_SERVICES_LATE_RUNS_ENABLED,
@@ -282,6 +283,8 @@ def pytest_sessionstart(session):
             PREFECT_ORION_SERVICES_LATE_RUNS_ENABLED: False,
             PREFECT_ORION_SERVICES_SCHEDULER_ENABLED: False,
             PREFECT_ORION_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED: False,
+            # Disable auto-registration of block types as they can conflict
+            PREFECT_ORION_BLOCKS_REGISTER_ON_START: False,
         },
         source=__file__,
     )

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -23,6 +23,7 @@ def flow_function():
 @pytest.fixture(scope="module")
 def test_block():
     class x(Block):
+        _block_type_slug = "x-fixture"
         _logo_url = "https://en.wiktionary.org/wiki/File:LetterX.svg"
         _documentation_url = "https://en.wiktionary.org/wiki/X"
         foo: str

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -3,10 +3,8 @@ import warnings
 
 import pendulum
 import pytest
-import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prefect.blocks.core import Block
 from prefect.blocks.notifications import NotificationBlock
 from prefect.filesystems import LocalFileSystem
 from prefect.infrastructure import DockerContainer, Process
@@ -241,22 +239,12 @@ async def work_queue(session):
 
 @pytest.fixture
 async def block_type_x(session):
-    # Ignore warnings caused by block reuse in fixtuer
-    warnings.filterwarnings("ignore", category=UserWarning)
-    # TODO: In some cases, this fixture can run more than once which results in a
-    #       failure due to the block already existing. Instead of failing, we'll read
-    #       the existing block
-    try:
-        block_type = await models.block_types.create_block_type(
-            session=session,
-            block_type=schemas.actions.BlockTypeCreate(name="x", slug="x"),
-        )
-        await session.commit()
-        return block_type
-    except sa.exc.IntegrityError:
-        return await models.block_types.read_block_type_by_slug(
-            session=session, block_type_slug="x"
-        )
+    block_type = await models.block_types.create_block_type(
+        session=session,
+        block_type=schemas.actions.BlockTypeCreate(name="x", slug="x"),
+    )
+    await session.commit()
+    return block_type
 
 
 @pytest.fixture
@@ -279,7 +267,6 @@ async def block_type_z(session):
 
 @pytest.fixture
 async def block_schema(session, block_type_x):
-    # TODO: See `block_type_x` for integrity error description
     fields = {
         "title": "x",
         "type": "object",
@@ -288,20 +275,15 @@ async def block_schema(session, block_type_x):
         "block_schema_references": {},
         "block_type_slug": block_type_x.slug,
     }
-    try:
-        block_schema = await models.block_schemas.create_block_schema(
-            session=session,
-            block_schema=schemas.actions.BlockSchemaCreate(
-                fields=fields,
-                block_type_id=block_type_x.id,
-            ),
-        )
-        await session.commit()
-        return block_schema
-    except sa.exc.IntegrityError:
-        return await models.block_schemas.read_block_schema_by_checksum(
-            Block._calculate_schema_checksum(fields)
-        )
+    block_schema = await models.block_schemas.create_block_schema(
+        session=session,
+        block_schema=schemas.actions.BlockSchemaCreate(
+            fields=fields,
+            block_type_id=block_type_x.id,
+        ),
+    )
+    await session.commit()
+    return block_schema
 
 
 @pytest.fixture

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -241,7 +241,7 @@ async def work_queue(session):
 async def block_type_x(session):
     block_type = await models.block_types.create_block_type(
         session=session,
-        block_type=schemas.actions.BlockTypeCreate(name="x", slug="x"),
+        block_type=schemas.actions.BlockTypeCreate(name="x", slug="x-fixture"),
     )
     await session.commit()
     return block_type

--- a/tests/orion/models/test_block_types.py
+++ b/tests/orion/models/test_block_types.py
@@ -136,7 +136,7 @@ class TestReadBlockTypes:
 
     async def test_read_block_type_by_name(self, session, block_type_x):
         db_block_type = await models.block_types.read_block_type_by_slug(
-            session=session, block_type_slug=block_type_x.name
+            session=session, block_type_slug=block_type_x.slug
         )
 
         assert db_block_type.id == block_type_x.id


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds the setting `PREFECT_ORION_BLOCKS_REGISTER_ON_START` which is used to determine if blocks should be registered as a server startup step. This may also solve issues being worked on in #6841.

This setting defaults to `True`, but I could see the argument for defaulting it to `False` and then setting it to `True` during `prefect orion start`. This would be a significant improvement to ephemeral client performance, but #6841 could accomplish something similar without changing the default.

Automatic registration of blocks was creating integrity errors during our test seeding process as we seed type models that happened to match a block type that was used in another fixture and auto-registered when a client was started. Previously, we implemented a workaround for this but additional issues were encountered indicating that our workaround was not robust. 

Now that we have a toggle, we can disable registration on application startup during test runs. This resolves the integrity errors and, as an added bonus, appears to improve test suite runtimes significantly:
- Py3.8 on Postgres went from 12m -> 7m: **40%** faster
- Py3.8 on SQLite went from 24m -> 9m: **62%** faster

This is part 2/2 resolving issues with blocks failing tests in https://github.com/PrefectHQ/prefect/pull/6847

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
