### PR TITLE
Add persistence of data when users return states from tasks/flows

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -214,7 +214,14 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
         and not retval.state_details.flow_run_id
         and not retval.state_details.task_run_id
     ):
-        return retval
+        state = retval
+
+        # Unless the user has already constructed a result explicitly, use the factory
+        # to update the data to the correct type
+        if not isinstance(state.data, BaseResult):
+            state.data = await result_factory.create_result(state.data)
+
+        return state
 
     # Determine a new state from the aggregate of contained states
     if is_state(retval) or is_state_iterable(retval):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Previously, the following example would fail with a `MissingResult` exception since the user did not provide `data` for the state. Now it will work with `None` as the result.

```python
@flow
def foo():
  return Completed(message="test")

foo()
```

Previously, the following example would result in unpersisted data. Now, it will persist the data attached to the state:
```python
@flow(persist_result=True)
def foo():
  return Completed(data="test")

foo()

# If read from the API later, the flow run state would have no data
```


The following example does not have any change in behavior, the user can attach a custom `BaseResult`:

```python
@flow
def foo():
  return Completed(data=LiteralResult(value=False))

foo()
```

The following example does not have any change in behavior, the user can attach data without persistence:

```python
@flow(persist_result=False)
def foo():
  return Completed(data="foo!")

foo()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
