### PR TITLE
Fix task_input_hash for blocks

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,6 +9,7 @@ import anyio
 import pytest
 
 from prefect import flow, get_run_logger, tags
+from prefect.blocks.core import Block
 from prefect.context import PrefectObjectRegistry, TaskRunContext, get_run_context
 from prefect.engine import get_state_for_result
 from prefect.exceptions import (
@@ -934,6 +935,32 @@ class TestCacheFunctionBuiltins:
                 foo._run(TestClass(1)),
                 foo._run(TestClass(2)),
                 foo._run(TestClass(1)),
+            )
+
+        first_state, second_state, third_state = bar()
+        assert first_state.name == "Completed"
+        assert second_state.name == "Completed"
+        assert third_state.name == "Cached"
+
+        assert first_state.result() != second_state.result()
+        assert first_state.result() == third_state.result() == 1
+
+    def test_task_input_hash_works_with_block_input_types(self):
+        class TestBlock(Block):
+            x: int
+            y: int
+            z: int
+
+        @task(cache_key_fn=task_input_hash)
+        def foo(instance):
+            return instance.x
+
+        @flow
+        def bar():
+            return (
+                foo._run(TestBlock(x=1, y=2, z=3)),
+                foo._run(TestBlock(x=4, y=2, z=3)),
+                foo._run(TestBlock(x=1, y=2, z=3)),
             )
 
         first_state, second_state, third_state = bar()


### PR DESCRIPTION
Adds custom JSONEncoder to fix cache key function `task_input_hash` for blocks.

Using `cloudpickle` to dump certain objects before hashing them produced inconsistent hashes, causing tasks with blocks as parameters to not cache correctly when using `task_input_hash`. With this custom JSONEncoder `json.dumps` is used with more parameter types, producing stable hashes and fixing cache issues.

Types currently supported by the encoder, more can be added as needed:

- **bytes**
  - In `task_input_hash`, one of the objects being hashed is `task.fn.__code__.co_code` which a `bytes` object. Since `bytes` are not JSON serializable by the default JSONEncoder, `cloudpickle.dumps` was always used for hash input.
- **set**
- **pydantic.BaseModel**
  - Includes subclasses, like blocks.


Closes #7010.

### Example

With this change, these tasks are cached correctly:
```
@task(cache_key_fn=task_input_hash)
def task_with_block(param: TestBlock):
    return 42


@task(cache_key_fn=task_input_hash)
def task_with_set(param: set):
    return 42


@flow
def dummy_flow():
    input_block = TestBlock.load("test-block")
    task_with_block(input_block)
    
    input_set = {"a", "b", "c", "d"}
    task_with_set(input_set)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->