### PR TITLE
Remove types in blocks docstring attributes to avoid annotation parsing error

### DIFF
--- a/src/prefect/blocks/kubernetes.py
+++ b/src/prefect/blocks/kubernetes.py
@@ -23,8 +23,8 @@ class KubernetesClusterConfig(Block):
     See `from_file` for creation.
 
     Args:
-        config (dict): The entire loaded YAML contents of a kubectl config file
-        context_name (str): The name of the kubectl context to use
+        config: The entire loaded YAML contents of a kubectl config file
+        context_name: The name of the kubectl context to use
 
     Example:
         Load a saved Kubernetes cluster config:

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -75,7 +75,7 @@ class SlackWebhook(AppriseNotificationBlock):
     Enables sending notifications via a provided Slack webhook.
 
     Args:
-        url (SecretStr): Slack webhook URL which can be used to send messages
+        url: Slack webhook URL which can be used to send messages
             (e.g. `https://hooks.slack.com/XXX`).
 
     Examples:
@@ -103,7 +103,7 @@ class MicrosoftTeamsWebhook(AppriseNotificationBlock):
     """
     Enables sending notifications via a provided Microsoft Teams webhook.
     Args:
-        url (SecretStr): Teams webhook URL which can be used to send messages
+        url: Teams webhook URL which can be used to send messages
     Examples:
         Load a saved Teams webhook and send a message:
         ```python


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

When upgrading to prefect 2.4.1, this error is spawned multiple times when running a flow:
```
Failed to parse annotation from 'Name' node: 'NoneType' object has no attribute 'resolve'
```
This is somehow due to the types of some attributes in blocks classes docstring. Maybe a dependency update caused this ?

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
