### PR TITLE
Add multi-delete to flowRuns, Flow, Deployment and WorkQueue pages

### DIFF
--- a/orion-ui/package-lock.json
+++ b/orion-ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ui-orion",
       "version": "0.1.0",
       "dependencies": {
-        "@prefecthq/orion-design": "1.0.104",
+        "@prefecthq/orion-design": "1.0.105",
         "@prefecthq/prefect-design": "1.1.15",
         "@prefecthq/vue-compositions": "0.1.49",
         "@types/lodash.debounce": "4.0.7",
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@prefecthq/orion-design": {
-      "version": "1.0.104",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.104.tgz",
-      "integrity": "sha512-TZHs7eo4DbswzvrYwiSAk0tD6XWG3YjdT1RNLM7mkcc0jmQz8Y9PQWqxS2ld/BXwwHQ42rIWoCd+y3FNbmk//g==",
+      "version": "1.0.105",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.105.tgz",
+      "integrity": "sha512-bGmeq2pA67z1VCe+evW9Nk1fdlqfdFIPVwcdiTyRbVWsC6n72omv7NEx71MHCwaBcMDetkCUQTnCEGq4lX62BQ==",
       "dependencies": {
         "@fontsource/inconsolata": "^4.5.8",
         "@fontsource/inter": "4.5.12",
@@ -5162,9 +5162,9 @@
       }
     },
     "@prefecthq/orion-design": {
-      "version": "1.0.104",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.104.tgz",
-      "integrity": "sha512-TZHs7eo4DbswzvrYwiSAk0tD6XWG3YjdT1RNLM7mkcc0jmQz8Y9PQWqxS2ld/BXwwHQ42rIWoCd+y3FNbmk//g==",
+      "version": "1.0.105",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.0.105.tgz",
+      "integrity": "sha512-bGmeq2pA67z1VCe+evW9Nk1fdlqfdFIPVwcdiTyRbVWsC6n72omv7NEx71MHCwaBcMDetkCUQTnCEGq4lX62BQ==",
       "requires": {
         "@fontsource/inconsolata": "^4.5.8",
         "@fontsource/inter": "4.5.12",

--- a/orion-ui/package.json
+++ b/orion-ui/package.json
@@ -10,7 +10,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@prefecthq/orion-design": "1.0.104",
+    "@prefecthq/orion-design": "1.0.105",
     "@prefecthq/prefect-design": "1.1.15",
     "@prefecthq/vue-compositions": "0.1.49",
     "@types/lodash.debounce": "4.0.7",

--- a/orion-ui/src/pages/FlowRuns.vue
+++ b/orion-ui/src/pages/FlowRuns.vue
@@ -22,9 +22,10 @@
               <SearchInput v-model="name" placeholder="Search by run name" label="Search by run name" />
             </template>
             <FlowRunsSort v-model="sort" />
+            <DeleteFlowRunsButton :selected="selectedFlowRuns" @delete="deleteFlowRuns" />
           </div>
 
-          <FlowRunList :flow-runs="flowRuns" :selected="selectedFlowRuns" disabled />
+          <FlowRunList v-model:selected="selectedFlowRuns" :flow-runs="flowRuns" />
 
           <template v-if="!flowRuns.length">
             <PEmptyResults>
@@ -42,7 +43,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PageHeadingFlowRuns, FlowRunsPageEmptyState, FlowRunsSort, FlowRunList, FlowRunsScatterPlot, SearchInput, ResultsCount, useFlowRunFilterFromRoute } from '@prefecthq/orion-design'
+  import { PageHeadingFlowRuns, FlowRunsPageEmptyState, FlowRunsSort, FlowRunList, FlowRunsScatterPlot, SearchInput, ResultsCount, useFlowRunFilterFromRoute, DeleteFlowRunsButton } from '@prefecthq/orion-design'
   import { PEmptyResults, media } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
@@ -77,6 +78,11 @@
 
   function clear(): void {
     router.push(routes.flowRuns())
+  }
+
+  const deleteFlowRuns =  async (): Promise<void> => {
+    selectedFlowRuns.value = []
+    await Promise.all([flowRunsSubscription.refresh(), flowRunCountSubscription.refresh()])
   }
 
   usePageTitle('Flow Runs')

--- a/orion-ui/src/pages/FlowRuns.vue
+++ b/orion-ui/src/pages/FlowRuns.vue
@@ -80,9 +80,10 @@
     router.push(routes.flowRuns())
   }
 
-  const deleteFlowRuns =  async (): Promise<void> => {
+  const deleteFlowRuns = (): void => {
     selectedFlowRuns.value = []
-    await Promise.all([flowRunsSubscription.refresh(), flowRunCountSubscription.refresh()])
+    flowRunsSubscription.refresh()
+    flowRunCountSubscription.refresh()
   }
 
   usePageTitle('Flow Runs')


### PR DESCRIPTION
This PR adds the ability to perform multiple delete on flow runs on flowRuns, Flow, Deployment, and WorkQueue pages
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
