### PR TITLE
UI: Remove flakey integration test

### DIFF
--- a/orion-ui/tests/notifications.spec.ts
+++ b/orion-ui/tests/notifications.spec.ts
@@ -64,22 +64,3 @@ test('Can edit notification', async () => {
 
   await expect(tag).toBeVisible()
 })
-
-test('Can delete notification', async () => {
-  const { rows: notifications } = useTable()
-  const notification = notifications.first()
-  const existingNotifications = await notifications.count()
-
-  const { selectItem } = useIconButtonMenu(undefined, notification)
-  await selectItem('Delete')
-
-  const { footer, closed } = useModal()
-  const { button } = useButton('Delete', footer)
-
-  await button.click()
-  await closed()
-
-  const newNotifications = await notifications.count()
-
-  expect(newNotifications).toBe(existingNotifications - 1)
-})


### PR DESCRIPTION
# Description
The "can delete notification" integration test has been flakey lately. I tried fixing it but don't have enough time to figure it out. So I'm removing it since a flakey test isn't a useful test. 