### PR TITLE
Add support for annotations to `visit_collection`

### DIFF
--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -1,9 +1,27 @@
-from typing import Any, Generic, TypeVar
+from abc import ABC
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
 
-class unmapped:
+class BaseAnnotation(ABC):
+    """
+    Base class for Prefect annotation types
+    """
+
+    def __init__(self, value: T):
+        self.value = value
+
+    def unwrap(self) -> T:
+        return self.value
+
+    def __eq__(self, other: object) -> bool:
+        if not type(self) == type(other):
+            return False
+        return self.unwrap() == other.unwrap()
+
+
+class unmapped(BaseAnnotation):
     """
     Wrapper for iterables.
 
@@ -11,15 +29,12 @@ class unmapped:
     operation instead of being split.
     """
 
-    def __init__(self, value: Any):
-        self.value = value
-
-    def __getitem__(self, _) -> Any:
+    def __getitem__(self, _) -> T:
         # Internally, this acts as an infinite array where all items are the same value
-        return self.value
+        return self.unwrap()
 
 
-class allow_failure:
+class allow_failure(BaseAnnotation):
     """
     Wrapper for states or futures.
 
@@ -32,12 +47,6 @@ class allow_failure:
     If the input is from a failed run, the attached exception will be passed to your
     function.
     """
-
-    def __init__(self, value: Any):
-        self.value = value
-
-    def unwrap(self) -> Any:
-        return self.value
 
 
 class Quote(Generic[T]):

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -28,7 +28,7 @@ from unittest.mock import Mock
 import pydantic
 
 # Moved to `prefect.utilities.annotations` but preserved here for compatibility
-from prefect.utilities.annotations import Quote, quote  # noqa
+from prefect.utilities.annotations import BaseAnnotation, Quote, quote  # noqa
 
 
 class AutoEnum(str, Enum):
@@ -228,6 +228,7 @@ def visit_collection(
     - Dict (note: keys are also visited recursively)
     - Dataclass
     - Pydantic model
+    - Prefect annotations
 
     Args:
         expr (Any): a Python object or expression
@@ -319,6 +320,10 @@ def visit_collection(
             result = model_instance
         else:
             result = None
+
+    elif isinstance(expr, BaseAnnotation):
+        result = type(expr)(visit_nested(expr.unwrap()))
+
     else:
         result = result if return_data else None
 

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -6,6 +6,7 @@ from typing import Any
 import pydantic
 import pytest
 
+from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.collections import (
     AutoEnum,
     dict_to_flatdict,
@@ -14,6 +15,10 @@ from prefect.utilities.collections import (
     remove_nested_keys,
     visit_collection,
 )
+
+
+class ExampleAnnotation(BaseAnnotation):
+    pass
 
 
 class Color(AutoEnum):
@@ -213,6 +218,7 @@ class TestVisitCollection:
             (SimpleDataclass(x=1, y=2), SimpleDataclass(x=1, y=-2)),
             (SimplePydantic(x=1, y=2), SimplePydantic(x=1, y=-2)),
             (ExtraPydantic(x=1, y=2, z=3), ExtraPydantic(x=1, y=-2, z=3)),
+            (ExampleAnnotation(4), ExampleAnnotation(-4)),
         ],
     )
     def test_visit_collection_and_transform_data(self, inp, expected):


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect-dask/issues/43

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Items inside annotations like `allow_failure` are not visited by `visit_collection` which means that when we wrap futures e.g. in https://github.com/PrefectHQ/prefect-dask/issues/43 they may not be resolved correctly. This pull request adds a base class for annotations and support for visiting.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
