### PR TITLE
Fix broken flow run URLs for notifications and creating runs from CLI

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -429,7 +429,7 @@ async def run(
     ui_url = ui_base_url(connection_status)
 
     if ui_url:
-        run_url = f"{ui_url}/flow-run/{flow_run.id}"
+        run_url = f"{ui_url}/flow-runs/flow-run/{flow_run.id}"
     else:
         run_url = "<no dashboard available>"
 

--- a/src/prefect/orion/services/flow_run_notifications.py
+++ b/src/prefect/orion/services/flow_run_notifications.py
@@ -143,7 +143,7 @@ class FlowRunNotifications(LoopService):
         """
         api_url = PREFECT_API_URL.value() or "http://ephemeral-orion/api"
         ui_url = api_url.strip("/api")
-        return f"{ui_url}/flow-run/{flow_run_id}"
+        return f"{ui_url}/flow-runs/flow-run/{flow_run_id}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Failure notification URL currently has a format:

https://app.prefect.cloud/account/c5276cbb-62a2-4501-b64a-74d3d900d781/workspace/aaeffa0e-13fa-460e-a1f9-79b53c05ab36/flow-run/bc43a65c-b03b-4aca-9724-9ce362a40959

It should be:
https://app.prefect.cloud/account/c5276cbb-62a2-4501-b64a-74d3d900d781/workspace/aaeffa0e-13fa-460e-a1f9-79b53c05ab36/flow-runs/flow-run/bc43a65c-b03b-4aca-9724-9ce362a40959

The `flow-runs/` is missing. The same is true for URL added with this PR https://github.com/PrefectHQ/prefect/pull/7018 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
