### PR TITLE
Add support for multiple work queue prefixes

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -25,7 +25,7 @@ class OrionAgent:
     def __init__(
         self,
         work_queues: List[str] = None,
-        work_queue_prefix: str = None,
+        work_queue_prefix: List[str] = None,
         prefetch_seconds: int = None,
         default_infrastructure: Infrastructure = None,
         default_infrastructure_document_id: UUID = None,
@@ -63,7 +63,9 @@ class OrionAgent:
 
     async def update_matched_agent_work_queues(self):
         if self.work_queue_prefix:
-            matched_queues = await self.client.match_work_queues(self.work_queue_prefix)
+            matched_queues = []
+            for prefix in self.work_queue_prefix:
+                matched_queues += await self.client.match_work_queues(prefix)
             matched_queues = set(q.name for q in matched_queues)
             if matched_queues != self.work_queues:
                 new_queues = matched_queues - self.work_queues

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -25,7 +25,7 @@ class OrionAgent:
     def __init__(
         self,
         work_queues: List[str] = None,
-        work_queue_prefix: List[str] = None,
+        work_queue_prefix: Union[str, List[str]] = None,
         prefetch_seconds: int = None,
         default_infrastructure: Infrastructure = None,
         default_infrastructure_document_id: UUID = None,
@@ -44,6 +44,8 @@ class OrionAgent:
         self.task_group: Optional[anyio.abc.TaskGroup] = None
         self.client: Optional[OrionClient] = None
 
+        if isinstance(work_queue_prefix, str):
+            work_queue_prefix = [work_queue_prefix]
         self.work_queue_prefix = work_queue_prefix
 
         self._work_queue_cache_expiration: pendulum.DateTime = None

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -63,9 +63,7 @@ class OrionAgent:
 
     async def update_matched_agent_work_queues(self):
         if self.work_queue_prefix:
-            matched_queues = []
-            for prefix in self.work_queue_prefix:
-                matched_queues += await self.client.match_work_queues(prefix)
+            matched_queues = await self.client.match_work_queues(self.work_queue_prefix)
             matched_queues = set(q.name for q in matched_queues)
             if matched_queues != self.work_queues:
                 new_queues = matched_queues - self.work_queues

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -45,7 +45,7 @@ async def start(
         "--work-queue",
         help="One or more work queue names for the agent to pull from.",
     ),
-    work_queue_prefix: str = typer.Option(
+    work_queue_prefix: List[str] = typer.Option(
         None,
         "-m",
         "--match",

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -808,7 +808,7 @@ class OrionClient:
         """
         page_length = 100
         current_page = 0
-        work_queues = []
+        work_queues = set()
 
         while True:
             new_queues = await self.read_work_queues(
@@ -816,15 +816,15 @@ class OrionClient:
             )
             if not new_queues:
                 break
-            filtered_queues = []
+            filtered_queues = set()
             for q in new_queues:
                 for p in prefixes:
                     if q.name.startswith(p):
-                        filtered_queues.append(q)
-            work_queues += filtered_queues
+                        filtered_queues.add(q)
+            work_queues.update(filtered_queues)
             current_page += 1
 
-        return work_queues
+        return list(work_queues)
 
     async def delete_work_queue_by_id(
         self,

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -808,7 +808,7 @@ class OrionClient:
         """
         page_length = 100
         current_page = 0
-        work_queues = set()
+        work_queues = []
 
         while True:
             new_queues = await self.read_work_queues(
@@ -816,15 +816,15 @@ class OrionClient:
             )
             if not new_queues:
                 break
-            filtered_queues = set()
+            filtered_queues = []
             for q in new_queues:
                 for p in prefixes:
                     if q.name.startswith(p):
-                        filtered_queues.add(q)
-            work_queues.update(filtered_queues)
+                        filtered_queues.append(q)
+            work_queues += filtered_queues
             current_page += 1
 
-        return list(work_queues)
+        return work_queues
 
     async def delete_work_queue_by_id(
         self,

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -818,9 +818,8 @@ class OrionClient:
                 break
             filtered_queues = []
             for q in new_queues:
-                for p in prefixes:
-                    if q.name.startswith(p):
-                        filtered_queues.append(q)
+                if any((q.name.startswith(p) for p in prefixes)):
+                    filtered_queues.append(q)
             work_queues += filtered_queues
             current_page += 1
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -794,13 +794,13 @@ class OrionClient:
 
     async def match_work_queues(
         self,
-        prefix: str,
+        prefixes: List[str],
     ) -> List[schemas.core.WorkQueue]:
         """
         Query Orion for work queues with names with a specific prefix.
 
         Args:
-            prefix: a string used to match work queue name prefixes
+            prefixes: a list of strings used to match work queue name prefixes
 
         Returns:
             a list of [WorkQueue model][prefect.orion.schemas.core.WorkQueue] representations
@@ -816,9 +816,11 @@ class OrionClient:
             )
             if not new_queues:
                 break
-            filtered_queues = list(
-                filter(lambda q: q.name.startswith(prefix), new_queues)
-            )
+            filtered_queues = []
+            for q in new_queues:
+                for p in prefixes:
+                    if q.name.startswith(p):
+                        filtered_queues.append(q)
             work_queues += filtered_queues
             current_page += 1
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -106,7 +106,7 @@ async def test_agent_matches_work_queues_dynamically(
 ):
     name = "wq-1"
     assert await models.work_queues.read_work_queue_by_name(session=session, name=name)
-    async with OrionAgent(work_queue_prefix="wq-") as agent:
+    async with OrionAgent(work_queue_prefix=["wq-"]) as agent:
         assert name not in agent.work_queues
         await agent.get_and_submit_flow_runs()
         assert name in agent.work_queues
@@ -124,7 +124,7 @@ async def test_agent_matches_multiple_work_queues_dynamically(
     await orion_client.create_work_queue(name=prod1)
     await orion_client.create_work_queue(name=prod2)
 
-    async with OrionAgent(work_queue_prefix="prod-") as agent:
+    async with OrionAgent(work_queue_prefix=["prod-"]) as agent:
         assert not agent.work_queues
         await agent.get_and_submit_flow_runs()
         assert prod1 in agent.work_queues
@@ -148,7 +148,7 @@ async def test_matching_work_queues_handes_work_queue_deletion(
 ):
     name = "wq-1"
     assert await models.work_queues.read_work_queue_by_name(session=session, name=name)
-    async with OrionAgent(work_queue_prefix="wq-") as agent:
+    async with OrionAgent(work_queue_prefix=["wq-"]) as agent:
         await agent.get_and_submit_flow_runs()
         assert name in agent.work_queues
 
@@ -184,7 +184,7 @@ async def test_agent_does_not_create_work_queues_if_matching_with_prefix(
         session=session, name=name
     )
     async with OrionAgent(work_queues=[name]) as agent:
-        agent.work_queue_prefix = "goodbye-"
+        agent.work_queue_prefix = ["goodbye-"]
         await agent.get_and_submit_flow_runs()
     assert not await models.work_queues.read_work_queue_by_name(
         session=session, name=name

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -143,6 +143,21 @@ async def test_agent_matches_multiple_work_queues_dynamically(
         ), "work queue matcher should not match partial names"
 
 
+async def test_agent_matches_multiple_work_queue_prefixes(
+    session, orion_client, prefect_caplog
+):
+    prod = "prod-deployment"
+    dev = "dev-data-producer"
+    await orion_client.create_work_queue(name=prod)
+    await orion_client.create_work_queue(name=dev)
+
+    async with OrionAgent(work_queue_prefix=["prod-", "dev-"]) as agent:
+        assert not agent.work_queues
+        await agent.get_and_submit_flow_runs()
+        assert prod in agent.work_queues
+        assert dev in agent.work_queues
+
+
 async def test_matching_work_queues_handes_work_queue_deletion(
     session, work_queue, orion_client, prefect_caplog
 ):


### PR DESCRIPTION
Fixes #7221 

### Example
```
prefect agent start -m "q1-" -m "q2-"
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`

