### PR TITLE
Expose setting custom flow run names

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -39,6 +39,7 @@ async def run_deployment(
     client: OrionClient = None,
     parameters: dict = None,
     scheduled_time: datetime = None,
+    flow_run_name: str = None,
     timeout: float = None,
     poll_interval: float = 5,
 ):
@@ -56,6 +57,7 @@ async def run_deployment(
             defaults
         scheduled_time: The time to schedule the flow run for, defaults to scheduling
             the flow run to start now.
+        flow_run_name: A name for the created flow run
         timeout: The amount of time to wait for the flow run to complete before
             returning. Setting `timeout` to 0 will return the flow run immediately.
             Setting `timeout` to None will allow this function to poll indefinitely.
@@ -73,6 +75,7 @@ async def run_deployment(
         deployment.id,
         state=schemas.states.Scheduled(scheduled_time=scheduled_time),
         parameters=parameters,
+        name=flow_run_name,
     )
 
     flow_run_id = flow_run.id

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -684,9 +684,7 @@ class TestRunDeployment:
             run_deployment(f"{d.flow_name}/{d.name}", timeout=None, poll_interval=0)
             assert len(flow_polls.calls) == 100
 
-    def test_schedules_immediately_by_default(
-        self, test_deployment, use_hosted_orion
-    ):
+    def test_schedules_immediately_by_default(self, test_deployment, use_hosted_orion):
         d, deployment_id = test_deployment
 
         scheduled_time = pendulum.now()
@@ -698,9 +696,7 @@ class TestRunDeployment:
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
 
-    def test_accepts_custom_scheduled_time(
-        self, test_deployment, use_hosted_orion
-    ):
+    def test_accepts_custom_scheduled_time(self, test_deployment, use_hosted_orion):
         d, deployment_id = test_deployment
 
         scheduled_time = pendulum.now() + pendulum.Duration(minutes=5)
@@ -713,9 +709,7 @@ class TestRunDeployment:
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
 
-    def test_custom_flow_run_names(
-        self, test_deployment, use_hosted_orion
-    ):
+    def test_custom_flow_run_names(self, test_deployment, use_hosted_orion):
         d, deployment_id = test_deployment
 
         scheduled_time = pendulum.now() + pendulum.Duration(minutes=5)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -684,7 +684,7 @@ class TestRunDeployment:
             run_deployment(f"{d.flow_name}/{d.name}", timeout=None, poll_interval=0)
             assert len(flow_polls.calls) == 100
 
-    def test_schedule_deployment_schedules_immediately_by_default(
+    def test_schedules_immediately_by_default(
         self, test_deployment, use_hosted_orion
     ):
         d, deployment_id = test_deployment
@@ -698,7 +698,7 @@ class TestRunDeployment:
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
 
-    def test_schedule_deployment_accepts_custom_scheduled_time(
+    def test_accepts_custom_scheduled_time(
         self, test_deployment, use_hosted_orion
     ):
         d, deployment_id = test_deployment
@@ -712,3 +712,18 @@ class TestRunDeployment:
         )
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
+
+    def test_custom_flow_run_names(
+        self, test_deployment, use_hosted_orion
+    ):
+        d, deployment_id = test_deployment
+
+        scheduled_time = pendulum.now() + pendulum.Duration(minutes=5)
+        flow_run = run_deployment(
+            f"{d.flow_name}/{d.name}",
+            flow_run_name="a custom flow run name",
+            timeout=0,
+            poll_interval=0,
+        )
+
+        assert flow_run.name == "a custom flow run name"

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -575,7 +575,7 @@ class TestRunDeployment:
 
         flow_run = await run_deployment(
             f"{d.flow_name}/{d.name}",
-            timeout=2,
+            timeout=0,
             poll_interval=0,
             client=orion_client,
         )
@@ -712,7 +712,6 @@ class TestRunDeployment:
     def test_custom_flow_run_names(self, test_deployment, use_hosted_orion):
         d, deployment_id = test_deployment
 
-        scheduled_time = pendulum.now() + pendulum.Duration(minutes=5)
         flow_run = run_deployment(
             f"{d.flow_name}/{d.name}",
             flow_run_name="a custom flow run name",


### PR DESCRIPTION
#5968

Allow setting custom flow run names when creating a flow run with `run_deployment`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
