### PR TITLE
Add `CompressedSerializer` for compression of other result serializers

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -399,6 +399,19 @@ You may configure the result serializer using:
 - A type name, e.g. `"json"` or `"pickle"` &mdash; this corresponds to an instance with default values
 - An instance, e.g. `JSONSerializer(jsonlib="orjson")`
 
+#### Compressing results
+
+Prefect provides a `CompressedSerializer` which can be used to _wrap_ other serializers to provide compression over the bytes they generate. The compressed serializer uses `lzma` compression by default. We test other compression schemes provided in the Python standard library such as `bz2` and `zlib`, but you should be able to use any compression library that provides `compress` and `decompress` methods.
+
+You may configure compression of results using:
+
+- A type name, prefixed with `compressed/` e.g. `"compressed/json"` or `"compressed/pickle"`
+- An instance e.g. `CompressedSerializer(serializer="pickle", compressionlib="lzma")`
+
+Note that the `"compressed/<serializer-type>"` shortcut will only work for serializers provided by Prefect. 
+If you are using custom serializers, you must pass a full instance.
+
+
 ### Storage of results in Prefect
 
 The Prefect API does not store your results in most cases for the following reasons:

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -219,13 +219,13 @@ class JSONSerializer(Serializer):
 
 class CompressedSerializer(Serializer):
     """
-    Wraps another serializer, compressing its output
+    Wraps another serializer, compressing its output.
     Uses `lzma` by default. See `compressionlib` for using alternative libraries.
 
     Attributes:
-        serializer: The serializer to use before compression
+        serializer: The serializer to use before compression.
         compressionlib: The import path of a compression module to use.
-            Must have methods `compress(bytes) -> bytes` and `decompress(bytes) -> bytes`
+            Must have methods `compress(bytes) -> bytes` and `decompress(bytes) -> bytes`.
         level: If not null, the level of compression to pass to `compress`.
     """
 

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -215,3 +215,80 @@ class JSONSerializer(Serializer):
         if self.object_decoder:
             kwargs["object_hook"] = from_qualified_name(self.object_decoder)
         return json.loads(blob.decode(), **kwargs)
+
+
+class CompressedSerializer(Serializer):
+    """
+    Wraps another serializer, compressing its output
+    Uses `lzma` by default. See `compressionlib` for using alternative libraries.
+
+    Attributes:
+        serializer: The serializer to use before compression
+        compressionlib: The import path of a compression module to use.
+            Must have methods `compress(bytes) -> bytes` and `decompress(bytes) -> bytes`
+        level: If not null, the level of compression to pass to `compress`.
+    """
+
+    type: Literal["compressed"] = "compressed"
+
+    serializer: Serializer
+    compressionlib: str = "lzma"
+
+    @pydantic.validator("serializer", pre=True)
+    def cast_type_names_to_serializers(cls, value):
+        if isinstance(value, str):
+            return Serializer(type=value)
+        return value
+
+    @pydantic.validator("compressionlib")
+    def check_compressionlib(cls, value):
+        """
+        Check that the given pickle library is importable and has compress/decompress
+        methods.
+        """
+        try:
+            compresser = from_qualified_name(value)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(
+                f"Failed to import requested compression library: {value!r}."
+            ) from exc
+
+        if not callable(getattr(compresser, "compress", None)):
+            raise ValueError(
+                f"Compression library at {value!r} does not have a 'compress' method."
+            )
+
+        if not callable(getattr(compresser, "decompress", None)):
+            raise ValueError(
+                f"Compression library at {value!r} does not have a 'decompress' method."
+            )
+
+        return value
+
+    def dumps(self, obj: Any) -> bytes:
+        blob = self.serializer.dumps(obj)
+        compresser = from_qualified_name(self.compressionlib)
+        return base64.encodebytes(compresser.compress(blob))
+
+    def loads(self, blob: bytes) -> Any:
+        compresser = from_qualified_name(self.compressionlib)
+        uncompressed = compresser.decompress(base64.decodebytes(blob))
+        return self.serializer.loads(uncompressed)
+
+
+class CompressedPickleSerializer(CompressedSerializer):
+    """
+    A compressed serializer preconfigured to use the pickle serializer.
+    """
+
+    type: Literal["compressed/pickle"] = "compressed/pickle"
+    serializer: Serializer = pydantic.Field(default_factory=PickleSerializer)
+
+
+class CompressedJSONSerializer(CompressedSerializer):
+    """
+    A compressed serializer preconfigured to use the json serializer.
+    """
+
+    type: Literal["compressed/json"] = "compressed/json"
+    serializer: Serializer = pydantic.Field(default_factory=JSONSerializer)

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -4,7 +4,12 @@ from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.results import LiteralResult
-from prefect.serializers import JSONSerializer, PickleSerializer, Serializer
+from prefect.serializers import (
+    CompressedSerializer,
+    JSONSerializer,
+    PickleSerializer,
+    Serializer,
+)
 from prefect.settings import PREFECT_HOME
 from prefect.testing.utilities import (
     assert_uses_result_serializer,
@@ -95,7 +100,17 @@ async def test_flow_exception_is_persisted(orion_client):
 
 @pytest.mark.parametrize(
     "serializer",
-    ["json", "pickle", JSONSerializer(), PickleSerializer(), MyIntSerializer()],
+    [
+        "json",
+        "pickle",
+        JSONSerializer(),
+        PickleSerializer(),
+        MyIntSerializer(),
+        "int-custom",
+        "compressed/pickle",
+        "compressed/json",
+        CompressedSerializer(serializer=MyIntSerializer()),
+    ],
 )
 async def test_flow_result_serializer(serializer, orion_client):
     @flow(result_serializer=serializer, persist_result=True)

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -74,7 +74,14 @@ async def test_task_persisted_result_due_to_opt_in(orion_client):
 
 @pytest.mark.parametrize(
     "serializer",
-    ["json", "pickle", JSONSerializer(), PickleSerializer()],
+    [
+        "json",
+        "pickle",
+        JSONSerializer(),
+        PickleSerializer(),
+        "compressed/pickle",
+        "compressed/json",
+    ],
 )
 @pytest.mark.parametrize("source", ["child", "parent"])
 async def test_task_result_serializer(orion_client, source, serializer):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds ` CompressedSerializer` similar to the one in v1 which lets you use arbitrary (defaults to lzma) compression libraries to compress the bytes returned by an arbitrary serializer.

[Documentation preview](https://deploy-preview-7164--prefect-orion.netlify.app/concepts/results/#compressing-results)

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
@flow(result_serializer="compressed/json")
...

@flow(result_serializer="compressed/pickle")
...

@flow(result_serializer=CompressedSerializer(compressionlib="zlib", serializer="pickle"))
...
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
