### PR TITLE
Fix positioning of Prefect Cloud link

### DIFF
--- a/docs/overrides/partials/tabs.html
+++ b/docs/overrides/partials/tabs.html
@@ -31,7 +31,8 @@
       {% for nav_item in nav %}
         {% include "partials/tabs-item.html" %}
       {% endfor %}
-      <li class="md-tabs__item cloud-link" style="float: right;"><a class="md-tabs__link" target="_blank" rel="noopener noreferrer" href="https://app.prefect.cloud"><b>Go to Prefect Cloud &#187;</b></a></li>
+      <li class="md-tabs__item cloud-filler"></li>
+      <li class="md-tabs__item cloud-link"><a class="md-tabs__link" target="_blank" rel="noopener noreferrer" href="https://app.prefect.cloud"><b>Go to Prefect Cloud &#187;</b></a></li>
     </ul>
   </div>
 </nav>

--- a/docs/overrides/partials/tabs.html
+++ b/docs/overrides/partials/tabs.html
@@ -31,7 +31,6 @@
       {% for nav_item in nav %}
         {% include "partials/tabs-item.html" %}
       {% endfor %}
-      <li class="md-tabs__item cloud-filler"></li>
       <li class="md-tabs__item cloud-link"><a class="md-tabs__link" target="_blank" rel="noopener noreferrer" href="https://app.prefect.cloud"><b>Go to Prefect Cloud &#187;</b></a></li>
     </ul>
   </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -60,6 +60,11 @@ img {
     margin-bottom: 0;
 }
 
+/* push "go to prefect cloud" */
+.cloud-filler {
+    flex-grow: 1;
+}
+
 /* Table formatting */
 .md-typeset table:not([class]) {
     font-size: .8rem;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -61,8 +61,8 @@ img {
 }
 
 /* push "go to prefect cloud" */
-.cloud-filler {
-    flex-grow: 1;
+.cloud-link {
+    margin-left: auto;
 }
 
 /* Table formatting */


### PR DESCRIPTION
Fixes positioning of "Go to Prefect Cloud" link in docs header.

This was floating right properly, but somewhere along the way it moved back to the left. I think this is a CSS difference between Material for Mkdocs and Insiders. 

Anyway minor adjustment to get it right-justified with Insiders builds again.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
