### PR TITLE
Move block protection to be called with auto-registration

### DIFF
--- a/src/prefect/orion/api/block_types.py
+++ b/src/prefect/orion/api/block_types.py
@@ -5,7 +5,6 @@ import sqlalchemy as sa
 from fastapi import Body, Depends, HTTPException, Path, Query, status
 from packaging.version import Version
 
-import prefect
 from prefect.orion import models, schemas
 from prefect.orion.api import dependencies
 from prefect.orion.database.dependencies import provide_database_interface

--- a/src/prefect/orion/api/block_types.py
+++ b/src/prefect/orion/api/block_types.py
@@ -211,5 +211,7 @@ async def read_block_document_by_name_for_block_type(
 async def install_system_block_types(
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
-    async with db.session_context(begin_transaction=True) as session:
+    # Don't begin a transaction. _install_protected_system_blocks will manage
+    # the transactions.
+    async with db.session_context(begin_transaction=False) as session:
         await models.block_registration._install_protected_system_blocks(session)

--- a/src/prefect/orion/api/block_types.py
+++ b/src/prefect/orion/api/block_types.py
@@ -116,9 +116,6 @@ async def update_block_type(
     Update a block type.
     """
     async with db.session_context(begin_transaction=True) as session:
-        # ensure system blocks are protected before update
-        await install_protected_system_blocks(session)
-
         db_block_type = await models.block_types.read_block_type(
             session=session, block_type_id=block_type_id
         )
@@ -143,9 +140,6 @@ async def delete_block_type(
     api_version=Depends(dependencies.provide_request_api_version),
 ):
     async with db.session_context(begin_transaction=True) as session:
-        # ensure system blocks are protected before update
-        await install_protected_system_blocks(session)
-
         db_block_type = await models.block_types.read_block_type(
             session=session, block_type_id=block_type_id
         )
@@ -214,31 +208,9 @@ async def read_block_document_by_name_for_block_type(
     return block_document
 
 
-async def install_protected_system_blocks(session):
-    """Install block types that the system expects to be present"""
-    for block in [
-        prefect.blocks.system.JSON,
-        prefect.blocks.system.DateTime,
-        prefect.blocks.system.Secret,
-        prefect.filesystems.LocalFileSystem,
-        prefect.infrastructure.Process,
-    ]:
-        block_type = block._to_block_type()
-        block_type.is_protected = True
-
-        block_type = await models.block_types.create_block_type(
-            session=session, block_type=block_type, override=True
-        )
-        block_schema = await models.block_schemas.create_block_schema(
-            session=session,
-            block_schema=block._to_block_schema(block_type_id=block_type.id),
-            override=True,
-        )
-
-
 @router.post("/install_system_block_types")
 async def install_system_block_types(
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     async with db.session_context(begin_transaction=True) as session:
-        await install_protected_system_blocks(session)
+        await models.block_registration._install_protected_system_blocks(session)

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -5,6 +5,7 @@ import pytest
 from prefect.blocks import system
 from prefect.client import OrionClient
 from prefect.exceptions import ObjectNotFound
+from prefect.orion import models
 from prefect.settings import PREFECT_ORION_BLOCKS_REGISTER_ON_START, temporary_settings
 from prefect.testing.cli import invoke_and_assert
 
@@ -20,6 +21,13 @@ from prefect.blocks.core import Bloc
 class TestForFileRegister(Block):
     message: str
 """
+
+
+@pytest.fixture
+async def install_system_block_types(session):
+    return await models.block_registration._install_protected_system_blocks(
+        session=session
+    )
 
 
 def test_register_blocks_from_module():
@@ -276,13 +284,9 @@ def test_deleting_a_block_type(tmp_path, orion_client):
         )
 
 
-def test_deleting_a_protected_block_type(tmp_path, orion_client):
-    invoke_and_assert(
-        ["block", "register", "-m", "prefect.blocks.system"],
-        expected_code=0,
-        expected_output_contains=["Successfully registered", "blocks"],
-    )
-
+def test_deleting_a_protected_block_type(
+    tmp_path, orion_client, install_system_block_types
+):
     expected_output = "is a protected block"
 
     invoke_and_assert(

--- a/tests/orion/api/test_block_types.py
+++ b/tests/orion/api/test_block_types.py
@@ -376,22 +376,6 @@ class TestUpdateBlockType:
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    async def test_update_block_type_ensures_system_blocks_are_protected(
-        self, client, system_block_type, monkeypatch
-    ):
-        mock_block_protection = AsyncMock()
-        monkeypatch.setattr(
-            "prefect.orion.api.block_types.install_protected_system_blocks",
-            mock_block_protection,
-        )
-        await client.patch(
-            f"/block_types/{system_block_type.id}",
-            json=BlockTypeUpdate(
-                description="Hi there!",
-            ).dict(json_compatible=True),
-        )
-        mock_block_protection.assert_called()
-
 
 class TestDeleteBlockType:
     async def test_delete_block_type(self, client, block_type_x):
@@ -417,17 +401,6 @@ class TestDeleteBlockType:
             f"/block_types/{system_block_type.id}"
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    async def test_dete_block_type_ensures_system_blocks_are_protected(
-        self, client, system_block_type, monkeypatch
-    ):
-        mock_block_protection = AsyncMock()
-        monkeypatch.setattr(
-            "prefect.orion.api.block_types.install_protected_system_blocks",
-            mock_block_protection,
-        )
-        await client.delete(f"/block_types/{system_block_type.id}")
-        mock_block_protection.assert_called()
 
 
 class TestReadBlockDocumentsForBlockType:

--- a/tests/orion/api/test_block_types.py
+++ b/tests/orion/api/test_block_types.py
@@ -7,6 +7,7 @@ import pydantic
 import pytest
 from fastapi import status
 
+import prefect
 from prefect.blocks.core import Block
 from prefect.orion import models, schemas
 from prefect.orion.schemas.actions import BlockTypeCreate, BlockTypeUpdate

--- a/tests/orion/api/test_block_types.py
+++ b/tests/orion/api/test_block_types.py
@@ -7,12 +7,10 @@ import pydantic
 import pytest
 from fastapi import status
 
-import prefect
 from prefect.blocks.core import Block
 from prefect.orion import models, schemas
 from prefect.orion.schemas.actions import BlockTypeCreate, BlockTypeUpdate
 from prefect.orion.schemas.core import BlockDocument, BlockType
-from prefect.testing.utilities import AsyncMock
 from prefect.utilities.slugify import slugify
 from tests.orion.models.test_block_types import CODE_EXAMPLE
 

--- a/tests/orion/models/test_block_registration.py
+++ b/tests/orion/models/test_block_registration.py
@@ -65,6 +65,8 @@ class TestRunAutoRegistration:
             await session.commit()
 
             registered_blocks = await read_block_types(session)
+
+            # this assertion assumes that users cannot protect blocks manually
             assert len(registered_blocks) == expected_number_of_registered_block_types
 
 

--- a/tests/orion/models/test_block_registration.py
+++ b/tests/orion/models/test_block_registration.py
@@ -31,6 +31,14 @@ class TestRunAutoRegistration:
     async def test_full_registration_with_empty_database(
         self, session, expected_number_of_registered_block_types
     ):
+        PROTECTED_BLOCKS = {
+            "json",
+            "date-time",
+            "secret",
+            "local-file-system",
+            "process",
+        }
+
         starting_block_types = await read_block_types(session)
         assert len(starting_block_types) == 0
         await session.commit()
@@ -40,6 +48,14 @@ class TestRunAutoRegistration:
 
         registered_blocks = await read_block_types(session)
         assert len(registered_blocks) == expected_number_of_registered_block_types
+
+        registered_block_slugs = {b.slug for b in registered_blocks}
+        assert PROTECTED_BLOCKS.issubset(
+            registered_block_slugs
+        ), "When changing protected blocks, edit PROTECTED_BLOCKS defined above"
+        assert sum(b.is_protected for b in registered_blocks) == len(
+            PROTECTED_BLOCKS
+        ), "When changing protected blocks, edit PROTECTED_BLOCKS defined above"
 
     async def test_registration_works_with_populated_database(
         self, session, expected_number_of_registered_block_types


### PR DESCRIPTION
Ensuring that all system blocks are protected was previously the responsibility of destructive routes. This was happening too often, causing slowdowns in some cases. Here we move block protection to auto-registration so this update should happen much less frequently.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
