### PR TITLE
Add option to drop task or flow return values from memory

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -282,7 +282,7 @@ The following Prefect features require results to be persisted:
 
 If results are not persisted, these features will not be usable.
 
-### Configuring persistence results
+### Configuring persistence of results
 
 Persistence of results requires a [**serializer**](#result-serializers) and a [**storage** location](#result-storage). Prefect sets defaults for these, and you should not need to adjust them until you want to customize behavior. You can configure results on the `flow` and `task` decorators with the following options:
 
@@ -434,7 +434,7 @@ If `persist_result` is set to `False`, these values will never be stored.
 
 When running your workflows, Prefect will keep the results of all tasks and flows in memory so they can be passed downstream. In some cases, it is desirable to override this behavior. For example, if you are returning a large amount of data from a task it can be costly to keep it memory for the entire duration of the flow run.
 
-Flows and tasks both include an option to drop the result from memory:
+Flows and tasks both include an option to drop the result from memory with `cache_result_in_memory`:
 
 ```python
 @flow(cache_result_in_memory=False)

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -279,8 +279,9 @@ The following Prefect features require results to be persisted:
 
 - Task cache keys
 - Flow run retries
+- Disabling in-memory caching
 
-If results are not persisted, these features will not be usable.
+If results are not persisted, these features may not be usable.
 
 ### Configuring persistence of results
 
@@ -293,12 +294,6 @@ Persistence of results requires a [**serializer**](#result-serializers) and a [*
 #### Toggling persistence
 
 Persistence of the result of a task or flow can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used by the flow or task.
-
-The effect of features on persistence of results:
-- Flow retries: enables persistence of task and subflow results
-- Disabling in-memory caching: enables persistence of the given flow or task result
-- Task cache key: enables persistence of the given task result
-- Task retries: does not affect persistence of results
 
 For example, the following flow has retries enabled. Flow retries require that all task results are persisted, so the task's result will be persisted:
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -128,6 +128,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        cache_result_in_memory: bool = True,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -185,6 +186,7 @@ class Flow(Generic[P, R]):
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer
+        self.cache_result_in_memory = cache_result_in_memory
 
         # Check for collision in the registry
         registry = PrefectObjectRegistry.get()
@@ -217,6 +219,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        cache_result_in_memory: bool = None,
     ):
         """
         Create a new flow from the current object, updating provided options.
@@ -236,6 +239,8 @@ class Flow(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
+            cache_result_in_memory: A new toggle indicating if the flow's result should
+                be cached in memory.
 
         Returns:
             A new `Flow` instance.
@@ -289,6 +294,11 @@ class Flow(Generic[P, R]):
                 result_serializer
                 if result_serializer is not NotSet
                 else self.result_serializer
+            ),
+            cache_result_in_memory=(
+                cache_result_in_memory
+                if cache_result_in_memory is not None
+                else self.cache_result_in_memory
             ),
         )
 
@@ -491,6 +501,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    cache_result_in_memory: bool = True,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
 
@@ -509,6 +520,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    cache_result_in_memory: bool = True,
 ):
     """
     Decorator to designate a function as a Prefect workflow.
@@ -607,6 +619,7 @@ def flow(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                cache_result_in_memory=cache_result_in_memory,
             ),
         )
     else:
@@ -625,6 +638,7 @@ def flow(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                cache_result_in_memory=cache_result_in_memory,
             ),
         )
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -239,7 +239,7 @@ class Flow(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
-            cache_result_in_memory: A new toggle indicating if the flow's result should
+            cache_result_in_memory: A new value indicating if the flow's result should
                 be cached in memory.
 
         Returns:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -138,6 +138,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        cache_result_in_memory: bool = True,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -167,6 +168,7 @@ class Task(Generic[P, R]):
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer
+        self.cache_result_in_memory = cache_result_in_memory
 
         # Warn if this task's `name` conflicts with another task while having a
         # different function. This is to detect the case where two or more tasks
@@ -204,6 +206,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        cache_result_in_memory: Optional[bool] = None,
     ):
         """
         Create a new task from the current object, updating provided options.
@@ -278,6 +281,11 @@ class Task(Generic[P, R]):
                 result_serializer
                 if result_serializer is not NotSet
                 else self.result_serializer
+            ),
+            cache_result_in_memory=(
+                cache_result_in_memory
+                if cache_result_in_memory is None
+                else self.cache_result_in_memory
             ),
         )
 
@@ -723,6 +731,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    cache_result_in_memory: bool = True,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 
@@ -741,6 +750,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    cache_result_in_memory: bool = True,
 ):
     """
     Decorator to designate a function as a task in a Prefect workflow.
@@ -838,6 +848,7 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                cache_result_in_memory=cache_result_in_memory,
             ),
         )
     else:
@@ -856,5 +867,6 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                cache_result_in_memory=cache_result_in_memory,
             ),
         )

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -24,12 +24,12 @@ async def test_result_reference_create_and_get(cache_object, storage_block):
         cache_object=cache_object,
     )
     if not cache_object:
-        assert not result._has_cached_object()
+        assert not result.has_cached_object()
 
     assert await result.get() == "test"
 
     # After retrieval, it should be cached again
-    assert result._has_cached_object()
+    assert result.has_cached_object()
 
 
 async def test_result_reference_create_uses_storage(storage_block):

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -36,7 +36,7 @@ async def test_create_result_reference(factory):
 
 async def test_create_result_reference_has_cached_object(factory):
     result = await factory.create_result({"foo": "bar"})
-    assert result._has_cached_object()
+    assert result.has_cached_object()
 
 
 def test_root_flow_default_result_settings():
@@ -46,6 +46,7 @@ def test_root_flow_default_result_settings():
 
     result_factory = foo()
     assert result_factory.persist_result is False
+    assert result_factory.cache_result_in_memory is True
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
@@ -59,6 +60,23 @@ def test_root_flow_custom_persist_setting(toggle):
 
     result_factory = foo()
     assert result_factory.persist_result is toggle
+    assert result_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("toggle", [True, False])
+def test_root_flow_custom_cache_setting(toggle):
+    result_factory = None
+
+    @flow(cache_result_in_memory=toggle)
+    def foo():
+        nonlocal result_factory
+        result_factory = get_run_context().result_factory
+
+    foo()
+    assert result_factory.persist_result is False
+    assert result_factory.cache_result_in_memory is toggle
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(result_factory.storage_block_id, uuid.UUID)
@@ -168,6 +186,29 @@ def test_child_flow_custom_persist_setting():
     parent_factory, child_factory = foo()
     assert parent_factory.persist_result is False
     assert child_factory.persist_result is True
+    assert child_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("toggle", [True, False])
+def test_child_flow_custom_cache_setting(toggle):
+    child_factory = None
+
+    @flow
+    def foo():
+        bar()
+        return get_run_context().result_factory
+
+    @flow(cache_result_in_memory=toggle)
+    def bar():
+        nonlocal child_factory
+        child_factory = get_run_context().result_factory
+
+    parent_factory = foo()
+    assert parent_factory.cache_result_in_memory is True
+    assert child_factory.persist_result is False
+    assert child_factory.cache_result_in_memory is toggle
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(child_factory.storage_block_id, uuid.UUID)
@@ -341,6 +382,29 @@ def test_task_custom_persist_setting():
     flow_factory, task_factory = foo()
     assert flow_factory.persist_result is False
     assert task_factory.persist_result is True
+    assert task_factory.serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("toggle", [True, False])
+def test_task_custom_cache_setting(toggle):
+    task_factory = None
+
+    @flow
+    def foo():
+        bar()
+        return get_run_context().result_factory
+
+    @task(cache_result_in_memory=toggle)
+    def bar():
+        nonlocal task_factory
+        task_factory = get_run_context().result_factory
+
+    flow_factory = foo()
+    assert flow_factory.cache_result_in_memory is True
+    assert task_factory.persist_result is False
+    assert task_factory.cache_result_in_memory is toggle
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(task_factory.storage_block_id, uuid.UUID)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,11 +31,7 @@ from prefect.exceptions import (
 from prefect.futures import PrefectFuture
 from prefect.orion.schemas.filters import FlowRunFilter
 from prefect.orion.schemas.states import StateDetails, StateType
-from prefect.results import (
-    ResultFactory,
-    get_default_result_serializer,
-    get_default_result_storage,
-)
+from prefect.results import ResultFactory
 from prefect.states import Cancelled, Failed, Pending, Running, State
 from prefect.task_runners import SequentialTaskRunner
 from prefect.testing.utilities import AsyncMock, exceptions_equal, flaky_on_windows
@@ -45,10 +41,7 @@ from prefect.utilities.pydantic import PartialModel
 
 @pytest.fixture
 async def result_factory(orion_client):
-    return await ResultFactory.from_settings(
-        result_storage=get_default_result_storage(),
-        result_serializer=get_default_result_serializer(),
-        persist_result=False,
+    return await ResultFactory.default_factory(
         client=orion_client,
     )
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds a `cache_result_in_memory` option to flows and tasks to drop a result from memory instead of holding it. You _can_ use this while disabling persistence which is the equivalent of saying "I shall not use this result downstream". By default, using it will enable persistence.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
See the examples in the [documentation](https://deploy-preview-7174--prefect-orion.netlify.app/concepts/results/#caching-of-results-in-memory)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
