### PR TITLE
docs: fix typo in concepts/task-runner.md document

### DIFF
--- a/docs/concepts/task-runners.md
+++ b/docs/concepts/task-runners.md
@@ -258,12 +258,13 @@ The `.result()` method will wait for the task to complete before returning the r
 from prefect import flow, task
 
 @task
-def my_task(name):
+def my_task():
     return "I'm a task!"
+
 
 @flow
 def my_flow():
-    future = my_task()
+    future = my_task.submit()
     result = future.result(raise_on_failure=False)
     if future.get_state().is_failed():
         # `result` is an exception! handle accordingly


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This is a very simple merge request that resolves a typo in the concepts/task-runner docs which confused me when I was trying to follow the docs.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

The code example shown used to be:
```python
from prefect import flow, task

@task
def my_task(name):
    return "I'm a task!"

@flow
def my_flow():
    future = my_task()
    result = future.result(raise_on_failure=False)
    if future.get_state().is_failed():
        # `result` is an exception! handle accordingly
        ...
    else:
        # `result` is the expected return value of our task
        ...
```
What confused me is the call to `my_task`:
- `my_task.__call__` expects a `name` argument but we don't pass it anything 
- invoking `my_task.__call__` should not return a future but instead should execute the underlying python function. 



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
