### PR TITLE
UI: Add `resolve.dedupe` settings for vite

### DIFF
--- a/orion-ui/vite.config.ts
+++ b/orion-ui/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   base: process.env.ORION_UI_SERVE_BASE ?? '',
   resolve: {
     alias: [{ find: '@', replacement: resolve(__dirname, './src') }],
+    dedupe: ['vue'],
   },
   css: {
     devSourcemap: true,


### PR DESCRIPTION
# Description
We've been having quite a few issues when linking orion-design locally for development. Adding `vue` to vite's dedupe config seems to resolve those issues. 