### PR TITLE
UI: removed date-fns

### DIFF
--- a/orion-ui/package-lock.json
+++ b/orion-ui/package-lock.json
@@ -25,7 +25,6 @@
         "@types/d3": "^7.4.0",
         "@vitejs/plugin-vue": "^2.3.3",
         "autoprefixer": "10.4.12",
-        "date-fns": "^2.29.3",
         "dotenv": "16.0.3",
         "eslint": "^8.26.0",
         "ts-node": "10.9.1",

--- a/orion-ui/package.json
+++ b/orion-ui/package.json
@@ -10,8 +10,8 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@prefecthq/prefect-design": "1.1.23",
     "@prefecthq/orion-design": "1.1.3",
+    "@prefecthq/prefect-design": "1.1.23",
     "@prefecthq/vue-compositions": "0.2.4",
     "@types/lodash.debounce": "4.0.7",
     "axios": "0.27.2",
@@ -27,7 +27,6 @@
     "@types/d3": "^7.4.0",
     "@vitejs/plugin-vue": "^2.3.3",
     "autoprefixer": "10.4.12",
-    "date-fns": "^2.29.3",
     "dotenv": "16.0.3",
     "eslint": "^8.26.0",
     "ts-node": "10.9.1",


### PR DESCRIPTION
[This PR](https://github.com/PrefectHQ/orion-design/pull/730) introduces an overload to all date-fns functions that make them aware of users timezone preference. Once that is merged, this PR removes `date-fns` in favor of these orion-design methods