### PR TITLE
Remove the "sync caller" check from `sync_compatible`

### DIFF
--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -288,13 +288,12 @@ async def test_sync_compatible_call_from_sync_in_async_thread():
 
     def run_fn():
         # Here we are back in a sync context but still in the async main thread
-        sync_compatible_fn(1, y=2)
+        return sync_compatible_fn(1, y=2)
 
-    with pytest.raises(
-        RuntimeError,
-        match="method was called from a context that was previously async but is now sync",
-    ):
-        run_fn()
+    # Returns a coroutine
+    coro = run_fn()
+
+    assert await coro == 6
 
 
 async def test_sync_compatible_call_with_taskgroup():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Removes the check for a call pattern like: async -> sync -> sync_compatible

This check was added in https://github.com/PrefectHQ/prefect/pull/6565 which includes a bit more context on the issue it attempted to solve.

This check could only peek at the immediately caller and is not robust to use of decorators and such. It was introduced in an attempt to help prevent improper usage of async code, but it's caused more difficulties than it has fixed and sometimes we actually _want_ to perform this behavior as in #7071.

Separately, we still must address cases where we are incorrectly calling code that expects to be synchronous. For example, whenever we execute a top-level script it _never_ expects to be asynchronous and its not possible for the user to await calls. If we execute such code without running it in a worker thread, it will encounter this case and a coroutine will be returned from sync compatible calls instead of the result. This is the **correct** behavior because otherwise IO would occur on the main thread without an await — this blocks the event loop and is very bad for async performance. In contrast, executing the script in a worker thread will allow the sync compatible calls to block their thread and execute without blocking the event loop.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
async def foo():
    # Here we are in the async main thread

    def run_fn():
        # Prior to this change, this call would throw an error as this function is not async
        return sync_compatible_fn(1, y=2)

    # Now, returns a coroutine
    coro = run_fn()

    # That we can await later
    assert await coro == 6
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
