### PR TITLE
Raise a `MissingContextError` when `get_run_logger` is called outside a run context

### DIFF
--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import prefect
+from prefect.exceptions import MissingContextError
 
 if TYPE_CHECKING:
     from prefect.context import RunContext
@@ -106,7 +107,7 @@ def get_run_logger(context: "RunContext" = None, **kwargs: str) -> logging.Logge
     ):
         logger = logging.getLogger("null")
     else:
-        raise RuntimeError("There is no active flow or task run context.")
+        raise MissingContextError("There is no active flow or task run context.")
 
     return logger
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,6 +18,7 @@ import prefect.logging.configuration
 import prefect.settings
 from prefect import flow, task
 from prefect.context import FlowRunContext, TaskRunContext
+from prefect.exceptions import MissingContextError
 from prefect.infrastructure import Process
 from prefect.logging.configuration import (
     DEFAULT_LOGGING_SETTINGS_PATH,
@@ -907,7 +908,7 @@ def test_task_run_logger_with_kwargs(task_run):
 
 
 def test_run_logger_fails_outside_context():
-    with pytest.raises(RuntimeError, match="no active flow or task run context"):
+    with pytest.raises(MissingContextError, match="no active flow or task run context"):
         get_run_logger()
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect/issues/6977

Note changing exception types is generally a breaking change. However, `MissingContextError` inherits from `RuntimeError` so this is backwards compatible.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
try:
   logger = get_run_logger()
except MissingContextError:
   # Can catch the specific error instead of all `RuntimeError`
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
