### PR TITLE
Adds retries and retry_delay_seconds to flow.with_options doc

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -204,6 +204,10 @@ class Flow(Generic[P, R]):
                 running.
             validate_parameters: A new value indicating if flow calls should validate
                 given parameters.
+            retries: A new number of times to retry on flow run failure.
+            retry_delay_seconds: A new number of seconds to wait before retrying the
+                flow after failure. This is only applicable if `retries` is nonzero.
+
 
         Returns:
             A new `Flow` instance.


### PR DESCRIPTION
Updates the `Flow.with_options` docstring to include `retries` and `retry_delay_seconds`.
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
