### PR TITLE
UI: updated deployment tabs

### DIFF
--- a/orion-ui/src/pages/Deployment.vue
+++ b/orion-ui/src/pages/Deployment.vue
@@ -10,7 +10,7 @@
     </template>
 
     <p-tabs v-if="deployment" :tabs="tabs">
-      <template #overview>
+      <template #description>
         <p-content secondary>
           <DeploymentDeprecatedMessage v-if="deployment.deprecated" />
           <template v-else-if="deployment.description">
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { DeploymentDescription, FlowRunFilteredList, DeploymentDescriptionEmptyState, DeploymentDeprecatedMessage, PageHeadingDeployment, DeploymentDetails, ParametersTable, localization, useRecentFlowRunFilter } from '@prefecthq/orion-design'
+  import { DeploymentDescription, FlowRunFilteredList, DeploymentDescriptionEmptyState, DeploymentDeprecatedMessage, PageHeadingDeployment, DeploymentDetails, ParametersTable, localization, useRecentFlowRunFilter, useTabs } from '@prefecthq/orion-design'
   import { media } from '@prefecthq/prefect-design'
   import { useSubscription, useRouteParam } from '@prefecthq/vue-compositions'
   import { computed, watch } from 'vue'
@@ -65,18 +65,13 @@
     interval: 300000,
   }
 
-  const tabs = computed(() => {
-    const values = ['Overview', 'Runs']
-
-    if (!deployment.value?.deprecated) {
-      values.push('Parameters')
-    }
-    if (!media.xl) {
-      values.push('Details')
-    }
-
-    return values
-  })
+  const computedTabs = computed(() => [
+    { label: 'Details', hidden: media.xl },
+    { label: 'Description' },
+    { label: 'Runs' },
+    { label: 'Parameters', hidden: deployment.value?.deprecated },
+  ])
+  const tabs = useTabs(computedTabs)
 
   const deploymentSubscription = useSubscription(deploymentsApi.getDeployment, [deploymentId.value], subscriptionOptions)
   const deployment = computed(() => deploymentSubscription.response)


### PR DESCRIPTION
renames "overview" tab to more limited "description"
uses simpler `useTabs` utility to control visibility
on small screen, details still gets added to tabset but now in first position (like it is in nebula)

closes https://github.com/PrefectHQ/orion-design/issues/450

after: 
<img width="456" alt="image" src="https://user-images.githubusercontent.com/6098901/196539646-86780467-a26e-42d5-b849-1a54d5db6aa2.png">


