### PR TITLE
Fix linking to Collections catalog

### DIFF
--- a/docs/concepts/blocks.md
+++ b/docs/concepts/blocks.md
@@ -257,7 +257,7 @@ Blocks can be registered from a Python module available in the current virtual e
 $ prefect block register --module prefect_aws.credentials
 ```
 
-This command is useful for registering all blocks found in the credentials module within [Prefect Collections](/collections/overview).
+This command is useful for registering all blocks found in the credentials module within [Prefect Collections](/collections/catalog/).
 
 Or, if a block has been created in a `.py` file, the block can also be registered with the CLI command:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,13 @@ prefect dev build-docs  \
 """
 publish = "site"
 
+# moved page redirects #
+
+[[redirects]]
+  from = "/collections/overview/"
+  to = "/collections/catalog/"
+  status = 301
+
 # redirect v1 traffic to docs-v1.prefect.io
 [[redirects]]
   from = "/core/*"


### PR DESCRIPTION
Reorganizing the collections catalog broke a previous URL to the collections. Fixing link in Blocks docs and adding a redirect to handle any user bookmarks.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
