### PR TITLE
Replace deprecated set-output command in the integration-test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-    
+
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -51,7 +51,7 @@ jobs:
       - name: Retrieve Playwright version
         id: playwright-cache-key
         run: |
-          echo "::set-output name=version::$(npx playwright -V)"
+          echo "version=$(npx playwright -V)" >> $GITHUB_OUTPUT
 
       - name: Retrieve cached Playwright browsers
         id: cache-playwright-browsers


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
`set-output` used in the integration-test github action is deprecated and should be replaced by piping to `$GITHUB_OUTPUT`
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
From 01.06.2023 all github actions still using set-output will fail.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
