### PR TITLE
Fix typo in Docker tutorial

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -86,7 +86,7 @@ The `prefect deployment build` command also supports specifying a built-in infra
 To demonstrate using an infrastructure block, we'll create a new variation of the deployment for the `log_flow` example from the [deployments tutorial](/tutorials/deployments/). For this deployment, we'll include the following options to the `prefect deployment build` command:
 
 - Use the storage block created in the [Storage and Infrastructure](/tutorials/storage/) tutorial by passing `-sb s3/log-test` or `--storage-block s3/log-test`.
-- Use the infrastructure block created earlier by passing `-ib docker-container/log-tutorial` or `--storage-block s3/log-tutorial`.
+- Use the infrastructure block created earlier by passing `-ib docker-container/log-tutorial` or `--infra-block docker-container/log-tutorial`.
 
 <div class="terminal">
 ```bash


### PR DESCRIPTION
This PR just fixes a small typo in the docker tutorial in the docs

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
