### PR TITLE
Update pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/fsouza/autoflake8
-    rev: v0.3.2
+    rev: v0.4.0
     hooks:
       - id: autoflake8
         language_version: python3
@@ -14,7 +14,7 @@ repos:
       - id: isort
         language_version: python3
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -19,7 +19,11 @@ from prefect.blocks.core import Block
 from prefect.client.orion import OrionClient, get_client
 from prefect.client.utilities import inject_client
 from prefect.context import FlowRunContext, PrefectObjectRegistry
-from prefect.exceptions import BlockMissingCapabilities, ObjectAlreadyExists, ObjectNotFound
+from prefect.exceptions import (
+    BlockMissingCapabilities,
+    ObjectAlreadyExists,
+    ObjectNotFound,
+)
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import Flow
 from prefect.infrastructure import Infrastructure, Process


### PR DESCRIPTION
Bumps pre-commit tools versions. Fixes pre-commit failures on `main`.

See `./scripts/precommit-verisons.py` for updating verisons outside precommit.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
