### PR TITLE
Show the link to a deployment when using the parameter `-a` in `prefect deployment build`

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -920,6 +920,13 @@ async def build(
             f"Deployment '{deployment.flow_name}/{deployment.name}' successfully created with id '{deployment_id}'.",
             style="green",
         )
+        connection_status = await check_orion_connection()
+        ui = ui_base_url(connection_status)
+
+        if ui:
+            app.console.print(
+                f"View Deployment in UI: {ui}/deployments/deployment/{deployment_id}"
+            )
         if deployment.work_queue_name is not None:
             app.console.print(
                 "\nTo execute flow runs from this deployment, start an agent "

--- a/tests/cli/test_deployment_cli.py
+++ b/tests/cli/test_deployment_cli.py
@@ -551,6 +551,23 @@ class TestOutputMessages:
             expected_output_contains="/deployments/deployment/",
         )
 
+    def test_linking_to_deployment_when_using_apply_in_build(
+        self,
+        patch_import,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "prefect.cli.deployment.ui_base_url", lambda status: "127.0.0.1:1234"
+        )
+
+        invoke_and_assert(
+            ["deployment", "build", "fake-path.py:fn", "-n", "TEST", "-a"],
+            expected_code=0,
+            temp_dir=tmp_path,
+            expected_output_contains=["View Deployment in UI"],
+        )
+
     def test_updating_work_queue_concurrency_from_python_build(
         self, patch_import, tmp_path
     ):


### PR DESCRIPTION
Add the link to the deployment when using `-a` in `prefect deployment build`.

Closes #7425

### Example
There should be a link to the deployment when adding `-a` to `prefect deployment build`. This would make it easier for users to find the associated deployment. 

The output looks like this:

```bash
$ prefect deployment build src/test4.py:main -n test-retries -a
Found flow 'Main Flow'
Deployment YAML created at '/Users/khuyen/test/main-deployment.yaml'.
Deployment storage None does not have upload capabilities; no files uploaded.  Pass --skip-upload to 
suppress this warning.
Deployment 'Main Flow/test-retries' successfully created with id '26096598-e23f-4183-9afd-bb213698050a'.
View Deployment in UI: 
https://app.prefect.cloud/account/804d0209-2a32-420b-8f8b-6ce3eb1d0211/workspace/ac926a68-ea8d-4d20-b186-4
c7beac6e8a3/deployments/deployment/26096598-e23f-4183-9afd-bb213698050a

To execute flow runs from this deployment, start an agent that pulls work from the 'default' work queue:
$ prefect agent start -q 'default'
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
