### PR TITLE
Cut release notes for 2.4.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@
 ### Fixes
 - Fix login to private Docker registries — https://github.com/PrefectHQ/prefect/pull/6889
 - Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
-- Protected block compatibility — https://github.com/PrefectHQ/prefect/pull/6986
+- Fix compatibility for protected blocks when client/server versions are mismatched — https://github.com/PrefectHQ/prefect/pull/6986
 - Ensure python-slugify is always used — https://github.com/PrefectHQ/prefect/pull/6955
 - Fix configuration caching — https://github.com/PrefectHQ/prefect/pull/7003
 - Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ### Collections
 - New [`prefect-hex` collection](https://prefecthq.github.io/prefect-hex/) — https://github.com/PrefectHQ/prefect/pull/6974
+- New [`CloudRunJob` infrastructure block](https://prefecthq.github.io/prefect-gcp/cloud_run/) in `prefect-gcp` — https://github.com/PrefectHQ/prefect-gcp/pull/48
 
 ### Contributors
 * @Hongbo-Miao made their first contribution in https://github.com/PrefectHQ/prefect/pull/6956

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 - Raise a `MissingContextError` when `get_run_logger` is called outside a run context — https://github.com/PrefectHQ/prefect/pull/6980
 - Cache configuration lookups — https://github.com/PrefectHQ/prefect/pull/6959
 - Move `quote` to `prefect.utilities.annotations` — https://github.com/PrefectHQ/prefect/pull/6993
-- Add state filters and sort-by to the work-queue, flow and deployment … — https://github.com/PrefectHQ/prefect/pull/6985
+- Add state filters and sort-by to the work-queue, flow and deployment pages — https://github.com/PrefectHQ/prefect/pull/6985
 
 ### Fixes
 - Fix login to private Docker registries — https://github.com/PrefectHQ/prefect/pull/6889

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,36 @@
 # Prefect Release Notes
 
+## Release 2.4.3
+
+### Enhancements
+- Warn if user tries to login with API key from Cloud 1 — https://github.com/PrefectHQ/prefect/pull/6958
+- Remove single subheading example from main index page — https://github.com/PrefectHQ/prefect/pull/6972
+- Improve concurrent task runner performance — https://github.com/PrefectHQ/prefect/pull/6948
+- Raise a `MissingContextError` when `get_run_logger` is called outside a run context — https://github.com/PrefectHQ/prefect/pull/6980
+- Cache configuration lookups — https://github.com/PrefectHQ/prefect/pull/6959
+- Move `quote` to `prefect.utilities.annotations` — https://github.com/PrefectHQ/prefect/pull/6993
+- Add state filters and sort-by to the work-queue, flow and deployment … — https://github.com/PrefectHQ/prefect/pull/6985
+
+### Fixes
+- Fix login to private Docker registries — https://github.com/PrefectHQ/prefect/pull/6889
+- Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
+- Protected block compatibility — https://github.com/PrefectHQ/prefect/pull/6986
+- Ensure python-slugify is always used — https://github.com/PrefectHQ/prefect/pull/6955
+- Fix configuration caching — https://github.com/PrefectHQ/prefect/pull/7003
+- Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008
+
+### Documentation
+- Update docs regarding schedules and the CLI — https://github.com/PrefectHQ/prefect/pull/6968
+- Fix deployment file name in the tutorial — https://github.com/PrefectHQ/prefect/pull/6956
+- Add results concept to documentation — https://github.com/PrefectHQ/prefect/pull/6992
+
+### Collections
+- Adds prefect hex to catalog — https://github.com/PrefectHQ/prefect/pull/6974
+
+### Contributors
+* @Hongbo-Miao made their first contribution in https://github.com/PrefectHQ/prefect/pull/6956
+* @hateyouinfinity made their first contribution in https://github.com/PrefectHQ/prefect/pull/6955
+
 ## Release 2.4.2
 
 ### Fixes

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,7 +6,7 @@
 - Warn if user tries to login with API key from Cloud 1 — https://github.com/PrefectHQ/prefect/pull/6958
 - Improve concurrent task runner performance — https://github.com/PrefectHQ/prefect/pull/6948
 - Raise a `MissingContextError` when `get_run_logger` is called outside a run context — https://github.com/PrefectHQ/prefect/pull/6980
-- Cache configuration lookups — https://github.com/PrefectHQ/prefect/pull/6959
+- Adding caching to API configuration lookups to improve performance — https://github.com/PrefectHQ/prefect/pull/6959
 - Move `quote` to `prefect.utilities.annotations` — https://github.com/PrefectHQ/prefect/pull/6993
 - Add state filters and sort-by to the work-queue, flow and deployment pages — https://github.com/PrefectHQ/prefect/pull/6985
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,7 +21,7 @@
 - Add results concept to documentation — https://github.com/PrefectHQ/prefect/pull/6992
 
 ### Collections
-- Adds prefect hex to catalog — https://github.com/PrefectHQ/prefect/pull/6974
+- New [`prefect-hex` collection](https://prefecthq.github.io/prefect-hex/) — https://github.com/PrefectHQ/prefect/pull/6974
 
 ### Contributors
 * @Hongbo-Miao made their first contribution in https://github.com/PrefectHQ/prefect/pull/6956

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,7 +19,6 @@
 
 ### Documentation
 - Update documentation for specifying schedules from the CLI — https://github.com/PrefectHQ/prefect/pull/6968
-- Fix deployment file name in the tutorial — https://github.com/PrefectHQ/prefect/pull/6956
 - Add results concept to documentation — https://github.com/PrefectHQ/prefect/pull/6992
 
 ### Collections

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,7 +15,6 @@
 - Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
 - Fix compatibility for protected blocks when client/server versions are mismatched — https://github.com/PrefectHQ/prefect/pull/6986
 - Ensure `python-slugify` is always used even if [unicode-slugify](https://github.com/mozilla/unicode-slugify) is installed — https://github.com/PrefectHQ/prefect/pull/6955
-- Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008
 
 ### Documentation
 - Update documentation for specifying schedules from the CLI — https://github.com/PrefectHQ/prefect/pull/6968

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,7 @@
 - Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008
 
 ### Documentation
-- Update docs regarding schedules and the CLI — https://github.com/PrefectHQ/prefect/pull/6968
+- Update documentation for specifying schedules from the CLI — https://github.com/PrefectHQ/prefect/pull/6968
 - Fix deployment file name in the tutorial — https://github.com/PrefectHQ/prefect/pull/6956
 - Add results concept to documentation — https://github.com/PrefectHQ/prefect/pull/6992
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,7 +15,6 @@
 - Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
 - Fix compatibility for protected blocks when client/server versions are mismatched — https://github.com/PrefectHQ/prefect/pull/6986
 - Ensure `python-slugify` is always used even if [unicode-slugify](https://github.com/mozilla/unicode-slugify) is installed — https://github.com/PrefectHQ/prefect/pull/6955
-- Fix configuration caching — https://github.com/PrefectHQ/prefect/pull/7003
 - Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008
 
 ### Documentation

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,7 +14,7 @@
 - Fix login to private Docker registries — https://github.com/PrefectHQ/prefect/pull/6889
 - Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
 - Fix compatibility for protected blocks when client/server versions are mismatched — https://github.com/PrefectHQ/prefect/pull/6986
-- Ensure python-slugify is always used — https://github.com/PrefectHQ/prefect/pull/6955
+- Ensure `python-slugify` is always used even if [unicode-slugify](https://github.com/mozilla/unicode-slugify) is installed — https://github.com/PrefectHQ/prefect/pull/6955
 - Fix configuration caching — https://github.com/PrefectHQ/prefect/pull/7003
 - Add block registration to models init — https://github.com/PrefectHQ/prefect/pull/7008
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,6 @@
 
 ### Enhancements
 - Warn if user tries to login with API key from Cloud 1 — https://github.com/PrefectHQ/prefect/pull/6958
-- Remove single subheading example from main index page — https://github.com/PrefectHQ/prefect/pull/6972
 - Improve concurrent task runner performance — https://github.com/PrefectHQ/prefect/pull/6948
 - Raise a `MissingContextError` when `get_run_logger` is called outside a run context — https://github.com/PrefectHQ/prefect/pull/6980
 - Cache configuration lookups — https://github.com/PrefectHQ/prefect/pull/6959


### PR DESCRIPTION
## Release 2.4.3

### Enhancements
- Warn if user tries to login with API key from Cloud 1 — https://github.com/PrefectHQ/prefect/pull/6958
- Improve concurrent task runner performance — https://github.com/PrefectHQ/prefect/pull/6948
- Raise a `MissingContextError` when `get_run_logger` is called outside a run context — https://github.com/PrefectHQ/prefect/pull/6980
- Adding caching to API configuration lookups to improve performance — https://github.com/PrefectHQ/prefect/pull/6959
- Move `quote` to `prefect.utilities.annotations` — https://github.com/PrefectHQ/prefect/pull/6993
- Add state filters and sort-by to the work-queue, flow and deployment pages — https://github.com/PrefectHQ/prefect/pull/6985

### Fixes
- Fix login to private Docker registries — https://github.com/PrefectHQ/prefect/pull/6889
- Update `Flow.with_options` to actually pass retry settings to new object — https://github.com/PrefectHQ/prefect/pull/6963
- Fix compatibility for protected blocks when client/server versions are mismatched — https://github.com/PrefectHQ/prefect/pull/6986
- Ensure `python-slugify` is always used even if [unicode-slugify](https://github.com/mozilla/unicode-slugify) is installed — https://github.com/PrefectHQ/prefect/pull/6955

### Documentation
- Update documentation for specifying schedules from the CLI — https://github.com/PrefectHQ/prefect/pull/6968
- Add results concept to documentation — https://github.com/PrefectHQ/prefect/pull/6992

### Collections
- New [`prefect-hex` collection](https://prefecthq.github.io/prefect-hex/) — https://github.com/PrefectHQ/prefect/pull/6974
- New [`CloudRunJob` infrastructure block](https://prefecthq.github.io/prefect-gcp/cloud_run/) in `prefect-gcp` — https://github.com/PrefectHQ/prefect-gcp/pull/48

### Contributors
* @Hongbo-Miao made their first contribution in https://github.com/PrefectHQ/prefect/pull/6956
* @hateyouinfinity made their first contribution in https://github.com/PrefectHQ/prefect/pull/6955