### PR TITLE
Fixes `inject_client` in scenarios where the `client` kwarg is passed `None`

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -682,7 +682,6 @@ class Block(BaseModel, ABC):
                 "subclass and not on a Block interface class directly."
             )
 
-        client = client or client_from_context
         for field in cls.__fields__.values():
             if Block.is_block_class(field.type_):
                 await field.type_.register_type_and_schema(client=client)

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -72,8 +72,10 @@ def inject_client(fn):
             client_context = asyncnullcontext()
         else:
             # A new client is needed
-            kwargs.pop("client", None)  # Remove null values
             client_context = get_client()
+
+        # Removes existing client to allow it to be set by setdefault below
+        kwargs.pop("client", None)
 
         async with client_context as new_client:
             kwargs.setdefault("client", new_client or client)

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -754,6 +754,19 @@ class TestAPICompatibility:
         ):
             await test_block.load("blocky")
 
+    def test_save_block_from_flow(self):
+        class Test(Block):
+            a: str
+
+        @prefect.flow
+        def save_block_flow():
+            Test(a="foo").save("test")
+
+        save_block_flow()
+
+        block = Test.load("test")
+        assert block.a == "foo"
+
 
 class TestRegisterBlockTypeAndSchema:
     class NewBlock(Block):

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -85,6 +85,14 @@ class TestInjectClient:
         assert client is orion_client, "Client should be the same object"
         assert not client._closed, "Client should not be closed after function returns"
 
+    async def test_use_existing_client_from_flow_run_ctx_with_null_kwarg(
+        self, orion_client
+    ):
+        with prefect.context.FlowRunContext.construct(client=orion_client):
+            client = await TestInjectClient.injected_func(client=None)
+        assert client is orion_client, "Client should be the same object"
+        assert not client._closed, "Client should not be closed after function returns"
+
 
 def not_enough_open_files() -> bool:
     """


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Got a report of failures saving blocks from the Slack community. Blocks could be saved outside of flows, but not within flows. Root cause seems to be that `inject_client` was working when creating a new client, but not when retrieving an existing one for functions that had a default value of `None` due to `setdefault` behavior. This change pops `client` from `kwargs` in all scenarios to allow `setdefault` to do it's thing.

Closes https://github.com/PrefectHQ/prefect/issues/6940
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
