### PR TITLE
Add backwards compatibility for return of server-states from flows and tasks

### DIFF
--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -141,12 +141,12 @@ class State(IDBaseModel, Generic[R]):
 
     def to_state_create(self):
         # Backwards compatibility for `to_state_create`
-        from prefect.orion.schemas import State
+        from prefect.client.schemas import State
 
         warnings.warn(
-            "`to_state_create` is not supported by `prefect.orion.schemas.states.State` "
-            "and will be removed in a future release. When working with states, use "
-            "`prefect.states.State` instead.",
+            "Use of `prefect.orion.schemas.states.State` from the client is deprecated "
+            "and support will be removed in a future release. "
+            "Use `prefect.states.State` instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -330,11 +330,13 @@ async def raise_state_exception(state: State) -> None:
     raise await get_state_exception(state)
 
 
-def is_state(obj: Any) -> TypeGuard[State]:
+def is_state(obj: Any) -> TypeGuard[schemas.states.State]:
     """
-    Check if the given object is a state type
+    Check if the given object is a state instance
     """
-    return isinstance(obj, State)
+    # We may want to narrow this to client-side state types but for now this provides
+    # backwards compatibility
+    return isinstance(obj, schemas.states.State)
 
 
 def is_state_iterable(obj: Any) -> TypeGuard[Iterable[State]]:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Fixes a backwards compatibility edge-case where an `isinstance` check in `return_value_to_state` did not include server-side state schemas.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
 
 Did not work prior to change, flow ended in `Completed` state and treated returned value as a result:
```python

from prefect.orion.schemas.states import Cancelled

@flow
def foo():
    return Cancelled()
```
The above works now and displays deprecation warnings.

Did work prior to change:
```python

from prefect.states import Cancelled

@flow
def foo():
    return Cancelled()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
