### PR TITLE
Fix `visit_collection` handling of IO objects

### DIFF
--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -1,6 +1,7 @@
 """
 Utilities for extensions of and operations on Python collections.
 """
+import io
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterator as IteratorABC
@@ -134,13 +135,14 @@ def isiterable(obj: Any) -> bool:
     Excludes types that are iterable but typically used as singletons:
     - str
     - bytes
+    - IO objects
     """
     try:
         iter(obj)
     except TypeError:
         return False
     else:
-        return not isinstance(obj, (str, bytes))
+        return not isinstance(obj, (str, bytes, io.IOBase))
 
 
 def ensure_iterable(obj: Union[T, Iterable[T]]) -> Iterable[T]:
@@ -266,7 +268,7 @@ def visit_collection(
         return result if return_data else None
 
     # Get the expression type; treat iterators like lists
-    typ = list if isinstance(expr, IteratorABC) else type(expr)
+    typ = list if isinstance(expr, IteratorABC) and isiterable(expr) else type(expr)
     typ = cast(type, typ)  # mypy treats this as 'object' otherwise and complains
 
     # Then visit every item in the expression if it is a collection

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -1,3 +1,4 @@
+import io
 import json
 import uuid
 from dataclasses import dataclass
@@ -251,6 +252,30 @@ class TestVisitCollection:
         result = visit_collection(inp, visit_fn=add_to_visited_list, return_data=False)
         assert result is None
         assert VISITED == expected
+
+    @pytest.mark.parametrize(
+        "inp,expected",
+        [
+            (sorted([1, 2, 3]), [1, -2, 3]),
+            # Not treated as iterators:
+            ("test", "test"),
+            (b"test", b"test"),
+        ],
+    )
+    def test_visit_collection_iterators(self, inp, expected):
+        result = visit_collection(inp, visit_fn=negative_even_numbers, return_data=True)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            io.StringIO("test"),
+            io.BytesIO(b"test"),
+        ],
+    )
+    def test_visit_collection_io_iterators(self, inp):
+        result = visit_collection(inp, visit_fn=lambda x: x, return_data=True)
+        assert result is inp
 
     def test_visit_collection_allows_mutation_of_nodes(self):
         def collect_and_drop_x_from_dicts(node):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

`visit_collection` treats all iterators as lists which does not work for `io.BaseIO` types, coercing them to an empty list. This means users could not pass IO objects between tasks. This pull request does not attempt to traverse IO types, making use of (and extending) our `isiterator` utility.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
import io
from prefect import task, flow


@task
def string_to_io():
    return io.StringIO("hello prefect")


@task
def consume(string_io):
    print(type(string_io))
   # <--- Previously the failure would occur here as `string_io` would be `[]`
    return string_io.read()


@flow
def test():
    str_io = string_to_io()
    r = consume(str_io)
    print(r)


test()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
