### PR TITLE
Drop cache upload for Conda flavor Docker images

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -128,7 +128,8 @@ jobs:
           tags: prefecthq/prefect:dev-python${{ matrix.python-version }}-conda
           outputs: type=docker,dest=/tmp/image-conda.tar
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # We do not cache Conda image layers because they very big and slow to upload
+          # cache-to: type=gha,mode=max
 
       - name: Test Conda flavored Docker image
         if: ${{ matrix.build-docker-images }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,7 +161,8 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           outputs: type=docker,dest=/tmp/image-conda.tar
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # We do not cache Conda image layers because they very big and slow to upload
+          # cache-to: type=gha,mode=max
 
       - name: Test docker image
         run: |


### PR DESCRIPTION
Conda flavored Docker images are taking 8+ minutes to build compared to the base image build of 2 minutes. The build time is dominated by ~7 minutes of uploading image layers to a cache. Here, we disable the caching as it cannot possible be worth the runtime.