### PR TITLE
Fix bug where return values could be incorrectly parsed as `BaseResult`

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -276,13 +276,13 @@ class ResultFactory(pydantic.BaseModel):
 class BaseResult(pydantic.BaseModel, abc.ABC, Generic[R]):
     type: str
 
-    @sync_compatible
     @abc.abstractmethod
+    @sync_compatible
     async def get(self) -> R:
         ...
 
-    @sync_compatible
     @abc.abstractclassmethod
+    @sync_compatible
     async def create(
         cls: "Type[BaseResult[R]]",
         obj: R,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1,3 +1,4 @@
+import abc
 import uuid
 from typing import TYPE_CHECKING, Any, Generic, Tuple, Type, TypeVar, Union
 
@@ -272,21 +273,22 @@ class ResultFactory(pydantic.BaseModel):
 
 
 @add_type_dispatch
-class BaseResult(pydantic.BaseModel, Generic[R]):
+class BaseResult(pydantic.BaseModel, abc.ABC, Generic[R]):
     type: str
 
     @sync_compatible
+    @abc.abstractmethod
     async def get(self) -> R:
-        pass
+        ...
 
-    @classmethod
     @sync_compatible
+    @abc.abstractclassmethod
     async def create(
         cls: "Type[BaseResult[R]]",
         obj: R,
         **kwargs: Any,
     ) -> "BaseResult[R]":
-        pass
+        ...
 
     class Config:
         extra = "forbid"

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -258,3 +258,37 @@ async def test_child_flow_result_not_missing_with_null_return(orion_client):
         await orion_client.read_flow_run(child_state.state_details.flow_run_id)
     ).state
     assert await api_state.result() is None
+
+
+@pytest.mark.parametrize("empty_type", [dict, list])
+@pytest.mark.parametrize("persist_result", [True, False])
+def test_flow_empty_result_is_retained(persist_result, empty_type):
+    @flow(persist_result=persist_result)
+    def my_flow():
+        return empty_type()
+
+    result = my_flow()
+    assert result == empty_type()
+
+
+@pytest.mark.parametrize(
+    "resultlike",
+    [
+        {"type": "foo"},
+        {"type": "literal", "user-stuff": "bar"},
+        {"type": "persisted"},
+    ],
+)
+@pytest.mark.parametrize("persist_result", [True, False])
+def test_flow_resultlike_result_is_retained(persist_result, resultlike):
+    """
+    Since Pydantic will coerce dictionaries into `BaseResult` types, we need to be sure
+    that user dicts that look like a bit like results do not cause problems
+    """
+
+    @flow(persist_result=persist_result)
+    def my_flow():
+        return resultlike
+
+    result = my_flow()
+    assert result == resultlike

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -190,3 +190,45 @@ async def test_task_exception_is_persisted(orion_client):
     ).state
     with pytest.raises(ValueError, match="Hello world"):
         await api_state.result()
+
+
+@pytest.mark.parametrize("empty_type", [dict, list])
+@pytest.mark.parametrize("persist_result", [True, False])
+def test_task_empty_result_is_retained(persist_result, empty_type):
+    @task(persist_result=persist_result)
+    def my_task():
+        return empty_type()
+
+    @flow
+    def my_flow():
+        return quote(my_task())
+
+    result = my_flow().unquote()
+    assert result == empty_type()
+
+
+@pytest.mark.parametrize(
+    "resultlike",
+    [
+        {"type": "foo"},
+        {"type": "literal", "user-stuff": "bar"},
+        {"type": "persisted"},
+    ],
+)
+@pytest.mark.parametrize("persist_result", [True, False])
+def test_task_resultlike_result_is_retained(persist_result, resultlike):
+    """
+    Since Pydantic will coerce dictionaries into `BaseResult` types, we need to be sure
+    that user dicts that look like a bit like results do not cause problems
+    """
+
+    @task(persist_result=persist_result)
+    def my_task():
+        return resultlike
+
+    @flow
+    def my_flow():
+        return quote(my_task())
+
+    result = my_flow().unquote()
+    assert result == resultlike


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Pydantic was incorrectly parsing some user return values as the `BaseResult` type (which should never be insantiated) causing the incorrect type to be returned when `result()` is called. Users can workaround this before release by enabling result persistence. Luckily, this was easy to fix by making `BaseResult` uninstantiable.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
@task()
def my_task():
    return []


@flow()
def my_flow():
    result = my_task()
    print(result)
```

In 2.5 `results == []`
In 2.6 `results is None`
With fix `results == []`

This applies to `{}` and to flows as well.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
