### PR TITLE
Fixes integration tests for 2.6 to include the current client

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+    
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -120,6 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -89,6 +89,7 @@ jobs:
           - "2.3"
           - "2.4"
           - "2.5"
+          - "2.6"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
@@ -112,8 +113,6 @@ jobs:
           - prefect-version: "2.4"
             server-incompatible: true
           - prefect-version: "2.5"
-            server-incompatible: true
-          - prefect-version: "2.6"
             server-incompatible: true
 
       fail-fast: false

--- a/flows/flow_results.py
+++ b/flows/flow_results.py
@@ -4,8 +4,8 @@ from packaging.version import Version
 import prefect
 from prefect import flow, get_client
 
-# The version results were added in; commit g9986f5e4d
-RESULTS_VERSION = "2.5.0+42"
+# The version results were added in
+RESULTS_VERSION = "2.6.0"
 
 
 @flow

--- a/flows/flow_results.py
+++ b/flows/flow_results.py
@@ -4,8 +4,8 @@ from packaging.version import Version
 import prefect
 from prefect import flow, get_client
 
-# The version results were added in
-RESULTS_VERSION = "2.5.0+42.g9986f5e4d"
+# The version results were added in; commit g9986f5e4d
+RESULTS_VERSION = "2.5.0+42"
 
 
 @flow

--- a/flows/task_results.py
+++ b/flows/task_results.py
@@ -4,8 +4,8 @@ from packaging.version import Version
 import prefect
 from prefect import flow, get_client, task
 
-# The version results were added in
-RESULTS_VERSION = "2.5.0+42.g9986f5e4d"
+# The version results were added in; commit g9986f5e4d
+RESULTS_VERSION = "2.5.0+42"
 
 
 @task

--- a/flows/task_results.py
+++ b/flows/task_results.py
@@ -4,8 +4,8 @@ from packaging.version import Version
 import prefect
 from prefect import flow, get_client, task
 
-# The version results were added in; commit g9986f5e4d
-RESULTS_VERSION = "2.5.0+42"
+# The version results were added in
+RESULTS_VERSION = "2.6.0"
 
 
 @task

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -23,6 +23,7 @@ DEFAULT_PATH = __root_path__ / "flows"
 
 
 def run_flows(search_path: Union[str, Path]):
+    count = 0
     print(f"Running integration tests with client version: {__version__}")
     for file in sorted(Path(search_path).glob("*.py")):
         print(f" {file.relative_to(search_path)} ".center(90, "-"), flush=True)

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -17,12 +17,13 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from prefect import __root_path__
+from prefect import __root_path__, __version__
 
 DEFAULT_PATH = __root_path__ / "flows"
 
 
 def run_flows(search_path: Union[str, Path]):
+    print(f"Running integration tests with client version: {__version__}")
     for file in sorted(Path(search_path).glob("*.py")):
         print(f" {file.relative_to(search_path)} ".center(90, "-"), flush=True)
         runpy.run_path(file, run_name="__main__")


### PR DESCRIPTION
The client tests are being skipped e.g. https://github.com/PrefectHQ/prefect/actions/runs/3268773790/jobs/5375567361

This led to a bad release in 2.6.2 and was definitely my fault as I added it incorrectly. I want to generate the matrix dynamically at some point, perhaps that point is soon as it would guard against this.


## Example

https://github.com/PrefectHQ/prefect/actions/runs/3276226541/jobs/5392036236