### PR TITLE
Add `allow_failure` annotation to allow failed runs to be passed downstream

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -28,7 +28,7 @@ from prefect.tasks import task, Task
 from prefect.context import tags
 from prefect.client import get_client
 from prefect.manifests import Manifest
-from prefect.utilities.annotations import unmapped
+from prefect.utilities.annotations import unmapped, allow_failure
 
 # Import modules that register types
 import prefect.serializers

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -4,14 +4,39 @@ T = TypeVar("T")
 
 
 class unmapped:
-    """A container that acts as an infinite array where all items are the same
-    value. Used for Task.map where there is a need to map over a single
-    value"""
+    """
+    Wrapper for iterables.
+
+    Indicates that this input should be sent as-is to all runs created during a mapping
+    operation instead of being split.
+    """
 
     def __init__(self, value: Any):
         self.value = value
 
     def __getitem__(self, _) -> Any:
+        # Internally, this acts as an infinite array where all items are the same value
+        return self.value
+
+
+class allow_failure:
+    """
+    Wrapper for states or futures.
+
+    Indicates that the upstream run for this input can be failed.
+
+    Generally, Prefect will not allow a downstream run to start if any of its inputs
+    are failed. This annotation allows you to opt into receiving a failed input
+    downstream.
+
+    If the input is from a failed run, the attached exception will be passed to your
+    function.
+    """
+
+    def __init__(self, value: Any):
+        self.value = value
+
+    def unwrap(self) -> Any:
         return self.value
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -23,7 +23,7 @@ from prefect.orion.schemas.data import DataDocument
 from prefect.orion.schemas.states import State, StateType
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal, flaky_on_windows
-from prefect.utilities.annotations import unmapped
+from prefect.utilities.annotations import allow_failure, unmapped
 from prefect.utilities.collections import quote
 
 
@@ -330,6 +330,62 @@ class TestTaskSubmit:
             return "bar"
 
         assert bar() == "bar"
+
+    def test_downstream_does_not_run_if_upstream_fails(self):
+        @task
+        def fails():
+            raise ValueError("Fail task!")
+
+        @task
+        def bar(y):
+            return y
+
+        @flow
+        def test_flow():
+            f = fails.submit()
+            b = bar.submit(f)
+            return b
+
+        flow_state = test_flow(return_state=True)
+        task_state = flow_state.result(raise_on_failure=False)
+        assert task_state.is_pending()
+        assert task_state.name == "NotReady"
+
+    def test_downstream_runs_if_upstream_succeeds(self):
+        @task
+        def foo(x):
+            return x
+
+        @task
+        def bar(y):
+            return y + 1
+
+        @flow
+        def test_flow():
+            f = foo.submit(1)
+            b = bar.submit(f)
+            return b
+
+        assert test_flow() == 2
+
+    def test_downstream_receives_exception_if_upstream_fails_and_allow_failure(self):
+        @task
+        def fails():
+            raise ValueError("Fail task!")
+
+        @task
+        def bar(y):
+            return y
+
+        @flow
+        def test_flow():
+            f = fails.submit()
+            b = bar.submit(allow_failure(f))
+            return b.result()
+
+        result = test_flow()
+        assert isinstance(result, ValueError)
+        assert "Fail task!" in str(result)
 
 
 class TestTaskStates:
@@ -1447,6 +1503,35 @@ class TestTaskInputs:
             x=[TaskRunResult(id=upstream_state.state_details.task_run_id)],
         )
 
+    async def test_task_inputs_populated_with_state_upstream_wrapped_with_allow_failure(
+        self, orion_client
+    ):
+        @task
+        def upstream(x):
+            return x
+
+        @task
+        def downstream(x):
+            return x
+
+        @flow
+        def test_flow():
+            upstream_state = upstream(1, return_state=True)
+            downstream_state = downstream(
+                allow_failure(upstream_state), return_state=True
+            )
+            return upstream_state, downstream_state
+
+        upstream_state, downstream_state = test_flow()
+
+        task_run = await orion_client.read_task_run(
+            downstream_state.state_details.task_run_id
+        )
+
+        assert task_run.task_inputs == dict(
+            x=[TaskRunResult(id=upstream_state.state_details.task_run_id)],
+        )
+
     @pytest.mark.parametrize("result", [["Fred"], {"one": 1}, {1, 2, 2}, (1, 2)])
     async def test_task_inputs_populated_with_collection_result_upstream(
         self, result, orion_client, flow_with_upstream_downstream
@@ -1696,6 +1781,25 @@ class TestTaskWaitFor:
             @task
             def foo(wait_for):
                 pass
+
+    def test_downstream_runs_if_upstream_fails_with_allow_failure_annotation(self):
+        @task
+        def fails():
+            raise ValueError("Fail task!")
+
+        @task
+        def bar(y):
+            return y
+
+        @flow
+        def test_flow():
+            f = fails.submit()
+            b = bar(2, wait_for=[allow_failure(f)], return_state=True)
+            return b
+
+        flow_state = test_flow(return_state=True)
+        task_state = flow_state.result(raise_on_failure=False)
+        assert task_state.result() == 2
 
 
 @pytest.mark.enable_orion_handler

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -364,7 +364,7 @@ class TestTaskSubmit:
         def test_flow():
             f = foo.submit(1)
             b = bar.submit(f)
-            return b
+            return b.result()
 
         assert test_flow() == 2
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect/issues/7098

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
@task
def fails():
    raise ValueError("Fail task!")

@task
def bar(y):
    return y

@flow
def test_flow():
    f = fails.submit()

    # Previously, `bar` would fail with a `NotReady` state
    # Now, it will receive an exception
    b = bar.submit(allow_failure(f))
    assert isinstance(b.result(), ValueError)
    
    # Previously, `bar` would fail with a `NotReady` state
    # Now, it will run after the upstream completes
    b = bar.submit(1, wait_for=[allow_failure(f)])
    assert b.result() == 1
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
