### PR TITLE
Change Storage `put_directory` to only count the number of files uploaded

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -358,7 +358,7 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
                 else:
                     self.filesystem.put_file(f, fpath)
 
-            counter += 1
+                counter += 1
 
         return counter
 

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -148,13 +148,16 @@ class TestRemoteFileSystem:
         # Put files
         fs = RemoteFileSystem(basepath="memory://tree")
         num_files_put = await fs.put_directory(
-            os.path.join(TEST_PROJECTS_DIR, "tree-project"), ignore_file=ignore_file,
+            os.path.join(TEST_PROJECTS_DIR, "tree-project"),
+            ignore_file=ignore_file,
         )
 
         # Expected files
         ignore_patterns = Path(ignore_file).read_text().splitlines(keepends=False)
         included_files = prefect.utilities.filesystem.filter_files(
-            os.path.join(TEST_PROJECTS_DIR, "tree-project"), ignore_patterns, include_dirs=False
+            os.path.join(TEST_PROJECTS_DIR, "tree-project"),
+            ignore_patterns,
+            include_dirs=False,
         )
         num_files_expected = len(included_files)
 

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -142,6 +142,24 @@ class TestRemoteFileSystem:
             "/tree/shared_libs/foo.py",
         }
 
+    async def test_put_directory_put_file_count(self):
+        ignore_file = os.path.join(TEST_PROJECTS_DIR, "tree-project", ".prefectignore")
+
+        # Put files
+        fs = RemoteFileSystem(basepath="memory://tree")
+        num_files_put = await fs.put_directory(
+            os.path.join(TEST_PROJECTS_DIR, "tree-project"), ignore_file=ignore_file,
+        )
+
+        # Expected files
+        ignore_patterns = Path(ignore_file).read_text().splitlines(keepends=False)
+        included_files = prefect.utilities.filesystem.filter_files(
+            os.path.join(TEST_PROJECTS_DIR, "tree-project"), ignore_patterns, include_dirs=False
+        )
+        num_files_expected = len(included_files)
+
+        assert num_files_put == num_files_expected
+
 
 class TestGitHub:
     async def test_subprocess_errors_are_surfaced(self):


### PR DESCRIPTION
`Deployment().upload_to_storage()` returns the number of files uploaded (obtained from the relevant storage/filesystem `put_directory()`).  It caught me off-guard in that it seems to upload more files than I have in my folder.

### Example
I found, for example, for the [test `tree-project`](https://github.com/PrefectHQ/prefect/tree/3a3a22b06b769a247602e195d0bd5644a14a5d25/tests/test-projects/tree-project), it returns `7` files uploaded.
That is because it also counts the folders.
![image](https://user-images.githubusercontent.com/6089256/193597199-e92c5eae-8b45-482a-8ae5-3193fe914016.png)


**Important**: This PR changes the behavior of the file counter to only count the files, and not the folders as well.


### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
