### PR TITLE
Append "-" to non-random part of K8s job name

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -391,7 +391,7 @@ class KubernetesJob(Infrastructure):
                 {
                     "op": "add",
                     "path": "/metadata/generateName",
-                    "value": self._slugify_name(self.name),
+                    "value": self._slugify_name(self.name) + "-",
                 }
             )
         else:
@@ -406,7 +406,8 @@ class KubernetesJob(Infrastructure):
                         *self.command,
                         *self.env.keys(),
                         *[v for v in self.env.values() if v is not None],
-                    ),
+                    )
+                    + "-",
                 }
             )
 

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -164,13 +164,15 @@ async def test_task_group_start_returns_job_name(
 @pytest.mark.parametrize(
     "job_name,clean_name",
     [
-        ("_infra_run", "infra-run"),
-        ("...infra_run", "infra-run"),
-        ("._-infra_run", "infra-run"),
-        ("9infra-run", "9infra-run"),
-        ("-infra.run", "infra-run"),
-        ("infra*run", "infra-run"),
-        ("infra9.-foo_bar^x", "infra9-foo-bar-x"),
+        ("infra-run", "infra-run-"),
+        ("infra-run-", "infra-run-"),
+        ("_infra_run", "infra-run-"),
+        ("...infra_run", "infra-run-"),
+        ("._-infra_run", "infra-run-"),
+        ("9infra-run", "9infra-run-"),
+        ("-infra.run", "infra-run-"),
+        ("infra*run", "infra-run-"),
+        ("infra9.-foo_bar^x", "infra9-foo-bar-x-"),
     ],
 )
 def test_job_name_creates_valid_name(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Currently, K8s Jobs have names that look like `f"{job_object.name}{alnum5}"` or `f"{flow_run.name}{alnum5}"`, where `alnum5` is generated by K8s.
I believe this looks ugly and the common approach is to have `Job.metadata.generateName` end with a dash ([1](https://github.com/kubernetes/kubernetes/issues/44501), [2](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/)).
This change makes Job names look nicer (e.g. ` f"{job_object.name}-{alnum5}"`).

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Before: ![generateName_before](https://i.imgur.com/elXw7jj.png)

After: ![generateName_after](https://i.imgur.com/O7JFR3j.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
