### PR TITLE
Fix GitHub storage error for Windows

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -894,16 +894,18 @@ class GitHub(ReadableDeploymentStorage):
             local_path: A local path to clone to; defaults to present working directory.
         """
         # CONSTRUCT COMMAND
-        cmd = f"git clone {self._create_repo_url()}"
+        cmd = ["git", "clone", self._create_repo_url()]
         if self.reference:
-            cmd += f" -b {self.reference}"
+            cmd.append("-b")
+            cmd.append(self.reference)
 
         # Limit git history
-        cmd += " --depth 1"
+        cmd.append("--depth")
+        cmd.append("1")
 
         # Clone to a temporary directory and move the subdirectory over
         with TemporaryDirectory(suffix="prefect") as tmp_dir:
-            cmd += f" {tmp_dir}"
+            cmd.append(tmp_dir)
 
             err_stream = io.StringIO()
             out_stream = io.StringIO()

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -230,7 +230,8 @@ class TestGitHub:
         await g.get_directory()
 
         assert mock.await_count == 1
-        assert f"git clone prefect" in mock.await_args[0][0]
+        expected_cmd = ["git", "clone", "prefect"]
+        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
     async def test_reference_default(self, monkeypatch):
         class p:
@@ -242,7 +243,8 @@ class TestGitHub:
         await g.get_directory()
 
         assert mock.await_count == 1
-        assert f"git clone prefect -b 2.0.0 --depth 1" in mock.await_args[0][0]
+        expected_cmd = ["git", "clone", "prefect", "-b", "2.0.0", "--depth", "1"]
+        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
     async def test_token_added_correctly_from_credential(self, monkeypatch):
         """Ensure that the repo url is in the format `https://<oauth-key>@github.com/<username>/<repo>.git`."""  # noqa: E501
@@ -260,10 +262,14 @@ class TestGitHub:
         )
         await g.get_directory()
         assert mock.await_count == 1
-        assert (
-            f"git clone https://{credential}@github.com/PrefectHQ/prefect.git --depth 1"
-            in mock.await_args[0][0]
-        )
+        expected_cmd = [
+            "git",
+            "clone",
+            f"https://{credential}@github.com/PrefectHQ/prefect.git",
+            "--depth",
+            "1",
+        ]
+        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
     async def test_ssh_fails_with_credential(self, monkeypatch):
         """Ensure that credentials cannot be passed in if the URL is not in the HTTPS


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
A user encountered an error with the GitHub block: https://prefect-community.slack.com/archives/C03CY667GGM/p1666901179640649

Running `my_github_block.get_directory()` on a Windows machine results in an error `'g' is not recognized as an internal or external command, operable program or batch file.` . This is because we pass a string with the git pull command to `run_process`, which in turn calls `open_process`, inside of which we check `if sys.platform == "win32": command = " ".join(command)`.

This pull request changes the command to be a list of command components instead of a string. After replicating the error on a Windows VM, I made the code changes and tested running `get_directory()`, which behaved as desired. 

I updated the tests to reflect that we expect a list instead of a string.
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
