### PR TITLE
Improve concurrent task runner performance

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -294,10 +294,14 @@ class ConcurrentTaskRunner(BaseTaskRunner):
 
         self._result_events[key].set()
 
-    async def _get_run_result(self, key: UUID, timeout: float = None):
+    async def _get_run_result(
+        self, key: UUID, timeout: float = None
+    ) -> Optional[State]:
         """
         Block until the run result has been populated.
         """
+        result = None  # Return value on timeout
+
         with anyio.move_on_after(timeout):
 
             # Attempt to use the event to wait the result. This is much more efficient
@@ -312,6 +316,7 @@ class ConcurrentTaskRunner(BaseTaskRunner):
             while not result:
                 await anyio.sleep(0)  # yield to other tasks
                 result = self._results.get(key)
+
         return result
 
     async def _start(self, exit_stack: AsyncExitStack):

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -304,7 +304,7 @@ class ConcurrentTaskRunner(BaseTaskRunner):
 
         with anyio.move_on_after(timeout):
 
-            # Attempt to use the event to wait the result. This is much more efficient
+            # Attempt to use the event to wait for the result. This is much more efficient
             # than the spin-lock that follows but does not work if the wait call
             # happens from an event loop in a different thread than the one from which
             # the event was created

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -49,6 +49,7 @@ Example:
 For usage details, see the [Task Runners](/concepts/task-runners/) documentation.
 """
 import abc
+import asyncio
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import (
     TYPE_CHECKING,
@@ -230,8 +231,10 @@ class ConcurrentTaskRunner(BaseTaskRunner):
 
         # Runtime attributes
         self._task_group: anyio.abc.TaskGroup = None
+        self._result_events: Dict[UUID, anyio.abc.Event] = {}
         self._results: Dict[UUID, Any] = {}
         self._keys: Set[UUID] = set()
+
         super().__init__()
 
     @property
@@ -253,6 +256,8 @@ class ConcurrentTaskRunner(BaseTaskRunner):
                 "The concurrent task runner cannot be used to submit work after "
                 "serialization."
             )
+
+        self._result_events[key] = anyio.Event()
 
         # Rely on the event loop for concurrency
         self._task_group.start_soon(self._run_and_store_result, key, call)
@@ -287,11 +292,22 @@ class ConcurrentTaskRunner(BaseTaskRunner):
         except BaseException as exc:
             self._results[key] = exception_to_crashed_state(exc)
 
+        self._result_events[key].set()
+
     async def _get_run_result(self, key: UUID, timeout: float = None):
         """
         Block until the run result has been populated.
         """
         with anyio.move_on_after(timeout):
+
+            # Attempt to use the event to wait the result. This is much more efficient
+            # than the spin-lock that follows but does not work if the wait call
+            # happens from an event loop in a different thread than the one from which
+            # the event was created
+            result_event = self._result_events[key]
+            if result_event._event._loop == asyncio.get_running_loop():
+                await result_event.wait()
+
             result = self._results.get(key)
             while not result:
                 await anyio.sleep(0)  # yield to other tasks


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Improves performance of the concurrent task runner by using events instead of spinlocks to wait for results where feasible. I believe this only doesn't apply to use of async tasks from sync flows. If performance is a major concern in that case, users should be using sync or async consistently. This follows a pattern established in `PrefectFuture.wait`.

Closes https://github.com/PrefectHQ/prefect/issues/6468
Supersedes #6239 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
In #6468 the concurrent task runner was demonstrated to be 7233% slower when performing synchronous IO. Replicated here, the concurrent task runner is 16% faster when performing synchronous IO. I did not attempt to reproduce the original slow download as my internet is not as fast as theirs and  their example would take a theoretical 3 hours to download on my machine.

I failed to demonstrate an improvement in total flow runtime with a benchmark using CPU intensive tasks derived from #6239.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
