### PR TITLE
Add last_polled and tracking to work queues

### DIFF
--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import pendulum
 import sqlalchemy as sa
-from fastapi import Body, Depends, Header, HTTPException, Path, status
+from fastapi import BackgroundTasks, Body, Depends, Header, HTTPException, Path, status
 
 import prefect.orion.api.dependencies as dependencies
 import prefect.orion.models as models
@@ -104,6 +104,7 @@ async def read_work_queue(
 
 @router.post("/{id}/get_runs")
 async def read_work_queue_runs(
+    background_tasks: BackgroundTasks,
     work_queue_id: UUID = Path(..., description="The work queue id", alias="id"),
     limit: int = dependencies.LimitBody(),
     scheduled_before: DateTimeTZ = Body(
@@ -131,6 +132,30 @@ async def read_work_queue_runs(
             limit=limit,
         )
 
+    background_tasks.add_task(
+        _record_work_queue_polls,
+        db=db,
+        work_queue_id=work_queue_id,
+        agent_id=agent_id,
+        x_prefect_ui=x_prefect_ui,
+    )
+
+    return flow_runs
+
+
+async def _record_work_queue_polls(
+    db: OrionDBInterface,
+    work_queue_id: UUID,
+    agent_id: Optional[UUID] = None,
+    x_prefect_ui: Optional[bool] = False,
+):
+    """
+    Records that a work queue has been polled.
+
+    If an agent_id is provided, we update this agent id's last poll time.
+    If x_prefect_ui is False, we will update `work_queue.last_polled`.
+    """
+    async with db.session_context(begin_transaction=True) as session:
         # The Prefect UI often calls this route to see which runs are enqueued.
         # We do not want to record this as an actual poll event.
         if not x_prefect_ui:
@@ -146,8 +171,6 @@ async def read_work_queue_runs(
             await models.agents.record_agent_poll(
                 session=session, agent_id=agent_id, work_queue_id=work_queue_id
             )
-
-    return flow_runs
 
 
 @router.post("/filter")

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_10_14_101423_3ced59d8806b_add_last_polled.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_10_14_101423_3ced59d8806b_add_last_polled.py
@@ -1,0 +1,33 @@
+"""Add last_polled
+
+Revision ID: 3ced59d8806b
+Revises: 22b7cb02e593
+Create Date: 2022-10-14 10:14:23.979848
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "3ced59d8806b"
+down_revision = "22b7cb02e593"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_polled",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.drop_column("last_polled")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_10_14_101423_3ced59d8806b_add_last_polled.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_10_14_101423_3ced59d8806b_add_last_polled.py
@@ -1,0 +1,33 @@
+"""Add last_polled
+
+Revision ID: 3ced59d8806b
+Revises: 22b7cb02e593
+Create Date: 2022-10-14 10:14:23.979848
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "3ced59d8806b"
+down_revision = "22b7cb02e593"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_polled",
+                prefect.orion.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.drop_column("last_polled")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -648,6 +648,10 @@ class ORMTaskRun(ORMRun):
                 "ix_task_run__state_name",
                 "state_name",
             ),
+            sa.Index(
+                "ix_task_run__state_timestamp",
+                "state_timestamp",
+            ),
         )
 
 
@@ -945,6 +949,10 @@ class ORMWorkQueue:
     is_paused = sa.Column(sa.Boolean, nullable=False, server_default="0", default=False)
     concurrency_limit = sa.Column(
         sa.Integer,
+        nullable=True,
+    )
+    last_polled = sa.Column(
+        Timestamp(),
         nullable=True,
     )
 

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -9,6 +9,7 @@ from pydantic import Field, root_validator, validator
 
 import prefect.orion.schemas as schemas
 from prefect.orion.utilities.schemas import (
+    DateTimeTZ,
     FieldFrom,
     PrefectBaseModel,
     copy_model_fields,
@@ -356,6 +357,7 @@ class WorkQueueUpdate(ActionBaseModel):
     description: Optional[str] = FieldFrom(schemas.core.WorkQueue)
     is_paused: bool = FieldFrom(schemas.core.WorkQueue)
     concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkQueue)
+    last_polled: Optional[DateTimeTZ] = FieldFrom(schemas.core.WorkQueue)
 
     # DEPRECATED
 

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -740,6 +740,9 @@ class WorkQueue(ORMBaseModel):
         description="DEPRECATED: Filter criteria for the work queue.",
         deprecated=True,
     )
+    last_polled: Optional[DateTimeTZ] = Field(
+        default=None, description="The last time an agent polled this queue for work."
+    )
 
     @validator("name", check_fields=False)
     def validate_name_characters(cls, v):


### PR DESCRIPTION
This PR adds a `last_polled` field to work queues and updates that field each time `/get_runs` is called, allowing users to monitor the health of their work queues.

`last_polled` will not be updated if the api request originated from the UI. This PR should go out after the relevant UI changes.

Backend work for https://github.com/PrefectHQ/orion-design/issues/671. See ticket for full discussion.

### Example

```
async def test_read_work_queue_runs_updates_work_queue_last_polled_time(
        self,
        client,
        work_queue,
        session,
    ):
        now = pendulum.now("UTC")
        response = await client.post(
            f"/work_queues/{work_queue.id}/get_runs",
            json=dict(),
        )
        assert response.status_code == status.HTTP_200_OK

        session.expunge_all()
        updated_work_queue = await models.work_queues.read_work_queue(
            session=session, work_queue_id=work_queue.id
        )
        assert updated_work_queue.last_polled > now

        # The Prefect UI often calls this route to see which runs are enqueued.
        # We do not want to record this as an actual poll event.
        ui_response = await client.post(
            f"/work_queues/{work_queue.id}/get_runs",
            json=dict(),
            headers={"X-PREFECT-UI": "true"},
        )
        assert ui_response.status_code == status.HTTP_200_OK

        session.expunge_all()
        ui_updated_work_queue = await models.work_queues.read_work_queue(
            session=session, work_queue_id=work_queue.id
        )
        assert ui_updated_work_queue.last_polled == updated_work_queue.last_polled
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
