### PR TITLE
Return a better exception when decorator is associated to a method

### DIFF
--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -27,7 +27,10 @@ def get_call_parameters(
     Raises a ParameterBindError if the arguments/kwargs are not valid for the function
     """
     try:
-        bound_signature = inspect.signature(fn).bind(*call_args, **call_kwargs)
+        signature_fn = inspect.signature(fn)
+        if "self" in signature_fn.parameters:
+            raise TypeError(f"Decorator does not support class methods")
+        bound_signature = signature_fn.bind(*call_args, **call_kwargs)
     except TypeError as exc:
         raise ParameterBindError.from_bind_failure(fn, exc, call_args, call_kwargs)
     bound_signature.apply_defaults()


### PR DESCRIPTION
There is a huge consensus that decorators are being used for functions due to the ability to create stateless procedures. Classes have state and according to several discussions methods cannot be turned into tasks. Then, it should be properly captured and raised by the flow.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
```python
class Tasks:
    @task
    def task1(self, in):
        return in

    @task
    def task2(self, in1, in2):
        return in1, in2
```
The code above is not technically allowed and when we run a pipeline, the error is not trivial. The fix is a small one just to throw a better and clear exception.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
