### PR TITLE
Fix handling of `cache_result_in_memory` in `Task.with_options`

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -284,7 +284,7 @@ class Task(Generic[P, R]):
             ),
             cache_result_in_memory=(
                 cache_result_in_memory
-                if cache_result_in_memory is None
+                if cache_result_in_memory is not None
                 else self.cache_result_in_memory
             ),
         )

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -155,6 +155,7 @@ class TestFlowWithOptions:
             persist_result=True,
             result_serializer="pickle",
             result_storage=LocalFileSystem(basepath="foo"),
+            cache_result_in_memory=False,
         )
         def initial_flow():
             pass
@@ -170,6 +171,7 @@ class TestFlowWithOptions:
             persist_result=False,
             result_serializer="json",
             result_storage=LocalFileSystem(basepath="bar"),
+            cache_result_in_memory=True,
         )
 
         assert flow_with_options.name == "Copied flow"
@@ -182,6 +184,7 @@ class TestFlowWithOptions:
         assert flow_with_options.persist_result is False
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem(basepath="bar")
+        assert flow_with_options.cache_result_in_memory is True
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         @flow(
@@ -195,6 +198,7 @@ class TestFlowWithOptions:
             persist_result=False,
             result_serializer="json",
             result_storage=LocalFileSystem(),
+            cache_result_in_memory=False,
         )
         def initial_flow():
             pass
@@ -212,6 +216,7 @@ class TestFlowWithOptions:
         assert flow_with_options.persist_result is False
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem()
+        assert flow_with_options.cache_result_in_memory is False
 
     def test_with_options_can_unset_timeout_seconds_with_zero(self):
         @flow(timeout_seconds=1)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1958,6 +1958,7 @@ class TestTaskWithOptions:
             persist_result=True,
             result_serializer="pickle",
             result_storage=LocalFileSystem(basepath="foo"),
+            cache_result_in_memory=False,
         )
         def initial_task():
             pass
@@ -1973,6 +1974,7 @@ class TestTaskWithOptions:
             persist_result=False,
             result_serializer="json",
             result_storage=LocalFileSystem(basepath="bar"),
+            cache_result_in_memory=True,
         )
 
         assert task_with_options.name == "Copied task"
@@ -1985,6 +1987,7 @@ class TestTaskWithOptions:
         assert task_with_options.persist_result is False
         assert task_with_options.result_serializer == "json"
         assert task_with_options.result_storage == LocalFileSystem(basepath="bar")
+        assert task_with_options.cache_result_in_memory is True
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         def cache_key_fn(*_):
@@ -2001,6 +2004,7 @@ class TestTaskWithOptions:
             persist_result=False,
             result_serializer="json",
             result_storage=LocalFileSystem(),
+            cache_result_in_memory=False,
         )
         def initial_task():
             pass
@@ -2021,6 +2025,7 @@ class TestTaskWithOptions:
         assert task_with_options.persist_result is False
         assert task_with_options.result_serializer == "json"
         assert task_with_options.result_storage == LocalFileSystem()
+        assert task_with_options.cache_result_in_memory is False
 
     def test_with_options_can_unset_result_options_with_none(self):
         @task(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This one has bitten me once again. We'll need to be careful about test coverage for this in the future.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

The bug:

```python
@task
def foo():
   pass

bar = foo.with_options()

# Using `bar` will fail since `cache_result_in_memory` will be `None` which is not allowed
# To workaround, specify the value:

bar = foo.with_options(cache_result_in_memory=True)
```

After this fix, `with_options` works as intended.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
