### PR TITLE
Improve scheduler selectivity for performance

### DIFF
--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_11_05_180555_54c1876c68ae_add_index_for_scheduled_deployments.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_11_05_180555_54c1876c68ae_add_index_for_scheduled_deployments.py
@@ -1,0 +1,34 @@
+"""Add index for scheduled deployments
+
+Revision ID: 54c1876c68ae
+Revises: 41e5ed9e1034
+Create Date: 2022-11-05 18:05:55.050650
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "54c1876c68ae"
+down_revision = "41e5ed9e1034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY ix_flow_run__scheduler_deployment_id_auto_scheduled_next_scheduled_start_time 
+            ON flow_run (deployment_id, auto_scheduled, next_scheduled_start_time) 
+            WHERE state_type = 'SCHEDULED';
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY ix_flow_run__scheduler_deployment_id_auto_scheduled_next_scheduled_start_time;
+            """
+        )

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_11_05_180619_a0284438370e_add_index_for_scheduled_deployments.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_11_05_180619_a0284438370e_add_index_for_scheduled_deployments.py
@@ -1,0 +1,32 @@
+"""Add index for scheduled deployments
+
+Revision ID: a0284438370e
+Revises: af52717cf201
+Create Date: 2022-11-05 18:06:19.568896
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a0284438370e"
+down_revision = "af52717cf201"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE INDEX ix_flow_run__scheduler_deployment_id_auto_scheduled_next_scheduled_start_time 
+        ON flow_run (deployment_id, auto_scheduled, next_scheduled_start_time) 
+        WHERE state_type = 'SCHEDULED';
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DROP INDEX ix_flow_run__scheduler_deployment_id_auto_scheduled_next_scheduled_start_time;
+        """
+    )

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -414,6 +414,7 @@ async def schedule_runs(
 
     start_time = pendulum.instance(start_time)
     end_time = pendulum.instance(end_time)
+    min_time = pendulum.instance(min_time)
 
     runs = await _generate_scheduled_flow_runs(
         session=session,

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -414,7 +414,6 @@ async def schedule_runs(
 
     start_time = pendulum.instance(start_time)
     end_time = pendulum.instance(end_time)
-    min_time = pendulum.instance(min_time)
 
     runs = await _generate_scheduled_flow_runs(
         session=session,

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -120,6 +120,7 @@ class Scheduler(LoopService):
         Returns a sqlalchemy query for selecting deployments to schedule.
 
         The query gets the IDs of any deployments with:
+        
             - an active schedule
             - EITHER:
                 - fewer than `min_runs` auto-scheduled runs

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -138,7 +138,7 @@ class Scheduler(LoopService):
                 db.FlowRun,
                 # join on matching deployments, only picking up future scheduled runs
                 sa.and_(
-                    db.Deployment.id == db.FlowRun.id,
+                    db.Deployment.id == db.FlowRun.deployment_id,
                     db.FlowRun.state_type == StateType.SCHEDULED,
                     db.FlowRun.next_scheduled_start_time >= now,
                     db.FlowRun.auto_scheduled.is_(True),

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -120,7 +120,7 @@ class Scheduler(LoopService):
         Returns a sqlalchemy query for selecting deployments to schedule.
 
         The query gets the IDs of any deployments with:
-        
+
             - an active schedule
             - EITHER:
                 - fewer than `min_runs` auto-scheduled runs

--- a/src/prefect/orion/services/scheduler.py
+++ b/src/prefect/orion/services/scheduler.py
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 import prefect.orion.models as models
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
+from prefect.orion.schemas.states import StateType
 from prefect.orion.services.loop_service import LoopService, run_multiple_services
 from prefect.settings import (
     PREFECT_ORION_SERVICES_SCHEDULER_DEPLOYMENT_BATCH_SIZE,
@@ -116,13 +117,46 @@ class Scheduler(LoopService):
     @inject_db
     def _get_select_deployments_to_schedule_query(self, db: OrionDBInterface):
         """
-        Returns a sqlalchemy query for selecting deployments to schedule
+        Returns a sqlalchemy query for selecting deployments to schedule.
+
+        The query gets the IDs of any deployments with:
+            - an active schedule
+            - EITHER:
+                - fewer than `min_runs` auto-scheduled runs
+                - OR the max scheduled time is less than `max_scheduled_time` in the future
         """
+        now = pendulum.now("UTC")
         query = (
             sa.select(db.Deployment.id)
+            .select_from(db.Deployment)
+            # TODO: on Postgres, this could be replaced with a lateral join that
+            # sorts by `next_scheduled_start_time desc` and limits by
+            # `self.min_runs` for a ~ 50% speedup. At the time of writing,
+            # performance of this universal query appears to be fast enough that
+            # this optimization is not worth maintaining db-specific queries
+            .join(
+                db.FlowRun,
+                # join on matching deployments, only picking up future scheduled runs
+                sa.and_(
+                    db.Deployment.id == db.FlowRun.id,
+                    db.FlowRun.state_type == StateType.SCHEDULED,
+                    db.FlowRun.next_scheduled_start_time >= now,
+                    db.FlowRun.auto_scheduled.is_(True),
+                ),
+                isouter=True,
+            )
             .where(
                 db.Deployment.is_schedule_active.is_(True),
                 db.Deployment.schedule.is_not(None),
+            )
+            .group_by(db.Deployment.id)
+            # having EITHER fewer than three runs OR runs not scheduled far enough out
+            .having(
+                sa.or_(
+                    sa.func.count(db.FlowRun.next_scheduled_start_time) < self.min_runs,
+                    sa.func.max(db.FlowRun.next_scheduled_start_time)
+                    < now + self.min_scheduled_time,
+                )
             )
             .order_by(db.Deployment.id)
             .limit(self.deployment_batch_size)


### PR DESCRIPTION
Follow up to #7433 (and builds on it).

If #7433 is merged, the scheduler will begin scheduling the _smallest_ number of runs that satisfy certain minimum criteria (a minimum number of runs and a minimum duration to schedule into the future). This has the major effect of reducing the number of runs the scheduler attempts to insert, which is important because the scheduler runs on a relatively tight loop and relies on idempotency to allow it to eagerly attempt to create redundant runs.

However, the fact that the scheduler is constantly trying to create runs that already exist is, itself, a larger source of potential performance problems. Even if every single deployment had just been scheduled and nothing had changed, on its next loop the scheduler will revisit every single deployment and attempt to recreate all of its runs. 

This PR makes a small change to the query that loads deployments to schedule. Instead of just looking for ones with active schedules, this PR adds additional criteria to only get ones with fewer than `min_runs` runs, or no runs outside `min_scheduled_time`. In other words: only deployments whose future work would actually be affected by scheduling. A new index is introduced to make this efficient.

### Please note
The performance gains of modifying the scheduler selectivity in this PR may outweigh those gained by adopting the "least number of runs" in #7433. The logic in this PR can be implemented independently of #7433 with a minor modification (namely, removing the `min_scheduled_time` constraint and changing `min_runs` back to `max_runs`). This could be done if the approach in #7433 is deemed to be confusing or overly complicated. The result would be that the scheduler would maintain `20` scheduled runs for every deployment, but only query those with fewer than `20` runs at any time - old scheduling behavior, new way of figuring out what to schedule.