### PR TITLE
Fix flaky deployment run test

### DIFF
--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -16,7 +16,6 @@ from prefect.filesystems import S3, GitHub, LocalFileSystem
 from prefect.infrastructure import DockerContainer, Infrastructure, Process
 from prefect.orion.schemas import states
 from prefect.settings import PREFECT_API_URL
-from prefect.testing.cli import invoke_and_assert
 
 
 class TestDeploymentBasicInterface:
@@ -441,30 +440,9 @@ def patch_import(monkeypatch):
 
 
 @pytest.fixture
-def test_deployment(patch_import, tmp_path):
-    d = Deployment(
-        name="TEST",
-        flow_name="fn",
-    )
-    deployment_id = d.apply()
-
-    invoke_and_assert(
-        [
-            "deployment",
-            "build",
-            "fake-path.py:fn",
-            "-n",
-            "TEST",
-            "-o",
-            str(tmp_path / "test.yaml"),
-            "--apply",
-        ],
-        expected_code=0,
-        expected_output_contains=[
-            f"Deployment '{d.flow_name}/{d.name}' successfully created with id '{deployment_id}'."
-        ],
-        temp_dir=tmp_path,
-    )
+async def test_deployment(patch_import, tmp_path):
+    d = Deployment(name="TEST", flow_name="fn")
+    deployment_id = await d.apply()
     return d, deployment_id
 
 
@@ -575,7 +553,7 @@ class TestRunDeployment:
 
         flow_run = await run_deployment(
             f"{d.flow_name}/{d.name}",
-            timeout=2,
+            timeout=0,
             poll_interval=0,
             client=orion_client,
         )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

@anticorrelator and I have not determined the root cause yet, but this ephemeral API test fails if it has a timeout with either "Event loop closed" errors or some SQLite driver complaints.

Setting the `timeout` to `0` looks like it fixes the flake and the timeout doesn't matter for the test. This also removes an unneeded CLI call from the deployment fixture.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
