### PR TITLE
Hotfix: Disable block protection

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -87,7 +87,8 @@ jobs:
           - "2.1"
           - "2.2"
           - "2.3"
-          - "2.4"
+          - "2.4.2"
+          - "2.4.4"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
@@ -101,6 +102,8 @@ jobs:
           - prefect-version: "2.0"
             server-incompatible: true
           - prefect-version: "2.1"
+            server-incompatible: true
+          - prefect-version: "2.4.4"
             server-incompatible: true
 
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,11 +1,5 @@
 # Prefect Release Notes
 
-
-## Release 2.4.4
-
-### Fixes
-- Disable block memoization by default to workaround bug where block schemas cannot be saved — https://github.com/PrefectHQ/prefect/pull/7022
-
 ## Release 2.4.3
 
 ### Enhancements

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,14 @@
 # Prefect Release Notes
 
+## Release 2.4.5
+
+This release disables block protection. With block protection enabled, as in 2.4.3 and 2.4.4, client and server versions cannot be mismatched unless you are on a version before 2.4.0. Disabling block protection restores the ability for a client and server to have different version.
+
+Block protection was added in 2.4.1 to prevent users from deleting block types that are necessary for the system to function. With this change, you are able to delete block types that will cause your flow runs to fail. New safeguards that do not affect client/server compatibility will be added in the future.
+
 ## Release 2.4.3
+
+**When running a server with this version, the client must be the same version. This does not apply to clients connecting to Prefect Cloud.**
 
 ### Enhancements
 - Warn if user tries to login with API key from Cloud 1 — https://github.com/PrefectHQ/prefect/pull/6958

--- a/src/prefect/orion/api/block_types.py
+++ b/src/prefect/orion/api/block_types.py
@@ -16,9 +16,7 @@ LAST_UNPROTECTED_BLOCK_VERSION = Version("0.8.0")
 
 
 def api_handles_protected_blocks(api_version):
-    if api_version is None:
-        return True
-    return api_version > LAST_UNPROTECTED_BLOCK_VERSION
+    return False
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -330,7 +330,7 @@ PREFECT_MEMO_STORE_PATH = Setting(
 
 PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION = Setting(
     bool,
-    default=False,
+    default=True,
     description="""Controls whether or not block auto-registration on start 
     up should be memoized. Setting to False may result in slower server start
     up times.""",


### PR DESCRIPTION
Follow-up to #7022 disabling block protection entirely. With block protection enabled, as in 2.4.3 and 2.4.4, client and server versions cannot be mismatched unless you are on a version before 2.4.0. Disabling block protection restores the ability for a client and server to have different version tags.