### PR TITLE
Exempt `status:accepted` labels from being marked as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
           days-before-stale: 30
           days-before-close: 14
           exempt-draft-pr: true
-          exempt-issue-labels: "status:backlog,status:in-progress,status:roadmap,status:accepted"
+          exempt-issue-labels: "status:in-progress,status:roadmap,status:accepted"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
           days-before-stale: 30
           days-before-close: 14
           exempt-draft-pr: true
-          exempt-issue-labels: "status:backlog,status:in-progress,status:roadmap"
+          exempt-issue-labels: "status:backlog,status:in-progress,status:roadmap,status:accepted"


### PR DESCRIPTION
Adds `status:accepted` to the Stale action's exempt label list.