### PR TITLE
Agent: Add limit to control number of concurrent flow runs

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -2,7 +2,6 @@
 The agent is responsible for checking for flow runs that are ready to run and starting
 their execution.
 """
-import platform
 from typing import Iterator, List, Optional, Set, Union
 from uuid import UUID
 
@@ -188,7 +187,9 @@ class OrionAgent:
                     flow_run,
                 )
 
-        return list(filter(lambda run: run.id in self.submitting_flow_run_ids, submittable_runs))
+        return list(
+            filter(lambda run: run.id in self.submitting_flow_run_ids, submittable_runs)
+        )
 
     async def get_infrastructure(self, flow_run: FlowRun) -> Infrastructure:
         deployment = await self.client.read_deployment(flow_run.deployment_id)
@@ -360,7 +361,9 @@ class OrionAgent:
     async def start(self):
         self.started = True
         self.task_group = anyio.create_task_group()
-        self.limiter = anyio.CapacityLimiter(self.limit) if self.limit is not None else None
+        self.limiter = (
+            anyio.CapacityLimiter(self.limit) if self.limit is not None else None
+        )
         self.client = get_client()
         await self.client.__aenter__()
         await self.task_group.__aenter__()

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -188,7 +188,7 @@ class OrionAgent:
                     flow_run,
                 )
 
-        return submittable_runs
+        return list(filter(lambda run: run.id in self.submitting_flow_run_ids, submittable_runs))
 
     async def get_infrastructure(self, flow_run: FlowRun) -> Infrastructure:
         deployment = await self.client.read_deployment(flow_run.deployment_id)

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -2,6 +2,7 @@
 The agent is responsible for checking for flow runs that are ready to run and starting
 their execution.
 """
+import platform
 from typing import Iterator, List, Optional, Set, Union
 from uuid import UUID
 
@@ -29,6 +30,7 @@ class OrionAgent:
         prefetch_seconds: int = None,
         default_infrastructure: Infrastructure = None,
         default_infrastructure_document_id: UUID = None,
+        limit: Optional[int] = None,
     ) -> None:
 
         if default_infrastructure and default_infrastructure_document_id:
@@ -42,6 +44,8 @@ class OrionAgent:
         self.started = False
         self.logger = get_logger("agent")
         self.task_group: Optional[anyio.abc.TaskGroup] = None
+        self.limit: Optional[int] = limit
+        self.limiter: Optional[anyio.CapacityLimiter] = None
         self.client: Optional[OrionClient] = None
 
         if isinstance(work_queue_prefix, str):
@@ -163,17 +167,25 @@ class OrionAgent:
                     self.logger.exception(exc)
 
         for flow_run in submittable_runs:
-            self.logger.info(f"Submitting flow run '{flow_run.id}'")
 
             # don't resubmit a run
             if flow_run.id in self.submitting_flow_run_ids:
                 continue
 
-            self.submitting_flow_run_ids.add(flow_run.id)
-            self.task_group.start_soon(
-                self.submit_run,
-                flow_run,
-            )
+            try:
+                if self.limiter:
+                    self.limiter.acquire_on_behalf_of_nowait(flow_run.id)
+            except anyio.WouldBlock:
+                self.logger.info(f"Flow run limit reached'")
+                break
+            else:
+                self.logger.info(f"Submitting flow run '{flow_run.id}'")
+                self.submitting_flow_run_ids.add(flow_run.id)
+                self.task_group.start_soon(
+                    self.submit_run,
+                    flow_run,
+                    self.limiter,
+                )
 
         return submittable_runs
 
@@ -224,7 +236,7 @@ class OrionAgent:
 
         return prepared_infrastructure
 
-    async def submit_run(self, flow_run: FlowRun) -> None:
+    async def submit_run(self, flow_run: FlowRun, limiter: Optional[anyio.CapacityLimiter]) -> None:
         """
         Submit a flow run to the infrastructure
         """
@@ -238,11 +250,13 @@ class OrionAgent:
                     f"Failed to get infrastructure for flow run '{flow_run.id}'."
                 )
                 await self._propose_failed_state(flow_run, exc)
+                if limiter:
+                    limiter.release_on_behalf_of(flow_run.id)
             else:
                 # Wait for submission to be completed. Note that the submission function
                 # may continue to run in the background after this exits.
                 await self.task_group.start(
-                    self._submit_run_and_capture_errors, flow_run, infrastructure
+                    self._submit_run_and_capture_errors, flow_run, infrastructure, limiter
                 )
                 self.logger.info(f"Completed submission of flow run '{flow_run.id}'")
 
@@ -252,6 +266,7 @@ class OrionAgent:
         self,
         flow_run: FlowRun,
         infrastructure: Infrastructure,
+        limiter: Optional[anyio.CapacityLimiter],
         task_status: anyio.abc.TaskStatus = None,
     ) -> Union[InfrastructureResult, Exception]:
 
@@ -279,6 +294,9 @@ class OrionAgent:
                     "occurred."
                 )
             return exc
+        finally:
+            if limiter:
+                limiter.release_on_behalf_of(flow_run.id)
 
         if not task_status._future.done():
             self.logger.error(
@@ -342,6 +360,7 @@ class OrionAgent:
     async def start(self):
         self.started = True
         self.task_group = anyio.create_task_group()
+        self.limiter = anyio.CapacityLimiter(self.limit) if self.limit is not None else None
         self.client = get_client()
         await self.client.__aenter__()
         await self.task_group.__aenter__()

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -142,7 +142,7 @@ class OrionAgent:
             seconds=self.prefetch_seconds or PREFECT_AGENT_PREFETCH_SECONDS.value()
         )
 
-        submittable_runs = []
+        submittable_runs: List[FlowRun] = []
 
         # load runs from each work queue
         async for work_queue in self.get_work_queues():
@@ -165,6 +165,8 @@ class OrionAgent:
                     )
                 except Exception as exc:
                     self.logger.exception(exc)
+
+        submittable_runs.sort(key=lambda run: run.next_scheduled_start_time)
 
         for flow_run in submittable_runs:
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -71,6 +71,12 @@ async def start(
         "--tag",
         help="DEPRECATED: One or more optional tags that will be used to create a work queue",
     ),
+    limit: int = typer.Option(
+        None,
+        "-l",
+        "--limit",
+        help="Maximum number of flow runs to start simultaneously.",
+    ),
 ):
     """
     Start an agent process to poll one or more work queues for flow runs.
@@ -137,6 +143,7 @@ async def start(
         work_queues=work_queues,
         work_queue_prefix=work_queue_prefix,
         prefetch_seconds=prefetch_seconds,
+        limit=limit,
     ) as agent:
         if not hide_welcome:
             app.console.print(ascii_name)

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -67,7 +67,10 @@ def test_start_agent_with_prefetch_seconds(monkeypatch):
         expected_code=0,
     )
     mock_agent.assert_called_once_with(
-        work_queues=["test"], work_queue_prefix=ANY, prefetch_seconds=30
+        work_queues=["test"],
+        work_queue_prefix=ANY,
+        prefetch_seconds=30,
+        limit=None,
     )
 
 
@@ -86,7 +89,10 @@ def test_start_agent_with_prefetch_seconds_from_setting_by_default(monkeypatch):
             expected_code=0,
         )
     mock_agent.assert_called_once_with(
-        work_queues=ANY, work_queue_prefix=ANY, prefetch_seconds=100
+        work_queues=ANY,
+        work_queue_prefix=ANY,
+        prefetch_seconds=100,
+        limit=None,
     )
 
 
@@ -101,6 +107,7 @@ def test_start_agent_respects_work_queue_names(monkeypatch):
         work_queues=["a", "b"],
         work_queue_prefix=[],
         prefetch_seconds=ANY,
+        limit=None,
     )
 
 
@@ -115,6 +122,22 @@ def test_start_agent_respects_work_queue_prefixes(monkeypatch):
         work_queues=[],
         work_queue_prefix=["a", "b"],
         prefetch_seconds=ANY,
+        limit=None,
+    )
+
+
+def test_start_agent_respects_limit(monkeypatch):
+    mock_agent = MagicMock()
+    monkeypatch.setattr(prefect.cli.agent, "OrionAgent", mock_agent)
+    invoke_and_assert(
+        command=["agent", "start", "--limit", "10", "--run-once", "-q", "test"],
+        expected_code=0,
+    )
+    mock_agent.assert_called_once_with(
+        work_queues=["test"],
+        work_queue_prefix=[],
+        prefetch_seconds=ANY,
+        limit=10,
     )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 
-import prefect.logging
 from prefect import flow
 from prefect.agent import OrionAgent
 from prefect.blocks.core import Block

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 
+import prefect.logging
 from prefect import flow
 from prefect.agent import OrionAgent
 from prefect.blocks.core import Block
@@ -99,6 +100,69 @@ async def test_agent_with_work_queue(orion_client, deployment):
 
     submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
     assert submitted_flow_run_ids == work_queue_flow_run_ids
+
+
+async def test_agent_with_work_queue_and_limit(orion_client, deployment):
+    @flow
+    def foo():
+        pass
+
+    create_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment.id, state=state
+        )
+    )
+
+    flow_runs = [
+        await create_run_with_deployment(Pending()),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=4))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=20))
+        ),
+        await create_run_with_deployment(Running()),
+        await create_run_with_deployment(Completed()),
+        await orion_client.create_flow_run(foo, state=Scheduled()),
+    ]
+    flow_run_ids = [run.id for run in flow_runs]
+
+    # Pull runs from the work queue to get expected runs
+    work_queue = await orion_client.read_work_queue_by_name(deployment.work_queue_name)
+    work_queue_runs = await orion_client.get_runs_in_work_queue(
+        work_queue.id, scheduled_before=pendulum.now().add(seconds=10)
+    )
+    work_queue_runs.sort(key=lambda run: run.next_scheduled_start_time)
+    work_queue_flow_run_ids = [run.id for run in work_queue_runs]
+
+    # Should only include scheduled runs in the past or next prefetch seconds
+    # Should not include runs without deployments
+    assert set(work_queue_flow_run_ids) == set(flow_run_ids[1:4])
+
+    agent = OrionAgent(work_queues=[work_queue.name], prefetch_seconds=10, limit=2)
+
+    async with agent:
+        agent.submit_run = AsyncMock()  # do not actually run anything
+
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+        submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+        assert submitted_flow_run_ids == set(work_queue_flow_run_ids[0:2])
+
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+        submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+        assert submitted_flow_run_ids == set(work_queue_flow_run_ids[0:2])
+
+        agent.limiter.release_on_behalf_of(work_queue_flow_run_ids[0])
+
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+        submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+        assert submitted_flow_run_ids == set(work_queue_flow_run_ids[0:3])
 
 
 async def test_agent_matches_work_queues_dynamically(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Added a --limit option on 'prefect agent start' to limit the number of flow runs an agent will start simultaneously.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
`prefect agent start -l 4`
`prefect agent start --limit 4`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
