### PR TITLE
Additional test coverage for results

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -87,6 +87,13 @@ class UnspecifiedFlowError(PrefectException):
     """
 
 
+class MissingResult(PrefectException):
+    """
+    Raised when a result is missing from a state; often when result persistence is
+    disabled and the state is retrieved from the API.
+    """
+
+
 class ScriptError(PrefectException):
     """
     Raised when a script errors during evaluation while attempting to load data

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -15,7 +15,7 @@ from prefect.deprecated.data_documents import (
     DataDocument,
     result_from_state_with_data_document,
 )
-from prefect.exceptions import CrashedRun, FailedRun
+from prefect.exceptions import CrashedRun, FailedRun, MissingResult
 from prefect.orion import schemas
 from prefect.orion.schemas.states import StateType
 from prefect.results import BaseResult, R, ResultFactory
@@ -83,7 +83,7 @@ async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
         if state.is_failed() or state.is_crashed():
             return await get_state_exception(state)
         else:
-            raise ValueError(
+            raise MissingResult(
                 "State data is missing. "
                 "Typically, this occurs when result persistence is disabled and the "
                 "state has been retrieved from the API."

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -14,8 +14,15 @@ import pytest
 import prefect.context
 import prefect.orion.schemas as schemas
 import prefect.settings
+from prefect.blocks.core import Block
 from prefect.client import OrionClient, get_client
+from prefect.client.orion import OrionClient
+from prefect.client.utilities import inject_client
+from prefect.filesystems import ReadableFileSystem
 from prefect.orion.database.dependencies import temporary_database_interface
+from prefect.results import PersistedResult
+from prefect.serializers import Serializer
+from prefect.states import State
 
 
 def flaky_on_windows(fn, **kwargs):
@@ -141,3 +148,53 @@ async def get_most_recent_flow_run(client: OrionClient = None):
     )
 
     return flow_runs[0]
+
+
+def assert_blocks_equal(
+    found, expected, exclude_private: bool = True, **kwargs
+) -> bool:
+    assert isinstance(
+        found, type(expected)
+    ), f"Unexpected type {type(found).__name__}, expected {type(expected).__name__}"
+
+    if exclude_private:
+        exclude = set(kwargs.pop("exclude", set()))
+        for attr, _ in found._iter():
+            if attr.startswith("_"):
+                exclude.add(attr)
+
+    assert found.dict(exclude=exclude, **kwargs) == expected.dict(
+        exclude=exclude, **kwargs
+    )
+
+
+async def assert_uses_result_serializer(
+    state: State, serializer: Union[str, Serializer]
+):
+    assert isinstance(state.data, PersistedResult)
+    assert (
+        state.data.serializer_type == serializer
+        if isinstance(serializer, str)
+        else serializer.type
+    )
+    blob = await state.data._read_blob()
+    assert (
+        blob.serializer == serializer
+        if isinstance(serializer, Serializer)
+        else Serializer(type=serializer)
+    )
+
+
+@inject_client
+async def assert_uses_result_storage(
+    state: State, storage: Union[str, ReadableFileSystem], client: "OrionClient"
+):
+    assert isinstance(state.data, PersistedResult)
+    assert_blocks_equal(
+        Block._from_block_document(
+            await client.read_block_document(state.data.storage_block_id)
+        ),
+        storage
+        if isinstance(storage, Block)
+        else await Block.load(storage, client=client),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ import asyncpg
 import pytest
 from sqlalchemy.dialects.postgresql.asyncpg import dialect as postgres_dialect
 
+# Improve diff display for assertions in utilities
+# Note: This must occur before import of the module
+pytest.register_assert_rewrite("prefect.testing.utilities")
+
 import prefect
 import prefect.settings
 from prefect.logging.configuration import setup_logging

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -1,0 +1,188 @@
+import pytest
+
+from prefect.exceptions import MissingResult
+from prefect.filesystems import LocalFileSystem
+from prefect.flows import flow
+from prefect.serializers import JSONSerializer, PickleSerializer, Serializer
+from prefect.settings import PREFECT_HOME
+from prefect.testing.utilities import (
+    assert_uses_result_serializer,
+    assert_uses_result_storage,
+)
+
+
+class MyIntSerializer(Serializer):
+    """
+    Custom serializer for test coverage of user-defined serializers
+    """
+
+    type = "int-custom"
+
+    def dumps(self, obj: int):
+        return obj.to_bytes(8, byteorder="little")
+
+    def loads(self, blob):
+        return int.from_bytes(blob, byteorder="little")
+
+
+@pytest.mark.parametrize("persist_result", [False, None])
+async def test_flow_with_unpersisted_result(orion_client, persist_result):
+    @flow(persist_result=persist_result)
+    def foo():
+        return 1
+
+    state = foo(return_state=True)
+    assert await state.result() == 1
+
+    api_state = (
+        await orion_client.read_flow_run(state.state_details.flow_run_id)
+    ).state
+    with pytest.raises(MissingResult):
+        await api_state.result()
+
+
+@pytest.mark.parametrize(
+    "serializer",
+    ["json", "pickle", JSONSerializer(), PickleSerializer(), MyIntSerializer()],
+)
+async def test_flow_result_serializer(serializer, orion_client):
+    @flow(result_serializer=serializer, persist_result=True)
+    def foo():
+        return 1
+
+    state = foo(return_state=True)
+    assert await state.result() == 1
+    await assert_uses_result_serializer(state, serializer)
+
+    api_state = (
+        await orion_client.read_flow_run(state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_serializer(api_state, serializer)
+
+
+async def test_flow_result_storage_by_instance(orion_client):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow(result_storage=storage, persist_result=True)
+    def foo():
+        return 1
+
+    state = foo(return_state=True)
+    assert await state.result() == 1
+    await assert_uses_result_storage(state, storage)
+
+    api_state = (
+        await orion_client.read_flow_run(state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_storage(api_state, storage)
+
+
+async def test_flow_result_storage_by_slug(orion_client):
+    await LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage").save("test")
+    slug = LocalFileSystem.get_block_type_slug() + "/test"
+
+    @flow(result_storage=slug, persist_result=True)
+    def foo():
+        return 1
+
+    state = foo(return_state=True)
+    assert await state.result() == 1
+    await assert_uses_result_storage(state, slug, client=orion_client)
+
+    api_state = (
+        await orion_client.read_flow_run(state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_storage(api_state, slug, client=orion_client)
+
+
+@pytest.mark.parametrize("options", [{"retries": 3}])
+async def test_child_flow_persisted_result_due_to_parent_feature(orion_client, options):
+    @flow(**options)
+    def foo():
+        return bar(return_state=True)
+
+    @flow
+    def bar():
+        return 1
+
+    parent_state = foo(return_state=True)
+    child_state = await parent_state.result()
+    assert await child_state.result() == 1
+
+    api_state = (
+        await orion_client.read_flow_run(child_state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+
+
+async def test_child_flow_persisted_result_due_to_opt_in(orion_client):
+    @flow
+    def foo():
+        return bar(return_state=True)
+
+    @flow(persist_result=True)
+    def bar():
+        return 1
+
+    parent_state = foo(return_state=True)
+    child_state = await parent_state.result()
+    assert await child_state.result() == 1
+
+    api_state = (
+        await orion_client.read_flow_run(child_state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+
+
+@pytest.mark.parametrize("source", ["child", "parent"])
+async def test_child_flow_result_serializer(orion_client, source):
+    serializer = "json"
+
+    @flow(result_serializer=serializer if source == "parent" else None)
+    def foo():
+        return bar(return_state=True)
+
+    @flow(
+        result_serializer=serializer if source == "child" else None,
+        persist_result=True,
+    )
+    def bar():
+        return 1
+
+    parent_state = foo(return_state=True)
+    child_state = await parent_state.result()
+    assert await child_state.result() == 1
+    await assert_uses_result_serializer(child_state, serializer)
+
+    api_state = (
+        await orion_client.read_flow_run(child_state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_serializer(api_state, serializer)
+
+
+@pytest.mark.parametrize("source", ["child", "parent"])
+async def test_child_flow_result_storage(orion_client, source):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow(result_storage=storage if source == "parent" else None)
+    def foo():
+        return bar(return_state=True)
+
+    @flow(result_storage=storage if source == "child" else None, persist_result=True)
+    def bar():
+        return 1
+
+    parent_state = foo(return_state=True)
+    child_state = await parent_state.result()
+    assert await child_state.result() == 1
+    await assert_uses_result_storage(child_state, storage)
+
+    api_state = (
+        await orion_client.read_flow_run(child_state.state_details.flow_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_storage(api_state, storage)

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -8,27 +8,10 @@ from prefect.filesystems import LocalFileSystem
 from prefect.results import LiteralResult, PersistedResult, ResultFactory
 from prefect.serializers import JSONSerializer, PickleSerializer
 from prefect.settings import PREFECT_LOCAL_STORAGE_PATH
+from prefect.testing.utilities import assert_blocks_equal
 
 DEFAULT_SERIALIZER = PickleSerializer
 DEFAULT_STORAGE = lambda: LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
-
-
-def assert_blocks_equal(
-    found, expected, exclude_private: bool = True, **kwargs
-) -> bool:
-    assert isinstance(
-        found, type(expected)
-    ), f"Unexpected type {type(found).__name__}, expected {type(expected).__name__}"
-
-    if exclude_private:
-        exclude = set(kwargs.pop("exclude", set()))
-        for attr, _ in found._iter():
-            if attr.startswith("_"):
-                exclude.add(attr)
-
-    assert found.dict(exclude=exclude, **kwargs) == expected.dict(
-        exclude=exclude, **kwargs
-    )
 
 
 @pytest.fixture

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -1,0 +1,123 @@
+import pytest
+
+from prefect.filesystems import LocalFileSystem
+from prefect.flows import flow
+from prefect.serializers import JSONSerializer, PickleSerializer
+from prefect.settings import PREFECT_HOME
+from prefect.tasks import task
+from prefect.testing.utilities import (
+    assert_uses_result_serializer,
+    assert_uses_result_storage,
+)
+
+
+@pytest.mark.parametrize("options", [{"retries": 3}])
+async def test_task_persisted_result_due_to_flow_feature(orion_client, options):
+    @flow(**options)
+    def foo():
+        return bar(return_state=True)
+
+    @task
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+
+
+@pytest.mark.parametrize("options", [{"cache_key_fn": lambda *_: "foo"}])
+async def test_task_persisted_result_due_to_task_feature(orion_client, options):
+    @flow()
+    def foo():
+        return bar(return_state=True)
+
+    @task(**options)
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+
+
+async def test_task_persisted_result_due_to_opt_in(orion_client):
+    @flow
+    def foo():
+        return bar(return_state=True)
+
+    @task(persist_result=True)
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+
+
+@pytest.mark.parametrize(
+    "serializer",
+    ["json", "pickle", JSONSerializer(), PickleSerializer()],
+)
+@pytest.mark.parametrize("source", ["child", "parent"])
+async def test_task_result_serializer(orion_client, source, serializer):
+    @flow(result_serializer=serializer if source == "parent" else None)
+    def foo():
+        return bar(return_state=True)
+
+    @task(
+        result_serializer=serializer if source == "child" else None,
+        persist_result=True,
+    )
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+    await assert_uses_result_serializer(task_state, serializer)
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_serializer(api_state, serializer)
+
+
+@pytest.mark.parametrize("source", ["child", "parent"])
+async def test_task_result_storage(orion_client, source):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow(result_storage=storage if source == "parent" else None)
+    def foo():
+        return bar(return_state=True)
+
+    @task(result_storage=storage if source == "child" else None, persist_result=True)
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+    await assert_uses_result_storage(task_state, storage)
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+    await assert_uses_result_storage(api_state, storage)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -15,6 +15,7 @@ from prefect.context import PrefectObjectRegistry
 from prefect.deprecated.data_documents import DataDocument
 from prefect.exceptions import (
     InvalidNameError,
+    MissingResult,
     ParameterTypeError,
     ReservedArgumentError,
 )
@@ -1256,7 +1257,7 @@ class TestFlowResults:
         flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
         assert flow_run.state.data is None
 
-        with pytest.raises(ValueError, match="State data is missing"):
+        with pytest.raises(MissingResult, match="State data is missing"):
             await flow_run.state.result()
 
     async def test_flow_results_are_stored_locally_if_enabled(self, orion_client):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1241,6 +1241,13 @@ class TestSubflowRunLogs:
 
 
 class TestFlowResults:
+    """
+    See `tests/results/test_flow_results.py` instead please.
+
+    These tests were retained during the results rewrite but new tests should be added
+    in the dedicated file.
+    """
+
     async def test_flow_results_are_not_stored_by_default(self, orion_client):
         @flow
         def foo():


### PR DESCRIPTION
### Changes

- Abstract `PersistedResult._read_blob` for testing persisted results
- Consolidate result testing utilities into `prefect.testing.utilities`
- Add pytest assertion rewrites for testing utilities
- Add flow and test result coverage
- Add `MissingResult` exception instead of `ValueError` when data is null

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
