### PR TITLE
Fix bug where `OrionClient.read_logs` filter was ignored

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -1670,7 +1670,7 @@ class OrionClient:
         Read flow and task run logs.
         """
         body = {
-            "filter": log_filter.dict(json_compatible=True) if log_filter else None,
+            "logs": log_filter.dict(json_compatible=True) if log_filter else None,
             "limit": limit,
             "offset": offset,
         }

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1,7 +1,7 @@
 import datetime
 import random
 import threading
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -902,22 +902,28 @@ async def test_set_then_read_task_run_state(orion_client):
     assert run.state.message == "Test!"
 
 
-async  def test_read_filtered_logs(
-        session, orion_client, deployment
-        ):
+async def test_read_filtered_logs(session, orion_client, deployment):
 
     flow_runs = [uuid4() for i in range(5)]
-    logs = [LogCreate(name="prefect.flow_runs", level=20, message=f"Log from flow_run {id}.", timestamp=datetime.now(
-        tz=timezone.utc), flow_run_id=id)
-            for id in flow_runs]
+    logs = [
+        LogCreate(
+            name="prefect.flow_runs",
+            level=20,
+            message=f"Log from flow_run {id}.",
+            timestamp=datetime.now(tz=timezone.utc),
+            flow_run_id=id,
+        )
+        for id in flow_runs
+    ]
 
     await orion_client.create_logs(logs)
 
-    logs = await orion_client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_runs[:3])))
+    logs = await orion_client.read_logs(
+        log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_runs[:3]))
+    )
     for log in logs:
         assert log.flow_run_id in flow_runs[:3]
         assert log.flow_run_id not in flow_runs[3:]
-
 
 
 class TestResolveDataDoc:

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -910,8 +910,8 @@ async  def test_read_filtered_logs(
     logs = [LogCreate(name="prefect.flow_runs", level=20, message=f"Log from flow_run {id}.", timestamp=datetime.now(
         tz=timezone.utc), flow_run_id=id)
             for id in flow_runs]
-    for i in flow_runs:
-        await orion_client.create_logs(logs)
+
+    await orion_client.create_logs(logs)
 
     logs = await orion_client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_runs[:3])))
     for log in logs:

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -19,6 +19,7 @@ from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
 from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas.data import DataDocument
+from prefect.orion.schemas.filters import LogFilter, LogFilterFlowRunId
 from prefect.orion.schemas.schedules import IntervalSchedule
 from prefect.orion.schemas.states import Pending, Running, Scheduled, StateType
 from prefect.settings import (
@@ -897,6 +898,22 @@ async def test_set_then_read_task_run_state(orion_client):
     assert isinstance(run.state, schemas.states.State)
     assert run.state.type == schemas.states.StateType.COMPLETED
     assert run.state.message == "Test!"
+
+
+async  def test_read_filtered_logs(
+        session, orion_client, deployment
+        ):
+
+    flow_runs = []
+    for i in range(5):
+        run = await orion_client.create_flow_run_from_deployment(deployment_id=deployment.id)
+        flow_runs.append(run.id)
+
+    logs = await orion_client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_runs[:3])))
+    for log in logs:
+        assert log.flow_run_id in flow_runs[:3]
+        assert log.flow_run_id not in flow_runs[3:]
+
 
 
 class TestResolveDataDoc:

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -19,7 +19,6 @@ from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
 from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.filters import LogFilter, LogFilterFlowRunId
 from prefect.orion.schemas.schedules import IntervalSchedule
 from prefect.orion.schemas.states import Pending, Running, Scheduled, StateType
 from prefect.settings import (
@@ -898,22 +897,6 @@ async def test_set_then_read_task_run_state(orion_client):
     assert isinstance(run.state, schemas.states.State)
     assert run.state.type == schemas.states.StateType.COMPLETED
     assert run.state.message == "Test!"
-
-
-async  def test_read_filtered_logs(
-        session, orion_client, deployment
-        ):
-
-    flow_runs = []
-    for i in range(5):
-        run = await orion_client.create_flow_run_from_deployment(deployment_id=deployment.id)
-        flow_runs.append(run.id)
-
-    logs = await orion_client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_runs[:3])))
-    for log in logs:
-        assert log.flow_run_id in flow_runs[:3]
-        assert log.flow_run_id not in flow_runs[3:]
-
 
 
 class TestResolveDataDoc:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Changed the name of the 'filter' property to 'logs', because it was not picked up by the api. 
This pull request closes #6883. 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
