### PR TITLE
Update engine to use new results

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -87,8 +87,6 @@ jobs:
           - "2.1"
           - "2.2"
           - "2.3"
-          - "2.4.2"
-          - "2.4.4"
           - "2.4"
 
           # We can include the following to always test against the last release
@@ -100,14 +98,18 @@ jobs:
           # While old clients should always be supported by new servers, a new
           # client may send data that an old server does not support. These
           # incompatibilities are allowed.
+
+          # All servers prior to 2.6.0 will not accept 2.6.0+ result types
           - prefect-version: "2.0"
             server-incompatible: true
           - prefect-version: "2.1"
             server-incompatible: true
-          - prefect-version: "2.4.4"
-            # This server release had a bug that made it incompatible
+          - prefect-version: "2.2"
             server-incompatible: true
-
+          - prefect-version: "2.3"
+            server-incompatible: true
+          - prefect-version: "2.4"
+            server-incompatible: true
 
       fail-fast: false
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -394,7 +394,7 @@ You can configure this to use a specific storage using one of the following:
 Generally, this means that tasks will use the result serializer configured on the flow unless otherwise specified.
 If there is no context to load the serializer from, the serializer defined by `PREFECT_RESULTS_DEFAULT_SERIALIZER` will be used. This setting defaults to Prefect's pickle serializer.
 
-You may set the configure the result serializer using:
+You may configure the result serializer using:
 
 - A type name, e.g. `"json"` or `"pickle"` &mdash; this corresponds to an instance with default values
 - An instance, e.g. `JSONSerializer(jsonlib="orjson")`

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -12,14 +12,14 @@ import pendulum
 
 from prefect.blocks.core import Block
 from prefect.client import OrionClient, get_client
-from prefect.deprecated.data_documents import DataDocument
 from prefect.engine import propose_state
 from prefect.exceptions import Abort, ObjectNotFound
 from prefect.infrastructure import Infrastructure, InfrastructureResult, Process
 from prefect.logging import get_logger
 from prefect.orion.schemas.core import BlockDocument, FlowRun, WorkQueue
-from prefect.orion.schemas.states import Failed, Pending
+from prefect.orion.schemas.states import Pending
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
+from prefect.states import exception_to_failed_state
 
 
 class OrionAgent:
@@ -292,10 +292,7 @@ class OrionAgent:
         try:
             await propose_state(
                 self.client,
-                Failed(
-                    message="Submission failed.",
-                    data=DataDocument.encode("cloudpickle", exc),
-                ),
+                await exception_to_failed_state(message="Submission failed.", exc=exc),
                 flow_run_id=flow_run.id,
             )
         except Abort:

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -12,12 +12,12 @@ import pendulum
 
 from prefect.blocks.core import Block
 from prefect.client import OrionClient, get_client
+from prefect.client.schemas import Pending
 from prefect.engine import propose_state
 from prefect.exceptions import Abort, ObjectNotFound
 from prefect.infrastructure import Infrastructure, InfrastructureResult, Process
 from prefect.logging import get_logger
 from prefect.orion.schemas.core import BlockDocument, FlowRun, WorkQueue
-from prefect.orion.schemas.states import Pending
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
 from prefect.states import exception_to_failed_state
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -1438,12 +1438,12 @@ class OrionClient:
             a [OrchestrationResult model][prefect.orion.orchestration.rules.OrchestrationResult]
                 representation of state orchestration output
         """
-        state_data = state.to_state_create()
-        state_data.state_details.flow_run_id = flow_run_id
+        state_create = state.to_state_create()
+        state_create.state_details.flow_run_id = flow_run_id
 
         response = await self._client.post(
             f"/flow_runs/{flow_run_id}/set_state",
-            json=dict(state=state_data.dict(json_compatible=True), force=force),
+            json=dict(state=state_create.dict(json_compatible=True), force=force),
         )
         return OrchestrationResult.parse_obj(response.json())
 
@@ -1604,11 +1604,11 @@ class OrionClient:
             a [OrchestrationResult model][prefect.orion.orchestration.rules.OrchestrationResult]
                 representation of state orchestration output
         """
-        state_data = state.to_state_create()
-        state_data.state_details.task_run_id = task_run_id
+        state_create = state.to_state_create()
+        state_create.state_details.task_run_id = task_run_id
         response = await self._client.post(
             f"/task_runs/{task_run_id}/set_state",
-            json=dict(state=state_data.dict(json_compatible=True), force=force),
+            json=dict(state=state_create.dict(json_compatible=True), force=force),
         )
         return OrchestrationResult.parse_obj(response.json())
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -357,7 +357,7 @@ class OrionClient:
         flow_run_create = schemas.actions.DeploymentFlowRunCreate(
             parameters=parameters,
             context=context,
-            state=state,
+            state=state.to_state_create(),
             tags=tags,
             name=name,
         )
@@ -415,7 +415,7 @@ class OrionClient:
             context=context,
             tags=list(tags or []),
             parent_task_run_id=parent_task_run_id,
-            state=state,
+            state=state.to_state_create(),
             empirical_policy=schemas.core.FlowRunPolicy(
                 retries=flow.retries,
                 retry_delay=flow.retry_delay_seconds,
@@ -1514,7 +1514,7 @@ class OrionClient:
                 retries=task.retries,
                 retry_delay=task.retry_delay_seconds,
             ),
-            state=state,
+            state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -19,6 +19,7 @@ import prefect.settings
 from prefect.client.schemas import (
     FlowRun,
     OrchestrationResult,
+    Pending,
     Scheduled,
     State,
     TaskRun,
@@ -402,7 +403,7 @@ class OrionClient:
         context = context or {}
 
         if state is None:
-            state = schemas.states.Pending()
+            state = Pending()
 
         # Retrieve the flow id
         flow_id = await self.create_flow(flow)
@@ -1501,7 +1502,7 @@ class OrionClient:
         tags = set(task.tags).union(extra_tags or [])
 
         if state is None:
-            state = schemas.states.Pending()
+            state = Pending()
 
         task_run_data = schemas.actions.TaskRunCreate(
             name=name,

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -140,6 +140,13 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
             return get_state_result(self, raise_on_failure=raise_on_failure)
 
     def to_state_create(self) -> schemas.actions.StateCreate:
+        """
+        Convert this state to a `StateCreate` type which can be used to set the state of
+        a run in the API.
+
+        This method will drop this state's `data` if it is not a result type. Only
+        results should be sent to the API. Other data is only available locally.
+        """
         from prefect.results import BaseResult
 
         return schemas.actions.StateCreate(

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, parse_obj_as, validator
 from prefect.blocks.core import Block
 from prefect.client import OrionClient, get_client
 from prefect.client.orion import inject_client
+from prefect.client.schemas import Scheduled
 from prefect.context import PrefectObjectRegistry
 from prefect.exceptions import BlockMissingCapabilities, ObjectNotFound
 from prefect.filesystems import LocalFileSystem
@@ -71,7 +72,7 @@ async def run_deployment(
     deployment = await client.read_deployment_by_name(name)
     flow_run = await client.create_flow_run_from_deployment(
         deployment.id,
-        state=schemas.states.Scheduled(scheduled_time=scheduled_time),
+        state=Scheduled(scheduled_time=scheduled_time),
         parameters=parameters,
     )
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1257,6 +1257,7 @@ async def wait_for_task_runs_and_report_crashes(
         if not state.type == StateType.CRASHED:
             continue
 
+        # We use this utility instead of `state.result` for type checking
         exception = await get_state_exception(state)
 
         task_run = await client.read_task_run(future.task_run.id)

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -59,6 +59,9 @@ class PrefectException(Exception):
 class CrashedRun(PrefectException):
     """
     Raised when the result from a crashed run is retrieved.
+
+    This occurs when a string is attached to the state instead of an exception or if
+    the state's data is null.
     """
 
 
@@ -67,8 +70,8 @@ class FailedRun(PrefectException):
     Raised when the result from a failed run is retrieved and an exception is not
     attached.
 
-    This occurs when a string is attached to the state instead of an exception
-    or the attached exception is a `BaseException` and is not safe to raise.
+    This occurs when a string is attached to the state instead of an exception or if
+    the state's data is null.
     """
 
 

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -56,6 +56,22 @@ class PrefectException(Exception):
     """
 
 
+class CrashedRun(PrefectException):
+    """
+    Raised when the result from a crashed run is retrieved.
+    """
+
+
+class FailedRun(PrefectException):
+    """
+    Raised when the result from a failed run is retrieved and an exception is not
+    attached.
+
+    This occurs when a string is attached to the state instead of an exception
+    or the attached exception is a `BaseException` and is not safe to raise.
+    """
+
+
 class MissingFlowError(PrefectException):
     """
     Raised when a given flow name is not found in the expected script.

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -488,6 +488,9 @@ def flow(
     description: str = None,
     timeout_seconds: Union[int, float] = None,
     validate_parameters: bool = True,
+    persist_result: Optional[bool] = None,
+    result_storage: Optional[ResultStorage] = None,
+    result_serializer: Optional[ResultSerializer] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
 

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -234,7 +234,7 @@ class PrefectFuture(Generic[R, A]):
         final_state = await self._wait(timeout=timeout)
         if not final_state:
             raise TimeoutError("Call timed out before task finished.")
-        return await final_state._result(raise_on_failure=raise_on_failure)
+        return await final_state.result(raise_on_failure=raise_on_failure, fetch=True)
 
     @overload
     def get_state(

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -145,11 +145,17 @@ class State(IDBaseModel, Generic[R]):
 
         `MyCompletedState(message="my message", type=COMPLETED, result=...)`
         """
+        from prefect.deprecated.data_documents import DataDocument
+
+        if isinstance(self.data, DataDocument):
+            result = self.data.decode()
+        else:
+            result = self.data
 
         display = dict(
             message=repr(self.message),
             type=self.type,
-            result=repr(self.data),
+            result=repr(result),
         )
 
         return f"{self.name}({', '.join(f'{k}={v}' for k, v in display.items())})"

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -149,7 +149,7 @@ class State(IDBaseModel, Generic[R]):
         display = dict(
             message=repr(self.message),
             type=self.type,
-            result=repr(self.data.decode()) if self.data else None,
+            result=repr(self.data),
         )
 
         return f"{self.name}({', '.join(f'{k}={v}' for k, v in display.items())})"

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -67,9 +67,6 @@ def task_features_require_result_persistence(task: "Task") -> bool:
     return False
 
 
-DEFAULT_FACTORY: "ResultFactory" = None
-
-
 class ResultFactory(pydantic.BaseModel):
     """
     A utility to generate `Result` types.

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -23,9 +23,9 @@ from prefect.utilities.pydantic import add_type_dispatch
 if TYPE_CHECKING:
     from prefect import Flow, Task
 
-LITERAL_TYPES = {type(None), bool}
 ResultStorage = Union[WritableFileSystem, str]
 ResultSerializer = Union[Serializer, str]
+LITERAL_TYPES = {type(None), bool}
 
 logger = get_logger("results")
 
@@ -296,7 +296,7 @@ class BaseResult(pydantic.BaseModel, Generic[R]):
 
 class ResultLiteral(BaseResult):
     """
-    Result type for literal values like `None`, `True`, and `False`.
+    Result type for literal values like `None`, `True`, `False`.
 
     These values are stored inline and JSON serialized when sent to the Prefect API.
     They are not persisted to external result storage.

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -1,12 +1,19 @@
 """
-Data serializer implementations
+Serializer implementations for converting objects to bytes and bytes to objects.
 
-These serializers are registered for use with `DataDocument` types
+All serializers are based on the `Serializer` class and include a `type` string that
+allows them to be referenced without referencing the actual class. For example, you
+can get often specify the `JSONSerializer` with the string "json". Some serializers
+support additional settings for configuration of serialization. These are stored on
+the instance so the same settings can be used to load saved objects.
+
+All serializers must implement `dumps` and `loads` which convert objects to bytes and
+bytes to an object respectively.
 """
 import abc
 import base64
 import warnings
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 import pydantic
 from pydantic import BaseModel
@@ -17,10 +24,6 @@ from prefect.utilities.importtools import from_qualified_name, to_qualified_name
 from prefect.utilities.pydantic import add_type_dispatch
 
 D = TypeVar("D")
-
-
-if TYPE_CHECKING:
-    pass
 
 
 def prefect_json_object_encoder(obj: Any) -> Any:

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -190,6 +190,9 @@ async def raise_failed_state(state: State) -> None:
         for state in result:
             await raise_failed_state(state)
 
+    elif isinstance(result, str):
+        raise Exception(result)
+
     else:
         raise TypeError(
             f"Unexpected result for failure state: {result!r} —— "

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -85,7 +85,10 @@ async def exception_to_failed_state(
     existing_message = kwargs.pop("message", "")
     if existing_message and not existing_message.endswith(" "):
         existing_message += " "
-    message = existing_message + format_exception(exc, exc_tb)
+
+    # TODO: Consider if we want to include traceback information, it is intentionally
+    #       excluded from messages for now
+    message = existing_message + format_exception(exc)
 
     return Failed(data=data, message=message, **kwargs)
 

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -203,7 +203,7 @@ class SequentialTaskRunner(BaseTaskRunner):
         try:
             result = await call()
         except BaseException as exc:
-            result = exception_to_crashed_state(exc)
+            result = await exception_to_crashed_state(exc)
 
         self._results[key] = result
 
@@ -290,7 +290,7 @@ class ConcurrentTaskRunner(BaseTaskRunner):
         try:
             self._results[key] = await call()
         except BaseException as exc:
-            self._results[key] = exception_to_crashed_state(exc)
+            self._results[key] = await exception_to_crashed_state(exc)
 
         self._result_events[key].set()
 

--- a/src/prefect/utilities/pydantic.py
+++ b/src/prefect/utilities/pydantic.py
@@ -154,7 +154,10 @@ def add_type_dispatch(model_cls: Type[M]) -> Type[M]:
 
     def __new__(cls: Type[Self], **kwargs) -> Self:
         if "type" in kwargs:
-            subcls = lookup_type(cls, dispatch_key=kwargs["type"])
+            try:
+                subcls = lookup_type(cls, dispatch_key=kwargs["type"])
+            except KeyError as exc:
+                raise pydantic.ValidationError(errors=[exc], model=cls)
             return cls_new(subcls)
         else:
             return cls_new(cls)

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -4,7 +4,7 @@ import pytest
 
 import prefect.exceptions
 from prefect import flow
-from prefect.orion.schemas import states
+from prefect.client.schemas import Completed, Late, Running, Scheduled
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import sync_compatible
 
@@ -48,28 +48,28 @@ def assert_flow_runs_in_result(result, expected, unexpected=None):
 @pytest.fixture
 async def scheduled_flow_run(orion_client):
     return await orion_client.create_flow_run(
-        name="scheduled_flow_run", flow=hello_flow, state=states.Scheduled()
+        name="scheduled_flow_run", flow=hello_flow, state=Scheduled()
     )
 
 
 @pytest.fixture
 async def completed_flow_run(orion_client):
     return await orion_client.create_flow_run(
-        name="completed_flow_run", flow=hello_flow, state=states.Completed()
+        name="completed_flow_run", flow=hello_flow, state=Completed()
     )
 
 
 @pytest.fixture
 async def running_flow_run(orion_client):
     return await orion_client.create_flow_run(
-        name="running_flow_run", flow=goodbye_flow, state=states.Running()
+        name="running_flow_run", flow=goodbye_flow, state=Running()
     )
 
 
 @pytest.fixture
 async def late_flow_run(orion_client):
     return await orion_client.create_flow_run(
-        name="late_flow_run", flow=goodbye_flow, state=states.Late()
+        name="late_flow_run", flow=goodbye_flow, state=Late()
     )
 
 

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -17,7 +17,14 @@ import prefect.exceptions
 from prefect import flow, tags
 from prefect.client import OrionClient, get_client
 from prefect.client.orion import OrionClient, get_client, inject_client
-from prefect.client.schemas import OrchestrationResult, Pending, Running, Scheduled
+from prefect.client.schemas import (
+    Completed,
+    OrchestrationResult,
+    Pending,
+    Running,
+    Scheduled,
+    State,
+)
 from prefect.deprecated.data_documents import DataDocument
 from prefect.orion import schemas
 from prefect.orion.api.server import ORION_API_VERSION, create_app
@@ -667,7 +674,7 @@ async def test_create_flow_run_with_state(orion_client):
     def foo():
         pass
 
-    flow_run = await orion_client.create_flow_run(foo, state=schemas.states.Running())
+    flow_run = await orion_client.create_flow_run(foo, state=Running())
     assert flow_run.state.is_running()
 
 
@@ -679,7 +686,7 @@ async def test_set_then_read_flow_run_state(orion_client):
     flow_run_id = (await orion_client.create_flow_run(foo)).id
     response = await orion_client.set_flow_run_state(
         flow_run_id,
-        state=schemas.states.Completed(message="Test!"),
+        state=Completed(message="Test!"),
     )
     assert isinstance(response, OrchestrationResult)
     assert response.status == schemas.responses.SetStateStatus.ACCEPT
@@ -804,7 +811,7 @@ async def test_create_flow_run_from_deployment(orion_client, deployment):
     # Flow version is not populated yet
     assert flow_run.flow_version is None
     # State is scheduled for now
-    assert flow_run.state.type == schemas.states.StateType.SCHEDULED
+    assert flow_run.state.type == StateType.SCHEDULED
     assert (
         pendulum.now("utc")
         .diff(flow_run.state.state_details.scheduled_time)
@@ -916,7 +923,7 @@ async def test_create_then_read_task_run_with_state(orion_client):
 
     flow_run = await orion_client.create_flow_run(foo)
     task_run = await orion_client.create_task_run(
-        bar, flow_run_id=flow_run.id, state=schemas.states.Running(), dynamic_key="0"
+        bar, flow_run_id=flow_run.id, state=Running(), dynamic_key="0"
     )
     assert task_run.state.is_running()
 
@@ -937,15 +944,15 @@ async def test_set_then_read_task_run_state(orion_client):
 
     response = await orion_client.set_task_run_state(
         task_run.id,
-        schemas.states.Completed(message="Test!"),
+        Completed(message="Test!"),
     )
 
     assert isinstance(response, OrchestrationResult)
     assert response.status == schemas.responses.SetStateStatus.ACCEPT
 
     run = await orion_client.read_task_run(task_run.id)
-    assert isinstance(run.state, schemas.states.State)
-    assert run.state.type == schemas.states.StateType.COMPLETED
+    assert isinstance(run.state, State)
+    assert run.state.type == StateType.COMPLETED
     assert run.state.message == "Test!"
 
 

--- a/tests/orion/database/test_queries.py
+++ b/tests/orion/database/test_queries.py
@@ -165,7 +165,7 @@ class TestGetRunsInQueueQuery:
     async def test_query_skips_locked(self, db):
         """Concurrent queries should not both receive runs"""
         if db.database_config.connection_url.startswith("sqlite"):
-            pytest.skip(reason="FOR UDPATE SKIP LOCKED is not supported on SQLite")
+            pytest.skip("FOR UDPATE SKIP LOCKED is not supported on SQLite")
 
         query = db.queries.get_scheduled_flow_runs_from_work_queues(db=db)
 

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -32,31 +32,27 @@ def assert_blocks_equal(
 
 
 @pytest.fixture
-async def default_factory(orion_client):
-    @flow
-    def foo():
-        pass
-
-    return await ResultFactory.from_flow(foo, client=orion_client)
+async def factory(orion_client):
+    return await ResultFactory.default_factory(client=orion_client, persist_result=True)
 
 
 @pytest.mark.parametrize("value", [True, False, None])
-async def test_create_result_literal(value, default_factory):
-    result = await default_factory.create_result(value)
+async def test_create_result_literal(value, factory):
+    result = await factory.create_result(value)
     assert isinstance(result, ResultLiteral)
     assert await result.get() == value
 
 
-async def test_create_result_reference(default_factory):
-    result = await default_factory.create_result({"foo": "bar"})
+async def test_create_result_reference(factory):
+    result = await factory.create_result({"foo": "bar"})
     assert isinstance(result, ResultReference)
-    assert result.serializer_type == default_factory.serializer.type
-    assert result.storage_block_id == default_factory.storage_block_id
+    assert result.serializer_type == factory.serializer.type
+    assert result.storage_block_id == factory.storage_block_id
     assert await result.get() == {"foo": "bar"}
 
 
-async def test_create_result_reference_has_cached_object(default_factory):
-    result = await default_factory.create_result({"foo": "bar"})
+async def test_create_result_reference_has_cached_object(factory):
+    result = await factory.create_result({"foo": "bar"})
     assert result._has_cached_object()
 
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -26,7 +26,7 @@ from prefect.orion.schemas.sorting import FlowRunSort
 from prefect.orion.schemas.states import StateType
 from prefect.results import ResultReference
 from prefect.settings import PREFECT_LOCAL_STORAGE_PATH, temporary_settings
-from prefect.states import StateType, raise_failed_state
+from prefect.states import StateType, raise_state_exception
 from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
 from prefect.testing.utilities import (
     exceptions_equal,
@@ -366,7 +366,7 @@ class TestFlowCall:
         task_run_state = task_run_states[0]
         assert task_run_state.is_failed()
         with pytest.raises(ValueError, match="Test"):
-            raise_failed_state(task_run_states[0])
+            raise_state_exception(task_run_states[0])
 
     def test_flow_state_defaults_to_task_states_when_no_return_completed(self):
         @task
@@ -407,7 +407,7 @@ class TestFlowCall:
         assert all(isinstance(state, State) for state in states)
         assert states[0].result() == "foo"
         with pytest.raises(ValueError, match="bar"):
-            raise_failed_state(states[1])
+            raise_state_exception(states[1])
 
     def test_flow_state_default_handles_nested_failures(self):
         @task
@@ -432,7 +432,7 @@ class TestFlowCall:
         state = states[0]
         assert isinstance(state, State)
         with pytest.raises(ValueError, match="foo"):
-            raise_failed_state(state)
+            raise_state_exception(state)
 
     def test_flow_state_reflects_returned_multiple_task_run_states(self):
         @task

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -94,7 +94,9 @@ class TestRaiseStateException:
         ):
             await raise_state_exception(state_cls(data=value))
 
-    async def test_raises_wrapper_if_result_is_base_exception(self, state_cls):
+    async def test_warns_and_raises_wrapper_if_result_is_base_exception(
+        self, state_cls
+    ):
         with pytest.raises(
             FailedRun if state_cls == Failed else CrashedRun, match="foo"
         ):
@@ -103,6 +105,12 @@ class TestRaiseStateException:
                 match="State result is a 'BaseException' type and is not safe to re-raise",
             ):
                 await raise_state_exception(state_cls(data=BaseException("foo")))
+
+    async def test_raises_wrapper_with_state_message_if_result_is_null(self, state_cls):
+        with pytest.raises(
+            FailedRun if state_cls == Failed else CrashedRun, match="foo"
+        ):
+            await raise_state_exception(state_cls(data=None, message="foo"))
 
     async def test_raises_error_if_failed_state_does_not_contain_exception(
         self, state_cls

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -4,6 +4,7 @@ from prefect.client.schemas import Completed, Failed, Pending, Running, State
 from prefect.deprecated.data_documents import DataDocument
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.states import StateType
+from prefect.results import ResultFactory
 from prefect.states import (
     is_state,
     is_state_iterable,
@@ -97,6 +98,10 @@ class TestRaiseFailedState:
 
 
 class TestReturnValueToState:
+    @pytest.fixture
+    async def default_factory(orion_client):
+        return await ResultFactory.default_factory(client=orion_client)
+
     async def test_returns_single_state_unaltered(self):
         state = Completed(data=DataDocument.encode("json", "hello"))
         assert await return_value_to_state(state) is state

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -58,7 +58,7 @@ class TestRaiseStateException:
 
     async def test_raises_value_error_if_nested_state_is_not_failed(self, state_cls):
         with pytest.raises(
-            ValueError, match="Failed state result was a state that was not failed"
+            ValueError, match="Expected failed or crashed state got Completed"
         ):
             await raise_state_exception(state_cls(data=Completed(data="test")))
 
@@ -81,7 +81,7 @@ class TestRaiseStateException:
         ]
         with pytest.raises(
             ValueError,
-            match="Failed state result contained multiple states but none were failed",
+            match="Failed state result was an iterable of states but none were failed",
         ):
             await raise_state_exception(state_cls(data=inner_states))
 
@@ -94,17 +94,9 @@ class TestRaiseStateException:
         ):
             await raise_state_exception(state_cls(data=value))
 
-    async def test_warns_and_raises_wrapper_if_result_is_base_exception(
-        self, state_cls
-    ):
-        with pytest.raises(
-            FailedRun if state_cls == Failed else CrashedRun, match="foo"
-        ):
-            with pytest.warns(
-                UserWarning,
-                match="State result is a 'BaseException' type and is not safe to re-raise",
-            ):
-                await raise_state_exception(state_cls(data=BaseException("foo")))
+    async def test_raises_base_exception(self, state_cls):
+        with pytest.raises(BaseException):
+            await raise_state_exception(state_cls(data=BaseException("foo")))
 
     async def test_raises_wrapper_with_state_message_if_result_is_null(self, state_cls):
         with pytest.raises(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Hooks everything up! Everywhere in the engine where we were creating `DataDocument` types, we are now creating  new result types. 

The largest changes here are dealing with cases where we previously would pickle exceptions and attach them to states. We do this all over the place — sometimes where we do not have access to the user's result settings. To support those cases, I've refactored failed/crashed results to allow generation of an exception from a string. This means we do not need to actually serialize an exception to report a failure, e.g. when an agent fails to submit a flow run.

Unlike the other pull requests in #6908 this one is a little sprawling — at some point everything's got to switch over and little edge cases need to be addressed. I think this makes this a good candidate for synchronous review.

I have not added tests here covering usage of results. Instead, I've focused on fixing the existing tests which make extensive usage of results anyway. I'm going to add dedicated tests in a follow-up pull request but want to get this merged ASAP to facilitate QA of this feature.
