### PR TITLE
Introduce `prefect.client.schemas` and client-side state type

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -16,20 +16,24 @@ import prefect
 import prefect.exceptions
 import prefect.orion.schemas as schemas
 import prefect.settings
+from prefect.client.schemas import (
+    FlowRun,
+    OrchestrationResult,
+    Scheduled,
+    State,
+    TaskRun,
+)
 from prefect.logging import get_logger
 from prefect.orion.api.server import ORION_API_VERSION, create_app
-from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas.actions import LogCreate, WorkQueueCreate, WorkQueueUpdate
 from prefect.orion.schemas.core import (
     BlockDocument,
     BlockSchema,
     BlockType,
     QueueFilter,
-    TaskRun,
 )
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.filters import LogFilter
-from prefect.orion.schemas.states import Scheduled
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_REQUEST_TIMEOUT,
@@ -312,10 +316,10 @@ class OrionClient:
         *,
         parameters: Dict[str, Any] = None,
         context: dict = None,
-        state: schemas.states.State = None,
+        state: State = None,
         name: str = None,
         tags: Iterable[str] = None,
-    ) -> schemas.core.FlowRun:
+    ) -> FlowRun:
         """
         Create a flow run for a deployment.
 
@@ -350,7 +354,7 @@ class OrionClient:
             f"/deployments/{deployment_id}/create_flow_run",
             json=flow_run_create.dict(json_compatible=True),
         )
-        return schemas.core.FlowRun.parse_obj(response.json())
+        return FlowRun.parse_obj(response.json())
 
     async def create_flow_run(
         self,
@@ -360,8 +364,8 @@ class OrionClient:
         context: dict = None,
         tags: Iterable[str] = None,
         parent_task_run_id: UUID = None,
-        state: schemas.states.State = None,
-    ) -> schemas.core.FlowRun:
+        state: State = None,
+    ) -> FlowRun:
         """
         Create a flow run for a flow.
 
@@ -408,7 +412,7 @@ class OrionClient:
 
         flow_run_create_json = flow_run_create.dict(json_compatible=True)
         response = await self._client.post("/flow_runs/", json=flow_run_create_json)
-        flow_run = schemas.core.FlowRun.parse_obj(response.json())
+        flow_run = FlowRun.parse_obj(response.json())
 
         # Restore the parameters to the local objects to retain expectations about
         # Python objects
@@ -694,7 +698,7 @@ class OrionClient:
         id: UUID,
         limit: int = 10,
         scheduled_before: datetime.datetime = None,
-    ) -> List[schemas.core.FlowRun]:
+    ) -> List[FlowRun]:
         """
         Read flow runs off a work queue.
 
@@ -709,7 +713,7 @@ class OrionClient:
             httpx.RequestError: If request fails
 
         Returns:
-            List[schemas.core.FlowRun]: a list of FlowRun objects read from the queue
+            List[FlowRun]: a list of FlowRun objects read from the queue
         """
         if scheduled_before is None:
             scheduled_before = pendulum.now()
@@ -727,7 +731,7 @@ class OrionClient:
                 raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
             else:
                 raise
-        return pydantic.parse_obj_as(List[schemas.core.FlowRun], response.json())
+        return pydantic.parse_obj_as(List[FlowRun], response.json())
 
     async def read_work_queue(
         self,
@@ -1334,7 +1338,7 @@ class OrionClient:
             else:
                 raise
 
-    async def read_flow_run(self, flow_run_id: UUID) -> schemas.core.FlowRun:
+    async def read_flow_run(self, flow_run_id: UUID) -> FlowRun:
         """
         Query Orion for a flow run by id.
 
@@ -1342,7 +1346,7 @@ class OrionClient:
             flow_run_id: the flow run ID of interest
 
         Returns:
-            a [Flow Run model][prefect.orion.schemas.core.FlowRun] representation of the flow run
+            a [Flow Run model][prefect.orion.FlowRun] representation of the flow run
         """
         try:
             response = await self._client.get(f"/flow_runs/{flow_run_id}")
@@ -1351,7 +1355,7 @@ class OrionClient:
                 raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
             else:
                 raise
-        return schemas.core.FlowRun.parse_obj(response.json())
+        return FlowRun.parse_obj(response.json())
 
     async def read_flow_runs(
         self,
@@ -1363,7 +1367,7 @@ class OrionClient:
         sort: schemas.sorting.FlowRunSort = None,
         limit: int = None,
         offset: int = 0,
-    ) -> List[schemas.core.FlowRun]:
+    ) -> List[FlowRun]:
         """
         Query Orion for flow runs. Only flow runs matching all criteria will
         be returned.
@@ -1378,7 +1382,7 @@ class OrionClient:
             offset: offset for the flow run query
 
         Returns:
-            a list of [Flow Run model][prefect.orion.schemas.core.FlowRun] representation
+            a list of [Flow Run model][prefect.orion.FlowRun] representation
                 of the flow runs
         """
         body = {
@@ -1400,12 +1404,12 @@ class OrionClient:
         }
 
         response = await self._client.post(f"/flow_runs/filter", json=body)
-        return pydantic.parse_obj_as(List[schemas.core.FlowRun], response.json())
+        return pydantic.parse_obj_as(List[FlowRun], response.json())
 
     async def set_flow_run_state(
         self,
         flow_run_id: UUID,
-        state: schemas.states.State,
+        state: State,
         force: bool = False,
         backend_state_data: schemas.data.DataDocument = None,
     ) -> OrchestrationResult:
@@ -1447,9 +1451,7 @@ class OrionClient:
         )
         return OrchestrationResult.parse_obj(response.json())
 
-    async def read_flow_run_states(
-        self, flow_run_id: UUID
-    ) -> List[schemas.states.State]:
+    async def read_flow_run_states(self, flow_run_id: UUID) -> List[State]:
         """
         Query for the states of a flow run
 
@@ -1457,13 +1459,13 @@ class OrionClient:
             flow_run_id: the id of the flow run
 
         Returns:
-            a list of [State model][prefect.orion.schemas.states.State] representation
+            a list of [State model][prefect.client.schemas.State] representation
                 of the flow run states
         """
         response = await self._client.get(
             "/flow_run_states/", params=dict(flow_run_id=flow_run_id)
         )
-        return pydantic.parse_obj_as(List[schemas.states.State], response.json())
+        return pydantic.parse_obj_as(List[State], response.json())
 
     async def create_task_run(
         self,
@@ -1472,7 +1474,7 @@ class OrionClient:
         dynamic_key: str,
         name: str = None,
         extra_tags: Iterable[str] = None,
-        state: schemas.states.State = None,
+        state: State = None,
         task_inputs: Dict[
             str,
             List[
@@ -1526,7 +1528,7 @@ class OrionClient:
         )
         return TaskRun.parse_obj(response.json())
 
-    async def read_task_run(self, task_run_id: UUID) -> schemas.core.TaskRun:
+    async def read_task_run(self, task_run_id: UUID) -> TaskRun:
         """
         Query Orion for a task run by id.
 
@@ -1534,10 +1536,10 @@ class OrionClient:
             task_run_id: the task run ID of interest
 
         Returns:
-            a [Task Run model][prefect.orion.schemas.core.TaskRun] representation of the task run
+            a [Task Run model][prefect.client.schemas.TaskRun] representation of the task run
         """
         response = await self._client.get(f"/task_runs/{task_run_id}")
-        return schemas.core.TaskRun.parse_obj(response.json())
+        return TaskRun.parse_obj(response.json())
 
     async def read_task_runs(
         self,
@@ -1549,7 +1551,7 @@ class OrionClient:
         sort: schemas.sorting.TaskRunSort = None,
         limit: int = None,
         offset: int = 0,
-    ) -> List[schemas.core.TaskRun]:
+    ) -> List[TaskRun]:
         """
         Query Orion for task runs. Only task runs matching all criteria will
         be returned.
@@ -1564,7 +1566,7 @@ class OrionClient:
             offset: an offset for the task run query
 
         Returns:
-            a list of [Task Run model][prefect.orion.schemas.core.TaskRun] representation
+            a list of [Task Run model][prefect.client.schemas.TaskRun] representation
                 of the task runs
         """
         body = {
@@ -1585,12 +1587,12 @@ class OrionClient:
             "offset": offset,
         }
         response = await self._client.post(f"/task_runs/filter", json=body)
-        return pydantic.parse_obj_as(List[schemas.core.TaskRun], response.json())
+        return pydantic.parse_obj_as(List[TaskRun], response.json())
 
     async def set_task_run_state(
         self,
         task_run_id: UUID,
-        state: schemas.states.State,
+        state: State,
         force: bool = False,
         backend_state_data: schemas.data.DataDocument = None,
     ) -> OrchestrationResult:
@@ -1632,9 +1634,7 @@ class OrionClient:
         )
         return OrchestrationResult.parse_obj(response.json())
 
-    async def read_task_run_states(
-        self, task_run_id: UUID
-    ) -> List[schemas.states.State]:
+    async def read_task_run_states(self, task_run_id: UUID) -> List[State]:
         """
         Query for the states of a task run
 
@@ -1642,13 +1642,13 @@ class OrionClient:
             task_run_id: the id of the task run
 
         Returns:
-            a list of [State model][prefect.orion.schemas.states.State] representation
+            a list of [State model][prefect.client.schemas.State] representation
                 of the task run states
         """
         response = await self._client.get(
             "/task_run_states/", params=dict(task_run_id=task_run_id)
         )
-        return pydantic.parse_obj_as(List[schemas.states.State], response.json())
+        return pydantic.parse_obj_as(List[State], response.json())
 
     async def create_logs(self, logs: Iterable[Union[LogCreate, dict]]) -> None:
         """

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -4,7 +4,10 @@ from typing import Generic, Iterable, Optional, Type, TypeVar, Union, overload
 
 from pydantic import Field
 
-from prefect.orion import orchestration, schemas
+from prefect.orion import schemas
+from prefect.orion.orchestration.rules import (
+    OrchestrationResult as ServerOrchestrationResult,
+)
 
 R = TypeVar("R")
 
@@ -229,5 +232,5 @@ class TaskRun(schemas.core.TaskRun.subclass()):
     state: Optional[State] = Field(default=None)
 
 
-class OrchestrationResult(orchestration.rules.OrchestrationResult.subclass()):
+class OrchestrationResult(ServerOrchestrationResult.subclass()):
     state: Optional[State]

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -1,0 +1,233 @@
+import datetime
+import warnings
+from typing import Generic, Iterable, Optional, Type, TypeVar, Union, overload
+
+from pydantic import Field
+
+from prefect.orion import orchestration, schemas
+
+R = TypeVar("R")
+
+
+class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
+    """
+    The state of a run.
+
+    This client-side extension adds a `result` interface.
+    """
+
+    data: Optional[schemas.data.DataDocument[R]] = Field(
+        default=None,
+    )
+
+    @overload
+    def result(state_or_future: "State[R]", raise_on_failure: bool = True) -> R:
+        ...
+
+    @overload
+    def result(
+        state_or_future: "State[R]", raise_on_failure: bool = False
+    ) -> Union[R, Exception]:
+        ...
+
+    def result(self, raise_on_failure: bool = True):
+        """
+        Convenience method for access the data on the state's data document.
+
+        Args:
+            raise_on_failure: a boolean specifying whether to raise an exception
+                if the state is of type `FAILED` and the underlying data is an exception
+
+        Raises:
+            TypeError: if the state is failed but without an exception
+
+        Returns:
+            The underlying decoded data
+
+        Examples:
+            >>> from prefect import flow, task
+            >>> @task
+            >>> def my_task(x):
+            >>>     return x
+
+            Get the result from a task future in a flow
+
+            >>> @flow
+            >>> def my_flow():
+            >>>     future = my_task("hello")
+            >>>     state = future.wait()
+            >>>     result = state.result()
+            >>>     print(result)
+            >>> my_flow()
+            hello
+
+            Get the result from a flow state
+
+            >>> @flow
+            >>> def my_flow():
+            >>>     return "hello"
+            >>> my_flow().result()
+            hello
+
+            Get the result from a failed state
+
+            >>> @flow
+            >>> def my_flow():
+            >>>     raise ValueError("oh no!")
+            >>> state = my_flow()  # Error is wrapped in FAILED state
+            >>> state.result()  # Raises `ValueError`
+
+            Get the result from a failed state without erroring
+
+            >>> @flow
+            >>> def my_flow():
+            >>>     raise ValueError("oh no!")
+            >>> state = my_flow()
+            >>> result = state.result(raise_on_failure=False)
+            >>> print(result)
+            ValueError("oh no!")
+        """
+        data = None
+
+        if self.data:
+            data = self.data.decode()
+
+        # Link the result to this state for dependency tracking
+        # Performing this here lets us capture relationships for futures resolved into
+        # data
+
+        if (self.is_failed() or self.is_crashed()) and raise_on_failure:
+            if isinstance(data, Exception):
+                raise data
+            elif isinstance(data, BaseException):
+                warnings.warn(
+                    f"State result is a {type(data).__name__!r} type and is not safe "
+                    "to re-raise, it will be returned instead."
+                )
+                return data
+            elif isinstance(data, State):
+                data.result()
+            elif isinstance(data, Iterable) and all(
+                [isinstance(o, State) for o in data]
+            ):
+                # raise the first failure we find
+                for state in data:
+                    state.result()
+
+            # we don't make this an else in case any of the above conditionals doesn't raise
+            raise TypeError(
+                f"Unexpected result for failure state: {data!r} —— "
+                f"{type(data).__name__} cannot be resolved into an exception"
+            )
+
+        return data
+
+
+def Scheduled(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
+    """Convenience function for creating `Scheduled` states.
+
+    Returns:
+        State: a Scheduled state
+    """
+    return schemas.states.Scheduled(cls=cls, scheduled_time=scheduled_time, **kwargs)
+
+
+def Completed(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Completed` states.
+
+    Returns:
+        State: a Completed state
+    """
+    return schemas.states.Completed(cls=cls, **kwargs)
+
+
+def Running(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Running` states.
+
+    Returns:
+        State: a Running state
+    """
+    return schemas.states.Running(cls=cls, **kwargs)
+
+
+def Failed(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Failed` states.
+
+    Returns:
+        State: a Failed state
+    """
+    return schemas.states.Failed(cls=cls, **kwargs)
+
+
+def Crashed(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Crashed` states.
+
+    Returns:
+        State: a Crashed state
+    """
+    return schemas.states.Crashed(cls=cls, **kwargs)
+
+
+def Cancelled(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Cancelled` states.
+
+    Returns:
+        State: a Cancelled state
+    """
+    return schemas.states.Cancelled(cls=cls, **kwargs)
+
+
+def Pending(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Pending` states.
+
+    Returns:
+        State: a Pending state
+    """
+    return schemas.states.Pending(cls=cls, **kwargs)
+
+
+def AwaitingRetry(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
+    """Convenience function for creating `AwaitingRetry` states.
+
+    Returns:
+        State: a AwaitingRetry state
+    """
+    return schemas.states.AwaitingRetry(
+        cls=cls, scheduled_time=scheduled_time, **kwargs
+    )
+
+
+def Retrying(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Retrying` states.
+
+    Returns:
+        State: a Retrying state
+    """
+    return schemas.states.Retrying(cls=cls, **kwargs)
+
+
+def Late(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
+    """Convenience function for creating `Late` states.
+
+    Returns:
+        State: a Late state
+    """
+    return schemas.states.Late(cls=cls, scheduled_time=scheduled_time, **kwargs)
+
+
+class FlowRun(schemas.core.FlowRun.subclass()):
+    state: Optional[State] = Field(default=None)
+
+
+class TaskRun(schemas.core.TaskRun.subclass()):
+    state: Optional[State] = Field(default=None)
+
+
+class OrchestrationResult(orchestration.rules.OrchestrationResult.subclass()):
+    state: Optional[State]

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -5,9 +5,6 @@ from typing import Generic, Iterable, Optional, Type, TypeVar, Union, overload
 from pydantic import Field
 
 from prefect.orion import schemas
-from prefect.orion.orchestration.rules import (
-    OrchestrationResult as ServerOrchestrationResult,
-)
 
 R = TypeVar("R")
 
@@ -232,5 +229,5 @@ class TaskRun(schemas.core.TaskRun.subclass()):
     state: Optional[State] = Field(default=None)
 
 
-class OrchestrationResult(ServerOrchestrationResult.subclass()):
+class OrchestrationResult(schemas.responses.OrchestrationResult.subclass()):
     state: Optional[State]

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -31,11 +31,10 @@ import prefect.logging
 import prefect.logging.configuration
 import prefect.settings
 from prefect.client import OrionClient
+from prefect.client.schemas import FlowRun, State, TaskRun
 from prefect.exceptions import MissingContextError
 from prefect.filesystems import WritableFileSystem
 from prefect.futures import PrefectFuture
-from prefect.orion.schemas.core import FlowRun, TaskRun
-from prefect.orion.schemas.states import State
 from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.task_runners import BaseTaskRunner

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -31,6 +31,7 @@ import prefect
 import prefect.context
 from prefect.client import OrionClient, get_client
 from prefect.client.orion import inject_client
+from prefect.client.schemas import Failed, FlowRun, Pending, Running, State, TaskRun
 from prefect.context import (
     FlowRunContext,
     PrefectObjectRegistry,
@@ -55,20 +56,12 @@ from prefect.logging.loggers import (
     get_run_logger,
     task_run_logger,
 )
-from prefect.orion.schemas import core
-from prefect.orion.schemas.core import FlowRun, TaskRun, TaskRunInput
+from prefect.orion.schemas.core import TaskRunInput, TaskRunResult
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.filters import FlowRunFilter
 from prefect.orion.schemas.responses import SetStateStatus
 from prefect.orion.schemas.sorting import FlowRunSort
-from prefect.orion.schemas.states import (
-    Failed,
-    Pending,
-    Running,
-    State,
-    StateDetails,
-    StateType,
-)
+from prefect.orion.schemas.states import StateDetails, StateType
 from prefect.results import (
     _persist_serialized_result,
     _retrieve_result,
@@ -827,14 +820,14 @@ async def collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRun
     def add_futures_and_states_to_inputs(obj):
         if isinstance(obj, PrefectFuture):
             run_async_from_worker_thread(obj._wait_for_submission)
-            inputs.add(core.TaskRunResult(id=obj.task_run.id))
+            inputs.add(TaskRunResult(id=obj.task_run.id))
         elif isinstance(obj, State):
             if obj.state_details.task_run_id:
-                inputs.add(core.TaskRunResult(id=obj.state_details.task_run_id))
+                inputs.add(TaskRunResult(id=obj.state_details.task_run_id))
         else:
             state = get_state_for_result(obj)
             if state and state.state_details.task_run_id:
-                inputs.add(core.TaskRunResult(id=state.state_details.task_run_id))
+                inputs.add(TaskRunResult(id=state.state_details.task_run_id))
 
     await run_sync_in_worker_thread(
         visit_collection,

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -24,7 +24,7 @@ import anyio
 
 from prefect.client import OrionClient
 from prefect.client.orion import inject_client
-from prefect.orion.schemas.states import State
+from prefect.client.schemas import State
 from prefect.utilities.asyncutils import (
     A,
     Async,

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -20,7 +20,7 @@ from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.models.flow_runs import DependencyResult
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
-from prefect.orion.orchestration.rules import OrchestrationResult
+from prefect.orion.schemas.responses import OrchestrationResult
 from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 

--- a/src/prefect/orion/api/task_runs.py
+++ b/src/prefect/orion/api/task_runs.py
@@ -17,7 +17,7 @@ from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.orchestration import dependencies as orchestration_dependencies
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
-from prefect.orion.orchestration.rules import OrchestrationResult
+from prefect.orion.schemas.responses import OrchestrationResult
 from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
 

--- a/src/prefect/orion/models/flow_runs.py
+++ b/src/prefect/orion/models/flow_runs.py
@@ -23,12 +23,9 @@ from prefect.orion.exceptions import ObjectNotFoundError
 from prefect.orion.orchestration.core_policy import MinimalFlowPolicy
 from prefect.orion.orchestration.global_policy import GlobalFlowPolicy
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
-from prefect.orion.orchestration.rules import (
-    FlowOrchestrationContext,
-    OrchestrationResult,
-)
+from prefect.orion.orchestration.rules import FlowOrchestrationContext
 from prefect.orion.schemas.core import TaskRunResult
-from prefect.orion.schemas.responses import SetStateStatus
+from prefect.orion.schemas.responses import OrchestrationResult, SetStateStatus
 from prefect.orion.schemas.states import State
 from prefect.orion.utilities.schemas import PrefectBaseModel
 

--- a/src/prefect/orion/models/task_runs.py
+++ b/src/prefect/orion/models/task_runs.py
@@ -18,10 +18,8 @@ from prefect.orion.exceptions import ObjectNotFoundError
 from prefect.orion.orchestration.core_policy import MinimalTaskPolicy
 from prefect.orion.orchestration.global_policy import GlobalTaskPolicy
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
-from prefect.orion.orchestration.rules import (
-    OrchestrationResult,
-    TaskOrchestrationContext,
-)
+from prefect.orion.orchestration.rules import TaskOrchestrationContext
+from prefect.orion.schemas.responses import OrchestrationResult
 
 
 @inject_db

--- a/src/prefect/orion/orchestration/__init__.py
+++ b/src/prefect/orion/orchestration/__init__.py
@@ -1,0 +1,2 @@
+from . import rules
+from . import core_policy

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -35,6 +35,7 @@ from prefect.orion.schemas.responses import (
     StateAbortDetails,
     StateAcceptDetails,
     StateRejectDetails,
+    StateResponseDetails,
     StateWaitDetails,
 )
 from prefect.orion.utilities.schemas import PrefectBaseModel
@@ -46,20 +47,6 @@ ALL_ORCHESTRATION_STATES = {*states.StateType, None}
 TERMINAL_STATES = states.TERMINAL_STATES
 
 logger = get_logger("orion")
-
-StateResponseDetails = Union[
-    StateAcceptDetails, StateWaitDetails, StateRejectDetails, StateAbortDetails
-]
-
-
-class OrchestrationResult(PrefectBaseModel):
-    """
-    A container for the output of state orchestration.
-    """
-
-    state: Optional[states.State]
-    status: SetStateStatus
-    details: StateResponseDetails
 
 
 class OrchestrationContext(PrefectBaseModel):

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -3,7 +3,7 @@ Schemas for special responses from the Orion API.
 """
 
 import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -104,3 +104,18 @@ class HistoryResponse(PrefectBaseModel):
     states: List[HistoryResponseState] = Field(
         default=..., description="A list of state histories during the interval."
     )
+
+
+StateResponseDetails = Union[
+    StateAcceptDetails, StateWaitDetails, StateRejectDetails, StateAbortDetails
+]
+
+
+class OrchestrationResult(PrefectBaseModel):
+    """
+    A container for the output of state orchestration.
+    """
+
+    state: Optional[schemas.states.State]
+    status: SetStateStatus
+    details: StateResponseDetails

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -165,13 +165,15 @@ class State(IDBaseModel, Generic[R]):
 
 
 def Scheduled(
-    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+    scheduled_time: datetime.datetime = None, cls: Type[State] = State, **kwargs
 ) -> State:
     """Convenience function for creating `Scheduled` states.
 
     Returns:
         State: a Scheduled state
     """
+    # NOTE: `scheduled_time` must come first for backwards compatibility
+
     state_details = StateDetails.parse_obj(kwargs.pop("state_details", {}))
     if scheduled_time is None:
         scheduled_time = pendulum.now("UTC")
@@ -237,7 +239,7 @@ def Pending(cls: Type[State] = State, **kwargs) -> State:
 
 
 def AwaitingRetry(
-    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+    scheduled_time: datetime.datetime = None, cls: Type[State] = State, **kwargs
 ) -> State:
     """Convenience function for creating `AwaitingRetry` states.
 
@@ -259,7 +261,7 @@ def Retrying(cls: Type[State] = State, **kwargs) -> State:
 
 
 def Late(
-    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+    scheduled_time: datetime.datetime = None, cls: Type[State] = State, **kwargs
 ) -> State:
     """Convenience function for creating `Late` states.
 

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -3,9 +3,7 @@ State schemas.
 """
 
 import datetime
-import warnings
-from collections.abc import Iterable
-from typing import Generic, Optional, TypeVar, Union, overload
+from typing import Generic, Optional, Type, TypeVar
 from uuid import UUID
 
 import pendulum
@@ -63,108 +61,6 @@ class State(IDBaseModel, Generic[R]):
         default=None,
     )
     state_details: StateDetails = Field(default_factory=StateDetails)
-
-    @overload
-    def result(state_or_future: "State[R]", raise_on_failure: bool = True) -> R:
-        ...
-
-    @overload
-    def result(
-        state_or_future: "State[R]", raise_on_failure: bool = False
-    ) -> Union[R, Exception]:
-        ...
-
-    def result(self, raise_on_failure: bool = True):
-        """
-        Convenience method for access the data on the state's data document.
-
-        Args:
-            raise_on_failure: a boolean specifying whether to raise an exception
-                if the state is of type `FAILED` and the underlying data is an exception
-
-        Raises:
-            TypeError: if the state is failed but without an exception
-
-        Returns:
-            The underlying decoded data
-
-        Examples:
-            >>> from prefect import flow, task
-            >>> @task
-            >>> def my_task(x):
-            >>>     return x
-
-            Get the result from a task future in a flow
-
-            >>> @flow
-            >>> def my_flow():
-            >>>     future = my_task("hello")
-            >>>     state = future.wait()
-            >>>     result = state.result()
-            >>>     print(result)
-            >>> my_flow()
-            hello
-
-            Get the result from a flow state
-
-            >>> @flow
-            >>> def my_flow():
-            >>>     return "hello"
-            >>> my_flow().result()
-            hello
-
-            Get the result from a failed state
-
-            >>> @flow
-            >>> def my_flow():
-            >>>     raise ValueError("oh no!")
-            >>> state = my_flow()  # Error is wrapped in FAILED state
-            >>> state.result()  # Raises `ValueError`
-
-            Get the result from a failed state without erroring
-
-            >>> @flow
-            >>> def my_flow():
-            >>>     raise ValueError("oh no!")
-            >>> state = my_flow()
-            >>> result = state.result(raise_on_failure=False)
-            >>> print(result)
-            ValueError("oh no!")
-        """
-        data = None
-
-        if self.data:
-            data = self.data.decode()
-
-        # Link the result to this state for dependency tracking
-        # Performing this here lets us capture relationships for futures resolved into
-        # data
-
-        if (self.is_failed() or self.is_crashed()) and raise_on_failure:
-            if isinstance(data, Exception):
-                raise data
-            elif isinstance(data, BaseException):
-                warnings.warn(
-                    f"State result is a {type(data).__name__!r} type and is not safe "
-                    "to re-raise, it will be returned instead."
-                )
-                return data
-            elif isinstance(data, State):
-                data.result()
-            elif isinstance(data, Iterable) and all(
-                [isinstance(o, State) for o in data]
-            ):
-                # raise the first failure we find
-                for state in data:
-                    state.result()
-
-            # we don't make this an else in case any of the above conditionals doesn't raise
-            raise TypeError(
-                f"Unexpected result for failure state: {data!r} —— "
-                f"{type(data).__name__} cannot be resolved into an exception"
-            )
-
-        return data
 
     @validator("name", always=True)
     def default_name_from_type(cls, v, *, values, **kwargs):
@@ -268,7 +164,9 @@ class State(IDBaseModel, Generic[R]):
         )
 
 
-def Scheduled(scheduled_time: datetime.datetime = None, **kwargs) -> State:
+def Scheduled(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
     """Convenience function for creating `Scheduled` states.
 
     Returns:
@@ -281,85 +179,91 @@ def Scheduled(scheduled_time: datetime.datetime = None, **kwargs) -> State:
         raise ValueError("An extra scheduled_time was provided in state_details")
     state_details.scheduled_time = scheduled_time
 
-    return State(type=StateType.SCHEDULED, state_details=state_details, **kwargs)
+    return cls(type=StateType.SCHEDULED, state_details=state_details, **kwargs)
 
 
-def Completed(**kwargs) -> State:
+def Completed(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Completed` states.
 
     Returns:
         State: a Completed state
     """
-    return State(type=StateType.COMPLETED, **kwargs)
+    return cls(type=StateType.COMPLETED, **kwargs)
 
 
-def Running(**kwargs) -> State:
+def Running(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Running` states.
 
     Returns:
         State: a Running state
     """
-    return State(type=StateType.RUNNING, **kwargs)
+    return cls(type=StateType.RUNNING, **kwargs)
 
 
-def Failed(**kwargs) -> State:
+def Failed(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Failed` states.
 
     Returns:
         State: a Failed state
     """
-    return State(type=StateType.FAILED, **kwargs)
+    return cls(type=StateType.FAILED, **kwargs)
 
 
-def Crashed(**kwargs) -> State:
+def Crashed(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Crashed` states.
 
     Returns:
         State: a Crashed state
     """
-    return State(type=StateType.CRASHED, **kwargs)
+    return cls(type=StateType.CRASHED, **kwargs)
 
 
-def Cancelled(**kwargs) -> State:
+def Cancelled(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Cancelled` states.
 
     Returns:
         State: a Cancelled state
     """
-    return State(type=StateType.CANCELLED, **kwargs)
+    return cls(type=StateType.CANCELLED, **kwargs)
 
 
-def Pending(**kwargs) -> State:
+def Pending(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Pending` states.
 
     Returns:
         State: a Pending state
     """
-    return State(type=StateType.PENDING, **kwargs)
+    return cls(type=StateType.PENDING, **kwargs)
 
 
-def AwaitingRetry(scheduled_time: datetime.datetime = None, **kwargs) -> State:
+def AwaitingRetry(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
     """Convenience function for creating `AwaitingRetry` states.
 
     Returns:
         State: a AwaitingRetry state
     """
-    return Scheduled(scheduled_time=scheduled_time, name="AwaitingRetry", **kwargs)
+    return Scheduled(
+        cls=cls, scheduled_time=scheduled_time, name="AwaitingRetry", **kwargs
+    )
 
 
-def Retrying(**kwargs) -> State:
+def Retrying(cls: Type[State] = State, **kwargs) -> State:
     """Convenience function for creating `Retrying` states.
 
     Returns:
         State: a Retrying state
     """
-    return State(type=StateType.RUNNING, name="Retrying", **kwargs)
+    return cls(type=StateType.RUNNING, name="Retrying", **kwargs)
 
 
-def Late(scheduled_time: datetime.datetime = None, **kwargs) -> State:
+def Late(
+    cls: Type[State] = State, scheduled_time: datetime.datetime = None, **kwargs
+) -> State:
     """Convenience function for creating `Late` states.
 
     Returns:
         State: a Late state
     """
-    return Scheduled(scheduled_time=scheduled_time, name="Late", **kwargs)
+    return Scheduled(cls=cls, scheduled_time=scheduled_time, name="Late", **kwargs)

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -3,6 +3,7 @@ State schemas.
 """
 
 import datetime
+import warnings
 from typing import Generic, Optional, Type, TypeVar
 from uuid import UUID
 
@@ -119,6 +120,20 @@ class State(IDBaseModel, Generic[R]):
         update = update or {}
         update.setdefault("timestamp", self.__fields__["timestamp"].get_default())
         return super().copy(reset_fields=reset_fields, update=update, **kwargs)
+
+    def result(self, raise_on_failure: bool = True):
+        from prefect.client.schemas import State
+
+        warnings.warn(
+            "`result` is no longer supported by `prefect.orion.schemas.states.State` "
+            "and will be removed in a future release. When result retrieval is needed, "
+            "use `prefect.client.schemas.State`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        state = State.parse_obj(self)
+        return state.result(raise_on_failure=raise_on_failure)
 
     def __repr__(self) -> str:
         """

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -7,14 +7,12 @@ from typing_extensions import TypeGuard
 
 from prefect.client import OrionClient
 from prefect.client.orion import inject_client
+from prefect.client.schemas import Completed, Crashed, State
 from prefect.futures import resolve_futures_to_states
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.states import Completed, Crashed, StateType
+from prefect.orion.schemas.states import StateType
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import ensure_iterable
-
-# Expose the state schema from Orion
-from .orion.schemas.states import State
 
 
 def exception_to_crashed_state(exc: BaseException) -> Crashed:

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -9,9 +9,9 @@ import cloudpickle
 import pytest
 
 from prefect import flow, task
-from prefect.orion.schemas.core import TaskRun
+from prefect.client.schemas import State, TaskRun
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.states import State, StateType
+from prefect.orion.schemas.states import StateType
 from prefect.task_runners import BaseTaskRunner, TaskConcurrencyType
 from prefect.testing.utilities import exceptions_equal
 

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -15,12 +15,12 @@ import prefect.context
 import prefect.exceptions
 from prefect import flow, tags
 from prefect.client import OrionClient, get_client
+from prefect.client.schemas import OrchestrationResult, Pending, Running, Scheduled
 from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
-from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.schedules import IntervalSchedule
-from prefect.orion.schemas.states import Pending, Running, Scheduled, StateType
+from prefect.orion.schemas.states import StateType
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_ORION_DATABASE_MIGRATE_ON_START,

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -8,9 +8,9 @@ import sqlalchemy as sa
 from fastapi import status
 
 from prefect.orion import models, schemas
-from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas import actions, core, responses, states
 from prefect.orion.schemas.core import TaskRunResult
+from prefect.orion.schemas.responses import OrchestrationResult
 
 
 class TestCreateFlowRun:

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -5,8 +5,8 @@ import pytest
 from fastapi import status
 
 from prefect.orion import models, schemas
-from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas import responses, states
+from prefect.orion.schemas.responses import OrchestrationResult
 
 
 class TestCreateTaskRun:

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -13,11 +13,11 @@ from prefect.orion.orchestration.rules import (
     BaseOrchestrationRule,
     BaseUniversalTransform,
     OrchestrationContext,
-    OrchestrationResult,
     TaskOrchestrationContext,
 )
 from prefect.orion.schemas import states
 from prefect.orion.schemas.responses import (
+    OrchestrationResult,
     SetStateStatus,
     StateAbortDetails,
     StateRejectDetails,

--- a/tests/orion/schemas/test_states.py
+++ b/tests/orion/schemas/test_states.py
@@ -57,6 +57,11 @@ class TestState:
         # New state timestamp
         assert new_state.timestamp >= dt
 
+    def test_state_result_warns_and_uses_client_result(self):
+        state = State(data=DataDocument(encoding="text", blob=b"abc"), type="COMPLETED")
+        with pytest.warns(DeprecationWarning, match="`result` is no longer supported"):
+            assert state.result() == "abc"
+
 
 class TestStateTypeFunctions:
     @pytest.mark.parametrize("state_type", StateType)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -11,6 +11,7 @@ import pytest
 from prefect import flow, get_run_logger, tags, task
 from prefect.blocks.core import Block
 from prefect.client import OrionClient
+from prefect.client.schemas import State
 from prefect.context import PrefectObjectRegistry
 from prefect.exceptions import (
     InvalidNameError,
@@ -23,7 +24,7 @@ from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.orion.schemas.sorting import FlowRunSort
-from prefect.orion.schemas.states import State, StateType
+from prefect.orion.schemas.states import StateType
 from prefect.results import _retrieve_result
 from prefect.settings import PREFECT_LOCAL_STORAGE_PATH, temporary_settings
 from prefect.states import StateType, raise_failed_state

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -5,10 +5,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from prefect.client import OrionClient
+from prefect.client.schemas import Completed
 from prefect.flows import flow
 from prefect.futures import PrefectFuture, resolve_futures_to_data
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.states import Completed
 from prefect.tasks import task
 from prefect.testing.utilities import assert_does_not_warn
 

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -1,15 +1,9 @@
 import pytest
 
+from prefect.client.schemas import Completed, Failed, Pending, Running, State
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.states import (
-    Completed,
-    Failed,
-    Pending,
-    Running,
-    State,
-    StateType,
-)
+from prefect.orion.schemas.states import StateType
 from prefect.states import (
     is_state,
     is_state_iterable,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,6 +9,7 @@ import anyio
 import pytest
 
 from prefect import flow, get_run_logger, tags
+from prefect.client.schemas import State
 from prefect.context import PrefectObjectRegistry, TaskRunContext, get_run_context
 from prefect.engine import get_state_for_result
 from prefect.exceptions import (
@@ -20,7 +21,7 @@ from prefect.futures import PrefectFuture
 from prefect.orion import models
 from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.data import DataDocument
-from prefect.orion.schemas.states import State, StateType
+from prefect.orion.schemas.states import StateType
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal, flaky_on_windows
 from prefect.utilities.annotations import unmapped


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

- Adds `prefect.client.schemas` with:
   - `State`: extends server-side schema to include result retrieval
   - `FlowRun`: uses client-side state type for field
   - `TaskRun`: uses client-side state type for field
   - `OrchestrationResult`: uses client-side state type for field
- Add `cls` argument to `prefect.orion.schemas.states` state type utilities for reuse client-side
- Removes `result` from server-side `State` type
- Updates the `OrionClient` to parse API responses as client types
- Moves `OrchestrationResult` to `schemas.responses` to fix circular imports

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
