### PR TITLE
Removes aiohttp from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp>=3.8.1
 aiosqlite >= 0.17.0
 alembic >= 1.7.5
 anyio >= 3.4.0


### PR DESCRIPTION
This appears to be unused.

