### PR TITLE
Add `JSONSerializer` and `PickleSerializer` to `prefect.serializers`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ orjson >= 3.7
 packaging >= 21.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2
-pydantic >= 1.8.2, != 1.9.1
+pydantic >= 1.10.0
 python-slugify >= 5.0
 pytz >= 2021.1
 pyyaml >= 5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ slack-sdk>=3.15.1
 sqlalchemy[asyncio] >= 1.4.20, != 1.4.33
 toml >= 0.10.0
 typer >= 0.4.1
-typing_extensions >= 4.0.1
+typing_extensions >= 4.1.0
 uvicorn  >= 0.14.0

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -15,6 +15,128 @@ if TYPE_CHECKING:
     from prefect.packaging.base import PackageManifest
     from prefect.results import _Result
 
+import abc
+import base64
+import json
+import warnings
+from typing import Any, Generic, TypeVar
+
+import cloudpickle
+import pydantic
+from anyio._core._exceptions import ExceptionGroup
+from pydantic import BaseModel
+from typing_extensions import Literal
+
+from prefect.orion.serializers import register_serializer
+from prefect.utilities.importtools import from_qualified_name
+from prefect.utilities.pydantic import add_type_dispatch
+
+D = TypeVar("D")
+
+
+def _exception_group_reduce_patch(self: ExceptionGroup):
+    return (self.__class__, (self.exceptions,))
+
+
+@add_type_dispatch
+class Serializer(BaseModel, Generic[D], abc.ABC):
+    """
+    A serializer that can encode objects of type 'D' into bytes.
+    """
+
+    type: str
+
+    def dumps(self, obj: D) -> bytes:
+        """Encode the object into a blob of bytes."""
+
+    def loads(self, blob: bytes) -> D:
+        """Decode the blob of bytes into an object."""
+
+
+class PickleSerializer(Serializer):
+    """
+    Serializes objects using the pickle protocol.
+
+    Wraps pickles in base64 for safe transmission.
+    """
+
+    type: Literal["pickle"] = "pickle"
+
+    picklelib: str = "cloudpickle"
+    picklelib_version: str = None
+
+    @pydantic.validator("picklelib")
+    def check_picklelib(cls, value):
+        """
+        Check that the given pickle library is importable and has dumps/loads methods.
+        """
+        try:
+            pickler = from_qualified_name(value)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(
+                f"Failed to import requested pickle library: {value!r}."
+            ) from exc
+
+        if not callable(getattr(pickler, "dumps", None)):
+            raise ValueError(
+                f"Pickle library at {value!r} does not have a 'dumps' method."
+            )
+
+        if not callable(getattr(pickler, "loads", None)):
+            raise ValueError(
+                f"Pickle library at {value!r} does not have a 'loads' method."
+            )
+
+        return value
+
+    @pydantic.root_validator
+    def check_picklelib_version(cls, values):
+        """
+        Infers a default value for `picklelib_version` if null or ensures it matches
+        the version retrieved from the `pickelib`.
+        """
+        picklelib = values.get("picklelib")
+        picklelib_version = values.get("picklelib_version")
+
+        if not picklelib:
+            raise ValueError("Unable to check version of unrecognized picklelib module")
+
+        pickler = from_qualified_name(picklelib)
+        pickler_version = getattr(pickler, "__version__", None)
+
+        if not picklelib_version:
+            values["picklelib_version"] = pickler_version
+        elif picklelib_version != pickler_version:
+            warnings.warn(
+                f"Mismatched {picklelib!r} versions. Found {pickler_version} in the "
+                f"environment but {picklelib_version} was requested. This may cause "
+                "the serializer to fail.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+        return values
+
+    def dumps(self, obj: Any) -> bytes:
+        pickler = from_qualified_name(self.picklelib)
+
+        # Workaround for exception group type which is otherwise not recoverable after
+        # serialization
+        if isinstance(obj, ExceptionGroup):
+            obj.__reduce__ = _exception_group_reduce_patch
+
+        blob = pickler.dumps(obj)
+
+        return base64.encodebytes(blob)
+
+    def loads(self, blob: bytes) -> Any:
+        pickler = from_qualified_name(self.picklelib)
+        return pickler.loads(base64.decodebytes(blob))
+
+
+# DEPRECATED
+# Data document serializers ----------------
+
 
 @register_serializer("json")
 class JSONSerializer:

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -23,7 +23,6 @@ from typing import Any, Generic, TypeVar
 
 import cloudpickle
 import pydantic
-from anyio._core._exceptions import ExceptionGroup
 from pydantic import BaseModel
 from pydantic.json import pydantic_encoder
 from typing_extensions import Literal
@@ -33,10 +32,6 @@ from prefect.utilities.importtools import from_qualified_name, to_qualified_name
 from prefect.utilities.pydantic import add_type_dispatch
 
 D = TypeVar("D")
-
-
-def _exception_group_reduce_patch(self: ExceptionGroup):
-    return (self.__class__, (self.exceptions,))
 
 
 def prefect_json_object_encoder(obj: Any) -> Any:

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -66,9 +66,11 @@ class Serializer(BaseModel, Generic[D], abc.ABC):
 
     type: str
 
+    @abc.abstractmethod
     def dumps(self, obj: D) -> bytes:
         """Encode the object into a blob of bytes."""
 
+    @abc.abstractmethod
     def loads(self, blob: bytes) -> D:
         """Decode the blob of bytes into an object."""
 

--- a/tests/test-projects/import-project/my_module/flow.py
+++ b/tests/test-projects/import-project/my_module/flow.py
@@ -1,0 +1,8 @@
+from prefect import flow
+
+from .utils import get_output
+
+
+@flow
+def test_flow():
+    return get_output()

--- a/tests/test-projects/import-project/my_module/utils.py
+++ b/tests/test-projects/import-project/my_module/utils.py
@@ -1,0 +1,2 @@
+def get_output():
+    return "test!"

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -114,6 +114,12 @@ class TestBaseSerializer:
         class Bar(Serializer):
             type = "bar"
 
+            def dumps(self, obj):
+                pass
+
+            def loads(self, obj):
+                pass
+
         model = Foo(serializer="bar")
         assert isinstance(model.serializer, Bar)
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -213,7 +213,7 @@ class TestJSONSerializer:
 
         serializer = JSONSerializer(object_encoder="prefect.fake_object_encoder")
 
-        # Encoder hooks are only called for unsuipported objects
+        # Encoder hooks are only called for unsupported objects
         obj = uuid.uuid4()
         result = serializer.dumps(obj)
         assert result == b'"foobar!"'

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -60,6 +60,12 @@ class TestBaseSerializer:
         class Foo(Serializer):
             type = "foo"
 
+            def dumps(self, obj):
+                pass
+
+            def loads(self, obj):
+                pass
+
         with pytest.raises(pydantic.ValidationError):
             Foo(x="test")
 
@@ -70,6 +76,12 @@ class TestBaseSerializer:
         class Bar(Serializer):
             type = "bar"
 
+            def dumps(self, obj):
+                pass
+
+            def loads(self, obj):
+                pass
+
         model = Foo(serializer={"type": "bar"})
         assert isinstance(model.serializer, Bar)
 
@@ -79,6 +91,12 @@ class TestBaseSerializer:
 
         class Bar(Serializer):
             type = "bar"
+
+            def dumps(self, obj):
+                pass
+
+            def loads(self, obj):
+                pass
 
         model = Foo(serializer=Bar())
         assert isinstance(model.serializer, Bar)
@@ -239,4 +257,4 @@ class TestJSONSerializer:
 
     def test_does_not_allow_default_collision(self):
         with pytest.raises(pydantic.ValidationError):
-            JSONSerializer(loads_kwargs={"default": "foo"})
+            JSONSerializer(dumps_kwargs={"default": "foo"})

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -33,7 +33,7 @@ class MyDataclass:
 
 
 # Simple test cases that all serializers should support roundtrips for
-SIMPLE_CASES = [
+SERIALIZER_TEST_CASES = [
     1,
     "test",
     {"foo": "bar"},
@@ -125,7 +125,7 @@ class TestBaseSerializer:
 
 
 class TestPickleSerializer:
-    @pytest.mark.parametrize("data", SIMPLE_CASES)
+    @pytest.mark.parametrize("data", SERIALIZER_TEST_CASES)
     def test_simple_roundtrip(self, data):
         serializer = PickleSerializer()
         serialized = serializer.dumps(data)
@@ -172,7 +172,7 @@ class TestPickleSerializer:
 
 
 class TestJSONSerializer:
-    @pytest.mark.parametrize("data", SIMPLE_CASES)
+    @pytest.mark.parametrize("data", SERIALIZER_TEST_CASES)
     def test_simple_roundtrip(self, data):
         serializer = JSONSerializer()
         serialized = serializer.dumps(data)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,126 @@
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pydantic
+import pytest
+
+from prefect.serializers import JSONSerializer, PickleSerializer, Serializer
+from prefect.utilities.dispatch import get_registry_for_type
+
+# Freeze a UUID for deterministic tests
+TEST_UUID = UUID("a53e3495-d681-4a53-84b8-9d9542f7237c")
+
+# Simple test cases that all serializers should support roundtrips for
+SIMPLE_CASES = [1, "test", {"foo": "bar"}, ["x", "y"], TEST_UUID]
+
+
+class TestBaseSerializer:
+    @pytest.fixture(autouse=True)
+    def restore_dispatch_registry(self):
+        # Clears serializers defined in tests below to prevent warnings on collision
+        before = get_registry_for_type(Serializer).copy()
+
+        yield
+
+        registry = get_registry_for_type(Serializer)
+        registry.clear()
+        registry.update(before)
+
+    def test_serializers_do_not_allow_extra_fields(self):
+        class Foo(Serializer):
+            type = "foo"
+
+        with pytest.raises(pydantic.ValidationError):
+            Foo(x="test")
+
+    def test_serializers_can_be_created_by_dict(self):
+        class Foo(pydantic.BaseModel):
+            serializer: Serializer
+
+        class Bar(Serializer):
+            type = "bar"
+
+        model = Foo(serializer={"type": "bar"})
+        assert isinstance(model.serializer, Bar)
+
+    def test_serializers_can_be_created_by_object(self):
+        class Foo(pydantic.BaseModel):
+            serializer: Serializer
+
+        class Bar(Serializer):
+            type = "bar"
+
+        model = Foo(serializer=Bar())
+        assert isinstance(model.serializer, Bar)
+
+    def test_serializers_can_be_created_by_type_string(self):
+        class Foo(pydantic.BaseModel):
+            serializer: Serializer
+
+            @pydantic.validator("serializer", pre=True)
+            def cast_type_to_dict(cls, value):
+                if isinstance(value, str):
+                    return {"type": value}
+                return value
+
+        class Bar(Serializer):
+            type = "bar"
+
+        model = Foo(serializer="bar")
+        assert isinstance(model.serializer, Bar)
+
+
+class TestPickleSerializer:
+    @pytest.mark.parametrize("data", SIMPLE_CASES)
+    def test_simple_roundtrip(self, data):
+        serializer = PickleSerializer()
+        serialized = serializer.dumps(data)
+        assert serializer.loads(serialized) == data
+
+    def test_does_not_allow_pickle_modules_without_cloudpickle(self):
+        with pytest.raises(ValueError, match="cloudpickle"):
+            PickleSerializer(pickle_modules=["test"], picklelib="pickle")
+
+    def test_supports_module_serialization(self, monkeypatch):
+        monkeypatch.syspath_prepend(
+            str(Path(__file__).parent / "test-projects" / "import-project")
+        )
+
+        from my_module.flow import test_flow
+
+        serializer = PickleSerializer(pickle_modules=["my_module"])
+        content = serializer.dumps(test_flow)
+
+        monkeypatch.undo()
+        sys.modules.pop("my_module")
+
+        flow = serializer.loads(content)
+        assert flow() == "test!"
+
+    def test_fails_on_relative_import_without_module_serialization(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.syspath_prepend(
+            str(Path(__file__).parent / "test-projects" / "import-project")
+        )
+
+        from my_module.flow import test_flow
+
+        serializer = PickleSerializer()
+        content = serializer.dumps(test_flow)
+
+        monkeypatch.undo()
+        sys.modules.pop("my_module")
+
+        with pytest.raises(ModuleNotFoundError, match="No module named 'my_module'"):
+            serializer.loads(content)
+
+
+class TestJSONSerializer:
+    @pytest.mark.parametrize("data", SIMPLE_CASES)
+    def test_simple_roundtrip(self, data):
+        serializer = JSONSerializer()
+        serialized = serializer.dumps(data)
+        assert serializer.loads(serialized) == data


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This prepares `prefect.serializers` for use with results.

- Copies base serializer model from `prefect.packaging`
     - This model has support for dispatch so we will be able to dump/load subclasses from JSON
- Copies `PickleSerializer` from `prefect.packaging.serializers` and adds tests
- Adds `JSONSerializer` with support for:
    - Alternative JSON libraries (e.g. `orjson`)
    - Pydantic JSON encoders by default, extending support to include `Set`, `UUID`, etc.
    - User-specified JSON object encoders for custom types`
  
Future work:
- Deprecation of data document serializers (#6900)
- Removal of packaging serializers

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
