### PR TITLE
Allow test pypi publishing to fail during releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -176,44 +176,6 @@ jobs:
           name: release-image-${{ github.sha }}-${{ matrix.python-version }}-conda
           path: /tmp/image-conda.tar
 
-  publish-docs:
-    name: Publish documentation
-    needs: [build-release, publish-test-release]
-    environment: "prod"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Checkout current docs
-        run: git checkout docs-deploy --
-
-      - name: Create a temporary branch
-        # the release tag is parsed from the ref
-        run: git checkout -b "docs-for-release-${GITHUB_REF#refs/*/}"
-
-      - name: Merge with main
-        run: git merge origin/main --no-ff -m "Merge branch 'main' into temporary docs branch"
-
-      - name: Push and open PR
-        run: |
-          git push --set-upstream origin HEAD
-          gh pr create \
-            --title "Publish docs from release ${GITHUB_REF#refs/*/}" \
-            --body '_automatically created with `gh` cli on merge to `main`_' \
-            --base docs-deploy
-          gh pr merge --merge --delete-branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-test-release:
     name: Publish release to Test PyPI
     needs: [build-release]
@@ -257,8 +219,50 @@ jobs:
 
           name: ci
 
+  publish-docs:
+    name: Publish documentation
+    # See comment on `publish-release`
+    if: ${{ needs.build-release.result == 'success' }}
+    needs: [build-release, publish-test-release]
+    environment: "prod"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Checkout current docs
+        run: git checkout docs-deploy --
+
+      - name: Create a temporary branch
+        # the release tag is parsed from the ref
+        run: git checkout -b "docs-for-release-${GITHUB_REF#refs/*/}"
+
+      - name: Merge with main
+        run: git merge origin/main --no-ff -m "Merge branch 'main' into temporary docs branch"
+
+      - name: Push and open PR
+        run: |
+          git push --set-upstream origin HEAD
+          gh pr create \
+            --title "Publish docs from release ${GITHUB_REF#refs/*/}" \
+            --body '_automatically created with `gh` cli on merge to `main`_' \
+            --base docs-deploy
+          gh pr merge --merge --delete-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-docker-images:
     name: Publish to DockerHub
+    # See comment on `publish-release`
+    if: ${{ needs.build-release.result == 'success' && needs.build-conda-docker-images.result == 'success' && needs.build-docker-images.result == 'success'}}
     needs:
       [
         build-docker-images,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Due to [failures in the release of 2.6.4](https://github.com/PrefectHQ/prefect/actions/runs/3292121693/jobs/5427224009) it is concerning that Test PyPI downtime can cause a significant barrier to release. Here, I delve deep into the world of GitHub Actions to allow the release to be approved despite a failure in the `publish-to-testpypi` step. We still require that the release builds successfully, otherwise there's nothing to publish here.


See 
- https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution
- https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context
- https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

