### PR TITLE
Fix contributing dev setup instructions

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -17,10 +17,9 @@ First, you'll need to download the source code and install an editable version o
 
 <div class="terminal">
 ```bash
-# Clone the repository and switch to the 'orion' branch
+# Clone the repository
 git clone https://github.com/PrefectHQ/prefect.git
 cd prefect
-git checkout orion
 # Install the package with development dependencies
 pip install -e ".[dev]"
 # Setup pre-commit hooks for required formatting


### PR DESCRIPTION
Drops 'git checkout orion' from steps