### PR TITLE
UI: Subflow Runs not showing up on flow run page

### DIFF
--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -23,7 +23,7 @@
         <FlowRunTaskRuns v-if="flowRun" :flow-run-id="flowRun.id" />
       </template>
 
-      <template #sub-flow-runs>
+      <template #subflow-runs>
         <FlowRunSubFlows v-if="flowRun" :flow-run-id="flowRun.id" />
       </template>
 


### PR DESCRIPTION
Fixes the slot name for the subflow runs tab not matching the tab which caused the content to no be displayed.

Closes https://github.com/PrefectHQ/prefect/issues/7268

### Checklist


- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
