### PR TITLE
Adjust the scheduler to create the smallest number of runs 

### DIFF
--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -190,7 +190,14 @@ See the Python [RRuleSchedule class docs](/api-ref/orion/schemas/schedules/#pref
 
 The `Scheduler` service is started automatically when `prefect orion start` is run and it is a built-in service of Prefect Cloud. 
 
-By default, the `Scheduler` service visits deployments on a 60-second loop and attempts to create up to 100 scheduled flow runs up to 100 days in the future. These defaults can be shown with the terminal command `prefect config view --show-defaults`:
+By default, the `Scheduler` service visits deployments on a 60-second loop, though recently-modified deployments will be visited more frequently. The `Scheduler` evaluates each deployment's schedule and creates new runs appropriately. For typical deployments, it will create the next three runs, though more runs will be scheduled if the next 3 would all start in the next hour. 
+
+More specifically, the `Scheduler` tries to create the smallest number of runs that satisfy the following constraints, in order:
+- no more than 100 runs will be scheduled
+- runs will not be scheduled more than 100 days in the future
+- at least 3 runs will be scheduled
+- runs will be scheduled until at least one hour in the future
+These behaviors can all be adjusted through the relevant settings that can be viewed with the terminal command `prefect config view --show-defaults`:
 
 <div class='terminal'>
 ```bash
@@ -198,7 +205,9 @@ PREFECT_ORION_SERVICES_SCHEDULER_DEPLOYMENT_BATCH_SIZE='100'
 PREFECT_ORION_SERVICES_SCHEDULER_ENABLED='True' 
 PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE='500' 
 PREFECT_ORION_SERVICES_SCHEDULER_LOOP_SECONDS='60.0' 
+PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS='3' 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS='100' 
+PREFECT_ORION_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME='1:00:00' 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME='100 days, 0:00:00' 
 ```
 </div>

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -19,6 +19,8 @@ from prefect.orion.utilities.database import json_contains
 from prefect.settings import (
     PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS,
     PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME,
+    PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS,
+    PREFECT_ORION_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME,
 )
 
 
@@ -367,6 +369,8 @@ async def schedule_runs(
     deployment_id: UUID,
     start_time: datetime.datetime = None,
     end_time: datetime.datetime = None,
+    min_time: datetime.datetime = None,
+    min_runs: int = None,
     max_runs: int = None,
     auto_scheduled: bool = True,
 ) -> List[UUID]:
@@ -377,28 +381,48 @@ async def schedule_runs(
         session: a database session
         deployment_id: the id of the deployment to schedule
         start_time: the time from which to start scheduling runs
-        end_time: a limit on how far in the future runs will be scheduled
+        end_time: runs will be scheduled until at most this time
+        min_time: runs will be scheduled until at least this time
+        min_runs: a minimum amount of runs to schedule
         max_runs: a maximum amount of runs to schedule
+
+    This function will generate the minimum number of runs that satisfy the min
+    and max times, and the min and max counts. Specifically, the following order
+    will be respected:
+        - runs will be generated starting on or after the `start_time`
+        - no more than `max_runs` runs will be generated
+        - no runs will be generated after `end_time` is reached
+        - at least `min_runs` runs will be generated
+        - runs will be generated until at least `min_time` is reached
 
     Returns:
         a list of flow run ids scheduled for the deployment
     """
+    if min_runs is None:
+        min_runs = PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS.value()
     if max_runs is None:
         max_runs = PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
     if start_time is None:
         start_time = pendulum.now("UTC")
-    start_time = pendulum.instance(start_time)
     if end_time is None:
         end_time = start_time + (
             PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME.value()
         )
+    if min_time is None:
+        min_time = start_time + (
+            PREFECT_ORION_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME.value()
+        )
+    start_time = pendulum.instance(start_time)
     end_time = pendulum.instance(end_time)
+    min_time = pendulum.instance(min_time)
 
     runs = await _generate_scheduled_flow_runs(
         session=session,
         deployment_id=deployment_id,
         start_time=start_time,
         end_time=end_time,
+        min_time=min_time,
+        min_runs=min_runs,
         max_runs=max_runs,
         auto_scheduled=auto_scheduled,
     )
@@ -411,6 +435,8 @@ async def _generate_scheduled_flow_runs(
     deployment_id: UUID,
     start_time: datetime.datetime,
     end_time: datetime.datetime,
+    min_time: datetime.datetime,
+    min_runs: int,
     max_runs: int,
     db: OrionDBInterface,
     auto_scheduled: bool = True,
@@ -428,8 +454,19 @@ async def _generate_scheduled_flow_runs(
         session: a database session
         deployment_id: the id of the deployment to schedule
         start_time: the time from which to start scheduling runs
-        end_time: a limit on how far in the future runs will be scheduled
+        end_time: runs will be scheduled until at most this time
+        min_time: runs will be scheduled until at least this time
+        min_runs: a minimum amount of runs to schedule
         max_runs: a maximum amount of runs to schedule
+
+    This function will generate the minimum number of runs that satisfy the min
+    and max times, and the min and max counts. Specifically, the following order
+    will be respected:
+        - runs will be generated starting on or after the `start_time`
+        - no more than `max_runs` runs will be generated
+        - no runs will be generated after `end_time` is reached
+        - at least `min_runs` runs will be generated
+        - runs will be generated until at least `min_time` is reached
 
     Returns:
         a list of dictionary representations of the `FlowRun` objects to schedule
@@ -442,9 +479,17 @@ async def _generate_scheduled_flow_runs(
     if not deployment or not deployment.schedule or not deployment.is_schedule_active:
         return []
 
-    dates = await deployment.schedule.get_dates(
+    dates = []
+
+    # generate up to `n` dates satisfying the min of `max_runs` and `end_time`
+    async for dt in deployment.schedule._get_dates_generator(
         n=max_runs, start=start_time, end=end_time
-    )
+    ):
+        dates.append(dt)
+
+        # at any point, if we satisfy both of the minimums, we can stop
+        if len(dates) >= min_runs and dt >= min_time:
+            break
 
     tags = deployment.tags
     if auto_scheduled:

--- a/src/prefect/orion/schemas/schedules.py
+++ b/src/prefect/orion/schemas/schedules.py
@@ -2,9 +2,8 @@
 Schedule schemas
 """
 
-import asyncio
 import datetime
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Generator, List, Optional, Tuple, Union
 
 import dateutil
 import dateutil.rrule
@@ -15,7 +14,7 @@ from pydantic import Field, validator
 
 from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 
-MAX_ITERATIONS = 10000
+MAX_ITERATIONS = 1000
 
 
 def _prepare_scheduling_start_and_end(
@@ -108,7 +107,32 @@ class IntervalSchedule(PrefectBaseModel):
         start: datetime.datetime = None,
         end: datetime.datetime = None,
     ) -> List[pendulum.DateTime]:
-        """Retrieves dates from the schedule. Up to 10,000 candidate dates are checked
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
+        following the start date.
+
+        Args:
+            n (int): The number of dates to generate
+            start (datetime.datetime, optional): The first returned date will be on or
+                after this date. Defaults to None.  If a timezone-naive datetime is
+                provided, it is assumed to be in the schedule's timezone.
+            end (datetime.datetime, optional): The maximum scheduled date to return. If
+                a timezone-naive datetime is provided, it is assumed to be in the
+                schedule's timezone.
+
+        Returns:
+            List[pendulum.DateTime]: a list of dates
+        """
+        return sorted(
+            [i async for i in self._get_dates_generator(n=n, start=start, end=end)]
+        )
+
+    async def _get_dates_generator(
+        self,
+        n: int = None,
+        start: datetime.datetime = None,
+        end: datetime.datetime = None,
+    ) -> Generator[pendulum.DateTime, None, None]:
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
         following the start date.
 
         Args:
@@ -166,7 +190,9 @@ class IntervalSchedule(PrefectBaseModel):
                 break
 
             # ensure no duplicates; weird things can happen with DST
-            dates.add(next_date)
+            if next_date not in dates:
+                dates.add(next_date)
+                yield next_date
 
             # if enough dates have been collected or enough attempts were made, exit
             if len(dates) >= n or counter > MAX_ITERATIONS:
@@ -175,11 +201,6 @@ class IntervalSchedule(PrefectBaseModel):
             counter += 1
 
             next_date = next_date.add(days=interval_days, seconds=interval_seconds)
-
-            # yield event loop control
-            await asyncio.sleep(0)
-
-        return sorted(dates)
 
 
 class CronSchedule(PrefectBaseModel):
@@ -242,7 +263,32 @@ class CronSchedule(PrefectBaseModel):
         start: datetime.datetime = None,
         end: datetime.datetime = None,
     ) -> List[pendulum.DateTime]:
-        """Retrieves dates from the schedule. Up to 10,000 candidate dates are checked
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
+        following the start date.
+
+        Args:
+            n (int): The number of dates to generate
+            start (datetime.datetime, optional): The first returned date will be on or
+                after this date. Defaults to None.  If a timezone-naive datetime is
+                provided, it is assumed to be in the schedule's timezone.
+            end (datetime.datetime, optional): The maximum scheduled date to return. If
+                a timezone-naive datetime is provided, it is assumed to be in the
+                schedule's timezone.
+
+        Returns:
+            List[pendulum.DateTime]: a list of dates
+        """
+        return sorted(
+            [i async for i in self._get_dates_generator(n=n, start=start, end=end)]
+        )
+
+    async def _get_dates_generator(
+        self,
+        n: int = None,
+        start: datetime.datetime = None,
+        end: datetime.datetime = None,
+    ) -> Generator[pendulum.DateTime, None, None]:
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
         following the start date.
 
         Args:
@@ -305,18 +351,15 @@ class CronSchedule(PrefectBaseModel):
             if end and next_date > end:
                 break
             # ensure no duplicates; weird things can happen with DST
-            dates.add(next_date)
+            if next_date not in dates:
+                dates.add(next_date)
+                yield next_date
 
             # if enough dates have been collected or enough attempts were made, exit
             if len(dates) >= n or counter > MAX_ITERATIONS:
                 break
 
             counter += 1
-
-            # yield event loop control
-            await asyncio.sleep(0)
-
-        return sorted(dates)
 
 
 class RRuleSchedule(PrefectBaseModel):
@@ -472,7 +515,32 @@ class RRuleSchedule(PrefectBaseModel):
         start: datetime.datetime = None,
         end: datetime.datetime = None,
     ) -> List[pendulum.DateTime]:
-        """Retrieves dates from the schedule. Up to 10,000 candidate dates are checked
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
+        following the start date.
+
+        Args:
+            n (int): The number of dates to generate
+            start (datetime.datetime, optional): The first returned date will be on or
+                after this date. Defaults to None.  If a timezone-naive datetime is
+                provided, it is assumed to be in the schedule's timezone.
+            end (datetime.datetime, optional): The maximum scheduled date to return. If
+                a timezone-naive datetime is provided, it is assumed to be in the
+                schedule's timezone.
+
+        Returns:
+            List[pendulum.DateTime]: a list of dates
+        """
+        return sorted(
+            [i async for i in self._get_dates_generator(n=n, start=start, end=end)]
+        )
+
+    async def _get_dates_generator(
+        self,
+        n: int = None,
+        start: datetime.datetime = None,
+        end: datetime.datetime = None,
+    ) -> Generator[pendulum.DateTime, None, None]:
+        """Retrieves dates from the schedule. Up to 1,000 candidate dates are checked
         following the start date.
 
         Args:
@@ -514,18 +582,15 @@ class RRuleSchedule(PrefectBaseModel):
                 break
 
             # ensure no duplicates; weird things can happen with DST
-            dates.add(next_date)
+            if next_date not in dates:
+                dates.add(next_date)
+                yield next_date
 
             # if enough dates have been collected or enough attempts were made, exit
             if len(dates) >= n or counter > MAX_ITERATIONS:
                 break
 
             counter += 1
-
-            # yield event loop control
-            await asyncio.sleep(0)
-
-        return sorted(dates)
 
 
 SCHEDULE_TYPES = Union[IntervalSchedule, CronSchedule, RRuleSchedule]

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -559,12 +559,22 @@ deployment once. Defaults to `100`.
 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS = Setting(
     int,
-    default=20,
+    default=100,
 )
 """The scheduler will attempt to schedule up to this many
 auto-scheduled runs in the future. Note that runs may have fewer than
 this many scheduled runs, depending on the value of
-`scheduler_max_scheduled_time`.  Defaults to `20`.
+`scheduler_max_scheduled_time`.  Defaults to `100`.
+"""
+
+PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS = Setting(
+    int,
+    default=3,
+)
+"""The scheduler will attempt to schedule at least this many
+auto-scheduled runs in the future. Note that runs may have more than
+this many scheduled runs, depending on the value of
+`scheduler_min_scheduled_time`.  Defaults to `3`.
 """
 
 PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME = Setting(
@@ -574,8 +584,19 @@ PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME = Setting(
 """The scheduler will create new runs up to this far in the
 future. Note that this setting will take precedence over
 `scheduler_max_runs`: if a flow runs once a month and
-`scheduled_max_scheduled_time` is three months, then only three runs will be
+`scheduler_max_scheduled_time` is three months, then only three runs will be
 scheduled. Defaults to 100 days (`8640000` seconds).
+"""
+
+PREFECT_ORION_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME = Setting(
+    timedelta,
+    default=timedelta(hours=1),
+)
+"""The scheduler will create new runs at least this far in the
+future. Note that this setting will take precedence over `scheduler_min_runs`:
+if a flow runs every hour and `scheduler_min_scheduled_time` is three hours,
+then three runs will be scheduled even if `scheduler_min_runs` is 1. Defaults to
+1 hour (`3600` seconds).
 """
 
 PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE = Setting(

--- a/tests/orion/schemas/test_schedules.py
+++ b/tests/orion/schemas/test_schedules.py
@@ -10,6 +10,7 @@ from pendulum import datetime, now
 from pydantic import ValidationError
 
 from prefect.orion.schemas.schedules import (
+    MAX_ITERATIONS,
     CronSchedule,
     IntervalSchedule,
     RRuleSchedule,
@@ -125,7 +126,10 @@ class TestIntervalSchedule:
         )
 
         dates = await clock.get_dates(start=datetime(2018, 1, 1), end=end_date)
-        assert len(dates) == (end_date - datetime(2018, 1, 1)).days + 1
+        assert len(dates) == min(
+            MAX_ITERATIONS,
+            (end_date - datetime(2018, 1, 1)).days + 1,
+        )
 
     async def test_default_n_is_one_without_end_date(self):
         clock = IntervalSchedule(
@@ -306,7 +310,9 @@ class TestCronSchedule:
     async def test_get_dates_until_end_date(self, end_date):
         clock = CronSchedule(cron=self.every_day)
         dates = await clock.get_dates(start=datetime(2018, 1, 1), end=end_date)
-        assert len(dates) == (end_date - datetime(2018, 1, 1)).days + 1
+        assert len(dates) == min(
+            MAX_ITERATIONS, (end_date - datetime(2018, 1, 1)).days + 1
+        )
 
     async def test_default_n_is_one_without_end_date(self):
         clock = CronSchedule(cron=self.every_day)

--- a/tests/orion/services/test_scheduler.py
+++ b/tests/orion/services/test_scheduler.py
@@ -1,13 +1,14 @@
 import datetime
 
 import pendulum
+import pytest
 import sqlalchemy as sa
 
 from prefect.orion import models, schemas
 from prefect.orion.services.scheduler import RecentDeploymentsScheduler, Scheduler
 from prefect.settings import (
     PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE,
-    PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS,
+    PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS,
 )
 
 
@@ -31,8 +32,8 @@ async def test_create_schedules_from_deployment(flow, session):
     service = Scheduler(handle_signals=False)
     await service.start(loops=1)
     runs = await models.flow_runs.read_flow_runs(session)
-    assert len(runs) == service.max_runs
-    expected_dates = await deployment.schedule.get_dates(service.max_runs)
+    assert len(runs) == service.min_runs
+    expected_dates = await deployment.schedule.get_dates(service.min_runs)
     assert set(expected_dates) == {r.state.state_details.scheduled_time for r in runs}
 
     assert all(
@@ -118,7 +119,7 @@ async def test_create_schedules_from_multiple_deployments(flow, session):
     expected_dates = set()
     for deployment in [d1, d2, d3]:
         dep_runs = await deployment.schedule.get_dates(
-            service.max_runs,
+            service.min_runs,
             start=pendulum.now(),
             end=pendulum.now() + service.max_scheduled_time,
         )
@@ -135,7 +136,7 @@ async def test_create_schedules_from_multiple_deployments_in_batches(flow, sessi
     # flow runs in batches of scheduler_insertion_batch_size
     deployments_to_schedule = (
         PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE.value()
-        // PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
+        // PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS.value()
     ) + 1
     for i in range(deployments_to_schedule):
         await models.deployments.create_deployment(
@@ -145,9 +146,7 @@ async def test_create_schedules_from_multiple_deployments_in_batches(flow, sessi
                 flow_id=flow.id,
                 manifest_path="file.json",
                 schedule=schemas.schedules.IntervalSchedule(
-                    # assumes this interval is small enough that
-                    # the maximum amount of runs will be scheduled per deployment
-                    interval=datetime.timedelta(minutes=5)
+                    interval=datetime.timedelta(hours=1)
                 ),
             ),
         )
@@ -161,7 +160,7 @@ async def test_create_schedules_from_multiple_deployments_in_batches(flow, sessi
     runs = await models.flow_runs.read_flow_runs(session)
     assert (
         len(runs)
-        == deployments_to_schedule * PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS.value()
+        == deployments_to_schedule * PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS.value()
     )
     assert len(runs) > PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE.value()
 
@@ -218,7 +217,7 @@ class TestRecentDeploymentsScheduler:
         await recent_scheduler.start(loops=1)
 
         runs_count = (await session.execute(count_query)).scalar()
-        assert runs_count == recent_scheduler.max_runs
+        assert runs_count == recent_scheduler.min_runs
 
     async def test_schedules_runs_for_recently_updated_deployments(
         self, deployment, session, db
@@ -244,7 +243,7 @@ class TestRecentDeploymentsScheduler:
         await recent_scheduler.start(loops=1)
 
         runs_count = (await session.execute(count_query)).scalar()
-        assert runs_count == recent_scheduler.max_runs
+        assert runs_count == recent_scheduler.min_runs
 
     async def test_schedules_no_runs_for_deployments_updated_a_while_ago(
         self, deployment, session, db
@@ -271,3 +270,44 @@ class TestRecentDeploymentsScheduler:
 
         runs_count = (await session.execute(count_query)).scalar()
         assert runs_count == 0
+
+
+class TestScheduleRulesWaterfall:
+    @pytest.mark.parametrize(
+        "interval,n",
+        [
+            # schedule until we at least exceed an hour
+            (datetime.timedelta(minutes=1), 61),
+            # schedule at least 3 runs
+            (datetime.timedelta(hours=1), 3),
+            # schedule until we at least exceed an hour
+            (datetime.timedelta(minutes=5), 13),
+            # schedule until at most 100 days
+            (datetime.timedelta(days=60), 2),
+        ],
+    )
+    async def test_create_schedule_respects_max_future_time(
+        self, flow, session, interval, n
+    ):
+        deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name="test",
+                flow_id=flow.id,
+                schedule=schemas.schedules.IntervalSchedule(
+                    interval=interval,
+                    anchor_date=pendulum.now("UTC").add(seconds=1),
+                ),
+            ),
+        )
+        await session.commit()
+
+        # assert clean slate
+        assert (await models.flow_runs.count_flow_runs(session)) == 0
+
+        # run scheduler
+        service = Scheduler(handle_signals=False)
+        await service.start(loops=1)
+
+        runs = await models.flow_runs.read_flow_runs(session)
+        assert len(runs) == n


### PR DESCRIPTION
Draft PR that I'm exploring with @zangell44 

Currently, the scheduler attempts to create `N` runs for every deployment. `N` was previously 100 and Zach recently lowered it to 20. This has a couple negative effects:
- the runs view is "crowded" because of the volume of upcoming, scheduled runs
- the scheduler is constantly trying to insert runs to the database (runs are rejected on insert via idempotency keys)

This PR tries a new approach. Instead of always trying to create 20 runs, the scheduler now tries to create the fewest possible runs that satisfy a relatively heuristic:
- at least 3 but no more than 100 runs
- scheduled at least one hour in the future but not more than 100 days

The result is that for "typical" deployments having intervals of of > 20 minutes, only the next three runs will be scheduled at any time (I chose three because it seems like a nice but inoffensive look into the future at any moment). This should alleviate significant write pressure on the database at scale.

For "fast" deployments, more runs will be scheduled to guarantee visibility at least one hour out (e.g. if the interval is 5 minutes, 12 or 13 runs will be scheduled [depending on timing]).

However, under any circumstances, more than 100 runs won't be scheduled (for super fast deployments) and runs won't be scheduled more than 100 days in the future (for super slow deployments).

### Future enhancements
The scheduler performs this logic for every deployment no matter whether its runs were just scheduled. For typical deployments, this means that the same runs are being created over and over until one of them finally executes and permits a new run to be scheduled. We could evaluate skipping deployments that were recently scheduled or have more than 3 auto-scheduled runs already, depending on performance implications.