### PR TITLE
Update pytest requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ moto
 mypy
 pillow
 pre-commit
-pytest
+pytest > 7
 pytest-asyncio >= 0.18.2
 pytest-cov
 pytest-env


### PR DESCRIPTION
We require >7 or ` AttributeError: module 'pytest' has no attribute 'Config'` will be raised