### PR TITLE
UI: Clean up the vite config

### DIFF
--- a/orion-ui/vite.config.ts
+++ b/orion-ui/vite.config.ts
@@ -1,23 +1,15 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: process.env['ORION_UI_SERVE_BASE'] || '',
+  base: process.env.ORION_UI_SERVE_BASE ?? '',
   resolve: {
-    alias: [{ find: '@', replacement: resolve(__dirname, './src') }]
+    alias: [{ find: '@', replacement: resolve(__dirname, './src') }],
   },
   css: {
     devSourcemap: true,
-    preprocessorOptions: {
-      scss: {
-        charset: false,
-        additionalData: `
-        @use '@prefecthq/miter-design/src/styles/abstracts/variables' as *;
-        `
-      }
-    }
-  }
+  },
 })


### PR DESCRIPTION
# Description
vite.config.ts had some linting warnings and was also still referencing miter-design which we haven't used in a long time