### PR TITLE
Warn if user tries to login with API key from Cloud 1

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -160,7 +160,9 @@ async def login(
                 for workspace in workspaces
             }
         except CloudUnauthorizedError:
-            if not key.startswith("pnu"):
+            if key.startswith("pcu"):
+                help_message = "It looks like you're using API key from Cloud 1 (https://cloud.prefect.io). Make sure that you generate API key using Cloud 2 (https://app.prefect.cloud)"
+            elif not key.startswith("pnu"):
                 help_message = "Your key is not in our expected format."
             else:
                 help_message = "Please ensure your credentials are correct."

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -160,6 +160,10 @@ async def login(
                 for workspace in workspaces
             }
         except CloudUnauthorizedError:
+            if not key.startswith("pnu"):
+                exit_with_error(
+                    "Make sure you are using API key from https://app.prefect.cloud (Prefect 2) rather than https://cloud.prefect.io (Prefect 1)"
+                )
             exit_with_error(
                 "Unable to authenticate with Prefect Cloud. Please ensure your credentials are correct."
             )

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -161,11 +161,11 @@ async def login(
             }
         except CloudUnauthorizedError:
             if not key.startswith("pnu"):
-                exit_with_error(
-                    "Make sure you are using API key from https://app.prefect.cloud (Prefect 2) rather than https://cloud.prefect.io (Prefect 1)"
-                )
+                help_message = "Your key is not in our expected format."
+            else:
+                help_message = "Please ensure your credentials are correct."
             exit_with_error(
-                "Unable to authenticate with Prefect Cloud. Please ensure your credentials are correct."
+                f"Unable to authenticate with Prefect Cloud. {help_message}"
             )
         except httpx.HTTPStatusError as exc:
             exit_with_error(f"Error connecting to Prefect Cloud: {exc!r}")

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -68,10 +68,17 @@ def test_invalid_login(monkeypatch):
     )
 
     invoke_and_assert(
-        ["cloud", "login", "--key", "invalid_API_key"],
+        ["cloud", "login", "--key", "pnu_foo"],
         expected_code=1,
         expected_output=(
             "Unable to authenticate with Prefect Cloud. Please ensure your credentials are correct."
+        ),
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo"],
+        expected_code=1,
+        expected_output=(
+            "Make sure you are using API key from https://app.prefect.cloud (Prefect 2) rather than https://cloud.prefect.io (Prefect 1)"
         ),
     )
 

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -66,7 +66,13 @@ def test_invalid_login(monkeypatch):
     monkeypatch.setattr(
         "prefect.client.cloud.get_cloud_client", get_unauthorized_mock_cloud_client
     )
-
+    invoke_and_assert(
+        ["cloud", "login", "--key", "pcu_foo"],
+        expected_code=1,
+        expected_output=(
+            "Unable to authenticate with Prefect Cloud. It looks like you're using API key from Cloud 1 (https://cloud.prefect.io). Make sure that you generate API key using Cloud 2 (https://app.prefect.cloud)"
+        ),
+    )
     invoke_and_assert(
         ["cloud", "login", "--key", "pnu_foo"],
         expected_code=1,
@@ -78,7 +84,7 @@ def test_invalid_login(monkeypatch):
         ["cloud", "login", "--key", "foo"],
         expected_code=1,
         expected_output=(
-            "Make sure you are using API key from https://app.prefect.cloud (Prefect 2) rather than https://cloud.prefect.io (Prefect 1)"
+            "Unable to authenticate with Prefect Cloud. Your key is not in our expected format."
         ),
     )
 


### PR DESCRIPTION
### Problem 

We've seen some users trying to log in to Cloud 2 with Cloud 1 API key. It would be great to direct them to the right Cloud URL.

### Example

![image](https://user-images.githubusercontent.com/86264395/192163542-92b5347d-de93-468d-88d1-c401c0a20d78.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests 
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
