### PR TITLE
Discussion: Check that command is a list when passed to `open_process`

### DIFF
--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -24,6 +24,11 @@ async def open_process(command: List[str], **kwargs):
     # Passing a string to open_process is equivalent to shell=True which is
     # generally necessary for Unix-like commands on Windows but otherwise should
     # be avoided
+    if not isinstance(command, list):
+        raise TypeError(
+            "The command passed to open process must be a list. You passed the command"
+            f"'{command}', which is type '{type(command)}'."
+        )
     if sys.platform == "win32":
         command = " ".join(command)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This updates `processutils.open_process` to check that the command being passed to it is a list and raise an error if it is not. This is important because we've passed strings to it on a couple occasions, which works on a unix machine, but breaks on a windows machine. This should hopefully save us a few compatibility bugs down the line. 

Related PR: https://github.com/PrefectHQ/prefect/pull/7372

The PR also moves the tests for `run_process` under their own class.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
async def open_process(command: List[str], **kwargs):
    ...
    if not isinstance(command, list):
        raise TypeError(
            "The command passed to open process must be a list. You passed the command"
            f"'{command}', which is type '{type(command)}'."
        )
    ...
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
