### PR TITLE
Add extra entrypoints setting for user module injection

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -63,7 +63,7 @@ prefect.client.schemas.State.update_forward_refs(
 import prefect.plugins
 
 prefect.plugins.load_prefect_collections()
-
+prefect.plugins.load_extra_entrypoints()
 
 # Configure logging
 import prefect.logging.configuration

--- a/src/prefect/plugins.py
+++ b/src/prefect/plugins.py
@@ -7,24 +7,23 @@ Currently supported entrypoints:
     - prefect.collections: Identifies this package as a Prefect collection that
         should be imported when Prefect is imported.
 """
-
+import sys
 from types import ModuleType
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import prefect.settings
-from prefect.utilities.compat import EntryPoints, entry_points
+from prefect.utilities.compat import EntryPoint, EntryPoints, entry_points
 
 
-def safe_load_entrypoints(group: str) -> Dict[str, Union[Exception, ModuleType]]:
+def safe_load_entrypoints(entrypoints: EntryPoints) -> Dict[str, Union[Exception, Any]]:
     """
     Load entry points for a group capturing any exceptions that occur.
     """
-    entrypoints: EntryPoints = entry_points(group=group)
-
     # TODO: `load()` claims to return module types but could return arbitrary types
     #       too. We can cast the return type if we want to be more correct. We may
     #       also want to validate the type for the group for entrypoints that have
     #       a specific type we expect.
+
     results = {}
 
     for entrypoint in entrypoints:
@@ -34,7 +33,44 @@ def safe_load_entrypoints(group: str) -> Dict[str, Union[Exception, ModuleType]]
         except Exception as exc:
             result = exc
 
-        results[entrypoint.name] = result
+        results[entrypoint.name or entrypoint.value] = result
+
+    return results
+
+
+def load_extra_entrypoints() -> Dict[str, Union[Exception, Any]]:
+    # Note: Return values are only exposed for testing.
+    if not prefect.settings.PREFECT_EXTRA_ENTRYPOINTS.value():
+        return {}
+
+    values = prefect.settings.PREFECT_EXTRA_ENTRYPOINTS.value().split(",")
+    entrypoints = EntryPoints(
+        EntryPoint(name=None, value=value, group="prefect-extra") for value in values
+    )
+
+    results = {}
+    for value, result in zip(values, safe_load_entrypoints(entrypoints).values()):
+        results[value] = result
+
+        if isinstance(result, Exception):
+            print(
+                f"Warning! Failed to load extra entrypoint {value!r}: {type(result).__name__}: {result}",
+                file=sys.stderr,
+            )
+        elif callable(result):
+            try:
+                results[value] = result()
+            except Exception as exc:
+                print(
+                    f"Warning! Failed to run callable entrypoint {value!r}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+                results[value] = exc
+        else:
+            if prefect.settings.PREFECT_DEBUG_MODE:
+                print(
+                    "Loaded extra entrypoint {value!r} successfully.", file=sys.stderr
+                )
 
     return results
 
@@ -44,20 +80,21 @@ def load_prefect_collections() -> Dict[str, ModuleType]:
     Load all Prefect collections that define an entrypoint in the group
     `prefect.collections`.
     """
-    collections = safe_load_entrypoints(group="prefect.collections")
+    collection_entrypoints: EntryPoints = entry_points(group="prefect.collections")
+    collections = safe_load_entrypoints(collection_entrypoints)
 
     # TODO: Consider the utility of this once we've established this pattern.
     #       We cannot use a logger here because logging is not yet initialized.
     #       It would be nice if logging was initialized so we could log failures
     #       at least.
-    if prefect.settings.PREFECT_TEST_MODE or prefect.settings.PREFECT_DEBUG_MODE:
-        for name, result in collections.items():
-            if isinstance(result, Exception):
-                print(
-                    # TODO: Use exc_info if we have a logger
-                    f"Failed to load collection {name!r}: {type(result).__name__}: {result}"
-                )
-            else:
+    for name, result in collections.items():
+        if isinstance(result, Exception):
+            print(
+                # TODO: Use exc_info if we have a logger
+                f"Warning!  Failed to load collection {name!r}: {type(result).__name__}: {result}"
+            )
+        else:
+            if prefect.settings.PREFECT_DEBUG_MODE:
                 print(f"Loaded collection {name!r}.")
 
     return collections

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -318,6 +318,18 @@ PREFECT_HOME = Setting(
 directory may be created automatically when required.
 """
 
+PREFECT_EXTRA_ENTRYPOINTS = Setting(
+    str,
+    default="",
+)
+"""
+Modules for Prefect to import when Prefect is imported.
+
+Values should be separated by commas, e.g. `my_module,my_other_module`.
+Objects within modules may be specified by a ':' partition, e.g. `my_module:my_object`.
+If a callable object is provided, it will be called with no arguments on import.
+"""
+
 PREFECT_DEBUG_MODE = Setting(
     bool,
     default=False,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,191 @@
+import importlib
+import pathlib
+import textwrap
+
+import pytest
+
+from prefect.plugins import load_extra_entrypoints
+from prefect.settings import PREFECT_EXTRA_ENTRYPOINTS, temporary_settings
+from prefect.testing.utilities import exceptions_equal
+
+
+@pytest.fixture
+def module_fixture(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.syspath_prepend(tmp_path)
+    (tmp_path / ("test_module_name.py")).write_text(
+        textwrap.dedent(
+            """
+            import os
+            from unittest.mock import MagicMock
+
+            def returns_test():
+                return "test"
+
+            def raises_value_error():
+                raise ValueError("test")
+
+            def raises_base_exception():
+                raise BaseException("test")
+
+            def mock_function(*args, **kwargs):
+                mock = MagicMock()
+                mock(*args, **kwargs)
+                return mock
+            """
+        )
+    )
+
+    yield
+
+    importlib.invalidate_caches()
+
+
+@pytest.fixture
+def raising_module_fixture(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.syspath_prepend(tmp_path)
+    (tmp_path / ("raising_module_name.py")).write_text(
+        textwrap.dedent(
+            """
+            raise RuntimeError("test")
+            """
+        )
+    )
+
+    yield
+
+    importlib.invalidate_caches()
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_imports_module():
+    with temporary_settings({PREFECT_EXTRA_ENTRYPOINTS: "test_module_name"}):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name"}
+    assert result["test_module_name"] == importlib.import_module("test_module_name")
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_callable():
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name:returns_test"}
+    ):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name:returns_test"}
+    assert result["test_module_name:returns_test"] == "test"
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_callable_given_no_arguments():
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name:mock_function"}
+    ):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name:mock_function"}
+    result["test_module_name:mock_function"].assert_called_once_with()
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_callable_that_raises(capsys):
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name:raises_value_error"}
+    ):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name:raises_value_error"}
+    assert exceptions_equal(
+        result["test_module_name:raises_value_error"], ValueError("test")
+    )
+
+    _, stderr = capsys.readouterr()
+    assert (
+        "Warning! Failed to run callable entrypoint "
+        "'test_module_name:raises_value_error': ValueError: test"
+    ) in stderr
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_callable_that_raises_base_exception():
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name:raises_base_exception"}
+    ):
+        with pytest.raises(BaseException, match="test"):
+            load_extra_entrypoints()
+
+
+@pytest.mark.usefixtures("raising_module_fixture")
+def test_load_extra_entrypoints_error_on_import(capsys):
+    with temporary_settings({PREFECT_EXTRA_ENTRYPOINTS: "raising_module_name"}):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"raising_module_name"}
+    assert exceptions_equal(result["raising_module_name"], RuntimeError("test"))
+
+    _, stderr = capsys.readouterr()
+    assert (
+        "Warning! Failed to load extra entrypoint 'raising_module_name': "
+        "RuntimeError: test"
+    ) in stderr
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_missing_module(capsys):
+    with temporary_settings({PREFECT_EXTRA_ENTRYPOINTS: "nonexistant_module"}):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"nonexistant_module"}
+    assert exceptions_equal(
+        result["nonexistant_module"],
+        ModuleNotFoundError("No module named 'nonexistant_module'"),
+    )
+
+    _, stderr = capsys.readouterr()
+    assert (
+        "Warning! Failed to load extra entrypoint 'nonexistant_module': "
+        "ModuleNotFoundError"
+    ) in stderr
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_missing_submodule(capsys):
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name.missing_module"}
+    ):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name.missing_module"}
+    assert exceptions_equal(
+        result["test_module_name.missing_module"],
+        ModuleNotFoundError(
+            "No module named 'test_module_name.missing_module'; "
+            "'test_module_name' is not a package"
+        ),
+    )
+
+    _, stderr = capsys.readouterr()
+    assert (
+        "Warning! Failed to load extra entrypoint 'test_module_name.missing_module': "
+        "ModuleNotFoundError"
+    ) in stderr
+
+
+@pytest.mark.usefixtures("module_fixture")
+def test_load_extra_entrypoints_missing_attribute(capsys):
+    with temporary_settings(
+        {PREFECT_EXTRA_ENTRYPOINTS: "test_module_name:missing_attr"}
+    ):
+        result = load_extra_entrypoints()
+
+    assert set(result.keys()) == {"test_module_name:missing_attr"}
+    assert exceptions_equal(
+        result["test_module_name:missing_attr"],
+        AttributeError("module 'test_module_name' has no attribute 'missing_attr'"),
+    )
+
+    _, stderr = capsys.readouterr()
+    assert (
+        "Warning! Failed to load extra entrypoint 'test_module_name:missing_attr': "
+        "AttributeError"
+    ) in stderr


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

A potential fix for https://github.com/PrefectHQ/prefect/issues/7177

Uses a mechanism similar to our collections loading to allow users to define a list of modules to load on Prefect import via a setting.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Specifying a module that cannot be loaded
```
❯ PREFECT_EXTRA_ENTRYPOINTS=foo python -c "import prefect"
Warning! Failed to load extra entrypoint 'foo': ModuleNotFoundError: No module named 'foo'
```

Define `foo.py`
```python
print("Hi from foo!")

def test():
   print("Hi from a method in foo!")
```

Specifying a module loads it
```
❯ PREFECT_EXTRA_ENTRYPOINTS=foo python -c "import prefect"
Hi from foo!
```

Specifying a callable for contained side-effects
```
❯ PREFECT_EXTRA_ENTRYPOINTS=foo:test python -c "import prefect"
Hi from foo!
Hi from a method in foo!
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
