### PR TITLE
Remove old result handling from the engine and documentation

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -360,7 +360,7 @@ Toggling persistence manually will always override any behavior that Prefect wou
 
 [The result storage location](#result-storage-types) can be configured with the `result_storage` option. The `result_storage` option defaults to a null value, which infers storage from the context.
 Generally, this means that tasks will use the result storage configured on the flow unless otherwise specified.
-If there is no context to load the storage from and results must be persisted, results will be stored in `.prefect-results` in the run's working directory.
+If there is no context to load the storage from and results must be persisted, results will be stored in the path specified by the `PREFECT_LOCAL_STORAGE_PATH` setting (defaults to `~/.prefect/storage`).
 
 ```python
 from prefect import flow, task

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -102,17 +102,6 @@ def my_task():
     print("Hello, I'm a task")
 ```
 
-## Task results
-
-Task results are cached in memory during execution of your flow run.
-
-Currently, task results are persisted to the location specified by the `PREFECT_LOCAL_STORAGE_PATH` setting. 
-
-!!! note "Task results, retries, and caching"
-    Since task results are both cached in memory and persisted to `PREFECT_LOCAL_STORAGE_PATH`, results are available within the context of of flow run and task retries use these results.
-    
-    However, [task caching](#caching) between flow runs is currently limited to flow runs with access to that local storage path.
-
 ## Tags
 
 Tags are optional string labels that enable you to identify and group tasks other than by name or flow. Tags are useful for:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -33,7 +33,6 @@ import prefect.settings
 from prefect.client.orion import OrionClient
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.exceptions import MissingContextError
-from prefect.filesystems import WritableFileSystem
 from prefect.futures import PrefectFuture
 from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.results import ResultFactory
@@ -198,7 +197,6 @@ class FlowRunContext(RunContext):
         flow: The flow instance associated with the run
         flow_run: The API metadata for the flow run
         task_runner: The task runner instance being used for the flow run
-        result_filesystem: A block to used to persist run state data
         task_run_futures: A list of futures for task runs submitted within this flow run
         task_run_states: A list of states for task runs created within this flow run
         task_run_results: A mapping of result ids to task run states for this flow run
@@ -212,7 +210,6 @@ class FlowRunContext(RunContext):
     task_runner: BaseTaskRunner
 
     # Result handling
-    result_filesystem: WritableFileSystem
     result_factory: ResultFactory
 
     # Counter for task calls allowing unique
@@ -243,14 +240,12 @@ class TaskRunContext(RunContext):
     Attributes:
         task: The task instance associated with the task run
         task_run: The API metadata for this task run
-        result_filesystem: A block to used to persist run state data
     """
 
     task: "Task"
     task_run: TaskRun
 
     # Result handling
-    result_filesystem: WritableFileSystem
     result_factory: ResultFactory
 
     __var__ = ContextVar("task_run")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -106,7 +106,7 @@ async def test_flow_run_context(orion_client):
             assert ctx.flow_run == flow_run
             assert ctx.client is orion_client
             assert ctx.task_runner is test_task_runner
-            assert ctx.result_factory is result_factory
+            assert ctx.result_factory == result_factory
             assert isinstance(ctx.start_time, DateTime)
 
 
@@ -122,11 +122,12 @@ async def test_task_run_context(orion_client, flow_run):
         task=foo,
         task_run=task_run,
         client=orion_client,
+        result_factory=result_factory,
     ):
         ctx = TaskRunContext.get()
         assert ctx.task is foo
         assert ctx.task_run == task_run
-        assert ctx.result_factory is result_factory
+        assert ctx.result_factory == result_factory
         assert isinstance(ctx.start_time, DateTime)
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -115,7 +115,6 @@ async def get_flow_run_context(orion_client, result_factory, local_filesystem):
                 flow_run=flow_run,
                 client=orion_client,
                 task_runner=test_task_runner,
-                result_filesystem=local_filesystem,
                 result_factory=result_factory,
             )
 
@@ -154,7 +153,6 @@ class TestOrchestrateTaskRun:
                 task_run=task_run,
                 parameters={},
                 wait_for=None,
-                result_filesystem=local_filesystem,
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
@@ -187,7 +185,6 @@ class TestOrchestrateTaskRun:
             task_run=task_run,
             parameters={},
             wait_for=None,
-            result_filesystem=local_filesystem,
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
@@ -227,7 +224,6 @@ class TestOrchestrateTaskRun:
                 task_run=task_run,
                 parameters={},
                 wait_for=None,
-                result_filesystem=local_filesystem,
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
@@ -301,7 +297,6 @@ class TestOrchestrateTaskRun:
             # Nest the future in a collection to ensure that it is found
             parameters={"x": {"nested": [future]}},
             wait_for=None,
-            result_filesystem=local_filesystem,
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
@@ -343,7 +338,6 @@ class TestOrchestrateTaskRun:
             # Quote some data
             parameters={"x": quote(1)},
             wait_for=None,
-            result_filesystem=local_filesystem,
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
@@ -387,7 +381,6 @@ class TestOrchestrateTaskRun:
             task_run=task_run,
             parameters={"x": quote(upstream_task_state)},
             wait_for=None,
-            result_filesystem=local_filesystem,
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
@@ -439,7 +432,6 @@ class TestOrchestrateFlowRun:
             FlowRunContext,
             task_runner=SequentialTaskRunner(),
             sync_portal=None,
-            result_filesystem=local_filesystem,
             result_factory=result_factory,
         )
 


### PR DESCRIPTION
Previously this was left untouched even though it no longer used (since #7094), now it has been purged.