### PR TITLE
History query refactor

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -703,7 +703,8 @@ class OrionClient:
             name (str): a unique name for the work queue
 
         Raises:
-            httpx.StatusError: if no work queue is found
+            prefect.exceptions.ObjectNotFound: if no work queue is found
+            httpx.HTTPStatusError: other status errors
 
         Returns:
             schemas.core.WorkQueue: a work queue API object

--- a/src/prefect/orion/api/run_history.py
+++ b/src/prefect/orion/api/run_history.py
@@ -45,11 +45,9 @@ async def run_history(
     # prepare run-specific models
     if run_type == "flow_run":
         run_model = db.FlowRun
-        state_model = db.FlowRunState
         run_filter_function = models.flow_runs._apply_flow_run_filters
     elif run_type == "task_run":
         run_model = db.TaskRun
-        state_model = db.TaskRunState
         run_filter_function = models.task_runs._apply_task_run_filters
 
     # create a CTE for timestamp intervals
@@ -67,11 +65,9 @@ async def run_history(
                 run_model.expected_start_time,
                 run_model.estimated_run_time,
                 run_model.estimated_start_time_delta,
-                state_model.type.label("state_type"),
-                state_model.name.label("state_name"),
-            )
-            .select_from(run_model)
-            .join(state_model, run_model.state_id == state_model.id),
+                run_model.state_type,
+                run_model.state_name,
+            ).select_from(run_model),
             flow_filter=flows,
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,

--- a/src/prefect/orion/api/ui/flow_runs.py
+++ b/src/prefect/orion/api/ui/flow_runs.py
@@ -55,6 +55,9 @@ async def read_flow_run_history(
         db.FlowRun.start_time,
         db.FlowRun.expected_start_time,
         db.FlowRun.total_run_time,
+        # Although it isn't returned, we need to select
+        # this field in order to compute `estimated_run_time`
+        db.FlowRun.state_timestamp,
     ]
     async with db.session_context() as session:
         result = await models.flow_runs.read_flow_runs(

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
@@ -1,0 +1,44 @@
+"""Add state_timestamp
+
+Revision ID: 22b7cb02e593
+Revises: e757138e954a
+Create Date: 2022-10-12 10:20:48.760447
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "22b7cb02e593"
+down_revision = "e757138e954a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "state_timestamp",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+    with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "state_timestamp",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.drop_column("state_timestamp")
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_column("state_timestamp")

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
@@ -26,6 +26,9 @@ def upgrade():
                 nullable=True,
             )
         )
+        batch_op.create_index(
+            "ix_flow_run__state_timestamp", ["state_timestamp"], unique=False
+        )
 
     with op.batch_alter_table("task_run", schema=None) as batch_op:
         batch_op.add_column(
@@ -35,10 +38,50 @@ def upgrade():
                 nullable=True,
             )
         )
+        batch_op.create_index(
+            "ix_task_run__state_timestamp", ["state_timestamp"], unique=False
+        )
+
+    update_flow_run_state_timestamp_in_batches = """
+        WITH null_flow_run_state_timestamp_cte as (SELECT id from flow_run where state_timestamp is null and state_id is not null limit 500)
+        UPDATE flow_run
+        SET state_timestamp = flow_run_state.timestamp
+        FROM flow_run_state, null_flow_run_state_timestamp_cte
+        WHERE flow_run.state_id = flow_run_state.id
+        AND flow_run.id = null_flow_run_state_timestamp_cte.id;
+    """
+
+    update_task_run_state_timestamp_in_batches = """
+        WITH null_task_run_state_timestamp_cte as (SELECT id from task_run where state_timestamp is null and state_id is not null limit 500)
+        UPDATE task_run
+        SET state_timestamp = task_run_state.timestamp
+        FROM task_run_state, null_task_run_state_timestamp_cte
+        WHERE task_run.state_id = task_run_state.id
+        AND task_run.id = null_task_run_state_timestamp_cte.id;
+    """
+
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        while True:
+            # execute until we've backfilled all flow run state timestamps
+            # autocommit mode will commit each time `execute` is called
+            result = conn.execute(sa.text(update_flow_run_state_timestamp_in_batches))
+            if result.rowcount <= 0:
+                break
+
+        while True:
+            # execute until we've backfilled all task run state timestamps
+            # autocommit mode will commit each time `execute` is called
+            result = conn.execute(sa.text(update_task_run_state_timestamp_in_batches))
+            if result.rowcount <= 0:
+                break
 
 
 def downgrade():
     with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_task_run__state_timestamp")
         batch_op.drop_column("state_timestamp")
+
     with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_flow_run__state_timestamp")
         batch_op.drop_column("state_timestamp")

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
@@ -1,7 +1,7 @@
 """Add state_timestamp
 
 Revision ID: 22b7cb02e593
-Revises: e757138e954a
+Revises: 2d5e000696f1
 Create Date: 2022-10-12 10:20:48.760447
 
 """
@@ -12,7 +12,7 @@ import prefect
 
 # revision identifiers, used by Alembic.
 revision = "22b7cb02e593"
-down_revision = "e757138e954a"
+down_revision = "2d5e000696f1"
 branch_labels = None
 depends_on = None
 

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
@@ -1,0 +1,45 @@
+"""Add state_timestamp
+
+Revision ID: 22b7cb02e593
+Revises: e757138e954a
+Create Date: 2022-10-12 10:20:48.760447
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "22b7cb02e593"
+down_revision = "e757138e954a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "state_timestamp",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+    with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "state_timestamp",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.drop_column("state_timestamp")
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_column("state_timestamp")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_10_12_102048_22b7cb02e593_add_state_timestamp.py
@@ -26,6 +26,9 @@ def upgrade():
                 nullable=True,
             )
         )
+        batch_op.create_index(
+            "ix_flow_run__state_timestamp", ["state_timestamp"], unique=False
+        )
 
     with op.batch_alter_table("task_run", schema=None) as batch_op:
         batch_op.add_column(
@@ -35,11 +38,44 @@ def upgrade():
                 nullable=True,
             )
         )
+        batch_op.create_index(
+            "ix_task_run__state_timestamp", ["state_timestamp"], unique=False
+        )
+
+    update_flow_run_state_timestamp_in_batches = """
+        UPDATE flow_run
+        SET state_timestamp = (SELECT timestamp from flow_run_state where flow_run.state_id = flow_run_state.id)
+        WHERE flow_run.id in (SELECT id from flow_run where state_timestamp is null and state_id is not null limit 500);
+    """
+
+    update_task_run_state_timestamp_in_batches = """
+        UPDATE task_run
+        SET state_timestamp = (SELECT timestamp from task_run_state where task_run.state_id = task_run_state.id)
+        WHERE task_run.id in (SELECT id from task_run where state_timestamp is null and state_id is not null limit 500);
+    """
+
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        while True:
+            # execute until we've backfilled all flow run state timestamps
+            # autocommit mode will commit each time `execute` is called
+            result = conn.execute(sa.text(update_flow_run_state_timestamp_in_batches))
+            if result.rowcount <= 0:
+                break
+
+        while True:
+            # execute until we've backfilled all task run state timestamps
+            # autocommit mode will commit each time `execute` is called
+            result = conn.execute(sa.text(update_task_run_state_timestamp_in_batches))
+            if result.rowcount <= 0:
+                break
 
 
 def downgrade():
     with op.batch_alter_table("task_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_task_run__state_timestamp")
         batch_op.drop_column("state_timestamp")
 
     with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_flow_run__state_timestamp")
         batch_op.drop_column("state_timestamp")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -248,6 +248,7 @@ class ORMRun:
     )
     state_type = sa.Column(sa.Enum(schemas.states.StateType, name="state_type"))
     state_name = sa.Column(sa.String, nullable=True)
+    state_timestamp = sa.Column(Timestamp(), nullable=True)
     run_count = sa.Column(sa.Integer, server_default="0", default=0, nullable=False)
     expected_start_time = sa.Column(Timestamp())
     next_scheduled_start_time = sa.Column(Timestamp())
@@ -266,13 +267,14 @@ class ORMRun:
         state is exited. To give up-to-date estimates, we estimate incremental
         run time for any runs currently in a RUNNING state."""
         if self.state and self.state_type == schemas.states.StateType.RUNNING:
-            return self.total_run_time + (pendulum.now() - self.state.timestamp)
+            return self.total_run_time + (pendulum.now() - self.state_timestamp)
         else:
             return self.total_run_time
 
     @estimated_run_time.expression
     def estimated_run_time(cls):
         # use a correlated subquery to retrieve details from the state table
+        # TODO - does something need to happen here?
         state_table = cls.state.property.target
         return (
             sa.select(

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -493,6 +493,10 @@ class ORMFlowRun(ORMRun):
                 "ix_flow_run__state_name",
                 "state_name",
             ),
+            sa.Index(
+                "ix_flow_run__state_timestamp",
+                "state_timestamp",
+            ),
         )
 
 

--- a/src/prefect/orion/orchestration/global_policy.py
+++ b/src/prefect/orion/orchestration/global_policy.py
@@ -21,6 +21,7 @@ from prefect.orion.orchestration.rules import (
 COMMON_GLOBAL_TRANSFORMS = lambda: [
     SetRunStateType,
     SetRunStateName,
+    SetRunStateTimestamp,
     SetStartTime,
     SetEndTime,
     IncrementRunCount,
@@ -90,6 +91,16 @@ class SetStartTime(BaseUniversalTransform):
         if context.proposed_state.is_running() and context.run.start_time is None:
             # set the start time
             context.run.start_time = context.proposed_state.timestamp
+
+
+class SetRunStateTimestamp(BaseUniversalTransform):
+    """
+    Records the time a run changes states.
+    """
+
+    async def before_transition(self, context: OrchestrationContext) -> None:
+        # record the new state's timestamp
+        context.run.state_timestamp = context.proposed_state.timestamp
 
 
 class SetEndTime(BaseUniversalTransform):

--- a/tests/orion/api/test_run_history.py
+++ b/tests/orion/api/test_run_history.py
@@ -603,11 +603,11 @@ async def test_flow_run_lateness(client, session):
     assert interval.states[1].state_type == StateType.RUNNING
     assert interval.states[1].count_runs == 1
 
-    expected_lateness = pendulum.now("UTC") - dt.subtract(minutes=5)
+    expected_run_time = pendulum.now("UTC") - dt.subtract(minutes=5)
     assert (
-        expected_lateness - timedelta(seconds=2)
+        expected_run_time - timedelta(seconds=2)
         < interval.states[1].sum_estimated_run_time
-        < expected_lateness
+        < expected_run_time
     )
     assert interval.states[1].sum_estimated_lateness == timedelta(seconds=600)
 


### PR DESCRIPTION
This PR adds `state_timestamp` to the `flow_run` and `task_run` tables. This denormalization will speed up run history queries, which now do not need to join to the `flow_run_state` and `task_run_state` tables.

See https://github.com/PrefectHQ/nebula/issues/2110

### Example

n/a

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
