### PR TITLE
Add `--run-once` to `prefect agent start` CLI

### DIFF
--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -56,6 +56,9 @@ async def start(
     ),
     hide_welcome: bool = typer.Option(False, "--hide-welcome"),
     api: str = SettingsOption(PREFECT_API_URL),
+    run_once: bool = typer.Option(
+        False, help="Run the agent loop once, instead of forever."
+    ),
     # deprecated tags
     tags: List[str] = typer.Option(
         None,
@@ -145,6 +148,7 @@ async def start(
             agent.get_and_submit_flow_runs,
             PREFECT_AGENT_QUERY_INTERVAL.value(),
             printer=app.console.print,
+            run_once=run_once,
         )
 
     app.console.print("Agent stopped!")

--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -77,6 +77,7 @@ def invoke_and_assert(
         ctx = runner.isolated_filesystem(temp_dir=temp_dir)
     else:
         ctx = contextlib.nullcontext()
+
     with ctx:
         result = runner.invoke(app, command, catch_exceptions=False, input=user_input)
 

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -16,6 +16,7 @@ async def critical_service_loop(
     memory: int = 10,
     consecutive: int = 3,
     printer: Callable[..., None] = print,
+    run_once: bool = False,
 ):
     """
     Runs the given `workload` function on the specified `interval`, while being
@@ -24,11 +25,12 @@ async def critical_service_loop(
     exceptions to `printer`, then exit.
 
     Args:
-        `workload`: the function to call
-        `interval`: how frequently to call it
-        `memory`: how many recent errors to remember
-        `consecutive`: how many consecutive errors must we see before we exit
-        `printer`: a `print`-like function where errors will be reported
+        workload: the function to call
+        interval: how frequently to call it
+        memory: how many recent errors to remember
+        consecutive: how many consecutive errors must we see before we exit
+        printer: a `print`-like function where errors will be reported
+        run_once: if set, the loop will only run once then return
     """
 
     track_record: Deque[bool] = deque([True] * consecutive, maxlen=consecutive)
@@ -95,6 +97,9 @@ async def critical_service_loop(
             for exception, traceback in failures_by_type:
                 printer("".join(format_exception(None, exception, traceback)))
                 printer()
+            return
+
+        if run_once:
             return
 
         await anyio.sleep(interval)

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -1,4 +1,6 @@
+from prefect import OrionClient
 from prefect.testing.cli import invoke_and_assert
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
 
 def test_start_agent_with_no_args():
@@ -7,6 +9,27 @@ def test_start_agent_with_no_args():
         expected_output="No work queues provided!",
         expected_code=1,
     )
+
+
+def test_start_agent_run_once():
+    invoke_and_assert(
+        command=["agent", "start", "--run-once", "-q", "test"],
+        expected_code=0,
+        expected_output_contains=["Agent started!", "Agent stopped!"],
+    )
+
+
+async def test_start_agent_creates_work_queue(orion_client: OrionClient):
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        command=["agent", "start", "--run-once", "-q", "test"],
+        expected_code=0,
+        expected_output_contains=["Agent stopped!", "Agent started!"],
+    )
+
+    queue = await orion_client.read_work_queue_by_name("test")
+    assert queue
+    assert queue.name == "test"
 
 
 def test_start_agent_with_work_queue_and_tags():


### PR DESCRIPTION
The agent CLI is woefully untested and this is particularly useful for testing. I can see other cases where a user would want to run a single iteration of the agent as well, like a lambda.

Required for testing in #7498

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
❯ prefect agent start --run-once -q test
Starting v2.6.7+2.gb79491988 agent with ephemeral API...

  ___ ___ ___ ___ ___ ___ _____     _   ___ ___ _  _ _____
 | _ \ _ \ __| __| __/ __|_   _|   /_\ / __| __| \| |_   _|
 |  _/   / _|| _|| _| (__  | |    / _ \ (_ | _|| .` | | |
 |_| |_|_\___|_| |___\___| |_|   /_/ \_\___|___|_|\_| |_|


Agent started! Looking for work from queue(s): test...
Agent stopped!
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
