### PR TITLE
Fix deployment file name in the tutorial

### DIFF
--- a/docs/ui/cloud-getting-started.md
+++ b/docs/ui/cloud-getting-started.md
@@ -212,7 +212,7 @@ What did we do here? Let's break down the command:
 - `-n test-deployment` is an option to specify a name for the deployment.
 - `-q test` specifies a work queue for the deployment. The deployment's runs will be sent to any agents monitoring this work queue.
 
-The command outputs two files: `basic_flow-manifest.json` contains workflow-specific information such as the code location, the name of the entrypoint flow, and flow parameters. `deployment.yaml` contains details about the deployment for this flow.
+The command outputs `basic_flow-deployment.yaml`, which contains details about the deployment for this flow.
 
 ### Create the deployment
 
@@ -222,7 +222,7 @@ Run the following Prefect CLI command.
 
 <div class="terminal">
 ```bash
-$ prefect deployment apply `deployment.yaml`
+$ prefect deployment apply basic_flow-deployment.yaml
 Successfully loaded 'test-deployment'
 Deployment '66b3fdea-cd3a-4734-b3f2-65f6702ff260' successfully created.
 ```


### PR DESCRIPTION
Just a small fix. 😃
After running previous step `prefect deployment build ./basic_flow.py:basic_flow -n test-deployment -q test`, the file got generated is `basic_flow-deployment.yaml` instead of `deployment.yaml`.

BTW, I love Prefect, so neat!

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->


<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
