### PR TITLE
Expose `prefetch-seconds` in `prefect agent` CLI

### DIFF
--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -46,8 +46,8 @@ Configuration parameters you can specify when starting an agent include:
 | --- | --- |
 | -q, --work-queue | One or more work queues that the agent will poll for work. |
 | --api TEXT       | The API URL for the Prefect Orion server. Default is the value of `PREFECT_API_URL`. |
-| --run-oce        | Only run agent polling once. By default, the agent runs forever |
-| --prefetch-secods | The amount of time before a flow runs scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
+| --run-once        | Only run agent polling once. By default, the agent runs forever. |
+| --prefetch-seconds | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
 | --hide-welcome   | Do not display the startup ASCII art for the agent process.                          |
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -36,7 +36,7 @@ Agent processes are lightweight polling services that get scheduled work from a 
 
 It is possible for multiple agent processes to be started for a single work queue, or for one agent to pull work from multiple work queues. Each agent process sends a unique ID to the server to help disambiguate themselves and let users know how many agents are active.
 
-### Agent configuration
+### Agent options
 
 Agents are configured to pull work from one or more work queues. If the agent references a work queue that doesn't exist, it will be created automatically.
 
@@ -46,6 +46,8 @@ Configuration parameters you can specify when starting an agent include:
 | --- | --- |
 | -q, --work-queue | One or more work queues that the agent will poll for work. |
 | --api TEXT       | The API URL for the Prefect Orion server. Default is the value of `PREFECT_API_URL`. |
+| --run-oce        | Only run agent polling once. By default, the agent runs forever |
+| --prefetch-secods | The amount of time before a flow runs scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
 | --hide-welcome   | Do not display the startup ASCII art for the agent process.                          |
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.
@@ -57,6 +59,8 @@ You must start an agent within an environment that can access or create the infr
     `PREFECT_API_URL` must be set for the environment in which your agent is running or specified when starting the agent with the `--api` flag. 
 
     If you want an agent to communicate with Prefect Cloud or a Prefect Orion API server from a remote execution environment such as a VM or Docker container, you must configure `PREFECT_API_URL` in that environment.
+
+### Starting an agent
 
 Use the `prefect agent start` CLI command to start an agent. You must pass at least one work queue name that the agent will poll for work. If the work queue does not exist, it will be created.
 
@@ -89,6 +93,10 @@ Agent started! Looking for work from queue(s): my-queue...
 In this case, Prefect automatically created a new `my-queue` work queue.
 
 By default, the agent polls the API specified by the `PREFECT_API_URL` environment variable. To configure the agent to poll from a different server location, use the `--api` flag, specifying the URL of the server.
+
+### Configuring prefetch
+
+By default, the agent begins submission of flow runs a short time (10 seconds) before they are scheduled to run. This allows time for the infrastructure to be created, so the flow run can start on time. In some cases, infrastructure will take longer than this to actually start the flow run. In these cases, the prefetch can be increased using the `--prefetch-seconds` option or the `PREFECT_AGENT_PREFETCH_SECONDS` setting. Submission can begin an arbitrary amount of time before the flow run is scheduled to start. If this value is _larger_ than the amount of time it takes for the infrastructure to start, the flow run will _wait_ until its scheduled start time. This allows flow runs to start exactly on time.
 
 ## Work queue overview
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ readchar >= 3.0.6
 rich >= 11.0
 sqlalchemy[asyncio] >= 1.4.20, != 1.4.33
 toml >= 0.10.0
-typer >= 0.4.2m
+typer >= 0.4.2
 typing_extensions >= 4.1.0
 uvicorn  >= 0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ readchar >= 3.0.6
 rich >= 11.0
 sqlalchemy[asyncio] >= 1.4.20, != 1.4.33
 toml >= 0.10.0
-typer >= 0.4.1
+typer >= 0.4.2m
 typing_extensions >= 4.1.0
 uvicorn  >= 0.14.0

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -13,7 +13,11 @@ from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
 from prefect.client import get_client
 from prefect.exceptions import ObjectNotFound
-from prefect.settings import PREFECT_AGENT_QUERY_INTERVAL, PREFECT_API_URL
+from prefect.settings import (
+    PREFECT_AGENT_PREFETCH_SECONDS,
+    PREFECT_AGENT_QUERY_INTERVAL,
+    PREFECT_API_URL,
+)
 from prefect.utilities.services import critical_service_loop
 
 agent_app = PrefectTyper(
@@ -59,6 +63,7 @@ async def start(
     run_once: bool = typer.Option(
         False, help="Run the agent loop once, instead of forever."
     ),
+    prefetch_seconds: int = SettingsOption(PREFECT_AGENT_PREFETCH_SECONDS),
     # deprecated tags
     tags: List[str] = typer.Option(
         None,
@@ -129,7 +134,9 @@ async def start(
             )
 
     async with OrionAgent(
-        work_queues=work_queues, work_queue_prefix=work_queue_prefix
+        work_queues=work_queues,
+        work_queue_prefix=work_queue_prefix,
+        prefetch_seconds=prefetch_seconds,
     ) as agent:
         if not hide_welcome:
             app.console.print(ascii_name)

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -56,7 +56,7 @@ else:
 
 # MagicMock supports async magic methods in Python 3.8+
 
-if True or sys.version_info < (3, 8):
+if sys.version_info < (3, 8):
     from unittest.mock import MagicMock as _MagicMock
     from unittest.mock import MagicProxy as _MagicProxy
 

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -54,6 +54,46 @@ if sys.version_info < (3, 8):
 else:
     from unittest.mock import AsyncMock  # noqa
 
+# MagicMock supports async magic methods in Python 3.8+
+
+if True or sys.version_info < (3, 8):
+    from unittest.mock import MagicMock as _MagicMock
+    from unittest.mock import MagicProxy as _MagicProxy
+
+    class MagicMock(_MagicMock):
+        def _mock_set_magics(self):
+            """Patch to include proxies for async methods"""
+            super()._mock_set_magics()
+
+            for attr in {"__aenter__", "__aexit__", "__anext__"}:
+                if not hasattr(MagicMock, attr):
+                    setattr(MagicMock, attr, _MagicProxy(attr, self))
+
+        def _get_child_mock(self, **kw):
+            """Patch to return async mocks for async methods"""
+            # This implemetation copied from unittest in Python 3.8
+            _new_name = kw.get("_new_name")
+            if _new_name in self.__dict__.get("_spec_asyncs", {}):
+                return AsyncMock(**kw)
+
+            _type = type(self)
+            if issubclass(_type, MagicMock) and _new_name in {
+                "__aenter__",
+                "__aexit__",
+                "__anext__",
+            }:
+                if self._mock_sealed:
+                    attribute = "." + kw["name"] if "name" in kw else "()"
+                    mock_name = self._extract_mock_name() + attribute
+                    raise AttributeError(mock_name)
+
+                return AsyncMock(**kw)
+
+            return super()._get_child_mock(**kw)
+
+else:
+    from unittest.mock import MagicMock
+
 
 def kubernetes_environments_equal(
     actual: List[Dict[str, str]],

--- a/src/prefect/utilities/compat.py
+++ b/src/prefect/utilities/compat.py
@@ -23,6 +23,7 @@ if sys.version_info < (3, 9):
 else:
     from asyncio import to_thread as asyncio_to_thread
 
+
 if sys.version_info < (3, 8) and sys.platform != "win32":
     # https://docs.python.org/3/library/asyncio-policy.html#asyncio.ThreadedChildWatcher
     # `ThreadedChildWatcher` is the default child process watcher for Python 3.8+ but it

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -46,6 +46,21 @@ def test_start_agent_with_work_queue_and_tags():
     )
 
 
+def test_start_agent_with_prefetch_seconds():
+    invoke_and_assert(
+        command=[
+            "agent",
+            "start",
+            "--prefetch-seconds",
+            "30",
+            "-q",
+            "default",
+            "--run-once",
+        ],
+        expected_code=0,
+    )
+
+
 def test_start_agent_with_regex_and_work_queue():
     invoke_and_assert(
         command=["agent", "start", "hello", "-m", "blue"],

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -1,9 +1,10 @@
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY
 
 import prefect.cli.agent
 from prefect import OrionClient
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS, temporary_settings
 from prefect.testing.cli import invoke_and_assert
+from prefect.testing.utilities import MagicMock
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Adds `--prefetch-seconds` to the CLI, this was previously available only in the `OrionAgent` interface or by changing a setting.

The [documentation](https://deploy-preview-7498--prefect-orion.netlify.app/concepts/work-queues/#configuring-prefetch) should be a good overview of the use-case.

Includes a `prefect.testing.utilities.MagicMock` backport for Python 3.7 with async method support to resolve [3.7-specific CI failures](https://github.com/PrefectHQ/prefect/actions/runs/3447020891/jobs/5752588235).

Includes a minimum typer version bump to a fix a bug where lists were parsed as tuples.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

`prefect agent start --prefetch-seconds 60 -q test`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
