### PR TITLE
Add 2.4 to the compatibility checks to capture the latest release

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -89,6 +89,7 @@ jobs:
           - "2.3"
           - "2.4.2"
           - "2.4.4"
+          - "2.4"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
@@ -104,6 +105,7 @@ jobs:
           - prefect-version: "2.1"
             server-incompatible: true
           - prefect-version: "2.4.4"
+            # This server release had a bug that made it incompatible
             server-incompatible: true
 
 


### PR DESCRIPTION
Updates compatibility tests following #7026 — it should now include 2.4.5 as well as the relevant 2.4.x versions that we had issues with.