### PR TITLE
Add `PREFECT_RESULTS_PERSIST_BY_DEFAULT` to globally toggle the result persistence default

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -293,7 +293,7 @@ Persistence of results requires a [**serializer**](#result-serializers) and a [*
 
 #### Toggling persistence
 
-Persistence of the result of a task or flow can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used by the flow or task.
+Persistence of the result of a task or flow can be configured with the `persist_result` option. The `persist_result` option defaults to a null value, which will automatically enable persistence if it is needed for a Prefect feature used by the flow or task. Otherwise, persistence is disabled by default.
 
 For example, the following flow has retries enabled. Flow retries require that all task results are persisted, so the task's result will be persisted:
 
@@ -310,6 +310,8 @@ def my_flow():
     # so Prefect will persist its result at runtie
     my_task()
 ```
+
+Flow retries do not require the flow's result to be persisted, so it will not be.
 
 In this next example, one task has caching enabled. Task caching requires that the given task's result is persisted:
 
@@ -356,6 +358,14 @@ def my_task():
 ```
 
 Toggling persistence manually will always override any behavior that Prefect would infer.
+
+You may also change Prefect's default persistence behavior with the `PREFECT_RESULTS_PERSIST_BY_DEFAULT` setting. To persist results by default, even if they are not needed for a feature change the value to a truthy value:
+
+```
+$ prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
+```
+
+Task and flows with `persist_result=False` will not persist their results even if `PREFECT_RESULTS_PERSIST_BY_DEFAULT` is `true`.
 
 #### Result storage location
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -326,6 +326,17 @@ PREFECT_RESULTS_DEFAULT_SERIALIZER = Setting(
 )
 """The default serializer to use when not otherwise specified."""
 
+
+PREFECT_RESULTS_PERSIST_BY_DEFAULT = Setting(
+    bool,
+    default=False,
+)
+"""
+The default setting for persisting results when not otherwise specified. If enabled,
+flow and task results will be persisted unless they opt out.
+"""
+
+
 PREFECT_LOCAL_STORAGE_PATH = Setting(
     Path,
     default=Path("${PREFECT_HOME}") / "storage",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds a global setting to change the default value for persistence e.g. when opt-in/out is not provided and a feature is not used.

Simplified version of #7161 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

To enable persistence of all flow, task, and subflow results by default:
```
$ prefect config set PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
