### PR TITLE
Guard calling after_transition when exception encountered

### DIFF
--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -884,12 +884,12 @@ class BaseUniversalTransform(contextlib.AbstractAsyncContextManager):
         """
         Exit the async runtime context governed by this transform.
 
-        If the transition has been nullified upon exiting this transforms's context,
+        If the transition has been nullified or errorred upon exiting this transforms's context,
         nothing happens. Otherwise, `self.after_transition` will fire on every non-null
         proposed state.
         """
 
-        if not self.nullified_transition():
+        if not self.nullified_transition() and not self.errorred_transition():
             await self.after_transition(self.context)
             self.context.finalization_signature.append(str(self.__class__))
 
@@ -927,3 +927,13 @@ class BaseUniversalTransform(contextlib.AbstractAsyncContextManager):
         """
 
         return self.context.proposed_state is None
+
+    def errorred_transition(self) -> bool:
+        """
+        Determines if the transition has encountered an exception.
+
+        Returns:
+            True if the transition is encountered an exception, False otherwise.
+        """
+
+        return self.context.orchestration_error is not None

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -889,7 +889,7 @@ class BaseUniversalTransform(contextlib.AbstractAsyncContextManager):
         proposed state.
         """
 
-        if not self.nullified_transition() and not self.errorred_transition():
+        if not self.nullified_transition() and not self.exception_in_transition():
             await self.after_transition(self.context)
             self.context.finalization_signature.append(str(self.__class__))
 
@@ -928,7 +928,7 @@ class BaseUniversalTransform(contextlib.AbstractAsyncContextManager):
 
         return self.context.proposed_state is None
 
-    def errorred_transition(self) -> bool:
+    def exception_in_transition(self) -> bool:
         """
         Determines if the transition has encountered an exception.
 


### PR DESCRIPTION
This PR adds logic to guard against calling `after_transition` if orchestration encountered an error.

This applies in cases where, for example, we could encountered in error trying to secure concurrency slots in `before_transition` because of a connectivity issue with the database. Often exceptions of this sort will impact our ability to communicate with the database further, resulting in mishandled errors.

Closes https://github.com/PrefectHQ/nebula/issues/1041

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
