### PR TITLE
Update results settings to match new docstring format

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -323,8 +323,8 @@ PREFECT_PROFILES_PATH = Setting(
 PREFECT_RESULTS_DEFAULT_SERIALIZER = Setting(
     str,
     default="pickle",
-    description="The default serializer to use when not otherwise specified.",
 )
+"""The default serializer to use when not otherwise specified."""
 
 PREFECT_LOCAL_STORAGE_PATH = Setting(
     Path,
@@ -434,23 +434,18 @@ flow runs will not start before their scheduled time, even if they are
 prefetched. Defaults to `10`.
 """
 
-PREFECT_ASYNC_FETCH_STATE_RESULT = Setting(
-    bool,
-    default=False,
-    description=textwrap.dedent(
-        """
-        Determines whether `State.result()` fetches results automatically or not.
-        In Prefect 2.6.0, the `State.result()` method was updated to be async
-        to faciliate automatic retrieval of results from storage which means when 
-        writing async code you must `await` the call. For backwards compatibility, 
-        the result is not retrieved by default for async users. You may opt into this
-        per call by passing  `fetch=True` or toggle this setting to change the behavior
-        globally.
-        This setting does not affect users writing synchronous tasks and flows.
-        This setting does not affect retrieval of results when using `Future.result()`.
-        """
-    ),
-)
+PREFECT_ASYNC_FETCH_STATE_RESULT = Setting(bool, default=False)
+"""
+Determines whether `State.result()` fetches results automatically or not.
+In Prefect 2.6.0, the `State.result()` method was updated to be async
+to faciliate automatic retrieval of results from storage which means when 
+writing async code you must `await` the call. For backwards compatibility, 
+the result is not retrieved by default for async users. You may opt into this
+per call by passing  `fetch=True` or toggle this setting to change the behavior
+globally.
+This setting does not affect users writing synchronous tasks and flows.
+This setting does not affect retrieval of results when using `Future.result()`.
+"""
 
 PREFECT_ORION_BLOCKS_REGISTER_ON_START = Setting(
     bool,


### PR DESCRIPTION
Following https://github.com/PrefectHQ/prefect/pull/7067 the settings added in #6908 have improper docstrings.