### PR TITLE
Add block type slug to Slack Webhook

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -92,6 +92,7 @@ class SlackWebhook(AppriseNotificationBlock):
     """
 
     _block_type_name = "Slack Webhook"
+    _block_type_slug = "slack-webhook"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/7dkzINU9r6j44giEFuHuUC/85d4cd321ad60c1b1e898bc3fbd28580/5cb480cd5f1b6d3fbadece79.png?h=250"
 
     url: SecretStr = Field(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Slack Webhook doesn't have the `_block_type_slug` attribute. Thus, it is not possible to load the block with the `Block` object. This PR added `_block_type_slug` to the `SlackWebhook` block

 
### Example
```python
from prefect.blocks.core import Block

slack_block = Block.load("slack-webhook/test-slack")
slack_block.notify("Fail run")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
