### PR TITLE
Add upload_options to S3Upload

### DIFF
--- a/src/prefect/engine/results/s3_result.py
+++ b/src/prefect/engine/results/s3_result.py
@@ -25,7 +25,8 @@ class S3Result(Result):
         - boto3_kwargs (dict, optional): keyword arguments to pass on to boto3 when the [client
             session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
             is initialized.
-        - upload_options (dict, optional): additional options for s3 client upload_fileobj() 'ExtraArgs' argument.
+        - upload_options (dict, optional): Additional options for s3 client
+            `upload_fileobj()` method `ExtraArgs` argument
         - **kwargs (Any, optional): any additional `Result` initialization options
     """  # noqa: E501
 

--- a/src/prefect/storage/s3.py
+++ b/src/prefect/storage/s3.py
@@ -38,8 +38,8 @@ class S3(Storage):
             used. If neither are set then script will not be uploaded and users should manually place the
             script file in the desired `key` location in an S3 bucket.
         - client_options (dict, optional): Additional options for the `boto3` client.
-        - upload_options (dict, optional): Additional options s3 client upload_file()
-            and upload_fileobj() functions 'ExtraArgs' argument.
+        - upload_options (dict, optional): Additional options for s3 client
+            `upload_file()` and `upload_fileobj()` methods `ExtraArgs` argument
         - **kwargs (Any, optional): any additional `Storage` initialization options
     """
 

--- a/src/prefect/tasks/aws/s3.py
+++ b/src/prefect/tasks/aws/s3.py
@@ -102,12 +102,22 @@ class S3Upload(Task):
     Args:
         - bucket (str, optional): the name of the S3 Bucket to upload to
         - boto_kwargs (dict, optional): additional keyword arguments to forward to the boto client.
+        - upload_options (dict, optional): Additional options for s3 client
+            `upload_fileobj()` method `ExtraArgs` argument
         - **kwargs (dict, optional): additional keyword arguments to pass to the
             Task constructor
     """
 
-    def __init__(self, bucket: str = None, boto_kwargs: dict = None, **kwargs):
+    def __init__(
+        self,
+        bucket: str = None,
+        boto_kwargs: dict = None,
+        *,
+        upload_options: dict = None,
+        **kwargs,
+    ):
         self.bucket = bucket
+        self.upload_options = upload_options
 
         if boto_kwargs is None:
             self.boto_kwargs = {}
@@ -116,7 +126,7 @@ class S3Upload(Task):
 
         super().__init__(**kwargs)
 
-    @defaults_from_attrs("bucket")
+    @defaults_from_attrs("bucket", "upload_options")
     def run(
         self,
         data: str,
@@ -124,6 +134,7 @@ class S3Upload(Task):
         credentials: dict = None,
         bucket: str = None,
         compression: str = None,
+        upload_options: dict = None,
     ):
         """
         Task run method.
@@ -140,6 +151,8 @@ class S3Upload(Task):
             - bucket (str, optional): the name of the S3 Bucket to upload to
             - compression (str, optional): specifies a file format for compression,
                 compressing data before upload. Currently supports `'gzip'`.
+            - upload_options (dict, optional): Additional options for s3 client
+                `upload_fileobj()` method `ExtraArgs` argument
 
         Returns:
             - str: the name of the Key the data payload was uploaded to
@@ -167,7 +180,9 @@ class S3Upload(Task):
             key = str(uuid.uuid4())
 
         # upload
-        s3_client.upload_fileobj(stream, Bucket=bucket, Key=key)
+        s3_client.upload_fileobj(
+            stream, Bucket=bucket, Key=key, ExtraArgs=upload_options
+        )
         return key
 
 

--- a/tests/tasks/aws/test_s3.py
+++ b/tests/tasks/aws/test_s3.py
@@ -121,6 +121,15 @@ class TestS3Upload:
             "session.Session()" in mocked_boto_client.return_value._extract_mock_name()
         )
 
+    def test_upload_options_forwarded(self, mocked_boto_client):
+        custom_upload_options = {"a_custom": "option"}
+        task = S3Upload(bucket="test", upload_options=custom_upload_options)
+        task.run(data="")
+        assert (
+            mocked_boto_client.upload_fileobj.call_args[1]["ExtraArgs"]
+            == custom_upload_options
+        )
+
 
 class TestS3List:
     def test_initialization(self):


### PR DESCRIPTION
Brings S3Upload into line with similar functionality in S3 Storage, and Result

closes [7466](https://github.com/PrefectHQ/prefect/issues/7466)

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Enables you to pass options like server-side encryption to the upload

### Example
```
task = S3Upload(bucket="my_bucket", upload_options={'ServerSideEncryption': 'AES256'})
```
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
