### PR TITLE
Add login with a browser to `prefect cloud login`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pydantic >= 1.10.0
 python-slugify >= 5.0
 pytz >= 2021.1
 pyyaml >= 5.4.1
-readchar >= 3.0.6
+readchar >= 4.0.0
 rich >= 11.0
 sqlalchemy[asyncio] >= 1.4.20, != 1.4.33
 toml >= 0.10.0

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -32,6 +32,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_UI_URL,
     load_profiles,
     save_profiles,
     update_current_profile,
@@ -290,13 +291,9 @@ async def login_with_browser() -> str:
     On failure, this function will exit the process.
     On success, it will return an API key.
     """
-    cloud_api_url = PREFECT_CLOUD_URL.value()
-
+    # TODO: Search for a valid port
     target = urllib.parse.quote("http://localhost:3001")
-
-    # TODO: Create a separate setting for this?
-    cloud_ui_url = cloud_api_url.replace("https://api.", "https://")
-    ui_login_url = cloud_ui_url.replace("/api", f"/authorize?callback={target}")
+    ui_login_url = PREFECT_UI_URL.value() + f"/auth/client?callback={target}"
 
     # Set up an event that the login API will toggle on startup
     ready_event = login_api.extra["ready-event"] = anyio.Event()

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -133,6 +133,9 @@ def confirm_logged_in():
 
 
 def get_current_workspace(workspaces):
+    if not PREFECT_API_URL:
+        return None
+
     workspace_handles_by_id = {
         workspace[
             "workspace_id"
@@ -332,7 +335,7 @@ async def login_with_browser() -> str:
     if result.type == "success":
         return result.content.api_key
     elif result.type == "failure":
-        exit_with_success(f"Failed to login: {result.content.reason}")
+        exit_with_error(f"Failed to login. {result.content.reason}")
 
 
 async def check_key_is_valid_for_login(key: str):
@@ -393,10 +396,10 @@ async def login(
 
     elif already_logged_in_profiles:
         app.console.print(
-            "It looks like you're already authenticated on another profile."
+            "It looks like you're already authenticated with another profile."
         )
         if not typer.confirm(
-            "? Would you like to reauthenticate on this profile?", default=False
+            "? Would you like to reauthenticate with this profile?", default=False
         ):
             if typer.confirm(
                 "? Would you like to switch to an authenticated profile?", default=True
@@ -426,7 +429,7 @@ async def login(
         )
 
         if choice == "key":
-            key = typer.prompt("Paste your authentication key")
+            key = typer.prompt("Paste your authentication key", hide_input=True)
         elif choice == "browser":
             key = await login_with_browser()
 

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -2,6 +2,7 @@
 Command line interface for interacting with Prefect Cloud
 """
 import re
+import signal
 import traceback
 import urllib.parse
 import webbrowser
@@ -96,7 +97,7 @@ def receive_failure(payload: LoginFailed):
 
 
 async def serve_login_api(cancel_scope):
-    config = uvicorn.Config(login_api, port=3001, log_level="debug")
+    config = uvicorn.Config(login_api, port=3001, log_level="critical")
     server = uvicorn.Server(config)
 
     try:
@@ -324,7 +325,7 @@ async def login_with_browser() -> str:
 
         # Uvicorn installs signal handlers, this is the cleanest way to shutdown the
         # login API
-        # signal.raise_signal(signal.SIGINT)
+        signal.raise_signal(signal.SIGINT)
 
     result = login_api.extra.get("result")
     if not result:

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -366,7 +366,7 @@ async def login(
         )
 
         if choice == "key":
-            key = typer.prompt("Paste your authentication token")
+            key = typer.prompt("Paste your authentication key")
         elif choice == "browser":
             key = await login_with_browser()
 

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -418,7 +418,7 @@ async def login(
     if not key:
         choice = prompt_select_from_list(
             app.console,
-            "How would you like to authenticate the Prefect CLI?",
+            "How would you like to authenticate?",
             [
                 ("browser", "Login with a web browser"),
                 ("key", "Paste an authentication key"),

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -7,7 +7,6 @@ import traceback
 import urllib.parse
 import webbrowser
 from typing import Dict, Iterable, List, Optional, Tuple, Union
-from uuid import UUID
 
 import anyio
 import httpx
@@ -69,8 +68,6 @@ login_api.add_middleware(
 
 class LoginSuccess(BaseModel):
     api_key: str
-    workspace_id: UUID
-    account_id: UUID
 
 
 class LoginFailed(BaseModel):

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -37,6 +37,7 @@ from prefect.settings import (
     update_current_profile,
 )
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.collections import listrepr
 
 # Set up the `prefect cloud` and `prefect cloud workspaces` CLI applications
 cloud_app = PrefectTyper(
@@ -392,7 +393,10 @@ async def login(
             if workspace.handle == workspace_handle:
                 break
         else:
-            exit_with_error(f"Workspace {workspace_handle!r} not found.")
+            exit_with_error(
+                f"Workspace {workspace_handle!r} not found. "
+                f"Availablle workspaces: {listrepr((w.handle for w in workspaces), ', ')}"
+            )
     else:
         # Prompt a switch if the number of workspaces is greater than one
         prompt_switch_workspace = len(workspaces) > 1

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -393,10 +393,12 @@ async def login(
             if workspace.handle == workspace_handle:
                 break
         else:
-            exit_with_error(
-                f"Workspace {workspace_handle!r} not found. "
-                f"Availablle workspaces: {listrepr((w.handle for w in workspaces), ', ')}"
-            )
+            if workspaces:
+                hint = f" Available workspaces: {listrepr((w.handle for w in workspaces), ', ')}"
+            else:
+                hint = ""
+
+            exit_with_error(f"Workspace {workspace_handle!r} not found." + hint)
     else:
         # Prompt a switch if the number of workspaces is greater than one
         prompt_switch_workspace = len(workspaces) > 1

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -48,14 +48,15 @@ workspace_app = PrefectTyper(
 cloud_app.add_typer(workspace_app, aliases=["workspaces"])
 app.add_typer(cloud_app)
 
-# Set up a little API server for browser based `prefect cloud login`
-
 
 def set_login_api_ready_event():
     login_api.extra["ready-event"].set()
 
 
 login_api = FastAPI(on_startup=[set_login_api_ready_event])
+"""
+This small API server is used for data transmission for browser-based log in.
+"""
 
 login_api.add_middleware(
     CORSMiddleware,

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -38,6 +38,7 @@ from prefect.settings import (
 )
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.collections import listrepr
+from prefect.utilities.compat import raise_signal
 
 # Set up the `prefect cloud` and `prefect cloud workspaces` CLI applications
 cloud_app = PrefectTyper(
@@ -255,7 +256,7 @@ async def login_with_browser() -> str:
 
         # Uvicorn installs signal handlers, this is the cleanest way to shutdown the
         # login API
-        signal.raise_signal(signal.SIGINT)
+        raise_signal(signal.SIGINT)
 
     result = login_api.extra.get("result")
     if not result:

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -314,9 +314,11 @@ async def login(
     for name, profile in profiles.items():
         profile_key = profile.settings.get(PREFECT_API_KEY)
         if (
-            not key
-            and profile_key is not None
-            or (key and profile_key == key)
+            # If a key is provided, only show profiles with the same key
+            (key and profile_key == key)
+            # Otherwise, show all profiles with a key set
+            or (not key and profile_key is not None)
+            # Check that the key is usable to avoid suggesting unauthenticated profiles
             and await check_key_is_valid_for_login(profile_key)
         ):
             already_logged_in_profiles.append(name)

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -407,7 +407,7 @@ async def login(
                 [(workspace, workspace.handle) for workspace in workspaces],
             )
         else:
-            workspace = current_workspace
+            workspace = current_workspace or workspaces[0]
 
     update_current_profile(
         {

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -288,6 +288,11 @@ async def login(
     Creates a new profile configured to use the specified PREFECT_API_KEY.
     Uses a previously configured profile if it exists.
     """
+    if not app.console.is_interactive and (not key or not workspace_handle):
+        exit_with_error(
+            "When not using an interactive terminal, you must supply a `--key` and `--workspace`."
+        )
+
     profiles = load_profiles()
     current_profile = get_settings_context().profile
 

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -121,7 +121,7 @@ def confirm_logged_in():
         profile = prefect.context.get_settings_context().profile
         exit_with_error(
             f"Currently not authenticated in profile {profile.name!r}. "
-            "Please login with `prefect cloud login`."
+            "Please log in with `prefect cloud login`."
         )
 
 
@@ -265,7 +265,7 @@ async def login_with_browser() -> str:
     if result.type == "success":
         return result.content.api_key
     elif result.type == "failure":
-        exit_with_error(f"Failed to login. {result.content.reason}")
+        exit_with_error(f"Failed to log in. {result.content.reason}")
 
 
 async def check_key_is_valid_for_login(key: str):
@@ -359,7 +359,7 @@ async def login(
             app.console,
             "How would you like to authenticate?",
             [
-                ("browser", "Login with a web browser"),
+                ("browser", "Log in with a web browser"),
                 ("key", "Paste an authentication key"),
             ],
         )

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -31,6 +31,10 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
+def is_interactive():
+    return app.console.is_interactive
+
+
 @app.callback()
 @with_cli_exception_handling
 def main(

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -1,12 +1,14 @@
 import re
-from typing import Dict, List
+from typing import List
 
 import anyio
 import httpx
+import pydantic
 from fastapi import status
 
 import prefect.context
 import prefect.settings
+from prefect.client.schemas import Workspace
 from prefect.exceptions import PrefectException
 from prefect.settings import PREFECT_API_KEY, PREFECT_CLOUD_API_URL
 
@@ -64,8 +66,8 @@ class CloudClient:
         with anyio.fail_after(10):
             await self.read_workspaces()
 
-    async def read_workspaces(self) -> List[Dict]:
-        return await self.get("/me/workspaces")
+    async def read_workspaces(self) -> List[Workspace]:
+        return pydantic.parse_obj_as(List[Workspace], await self.get("/me/workspaces"))
 
     async def __aenter__(self):
         await self._client.__aenter__()

--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -1,8 +1,11 @@
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, overload
+from uuid import UUID
 
 from pydantic import Field
 
 from prefect.orion import schemas
+from prefect.orion.utilities.schemas import PrefectBaseModel
+from prefect.settings import PREFECT_CLOUD_API_URL
 
 if TYPE_CHECKING:
     from prefect.deprecated.data_documents import DataDocument
@@ -132,3 +135,42 @@ class TaskRun(schemas.core.TaskRun.subclass()):
 
 class OrchestrationResult(schemas.responses.OrchestrationResult.subclass()):
     state: Optional[State]
+
+
+class Workspace(PrefectBaseModel):
+    """
+    A Prefect Cloud workspace.
+
+    Expected payload for each workspace returned by the `me/workspaces` route.
+    """
+
+    account_id: UUID = Field(..., description="The account id of the workspace.")
+    account_name: str = Field(..., description="The account name.")
+    account_handle: str = Field(..., description="The account's unique handle.")
+    workspace_id: UUID = Field(..., description="The workspace id.")
+    workspace_name: str = Field(..., description="The workspace name.")
+    workspace_description: str = Field(..., description="Description of the workspace.")
+    workspace_handle: str = Field(..., description="The workspace's unique handle.")
+
+    class Config:
+        extra = "ignore"
+
+    @property
+    def handle(self) -> str:
+        """
+        The full handle of the workspace as `account_handle` / `workspace_handle`
+        """
+        return self.account_handle + "/" + self.workspace_handle
+
+    def api_url(self) -> str:
+        """
+        Generate the API URL for accessing this workspace
+        """
+        return (
+            f"{PREFECT_CLOUD_API_URL.value()}"
+            f"/accounts/{self.account_id}"
+            f"/workspaces/{self.workspace_id}"
+        )
+
+    def __hash__(self):
+        return hash(self.handle)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1266,6 +1266,9 @@ class ProfilesCollection:
     def __iter__(self):
         return self.profiles_by_name.__iter__()
 
+    def items(self):
+        return self.profiles_by_name.items()
+
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, ProfilesCollection):
             return False

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1339,6 +1339,24 @@ def load_profiles() -> ProfilesCollection:
     return profiles
 
 
+def load_current_profile():
+    """
+    Load the current profile from the default and current profile paths.
+
+    This will _not_ include settings from the current settings context. Only settings
+    that have been persisted to the profiles file will be saved.
+    """
+    from prefect.context import SettingsContext
+
+    profiles = load_profiles()
+    context = SettingsContext.get()
+
+    if context:
+        profiles.set_active(context.profile.name)
+
+    return profiles.active_profile
+
+
 def save_profiles(profiles: ProfilesCollection) -> None:
     """
     Writes all non-default profiles to the current profiles path.

--- a/src/prefect/utilities/compat.py
+++ b/src/prefect/utilities/compat.py
@@ -24,6 +24,14 @@ else:
     from asyncio import to_thread as asyncio_to_thread
 
 
+if sys.version_info < (3, 8):
+
+    def raise_signal(signal: int):
+        os.kill(os.getpid(), signal)
+
+else:
+    from signal import raise_signal
+
 if sys.version_info < (3, 8) and sys.platform != "win32":
     # https://docs.python.org/3/library/asyncio-policy.html#asyncio.ThreadedChildWatcher
     # `ThreadedChildWatcher` is the default child process watcher for Python 3.8+ but it

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -104,17 +104,23 @@ def test_login_with_invalid_key(key, expected_output, respx_mock):
 
 
 def test_login_with_key_and_missing_workspace(respx_mock):
-    workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
 
     respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
         return_value=httpx.Response(
-            status.HTTP_200_OK, json=[workspace.dict(json_compatible=True)]
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
         )
     )
+
     invoke_and_assert(
-        ["cloud", "login", "--key", "foo", "--workspace", "bar"],
+        ["cloud", "login", "--key", "foo", "--workspace", "apple/berry"],
         expected_code=1,
-        expected_output="Workspace 'bar' not found.",
+        expected_output="Workspace 'apple/berry' not found. Available workspaces: 'test/foo', 'test/bar'",
     )
 
 
@@ -142,6 +148,7 @@ def test_login_with_key_and_workspace(respx_mock):
             ],
         )
     )
+
     invoke_and_assert(
         ["cloud", "login", "--key", "foo", "--workspace", "test/foo"],
         expected_code=0,

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -377,6 +377,293 @@ def test_login_with_browser_failure_in_browser(respx_mock, mock_webbrowser):
     assert PREFECT_API_URL not in settings
 
 
+@pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_to_current_profile_no_reauth(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
+        )
+    )
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "foo",
+                    },
+                )
+            ],
+            active=None,
+        )
+    )
+
+    with use_profile("logged-in-profile"):
+        invoke_and_assert(
+            ["cloud", "login"],
+            expected_code=0,
+            user_input="n" + readchar.key.ENTER,
+            expected_output_contains=[
+                "Would you like to reauthenticate? [y/N]",
+                "Using the existing authentication on this profile.",
+                "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+            ],
+        )
+
+        settings = load_current_profile().settings
+
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_to_current_profile_no_reauth_new_workspace(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "foo",
+                    },
+                )
+            ],
+            active=None,
+        )
+    )
+
+    with use_profile("logged-in-profile"):
+        invoke_and_assert(
+            ["cloud", "login"],
+            expected_code=0,
+            user_input=(
+                # No, do not reuath
+                "n"
+                + readchar.key.ENTER
+                # Yes, switch workspaces
+                + "y"
+                + readchar.key.ENTER
+                # Select 'bar'
+                + readchar.key.DOWN
+                + readchar.key.ENTER
+            ),
+            expected_output_contains=[
+                "Would you like to reauthenticate? [y/N]",
+                "Using the existing authentication on this profile.",
+                "? Which workspace would you like to use? [Use arrows to move; enter to select]",
+                "Authenticated with Prefect Cloud! Using workspace 'test/bar'.",
+            ],
+        )
+
+        settings = load_current_profile().settings
+
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == bar_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_to_current_profile_yes_reauth(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
+        )
+    )
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "foo",
+                    },
+                )
+            ],
+            active=None,
+        )
+    )
+
+    with use_profile("logged-in-profile"):
+        invoke_and_assert(
+            ["cloud", "login"],
+            expected_code=0,
+            user_input=(
+                # Yes, reauth
+                "y"
+                + readchar.key.ENTER
+                # Enter key manually
+                + readchar.key.DOWN
+                + readchar.key.ENTER
+                # Enter new key
+                + "bar"
+                + readchar.key.ENTER
+            ),
+            expected_output_contains=[
+                "Would you like to reauthenticate? [y/N]",
+                "? How would you like to authenticate? [Use arrows to move; enter to select]",
+                "Log in with a web browser",
+                "Paste an authentication key",
+                "Paste your authentication key:",
+                "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+            ],
+        )
+
+        settings = load_current_profile().settings
+
+    assert settings[PREFECT_API_KEY] == "bar"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_to_another_profile(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
+        )
+    )
+
+    current_profile = load_current_profile()
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "foo",
+                    },
+                ),
+                current_profile,
+            ],
+            active=current_profile.name,
+        )
+    )
+
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=0,
+        user_input=(
+            # No, do not reauth
+            "n"
+            + readchar.key.ENTER
+            # Yes, switch profiles
+            + "y"
+            + readchar.key.ENTER
+            # Use the first profile
+            + readchar.key.ENTER
+        ),
+        expected_output_contains=[
+            "? Would you like to switch to an authenticated profile? [Y/n]:",
+            "? Which authenticated profile would you like to switch to?",
+            "logged-in-profile",
+            "Switched to authenticated profile 'logged-in-profile'.",
+        ],
+    )
+
+    profiles = load_profiles()
+    assert profiles.active_name == "logged-in-profile"
+    settings = profiles.active_profile.settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+    # Current is the test profile active in the context
+    previous_profile = load_current_profile()
+    assert PREFECT_API_KEY not in previous_profile.settings
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_to_another_profile_cancel_during_select(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
+        )
+    )
+
+    current_profile = load_current_profile()
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "foo",
+                    },
+                ),
+                current_profile,
+            ],
+            active=current_profile.name,
+        )
+    )
+
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=1,
+        user_input=(
+            # No, do not reauth
+            "n"
+            + readchar.key.ENTER
+            # Yes, switch profiles
+            + "y"
+            + readchar.key.ENTER
+            # Abort!
+            + readchar.key.CTRL_C
+        ),
+        expected_output_contains=[
+            "? Would you like to switch to an authenticated profile? [Y/n]:",
+            "? Which authenticated profile would you like to switch to?",
+            "logged-in-profile",
+            "Aborted.",
+        ],
+    )
+
+    current_profile = load_current_profile()
+    profiles = load_profiles()
+
+    # The active profile should not have changed
+    assert profiles.active_name != "logged-in-profile"
+    assert profiles.active_name == current_profile.name
+
+    # The current profile settings are not mutated
+    settings = current_profile.settings
+    assert PREFECT_API_KEY not in settings
+    assert PREFECT_API_URL not in settings
+
+    # Other profile should not be updated
+    assert PREFECT_API_KEY not in settings
+
+
 def test_logout_current_profile_is_not_logged_in():
     cloud_profile = "cloud-foo"
     save_profiles(

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -239,7 +239,7 @@ def test_login_with_interactive_key_single_workspace(respx_mock):
         user_input=readchar.key.DOWN + readchar.key.ENTER + "foo" + readchar.key.ENTER,
         expected_output_contains=[
             "? How would you like to authenticate? [Use arrows to move; enter to select]",
-            "Login with a web browser",
+            "Log in with a web browser",
             "Paste an authentication key",
             "Paste your authentication key:",
             "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
@@ -282,7 +282,7 @@ def test_login_with_interactive_key_multiple_workspaces(respx_mock):
         ),
         expected_output_contains=[
             "? How would you like to authenticate? [Use arrows to move; enter to select]",
-            "Login with a web browser",
+            "Log in with a web browser",
             "Paste an authentication key",
             "Paste your authentication key:",
         ],
@@ -324,7 +324,7 @@ def test_login_with_browser_single_workspace(respx_mock, mock_webbrowser):
         ),
         expected_output_contains=[
             "? How would you like to authenticate? [Use arrows to move; enter to select]",
-            "Login with a web browser",
+            "Log in with a web browser",
             "Paste an authentication key",
             "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
         ],
@@ -366,9 +366,9 @@ def test_login_with_browser_failure_in_browser(respx_mock, mock_webbrowser):
         ),
         expected_output_contains=[
             "? How would you like to authenticate? [Use arrows to move; enter to select]",
-            "Login with a web browser",
+            "Log in with a web browser",
             "Paste an authentication key",
-            "Failed to login. Oh no!",
+            "Failed to log in. Oh no!",
         ],
     )
 
@@ -430,7 +430,7 @@ def test_cannot_set_workspace_if_you_are_not_logged_in():
             expected_code=1,
             expected_output=(
                 f"Currently not authenticated in profile {cloud_profile!r}. "
-                "Please login with `prefect cloud login`."
+                "Please log in with `prefect cloud login`."
             ),
         )
 

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -1,163 +1,383 @@
+import sys
+import urllib.parse
 import uuid
+from unittest.mock import MagicMock
 
-import prefect.cli.cloud
-from prefect.context import use_profile
+import httpx
+import pytest
+import readchar
+from fastapi import status
+from typer import Exit
+
+from prefect.cli.cloud import LoginFailed, LoginSuccess
+from prefect.client.schemas import Workspace
+from prefect.context import get_settings_context, use_profile
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
+    PREFECT_CLOUD_API_URL,
+    PREFECT_PROFILES_PATH,
     Profile,
     ProfilesCollection,
+    load_current_profile,
     load_profiles,
     save_profiles,
+    temporary_settings,
 )
 from prefect.testing.cli import invoke_and_assert
 
-ACCOUNT_ID = uuid.uuid4()
-ACCOUNT_HANDLE = "account-1"
-WORKSPACE_ID = uuid.uuid4()
-WORKSPACE_HANDLE = "workspace-1"
-API_KEY = "valid_API_key"
-FULL_HANDLE = f"{ACCOUNT_HANDLE}/{WORKSPACE_HANDLE}"
-WORKSPACE = {
-    "account_id": ACCOUNT_ID,
-    "account_handle": ACCOUNT_HANDLE,
-    "workspace_id": WORKSPACE_ID,
-    "workspace_handle": WORKSPACE_HANDLE,
-}
-FULL_URL = prefect.cli.cloud.build_url_from_workspace(WORKSPACE)
+
+def gen_test_workspace(**kwargs) -> Workspace:
+    kwargs.setdefault("account_id", uuid.uuid4())
+    kwargs.setdefault("account_name", "account name")
+    kwargs.setdefault("account_handle", "account-handle")
+    kwargs.setdefault("workspace_id", uuid.uuid4())
+    kwargs.setdefault("workspace_name", "workspace name")
+    kwargs.setdefault("workspace_handle", "workspace-handle")
+    kwargs.setdefault("workspace_description", "workspace description")
+    return Workspace(**kwargs)
 
 
-class MockCloudClient:
-    async def __aenter__(self):
-        return self
+@pytest.fixture
+def interactive_console(monkeypatch):
+    monkeypatch.setattr("prefect.cli.cloud.is_interactive", lambda: True)
 
-    async def __aexit__(self, *args, **kwargs):
-        pass
+    # `readchar` does not like the fake stdin provided by typer isolation so we provide
+    # a version that does not require a fd to be attached
+    def readchar():
+        sys.stdin.flush()
+        position = sys.stdin.tell()
+        if not sys.stdin.read():
+            print("TEST ERROR: CLI is attempting to read input but stdin is empty.")
+            raise Exit(-2)
+        else:
+            sys.stdin.seek(position)
+        return sys.stdin.read(1)
 
-    async def read_workspaces(self):
-        return [WORKSPACE]
-
-
-def get_mock_cloud_client(*args, **kwargs):
-    """Returns a MockCloudClient with hardcoded responses"""
-    return MockCloudClient()
-
-
-class MockUnauthorizedCloudClient(MockCloudClient):
-    async def read_workspaces(self):
-        raise prefect.cli.cloud.CloudUnauthorizedError
+    monkeypatch.setattr("readchar._posix_read.readchar", readchar)
 
 
-def get_unauthorized_mock_cloud_client(*args, **kwargs):
-    """Returns a MockUnauthorizedCloudClient that will throw an error"""
-    return MockUnauthorizedCloudClient()
+@pytest.fixture(autouse=True)
+def temporary_profiles_path(tmp_path):
+    path = tmp_path / "profiles.toml"
+    with temporary_settings({PREFECT_PROFILES_PATH: path}):
+        # Ensure the test profile is persisted already to simplify assertions
+        save_profiles(
+            profiles=ProfilesCollection(profiles=[get_settings_context().profile])
+        )
+        yield path
 
 
-def mock_select_workspace(workspaces):
-    """
-    Mocks a user selecting a workspace via keyboard input.
-    Will return the first workspace.
-    """
-    return list(workspaces)[0]
+@pytest.fixture
+def mock_webbrowser(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("prefect.cli.cloud.webbrowser", mock)
+    yield mock
 
 
-def test_login_with_invalid_key(monkeypatch):
-    monkeypatch.setattr(
-        "prefect.client.cloud.get_cloud_client", get_unauthorized_mock_cloud_client
+@pytest.mark.parametrize(
+    "key,expected_output",
+    [
+        (
+            "pcu_foo",
+            "Unable to authenticate with Prefect Cloud. It looks like you're using API key from Cloud 1 (https://cloud.prefect.io). Make sure that you generate API key using Cloud 2 (https://app.prefect.cloud)",
+        ),
+        (
+            "pnu_foo",
+            "Unable to authenticate with Prefect Cloud. Please ensure your credentials are correct.",
+        ),
+        (
+            "foo",
+            "Unable to authenticate with Prefect Cloud. Your key is not in our expected format.",
+        ),
+    ],
+)
+def test_login_with_invalid_key(key, expected_output, respx_mock):
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(status.HTTP_403_FORBIDDEN)
     )
     invoke_and_assert(
-        ["cloud", "login", "--key", "pcu_foo"],
+        ["cloud", "login", "--key", key, "--workspace", "foo"],
         expected_code=1,
-        expected_output=(
-            "Unable to authenticate with Prefect Cloud. It looks like you're using API key from Cloud 1 (https://cloud.prefect.io). Make sure that you generate API key using Cloud 2 (https://app.prefect.cloud)"
-        ),
+        expected_output=expected_output,
+    )
+
+
+def test_login_with_key_and_missing_workspace(respx_mock):
+    workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK, json=[workspace.dict(json_compatible=True)]
+        )
     )
     invoke_and_assert(
-        ["cloud", "login", "--key", "pnu_foo"],
+        ["cloud", "login", "--key", "foo", "--workspace", "bar"],
         expected_code=1,
-        expected_output=(
-            "Unable to authenticate with Prefect Cloud. Please ensure your credentials are correct."
-        ),
+        expected_output="Workspace 'bar' not found.",
+    )
+
+
+def test_login_with_key_and_no_workspaces(respx_mock):
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json=[])
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo", "--workspace", "bar"],
+        expected_code=1,
+        expected_output="Workspace 'bar' not found.",
+    )
+
+
+def test_login_with_key_and_workspace(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo", "--workspace", "test/foo"],
+        expected_code=0,
+        expected_output="Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+    )
+
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.parametrize("args", [[], ["--workspace", "test/foo"], ["--key", "key"]])
+def test_login_with_non_interactive_missing_args(args):
+    invoke_and_assert(
+        ["cloud", "login", *args],
+        expected_code=1,
+        expected_output="When not using an interactive terminal, you must supply a `--key` and `--workspace`.",
+    )
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_key_and_select_first_workspace(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
     )
     invoke_and_assert(
         ["cloud", "login", "--key", "foo"],
-        expected_code=1,
-        expected_output=(
-            "Unable to authenticate with Prefect Cloud. Your key is not in our expected format."
+        expected_code=0,
+        user_input=readchar.key.ENTER,
+        expected_output_contains=[
+            "? Which workspace would you like to use?",
+            "test/foo",
+            "test/bar",
+            "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+        ],
+    )
+
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_key_and_select_second_workspace(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo"],
+        expected_code=0,
+        user_input=readchar.key.DOWN + readchar.key.ENTER,
+        expected_output_contains=[
+            "? Which workspace would you like to use?",
+            "test/foo",
+            "test/bar",
+            "Authenticated with Prefect Cloud! Using workspace 'test/bar'.",
+        ],
+    )
+
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == bar_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_interactive_key_single_workspace(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
+        )
+    )
+
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=0,
+        user_input=readchar.key.DOWN + readchar.key.ENTER + "foo" + readchar.key.ENTER,
+        expected_output_contains=[
+            "? How would you like to authenticate? [Use arrows to move; enter to select]",
+            "Login with a web browser",
+            "Paste an authentication key",
+            "Paste your authentication key:",
+            "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+        ],
+    )
+
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_interactive_key_multiple_workspaces(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
+
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=0,
+        user_input=(
+            # Select paste a key
+            readchar.key.DOWN
+            + readchar.key.ENTER
+            # Send a key
+            + "foo"
+            + readchar.key.ENTER
+            # Select the second workspace
+            + readchar.key.DOWN
+            + readchar.key.ENTER
         ),
+        expected_output_contains=[
+            "? How would you like to authenticate? [Use arrows to move; enter to select]",
+            "Login with a web browser",
+            "Paste an authentication key",
+            "Paste your authentication key:",
+        ],
     )
 
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == bar_workspace.api_url()
 
-def test_login_without_workspace_handle(monkeypatch):
-    monkeypatch.setattr("prefect.cli.cloud.get_cloud_client", get_mock_cloud_client)
-    monkeypatch.setattr("prefect.cli.cloud.select_workspace", mock_select_workspace)
 
-    cloud_profile = "cloud-foo"
-    save_profiles(
-        ProfilesCollection([Profile(name=cloud_profile, settings={})], active=None)
-    )
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_browser_single_workspace(respx_mock, mock_webbrowser):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
 
-    with use_profile(cloud_profile):
-        invoke_and_assert(
-            ["cloud", "login", "--key", API_KEY],
-            expected_code=0,
-            expected_output_contains=(
-                f"Logged in to Prefect Cloud using profile {cloud_profile!r}.\n"
-                f"Workspace is currently set to {FULL_HANDLE!r}. "
-                "The workspace can be changed using `prefect cloud workspace set`."
-            ),
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
         )
-
-    profiles = load_profiles()
-    assert profiles[cloud_profile].settings == {
-        PREFECT_API_URL: FULL_URL,
-        PREFECT_API_KEY: API_KEY,
-    }
-
-
-def test_login_with_workspace_handle(monkeypatch):
-    monkeypatch.setattr("prefect.cli.cloud.get_cloud_client", get_mock_cloud_client)
-
-    cloud_profile = "cloud-foo"
-    save_profiles(
-        ProfilesCollection([Profile(name=cloud_profile, settings={})], active=None)
     )
 
-    with use_profile(cloud_profile):
-        invoke_and_assert(
-            ["cloud", "login", "--key", API_KEY, "--workspace", FULL_HANDLE],
-            expected_code=0,
-            expected_output_contains=(
-                f"Logged in to Prefect Cloud using profile {cloud_profile!r}.\n"
-                f"Workspace is currently set to {FULL_HANDLE!r}. "
-                "The workspace can be changed using `prefect cloud workspace set`."
-            ),
+    def post_success(ui_url):
+        # Parse the callback url that the UI would send a response to
+        callback = urllib.parse.unquote(
+            urllib.parse.urlparse(ui_url).query.split("=")[1]
         )
+        # Bypass the mocks
+        respx_mock.route(url__startswith=callback).pass_through()
+        httpx.post(callback + "/success", content=LoginSuccess(api_key="foo").json())
 
-    profiles = load_profiles()
-    assert profiles[cloud_profile].settings == {
-        PREFECT_API_URL: FULL_URL,
-        PREFECT_API_KEY: API_KEY,
-    }
+    mock_webbrowser.open_new_tab.side_effect = post_success
 
-
-def test_login_with_invalid_workspace_handle(monkeypatch):
-    monkeypatch.setattr("prefect.cli.cloud.get_cloud_client", get_mock_cloud_client)
-
-    cloud_profile = "cloud-foo"
-    save_profiles(
-        ProfilesCollection([Profile(name=cloud_profile, settings={})], active=None)
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=0,
+        user_input=(
+            # Select with browser
+            readchar.key.ENTER
+        ),
+        expected_output_contains=[
+            "? How would you like to authenticate? [Use arrows to move; enter to select]",
+            "Login with a web browser",
+            "Paste an authentication key",
+            "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+        ],
     )
 
-    with use_profile(cloud_profile):
-        invoke_and_assert(
-            ["cloud", "login", "--key", API_KEY, "--workspace", "foo/bar"],
-            expected_code=1,
-            expected_output_contains="Workspace 'foo/bar' not found.",
+    settings = load_current_profile().settings
+    assert settings[PREFECT_API_KEY] == "foo"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_browser_failure_in_browser(respx_mock, mock_webbrowser):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[foo_workspace.dict(json_compatible=True)],
         )
+    )
+
+    def post_failure(ui_url):
+        # Parse the callback url that the UI would send a response to
+        callback = urllib.parse.unquote(
+            urllib.parse.urlparse(ui_url).query.split("=")[1]
+        )
+        # Bypass the mocks
+        respx_mock.route(url__startswith=callback).pass_through()
+        httpx.post(callback + "/failure", content=LoginFailed(reason="Oh no!").json())
+
+    mock_webbrowser.open_new_tab.side_effect = post_failure
+
+    invoke_and_assert(
+        ["cloud", "login"],
+        expected_code=1,
+        user_input=(
+            # Select with browser
+            readchar.key.ENTER
+        ),
+        expected_output_contains=[
+            "? How would you like to authenticate? [Use arrows to move; enter to select]",
+            "Login with a web browser",
+            "Paste an authentication key",
+            "Failed to login. Oh no!",
+        ],
+    )
+
+    settings = load_current_profile().settings
+    assert PREFECT_API_KEY not in settings
+    assert PREFECT_API_URL not in settings
 
 
-def test_logout_current_profile_is_not_logged():
+def test_logout_current_profile_is_not_logged_in():
     cloud_profile = "cloud-foo"
     save_profiles(
         ProfilesCollection([Profile(name=cloud_profile, settings={})], active=None)
@@ -178,7 +398,7 @@ def test_logout_reset_prefect_api_key_and_prefect_api_url():
             [
                 Profile(
                     name=cloud_profile,
-                    settings={PREFECT_API_URL: FULL_URL, PREFECT_API_KEY: API_KEY},
+                    settings={PREFECT_API_URL: "foo", PREFECT_API_KEY: "bar"},
                 )
             ],
             active=None,
@@ -192,9 +412,10 @@ def test_logout_reset_prefect_api_key_and_prefect_api_url():
             expected_output_contains="Logged out from Prefect Cloud.",
         )
 
-    profiles = load_profiles()
-    assert PREFECT_API_URL not in profiles[cloud_profile].settings
-    assert PREFECT_API_KEY not in profiles[cloud_profile].settings
+        settings = load_current_profile()
+
+    assert PREFECT_API_URL not in settings
+    assert PREFECT_API_KEY not in settings
 
 
 def test_cannot_set_workspace_if_you_are_not_logged_in():
@@ -205,18 +426,28 @@ def test_cannot_set_workspace_if_you_are_not_logged_in():
 
     with use_profile(cloud_profile):
         invoke_and_assert(
-            ["cloud", "workspace", "set", "--workspace", f"{FULL_HANDLE}"],
+            ["cloud", "workspace", "set", "--workspace", "foo/bar"],
             expected_code=1,
             expected_output=(
                 f"Currently not authenticated in profile {cloud_profile!r}. "
-                "Please login with `prefect cloud login --key <API_KEY>`."
+                "Please login with `prefect cloud login`."
             ),
         )
 
 
-def test_set_workspace_updates_profile(monkeypatch):
-    monkeypatch.setattr("prefect.cli.cloud.get_cloud_client", get_mock_cloud_client)
-    monkeypatch.setattr("prefect.cli.cloud.select_workspace", mock_select_workspace)
+def test_set_workspace_updates_profile(respx_mock):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
 
     cloud_profile = "cloud-foo"
     save_profiles(
@@ -225,8 +456,8 @@ def test_set_workspace_updates_profile(monkeypatch):
                 Profile(
                     name=cloud_profile,
                     settings={
-                        PREFECT_API_URL: "old workspace",
-                        PREFECT_API_KEY: API_KEY,
+                        PREFECT_API_URL: foo_workspace.api_url(),
+                        PREFECT_API_KEY: "fake-key",
                     },
                 )
             ],
@@ -236,16 +467,16 @@ def test_set_workspace_updates_profile(monkeypatch):
 
     with use_profile(cloud_profile):
         invoke_and_assert(
-            ["cloud", "workspace", "set"],
+            ["cloud", "workspace", "set", "--workspace", bar_workspace.handle],
             expected_code=0,
             expected_output=(
-                f"Successfully set workspace to {FULL_HANDLE!r} "
+                f"Successfully set workspace to {bar_workspace.handle!r} "
                 f"in profile {cloud_profile!r}."
             ),
         )
 
     profiles = load_profiles()
     assert profiles[cloud_profile].settings == {
-        PREFECT_API_URL: FULL_URL,
-        PREFECT_API_KEY: API_KEY,
+        PREFECT_API_URL: bar_workspace.api_url(),
+        PREFECT_API_KEY: "fake-key",
     }

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -651,7 +651,7 @@ def test_login_already_logged_in_to_another_profile_cancel_during_select(respx_m
             "? Would you like to switch to an authenticated profile? [Y/n]:",
             "? Which authenticated profile would you like to switch to?",
             "logged-in-profile",
-            "Aborted.",
+            "Aborted",
         ],
     )
 

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -80,7 +80,7 @@ class TestChangingProfileAndCheckingOrionConnection:
         with respx.mock:
             authorized = respx.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
-            ).mock(return_value=Response(200, json={}))
+            ).mock(return_value=Response(200, json=[]))
 
             yield authorized
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!

-->

<!-- Include an overview here -->

Merges into #7332. Requires a UI `/authorize` route. Authored with @znicholasbrown.

Adds login via the web browser to `prefect cloud login`, allowing you to login without creating an API key first.

This is a result of the UI workshop during TDP in which we were attempting to improve the user experience during onboarding. The user is prompted to create a workspace, then prompted to use the workspace from the CLI before they have logged in with an API key. Instead of adding more steps to the UI onboarding experience, we can improve the user experience by making it very easy to authenticate the CLI.

This works by spinning up a little API server from the CLI then opening the user's web browser to a dedicated UI page. When the user authorizes the login, the browser will send a new API key to the CLI's API server. The CLI then uses the key to login as normal.

We preserve the ability to pass a key via CLI argument or pasted into a prompt.

This also includes:
- Check if the user is logged in and prompt y/N to reauthenticate
- Check if the user is logged in via another profile and prompt a profile switch
- Login can be performed without any interactive elements
- `CloudClient.read_workspaces` parses workspaces into a schema

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

<img width="748" alt="Screen Shot 2022-11-03 at 1 04 31 PM" src="https://user-images.githubusercontent.com/2586601/199800241-c1b3691b-f18c-43ee-85e9-53cc3e5b1d48.png">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
