### PR TITLE
Add configuration of results

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -261,7 +261,7 @@ new_flow()  # The flow and task within it will use S3 for result storage.
 
 You can configure this to use a specific storage using one of the following:
 
-- A storage instance, e.g. `LocalFileSystem(basepath=".my-results"`
+- A storage instance, e.g. `LocalFileSystem(basepath=".my-results")`
 - A storage slug, e.g. `'s3/dev-s3-block'`
 - A UUID, e.g. `'cae1dda0-5000-4ca2-a18c-727d400145f2'`
 
@@ -297,7 +297,7 @@ If `persist_result` is set to `False`, these values will never be stored.
 
 ## Result storage types
 
-Result storage is responsible fo reading and writing serialized data to an external location. At this time, any file system block can be used for result storage.
+Result storage is responsible for reading and writing serialized data to an external location. At this time, any file system block can be used for result storage.
 ## Result serializer types
 
 A result serializer is responsible for converting your Python object to and from bytes. This is necessary to store the object outside of Python and retrieve it later.

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -263,8 +263,6 @@ You can configure this to use a specific storage using one of the following:
 
 - A storage instance, e.g. `LocalFileSystem(basepath=".my-results")`
 - A storage slug, e.g. `'s3/dev-s3-block'`
-- A UUID, e.g. `'cae1dda0-5000-4ca2-a18c-727d400145f2'`
-
 
 #### Result serializer
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -213,7 +213,7 @@ Persistence of results requires a [**serializer**](#result-serializers) and a [*
 - `result_storage`: Where to store the result when persisted
 - `result_serializer`: How to convert the result to a storable form
 
-#### Enabling and disabling persistence
+#### Toggling persistence
 
 Persistence of results can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used by the flow or task. Persistence of results can be manually toggled on or off:
 
@@ -232,10 +232,9 @@ def my_task():
     ...
 ```
 
+#### Result storage location
 
-#### Configuring the result storage location
-
-[The result storage location](#result-storage) can be configured with the `result_storage` option. The `result_storage` option defaults to a null value, which infers storage from the context.
+[The result storage location](#result-storage-types) can be configured with the `result_storage` option. The `result_storage` option defaults to a null value, which infers storage from the context.
 Generally, this means that tasks will use the result storage configured on the flow unless otherwise specified.
 If there is no context to load the storage from and results must be persisted, results will be stored in `.prefect-results` in the run's working directory.
 
@@ -267,9 +266,9 @@ You can configure this to use a specific storage using one of the following:
 - A UUID, e.g. `'cae1dda0-5000-4ca2-a18c-727d400145f2'`
 
 
-#### Configuring the result serializer
+#### Result serializer
 
-[The result serializer](#result-serializer) can be configured with the `result_storage` option. The `result_serialzier` option defaults to a null value, which infers the serializer from the context.
+[The result serializer](#result-serializer-types) can be configured with the `result_storage` option. The `result_serialzier` option defaults to a null value, which infers the serializer from the context.
 Generally, this means that tasks will use the result serializer configured on the flow unless otherwise specified.
 If there is no context to load the serializer from, the serializer defined by `PREFECT_RESULTS_DEFAULT_SERIALIZER` will be used. This setting defaults to Prefect's pickle serializer.
 
@@ -296,10 +295,10 @@ The following data types will be stored by the API without persistence to storag
 If `persist_result` is set to `False`, these values will never be stored.
 
 
-## Result storage
+## Result storage types
 
 Result storage is responsible fo reading and writing serialized data to an external location. At this time, any file system block can be used for result storage.
-## Result serializers
+## Result serializer types
 
 A result serializer is responsible for converting your Python object to and from bytes. This is necessary to store the object outside of Python and retrieve it later.
 
@@ -377,8 +376,8 @@ Result literals reduce the overhead required to persist simple results.
 
 Result references contain all of the information needed to retrieve the result from storage. This includes:
 
-- Storage: a reference to the [result storage](#result-storage) that can be used to read the serialized result
+- Storage: a reference to the [result storage](#result-storage-types) that can be used to read the serialized result
 - Key: indicates where this specific result is in storage
-- Serializer: description of the [result serializer](#result-serializers) that can be used to deserialize the result
+- Serializer: description of the [result serializer](#result-serializer-types) that can be used to deserialize the result
 
 The `get()` method on result references retrieves the data from storage, deserializes it, and returns the original object. The `get()` operation will cache the resolved object to reduce the overhead of subsequent calls.

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -213,7 +213,7 @@ Persistence of results requires a [**serializer**](#result-serializers) and a [*
 - `result_storage`: Where to store the result when persisted
 - `result_serializer`: How to convert the result to a storable form
 
-By default, flows and tasks will not persist their result unless necessary for a feature. Storage of results can be manually toggled by the `persist_result` option:
+Persistence of results can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect future used by the flow or task. Persistence of results can be manually toggled on or off:
 
 ```python
 from prefect import flow, task
@@ -262,7 +262,7 @@ You can configure this to use a specific storage using one of the following:
 
 [The result serializer](#result-serializer) can be configured with the `result_storage` option. The `result_serialzier` option defaults to a null value, which infers the serializer from the context.
 Generally, this means that tasks will use the result serializer configured on the flow unless otherwise specified.
-If there is no context to load the serializer from, Prefect's pickle serializer will be used.
+If there is no context to load the serializer from, the serializer defined by `PREFECT_RESULTS_DEFAULT_SERIALIZER` will be used. This setting defaults to Prefect's pickle serializer.
 
 You may set the configure the result serializer using:
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -268,7 +268,7 @@ You can configure this to use a specific storage using one of the following:
 
 #### Result serializer
 
-[The result serializer](#result-serializer-types) can be configured with the `result_storage` option. The `result_serialzier` option defaults to a null value, which infers the serializer from the context.
+[The result serializer](#result-serializer-types) can be configured with the `result_serializer` option. The `result_serializer` option defaults to a null value, which infers the serializer from the context.
 Generally, this means that tasks will use the result serializer configured on the flow unless otherwise specified.
 If there is no context to load the serializer from, the serializer defined by `PREFECT_RESULTS_DEFAULT_SERIALIZER` will be used. This setting defaults to Prefect's pickle serializer.
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -68,7 +68,7 @@ result = my_flow())
 assert result == 2
 ```
 
-## Handling failures
+### Handling failures
 
 Sometimes your flows or tasks will encounter an **exception**. Prefect captures all exceptions in order to report states to the orchestrator, but we do not hide them from you (unless you ask us to) as your program needs to know if an unexpected error has occurred.
 
@@ -193,3 +193,135 @@ def my_flow():
 
 my_flow()
 ```
+
+## Persisting results
+
+The Prefect API does not store your results [except in special cases](#storage-of-results-in-prefect). Instead, the result is **persisted** to a storage location in your infrastructure and Prefect stores a **reference** to the result.
+
+The following Prefect features require results to be persisted:
+
+- Task cache keys
+- Flow run retries
+
+If results are not persisted, these features will not be usable.
+
+### Configuring results
+
+Persistence of results requires a [**serializer**](#result-serializers) and a [**storage** location](#result-storage). Prefect sets defaults for these, and you should not need to adjust them until you want to customize behavior.
+
+#### Configuring results for flows
+
+The `flow` decorator provides result configuration options.
+
+By default, flows will not persist their own result. However, configuration at the flow level sets the default for all tasks in the flow.
+
+You may set the result storage using an instance:
+
+```python
+from prefect import flow
+from prefect.filesystems import LocalFileSystem
+
+@flow(result_storage=LocalFileSystem(basepath=".results"))
+```
+
+You may set the result storage using a block id:
+
+```python
+from prefect import flow
+from prefect.filesystems import LocalFileSystem
+
+@flow(result_storage='cae1dda0-5000-4ca2-a18c-727d400145f2')
+```
+
+Or you may **disable** result storage by setting it to a null value:
+
+```python
+from prefect import flow
+from prefect.filesystems import LocalFileSystem
+
+@flow(result_storage=None)
+```
+
+#### Configuring results for tasks
+
+By default, tasks will persist results to the local file system if required by a feature enabled on the flow. For example, if you enable retries on the flow we will persist task run results. Otherwise, your retries will be unable to restore completed task runs from the previous attempt.
+### Result storage
+
+Result storage is responsible fo reading and writing serialized data to an external location. At this time, any file system block can be used for result storage.
+
+### Result serializers
+
+A result serializer is responsible for converting your Python object to and from bytes. This is necessary to store the object outside of Python and retrieve it later.
+
+#### Pickle serializer
+
+Pickle is a standard Python protocol for encoding arbitrary Python objects. We supply a custom Pickle serializer at `prefect.serializers.PickleSerializer`. Prefect's pickle serializer uses the [cloudpickle](https://github.com/cloudpipe/cloudpickle) project by default to support more object types. Alternative pickle libraries can be specified:
+
+```python
+from prefect.serializers import PickleSerializer
+
+PickleSerializer(picklelib="custompickle")
+```
+
+Benefits of the pickle serializer:
+
+- Many object types are supported
+- Objects can define custom pickle support
+
+Drawbacks of the pickle serializer:
+
+- When nested attributes of an object cannot be pickled, it is hard to determine the cause
+- When deserializing objects, your Python and pickle library versions must match the one used at serialization time
+- Serialized objects cannot be easily shared across different programming languages
+- Serialized objects are not human readable
+
+#### JSON serializer
+
+
+We supply a custom JSON serializer at `prefect.serializers.JSONSerializer`. Prefect's JSON serializer uses custom hooks by default to support more object types. Specifically, we add support for all types supported by [Pydantic](https://pydantic-docs.helpmanual.io/). 
+
+
+By default, we use the standard Python `json` library. Alternative JSON libraries can be specified:
+
+```python
+from prefect.serializers import JSONSerializer
+
+JSONSerializer(jsonlib="orjson")
+```
+
+Benefits of the JSON serializer:
+
+- Serialized objects are human readable
+- Serialized objects can often be shared across different programming languages
+- Deserialization of serialized objects is generally version agnostic
+
+Drawbacks of the JSON serializer:
+
+- Supported types are limited
+- Implementing support for additional types must be done at the serializer level
+
+### Result references
+
+Result references contain all of the information needed to retrieve the result from storage. This includes:
+
+- Storage: a reference to the [result storage](#result-storage) that can be used to read the serialized result
+- Key: indicates where this specific result is in storage
+- Serializer: description of the [result serializer](#result-serializers) that can be used to deserialize the result
+
+Result references implement the `get()` method which retrieves the data from storage, deserializes it, and returns the original object. This is done automatically when the `result()` method is used on states or futures. The `get()` operation will cache the resolved object to reduce the overhead of subsequent calls.
+
+### Storage of results in Prefect
+
+The Prefect API does not store your results in most cases. The system is designed this way because:
+
+- Results can be large and slow to send to and from the API
+- Results often contain private information or data
+- Results would need to be stored in the database, or complex logic implemented to hydrate from another source
+
+There are a few cases where Prefect _will_ store your results directly in the database. This is an optimization to reduce the overhead of reading and writing to result storage. 
+
+The following data types will be stored by the API without persistence to storage:
+
+- booleans (`True`, `False`)
+- nulls (`None`)
+

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -196,7 +196,7 @@ my_flow()
 
 ## Persisting results
 
-The Prefect API does not store your results [except in special cases](#storage-of-results-in-prefect). Instead, the result is **persisted** to a storage location in your infrastructure and Prefect stores a **reference** to the result.
+The Prefect API does not store your results [except in special cases](#storage-of-results-in-prefect). Instead, the result is _persisted_ to a storage location in your infrastructure and Prefect stores a _reference_ to the result.
 
 The following Prefect features require results to be persisted:
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -209,9 +209,9 @@ If results are not persisted, these features will not be usable.
 
 Persistence of results requires a [**serializer**](#result-serializers) and a [**storage** location](#result-storage). Prefect sets defaults for these, and you should not need to adjust them until you want to customize behavior. You can configure results on the `flow` and `task` decorators with the following options:
 
-- `persist_result`: If the result be persisted to storage
-- `result_storage`: Where to store the result when persisted
-- `result_serializer`: How to convert the result to a storable form
+- `persist_result`: Whether the result should be persisted to storage.
+- `result_storage`: Where to store the result when persisted.
+- `result_serializer`: How to convert the result to a storable form.
 
 #### Toggling persistence
 
@@ -274,16 +274,16 @@ If there is no context to load the serializer from, the serializer defined by `P
 
 You may set the configure the result serializer using:
 
-- A type name, e.g. `"json"` or `"pickle"` — this corresponds to an instance with default values
+- A type name, e.g. `"json"` or `"pickle"` &mdash; this corresponds to an instance with default values
 - An instance, e.g. `JSONSerializer(jsonlib="orjson")`
 
 ### Storage of results in Prefect
 
 The Prefect API does not store your results in most cases for the following reasons:
 
-- Results can be large and slow to send to and from the API
-- Results often contain private information or data
-- Results would need to be stored in the database or complex logic implemented to hydrate from another source
+- Results can be large and slow to send to and from the API.
+- Results often contain private information or data.
+- Results would need to be stored in the database or complex logic implemented to hydrate from another source.
 
 There are a few cases where Prefect _will_ store your results directly in the database. This is an optimization to reduce the overhead of reading and writing to result storage.
 
@@ -304,7 +304,7 @@ A result serializer is responsible for converting your Python object to and from
 
 ### Pickle serializer
 
-Pickle is a standard Python protocol for encoding arbitrary Python objects. We supply a custom Pickle serializer at `prefect.serializers.PickleSerializer`. Prefect's pickle serializer uses the [cloudpickle](https://github.com/cloudpipe/cloudpickle) project by default to support more object types. Alternative pickle libraries can be specified:
+Pickle is a standard Python protocol for encoding arbitrary Python objects. We supply a custom pickle serializer at `prefect.serializers.PickleSerializer`. Prefect's pickle serializer uses the [cloudpickle](https://github.com/cloudpipe/cloudpickle) project by default to support more object types. Alternative pickle libraries can be specified:
 
 ```python
 from prefect.serializers import PickleSerializer
@@ -314,15 +314,15 @@ PickleSerializer(picklelib="custompickle")
 
 Benefits of the pickle serializer:
 
-- Many object types are supported
-- Objects can define custom pickle support
+- Many object types are supported.
+- Objects can define custom pickle support.
 
 Drawbacks of the pickle serializer:
 
-- When nested attributes of an object cannot be pickled, it is hard to determine the cause
-- When deserializing objects, your Python and pickle library versions must match the one used at serialization time
-- Serialized objects cannot be easily shared across different programming languages
-- Serialized objects are not human readable
+- When nested attributes of an object cannot be pickled, it is hard to determine the cause.
+- When deserializing objects, your Python and pickle library versions must match the one used at serialization time.
+- Serialized objects cannot be easily shared across different programming languages.
+- Serialized objects are not human readable.
 
 ### JSON serializer
 
@@ -340,14 +340,14 @@ JSONSerializer(jsonlib="orjson")
 
 Benefits of the JSON serializer:
 
-- Serialized objects are human readable
-- Serialized objects can often be shared across different programming languages
-- Deserialization of serialized objects is generally version agnostic
+- Serialized objects are human readable.
+- Serialized objects can often be shared across different programming languages.
+- Deserialization of serialized objects is generally version agnostic.
 
 Drawbacks of the JSON serializer:
 
-- Supported types are limited
-- Implementing support for additional types must be done at the serializer level
+- Supported types are limited.
+- Implementing support for additional types must be done at the serializer level.
 
 
 ## Result types
@@ -376,8 +376,8 @@ Result literals reduce the overhead required to persist simple results.
 
 Result references contain all of the information needed to retrieve the result from storage. This includes:
 
-- Storage: a reference to the [result storage](#result-storage-types) that can be used to read the serialized result
-- Key: indicates where this specific result is in storage
-- Serializer: description of the [result serializer](#result-serializer-types) that can be used to deserialize the result
+- Storage: a reference to the [result storage](#result-storage-types) that can be used to read the serialized result.
+- Key: indicates where this specific result is in storage.
+- Serializer: description of the [result serializer](#result-serializer-types) that can be used to deserialize the result.
 
 The `get()` method on result references retrieves the data from storage, deserializes it, and returns the original object. The `get()` operation will cache the resolved object to reduce the overhead of subsequent calls.

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -220,10 +220,13 @@ from prefect import flow, task
 
 @flow(persist_result=True)
 def my_flow():
+    # This flow will persist its result even if not necessary for a feature.
     ...
 
 @task(persist_result=False)
 def my_task():
+    # This task will never persist its result.
+    # If persistence needed for a feature, an error will be raised.
     ...
 ```
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -36,6 +36,7 @@ from prefect.exceptions import MissingContextError
 from prefect.filesystems import WritableFileSystem
 from prefect.futures import PrefectFuture
 from prefect.orion.utilities.schemas import DateTimeTZ
+from prefect.results import ResultFactory
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.task_runners import BaseTaskRunner
 from prefect.utilities.importtools import load_script_as_module
@@ -208,7 +209,10 @@ class FlowRunContext(RunContext):
     flow: "Flow"
     flow_run: FlowRun
     task_runner: BaseTaskRunner
+
+    # Result handling
     result_filesystem: WritableFileSystem
+    result_factory: ResultFactory
 
     # Counter for task calls allowing unique
     task_run_dynamic_keys: Dict[str, int] = Field(default_factory=dict)
@@ -243,7 +247,10 @@ class TaskRunContext(RunContext):
 
     task: "Task"
     task_run: TaskRun
+
+    # Result handling
     result_filesystem: WritableFileSystem
+    result_factory: ResultFactory
 
     __var__ = ContextVar("task_run")
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -207,6 +207,8 @@ class Flow(Generic[P, R]):
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = None,
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = None,
+        result_storage: ResultStorage = auto(),
+        result_serializer: ResultSerializer = "pickle",
     ):
         """
         Create a new flow from the current object, updating provided options.
@@ -223,7 +225,8 @@ class Flow(Generic[P, R]):
             retries: A new number of times to retry on flow run failure.
             retry_delay_seconds: A new number of seconds to wait before retrying the
                 flow after failure. This is only applicable if `retries` is nonzero.
-
+            result_storage: A new storage type to use for results.
+            result_serializer: A new serializer to use for results.
 
         Returns:
             A new `Flow` instance.
@@ -267,6 +270,8 @@ class Flow(Generic[P, R]):
                 if validate_parameters is not None
                 else self.should_validate_parameters
             ),
+            result_storage=result_storage,
+            result_serializer=result_serializer,
         )
 
     def validate_parameters(self, parameters: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -97,18 +97,18 @@ class Flow(Generic[P, R]):
         retries: An optional number of times to retry on flow run failure.
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             flow after failure. This is only applicable if `retries` is nonzero.
-        persist_result: An optional toggle indiciating if the result of this flow
-            should be persisted to result storage. Defaults to `None` which indicates
-            that Prefect should choose if the result should be persisted depending on
+        persist_result: An optional toggle indicating whether the result of this flow
+            should be persisted to result storage. Defaults to `None`, which indicates
+            that Prefect should choose whether the result should be persisted depending on
             the features being used.
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
             If not provided, the local file system will be used unless called as
-            a subflow at which point the default will be loaded from the parent flow.
+            a subflow, at which point the default will be loaded from the parent flow.
         result_serializer: An optional serializer to use to serialize the result of this
             flow for persistence. This value will be used as the default for any tasks
             in this flow. If not provided, the value of `PREFECT_RESULTS_DEFAULT_SERIALIZER`
-            will be used unless called as a subflow at which point the default will be
+            will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
     """
 
@@ -536,18 +536,18 @@ def flow(
         retries: An optional number of times to retry on flow run failure.
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             flow after failure. This is only applicable if `retries` is nonzero.
-        persist_result: An optional toggle indiciating if the result of this flow
-            should be persisted to result storage. Defaults to `None` which indicates
-            that Prefect should choose if the result should be persisted depending on
+        persist_result: An optional toggle indicating whether the result of this flow
+            should be persisted to result storage. Defaults to `None`, which indicates
+            that Prefect should choose whether the result should be persisted depending on
             the features being used.
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
             If not provided, the local file system will be used unless called as
-            a subflow at which point the default will be loaded from the parent flow.
+            a subflow, at which point the default will be loaded from the parent flow.
         result_serializer: An optional serializer to use to serialize the result of this
             flow for persistence. This value will be used as the default for any tasks
             in this flow. If not provided, the value of `PREFECT_RESULTS_DEFAULT_SERIALIZER`
-            will be used unless called as a subflow at which point the default will be
+            will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
 
     Returns:

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -126,8 +126,8 @@ class Flow(Generic[P, R]):
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = True,
         persist_result: Optional[bool] = None,
-        result_storage: ResultStorage = None,
-        result_serializer: ResultSerializer = None,
+        result_storage: Optional[ResultStorage] = None,
+        result_serializer: Optional[ResultSerializer] = None,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -215,8 +215,8 @@ class Flow(Generic[P, R]):
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = None,
         persist_result: Optional[bool] = NotSet,
-        result_storage: ResultStorage = NotSet,
-        result_serializer: ResultSerializer = NotSet,
+        result_storage: Optional[ResultStorage] = NotSet,
+        result_serializer: Optional[ResultSerializer] = NotSet,
     ):
         """
         Create a new flow from the current object, updating provided options.
@@ -504,8 +504,8 @@ def flow(
     timeout_seconds: Union[int, float] = None,
     validate_parameters: bool = True,
     persist_result: Optional[bool] = None,
-    result_storage: ResultStorage = None,
-    result_serializer: ResultSerializer = None,
+    result_storage: Optional[ResultStorage] = None,
+    result_serializer: Optional[ResultSerializer] = None,
 ):
     """
     Decorator to designate a function as a Prefect workflow.

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1,17 +1,23 @@
 import uuid
-from typing import Union
+from typing import TYPE_CHECKING, Tuple, Type, Union
 
 import pydantic
+from typing_extensions import Self
 
 from prefect.blocks.core import Block
 from prefect.client import OrionClient
 from prefect.client.orion import inject_client
 from prefect.deprecated.data_documents import DataDocument
-from prefect.filesystems import WritableFileSystem
+from prefect.exceptions import MissingContextError
+from prefect.filesystems import LocalFileSystem, WritableFileSystem
 from prefect.serializers import Serializer
+from prefect.settings import PREFECT_LOCAL_STORAGE_PATH
 
-ResultStorage = Union[WritableFileSystem, uuid.UUID, str, None]
+ResultStorage = Union[WritableFileSystem, uuid.UUID, str]
 ResultSerializer = Union[Serializer, str]
+
+if TYPE_CHECKING:
+    from prefect import Flow, Task
 
 
 async def _persist_serialized_result(
@@ -48,3 +54,194 @@ async def _retrieve_result(state):
 class _Result(pydantic.BaseModel):
     key: str
     filesystem_document_id: uuid.UUID
+
+
+def get_default_result_storage() -> ResultStorage:
+    """
+    Generate a default file system for result storage.
+    """
+    return LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
+
+
+def get_default_result_serializer() -> ResultSerializer:
+    """
+    Generate a default file system for result storage.
+    """
+    return LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
+
+
+def flow_features_require_child_result_persistence(flow: "Flow") -> bool:
+    """
+    Returns `True` if the given flow uses features that requires child flow and task
+    runs to persist their results.
+    """
+    if flow.retries:
+        return True
+    return False
+
+
+def task_features_require_result_persistence(task: "Task") -> bool:
+    """
+    Returns `True` if the given task uses features that requires its result to be
+    persisted.
+    """
+    if task.cache_key_fn:
+        return True
+    return False
+
+
+class ResultFactory(pydantic.BaseModel):
+    """
+    A utility to generate `Result` types.
+    """
+
+    persist_result: bool
+    serializer: Serializer
+    serialize_healthcheck: bool = True
+    storage_block_id: uuid.UUID
+    storage_block: WritableFileSystem
+
+    @classmethod
+    @inject_client
+    async def from_flow(cls: Type[Self], flow: "Flow", client: OrionClient) -> Self:
+        """
+        Create a new result factory for a flow.
+        """
+        from prefect.context import FlowRunContext
+
+        ctx = FlowRunContext.get()
+        if ctx:
+            result_storage = flow.result_storage or ctx.flow.result_storage
+            result_serializer = flow.result_serializer or ctx.flow.result_serializer
+            perist_result = (
+                flow.persist_result
+                if flow.persist_result is not None
+                else
+                # !! Child flows persist their result by default if the parent flow
+                #    uses a feature that requires it
+                flow_features_require_child_result_persistence(ctx.flow)
+            )
+        else:
+            result_storage = flow.result_storage or get_default_result_storage()
+            result_serializer = (
+                flow.result_serializer or get_default_result_serializer()
+            )
+            perist_result = (
+                flow.persist_result
+                if flow.persist_result is not None
+                # !! Root flows do not persist their result by default ever at this time
+                else False
+            )
+
+        return await cls.from_settings(
+            result_storage=result_storage,
+            result_serializer=result_serializer,
+            perist_result=perist_result,
+            client=client,
+        )
+
+    @classmethod
+    @inject_client
+    async def from_task(cls: Type[Self], task: "Task", client: OrionClient) -> Self:
+        """
+        Create a new result factory for a task.
+
+        """
+        from prefect.context import FlowRunContext
+
+        ctx = FlowRunContext.get()
+        if not ctx:
+            raise MissingContextError(
+                "A flow run context is required to create a result factory for a task."
+            )
+
+        result_storage = task.result_storage or ctx.flow.result_storage
+        result_serializer = task.result_serializer or ctx.flow.result_serializer
+        perist_result = (
+            task.persist_result
+            if task.persist_result is not None
+            else
+            # !! Tasks persist their result by default if their parent flow uses a
+            #    feature that requires it or the task uses a feature that requires it
+            (
+                flow_features_require_child_result_persistence(ctx.flow)
+                or task_features_require_result_persistence(task)
+            )
+        )
+
+        return await cls.from_settings(
+            result_storage=result_storage,
+            result_serializer=result_serializer,
+            perist_result=perist_result,
+            client=client,
+        )
+
+    @classmethod
+    @inject_client
+    async def from_settings(
+        cls: Type[Self],
+        result_storage: ResultStorage,
+        result_serializer: ResultSerializer,
+        perist_results: bool,
+        client: OrionClient,
+    ) -> Self:
+        storage_block_id, storage_block = await cls.resolve_storage_block(
+            result_storage, client=client
+        )
+        serializer = cls.resolve_serializer(result_serializer)
+
+        return cls(
+            storage_block=storage_block,
+            storage_block_id=storage_block_id,
+            serializer=serializer,
+            perist_results=perist_results,
+        )
+
+    @staticmethod
+    async def resolve_storage_block(
+        result_storage: ResultStorage, client: OrionClient
+    ) -> Tuple[uuid.UUID, WritableFileSystem]:
+        """
+        Resolve one of the valid `ResultStorage` input types into a saved block
+        document id and an instance of the block.
+        """
+        if isinstance(result_storage, uuid.UUID):
+            storage_block_id = result_storage
+            document = await client.read_block_document(storage_block_id)
+            storage_block = Block._from_block_document(document)
+        elif isinstance(result_storage, Block):
+            storage_block = result_storage
+            storage_block_id = (
+                # Avoid saving the block if it already has an identifier assigned
+                storage_block._block_document_id
+                # TODO: Overwrite is true to avoid issues where the save collides with
+                #       a previously saved document with a matching hash
+                or await storage_block._save(is_anonymous=True, overwrite=True)
+            )
+        elif isinstance(result_storage, str):
+            storage_block = await Block.load(result_storage, client=client)
+            storage_block_id = storage_block._block_document_id
+            assert storage_block_id is not None, "Loaded storage blocks must have ids"
+        else:
+            raise TypeError(
+                "Result storage must be one of the following types: 'UUID', 'Block', "
+                f"'str'. Got unsupported type {type(result_storage).__name__!r}."
+            )
+
+        return storage_block_id, storage_block
+
+    @staticmethod
+    def resolve_serializer(serializer: ResultSerializer) -> Serializer:
+        """
+        Result one of the valid `ResultSerializer` input types into a serializer
+        instance.
+        """
+        if isinstance(serializer, Serializer):
+            return serializer
+        elif isinstance(serializer, str):
+            return Serializer(type=serializer)
+        else:
+            raise TypeError(
+                "Result serializer must be one of the following types: 'Serializer', "
+                f"'str'. Got unsupported type {type(serializer).__name__!r}."
+            )

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -121,9 +121,9 @@ class ResultFactory(pydantic.BaseModel):
         ctx = FlowRunContext.get()
         if ctx:
             # This is a child flow run
-            result_storage = flow.result_storage or ctx.flow.result_storage
-            result_serializer = flow.result_serializer or ctx.flow.result_serializer
-            perist_result = (
+            result_storage = flow.result_storage or ctx.result_factory.storage_block
+            result_serializer = flow.result_serializer or ctx.result_factory.serializer
+            persist_result = (
                 flow.persist_result
                 if flow.persist_result is not None
                 else
@@ -136,7 +136,7 @@ class ResultFactory(pydantic.BaseModel):
             result_serializer = (
                 flow.result_serializer or get_default_result_serializer()
             )
-            perist_result = (
+            persist_result = (
                 flow.persist_result
                 if flow.persist_result is not None
                 # !! Root flows do not persist their result by default ever at this time
@@ -146,7 +146,7 @@ class ResultFactory(pydantic.BaseModel):
         return await cls.from_settings(
             result_storage=result_storage,
             result_serializer=result_serializer,
-            perist_result=perist_result,
+            persist_result=persist_result,
             client=client,
         )
 
@@ -164,9 +164,9 @@ class ResultFactory(pydantic.BaseModel):
                 "A flow run context is required to create a result factory for a task."
             )
 
-        result_storage = task.result_storage or ctx.flow.result_storage
-        result_serializer = task.result_serializer or ctx.flow.result_serializer
-        perist_result = (
+        result_storage = task.result_storage or ctx.result_factory.storage_block
+        result_serializer = task.result_serializer or ctx.result_factory.serializer
+        persist_result = (
             task.persist_result
             if task.persist_result is not None
             else
@@ -181,7 +181,7 @@ class ResultFactory(pydantic.BaseModel):
         return await cls.from_settings(
             result_storage=result_storage,
             result_serializer=result_serializer,
-            perist_result=perist_result,
+            persist_result=persist_result,
             client=client,
         )
 
@@ -191,7 +191,7 @@ class ResultFactory(pydantic.BaseModel):
         cls: Type[Self],
         result_storage: ResultStorage,
         result_serializer: ResultSerializer,
-        perist_results: bool,
+        persist_result: bool,
         client: OrionClient,
     ) -> Self:
         storage_block_id, storage_block = await cls.resolve_storage_block(
@@ -203,7 +203,7 @@ class ResultFactory(pydantic.BaseModel):
             storage_block=storage_block,
             storage_block_id=storage_block_id,
             serializer=serializer,
-            perist_results=perist_results,
+            persist_result=persist_result,
         )
 
     @staticmethod

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -16,7 +16,7 @@ from prefect.settings import (
     PREFECT_RESULTS_DEFAULT_SERIALIZER,
 )
 
-ResultStorage = Union[WritableFileSystem, uuid.UUID, str]
+ResultStorage = Union[WritableFileSystem, str]
 ResultSerializer = Union[Serializer, str]
 if TYPE_CHECKING:
     from prefect import Flow, Task
@@ -214,11 +214,7 @@ class ResultFactory(pydantic.BaseModel):
         Resolve one of the valid `ResultStorage` input types into a saved block
         document id and an instance of the block.
         """
-        if isinstance(result_storage, uuid.UUID):
-            storage_block_id = result_storage
-            document = await client.read_block_document(storage_block_id)
-            storage_block = Block._from_block_document(document)
-        elif isinstance(result_storage, Block):
+        if isinstance(result_storage, Block):
             storage_block = result_storage
             storage_block_id = (
                 # Avoid saving the block if it already has an identifier assigned

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Type, Union
 
 import pydantic
 
@@ -7,6 +8,13 @@ from prefect.client import OrionClient
 from prefect.client.orion import inject_client
 from prefect.deprecated.data_documents import DataDocument
 from prefect.filesystems import WritableFileSystem
+from prefect.serializers import Serializer
+from prefect.utilities.annotations import Auto
+
+ResultStorage = Union[
+    WritableFileSystem, Type[WritableFileSystem], uuid.UUID, Auto, None
+]
+ResultSerializer = Union[Serializer, Type[Serializer], str]
 
 
 async def _persist_serialized_result(

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -77,7 +77,7 @@ def get_default_result_serializer() -> ResultSerializer:
 
 def flow_features_require_child_result_persistence(flow: "Flow") -> bool:
     """
-    Returns `True` if the given flow uses features that requires child flow and task
+    Returns `True` if the given flow uses features that require child flow and task
     runs to persist their results.
     """
     if flow.retries:
@@ -87,7 +87,7 @@ def flow_features_require_child_result_persistence(flow: "Flow") -> bool:
 
 def task_features_require_result_persistence(task: "Task") -> bool:
     """
-    Returns `True` if the given task uses features that requires its result to be
+    Returns `True` if the given task uses features that require its result to be
     persisted.
     """
     if task.cache_key_fn:
@@ -242,7 +242,7 @@ class ResultFactory(pydantic.BaseModel):
     @staticmethod
     def resolve_serializer(serializer: ResultSerializer) -> Serializer:
         """
-        Result one of the valid `ResultSerializer` input types into a serializer
+        Resolve one of the valid `ResultSerializer` input types into a serializer
         instance.
         """
         if isinstance(serializer, Serializer):

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Type, Union
+from typing import Union
 
 import pydantic
 
@@ -9,12 +9,9 @@ from prefect.client.orion import inject_client
 from prefect.deprecated.data_documents import DataDocument
 from prefect.filesystems import WritableFileSystem
 from prefect.serializers import Serializer
-from prefect.utilities.annotations import Auto
 
-ResultStorage = Union[
-    WritableFileSystem, Type[WritableFileSystem], uuid.UUID, Auto, None
-]
-ResultSerializer = Union[Serializer, Type[Serializer], str]
+ResultStorage = Union[WritableFileSystem, uuid.UUID, str, None]
+ResultSerializer = Union[Serializer, str]
 
 
 async def _persist_serialized_result(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -314,6 +314,12 @@ PREFECT_PROFILES_PATH = Setting(
     value_callback=template_with_settings(PREFECT_HOME),
 )
 
+PREFECT_RESULTS_DEFAULT_SERIALIZER = Setting(
+    str,
+    default="pickle",
+    description="The default serializer to use when not otherwise specified.",
+)
+
 PREFECT_LOCAL_STORAGE_PATH = Setting(
     Path,
     default=Path("${PREFECT_HOME}") / "storage",

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -31,7 +31,9 @@ from typing_extensions import Literal, ParamSpec
 
 from prefect.context import PrefectObjectRegistry
 from prefect.futures import PrefectFuture
+from prefect.results import ResultSerializer, ResultStorage
 from prefect.states import State
+from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import Async, Sync
 from prefect.utilities.callables import (
     get_call_parameters,
@@ -107,6 +109,15 @@ class Task(Generic[P, R]):
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero.
+        persist_result: An optional toggle indiciating if the result of this task
+            should be persisted to result storage. Defaults to `None` which indicates
+            that Prefect should choose if the result should be persisted depending on
+            the features being used.
+        result_storage: An optional block to use to perist the result of this task.
+            Defaults to the value set in the flow the task is called in.
+        result_serializer: An optional serializer to use to serialize the result of this
+            task for persistence. Defaults to the value set in the flow the task is
+            called in.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -124,6 +135,9 @@ class Task(Generic[P, R]):
         cache_expiration: datetime.timedelta = None,
         retries: int = 0,
         retry_delay_seconds: Union[float, int] = 0,
+        persist_result: Optional[bool] = None,
+        result_storage: ResultStorage = None,
+        result_serializer: ResultSerializer = None,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -149,6 +163,10 @@ class Task(Generic[P, R]):
         #       validate that the user passes positive numbers here
         self.retries = retries
         self.retry_delay_seconds = retry_delay_seconds
+
+        self.persist_result = persist_result
+        self.result_storage = result_storage
+        self.result_serializer = result_serializer
 
         # Warn if this task's `name` conflicts with another task while having a
         # different function. This is to detect the case where two or more tasks
@@ -183,6 +201,9 @@ class Task(Generic[P, R]):
         cache_expiration: datetime.timedelta = None,
         retries: int = 0,
         retry_delay_seconds: Union[float, int] = 0,
+        persist_result: Optional[bool] = NotSet,
+        result_storage: ResultStorage = NotSet,
+        result_serializer: ResultSerializer = NotSet,
     ):
         """
         Create a new task from the current object, updating provided options.
@@ -197,6 +218,9 @@ class Task(Generic[P, R]):
             retries: A new number of times to retry on task run failure.
             retry_delay_seconds: A new number of seconds to wait before retrying the
                 task after failure. This is only applicable if `retries` is nonzero.
+            persist_result: A new option for enabling or disabling result persistence.
+            result_storage: A new storage type to use for results.
+            result_serializer: A new serializer to use for results.
 
         Returns:
             A new `Task` instance.
@@ -244,6 +268,17 @@ class Task(Generic[P, R]):
             cache_expiration=cache_expiration or self.cache_expiration,
             retries=retries or self.retries,
             retry_delay_seconds=retry_delay_seconds or self.retry_delay_seconds,
+            persist_result=(
+                persist_result if persist_result is not NotSet else self.persist_result
+            ),
+            result_storage=(
+                result_storage if result_storage is not NotSet else self.persist_result
+            ),
+            result_serializer=(
+                result_serializer
+                if result_serializer is not NotSet
+                else self.persist_result
+            ),
         )
 
     @overload
@@ -685,6 +720,9 @@ def task(
     cache_expiration: datetime.timedelta = None,
     retries: int = 0,
     retry_delay_seconds: Union[float, int] = 0,
+    persist_result: Optional[bool] = None,
+    result_storage: ResultStorage = None,
+    result_serializer: ResultSerializer = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 
@@ -700,6 +738,9 @@ def task(
     cache_expiration: datetime.timedelta = None,
     retries: int = 0,
     retry_delay_seconds: Union[float, int] = 0,
+    persist_result: Optional[bool] = None,
+    result_storage: ResultStorage = None,
+    result_serializer: ResultSerializer = None,
 ):
     """
     Decorator to designate a function as a task in a Prefect workflow.
@@ -723,6 +764,15 @@ def task(
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero.
+        persist_result: An optional toggle indiciating if the result of this task
+            should be persisted to result storage. Defaults to `None` which indicates
+            that Prefect should choose if the result should be persisted depending on
+            the features being used.
+        result_storage: An optional block to use to perist the result of this task.
+            Defaults to the value set in the flow the task is called in.
+        result_serializer: An optional serializer to use to serialize the result of this
+            task for persistence. Defaults to the value set in the flow the task is
+            called in.
 
     Returns:
         A callable `Task` object which, when called, will submit the task for execution.
@@ -785,6 +835,9 @@ def task(
                 cache_expiration=cache_expiration,
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
+                persist_result=persist_result,
+                result_storage=result_storage,
+                result_serializer=result_serializer,
             ),
         )
     else:
@@ -800,5 +853,8 @@ def task(
                 cache_expiration=cache_expiration,
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
+                persist_result=persist_result,
+                result_storage=result_storage,
+                result_serializer=result_serializer,
             ),
         )

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -136,8 +136,8 @@ class Task(Generic[P, R]):
         retries: int = 0,
         retry_delay_seconds: Union[float, int] = 0,
         persist_result: Optional[bool] = None,
-        result_storage: ResultStorage = None,
-        result_serializer: ResultSerializer = None,
+        result_storage: Optional[ResultStorage] = None,
+        result_serializer: Optional[ResultSerializer] = None,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -202,8 +202,8 @@ class Task(Generic[P, R]):
         retries: int = 0,
         retry_delay_seconds: Union[float, int] = 0,
         persist_result: Optional[bool] = NotSet,
-        result_storage: ResultStorage = NotSet,
-        result_serializer: ResultSerializer = NotSet,
+        result_storage: Optional[ResultStorage] = NotSet,
+        result_serializer: Optional[ResultSerializer] = NotSet,
     ):
         """
         Create a new task from the current object, updating provided options.
@@ -721,8 +721,8 @@ def task(
     retries: int = 0,
     retry_delay_seconds: Union[float, int] = 0,
     persist_result: Optional[bool] = None,
-    result_storage: ResultStorage = None,
-    result_serializer: ResultSerializer = None,
+    result_storage: Optional[ResultStorage] = None,
+    result_serializer: Optional[ResultSerializer] = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 
@@ -739,8 +739,8 @@ def task(
     retries: int = 0,
     retry_delay_seconds: Union[float, int] = 0,
     persist_result: Optional[bool] = None,
-    result_storage: ResultStorage = None,
-    result_serializer: ResultSerializer = None,
+    result_storage: Optional[ResultStorage] = None,
+    result_serializer: Optional[ResultSerializer] = None,
 ):
     """
     Decorator to designate a function as a task in a Prefect workflow.

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -109,11 +109,11 @@ class Task(Generic[P, R]):
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero.
-        persist_result: An optional toggle indiciating if the result of this task
-            should be persisted to result storage. Defaults to `None` which indicates
-            that Prefect should choose if the result should be persisted depending on
+        persist_result: An optional toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `None`, which indicates
+            that Prefect should choose whether the result should be persisted depending on
             the features being used.
-        result_storage: An optional block to use to perist the result of this task.
+        result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
@@ -764,11 +764,11 @@ def task(
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: An optional number of seconds to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero.
-        persist_result: An optional toggle indiciating if the result of this task
-            should be persisted to result storage. Defaults to `None` which indicates
-            that Prefect should choose if the result should be persisted depending on
+        persist_result: An optional toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `None`, which indicates
+            that Prefect should choose whether the result should be persisted depending on
             the features being used.
-        result_storage: An optional block to use to perist the result of this task.
+        result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -40,3 +40,9 @@ def quote(expr: T) -> Quote[T]:
         1
     """
     return Quote(expr)
+
+
+class NotSet:
+    """
+    Singleton to distinguish `None` from a value that is not provided by the user.
+    """

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -40,3 +40,11 @@ def quote(expr: T) -> Quote[T]:
         1
     """
     return Quote(expr)
+
+
+class Auto:
+    pass
+
+
+def auto():
+    return Auto

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -40,11 +40,3 @@ def quote(expr: T) -> Quote[T]:
         1
     """
     return Quote(expr)
-
-
-class Auto:
-    pass
-
-
-def auto():
-    return Auto

--- a/src/prefect/utilities/pydantic.py
+++ b/src/prefect/utilities/pydantic.py
@@ -222,8 +222,10 @@ class PartialModel(Generic[M]):
         self.fields[__name] = __value
 
     def __repr__(self) -> str:
-        dsp_fields = ", ".join(f"{key}={repr(value)}" for key, value in self.fields)
-        return f"PartialModel({self.model_cls.__name__}{dsp_fields})"
+        dsp_fields = ", ".join(
+            f"{key}={repr(value)}" for key, value in self.fields.items()
+        )
+        return f"PartialModel(cls={self.model_cls.__name__}, {dsp_fields})"
 
 
 class JsonPatch(JsonPatchBase):

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -21,7 +21,6 @@ from prefect.client.schemas import OrchestrationResult, Pending, Running, Schedu
 from prefect.deprecated.data_documents import DataDocument
 from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
-from prefect.orion.orchestration.rules import OrchestrationResult
 from prefect.orion.schemas.actions import LogCreate
 from prefect.orion.schemas.filters import LogFilter, LogFilterFlowRunId
 from prefect.orion.schemas.schedules import IntervalSchedule

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from prefect import flow
 from prefect.context import get_run_context
 from prefect.filesystems import LocalFileSystem
@@ -34,7 +36,20 @@ def test_root_flow_default_result_settings():
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("toggle", [True, False])
+def test_root_flow_custom_persist_setting(toggle):
+    @flow(persist_result=toggle)
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result is toggle
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
@@ -46,7 +61,7 @@ def test_root_flow_custom_serializer_by_type_string():
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
@@ -58,7 +73,7 @@ def test_root_flow_custom_serializer_by_instance():
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer(jsonlib="orjson")
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
@@ -73,7 +88,7 @@ def test_root_flow_custom_storage_by_slug(tmp_path):
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert result_factory.storage_block == storage
     assert result_factory.storage_block_id == storage_id
@@ -88,7 +103,7 @@ def test_root_flow_custom_storage_by_instance_presaved(tmp_path):
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert result_factory.storage_block == storage
     assert result_factory.storage_block._is_anonymous is False
@@ -103,13 +118,187 @@ async def test_root_flow_custom_storage_by_instance_unsaved(orion_client, tmp_pa
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result == False
+    assert result_factory.persist_result is False
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert result_factory.storage_block == storage
     assert result_factory.storage_block._is_anonymous is True
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
 
+    # Check that the block is matching in the API
     storage_block_document = await orion_client.read_block_document(
         result_factory.storage_block_id
     )
     assert LocalFileSystem._from_block_document(storage_block_document) == storage
+
+
+def test_child_flow_inherits_default_result_settings():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow
+    def bar():
+        return get_run_context().result_factory
+
+    _, child_factory = foo()
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+def test_child_flow_custom_persist_setting():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(persist_result=True)
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert parent_factory.persist_result is False
+    assert child_factory.persist_result is True
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("options", [{"retries": 3}])
+def test_child_flow_persists_result_when_parent_uses_feature(options):
+    @flow(**options)
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert parent_factory.persist_result is False
+    assert child_factory.persist_result is True
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature():
+    @flow(retries=3)
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(persist_result=False)
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert parent_factory.persist_result is False
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+def test_child_flow_inherits_custom_serializer():
+    @flow(result_serializer="json")
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow()
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == parent_factory.serializer
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+def test_child_flow_inherits_custom_storage(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow(result_storage="local-file-system/test")
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert child_factory.storage_block == parent_factory.storage_block
+    assert child_factory.storage_block_id == storage_id
+
+
+def test_child_flow_custom_serializer():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_serializer="json")
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert parent_factory.serializer == DEFAULT_SERIALIZER()
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == JSONSerializer()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+def test_child_flow_custom_storage(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow()
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_storage="local-file-system/test")
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+    assert_blocks_equal(parent_factory.storage_block, DEFAULT_STORAGE())
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert child_factory.storage_block == storage
+    assert child_factory.storage_block_id == storage_id
+
+
+async def test_child_flow_custom_storage_by_instance_unsaved(orion_client, tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow()
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_storage=storage)
+    def bar():
+        return get_run_context().result_factory
+
+    parent_factory, child_factory = foo()
+
+    # The parent should be unchanged
+    assert_blocks_equal(parent_factory.storage_block, DEFAULT_STORAGE())
+    assert parent_factory.storage_block_id != child_factory.storage_block_id
+
+    # The child should have a saved custom storage
+    assert child_factory.storage_block == storage
+    assert child_factory.storage_block._is_anonymous is True
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+    # Check that the block is matching in the API
+    storage_block_document = await orion_client.read_block_document(
+        child_factory.storage_block_id
+    )
+    assert LocalFileSystem._from_block_document(storage_block_document) == storage
+
+    # Other settings should not be changed
+    assert child_factory.persist_result is False
+    assert child_factory.serializer == DEFAULT_SERIALIZER()

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -1,0 +1,115 @@
+import uuid
+
+from prefect import flow
+from prefect.context import get_run_context
+from prefect.filesystems import LocalFileSystem
+from prefect.serializers import JSONSerializer, PickleSerializer
+from prefect.settings import PREFECT_LOCAL_STORAGE_PATH
+
+DEFAULT_SERIALIZER = PickleSerializer
+DEFAULT_STORAGE = lambda: LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
+
+
+def assert_blocks_equal(
+    found, expected, exclude_private: bool = True, **kwargs
+) -> bool:
+    assert isinstance(
+        found, type(expected)
+    ), f"Unexpected type {type(found).__name__}, expected {type(expected).__name__}"
+
+    if exclude_private:
+        exclude = set(kwargs.pop("exclude", set()))
+        for attr, _ in found._iter():
+            if attr.startswith("_"):
+                exclude.add(attr)
+
+    assert found.dict(exclude=exclude, **kwargs) == expected.dict(
+        exclude=exclude, **kwargs
+    )
+
+
+def test_root_flow_default_result_settings():
+    @flow
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+
+def test_root_flow_custom_serializer_by_type_string():
+    @flow(result_serializer="json")
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == JSONSerializer()
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+
+def test_root_flow_custom_serializer_by_instance():
+    @flow(result_serializer=JSONSerializer(jsonlib="orjson"))
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == JSONSerializer(jsonlib="orjson")
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+
+def test_root_flow_custom_storage_by_slug(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow(result_storage="local-file-system/test")
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert result_factory.storage_block == storage
+    assert result_factory.storage_block_id == storage_id
+
+
+def test_root_flow_custom_storage_by_instance_presaved(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow(result_storage=storage)
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert result_factory.storage_block == storage
+    assert result_factory.storage_block._is_anonymous is False
+    assert result_factory.storage_block_id == storage_id
+
+
+async def test_root_flow_custom_storage_by_instance_unsaved(orion_client, tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow(result_storage=storage)
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    assert result_factory.persist_result == False
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert result_factory.storage_block == storage
+    assert result_factory.storage_block._is_anonymous is True
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+    storage_block_document = await orion_client.read_block_document(
+        result_factory.storage_block_id
+    )
+    assert LocalFileSystem._from_block_document(storage_block_document) == storage

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -1,0 +1,221 @@
+import uuid
+
+import pytest
+
+from prefect import flow, task
+from prefect.context import get_run_context
+from prefect.filesystems import LocalFileSystem
+from prefect.serializers import JSONSerializer, PickleSerializer
+from prefect.settings import PREFECT_LOCAL_STORAGE_PATH
+
+DEFAULT_SERIALIZER = PickleSerializer
+DEFAULT_STORAGE = lambda: LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
+
+
+def assert_blocks_equal(
+    found, expected, exclude_private: bool = True, **kwargs
+) -> bool:
+    assert isinstance(
+        found, type(expected)
+    ), f"Unexpected type {type(found).__name__}, expected {type(expected).__name__}"
+
+    if exclude_private:
+        exclude = set(kwargs.pop("exclude", set()))
+        for attr, _ in found._iter():
+            if attr.startswith("_"):
+                exclude.add(attr)
+
+    assert found.dict(exclude=exclude, **kwargs) == expected.dict(
+        exclude=exclude, **kwargs
+    )
+
+
+def test_task_inherits_default_result_settings():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @task
+    def bar():
+        return get_run_context().result_factory
+
+    _, task_factory = foo()
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+def test_task_custom_persist_setting():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(persist_result=True)
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert flow_factory.persist_result is False
+    assert task_factory.persist_result is True
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("options", [{"retries": 3}])
+def test_task_persists_result_when_flow_uses_feature(options):
+    @flow(**options)
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @task
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert flow_factory.persist_result is False
+    assert task_factory.persist_result is True
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("options", [{"cache_key_fn": lambda *_: "foo"}])
+def test_task_persists_result_when_task_uses_feature(options):
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @task(**options)
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert flow_factory.persist_result is False
+    assert task_factory.persist_result is True
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature():
+    @flow(retries=3)
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(persist_result=False)
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert flow_factory.persist_result is False
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+def test_task_inherits_custom_serializer():
+    @flow(result_serializer="json")
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow()
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == flow_factory.serializer
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+def test_task_inherits_custom_storage(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow(result_storage="local-file-system/test")
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @task
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert task_factory.storage_block == flow_factory.storage_block
+    assert task_factory.storage_block_id == storage_id
+
+
+def test_task_custom_serializer():
+    @flow
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_serializer="json")
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert flow_factory.serializer == DEFAULT_SERIALIZER()
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == JSONSerializer()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+def test_task_custom_storage(tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+    storage_id = storage.save("test")
+
+    @flow()
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_storage="local-file-system/test")
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+    assert_blocks_equal(flow_factory.storage_block, DEFAULT_STORAGE())
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert task_factory.storage_block == storage
+    assert task_factory.storage_block_id == storage_id
+
+
+async def test_task_custom_storage_by_instance_unsaved(orion_client, tmp_path):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow()
+    def foo():
+        return get_run_context().result_factory, bar()
+
+    @flow(result_storage=storage)
+    def bar():
+        return get_run_context().result_factory
+
+    flow_factory, task_factory = foo()
+
+    # The flow should be unchanged
+    assert_blocks_equal(flow_factory.storage_block, DEFAULT_STORAGE())
+    assert flow_factory.storage_block_id != task_factory.storage_block_id
+
+    # The child should have a saved custom storage
+    assert task_factory.storage_block == storage
+    assert task_factory.storage_block._is_anonymous is True
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+    # Check that the block is matching in the API
+    storage_block_document = await orion_client.read_block_document(
+        task_factory.storage_block_id
+    )
+    assert LocalFileSystem._from_block_document(storage_block_document) == storage
+
+    # Other settings should not be changed
+    assert task_factory.persist_result is False
+    assert task_factory.serializer == DEFAULT_SERIALIZER()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -925,11 +925,10 @@ async def test_run_logger_with_explicit_context(
         pass
 
     task_run = await orion_client.create_task_run(foo, flow_run.id, dynamic_key="")
-    context = TaskRunContext(
+    context = TaskRunContext.construct(
         task=foo,
         task_run=task_run,
         client=orion_client,
-        result_filesystem=local_filesystem,
     )
 
     logger = get_run_logger(context)
@@ -958,11 +957,10 @@ async def test_run_logger_with_explicit_context_overrides_existing(
 
     task_run = await orion_client.create_task_run(foo, flow_run.id, dynamic_key="")
     # Use `bar` instead of `foo` in context
-    context = TaskRunContext(
+    context = TaskRunContext.construct(
         task=bar,
         task_run=task_run,
         client=orion_client,
-        result_filesystem=local_filesystem,
     )
 
     logger = get_run_logger(context)

--- a/tests/utilities/test_pydantic.py
+++ b/tests/utilities/test_pydantic.py
@@ -76,6 +76,10 @@ class TestPartialModel:
         assert isinstance(m, SimplePydantic)
         assert m == SimplePydantic(x=1, y=2)
 
+    def test_repr(self):
+        p = PartialModel(SimplePydantic, x=1, y=2)
+        assert repr(p) == "PartialModel(cls=SimplePydantic, x=1, y=2)"
+
     def test_init_with_invalid_field(self):
         with pytest.raises(ValueError, match="Field 'z' is not present in the model"):
             PartialModel(SimplePydantic, x=1, z=2)


### PR DESCRIPTION
Changes:
- Extensive documentation of user experience for configuration of results; see [the preview](https://deploy-preview-7004--prefect-orion.netlify.app/concepts/results/#persisting-results)
- Adds `result_serializer`, `persist_result`, `result_storage` to `Flow` and `Task` interfaces
- Adds `ResultFactory` utility to determine the result settings to be used
- Adds `ResultFactory` to flow and task run contexts
- Insantiates and passes result factories in the engine

This does not:
- Implement result types or creation in the factory
- Replace existing result mechanisms

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

See documentation for examples.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
