### PR TITLE
UI: fix naming of subflow runs tab on flow run page

### DIFF
--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -84,7 +84,12 @@
   const flowRunId = useRouteParam('id')
 
   const tabs = computed(() => {
-    const values = ['Logs', 'Task Runs', 'SubFlow Runs', 'Parameters']
+    const values = [
+      'Logs',
+      'Task Runs',
+      'Subflow Runs',
+      'Parameters',
+    ]
 
     if (!media.xl) {
       values.push('Details')

--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -84,7 +84,7 @@
   const flowRunId = useRouteParam('id')
 
   const tabs = computed(() => {
-    const values = ['Logs', 'Task Runs', 'Sub Flow Runs', 'Parameters']
+    const values = ['Logs', 'Task Runs', 'SubFlow Runs', 'Parameters']
 
     if (!media.xl) {
       values.push('Details')


### PR DESCRIPTION
This PR removes a space between sub and flow per documentation standards

> Task run, flow run, and subflow are the current usage in the docs