### PR TITLE
Add async support to `State.result()`

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -241,12 +241,14 @@ asyncio.run(main())
 !!! important "Resolving results"
     In Prefect 2.6.0, we added automatic retrieval of persisted results.
     Prior to this version, `State.result()` did not require an `await`.
-    For backwards compatibility, when used from an asynchronous context, `State.result()` will return a raw result type.
+    For backwards compatibility, when used from an asynchronous context, `State.result()` returns a raw result type.
+    
     You may opt-in to the new behavior by passing `fetch=True` as shown in the example above.
     If you would like this behavior to be used automatically, you may enable the `PREFECT_ASYNC_FETCH_STATE_RESULT` setting.
-    If you do not opt-in to this behavior you will see a warning.
+    If you do not opt-in to this behavior, you will see a warning.
+    
     You may also opt-out by setting `fetch=False`.
-    This will silence the warning but you will need to retrieve your result manually from the result type.
+    This will silence the warning, but you will need to retrieve your result manually from the result type.
 
 When submitting tasks to a runner, the result can be retreived with the `Future.result()` method:
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -227,8 +227,9 @@ async def my_task():
 
 @flow
 async def my_flow():
-    state = my_task(return_state=True)
-    return state.result() + 1
+    state = await my_task(return_state=True)
+    result = await state.result(fetch=True)
+    return result + 1
 
 async def main():
     state = await my_flow(return_state=True)
@@ -241,10 +242,11 @@ asyncio.run(main())
     In Prefect 2.6.0, we added automatic retrieval of persisted results.
     Prior to this version, `State.result()` did not require an `await`.
     For backwards compatibility, when used from an asynchronous context, `State.result()` will return a raw result type.
-    You may opt-in to the new behavior by passing `fetch=True`.
-    If you would like this behavior to be used everywhere without passing `fetch=True`, you may set the 
-    `PREFECT_OPT_IN_ASYNC_STATE_RESULT` variable.
-
+    You may opt-in to the new behavior by passing `fetch=True` as shown in the example above.
+    If you would like this behavior to be used automatically, you may enable the `PREFECT_OPT_IN_ASYNC_STATE_RESULT` setting.
+    If you do not opt-in to this behavior you will see a warning.
+    You may also opt-out by setting `fetch=False`.
+    This will silence the warning but you will need to retrieve your result manually from the result type.
 
 When submitting tasks to a runner, the result can be retreived with the `Future.result()` method:
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -239,7 +239,7 @@ asyncio.run(main())
 ```
 
 !!! important "Resolving results"
-    In Prefect 2.6.0, we added automatic retrieval of persisted results.
+    Prefect 2.6.0 added automatic retrieval of persisted results.
     Prior to this version, `State.result()` did not require an `await`.
     For backwards compatibility, when used from an asynchronous context, `State.result()` returns a raw result type.
     

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -243,7 +243,7 @@ asyncio.run(main())
     Prior to this version, `State.result()` did not require an `await`.
     For backwards compatibility, when used from an asynchronous context, `State.result()` will return a raw result type.
     You may opt-in to the new behavior by passing `fetch=True` as shown in the example above.
-    If you would like this behavior to be used automatically, you may enable the `PREFECT_OPT_IN_ASYNC_STATE_RESULT` setting.
+    If you would like this behavior to be used automatically, you may enable the `PREFECT_ASYNC_FETCH_STATE_RESULT` setting.
     If you do not opt-in to this behavior you will see a warning.
     You may also opt-out by setting `fetch=False`.
     This will silence the warning but you will need to retrieve your result manually from the result type.

--- a/flows/hello_tasks.py
+++ b/flows/hello_tasks.py
@@ -1,0 +1,15 @@
+from prefect import flow, get_run_logger, task
+
+
+@task
+def say_hello(name: str):
+    get_run_logger().info(f"Hello {name}!")
+
+
+@flow
+def hello(name: str = "world", count: int = 1):
+    say_hello.map(f"{name}-{i}" for i in range(count))
+
+
+if __name__ == "__main__":
+    hello(count=3)

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -1,9 +1,12 @@
 import datetime
 from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar, Union, overload
+import warnings
+from typing import Any, Generic, Iterable, Optional, Type, TypeVar, Union, overload
 
 from pydantic import Field
 
 from prefect.orion import schemas
+from prefect.utilities.asyncutils import sync_compatible
 
 if TYPE_CHECKING:
     from prefect.deprecated.data_documents import DataDocument
@@ -67,7 +70,7 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
             >>> @flow
             >>> def my_flow():
             >>>     return "hello"
-            >>> my_flow().result()
+            >>> my_flow(return_state=True).result()
             hello
 
             Get the result from a failed state
@@ -75,7 +78,7 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
             >>> @flow
             >>> def my_flow():
             >>>     raise ValueError("oh no!")
-            >>> state = my_flow()  # Error is wrapped in FAILED state
+            >>> state = my_flow(return_state=True)  # Error is wrapped in FAILED state
             >>> state.result()  # Raises `ValueError`
 
             Get the result from a failed state without erroring
@@ -83,10 +86,20 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
             >>> @flow
             >>> def my_flow():
             >>>     raise ValueError("oh no!")
-            >>> state = my_flow()
+            >>> state = my_flow(return_state=True)
             >>> result = state.result(raise_on_failure=False)
             >>> print(result)
             ValueError("oh no!")
+
+
+            Get the result from a flow state in an async context
+
+            >>> @flow
+            >>> async def my_flow():
+            >>>     return "hello"
+            >>> state = await my_flow(return_state=True)
+            >>> await state.result()
+            hello
         """
         from prefect.deprecated.data_documents import (
             DataDocument,

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -34,19 +34,23 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
     def result(self: "State[R]", raise_on_failure: bool = False) -> Union[R, Exception]:
         ...
 
-    def result(self, raise_on_failure: bool = True):
+    def result(self, raise_on_failure: bool = True, fetch: Optional[bool] = None):
         """
-        Convenience method for access the data on the state's data document.
+        Retrieve the result
 
         Args:
             raise_on_failure: a boolean specifying whether to raise an exception
                 if the state is of type `FAILED` and the underlying data is an exception
+            fetch: a boolean specifying whether to resolve references to persisted
+                results into data. For synchronous users, this defaults to `True`.
+                For asynchronous users, this defaults to `False` for backwards
+                compatibility.
 
         Raises:
-            TypeError: if the state is failed but without an exception
+            TypeError: If the state is failed but the result is not an exception.
 
         Returns:
-            The underlying decoded data
+            The result of the run
 
         Examples:
             >>> from prefect import flow, task

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar, Union, overl
 from pydantic import Field
 
 from prefect.orion import schemas
-from prefect.settings import PREFECT_OPT_IN_ASYNC_STATE_RESULT
+from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
 
 if TYPE_CHECKING:
@@ -111,7 +111,7 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
         )
 
         if fetch is None and (
-            PREFECT_OPT_IN_ASYNC_STATE_RESULT or not in_async_main_thread()
+            PREFECT_ASYNC_FETCH_STATE_RESULT or not in_async_main_thread()
         ):
             # Fetch defaults to `True` for sync users or async users who have opted in
             fetch = True

--- a/src/prefect/deprecated/data_documents.py
+++ b/src/prefect/deprecated/data_documents.py
@@ -241,11 +241,11 @@ def result_from_state_with_data_document(state: "State", raise_on_failure: bool)
             )
             return data
         elif isinstance(data, State):
-            data.result()
+            data.result(fetch=False)
         elif isinstance(data, Iterable) and all([isinstance(o, State) for o in data]):
             # raise the first failure we find
             for state in data:
-                state.result()
+                state.result(fetch=False)
 
         # we don't make this an else in case any of the above conditionals doesn't raise
         raise TypeError(

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -520,7 +520,7 @@ async def create_and_begin_subflow_run(
     if return_type == "state":
         return terminal_state
     elif return_type == "result":
-        return await terminal_state.result()
+        return await terminal_state.result(fetch=True)
     else:
         raise ValueError(f"Invalid return type for flow engine {return_type!r}.")
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -438,7 +438,6 @@ async def create_and_begin_subflow_run(
         flow_run = flow_runs[-1]
 
         # Hydrate the retrieved state
-        flow_run.state.data._cache_data(await _retrieve_result(flow_run.state, client))
 
         # Set up variables required downstream
         terminal_state = flow_run.state

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -230,7 +230,7 @@ async def create_then_begin_flow_run(
     if return_type == "state":
         return state
     elif return_type == "result":
-        return state.result()
+        return await state.result()
     else:
         raise ValueError(f"Invalid return type for flow engine {return_type!r}.")
 
@@ -520,7 +520,7 @@ async def create_and_begin_subflow_run(
     if return_type == "state":
         return terminal_state
     elif return_type == "result":
-        return terminal_state.result()
+        return await terminal_state.result()
     else:
         raise ValueError(f"Invalid return type for flow engine {return_type!r}.")
 
@@ -1319,7 +1319,7 @@ async def wait_for_task_runs_and_report_crashes(
         if not state.type == StateType.CRASHED:
             continue
 
-        exception = state.result(raise_on_failure=False)
+        exception = await state.result(raise_on_failure=False)
 
         logger.info(f"Crash detected! {state.message}")
         logger.debug("Crash details:", exc_info=exception)
@@ -1412,7 +1412,11 @@ async def resolve_inputs(
             )
 
         # Only retrieve the result if requested as it may be expensive
-        return state.result() if return_data else None
+        return (
+            run_async_from_worker_thread(state._result, raise_on_failure=True)
+            if return_data
+            else None
+        )
 
     return await run_sync_in_worker_thread(
         visit_collection,

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -230,7 +230,7 @@ async def create_then_begin_flow_run(
     if return_type == "state":
         return state
     elif return_type == "result":
-        return await state.result()
+        return await state.result(fetch=True)
     else:
         raise ValueError(f"Invalid return type for flow engine {return_type!r}.")
 

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -234,7 +234,7 @@ class PrefectFuture(Generic[R, A]):
         final_state = await self._wait(timeout=timeout)
         if not final_state:
             raise TimeoutError("Call timed out before task finished.")
-        return await final_state.result(raise_on_failure=raise_on_failure)
+        return await final_state._result(raise_on_failure=raise_on_failure)
 
     @overload
     def get_state(

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -234,7 +234,7 @@ class PrefectFuture(Generic[R, A]):
         final_state = await self._wait(timeout=timeout)
         if not final_state:
             raise TimeoutError("Call timed out before task finished.")
-        return final_state.result(raise_on_failure=raise_on_failure)
+        return await final_state.result(raise_on_failure=raise_on_failure)
 
     @overload
     def get_state(

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -11,7 +11,6 @@ import pendulum
 from pydantic import Field, root_validator, validator
 
 from prefect.orion.utilities.schemas import DateTimeTZ, IDBaseModel, PrefectBaseModel
-from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import AutoEnum
 
 R = TypeVar("R")
@@ -125,8 +124,7 @@ class State(IDBaseModel, Generic[R]):
         update.setdefault("timestamp", self.__fields__["timestamp"].get_default())
         return super().copy(reset_fields=reset_fields, update=update, **kwargs)
 
-    @sync_compatible
-    async def result(self, raise_on_failure: bool = True):
+    def result(self, raise_on_failure: bool = True, fetch: Optional[bool] = None):
         from prefect.client.schemas import State
 
         warnings.warn(
@@ -138,7 +136,7 @@ class State(IDBaseModel, Generic[R]):
         )
 
         state = State.parse_obj(self)
-        return await state.result(raise_on_failure=raise_on_failure)
+        return state.result(raise_on_failure=raise_on_failure, fetch=fetch)
 
     def __repr__(self) -> str:
         """

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -11,6 +11,7 @@ import pendulum
 from pydantic import Field, root_validator, validator
 
 from prefect.orion.utilities.schemas import DateTimeTZ, IDBaseModel, PrefectBaseModel
+from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import AutoEnum
 
 R = TypeVar("R")
@@ -124,7 +125,8 @@ class State(IDBaseModel, Generic[R]):
         update.setdefault("timestamp", self.__fields__["timestamp"].get_default())
         return super().copy(reset_fields=reset_fields, update=update, **kwargs)
 
-    def result(self, raise_on_failure: bool = True):
+    @sync_compatible
+    async def result(self, raise_on_failure: bool = True):
         from prefect.client.schemas import State
 
         warnings.warn(
@@ -136,7 +138,7 @@ class State(IDBaseModel, Generic[R]):
         )
 
         state = State.parse_obj(self)
-        return state.result(raise_on_failure=raise_on_failure)
+        return await state.result(raise_on_failure=raise_on_failure)
 
     def __repr__(self) -> str:
         """

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -417,6 +417,23 @@ PREFECT_AGENT_PREFETCH_SECONDS = Setting(
     prefetched. Defaults to `10`.""",
 )
 
+PREFECT_OPT_IN_ASYNC_STATE_RESULT = Setting(
+    bool,
+    default=False,
+    description=textwrap.dedent(
+        """
+        Determines whether `State.result()` fetches results automatically or not.
+        The `State.result()` method has been updated to be async to faciliate automatic
+        retrieval of results from the filesystem which means when writing async code you
+        must `await` the call. For backwards compatibility, the result is not retrieved
+        by default for async users. You may opt into this per call by passing 
+        `fetch=True` or toggle this setting to change the behavior globally.
+        This setting does not affect users writing synchronous tasks and flows.
+        This setting does not affect retrieval of results when using `Future.result()`.
+        """
+    ),
+)
+
 PREFECT_ORION_BLOCKS_REGISTER_ON_START = Setting(
     bool,
     default=True,

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -417,7 +417,7 @@ PREFECT_AGENT_PREFETCH_SECONDS = Setting(
     prefetched. Defaults to `10`.""",
 )
 
-PREFECT_OPT_IN_ASYNC_STATE_RESULT = Setting(
+PREFECT_ASYNC_FETCH_STATE_RESULT = Setting(
     bool,
     default=False,
     description=textwrap.dedent(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -423,11 +423,12 @@ PREFECT_OPT_IN_ASYNC_STATE_RESULT = Setting(
     description=textwrap.dedent(
         """
         Determines whether `State.result()` fetches results automatically or not.
-        The `State.result()` method has been updated to be async to faciliate automatic
-        retrieval of results from the filesystem which means when writing async code you
-        must `await` the call. For backwards compatibility, the result is not retrieved
-        by default for async users. You may opt into this per call by passing 
-        `fetch=True` or toggle this setting to change the behavior globally.
+        In Prefect 2.6.0, the `State.result()` method was updated to be async
+        to faciliate automatic retrieval of results from storage which means when 
+        writing async code you must `await` the call. For backwards compatibility, 
+        the result is not retrieved by default for async users. You may opt into this
+        per call by passing  `fetch=True` or toggle this setting to change the behavior
+        globally.
         This setting does not affect users writing synchronous tasks and flows.
         This setting does not affect retrieval of results when using `Future.result()`.
         """

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -81,7 +81,7 @@ async def return_value_to_state(result: Any, serializer: str = "cloudpickle") ->
     _single_ state. This prevents a flow from assuming the state of a single returned
     task future.
     """
-p
+
     if (
         is_state(result)
         # Check for manual creation

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -81,7 +81,7 @@ async def return_value_to_state(result: Any, serializer: str = "cloudpickle") ->
     _single_ state. This prevents a flow from assuming the state of a single returned
     task future.
     """
-
+p
     if (
         is_state(result)
         # Check for manual creation

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -341,7 +341,7 @@ class TaskRunnerStandardTestSuite(ABC):
             state = await task_runner.wait(task_run.id, 5)
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
-            assert state.result() == 1
+            assert await state.result() == 1
 
     @pytest.mark.parametrize("exception", [KeyboardInterrupt(), ValueError("test")])
     async def test_wait_captures_exceptions_as_crashed_state(

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -367,7 +367,7 @@ class TaskRunnerStandardTestSuite(ABC):
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
             assert state.type == StateType.CRASHED
-            result = state.result(raise_on_failure=False)
+            result = await state.result(raise_on_failure=False)
 
         assert exceptions_equal(result, exception)
 

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -3,7 +3,6 @@ Utilities for interoperability with async functions and workers from various con
 """
 import ctypes
 import inspect
-import sys
 import threading
 import warnings
 from contextlib import asynccontextmanager
@@ -182,26 +181,8 @@ def sync_compatible(async_fn: T) -> T:
     @wraps(async_fn)
     def wrapper(*args, **kwargs):
         if in_async_main_thread():
-            caller_frame = sys._getframe(1)
-            caller_module = caller_frame.f_globals.get("__name__", "unknown")
-            caller_async = caller_frame.f_code.co_flags & inspect.CO_COROUTINE
-            if caller_async or any(
-                # Add exceptions for the internals anyio/asyncio which can run
-                # coroutines from synchronous functions
-                caller_module.startswith(f"{module}.")
-                for module in ["asyncio", "anyio"]
-            ):
-                # In the main async context; return the coro for them to await
-                return async_fn(*args, **kwargs)
-            else:
-                # In the main thread but call was made from a sync method
-                raise RuntimeError(
-                    "A 'sync_compatible' method was called from a context that was "
-                    "previously async but is now sync. The sync call must be changed "
-                    "to run in a worker thread to support sending the coroutine for "
-                    f"{async_fn.__name__!r} to the main thread."
-                )
-
+            # In the main async context; return the coro for them to await
+            return async_fn(*args, **kwargs)
         elif in_async_worker_thread():
             # In a sync context but we can access the event loop thread; send the async
             # call to the parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ import prefect.settings
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_ASYNC_FETCH_STATE_RESULT,
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_HOME,
@@ -41,7 +42,6 @@ from prefect.settings import (
     PREFECT_LOGGING_LEVEL,
     PREFECT_LOGGING_ORION_ENABLED,
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
-    PREFECT_OPT_IN_ASYNC_STATE_RESULT,
     PREFECT_ORION_ANALYTICS_ENABLED,
     PREFECT_ORION_BLOCKS_REGISTER_ON_START,
     PREFECT_ORION_DATABASE_CONNECTION_URL,
@@ -276,7 +276,7 @@ def pytest_sessionstart(session):
             PREFECT_CLI_COLORS: False,
             PREFECT_CLI_WRAP_LINES: False,
             # Enable future change
-            PREFECT_OPT_IN_ASYNC_STATE_RESULT: True,
+            PREFECT_ASYNC_FETCH_STATE_RESULT: True,
             # Enable debug logging
             PREFECT_LOGGING_LEVEL: "DEBUG",
             # Disable shipping logs to the API;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from prefect.settings import (
     PREFECT_LOGGING_LEVEL,
     PREFECT_LOGGING_ORION_ENABLED,
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
+    PREFECT_OPT_IN_ASYNC_STATE_RESULT,
     PREFECT_ORION_ANALYTICS_ENABLED,
     PREFECT_ORION_BLOCKS_REGISTER_ON_START,
     PREFECT_ORION_DATABASE_CONNECTION_URL,
@@ -274,6 +275,8 @@ def pytest_sessionstart(session):
             # Disable pretty CLI output for easier assertions
             PREFECT_CLI_COLORS: False,
             PREFECT_CLI_WRAP_LINES: False,
+            # Enable future change
+            PREFECT_OPT_IN_ASYNC_STATE_RESULT: True,
             # Enable debug logging
             PREFECT_LOGGING_LEVEL: "DEBUG",
             # Disable shipping logs to the API;

--- a/tests/results/test_result_fetch.py
+++ b/tests/results/test_result_fetch.py
@@ -1,0 +1,137 @@
+import pytest
+
+from prefect import flow, task
+from prefect.client.schemas import Completed
+from prefect.results import ResultLiteral
+from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, temporary_settings
+
+
+@pytest.fixture(autouse=True)
+def disable_fetch_by_default():
+    """
+    The test suite defaults to the future behavior.
+
+    For these tests, we enable the default user behavior.
+    """
+    with temporary_settings({PREFECT_ASYNC_FETCH_STATE_RESULT: False}):
+        yield
+
+
+async def test_async_result_raises_deprecation_warning():
+    # This test creates a state directly because a flows do not yet return the new
+    # result types
+    state = Completed(data=await ResultLiteral.create(True))
+    result = state.result(fetch=False)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"State.result\(\) was called from an async context but not awaited.",
+    ):
+        result = state.result()
+
+    # A result type is returned
+    assert isinstance(result, ResultLiteral)
+    assert await result.get() is True
+
+
+async def test_async_result_warnings_are_not_raised_by_engine():
+    # Since most of our tests are run with the opt-in globally enabled, this test
+    # covers a bunch of features to cover remaining cases where we may internally
+    # call `State.result` incorrectly.
+
+    task_run_count = flow_run_count = subflow_run_count = 0
+
+    @task(retries=3)
+    async def my_task():
+        nonlocal task_run_count
+        task_run_count += 1
+        if task_run_count < 3:
+            raise ValueError()
+        return 1
+
+    @task(cache_key_fn=lambda *_: "test")
+    def foo():
+        return 1
+
+    @task(cache_key_fn=lambda *_: "test")
+    def bar():
+        return 2
+
+    @flow
+    def subflow():
+        return 1
+
+    @flow
+    async def async_subflow():
+        return 1
+
+    @flow(retries=3)
+    async def retry_subflow():
+        nonlocal subflow_run_count
+        subflow_run_count += 1
+        if subflow_run_count < 3:
+            raise ValueError()
+        return 1
+
+    @flow(retries=3)
+    async def my_flow():
+        a = await my_task()
+
+        b = foo()
+        c = bar()
+        d = subflow()
+        e = await async_subflow()
+        f = await retry_subflow()
+
+        nonlocal flow_run_count
+        flow_run_count += 1
+
+        if flow_run_count < 3:
+            raise ValueError()
+
+        return a + b + c + d + e + f
+
+    assert await my_flow() == 6
+
+
+async def test_async_result_does_not_raise_warning_with_opt_out():
+    # This test creates a state directly because a flows do not yet return the new
+    # result types
+    state = Completed(data=await ResultLiteral.create(True))
+    result = state.result(fetch=False)
+
+    # A result type is returned
+    assert isinstance(result, ResultLiteral)
+    assert await result.get() is True
+
+
+async def test_async_result_returns_coroutine_with_opt_in():
+    @flow
+    async def foo():
+        return 1
+
+    state = await foo(return_state=True)
+    coro = state.result(fetch=True)
+    assert await coro == 1
+
+
+async def test_async_result_returns_coroutine_with_setting():
+    @flow
+    async def foo():
+        return 1
+
+    state = await foo(return_state=True)
+    with temporary_settings({PREFECT_ASYNC_FETCH_STATE_RESULT: True}):
+        coro = state.result(fetch=True)
+
+    assert await coro == 1
+
+
+def test_sync_result_does_not_raise_warning():
+    @flow
+    def foo():
+        return 1
+
+    state = foo(return_state=True)
+    result = state.result()
+    assert result == 1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -717,7 +717,7 @@ class TestFlowRunCrashes:
         assert flow_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in flow_run.state.message
         assert exceptions_equal(
-            flow_run.state.result(raise_on_failure=False), interrupt_type()
+            await flow_run.state.result(raise_on_failure=False), interrupt_type()
         )
 
         child_runs = await orion_client.read_flow_runs(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -163,7 +163,7 @@ class TestOrchestrateTaskRun:
             )
 
         assert state.is_completed()
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_does_not_wait_for_scheduled_time_in_past(
         self, orion_client, flow_run, mock_anyio_sleep, result_factory, local_filesystem
@@ -197,7 +197,7 @@ class TestOrchestrateTaskRun:
 
         mock_anyio_sleep.assert_not_called()
         assert state.is_completed()
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_waits_for_awaiting_retry_scheduled_time(
         self, mock_anyio_sleep, orion_client, flow_run, result_factory, local_filesystem
@@ -236,7 +236,7 @@ class TestOrchestrateTaskRun:
             )
 
         # Check for a proper final result
-        assert state.result() == 1
+        assert await state.result() == 1
 
         # Check expected state transitions
         states = await orion_client.read_task_run_states(task_run.id)
@@ -473,7 +473,7 @@ class TestOrchestrateFlowRun:
                 partial_flow_run_context=partial_flow_run_context,
             )
 
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_does_not_wait_for_scheduled_time_in_past(
         self, orion_client, mock_anyio_sleep, partial_flow_run_context
@@ -505,7 +505,7 @@ class TestOrchestrateFlowRun:
             )
 
         mock_anyio_sleep.assert_not_called()
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_waits_for_awaiting_retry_scheduled_time(
         self, orion_client, mock_anyio_sleep, partial_flow_run_context
@@ -539,7 +539,7 @@ class TestOrchestrateFlowRun:
             )
 
         # Check for a proper final result
-        assert state.result() == 1
+        assert await state.result() == 1
 
         # Check expected state transitions
         states = await orion_client.read_flow_run_states(flow_run.id)
@@ -599,7 +599,7 @@ class TestFlowRunCrashes:
             in flow_run.state.message
         )
         assert exceptions_equal(
-            flow_run.state.result(raise_on_failure=False),
+            await flow_run.state.result(raise_on_failure=False),
             anyio.get_cancelled_exc_class()(),
         )
 
@@ -633,7 +633,7 @@ class TestFlowRunCrashes:
         assert parent_flow_run.state.is_crashed()
         assert parent_flow_run.state.type == StateType.CRASHED
         assert exceptions_equal(
-            parent_flow_run.state.result(raise_on_failure=False),
+            await parent_flow_run.state.result(raise_on_failure=False),
             anyio.get_cancelled_exc_class()(),
         )
 
@@ -667,7 +667,7 @@ class TestFlowRunCrashes:
         assert flow_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in flow_run.state.message
         assert exceptions_equal(
-            flow_run.state.result(raise_on_failure=False), interrupt_type()
+            await flow_run.state.result(raise_on_failure=False), interrupt_type()
         )
 
     @pytest.mark.parametrize("interrupt_type", [KeyboardInterrupt, SystemExit])
@@ -693,7 +693,7 @@ class TestFlowRunCrashes:
         assert flow_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in flow_run.state.message
         with pytest.warns(UserWarning, match="not safe to re-raise"):
-            assert exceptions_equal(flow_run.state.result(), interrupt_type())
+            assert exceptions_equal(await flow_run.state.result(), interrupt_type())
 
     @pytest.mark.parametrize("interrupt_type", [KeyboardInterrupt, SystemExit])
     async def test_interrupt_in_flow_function_crashes_subflow(
@@ -867,7 +867,7 @@ class TestTaskRunCrashes:
         assert flow_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in flow_run.state.message
         with pytest.warns(UserWarning, match="not safe to re-raise"):
-            assert exceptions_equal(flow_run.state.result(), interrupt_type())
+            assert exceptions_equal(await flow_run.state.result(), interrupt_type())
 
         task_runs = await orion_client.read_task_runs()
         assert len(task_runs) == 1
@@ -876,7 +876,7 @@ class TestTaskRunCrashes:
         assert task_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in task_run.state.message
         with pytest.warns(UserWarning, match="not safe to re-raise"):
-            assert exceptions_equal(task_run.state.result(), interrupt_type())
+            assert exceptions_equal(await task_run.state.result(), interrupt_type())
 
     @pytest.mark.parametrize("interrupt_type", [KeyboardInterrupt, SystemExit])
     async def test_interrupt_in_task_orchestration_crashes_task_and_flow(
@@ -905,7 +905,7 @@ class TestTaskRunCrashes:
         assert flow_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in flow_run.state.message
         with pytest.warns(UserWarning, match="not safe to re-raise"):
-            assert exceptions_equal(flow_run.state.result(), interrupt_type())
+            assert exceptions_equal(await flow_run.state.result(), interrupt_type())
 
         task_runs = await orion_client.read_task_runs()
         assert len(task_runs) == 1
@@ -914,7 +914,7 @@ class TestTaskRunCrashes:
         assert task_run.state.type == StateType.CRASHED
         assert "Execution was aborted" in task_run.state.message
         with pytest.warns(UserWarning, match="not safe to re-raise"):
-            assert exceptions_equal(task_run.state.result(), interrupt_type())
+            assert exceptions_equal(await task_run.state.result(), interrupt_type())
 
     async def test_error_in_task_orchestration_crashes_task_but_not_flow(
         self, flow_run, orion_client, monkeypatch
@@ -943,7 +943,7 @@ class TestTaskRunCrashes:
         assert flow_run.state.name == "Failed"
         assert "1/1 states failed" in flow_run.state.message
 
-        task_run_states = state.result(raise_on_failure=False)
+        task_run_states = await state.result(raise_on_failure=False)
         assert len(task_run_states) == 1
         task_run_state = task_run_states[0]
         assert task_run_state.is_crashed()
@@ -953,7 +953,7 @@ class TestTaskRunCrashes:
             in task_run_state.message
         )
         assert exceptions_equal(
-            task_run_state.result(raise_on_failure=False), exception
+            await task_run_state.result(raise_on_failure=False), exception
         )
 
         # Check that the state was reported to the server
@@ -990,7 +990,7 @@ class TestDeploymentFlowRun:
         state = await retrieve_flow_then_begin_flow_run(
             flow_run.id, client=orion_client
         )
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_retries_loaded_from_flow_definition(
         self, orion_client, patch_manifest_load, mock_anyio_sleep
@@ -1040,7 +1040,7 @@ class TestDeploymentFlowRun:
         )
         assert state.is_failed()
         with pytest.raises(ValueError, match="test!"):
-            state.result()
+            await state.result()
 
     async def test_parameters_are_cast_to_correct_type(
         self, orion_client, patch_manifest_load
@@ -1059,7 +1059,7 @@ class TestDeploymentFlowRun:
         state = await retrieve_flow_then_begin_flow_run(
             flow_run.id, client=orion_client
         )
-        assert state.result() == 1
+        assert await state.result() == 1
 
     async def test_state_is_failed_when_parameters_fail_validation(
         self, orion_client, patch_manifest_load
@@ -1084,7 +1084,7 @@ class TestDeploymentFlowRun:
             == "Validation of flow parameters failed with error: ParameterTypeError('Flow run received invalid parameters:\\n - x: value is not a valid integer')"
         )
         with pytest.raises(ParameterTypeError, match="value is not a valid integer"):
-            state.result()
+            await state.result()
 
 
 class TestDynamicKeyHandling:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1224,10 +1224,10 @@ class TestSubflowRunLogs:
         def my_flow():
             logger = get_run_logger()
             logger.info("Hello world!")
-            return my_subflow._run()
+            return my_subflow(return_state=True)
 
-        state = my_flow._run()
-        subflow_run_id = state.result().state_details.flow_run_id
+        subflow_state = my_flow()
+        subflow_run_id = subflow_state.state_details.flow_run_id
 
         logs = await orion_client.read_logs()
         log_messages = [log.message for log in logs]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1481,13 +1481,13 @@ class TestFlowRetries:
         def parent_flow():
             nonlocal flow_run_count
             flow_run_count += 1
-            child_state = child_flow()
+            child_result = child_flow()
 
             # Fail on the first flow run but not the retry
             if flow_run_count == 1:
                 raise ValueError()
 
-            return child_state
+            return child_result
 
         assert parent_flow() == "hello"
         assert flow_run_count == 2

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -974,7 +974,7 @@ async def test_run_logger_in_flow(orion_client):
 
     state = test_flow._run()
     flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-    logger = state.result()
+    logger = await state.result()
     assert logger.name == "prefect.flow_runs"
     assert logger.extra == {
         "flow_name": test_flow.name,
@@ -990,7 +990,7 @@ async def test_run_logger_extra_data(orion_client):
 
     state = test_flow._run()
     flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-    logger = state.result()
+    logger = await state.result()
     assert logger.name == "prefect.flow_runs"
     assert logger.extra == {
         "flow_name": "bar",
@@ -1009,9 +1009,9 @@ async def test_run_logger_in_nested_flow(orion_client):
     def test_flow():
         return child_flow._run()
 
-    child_state = test_flow._run().result()
+    child_state = await test_flow._run().result()
     flow_run = await orion_client.read_flow_run(child_state.state_details.flow_run_id)
-    logger = child_state.result()
+    logger = await child_state.result()
     assert logger.name == "prefect.flow_runs"
     assert logger.extra == {
         "flow_name": child_flow.name,
@@ -1031,9 +1031,9 @@ async def test_run_logger_in_task(orion_client):
 
     flow_state = test_flow._run()
     flow_run = await orion_client.read_flow_run(flow_state.state_details.flow_run_id)
-    task_state = flow_state.result()
+    task_state = await flow_state.result()
     task_run = await orion_client.read_task_run(task_state.state_details.task_run_id)
-    logger = task_state.result()
+    logger = await task_state.result()
     assert logger.name == "prefect.task_runs"
     assert logger.extra == {
         "task_name": test_task.name,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -187,7 +187,7 @@ class TestTaskRun:
 
         task_state = await bar()
         assert isinstance(task_state, State)
-        assert task_state.result() == 1
+        assert await task_state.result() == 1
 
     async def test_sync_task_run_inside_async_flow(self):
         @task
@@ -200,7 +200,7 @@ class TestTaskRun:
 
         task_state = await bar()
         assert isinstance(task_state, State)
-        assert task_state.result() == 1
+        assert await task_state.result() == 1
 
     def test_async_task_run_inside_sync_flow(self):
         @task
@@ -290,7 +290,7 @@ class TestTaskSubmit:
             return future
 
         task_state = await bar()
-        assert task_state.result() == 1
+        assert await task_state.result() == 1
 
     async def test_sync_task_submitted_inside_async_flow(self):
         @task
@@ -304,7 +304,7 @@ class TestTaskSubmit:
             return future
 
         task_state = await bar()
-        assert task_state.result() == 1
+        assert await task_state.result() == 1
 
     def test_async_task_submitted_inside_sync_flow(self):
         @task
@@ -569,11 +569,13 @@ class TestTaskRetries:
 
         if always_fail:
             assert task_run_state.is_failed()
-            assert exceptions_equal(task_run_state.result(raise_on_failure=False), exc)
+            assert exceptions_equal(
+                await task_run_state.result(raise_on_failure=False), exc
+            )
             assert mock.call_count == 4
         else:
             assert task_run_state.is_completed()
-            assert task_run_state.result() is True
+            assert await task_run_state.result() is True
             assert mock.call_count == 4
 
         states = await orion_client.read_task_run_states(task_run_id)
@@ -611,7 +613,7 @@ class TestTaskRetries:
         task_run_id = task_run_state.state_details.task_run_id
 
         assert task_run_state.is_completed()
-        assert task_run_state.result() is True
+        assert await task_run_state.result() is True
         assert mock.call_count == 2
 
         states = await orion_client.read_task_run_states(task_run_id)
@@ -1152,7 +1154,7 @@ class TestTaskInputs:
             return foo.submit(1)
 
         flow_state = test_flow._run()
-        x = flow_state.result()
+        x = await flow_state.result()
 
         task_run = await orion_client.read_task_run(x.state_details.task_run_id)
 
@@ -1170,7 +1172,7 @@ class TestTaskInputs:
             return foo.submit(1)
 
         flow_state = test_flow._run()
-        x = flow_state.result()
+        x = await flow_state.result()
 
         task_run = await orion_client.read_task_run(x.state_details.task_run_id)
 
@@ -1195,7 +1197,7 @@ class TestTaskInputs:
             return a, b, c
 
         flow_state = test_flow._run()
-        a, b, c = flow_state.result()
+        a, b, c = await flow_state.result()
 
         task_run = await orion_client.read_task_run(c.state_details.task_run_id)
 
@@ -1223,7 +1225,7 @@ class TestTaskInputs:
             return a, b, c
 
         flow_state = test_flow._run()
-        a, b, c = flow_state.result()
+        a, b, c = await flow_state.result()
 
         task_run = await orion_client.read_task_run(c.state_details.task_run_id)
 
@@ -1249,7 +1251,7 @@ class TestTaskInputs:
             return a, b, c
 
         flow_state = test_flow._run()
-        a, b, c = flow_state.result()
+        a, b, c = await flow_state.result()
 
         task_run = await orion_client.read_task_run(c.state_details.task_run_id)
 
@@ -1276,7 +1278,7 @@ class TestTaskInputs:
             return a, c
 
         flow_state = test_flow._run()
-        a, c = flow_state.result()
+        a, c = await flow_state.result()
 
         task_run = await orion_client.read_task_run(c.state_details.task_run_id)
 
@@ -1306,7 +1308,7 @@ class TestTaskInputs:
 
         flow_state = test_flow._run()
 
-        a, b, c, d = flow_state.result()
+        a, b, c, d = await flow_state.result()
 
         task_run = await orion_client.read_task_run(d.state_details.task_run_id)
 
@@ -1336,7 +1338,7 @@ class TestTaskInputs:
             return child_state, foo.submit(child_state)
 
         parent_state = parent._run()
-        child_state, task_state = parent_state.result()
+        child_state, task_state = await parent_state.result()
 
         task_run = await orion_client.read_task_run(
             task_state.state_details.task_run_id
@@ -1362,7 +1364,7 @@ class TestTaskInputs:
             return my_name, hi
 
         flow_state = test_flow._run()
-        name_state, hi_state = flow_state.result()
+        name_state, hi_state = await flow_state.result()
 
         task_run = await orion_client.read_task_run(hi_state.state_details.task_run_id)
 
@@ -1453,7 +1455,7 @@ class TestTaskInputs:
         self, result, orion_client, flow_with_upstream_downstream
     ):
         flow_state = flow_with_upstream_downstream._run(result)
-        upstream_state, downstream_state = flow_state.result()
+        upstream_state, downstream_state = await flow_state.result()
 
         task_run = await orion_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -1468,7 +1470,7 @@ class TestTaskInputs:
         self, result, orion_client, flow_with_upstream_downstream
     ):
         flow_state = flow_with_upstream_downstream._run(result)
-        upstream_state, downstream_state = flow_state.result()
+        upstream_state, downstream_state = await flow_state.result()
 
         task_run = await orion_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -1482,7 +1484,7 @@ class TestTaskInputs:
         self, result, orion_client, flow_with_upstream_downstream
     ):
         flow_state = flow_with_upstream_downstream._run(result)
-        _, downstream_state = flow_state.result()
+        _, downstream_state = await flow_state.result()
 
         task_run = await orion_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -2018,7 +2020,7 @@ class TestTaskMap:
             session, numbers_future.state_details.flow_run_id
         )
 
-        assert [a.result() for a in add_futures] == [1, 2, 3]
+        assert [await a.result() for a in add_futures] == [1, 2, 3]
 
         assert dependency_ids[numbers_future.state_details.task_run_id] == []
         assert all(
@@ -2049,7 +2051,7 @@ class TestTaskMap:
             session, numbers_futures[0].state_details.flow_run_id
         )
 
-        assert [a.result() for a in add_futures] == [2, 4, 6]
+        assert [await a.result() for a in add_futures] == [2, 4, 6]
 
         assert all(
             dependency_ids[n.state_details.task_run_id] == [] for n in numbers_futures

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2241,7 +2241,7 @@ class TestTaskMap:
         assert [future.result() for future in futures] == [3, 3, 3]
 
     @pytest.mark.parametrize("explicit", [True, False])
-    async def test_unmapped_int(self, explicit):
+    def test_unmapped_int(self, explicit):
         @flow
         def my_flow():
             numbers = [1, 2, 3]
@@ -2252,7 +2252,7 @@ class TestTaskMap:
         assert [future.result() for future in futures] == [6, 7, 8]
 
     @pytest.mark.parametrize("explicit", [True, False])
-    async def test_unmapped_str(self, explicit):
+    def test_unmapped_str(self, explicit):
         @flow
         def my_flow():
             letters = ["a", "b", "c"]
@@ -2262,7 +2262,7 @@ class TestTaskMap:
         futures = my_flow()
         assert [future.result() for future in futures] == ["atest", "btest", "ctest"]
 
-    async def test_unmapped_iterable(self):
+    def test_unmapped_iterable(self):
         @flow
         def my_flow():
             numbers = [[], [], []]
@@ -2276,7 +2276,7 @@ class TestTaskMap:
             [4, 5, 6, 7],
         ]
 
-    async def test_with_default_kwargs(self):
+    def test_with_default_kwargs(self):
         @task
         def add_some(x, y=5):
             return x + y

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -198,13 +198,12 @@ async def test_sync_compatible_call_from_sync_in_async_thread():
 
     def run_fn():
         # Here we are back in a sync context but still in the async main thread
-        sync_compatible_fn(1, y=2)
+        return sync_compatible_fn(1, y=2)
 
-    with pytest.raises(
-        RuntimeError,
-        match="method was called from a context that was previously async but is now sync",
-    ):
-        run_fn()
+    # Returns a coroutine
+    coro = run_fn()
+
+    assert await coro == 6
 
 
 async def test_sync_compatible_call_with_taskgroup():


### PR DESCRIPTION
Supersedes https://github.com/PrefectHQ/prefect/pull/6926; includes backwards compatibility.

`State.result()` needs async support for automatic retrieval of results that have been persisted. For our synchronous users, we can change the method to be `async` and just use the `sync_compatible `decorator and they will see no change in behavior but we will be able to make async calls. For our asynchronous users, this would be a breaking change since they would need to await the call. To avoid making a breaking change, we will _not_ make asynchronous calls if the user calls `State.result()` from an async context unless they opt-in. If they opt-in, we will return the coroutine for them to await. If they do not opt-in (or explicitly opt-out), we will display a warning:

> State.result() was called from an async context but not awaited. This method will be updated to return a coroutine by default in the future. Pass `fetch=True` and `await` the call to get rid of this warning.

See the [new documentation](https://deploy-preview-7071--prefect-orion.netlify.app/concepts/results/#working-with-async-results) which covers these changes for user-facing messaging.

Affected users may opt-in per call with `State.result(fetch=True)` or globally with the `PREFECT_ASYNC_FETCH_STATE_RESULT` setting. The defaults for these settings can change after a deprecation cycle.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->


```python
from prefect import flow, task
from prefect.settings import temporary_settings, PREFECT_OPT_IN_ASYNC_STATE_RESULT

@task
async def my_task(x = 0):
    return 1 + x

@flow
async def my_flow():

    # Not breaking: Calling to get result
    assert await my_task() == 1

    # Not breaking: Getting the result from the future
    future = await my_task.submit()
    assert await future.result() == 1

    # Not breaking: Passing the future or state downstream
    assert await my_task(future) == 2
    state = await future.wait()
    assert await my_task(state) == 2

    # Would be breaking: Use of `return_state` then `State.result`
    state = await my_task(return_state=True)
    # The result type will be returned; a warning will be displayed
    assert state.result() == ResultReference(...)

    # Would be breaking: Use of `wait` then `State.result`
    future = await my_task.submit()
    state = await future.wait()
    # The result type will be returned; a warning will be displayed
    assert state.result() == ResultReference(...)

    # Opt-in to new behavior
    state = await my_task(return_state=True)
    assert await state.result(fetch=True) == 1

    # Opt-in to new behavior globally
    with temporary_settings({PREFECT_OPT_IN_ASYNC_STATE_RESULT: True}):
          state = await my_task(return_state=True)
          # No `fetch` needed
          assert await state.result() == 1

    return 1
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
