### PR TITLE
Add `flow(persist_results_by_default=...)` to quickly set persistence for all children

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -290,9 +290,13 @@ Persistence of results requires a [**serializer**](#result-serializers) and a [*
 - `result_storage`: Where to store the result when persisted.
 - `result_serializer`: How to convert the result to a storable form.
 
+The flow decorator also includes the option:
+
+- `persist_results`: Whether the result of this flow and any tasks or subflows in it should be persisted to storage.
+
 #### Toggling persistence
 
-Persistence of the result of a task or flow can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used by the flow or task.
+Persistence of the results in a flow can be configured with the `persist_results` option. The `persist_results` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used in the flow.
 
 For example, the following flow has retries enabled. Flow retries require that all task results are persisted, so the task's result will be persisted:
 
@@ -337,7 +341,35 @@ def my_flow():
     my_other_task()
 ```
 
-Persistence of results can be manually toggled on or off:
+You may enable or disable persistence of all of the results in a flow manually by setting `persist_results`:
+
+```python
+from prefect import flow, task
+
+@flow(persist_results=True)
+def my_flow():
+    # This flow will persist its result
+
+    # This task will persist its result
+    my_task()
+
+    # This subflow will persist its result
+    my_subflow()
+
+
+@task
+def my_task():
+    ...
+
+@flow
+def my_subflow():
+    # Any tasks called in this subflow will not persist their results by default
+    ...
+```
+
+If you disable persistence with `persist_results`, results will not be persisted even if required for a feature you are using.
+
+Persistence of results can be manually toggled on or off per flow or task with `persist_result`:
 
 ```python
 from prefect import flow, task
@@ -355,6 +387,20 @@ def my_task():
 ```
 
 Toggling persistence manually will always override any behavior that Prefect would infer.
+
+You may toggle persistence of all of the results in a flow, but not persist the return value of the flow itself:
+
+```python
+from prefect import flow, task
+
+@flow(persist_result=False, persist_results=True)
+def my_flow():
+    # This task will persist its result
+    my_task()
+
+    # The return value of this flow will not be persisted
+    return 1
+```
 
 #### Result storage location
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -101,6 +101,12 @@ class Flow(Generic[P, R]):
             should be persisted to result storage. Defaults to `None`, which indicates
             that Prefect should choose whether the result should be persisted depending on
             the features being used.
+        persist_results: An optional toggle indicating whther the results of tasks and
+            flows within this flow should be persisted to result storage. Defaults to
+            `None` which follows the bhavior of `persist_result`. If `True``, this flow
+            and all tasks or flows within it will persist their results unless they have
+            opted out. If `False,` this flow and all tasks or flows within it will not
+            persist their results unless they have opted in.
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
             If not provided, the local file system will be used unless called as
@@ -126,6 +132,7 @@ class Flow(Generic[P, R]):
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = True,
         persist_result: Optional[bool] = None,
+        persist_results: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
     ):
@@ -183,6 +190,7 @@ class Flow(Generic[P, R]):
                 ) from exc
 
         self.persist_result = persist_result
+        self.persist_results = persist_results
         self.result_storage = result_storage
         self.result_serializer = result_serializer
 
@@ -489,6 +497,7 @@ def flow(
     timeout_seconds: Union[int, float] = None,
     validate_parameters: bool = True,
     persist_result: Optional[bool] = None,
+    persist_results: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
@@ -507,6 +516,7 @@ def flow(
     timeout_seconds: Union[int, float] = None,
     validate_parameters: bool = True,
     persist_result: Optional[bool] = None,
+    persist_results: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
 ):
@@ -543,6 +553,11 @@ def flow(
             should be persisted to result storage. Defaults to `None`, which indicates
             that Prefect should choose whether the result should be persisted depending on
             the features being used.
+        persist_results: An optional toggle indicating whther the results of tasks and
+            flows within this flow should be persisted to result storage. Defaults to
+            `None` which follows the bhavior of `persist_result`. If set, this flow and
+            all tasks or flows within it will persist their results unless they have
+            opted out. If
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
             If not provided, the local file system will be used unless called as
@@ -605,6 +620,7 @@ def flow(
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
                 persist_result=persist_result,
+                persist_results=persist_results,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
             ),
@@ -623,6 +639,7 @@ def flow(
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
                 persist_result=persist_result,
+                persist_results=persist_results,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
             ),

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -103,9 +103,9 @@ class Flow(Generic[P, R]):
             the features being used.
         persist_results: An optional toggle indicating whther the results of tasks and
             flows within this flow should be persisted to result storage. Defaults to
-            `None` which follows the bhavior of `persist_result`. If `True``, this flow
+            `None`, which follows the behavior of `persist_result`. If `True`, this flow
             and all tasks or flows within it will persist their results unless they have
-            opted out. If `False,` this flow and all tasks or flows within it will not
+            opted out. If `False`, this flow and all tasks or flows within it, will not
             persist their results unless they have opted in.
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
@@ -559,11 +559,11 @@ def flow(
             should be persisted to result storage. Defaults to `None`, which indicates
             that Prefect should choose whether the result should be persisted depending on
             the features being used.
-        persist_results: An optional toggle indicating whther the results of tasks and
+        persist_results: An optional toggle indicating whether the results of tasks and
             flows within this flow should be persisted to result storage. Defaults to
-            `None` which follows the bhavior of `persist_result`. If set, this flow and
+            `None`, which follows the behavior of `persist_result`. If set, this flow and
             all tasks or flows within it will persist their results unless they have
-            opted out. If
+            opted out.
         result_storage: An optional block to use to perist the result of this flow.
             This value will be used as the default for any tasks in this flow.
             If not provided, the local file system will be used unless called as

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -223,6 +223,7 @@ class Flow(Generic[P, R]):
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = None,
         persist_result: Optional[bool] = NotSet,
+        persist_results: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
     ):
@@ -290,13 +291,18 @@ class Flow(Generic[P, R]):
             persist_result=(
                 persist_result if persist_result is not NotSet else self.persist_result
             ),
+            persist_results=(
+                persist_results
+                if persist_results is not NotSet
+                else self.persist_results
+            ),
             result_storage=(
-                result_storage if result_storage is not NotSet else self.persist_result
+                result_storage if result_storage is not NotSet else self.result_storage
             ),
             result_serializer=(
                 result_serializer
                 if result_serializer is not NotSet
-                else self.persist_result
+                else self.result_serializer
             ),
         )
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -101,7 +101,7 @@ class Flow(Generic[P, R]):
             should be persisted to result storage. Defaults to `None`, which indicates
             that Prefect should choose whether the result should be persisted depending on
             the features being used.
-        persist_results: An optional toggle indicating whther the results of tasks and
+        persist_results: An optional toggle indicating whether the results of tasks and
             flows within this flow should be persisted to result storage. Defaults to
             `None`, which follows the behavior of `persist_result`. If `True`, this flow
             and all tasks or flows within it will persist their results unless they have

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -272,12 +272,12 @@ class Task(Generic[P, R]):
                 persist_result if persist_result is not NotSet else self.persist_result
             ),
             result_storage=(
-                result_storage if result_storage is not NotSet else self.persist_result
+                result_storage if result_storage is not NotSet else self.result_storage
             ),
             result_serializer=(
                 result_serializer
                 if result_serializer is not NotSet
-                else self.persist_result
+                else self.result_serializer
             ),
         )
 

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -13,8 +13,8 @@ from prefect.testing.utilities import (
 from prefect.utilities.annotations import quote
 
 
-@pytest.mark.parametrize("options", [{"retries": 3}])
-async def test_task_persisted_result_due_to_flow_feature(orion_client, options):
+@pytest.mark.parametrize("options", [{"retries": 3}, {"persist_results": True}])
+async def test_task_persisted_result_due_to_flow_options(orion_client, options):
     @flow(**options)
     def foo():
         return bar(return_state=True)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -19,6 +19,7 @@ from prefect.exceptions import (
     ParameterTypeError,
     ReservedArgumentError,
 )
+from prefect.filesystems import LocalFileSystem
 from prefect.flows import Flow
 from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.filters import FlowFilter, FlowRunFilter
@@ -151,6 +152,10 @@ class TestFlowWithOptions:
             task_runner=ConcurrentTaskRunner,
             timeout_seconds=10,
             validate_parameters=True,
+            persist_results=False,
+            persist_result=True,
+            result_serializer="pickle",
+            result_storage=LocalFileSystem(basepath="foo"),
         )
         def initial_flow():
             pass
@@ -163,6 +168,10 @@ class TestFlowWithOptions:
             retry_delay_seconds=20,
             timeout_seconds=5,
             validate_parameters=False,
+            persist_results=True,
+            persist_result=False,
+            result_serializer="json",
+            result_storage=LocalFileSystem(basepath="bar"),
         )
 
         assert flow_with_options.name == "Copied flow"
@@ -172,6 +181,10 @@ class TestFlowWithOptions:
         assert flow_with_options.retries == 3
         assert flow_with_options.retry_delay_seconds == 20
         assert flow_with_options.should_validate_parameters is False
+        assert flow_with_options.persist_results is True
+        assert flow_with_options.persist_result is False
+        assert flow_with_options.result_serializer == "json"
+        assert flow_with_options.result_storage == LocalFileSystem(basepath="bar")
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         @flow(
@@ -182,6 +195,10 @@ class TestFlowWithOptions:
             validate_parameters=True,
             retries=3,
             retry_delay_seconds=20,
+            persist_results=False,
+            persist_result=False,
+            result_serializer="json",
+            result_storage=LocalFileSystem(),
         )
         def initial_flow():
             pass
@@ -196,6 +213,10 @@ class TestFlowWithOptions:
         assert flow_with_options.should_validate_parameters is True
         assert flow_with_options.retries == 3
         assert flow_with_options.retry_delay_seconds == 20
+        assert flow_with_options.persist_results is False
+        assert flow_with_options.persist_result is False
+        assert flow_with_options.result_serializer == "json"
+        assert flow_with_options.result_storage == LocalFileSystem()
 
     def test_with_options_can_unset_timeout_seconds_with_zero(self):
         @flow(timeout_seconds=1)
@@ -204,6 +225,27 @@ class TestFlowWithOptions:
 
         flow_with_options = initial_flow.with_options(timeout_seconds=0)
         assert flow_with_options.timeout_seconds is None
+
+    def test_with_options_can_unset_result_options_with_none(self):
+        @flow(
+            persist_result=True,
+            persist_results=True,
+            result_serializer="json",
+            result_storage=LocalFileSystem(),
+        )
+        def initial_flow():
+            pass
+
+        flow_with_options = initial_flow.with_options(
+            persist_result=None,
+            persist_results=None,
+            result_serializer=None,
+            result_storage=None,
+        )
+        assert flow_with_options.persist_result is None
+        assert flow_with_options.persist_results is None
+        assert flow_with_options.result_serializer is None
+        assert flow_with_options.result_storage is None
 
     def test_with_options_signature_aligns_with_flow_signature(self):
         flow_params = set(inspect.signature(flow).parameters.keys())


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds `persist_results_by_default` to flows allowing you to toggle persistence for the flow _and_ its children rather than just for the flow.

The [documentation](https://deploy-preview-7161--prefect-orion.netlify.app/concepts/results/#toggling-persistence) should give a comprehensive overview.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python

# Flow result is persisted
@flow(persist_results=True)
def foo():
   one()
   two()
   three()
   return 0

# Task result is persisted
@task 
def one():
   return 1

# Task result is not persisted
@task(persist_result=False)
def two():
   return 2

# Subflow result is persisted
@flow
def three():
   four()
   return 3

# Subflow task result is not persisted
@task
def four():
   return 4
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
