### PR TITLE
Scheduler stability fixes

### DIFF
--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -70,8 +70,6 @@ class Scheduler(LoopService):
         """
         total_inserted_runs = 0
 
-        # session = await db.session()
-        # async with session:
         last_id = None
         while True:
             async with db.session_context(begin_transaction=False) as session:

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -70,45 +70,44 @@ class Scheduler(LoopService):
         """
         total_inserted_runs = 0
 
-        session = await db.session()
-        async with session:
-            last_id = None
-            while True:
-                async with session.begin():
-                    query = self._get_select_deployments_to_schedule_query()
+        # session = await db.session()
+        # async with session:
+        last_id = None
+        while True:
+            async with db.session_context(begin_transaction=False) as session:
+                query = self._get_select_deployments_to_schedule_query()
 
-                    # use cursor based pagination
-                    if last_id:
-                        query = query.where(db.Deployment.id > last_id)
+                # use cursor based pagination
+                if last_id:
+                    query = query.where(db.Deployment.id > last_id)
 
-                    result = await session.execute(query)
-                    deployment_ids = result.scalars().unique().all()
+                result = await session.execute(query)
+                deployment_ids = result.scalars().unique().all()
 
-                    # collect runs across all deployments
-                    try:
-                        runs_to_insert = await self._collect_flow_runs(
-                            session=session, deployment_ids=deployment_ids
-                        )
-                    except TryAgain:
-                        continue
+                # collect runs across all deployments
+                try:
+                    runs_to_insert = await self._collect_flow_runs(
+                        session=session, deployment_ids=deployment_ids
+                    )
+                except TryAgain:
+                    continue
 
-                    # bulk insert the runs based on batch size setting
-                    for batch in batched_iterable(
-                        runs_to_insert, self.insert_batch_size
-                    ):
-                        inserted_runs = await self._insert_scheduled_flow_runs(
-                            session=session, runs=batch
-                        )
-                        total_inserted_runs += len(inserted_runs)
+            # bulk insert the runs based on batch size setting
+            for batch in batched_iterable(runs_to_insert, self.insert_batch_size):
+                async with db.session_context(begin_transaction=True) as session:
+                    inserted_runs = await self._insert_scheduled_flow_runs(
+                        session=session, runs=batch
+                    )
+                    total_inserted_runs += len(inserted_runs)
 
-                # if this is the last page of deployments, exit the loop
-                if len(deployment_ids) < self.deployment_batch_size:
-                    break
-                else:
-                    # record the last deployment ID
-                    last_id = deployment_ids[-1]
+            # if this is the last page of deployments, exit the loop
+            if len(deployment_ids) < self.deployment_batch_size:
+                break
+            else:
+                # record the last deployment ID
+                last_id = deployment_ids[-1]
 
-            self.logger.info(f"Scheduled {total_inserted_runs} runs.")
+        self.logger.info(f"Scheduled {total_inserted_runs} runs.")
 
     @inject_db
     def _get_select_deployments_to_schedule_query(self, db: OrionDBInterface):

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -559,12 +559,12 @@ deployment once. Defaults to `100`.
 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS = Setting(
     int,
-    default=100,
+    default=20,
 )
 """The scheduler will attempt to schedule up to this many
 auto-scheduled runs in the future. Note that runs may have fewer than
 this many scheduled runs, depending on the value of
-`scheduler_max_scheduled_time`.  Defaults to `100`.
+`scheduler_max_scheduled_time`.  Defaults to `20`.
 """
 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME = Setting(

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -236,7 +236,7 @@ class TestCreateDeployment:
             session=session, deployment_id=deployment.id
         )
         n_runs = await models.flow_runs.count_flow_runs(session)
-        assert n_runs == 100
+        assert n_runs == PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
 
         # create a run manually to ensure it isn't deleted
         await models.flow_runs.create_flow_run(
@@ -278,7 +278,7 @@ class TestCreateDeployment:
             session=session, deployment_id=deployment.id
         )
         n_runs = await models.flow_runs.count_flow_runs(session)
-        assert n_runs == 100
+        assert n_runs == PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
 
         # create a run manually to ensure it isn't deleted
         await models.flow_runs.create_flow_run(
@@ -726,7 +726,7 @@ class TestSetScheduleActive:
             session=session, deployment_id=deployment.id
         )
         n_runs = await models.flow_runs.count_flow_runs(session)
-        assert n_runs == 100
+        assert n_runs == PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
 
         # create a run manually
         await models.flow_runs.create_flow_run(

--- a/tests/orion/services/test_scheduler.py
+++ b/tests/orion/services/test_scheduler.py
@@ -31,7 +31,7 @@ async def test_create_schedules_from_deployment(flow, session):
     service = Scheduler(handle_signals=False)
     await service.start(loops=1)
     runs = await models.flow_runs.read_flow_runs(session)
-    assert len(runs) == 100 == service.max_runs
+    assert len(runs) == service.max_runs
     expected_dates = await deployment.schedule.get_dates(service.max_runs)
     assert set(expected_dates) == {r.state.state_details.scheduled_time for r in runs}
 
@@ -114,7 +114,6 @@ async def test_create_schedules_from_multiple_deployments(flow, session):
     service = Scheduler(handle_signals=False)
     await service.start(loops=1)
     runs = await models.flow_runs.read_flow_runs(session)
-    assert len(runs) == 130
 
     expected_dates = set()
     for deployment in [d1, d2, d3]:


### PR DESCRIPTION
This PR makes a few changes to reduce the burden of scheduling flow runs on the orion database:
- Schedule the next 20 runs instead of 100 by default
- COMMIT scheduled runs in batches instead of batching multiple INSERTs in a single COMMIT

Part of https://github.com/PrefectHQ/nebula/issues/2503

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
