### PR TITLE
Add capacity limiter to ConcurrentTaskRunner

### DIFF
--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -1,8 +1,11 @@
+import time
 import pytest
+import anyio
 
 # Import the local 'tests' module to pickle to ray workers
 from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
 from prefect.testing.standard_test_suites import TaskRunnerStandardTestSuite
+from prefect import task, flow
 
 
 @pytest.fixture
@@ -21,7 +24,6 @@ async def test_task_runner_cannot_be_started_while_running():
             async with task_runner.start():
                 pass
 
-
 class TestSequentialTaskRunner(TaskRunnerStandardTestSuite):
     @pytest.fixture
     def task_runner(self):
@@ -32,3 +34,55 @@ class TestConcurrentTaskRunner(TaskRunnerStandardTestSuite):
     @pytest.fixture
     def task_runner(self):
         yield ConcurrentTaskRunner()
+
+class TestConcurrentTaskRunnerLimitedThreads(TaskRunnerStandardTestSuite):
+    @pytest.fixture
+    def task_runner(self):
+        yield ConcurrentTaskRunner(max_workers=3)
+
+class TestConcurrentTaskRunnerSingleThreaded(TaskRunnerStandardTestSuite):
+    @pytest.fixture
+    def task_runner(self):
+        yield ConcurrentTaskRunner(max_workers=1)
+
+    def test_sync_tasks_run_sequentially_with_single_thread(
+        self, task_runner, tmp_file
+    ):
+        @task
+        def foo():
+            time.sleep(self.get_sleep_time())
+            tmp_file.write_text("foo")
+
+        @task
+        def bar():
+            tmp_file.write_text("bar")
+
+        @flow(version="test", task_runner=task_runner)
+        def test_flow():
+            foo()
+            bar()
+
+        test_flow()
+
+        assert tmp_file.read_text() == "bar"
+
+    async def test_async_tasks_run_sequentially_with_single_thread(
+        self, task_runner, tmp_file
+    ):
+        @task
+        async def foo():
+            await anyio.sleep(self.get_sleep_time())
+            tmp_file.write_text("foo")
+
+        @task
+        async def bar():
+            tmp_file.write_text("bar")
+
+        @flow(version="test", task_runner=task_runner)
+        async def test_flow():
+            await foo.submit()
+            await bar.submit()
+
+        await test_flow()
+
+        assert tmp_file.read_text() == "bar"

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -1,11 +1,8 @@
-import time
 import pytest
-import anyio
 
 # Import the local 'tests' module to pickle to ray workers
-from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
+from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner, TaskConcurrencyType
 from prefect.testing.standard_test_suites import TaskRunnerStandardTestSuite
-from prefect import task, flow
 
 
 @pytest.fixture
@@ -43,46 +40,6 @@ class TestConcurrentTaskRunnerLimitedThreads(TaskRunnerStandardTestSuite):
 class TestConcurrentTaskRunnerSingleThreaded(TaskRunnerStandardTestSuite):
     @pytest.fixture
     def task_runner(self):
-        yield ConcurrentTaskRunner(max_workers=1)
-
-    def test_sync_tasks_run_sequentially_with_single_thread(
-        self, task_runner, tmp_file
-    ):
-        @task
-        def foo():
-            time.sleep(self.get_sleep_time())
-            tmp_file.write_text("foo")
-
-        @task
-        def bar():
-            tmp_file.write_text("bar")
-
-        @flow(version="test", task_runner=task_runner)
-        def test_flow():
-            foo()
-            bar()
-
-        test_flow()
-
-        assert tmp_file.read_text() == "bar"
-
-    async def test_async_tasks_run_sequentially_with_single_thread(
-        self, task_runner, tmp_file
-    ):
-        @task
-        async def foo():
-            await anyio.sleep(self.get_sleep_time())
-            tmp_file.write_text("foo")
-
-        @task
-        async def bar():
-            tmp_file.write_text("bar")
-
-        @flow(version="test", task_runner=task_runner)
-        async def test_flow():
-            await foo.submit()
-            await bar.submit()
-
-        await test_flow()
-
-        assert tmp_file.read_text() == "bar"
+        runner = ConcurrentTaskRunner(max_workers=1)
+        runner.concurrency_type = TaskConcurrencyType.SEQUENTIAL
+        yield runner


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Adds a CapacityLimiter to the ConcurrentTaskRunner to limit the number of concurrent threads. This is helpful for flows that would otherwise spawn hundreds of threads.

### Example

```
from prefect.task_runners import ConcurrentTaskRunner

@flow(task_runner=ConcurrentTaskRunner(max_workers=10))
def example_flow():
    # Flow that runs with at most 10 threads ...
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
