### PR TITLE
Restores proxy-awareness for the Orion client for remote Orion servers.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ tags:
 
 # Installation
 
-The first step to getting started with Prefect is installing the Prefect Python package. 
+The first step to getting started with Prefect is installing the Prefect Python package.
 
 <p align="left">
     <a href="https://pypi.python.org/pypi/prefect/" alt="PyPI version">
@@ -43,7 +43,7 @@ We recommend installing Prefect 2 using a Python virtual environment manager suc
 !!! warning "Windows and Linux requirements"
     See [Windows installation notes](#windows-installation-notes) and [Linux installation notes](#linux-installation-notes) for details on additional installation requirements and considerations.
 
-## Install Prefect 
+## Install Prefect
 
 The following sections describe how to install Prefect in your development or execution environment.
 
@@ -122,12 +122,12 @@ Server:
 
 ## Windows installation notes
 
-Prefect 2 supports running Prefect flows on Windows. 
+Prefect 2 supports running Prefect flows on Windows.
 
 !!! note "Prefect on Windows requires Python 3.8 or later"
     Make sure to use Python 3.8 or higher when running a Prefect agent on Windows.
 
-You can install and run Prefect as described above via Windows PowerShell, the Windows Command Prompt, or [`conda`](https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows.html). Note that, after installation, you may need to manually add the Python local packages `Scripts` folder to your `Path` environment variable. 
+You can install and run Prefect as described above via Windows PowerShell, the Windows Command Prompt, or [`conda`](https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows.html). Note that, after installation, you may need to manually add the Python local packages `Scripts` folder to your `Path` environment variable.
 
 The `Scripts` folder path looks something like this (the username and Python version may be different on your system):
 
@@ -140,10 +140,10 @@ Watch the `pip install` installation output messages for the `Scripts` folder pa
 If using Windows Subsystem for Linux (WSL), see [Linux installation notes](#linux-installation-notes).
 
 !!! note "Windows support is under development"
-    Support for Prefect on Windows is a work in progress. 
-    
-    Right now, we're focused on your ability to develop and run flows and tasks on Windows, along with running the API server, orchestration engine, and UI. 
-    
+    Support for Prefect on Windows is a work in progress.
+
+    Right now, we're focused on your ability to develop and run flows and tasks on Windows, along with running the API server, orchestration engine, and UI.
+
     If you encounter unexpected issues, please let us know via a [GitHub issue](https://github.com/PrefectHQ/prefect/issues), [Prefect Discourse](https://discourse.prefect.io/) discussion groups, or the [Prefect Community Slack](https://www.prefect.io/slack/).
 
 ## Linux installation notes
@@ -156,7 +156,7 @@ Known compatible releases include:
 
 - Ubuntu 20.04 LTS
 
-You can also: 
+You can also:
 
 - Use [Prefect Cloud](/ui/cloud/) as your API server and orchestration engine.
 - Use the `conda` virtual environment manager, which enables configuring a compatible SQLite version.
@@ -253,6 +253,16 @@ pip3 install prefect
 ```
 </div>
 
+## Using Prefect in an environment with HTTP proxies
+
+If you are using Prefect Cloud or hosting your own Orion instance, the Prefect library
+will connect to the API via any proxies you have listed in the `HTTP_PROXY`,
+`HTTPS_PROXY`, or `ALL_PROXY` environment variables.  You may also use the `NO_PROXY`
+environment variable to specify which hosts should not be sent through the proxy.
+
+For more information about these environment variables, see the [cURL
+documentation](https://everything.curl.dev/usingcurl/proxies/env).
+
 ## Upgrading from Prefect beta
 
 The following sections provide important notes for users upgrading from Prefect 2 beta releases.
@@ -273,11 +283,11 @@ You don't need to recreate any deployments or pause your schedules &mdash; stopp
 
 ### Upgrading to 2.0a10
 
-Upgrading from Prefect version 2.0a9 or earlier requires resetting the Prefect Orion database. 
+Upgrading from Prefect version 2.0a9 or earlier requires resetting the Prefect Orion database.
 
 Prior to 2.0a10, Prefect did not have database migrations and required a hard reset of the database between versions. Now that migrations have been added, your database will be upgraded automatically with each version change. However, you must still perform a hard reset of the database if you are upgrading from 2.0a9 or earlier.
 
 Resetting the database with the CLI command `prefect orion database reset` is not compatible a database from 2.0a9 or earlier. Instead, delete the database file `~/.prefect/orion.db`. Prefect automatically creates a new database on the next write.
 
 !!! warning "Resetting the database deletes data"
-    Note that resetting the database causes the loss of any existing data. 
+    Note that resetting the database causes the loss of any existing data.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,10 @@
 addopts = -rfEsx --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term
 norecursedirs = *.egg-info .git .mypy_cache node_modules .pytest_cache .vscode
 
-markers = 
+markers =
     service(arg): a service integration test. For example 'docker'
     enable_orion_handler: by default, sending logs to the API is disabled. Tests marked with this use the handler.
-    
+
 env =
     # NOTE: Additional Prefect setting values are set dynamically in conftest.py
     PREFECT_TEST_MODE = 1
@@ -39,8 +39,10 @@ filterwarnings =
     ignore:`DeploymentSpec` has been replaced by `Deployment`:DeprecationWarning
     # This warning is raised on Windows by Python internals
     ignore:the imp module is deprecated:DeprecationWarning
-    # Dockerpy is behind on this one 
+    # Dockerpy is behind on this one
     ignore:distutils Version classes are deprecated:DeprecationWarning
+    # distutils is deprecated, but we are using it directly in prefect/filesystems.py
+    ignore:The distutils package is deprecated:DeprecationWarning
 
 [isort]
 skip = __init__.py
@@ -85,7 +87,7 @@ style = pep440
 versionfile_source = src/prefect/_version.py
 versionfile_build = prefect/_version.py
 tag_prefix =
-parentdir_prefix = 
+parentdir_prefix =
 
 [coverage:run]
 branch = True

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -161,19 +161,25 @@ class OrionClient:
             **httpx_settings,
         )
 
-        # See https://www.python-httpx.org/advanced/#custom-transports
-        # If we're using an HTTP/S client (not the ephemeral client), adjust the
-        # transport to add retries _after_ it is instantiated. If we alter the transport
-        # before instantiation, the transport will not be aware of proxies unless we
-        # reproduce all of the logic to make it so.
+        # See https://www.python-httpx.org/advanced/#custom-transports If we're using an
+        # HTTP/S client (not the ephemeral client), adjust the transport to add retries
+        # _after_ it is instantiated. If we alter the transport before instantiation,
+        # the transport will not be aware of proxies unless we reproduce all of the
+        # logic to make it so.
         #
         # Only alter the transport to set our default of 3 retries, don't modify any
-        # transport a user may have provided via httpx_settings
+        # transport a user may have provided via httpx_settings.
+        #
+        # Making liberal use of getattr and isinstance checks here to avoid any
+        # surprises if the internals of httpx or httpcore change on us
         if isinstance(api, str) and not httpx_settings.get("transport"):
-            orion_transport = self._client._transport_for_url(httpx.URL(api))
-            if isinstance(orion_transport, httpx.AsyncHTTPTransport):
-                if isinstance(orion_transport._pool, httpcore.AsyncConnectionPool):
-                    orion_transport._pool._retries = 3
+            transport_for_url = getattr(self._client, "_transport_for_url", None)
+            if callable(transport_for_url):
+                orion_transport = transport_for_url(httpx.URL(api))
+                if isinstance(orion_transport, httpx.AsyncHTTPTransport):
+                    pool = getattr(orion_transport, "_pool", None)
+                    if isinstance(pool, httpcore.AsyncConnectionPool):
+                        pool._retries = 3
 
         self.logger = get_logger("client")
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -161,11 +161,12 @@ class OrionClient:
             **httpx_settings,
         )
 
-        # See https://www.python-httpx.org/advanced/#custom-transports If we're using an
-        # HTTP/S client (not the ephemeral client), adjust the transport to add retries
-        # _after_ it is instantiated. If we alter the transport before instantiation,
-        # the transport will not be aware of proxies unless we reproduce all of the
-        # logic to make it so.
+        # See https://www.python-httpx.org/advanced/#custom-transports
+        # 
+        # If we're using an HTTP/S client (not the ephemeral client), adjust the
+        # transport to add retries _after_ it is instantiated. If we alter the transport
+        # before instantiation, the transport will not be aware of proxies unless we
+        # reproduce all of the logic to make it so.
         #
         # Only alter the transport to set our default of 3 retries, don't modify any
         # transport a user may have provided via httpx_settings.

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -166,7 +166,10 @@ class OrionClient:
         # transport to add retries _after_ it is instantiated. If we alter the transport
         # before instantiation, the transport will not be aware of proxies unless we
         # reproduce all of the logic to make it so.
-        if isinstance(api, str):
+        #
+        # Only alter the transport to set our default of 3 retries, don't modify any
+        # transport a user may have provided via httpx_settings
+        if isinstance(api, str) and not httpx_settings.get("transport"):
             orion_transport = self._client._transport_for_url(httpx.URL(api))
             if isinstance(orion_transport, httpx.AsyncHTTPTransport):
                 if isinstance(orion_transport._pool, httpcore.AsyncConnectionPool):

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1,12 +1,14 @@
 import datetime
+import os
 import random
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import List
+from typing import Generator, List
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import anyio
+import httpcore
 import httpx
 import pendulum
 import pytest
@@ -33,6 +35,7 @@ from prefect.orion.schemas.schedules import IntervalSchedule
 from prefect.orion.schemas.states import StateType
 from prefect.settings import (
     PREFECT_API_KEY,
+    PREFECT_API_URL,
     PREFECT_ORION_DATABASE_MIGRATE_ON_START,
     temporary_settings,
 )
@@ -54,6 +57,93 @@ class TestGetClient:
             new_client = get_client()
             assert isinstance(new_client, OrionClient)
             assert new_client is not client
+
+
+class TestClientProxyAwareness:
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/2356, where
+    a customer reported that the Cloud client supported proxies, but the Orion client
+    did not.  This test suite is implementation-specific to httpx/httpcore, as there are
+    no other inexpensive ways to confirm both the proxy-awareness and preserving the
+    retry behavior without probing into the implementation details of the libraries."""
+
+    @pytest.fixture()
+    def remote_https_orion(self) -> Generator[httpx.URL, None, None]:
+        orion_url = "https://127.0.0.1:4242/"
+        with temporary_settings(updates={PREFECT_API_URL: orion_url}):
+            yield httpx.URL(orion_url)
+
+    def test_unproxied_remote_client_will_retry(self, remote_https_orion: httpx.URL):
+        """The original issue here was that we were overriding the `transport` in
+        order to set the retries to 3; this is what circumvented the proxy support.
+        This test (and those below) should confirm that we are setting the retries on
+        the transport's pool in all cases."""
+        httpx_client = get_client()._client
+        assert isinstance(httpx_client, httpx.AsyncClient)
+
+        transport_for_orion = httpx_client._transport_for_url(remote_https_orion)
+        assert isinstance(transport_for_orion, httpx.AsyncHTTPTransport)
+
+        pool = transport_for_orion._pool
+        assert isinstance(pool, httpcore.AsyncConnectionPool)
+        assert pool._retries == 3  # set in prefect.client.orion.get_client()
+
+    @pytest.fixture
+    def https_proxy(self) -> Generator[httpcore.URL, None, None]:
+        original = os.environ.get("HTTPS_PROXY")
+        try:
+            os.environ["HTTPS_PROXY"] = "https://127.0.0.1:6666"
+            yield httpcore.URL(os.environ["HTTPS_PROXY"])
+        finally:
+            if original is None:
+                del os.environ["HTTPS_PROXY"]
+            else:
+                os.environ["HTTPS_PROXY"] = original
+
+    async def test_client_is_aware_of_https_proxy(
+        self, remote_https_orion: httpx.URL, https_proxy: httpcore.URL
+    ):
+        httpx_client = get_client()._client
+        assert isinstance(httpx_client, httpx.AsyncClient)
+
+        transport_for_orion = httpx_client._transport_for_url(remote_https_orion)
+        assert isinstance(transport_for_orion, httpx.AsyncHTTPTransport)
+
+        pool = transport_for_orion._pool
+        assert isinstance(pool, httpcore.AsyncHTTPProxy)
+        assert pool._proxy_url == https_proxy
+        assert pool._retries == 3  # set in prefect.client.orion.get_client()
+
+    @pytest.fixture()
+    def remote_http_orion(self) -> Generator[httpx.URL, None, None]:
+        orion_url = "http://127.0.0.1:4242/"
+        with temporary_settings(updates={PREFECT_API_URL: orion_url}):
+            yield httpx.URL(orion_url)
+
+    @pytest.fixture
+    def http_proxy(self) -> Generator[httpcore.URL, None, None]:
+        original = os.environ.get("HTTP_PROXY")
+        try:
+            os.environ["HTTP_PROXY"] = "http://127.0.0.1:6666"
+            yield httpcore.URL(os.environ["HTTP_PROXY"])
+        finally:
+            if original is None:
+                del os.environ["HTTP_PROXY"]
+            else:
+                os.environ["HTTP_PROXY"] = original
+
+    async def test_client_is_aware_of_http_proxy(
+        self, remote_http_orion: httpx.URL, http_proxy: httpcore.URL
+    ):
+        httpx_client = get_client()._client
+        assert isinstance(httpx_client, httpx.AsyncClient)
+
+        transport_for_orion = httpx_client._transport_for_url(remote_http_orion)
+        assert isinstance(transport_for_orion, httpx.AsyncHTTPTransport)
+
+        pool = transport_for_orion._pool
+        assert isinstance(pool, httpcore.AsyncHTTPProxy)
+        assert pool._proxy_url == http_proxy
+        assert pool._retries == 3  # set in prefect.client.orion.get_client()
 
 
 class TestInjectClient:


### PR DESCRIPTION
We were overriding the `transport` on our Orion connections in order to set the number of retries.  When doing this, we would need to include all of the logic for how to discover if the user has proxies configured in their environment. Instead, just set the retries _after_ the fact.

Fixes PrefectHQ/nebula#2356
Fixes #7204

See the background thread in the [Prefect Community Slack](https://linen.prefect.io/t/2930204/Hi-I-m-having-some-issues-with-accessing-prefect-2-0-cloud-f) for more information.