### PR TITLE
Adds Orion database URL to block auto-registration memoization key

### DIFF
--- a/src/prefect/orion/api/server.py
+++ b/src/prefect/orion/api/server.py
@@ -31,6 +31,7 @@ from prefect.settings import (
     PREFECT_DEBUG_MODE,
     PREFECT_MEMO_STORE_PATH,
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
+    PREFECT_ORION_DATABASE_CONNECTION_URL,
 )
 from prefect.utilities.hashing import hash_objects
 
@@ -263,7 +264,10 @@ def _memoize_block_auto_registration(fn: Callable[[], Awaitable[None]]):
         blocks_registry = get_registry_for_type(Block)
         collection_blocks_data = await _load_collection_blocks_data()
         current_blocks_loading_hash = hash_objects(
-            blocks_registry, collection_blocks_data, hash_algo=sha256
+            blocks_registry,
+            collection_blocks_data,
+            PREFECT_ORION_DATABASE_CONNECTION_URL.value(),
+            hash_algo=sha256,
         )
 
         memo_store_path = PREFECT_MEMO_STORE_PATH.value()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds PREFECT_ORION_DATABASE_CONNECTION_URL to block auto-registration memoization key to ensure that block auto-registration happens each time the backing database is changed.

Closes #7347

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```bash
# From fresh install, start Orion server
prefect orion start

# View blocks in UI 👀 

# Stop Orion server and start Postgres instance
docker run -d --name orion_postgres -v oriondb:/var/lib/postgresql/data -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=yourTopSecretPassword -e POSTGRES_DB=orion postgres:latest

# Set Orion DB URL
export PREFECT_ORION_DATABASE_CONNECTION_URL="postgresql+asyncpg://postgres:yourTopSecretPassword@localhost:5432/orion"

# Start Orion server
prefect orion start

# Confirm blocks in UI 👀 
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
