### PR TITLE
Allow image/namespace fields to be loaded from Kubernetes job manifest

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -172,9 +172,10 @@ class KubernetesJob(Infrastructure):
 
     @root_validator
     def default_namespace(cls, values):
-        job = values["job"]
+        job = values.get("job")
+
         namespace = values.get("namespace")
-        job_namespace = job["metadata"].get("namespace")
+        job_namespace = job["metadata"].get("namespace") if job else None
 
         if not namespace and not job_namespace:
             values["namespace"] = "default"
@@ -183,9 +184,13 @@ class KubernetesJob(Infrastructure):
 
     @root_validator
     def default_image(cls, values):
-        job = values["job"]
+        job = values.get("job")
         image = values.get("image")
-        job_image = job["spec"]["template"]["spec"]["containers"][0].get("image")
+        job_image = (
+            job["spec"]["template"]["spec"]["containers"][0].get("image")
+            if job
+            else None
+        )
 
         if not image and not job_image:
             values["image"] = get_prefect_image_name()

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -75,11 +75,11 @@ class KubernetesJob(Infrastructure):
         default="kubernetes-job", description="The type of infrastructure."
     )
     # shortcuts for the most common user-serviceable settings
-    image: str = Field(
+    image: Optional[str] = Field(
         default_factory=get_prefect_image_name,
         description="The tag of a Docker image to use for the job. Defaults to the Prefect image.",
     )
-    namespace: str = Field(
+    namespace: Optional[str] = Field(
         default="default", description="The Kubernetes namespace to use for this job."
     )
     service_account_name: Optional[str] = Field(
@@ -278,18 +278,25 @@ class KubernetesJob(Infrastructure):
         """Produces the JSON 6902 patch for the most commonly used customizations, like
         image and namespace, which we offer as top-level parameters (with sensible
         default values)"""
-        shortcuts = [
-            {
-                "op": "add",
-                "path": "/metadata/namespace",
-                "value": self.namespace,
-            },
-            {
-                "op": "add",
-                "path": "/spec/template/spec/containers/0/image",
-                "value": self.image,
-            },
-        ]
+        shortcuts = []
+
+        if self.namespace:
+            shortcuts.append(
+                {
+                    "op": "add",
+                    "path": "/metadata/namespace",
+                    "value": self.namespace,
+                }
+            )
+
+        if self.image:
+            shortcuts.append(
+                {
+                    "op": "add",
+                    "path": "/spec/template/spec/containers/0/image",
+                    "value": self.image,
+                }
+            )
 
         shortcuts += [
             {

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 import anyio.abc
 import yaml
-from pydantic import Field, validator
+from pydantic import Field, root_validator, validator
 from typing_extensions import Literal
 
 from prefect.blocks.kubernetes import KubernetesClusterConfig
@@ -76,11 +76,18 @@ class KubernetesJob(Infrastructure):
     )
     # shortcuts for the most common user-serviceable settings
     image: Optional[str] = Field(
-        default_factory=get_prefect_image_name,
-        description="The tag of a Docker image to use for the job. Defaults to the Prefect image.",
+        default=None,
+        description=(
+            "The tag of a Docker image to use for the job. Defaults to the Prefect "
+            "image unless an image is already present in a provided job manifest."
+        ),
     )
     namespace: Optional[str] = Field(
-        default="default", description="The Kubernetes namespace to use for this job."
+        default=None,
+        description=(
+            "The Kubernetes namespace to use for this job. Defaults to 'default' "
+            "unless a namespace is already present in a provided job manifest."
+        ),
     )
     service_account_name: Optional[str] = Field(
         default=None, description="The Kubernetes service account to use for this job."
@@ -162,6 +169,28 @@ class KubernetesJob(Infrastructure):
         if isinstance(value, list):
             return JsonPatch(value)
         return value
+
+    @root_validator
+    def default_namespace(cls, values):
+        job = values["job"]
+        namespace = values.get("namespace")
+        job_namespace = job["metadata"].get("namespace")
+
+        if not namespace and not job_namespace:
+            values["namespace"] = "default"
+
+        return values
+
+    @root_validator
+    def default_image(cls, values):
+        job = values["job"]
+        image = values.get("image")
+        job_image = job["spec"]["template"]["spec"]["containers"][0].get("image")
+
+        if not image and not job_image:
+            values["image"] = get_prefect_image_name()
+
+        return values
 
     # Support serialization of the 'JsonPatch' type
     class Config:

--- a/tests/blocks/checksums.json
+++ b/tests/blocks/checksums.json
@@ -15,6 +15,6 @@
     "kubernetes-cluster-config": "sha256:90d421e948bfbe4cdc98b124995f0edd0f84b0837549ad1390423bad8e31cf3b",
     "docker-registry": "sha256:6db1457676eee0b54ca2834b06f80a80f7c90112e64f1bdd26afb2e62fcceed9",
     "docker-container": "sha256:ee3348b26a5d0e0226e2d3cf6f2e85a3592c3b19fb8a988dfccceee972b9b9eb",
-    "kubernetes-job": "sha256:686f931093d8fa3a80dee6eb66516be7b022bf29c44a38766da8571f25fede8b",
+    "kubernetes-job": "sha256:a27bd569f16c47d6e39f0c04d1724dc7a670ca5d6013d930c517b79954ee9b97",
     "process": "sha256:227b03037cf895d9a70603554b792f573e7e59b81a585d51a43ec1f826e81da3"
 }

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -205,19 +205,21 @@ def test_uses_image_setting(
     assert image == "foo"
 
 
-def test_allows_null_image_setting(
+def test_allows_image_setting_from_manifest(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-    KubernetesJob(command=["echo", "hello"], image=None).run(MagicMock())
+    manifest = KubernetesJob.base_job_manifest()
+    manifest["spec"]["template"]["spec"]["containers"][0]["image"] = "test"
+    KubernetesJob(command=["echo", "hello"], job=manifest).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
-    container = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["spec"][
+    image = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["spec"][
         "template"
-    ]["spec"]["containers"][0]
-    assert "image" not in container
+    ]["spec"]["containers"][0]["image"]
+    assert image == "test"
 
 
 def test_uses_labels_setting(
@@ -370,19 +372,20 @@ def test_uses_namespace_setting(
     assert namespace == "foo"
 
 
-def test_allows_null_namespace_setting(
+def test_allows_namespace_setting_from_manifest(
     mock_k8s_client,
     mock_watch,
     mock_k8s_batch_client,
 ):
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
-
-    KubernetesJob(command=["echo", "hello"], namespace=None).run(MagicMock())
+    manifest = KubernetesJob.base_job_manifest()
+    manifest["metadata"]["namespace"] = "test"
+    KubernetesJob(command=["echo", "hello"], job=manifest).run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
-    metadata = namespace = mock_k8s_batch_client.create_namespaced_job.call_args[0][1][
-        "metadata"
+    namespace = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
+        "namespace"
     ]
-    assert "namespace" not in metadata
+    assert namespace == "test"
 
 
 def test_uses_service_account_name_setting(

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -205,6 +205,21 @@ def test_uses_image_setting(
     assert image == "foo"
 
 
+def test_allows_null_image_setting(
+    mock_k8s_client,
+    mock_watch,
+    mock_k8s_batch_client,
+):
+    mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+
+    KubernetesJob(command=["echo", "hello"], image=None).run(MagicMock())
+    mock_k8s_batch_client.create_namespaced_job.assert_called_once()
+    container = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["spec"][
+        "template"
+    ]["spec"]["containers"][0]
+    assert "image" not in container
+
+
 def test_uses_labels_setting(
     mock_k8s_client,
     mock_watch,
@@ -353,6 +368,21 @@ def test_uses_namespace_setting(
         "namespace"
     ]
     assert namespace == "foo"
+
+
+def test_allows_null_namespace_setting(
+    mock_k8s_client,
+    mock_watch,
+    mock_k8s_batch_client,
+):
+    mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+
+    KubernetesJob(command=["echo", "hello"], namespace=None).run(MagicMock())
+    mock_k8s_batch_client.create_namespaced_job.assert_called_once()
+    metadata = namespace = mock_k8s_batch_client.create_namespaced_job.call_args[0][1][
+        "metadata"
+    ]
+    assert "namespace" not in metadata
 
 
 def test_uses_service_account_name_setting(

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -214,7 +214,9 @@ def test_allows_image_setting_from_manifest(
 
     manifest = KubernetesJob.base_job_manifest()
     manifest["spec"]["template"]["spec"]["containers"][0]["image"] = "test"
-    KubernetesJob(command=["echo", "hello"], job=manifest).run(MagicMock())
+    job = KubernetesJob(command=["echo", "hello"], job=manifest)
+    assert job.image is None
+    job.run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     image = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["spec"][
         "template"
@@ -380,7 +382,9 @@ def test_allows_namespace_setting_from_manifest(
     mock_watch.stream = _mock_pods_stream_that_returns_running_pod
     manifest = KubernetesJob.base_job_manifest()
     manifest["metadata"]["namespace"] = "test"
-    KubernetesJob(command=["echo", "hello"], job=manifest).run(MagicMock())
+    job = KubernetesJob(command=["echo", "hello"], job=manifest)
+    assert job.namespace is None
+    job.run(MagicMock())
     mock_k8s_batch_client.create_namespaced_job.assert_called_once()
     namespace = mock_k8s_batch_client.create_namespaced_job.call_args[0][1]["metadata"][
         "namespace"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->


Closes #7245

Only sets a default value for `image` and `namespace` if they are not provided in the given manifest. This allows users to provide a manifest that contains these preset.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Given `job.yaml`:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  generateName: prefect-job-d41d8cd98f00b204e9800998ecf8427e
  labels: {}
  namespace: my-namespace
spec:
  template:
    spec:
      completions: 1
      containers:
      - env: []
        image: my-image
        name: prefect-job
      parallelism: 1
      restartPolicy: Never
```

The image and namespace should be respected by this block:

```python
job = KubernetesJob(job=KubernetesJob.from_file("job.yaml"))
print(job.preview())
```

However, we overwrite `namespace` and `image` with Prefect's default values. This pull request updates this to respect the values in the job manifest if they exist.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
