### PR TITLE
Disable new client / old server tests for some versions

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -146,11 +146,11 @@ jobs:
 
       - name: Start server@dev
         run: |
-          # First, we must stop the server container
+          # First, we must stop the server container if it exists
           # TODO: Once we have `prefect orion stop` we can run these tests first and the
           #       optional tests above second
           #       https://github.com/PrefectHQ/prefect/issues/6989
-          docker stop "orion-server-${{ matrix.prefect-version }}"
+          docker stop "orion-server-${{ matrix.prefect-version }}" || echo "That's okay!"
 
           prefect orion start&
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,11 +32,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[dev]
-          
+
       - name: Build orion-ui
         run: |
           prefect dev build-ui
-          
+
       - name: Run Orion in background
         run: |
           prefect orion start&
@@ -46,12 +46,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache-dependency-path: '**/package-lock.json'
-      
+
       - name: Retrieve Playwright version
         id: playwright-cache-key
         run: |
           echo "::set-output name=version::$(npx playwright -V)"
-        
+
       - name: Retrieve cached Playwright browsers
         id: cache-playwright-browsers
         uses: actions/cache@v3
@@ -93,7 +93,7 @@ jobs:
           # but the value is not particularly clear and we can just append the
           # last minor version at each release time
           # - "2"
-        
+
         include:
           # While old clients should always be supported by new servers, a new
           # client may send data that an old server does not support. These
@@ -122,8 +122,36 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[dev]
 
+      - name: Start server@${{ matrix.prefect-version }}
+        if: ${{ ! matrix.server-incompatible }}
+        run: >
+          docker run
+          --name "orion-server-${{ matrix.prefect-version }}"
+          --detach
+          --publish 4200:4200
+          prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
+          prefect orion start --host 0.0.0.0
+
+          PREFECT_API_URL="http://127.0.0.1:4200/api"
+          ./scripts/wait-for-server.py
+
+          # TODO: Replace `wait-for-server` with dedicated command
+          #       https://github.com/PrefectHQ/prefect/issues/6990
+
+      - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
+        if: ${{ ! matrix.server-incompatible }}
+        run: >
+          PREFECT_API_URL="http://127.0.0.1:4200/api"
+          ./scripts/run-integration-flows.py
+
       - name: Start server@dev
         run: |
+          # First, we must stop the server container
+          # TODO: Once we have `prefect orion stop` we can run these tests first and the
+          #       optional tests above second
+          #       https://github.com/PrefectHQ/prefect/issues/6989
+          docker stop "orion-server-${{ matrix.prefect-version }}"
+
           prefect orion start&
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py
 
@@ -136,24 +164,3 @@ jobs:
           --network host
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows
-
-      - name: Start server@${{ matrix.prefect-version }}
-        if: ${{ ! matrix.server-incompatible }}
-        run: >
-          killall prefect  # Stop the existing server, can be removed once we add `--detach`
-
-          docker run
-          --name "orion-server-${{ matrix.prefect-version }}"
-          --detach
-          --publish 4200:4200
-          prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
-          prefect orion start --host 0.0.0.0
-
-          PREFECT_API_URL="http://127.0.0.1:4200/api"
-          ./scripts/wait-for-server.py
-
-      - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
-        if: ${{ ! matrix.server-incompatible }}
-        run: >
-          PREFECT_API_URL="http://127.0.0.1:4200/api"
-          ./scripts/run-integration-flows.py

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -140,6 +140,8 @@ jobs:
       - name: Start server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
+          killall python  # Stop the existing server, can be removed once we add `--detach`
+
           docker run
           --name "orion-server-${{ matrix.prefect-version }}"
           --detach

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: Start server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
-          killall python  # Stop the existing server, can be removed once we add `--detach`
+          killall prefect  # Stop the existing server, can be removed once we add `--detach`
 
           docker run
           --name "orion-server-${{ matrix.prefect-version }}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,9 +99,9 @@ jobs:
           # client may send data that an old server does not support. These
           # incompatibilities are allowed.
           - prefect-version: "2.0"
-            server-incompatible: false
+            server-incompatible: true
           - prefect-version: "2.1"
-            server-incompatible: false
+            server-incompatible: true
 
 
       fail-fast: false

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -83,10 +83,8 @@ jobs:
         prefect-version:
           # These versions correspond to Prefect image tags, the patch version is
           # excluded to always pull the latest patch of each minor version.
-
-          # TODO: The commented versions fail
-          # - "2.0"
-          # - "2.1"
+          - "2.0"
+          - "2.1"
           - "2.2"
           - "2.3"
           - "2.4"
@@ -95,6 +93,16 @@ jobs:
           # but the value is not particularly clear and we can just append the
           # last minor version at each release time
           # - "2"
+        
+        include:
+          # While old clients should always be supported by new servers, a new
+          # client may send data that an old server does not support. These
+          # incompatibilities are allowed.
+          - prefect-version: "2.0"
+            server-incompatible: false
+          - prefect-version: "2.1"
+            server-incompatible: false
+
 
       fail-fast: false
 
@@ -114,28 +122,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[dev]
 
-      - name: Start server@${{ matrix.prefect-version }}
-        run: >
-          docker run
-          --name "orion-server-${{ matrix.prefect-version }}"
-          --detach
-          --publish 4200:4200
-          prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
-          prefect orion start --host 0.0.0.0
-
-          PREFECT_API_URL="http://127.0.0.1:4200/api"
-          ./scripts/wait-for-server.py
-
-      - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }},
-        run: >
-          PREFECT_API_URL="http://127.0.0.1:4200/api"
-          ./scripts/run-integration-flows.py
-
       - name: Start server@dev
         run: |
-          docker stop "orion-server-${{ matrix.prefect-version }}"
           prefect orion start&
-
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py
 
       - name: Run integration flows with client@${{ matrix.prefect-version }}, server@dev
@@ -148,3 +137,21 @@ jobs:
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows
 
+      - name: Start server@${{ matrix.prefect-version }}
+        if: ${{ ! matrix.server-incompatible }}
+        run: >
+          docker run
+          --name "orion-server-${{ matrix.prefect-version }}"
+          --detach
+          --publish 4200:4200
+          prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
+          prefect orion start --host 0.0.0.0
+
+          PREFECT_API_URL="http://127.0.0.1:4200/api"
+          ./scripts/wait-for-server.py
+
+      - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
+        if: ${{ ! matrix.server-incompatible }}
+        run: >
+          PREFECT_API_URL="http://127.0.0.1:4200/api"
+          ./scripts/run-integration-flows.py


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Requires #6987 

Enables tests for 2.0 and 2.1 but disables checks in some cases where a new client is paired with an old server. New servers are always expected to support old clients, but new clients may attempt to _use_ functionality that an old server does not support. In this case, the server _should_ error to indicate that the requested functionality is not supported.

Closes #6978 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

On most versions, we still run all the tests https://github.com/PrefectHQ/prefect/actions/runs/3137761832/jobs/5096309392

For those that explicit note incompatibility, we will skip the old server tests https://github.com/PrefectHQ/prefect/actions/runs/3137780810/jobs/5096352330


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- ~[ ] This pull request includes tests or only affects documentation.~
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->

### Future work

Some improved ergonomics for working with the server:

- #6989 
- #6990 