### PR TITLE
run_process: only join strings when input is list

### DIFF
--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -24,7 +24,7 @@ async def open_process(command: List[str], **kwargs):
     # Passing a string to open_process is equivalent to shell=True which is
     # generally necessary for Unix-like commands on Windows but otherwise should
     # be avoided
-    if sys.platform == "win32":
+    if isinstance(command, list) and sys.platform == "win32":
         command = " ".join(command)
 
     process = await anyio.open_process(command, **kwargs)


### PR DESCRIPTION
This win32-specific logic got lost in https://github.com/PrefectHQ/prefect/commit/33cb068f095dc4f25629e6caa433e3b3ee12bed0, where this:
```
    if isinstance(command, list) and sys.platform == "win32":
        command = " ".join(command)
```

was changed into this:

```
    if sys.platform == "win32":
        command = " ".join(command)
```

Closes https://github.com/PrefectHQ/prefect/issues/6969.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation. (The existing `test_filesystems.py` was failing on Windows before this PR.)
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
