### PR TITLE
Improve rrule backend parsing

### DIFF
--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -371,10 +371,10 @@ class RRuleSchedule(PrefectBaseModel):
             unique_timezones = set(d.tzinfo for d in dtstarts if d.tzinfo is not None)
 
             if len(unique_timezones) > 1:
-                raise ValueError(f"rruleset has too many dtstart timezones: {rrule}")
+                raise ValueError(f"rruleset has too many dtstart timezones: {unique_timezones}")
 
             if len(unique_dstarts) > 1:
-                raise ValueError(f"rruleset has too many dtstarts: {rrule}")
+                raise ValueError(f"rruleset has too many dtstarts: {unique_dstarts}")
 
             if unique_dstarts and unique_timezones:
                 timezone = dtstarts[0].tzinfo.name

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -371,7 +371,9 @@ class RRuleSchedule(PrefectBaseModel):
             unique_timezones = set(d.tzinfo for d in dtstarts if d.tzinfo is not None)
 
             if len(unique_timezones) > 1:
-                raise ValueError(f"rruleset has too many dtstart timezones: {unique_timezones}")
+                raise ValueError(
+                    f"rruleset has too many dtstart timezones: {unique_timezones}"
+                )
 
             if len(unique_dstarts) > 1:
                 raise ValueError(f"rruleset has too many dtstarts: {unique_dstarts}")
@@ -393,9 +395,7 @@ class RRuleSchedule(PrefectBaseModel):
         rrule = dateutil.rrule.rrulestr(self.rrule, cache=True)
         timezone = dateutil.tz.gettz(self.timezone)
         if isinstance(rrule, dateutil.rrule.rrule):
-            kwargs = dict(
-                dtstart=rrule._dtstart.replace(tzinfo=timezone)
-            )
+            kwargs = dict(dtstart=rrule._dtstart.replace(tzinfo=timezone))
             if rrule._until:
                 kwargs.update(
                     until=rrule._until.replace(tzinfo=timezone),
@@ -405,9 +405,7 @@ class RRuleSchedule(PrefectBaseModel):
             new_rrset = dateutil.rrule.rruleset(cache=True)
             tz = self.timezone
             for ii, rr in enumerate(rrule._rrule):
-                kwargs = dict(
-                    dtstart=rr._dtstart.replace(tzinfo=timezone)
-                )
+                kwargs = dict(dtstart=rr._dtstart.replace(tzinfo=timezone))
                 if rr._until:
                     kwargs.update(
                         until=rr._until.replace(tzinfo=timezone),

--- a/tests/orion/schemas/test_schedules.py
+++ b/tests/orion/schemas/test_schedules.py
@@ -670,14 +670,24 @@ class TestRRuleSchedule:
         s2_dates = await s2.get_dates(5, start=datetime(1900, 1, 1, tz="UTC"))
         assert s1_dates == s2_dates
 
-    async def test_rrule_schedule_rejects_rrulesets_with_many_dtstarts(self):
+    async def test_rrule_schedule_rejects_rrulesets_with_many_dtstart_timezones(self):
         dt_nyc = datetime(2018, 1, 11, 4, tz="America/New_York")
         dt_chicago = datetime(2018, 1, 11, 3, tz="America/Chicago")
         rrset = rrule.rruleset(cache=True)
         rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_nyc))
         rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_chicago))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="too many dtstart timezones"):
+            s = RRuleSchedule.from_rrule(rrset)
+
+    async def test_rrule_schedule_rejects_rrulesets_with_many_dtstarts(self):
+        dt_1 = datetime(2018, 1, 11, 4, tz="America/New_York")
+        dt_2 = datetime(2018, 2, 11, 4, tz="America/New_York")
+        rrset = rrule.rruleset(cache=True)
+        rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_1))
+        rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_2))
+
+        with pytest.raises(ValueError, match="too many dtstarts"):
             s = RRuleSchedule.from_rrule(rrset)
 
     @pytest.mark.xfail(reason="we currently cannot roundtrip RRuleSchedule objects")

--- a/tests/orion/schemas/test_schedules.py
+++ b/tests/orion/schemas/test_schedules.py
@@ -647,6 +647,48 @@ class TestRRuleSchedule:
         with pytest.raises(ValidationError, match="(invalid 'FREQ': DAILYBAD)"):
             RRuleSchedule(rrule="FREQ=DAILYBAD")
 
+    async def test_rrule_schedule_handles_complex_rrulesets(self):
+        s = RRuleSchedule(
+            rrule="DTSTART:19970902T090000\n"
+            "RRULE:FREQ=YEARLY;COUNT=2;BYDAY=TU\n"
+            "RRULE:FREQ=YEARLY;COUNT=1;BYDAY=TH\n"
+        )
+        dates_from_1900 = await s.get_dates(5, start=datetime(1900, 1, 1, tz="UTC"))
+        dates_from_2000 = await s.get_dates(5, start=datetime(2000, 1, 1, tz="UTC"))
+        assert len(dates_from_1900) == 3
+        assert len(dates_from_2000) == 0
+
+    async def test_rrule_schedule_handles_rruleset_roundtrips(self):
+        s1 = RRuleSchedule(
+            rrule="DTSTART:19970902T090000\n"
+            "RRULE:FREQ=YEARLY;COUNT=2;BYDAY=TU\n"
+            "RRULE:FREQ=YEARLY;COUNT=1;BYDAY=TH\n"
+        )
+        s2 = RRuleSchedule.from_rrule(s1.to_rrule())
+        s1_dates = await s1.get_dates(5, start=datetime(1900, 1, 1, tz="UTC"))
+        s2_dates = await s2.get_dates(5, start=datetime(1900, 1, 1, tz="UTC"))
+        assert s1_dates == s2_dates
+
+    async def test_rrule_schedule_rejects_rrulesets_with_many_dtstarts(self):
+        dt_nyc = datetime(2018, 1, 11, 4, tz="America/New_York")
+        dt_chicago = datetime(2018, 1, 11, 3, tz="America/Chicago")
+        rrset = rrule.rruleset(cache=True)
+        rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_nyc))
+        rrset.rrule(rrule.rrule(rrule.HOURLY, count=10, dtstart=dt_chicago))
+
+        with pytest.raises(ValueError):
+            s = RRuleSchedule.from_rrule(rrset)
+
+    async def test_rrule_schedule_handles_rrule_roundtrips(self):
+        dt = datetime(2018, 3, 11, 4, tz="Europe/Berlin")
+        s1 = RRuleSchedule.from_rrule(rrule.rrule(rrule.HOURLY, dtstart=dt))
+        s2 = RRuleSchedule.from_rrule(s1.to_rrule())
+        assert s1.timezone == "Europe/Berlin"
+        assert s2.timezone == "Europe/Berlin"
+        s1_dates = await s1.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
+        s2_dates = await s2.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
+        assert s1_dates == s2_dates
+
     async def test_rrule_from_str(self):
         # create a schedule from an RRule object
         s1 = RRuleSchedule.from_rrule(

--- a/tests/orion/schemas/test_schedules.py
+++ b/tests/orion/schemas/test_schedules.py
@@ -658,6 +658,7 @@ class TestRRuleSchedule:
         assert len(dates_from_1900) == 3
         assert len(dates_from_2000) == 0
 
+    @pytest.mark.xfail(reason="we currently cannot roundtrip RRuleSchedule objects")
     async def test_rrule_schedule_handles_rruleset_roundtrips(self):
         s1 = RRuleSchedule(
             rrule="DTSTART:19970902T090000\n"
@@ -679,15 +680,18 @@ class TestRRuleSchedule:
         with pytest.raises(ValueError):
             s = RRuleSchedule.from_rrule(rrset)
 
+    @pytest.mark.xfail(reason="we currently cannot roundtrip RRuleSchedule objects")
     async def test_rrule_schedule_handles_rrule_roundtrips(self):
         dt = datetime(2018, 3, 11, 4, tz="Europe/Berlin")
-        s1 = RRuleSchedule.from_rrule(rrule.rrule(rrule.HOURLY, dtstart=dt))
+        base_rule = rrule.rrule(rrule.HOURLY, dtstart=dt)
+        s1 = RRuleSchedule.from_rrule(base_rule)
         s2 = RRuleSchedule.from_rrule(s1.to_rrule())
-        assert s1.timezone == "Europe/Berlin"
-        assert s2.timezone == "Europe/Berlin"
+        assert s1.timezone == "CET"
+        assert s2.timezone == "CET"
+        base_dates = list(base_rule.xafter(datetime(1900, 1, 1), count=5))
         s1_dates = await s1.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
         s2_dates = await s2.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
-        assert s1_dates == s2_dates
+        assert base_dates == s1_dates == s2_dates
 
     async def test_rrule_from_str(self):
         # create a schedule from an RRule object

--- a/tests/orion/schemas/test_schedules.py
+++ b/tests/orion/schemas/test_schedules.py
@@ -699,8 +699,12 @@ class TestRRuleSchedule:
         assert s1.timezone == "CET"
         assert s2.timezone == "CET"
         base_dates = list(base_rule.xafter(datetime(1900, 1, 1), count=5))
-        s1_dates = await s1.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
-        s2_dates = await s2.get_dates(5, start=pendulum.DateTime(year=1900, month=1, day=1))
+        s1_dates = await s1.get_dates(
+            5, start=pendulum.DateTime(year=1900, month=1, day=1)
+        )
+        s2_dates = await s2.get_dates(
+            5, start=pendulum.DateTime(year=1900, month=1, day=1)
+        )
         assert base_dates == s1_dates == s2_dates
 
     async def test_rrule_from_str(self):


### PR DESCRIPTION
`RRuleSchedule` cannot currently handle compound RRules, `dateutil`'s parser will sometimes return a complex `rruleset` object instead of an `rrule` when parsing an RRule string. I'm adding handling for `rrulesets`.

I could really use someone with some experience with working with schedules to give this a careful once-over to make sure I haven't missed/changed anything critical. I tried to add some tests that ensure that we can properly roundtrip a schedule using the `from_rrule` and `to_rrule` methods, but because of all the inconsistencies in naming timezones across the various timezone parsing libraries, this has proven to be difficult.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
