### PR TITLE
Provide docstring for ContextModel.copy

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -99,8 +99,8 @@ class ContextModel(BaseModel):
             update: Values to change/add in the new model. Note: the data is not validated before creating
                 the new model - you should trust this data.
             deep: Set to `True` to make a deep copy of the model.
-        
-        Returns: 
+
+        Returns:
             A new model instance.
         """
         # Remove the token on copy to avoid re-entrance errors

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -90,6 +90,19 @@ class ContextModel(BaseModel):
         return cls.__var__.get(None)
 
     def copy(self, **kwargs):
+        """
+        Duplicate the context model, optionally choosing which fields to include, exclude, or change.
+
+        Attributes:
+            include: Fields to include in new model.
+            exclude: Fields to exclude from new model, as with values this takes precedence over include.
+            update: Values to change/add in the new model. Note: the data is not validated before creating
+                the new model - you should trust this data.
+            deep: Set to `True` to make a deep copy of the model.
+        
+        Returns: 
+            A new model instance.
+        """
         # Remove the token on copy to avoid re-entrance errors
         new = super().copy(**kwargs)
         new._token = None


### PR DESCRIPTION
Add a docstring to override the imported pydantic docstring. Formatting of the imported docstring was not interpreted correctly by mkdocstrings.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

[Preview](https://deploy-preview-7539--prefect-orion.netlify.app/api-ref/prefect/context/#prefect.context.ContextModel.copy)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
