### PR TITLE
Add new Teams notification block to the release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,7 @@
 ## Release 2.5.0
 
 ### Exciting New Features 🎉
-- Add Microsoft Teams notification block
+- Add Microsoft Teams notification block — https://github.com/PrefectHQ/prefect/pull/6920
 
 ### Enhancements
 - Add TTL to `KubernetesJob` for automated cleanup of finished jobs — https://github.com/PrefectHQ/prefect/pull/6785

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,6 @@
 # Prefect Release Notes
 
-## Release 2.5.0
-
-### Exciting New Features 🎉
-- Add Microsoft Teams notification block — https://github.com/PrefectHQ/prefect/pull/6920
+## Release 2.4.1
 
 ### Enhancements
 - Add TTL to `KubernetesJob` for automated cleanup of finished jobs — https://github.com/PrefectHQ/prefect/pull/6785
@@ -23,6 +20,7 @@
 - Add flow run URLs to notifications — https://github.com/PrefectHQ/prefect/pull/6798
 - Add client retries on 503 responses — https://github.com/PrefectHQ/prefect/pull/6927
 - Update injected client retrieval to use the flow and task run context client for reduced overhead — https://github.com/PrefectHQ/prefect/pull/6859
+- Add Microsoft Teams notification block — https://github.com/PrefectHQ/prefect/pull/6920
 
 ### Fixes
 - Fix `LocalFileSystem.get_directory` when from and to paths match — https://github.com/PrefectHQ/prefect/pull/6824

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,9 @@
 # Prefect Release Notes
 
-## Release 2.4.1
+## Release 2.5.0
+
+### Exciting New Features 🎉
+- Add Microsoft Teams notification block
 
 ### Enhancements
 - Add TTL to `KubernetesJob` for automated cleanup of finished jobs — https://github.com/PrefectHQ/prefect/pull/6785
@@ -35,7 +38,7 @@
 - Add `prefect-firebolt` to collections catalog — https://github.com/PrefectHQ/prefect/pull/6917
 
 ### Helm Charts
-— Major overhaul in how helm charts in `prefect-helm` are structured and how we version and release them — [2022.09.21 release](https://github.com/PrefectHQ/prefect-helm/releases/tag/2022.09.21)
+- Major overhaul in how helm charts in `prefect-helm` are structured and how we version and release them — [2022.09.21 release](https://github.com/PrefectHQ/prefect-helm/releases/tag/2022.09.21)
 
 ### Contributors
 - @jmg-duarte


### PR DESCRIPTION
Add the Teams notification block to the release notes PR.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.