### PR TITLE
Handle __name__ for callable objects

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -152,7 +152,7 @@ class Task(Generic[P, R]):
             if not hasattr(self.fn, "__name__"):
                 self.name = type(self.fn).__name__
             else:
-                self.task_key = self.fn.__name__
+                self.name = self.fn.__name__
         else:
             self.name = name
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -148,7 +148,14 @@ class Task(Generic[P, R]):
         self.fn = fn
         self.isasync = inspect.iscoroutinefunction(self.fn)
 
-        self.name = name or self.fn.__name__
+        if not name:
+            if not hasattr(self.fn, "__name__"):
+                self.name = type(self.fn).__name__
+            else:
+                self.task_key = self.fn.__name__
+        else:
+            self.name = name
+
         self.version = version
 
         raise_for_reserved_arguments(self.fn, ["return_state", "wait_for"])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -155,7 +155,7 @@ class TestTaskCall:
         with pytest.raises(ValueError, match="Test"):
             state.result()
 
-    def test_task_supports_callable_objects(self):
+    def test_task_with_name_supports_callable_objects(self):
         class A:
             def __call__(self, *_args: Any, **_kwargs: Any) -> Any:
                 return "hello"
@@ -163,6 +163,47 @@ class TestTaskCall:
         a = A()
         task = Task(fn=a, name="Task")
         assert task.fn is a
+
+    def test_task_supports_callable_objects(self):
+        class A:
+            def __call__(self, *_args: Any, **_kwargs: Any) -> Any:
+                return "hello"
+
+        a = A()
+        task = Task(fn=a)
+        assert task.fn is a
+
+    def test_task_run_with_name_from_callable_object(self):
+        class Foo:
+            message = "hello"
+
+            def __call__(self, prefix: str, suffix: str) -> Any:
+                return prefix + self.message + suffix
+
+        obj = Foo()
+        foo = Task(fn=obj, name="Task")
+
+        @flow
+        def bar():
+            return foo("a", suffix="b")
+
+        assert bar() == "ahellob"
+
+    def test_task_run_from_callable_object(self):
+        class Foo:
+            message = "hello"
+
+            def __call__(self, prefix: str, suffix: str) -> Any:
+                return prefix + self.message + suffix
+
+        obj = Foo()
+        foo = Task(fn=obj)
+
+        @flow
+        def bar():
+            return foo("a", suffix="b")
+
+        assert bar() == "ahellob"
 
 
 class TestTaskRun:


### PR DESCRIPTION
Fixes #7241 

### Example

```py
 def test_task_run_from_callable_object(self):
        class Foo:
            message = "hello"

            def __call__(self, prefix: str, suffix: str) -> Any:
                return prefix + self.message + suffix

        obj = Foo()
        foo = Task(fn=obj)

        @flow
        def bar():
            return foo("a", suffix="b")

        assert bar() == "ahellob"
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
