### PR TITLE
Add timezone param to deployment build

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -238,6 +238,9 @@ async def set_schedule(
     cron_schedule = {"cron": cron_string, "day_or": cron_day_or, "timezone": timezone}
     if rrule_string is not None:
         rrule_schedule = json.loads(rrule_string)
+        if timezone:
+            # override timezone if specified via CLI argument
+            rrule_schedule.update({"timezone": timezone})
     else:
         # fall back to empty schedule dictionary
         rrule_schedule = {"rrule": None}
@@ -686,7 +689,7 @@ async def build(
     timezone: str = typer.Option(
         None,
         "--timezone",
-        help="A timezone that will be passed to cron or interval schedules.",
+        help="Deployment schedule timezone string e.g. 'America/New_York'",
     ),
     path: str = typer.Option(
         None,
@@ -800,8 +803,11 @@ async def build(
     elif rrule:
         try:
             schedule = RRuleSchedule(**json.loads(rrule))
+            if timezone:
+                # override timezone if specified via CLI argument
+                schedule.timezone = timezone
         except json.JSONDecodeError:
-            schedule = RRuleSchedule(rrule=rrule)
+            schedule = RRuleSchedule(rrule=rrule, timezone=timezone)
 
     # parse storage_block
     if storage_block:

--- a/tests/cli/test_deployment_cli.py
+++ b/tests/cli/test_deployment_cli.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta
 
+import pendulum
 import pytest
 
 from prefect import flow
@@ -250,6 +251,88 @@ class TestInputValidation:
             ],
             expected_code=1,
             temp_dir=tmp_path,
+        )
+
+    def test_passing_cron_schedules_to_build(self, patch_import, tmp_path):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+                "--cron",
+                "0 4 * * *",
+                "--timezone",
+                "Europe/Berlin",
+            ],
+            expected_code=0,
+            temp_dir=tmp_path,
+        )
+
+        deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        assert (
+            deployment.schedule.cron
+            == "0 4 * * *"
+        )
+        assert (
+            deployment.schedule.timezone
+            == "Europe/Berlin"
+        )
+
+    def test_passing_interval_schedules_to_build(self, patch_import, tmp_path):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+                "--interval",
+                "42",
+                "--anchor-date",
+                "2018-02-02",
+                "--timezone",
+                "America/New_York",
+            ],
+            expected_code=0,
+            temp_dir=tmp_path,
+        )
+
+        deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        assert (
+            deployment.schedule.interval
+            == timedelta(seconds=42)
+        )
+        assert (
+            deployment.schedule.anchor_date
+            == pendulum.parse("2018-02-02")
+        )
+        assert (
+            deployment.schedule.timezone
+            == "America/New_York"
+        )
+
+    def test_passing_anchor_without_interval_exits(self, patch_import, tmp_path):
+        invoke_and_assert(
+            [
+                "deployment",
+                "build",
+                "fake-path.py:fn",
+                "-n",
+                "TEST",
+                "-o",
+                str(tmp_path / "test.yaml"),
+                "--anchor-date",
+                "2018-02-02",
+            ],
+            expected_code=1,
+            temp_dir=tmp_path,
+            expected_output_contains="An anchor date can only be provided with an interval schedule"
         )
 
     def test_parsing_rrule_schedule_string_literal(self, patch_import, tmp_path):


### PR DESCRIPTION
closes #7202

Adds timezone handling to `prefect deployment build` to bring its behavior more in line with `prefect deployment set-schedule`. Also improves handling of anchor dates for interval schedules and explicit timezone overrides for RRule schedules.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
