### PR TITLE
Update `Flow.with_options` to actually pass retry settings to new object

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -241,8 +241,8 @@ class Flow(Generic[P, R]):
             description=description or self.description,
             version=version or self.version,
             task_runner=task_runner or self.task_runner,
-            retries=retries,
-            retry_delay_seconds=retry_delay_seconds,
+            retries=retries or self.retries,
+            retry_delay_seconds=retry_delay_seconds or self.retry_delay_seconds,
             timeout_seconds=(
                 timeout_seconds if timeout_seconds is not None else self.timeout_seconds
             ),

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -241,6 +241,8 @@ class Flow(Generic[P, R]):
             description=description or self.description,
             version=version or self.version,
             task_runner=task_runner or self.task_runner,
+            retries=retries,
+            retry_delay_seconds=retry_delay_seconds,
             timeout_seconds=(
                 timeout_seconds if timeout_seconds is not None else self.timeout_seconds
             ),

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -149,6 +149,8 @@ class TestFlowWithOptions:
             description="Flow before with options",
             task_runner=ConcurrentTaskRunner,
             timeout_seconds=10,
+            retries=3,
+            retry_delay_seconds=20,
             validate_parameters=True,
         )
         def initial_flow():
@@ -166,6 +168,8 @@ class TestFlowWithOptions:
         assert flow_with_options.description == "A copied flow"
         assert isinstance(flow_with_options.task_runner, SequentialTaskRunner)
         assert flow_with_options.timeout_seconds == 5
+        assert flow_with_options.retries == 3
+        assert flow_with_options.retry_delay_seconds == 20
         assert flow_with_options.should_validate_parameters is False
 
     def test_with_options_uses_existing_settings_when_no_override(self):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -149,8 +149,6 @@ class TestFlowWithOptions:
             description="Flow before with options",
             task_runner=ConcurrentTaskRunner,
             timeout_seconds=10,
-            retries=3,
-            retry_delay_seconds=20,
             validate_parameters=True,
         )
         def initial_flow():
@@ -160,6 +158,8 @@ class TestFlowWithOptions:
             name="Copied flow",
             description="A copied flow",
             task_runner=SequentialTaskRunner,
+            retries=3,
+            retry_delay_seconds=20,
             timeout_seconds=5,
             validate_parameters=False,
         )
@@ -179,6 +179,8 @@ class TestFlowWithOptions:
             task_runner=SequentialTaskRunner,
             timeout_seconds=10,
             validate_parameters=True,
+            retries=3,
+            retry_delay_seconds=20,
         )
         def initial_flow():
             pass
@@ -191,6 +193,8 @@ class TestFlowWithOptions:
         assert isinstance(flow_with_options.task_runner, SequentialTaskRunner)
         assert flow_with_options.timeout_seconds == 10
         assert flow_with_options.should_validate_parameters is True
+        assert flow_with_options.retries == 3
+        assert flow_with_options.retry_delay_seconds == 20
 
     def test_with_options_can_unset_timeout_seconds_with_zero(self):
         @flow(timeout_seconds=1)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This was missed somehow


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
@flow
def foo():
   pass

# Works now
bar = foo.with_options(retries=3, retry_delay_seconds=20)
assert bar.retries == 3

@flow(retries=3, retry_delay_seconds=20)
def foo():
   pass

# Works now
bar = foo.with_options()
assert bar.retries == 3
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
