### PR TITLE
Hotfix: Disable block memoization

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Prefect Release Notes
 
+
+## Release 2.4.4
+
+### Fixes
+- Disable block memoization by default to workaround bug where block schemas cannot be saved — https://github.com/PrefectHQ/prefect/pull/7022
+
 ## Release 2.4.3
 
 ### Enhancements

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -330,7 +330,7 @@ PREFECT_MEMO_STORE_PATH = Setting(
 
 PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION = Setting(
     bool,
-    default=True,
+    default=False,
     description="""Controls whether or not block auto-registration on start 
     up should be memoized. Setting to False may result in slower server start
     up times.""",


### PR DESCRIPTION
Fixes bug noted in #7020 where memoization can cause block schemas to be unregisterable.