### PR TITLE
Add client retries on 503 response

### DIFF
--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -9,12 +9,18 @@ from prefect.testing.utilities import AsyncMock
 
 
 class TestPrefectHttpxClient:
-    async def test_prefect_httpx_client_retries_429s(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "error_code",
+        [status.HTTP_429_TOO_MANY_REQUESTS, status.HTTP_503_SERVICE_UNAVAILABLE],
+    )
+    async def test_prefect_httpx_client_retries_on_designated_error_codes(
+        self, monkeypatch, error_code
+    ):
         base_client_send = AsyncMock()
         monkeypatch.setattr(AsyncClient, "send", base_client_send)
         client = PrefectHttpxClient()
         retry_response = Response(
-            status.HTTP_429_TOO_MANY_REQUESTS,
+            error_code,
             headers={"Retry-After": "0"},
             request=Request("a test request", "fake.url/fake/route"),
         )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Like 429, it is common for a 503 to include a Retry-After header. This retry mechanism will be useful for the client to retry failed requests the server has designated as retryable.

Related to #6748 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
