### PR TITLE
Update `sync_compatible` handling of wrapped async functions and generators

### DIFF
--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -2,7 +2,8 @@ import asyncio
 import threading
 import time
 import uuid
-from functools import partial
+from contextlib import asynccontextmanager, contextmanager
+from functools import partial, wraps
 
 import anyio
 import pytest
@@ -14,12 +15,101 @@ from prefect.utilities.asyncutils import (
     gather,
     in_async_main_thread,
     in_async_worker_thread,
+    is_async_fn,
+    is_async_gen_fn,
     run_async_from_worker_thread,
     run_async_in_new_loop,
     run_sync_in_interruptible_worker_thread,
     run_sync_in_worker_thread,
     sync_compatible,
 )
+
+
+def test_is_async_fn_sync():
+    def foo():
+        pass
+
+    assert not is_async_fn(foo)
+
+
+def test_is_async_fn_lambda():
+    assert not is_async_fn(lambda: True)
+
+
+def test_is_async_fn_sync_context_manager():
+    @contextmanager
+    def foo():
+        pass
+
+    assert not is_async_fn(foo)
+
+
+def test_is_async_fn_async():
+    async def foo():
+        pass
+
+    assert is_async_fn(foo)
+
+
+def test_is_async_fn_async_decorated_with_sync():
+    def wrapper(fn):
+        @wraps(fn)
+        def inner():
+            return fn()
+
+        return inner
+
+    @wrapper
+    async def foo():
+        pass
+
+    assert is_async_fn(foo)
+
+
+def test_is_async_fn_async_decorated_with_asyncontextmanager():
+    @asynccontextmanager
+    async def foo():
+        yield False
+
+    assert not is_async_fn(foo)
+
+
+def test_is_async_gen_fn_async_decorated_with_asyncontextmanager():
+    @asynccontextmanager
+    async def foo():
+        yield True
+
+    assert is_async_gen_fn(foo)
+
+
+def test_is_async_gen_fn_async_decorated_with_asyncontextmanager():
+    @asynccontextmanager
+    async def foo():
+        yield True
+
+    assert is_async_gen_fn(foo)
+
+
+def test_is_async_gen_fn_sync_decorated_with_contextmanager():
+    @contextmanager
+    def foo():
+        yield True
+
+    assert not is_async_gen_fn(foo)
+
+
+def test_is_async_gen_fn_async_that_returns():
+    async def foo():
+        return False
+
+    assert not is_async_gen_fn(foo)
+
+
+def test_is_async_gen_fn_async_that_yields():
+    async def foo():
+        yield True
+
+    assert is_async_gen_fn(foo)
 
 
 def test_in_async_main_thread_sync():
@@ -247,6 +337,15 @@ def test_sync_compatible_requires_async_function():
         @sync_compatible
         def foo():
             pass
+
+
+def test_sync_compatible_with_async_context_manager():
+    with pytest.raises(ValueError, match="Async generators cannot yet be marked"):
+
+        @sync_compatible
+        @asynccontextmanager
+        async def foo():
+            yield "bar"
 
 
 def test_add_event_loop_shutdown_callback_is_called_with_asyncio_run():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

While investigating https://github.com/PrefectHQ/prefect-dask/pull/33 two issues were found with `sync_compatible`.

1. It does not recognize async functions wrapped by sync decorators
2. Async generators are not detected as async by `iscoroutinefn` / `is_async_fn`

These were fixed by:

1. Updating `sync_compatible` to call `is_async_fn`
2. Updating `is_async_fn` to unwrap functions
3. Adding `is_async_gen_fn` to detect async generators

I briefly explored adding support to `sync_compatible` for async generators. I'm not actually sure it's possible. I've done some minor refactoring to allow us to do so in the future, but for now we will not allow it. The error message is clearer now, at least.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
async def foo():
   yield True

async def bar():
   return True

is_async_fn(foo)  # False
is_async_fn(bar)  # True

# New utility
is_async_gen_fn(foo)  # True
is_async_gen_fn(bar)  # False


# Support for wrappers that define a sync function
def wrapper(fn):
    @wraps(fn)
    def inner():
        return fn()

    return inner

@wrapper
async def foo():
    return True

is_async_fn(foo) # True (previously False)

sync_compatible(foo)  # Works (previously errored)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~[ ] This pull request references any related issue by including "closes `<link to issue>`"~
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
