### PR TITLE
Ensure that queries are sorted correctly when limits are used

### DIFF
--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -239,6 +239,8 @@ class BaseQueryComponents(ABC):
                 scheduled_before_clause,
             )
             .with_for_update(skip_locked=True)
+            # priority given to runs with earlier next_scheduled_start_time
+            .order_by(db.FlowRun.next_scheduled_start_time)
             # if null, no limit will be applied
             .limit(sa.func.least(limit_per_queue, work_queue_query.c.available_slots))
             .lateral("scheduled_flow_runs")

--- a/tests/orion/database/test_queries.py
+++ b/tests/orion/database/test_queries.py
@@ -121,6 +121,43 @@ class TestGetRunsInQueueQuery:
 
         assert [r[0].id for r in runs] == [fr_1.id, fr_3.id]
 
+    async def test_get_runs_in_queue_limit_sorts_correctly(
+        self, session, db, deployment_1
+    ):
+        """Tests that the query sorts by scheduled time correctly; the unit tests with a small nubmer of runs
+        can return the correct order even though no sort is applied.
+        """
+
+        # clear all runs
+        await session.execute(sa.delete(db.FlowRun))
+
+        now = pendulum.now("UTC")
+
+        # add a bunch of runs whose physical order is the opposite of the order they should be returned in
+        # in order to make it more likely (but not guaranteed!) that unsorted queries return the wrong value
+        for i in range(10, -10, -1):
+            await models.flow_runs.create_flow_run(
+                session=session,
+                flow_run=schemas.core.FlowRun(
+                    name="fr1",
+                    flow_id=deployment_1.flow_id,
+                    deployment_id=deployment_1.id,
+                    work_queue_name=deployment_1.work_queue_name,
+                    state=schemas.states.Scheduled(now.add(minutes=i)),
+                ),
+            )
+
+        await session.commit()
+
+        query = db.queries.get_scheduled_flow_runs_from_work_queues(
+            db=db, limit_per_queue=1
+        )
+        result = await session.execute(query)
+        runs = result.all()
+
+        assert len(runs) == 1
+        assert runs[0][0].next_scheduled_start_time == now.subtract(minutes=9)
+
     async def test_get_runs_in_queue_scheduled_before(
         self, session, db, fr_1, fr_2, fr_3
     ):


### PR DESCRIPTION
Tests in #7450 are failing because of a non-deterministic bug (that only shows up there because the introduction of an index led to slightly different row selectivity).

On Postgres, we use a lateral join to efficiently grab runs in each work queue that needs scheduling. We then sort the query to ensure that runs are returned in ascending order of scheduled start time. However, if the work queue has a concurrency limit or the `limit_per_queue` flag is passed, we apply a `LIMIT` in that lateral join. The limit is applied _before_ the sort, so it's possible for the lateral join to grab arbitrary runs in the future (not necessarily the next scheduled runs). The fix is to add a sort inside the lateral join. This also includes a test that maximizes the probability of observing the bug.