### PR TITLE
Add test coverage for bytes serialization and caching

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -30,10 +30,12 @@ class MyDataclass:
     x: int
     y: str
 
+
 @dataclass
 class MyDataclassBytes:
     x: int
     y: bytes
+
 
 # Simple test cases that all serializers should support roundtrips for
 SERIALIZER_TEST_CASES = [
@@ -54,6 +56,7 @@ def dog(some_param: str) -> int:
     print('woof!' + some_param)
     print('These are complex chars: !@#$%^&*()_+-')
 """
+
 
 class TestBaseSerializer:
     @pytest.fixture(autouse=True)
@@ -187,22 +190,22 @@ class TestPickleSerializer:
 
 
 class TestJSONSerializer:
-
     @pytest.mark.parametrize("data", SERIALIZER_TEST_CASES)
     def test_simple_roundtrip(self, data):
         serializer = JSONSerializer()
         serialized = serializer.dumps(data)
         assert serializer.loads(serialized) == data
 
-    @pytest.mark.parametrize("data", 
-    [
-        complex_str.encode('utf-8'),
-        complex_str.encode("ASCII"),
-        complex_str.encode("latin_1"),
-        [complex_str.encode('utf-8')],
-        {"key": complex_str.encode("ASCII")},
-        {complex_str.encode("latin_1")},
-    ]
+    @pytest.mark.parametrize(
+        "data",
+        [
+            complex_str.encode("utf-8"),
+            complex_str.encode("ASCII"),
+            complex_str.encode("latin_1"),
+            [complex_str.encode("utf-8")],
+            {"key": complex_str.encode("ASCII")},
+            {complex_str.encode("latin_1")},
+        ],
     )
     def test_simple_roundtrip_with_complex_bytes(self, data):
         serializer = JSONSerializer()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1030,11 +1030,11 @@ class TestCacheFunctionBuiltins:
         @flow
         def bar():
             return (
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))), # same
-                foo._run(TestBlock(x=4, y=2, z="dog".encode("utf-8"))), # different x
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))), # same
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("latin-1"))), # same
-                foo._run(TestBlock(x=1, y=2, z="cat".encode("utf-8"))), # different z
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))),  # same
+                foo._run(TestBlock(x=4, y=2, z="dog".encode("utf-8"))),  # different x
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))),  # same
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("latin-1"))),  # same
+                foo._run(TestBlock(x=1, y=2, z="cat".encode("utf-8"))),  # different z
             )
 
         first_state, second_state, third_state, fourth_state, fifth_state = bar()
@@ -1045,7 +1045,10 @@ class TestCacheFunctionBuiltins:
         assert fifth_state.name == "Completed"
 
         assert first_state.result() != second_state.result()
-        assert first_state.result() == third_state.result() == fourth_state.result() == 1
+        assert (
+            first_state.result() == third_state.result() == fourth_state.result() == 1
+        )
+
 
 class TestTaskRunTags:
     async def test_task_run_tags_added_at_submission(self, orion_client):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1017,6 +1017,35 @@ class TestCacheFunctionBuiltins:
         assert first_state.result() != third_state.result()
         assert fourth_state.result() == fifth_state.result() == 1
 
+    def test_task_input_hash_works_with_block_input_types_and_bytes(self):
+        class TestBlock(Block):
+            x: int
+            y: int
+            z: bytes
+
+        @task(cache_key_fn=task_input_hash)
+        def foo(instance):
+            return instance.x
+
+        @flow
+        def bar():
+            return (
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))), # same
+                foo._run(TestBlock(x=4, y=2, z="dog".encode("utf-8"))), # different x
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))), # same
+                foo._run(TestBlock(x=1, y=2, z="dog".encode("latin-1"))), # same
+                foo._run(TestBlock(x=1, y=2, z="cat".encode("utf-8"))), # different z
+            )
+
+        first_state, second_state, third_state, fourth_state, fifth_state = bar()
+        assert first_state.name == "Completed"
+        assert second_state.name == "Completed"
+        assert third_state.name == "Cached"
+        assert fourth_state.name == "Cached"
+        assert fifth_state.name == "Completed"
+
+        assert first_state.result() != second_state.result()
+        assert first_state.result() == third_state.result() == fourth_state.result() == 1
 
 class TestTaskRunTags:
     async def test_task_run_tags_added_at_submission(self, orion_client):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds test coverage for bytes serialization for our `serializers` module and test coverage for correct cache utilization for Prefect blocks that have bytes attributes. 

The tests include simple and complex byte strings, multiple encodings, and objects with byte attributes. 

The tests were originally written as part of an investigation into issue with bytes using the `JSONSerializer` mentioned in pull request https://github.com/PrefectHQ/prefect/pull/7048 , but the issue was not able to be reproduced. 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
