### PR TITLE
Add toggle to load existing deployment values

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -650,13 +650,11 @@ class Deployment(BaseModel):
         output: str = None,
         skip_upload: bool = False,
         apply: bool = False,
+        load_existing: bool = True,
         **kwargs,
     ) -> "Deployment":
         """
         Configure a deployment for a given flow.
-
-        Note that this method loads any settings that may already be configured for the named deployment
-        server-side (e.g., schedules, default parameter values, etc.).
 
         Args:
             flow: A flow function to deploy
@@ -665,6 +663,8 @@ class Deployment(BaseModel):
                 file in the location specified by `output`
             skip_upload: if True, deployment files are not automatically uploaded to remote storage
             apply: if True, the deployment is automatically registered with the API
+            load_existing: if True, load any settings that may already be configured for the named deployment
+                server-side (e.g., schedules, default parameter values, etc.)
             **kwargs: other keyword arguments to pass to the constructor for the `Deployment` class
         """
         if not name:
@@ -691,7 +691,8 @@ class Deployment(BaseModel):
             entry_path = Path(flow_file).absolute().relative_to(Path(".").absolute())
             deployment.entrypoint = f"{entry_path}:{flow.fn.__name__}"
 
-        await deployment.load()
+        if load_existing:
+            await deployment.load()
 
         # set a few attributes for this flow object
         deployment.parameter_openapi_schema = parameter_schema(flow)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -354,6 +354,32 @@ class TestDeploymentBuild:
         assert d.tags == ["A", "B"]
         assert d.version == "12"
 
+    async def test_build_from_flow_doesnt_load_existing(self, flow_function):
+        d = await Deployment.build_from_flow(
+            flow_function,
+            name="foo",
+            tags=["A", "B"],
+            description="foobar",
+            version="12",
+        )
+        assert d.flow_name == flow_function.name
+        assert d.name == "foo"
+        assert d.description == "foobar"
+        assert d.tags == ["A", "B"]
+        assert d.version == "12"
+
+        d = await Deployment.build_from_flow(
+            flow_function,
+            name="foo",
+            version="12",
+            load_existing=False,
+        )
+        assert d.flow_name == flow_function.name
+        assert d.name == "foo"
+        assert d.description != "foobar"
+        assert d.tags != ["A", "B"]
+        assert d.version == "12"
+
 
 class TestYAML:
     def test_deployment_yaml_roundtrip(self, tmp_path):


### PR DESCRIPTION
I know #6932 is still waiting on product feedback but I went ahead and added the feature anyway. Please accept/reject according to the product team feedback.

Adds `load_existing` to `Deployment.build_from_flow`, toggling the load existing settings behavior

Fixes #6932 

### Example

```py
# 1. Register a deployment with a path
Deployment.build_from_flow(
  flow,
  name=f"{deployment_name}-{infrastructure}",
  path="some/path"
).apply()

# 2. Re-register the same deployment without a path
Deployment.build_from_flow(
  flow,
  name=f"{deployment_name}-{infrastructure}",
  load_existing=False,
).apply()

# 3. The last deployment will NOT have path be "some/path"
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
