### PR TITLE
Allow filtering of Work Queues via the API based on name prefix

### DIFF
--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -228,7 +228,7 @@ async def ls(
 
     async with get_client() as client:
         if work_queue_prefix is not None:
-            queues = await client.match_work_queues(work_queue_prefix)
+            queues = await client.match_work_queues([work_queue_prefix])
         else:
             queues = await client.read_work_queues()
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -828,13 +828,13 @@ class OrionClient:
 
     async def match_work_queues(
         self,
-        prefix: str,
+        prefixes: List[str],
     ) -> List[schemas.core.WorkQueue]:
         """
         Query Orion for work queues with names with a specific prefix.
 
         Args:
-            prefix: a string used to match work queue name prefixes
+            prefixes: a list of strings used to match work queue name prefixes
 
         Returns:
             a list of [WorkQueue model][prefect.orion.schemas.core.WorkQueue] representations
@@ -849,7 +849,7 @@ class OrionClient:
                 offset=current_page * page_length,
                 limit=page_length,
                 work_queue_filter=schemas.filters.WorkQueueFilter(
-                    name=schemas.filters.WorkQueueFilterName(startswith_=prefix)
+                    name=schemas.filters.WorkQueueFilterName(startswith_=prefixes)
                 ),
             )
             if not new_queues:

--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -173,6 +173,7 @@ async def _record_work_queue_polls(
 async def read_work_queues(
     limit: int = dependencies.LimitBody(),
     offset: int = Body(0, ge=0),
+    work_queues: schemas.filters.WorkQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.WorkQueue]:
     """
@@ -180,9 +181,7 @@ async def read_work_queues(
     """
     async with db.session_context() as session:
         return await models.work_queues.read_work_queues(
-            session=session,
-            offset=offset,
-            limit=limit,
+            session=session, offset=offset, limit=limit, work_queue_filter=work_queues
         )
 
 

--- a/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,11 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+
+# Add index for partial work queue name match
+SQLite: None
+Postgres: `41e5ed9e1034`
+
 # Add version to block schema
 SQLite: `e757138e954a`
 Postgres: `2d5e000696f1`

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_10_31_161719_41e5ed9e1034_.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_10_31_161719_41e5ed9e1034_.py
@@ -1,0 +1,37 @@
+"""empty message
+
+Revision ID: 41e5ed9e1034
+Revises: 8ea825da948d
+Create Date: 2022-10-31 16:17:19.166384
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "41e5ed9e1034"
+down_revision = "8ea825da948d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # install pg_trgm
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY
+            trgm_ix_work_queue_name
+            ON work_queue USING gin (name gin_trgm_ops);
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY trgm_ix_work_queue_name;
+            """
+        )

--- a/src/prefect/orion/models/work_queues.py
+++ b/src/prefect/orion/models/work_queues.py
@@ -90,15 +90,16 @@ async def read_work_queues(
     session: AsyncSession,
     offset: int = None,
     limit: int = None,
+    work_queue_filter: schemas.filters.WorkQueueFilter = None,
 ):
     """
     Read WorkQueues.
 
     Args:
-        session (AsyncSession): A database session
-        offset (int): Query offset
-        limit(int): Query limit
-
+        session: A database session
+        offset: Query offset
+        limit: Query limit
+        work_queue_filter: only select work queues matching these filters
     Returns:
         List[db.WorkQueue]: WorkQueues
     """
@@ -109,6 +110,8 @@ async def read_work_queues(
         query = query.offset(offset)
     if limit is not None:
         query = query.limit(limit)
+    if work_queue_filter:
+        query = query.where(work_queue_filter.as_sql_filter(db))
 
     result = await session.execute(query)
     return result.scalars().unique().all()

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1340,7 +1340,7 @@ class TestClientWorkQueues:
         await orion_client.create_work_queue(
             name="can you tell which thing is not like the others"
         )
-        matched_queues = await orion_client.match_work_queues("one of these things")
+        matched_queues = await orion_client.match_work_queues(["one of these things"])
         assert len(matched_queues) == 2
 
     async def test_read_nonexistant_work_queue(self, orion_client):

--- a/tests/orion/api/test_work_queues.py
+++ b/tests/orion/api/test_work_queues.py
@@ -161,12 +161,19 @@ class TestReadWorkQueues:
                 name="wq-1 Y",
             ),
         )
+
+        await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name="wq-2 Y",
+            ),
+        )
         await session.commit()
 
     async def test_read_work_queues(self, work_queues, client):
         response = await client.post("/work_queues/filter")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()) == 2
+        assert len(response.json()) == 3
 
     async def test_read_work_queues_applies_limit(self, work_queues, client):
         response = await client.post("/work_queues/filter", json=dict(limit=1))
@@ -176,9 +183,19 @@ class TestReadWorkQueues:
     async def test_read_work_queues_offset(self, work_queues, client, session):
         response = await client.post("/work_queues/filter", json=dict(offset=1))
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()) == 1
+        assert len(response.json()) == 2
         # ordered by name by default
         assert response.json()[0]["name"] == "wq-1 Y"
+        assert response.json()[1]["name"] == "wq-2 Y"
+
+    async def test_read_work_queues_by_name(self, work_queues, client, session):
+        response = await client.post(
+            "/work_queues/filter",
+            json=dict(work_queues={"name": {"startswith_": "wq-1"}}),
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        assert {wq["name"] for wq in response.json()} == {"wq-1 X", "wq-1 Y"}
 
     async def test_read_work_queues_returns_empty_list(self, client):
         response = await client.post("/work_queues/filter")

--- a/tests/orion/api/test_work_queues.py
+++ b/tests/orion/api/test_work_queues.py
@@ -191,7 +191,7 @@ class TestReadWorkQueues:
     async def test_read_work_queues_by_name(self, work_queues, client, session):
         response = await client.post(
             "/work_queues/filter",
-            json=dict(work_queues={"name": {"startswith_": "wq-1"}}),
+            json=dict(work_queues={"name": {"startswith_": ["wq-1"]}}),
         )
         assert response.status_code == status.HTTP_200_OK
 

--- a/tests/orion/models/test_work_queues.py
+++ b/tests/orion/models/test_work_queues.py
@@ -110,8 +110,14 @@ class TestReadWorkQueues:
                 name="wq-2 1",
             ),
         )
+        work_queue_4 = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name="wq-3 1",
+            ),
+        )
         await session.commit()
-        return [work_queue_1, work_queue_2, work_queue_3]
+        return [work_queue_1, work_queue_2, work_queue_3, work_queue_4]
 
     async def test_read_work_queue(self, work_queues, session):
         read_work_queue = await models.work_queues.read_work_queues(session=session)
@@ -130,6 +136,7 @@ class TestReadWorkQueues:
         assert {queue.id for queue in read_work_queue} == {
             work_queues[1].id,
             work_queues[2].id,
+            work_queues[3].id,
         }
 
     async def test_read_work_queues_name_any(self, work_queues, session):
@@ -145,10 +152,14 @@ class TestReadWorkQueues:
         read_work_queue = await models.work_queues.read_work_queues(
             session=session,
             work_queue_filter=schemas.filters.WorkQueueFilter(
-                name=schemas.filters.WorkQueueFilterName(startswith_="wq-1")
+                name=schemas.filters.WorkQueueFilterName(startswith_=["wq-1", "wq-2"])
             ),
         )
-        assert {queue.name for queue in read_work_queue} == {"wq-1 1", "wq-1 2"}
+        assert {queue.name for queue in read_work_queue} == {
+            "wq-1 1",
+            "wq-1 2",
+            "wq-2 1",
+        }
 
     async def test_read_work_queue_returns_empty_list(self, session):
         read_work_queue = await models.work_queues.read_work_queues(session=session)


### PR DESCRIPTION
Adds support to the `work_queues/filter` route in the Orion API to filter Work Queues based on the name. The filter can perform `startswith_` queries that enable finding work queues with a matching prefix, as well as the standard `all_` query.

Closes #7205 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
