### PR TITLE
Update props on TaskRun and FlowRun pages

### DIFF
--- a/orion-ui/package-lock.json
+++ b/orion-ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ui-orion",
       "version": "0.1.0",
       "dependencies": {
-        "@prefecthq/orion-design": "1.1.6",
+        "@prefecthq/orion-design": "1.1.10",
         "@prefecthq/prefect-design": "1.1.29",
         "@prefecthq/vue-compositions": "0.2.6",
         "@types/lodash.debounce": "4.0.7",
@@ -229,15 +229,15 @@
       }
     },
     "node_modules/@prefecthq/orion-design": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.1.6.tgz",
-      "integrity": "sha512-4jcgPnZgfw9DhpZkVmPUyzV+N6caBFN90iStrE+p16GvA+JRYH0o779bKSQoB0EAXxoMAIqfdRxsPD2wHNZfMA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.1.10.tgz",
+      "integrity": "sha512-1JYtWIBUxhQeQukV4a4eOADf77biovxpveeN2hPlsA/oPcWdEefYXMARS3sokY/komt8RE6bbNb2k7oUjnzkBA==",
       "dependencies": {
         "@fontsource/inconsolata": "^4.5.9",
         "@fontsource/inter": "4.5.14",
         "@prefecthq/radar": "0.0.17",
         "@prefecthq/vue-charts": "0.0.19",
-        "@prefecthq/vue-compositions": "0.2.6",
+        "@prefecthq/vue-compositions": "0.2.9",
         "axios": "0.27.2",
         "cronstrue": "^2.14.0",
         "date-fns": "2.29.3",
@@ -250,6 +250,24 @@
         "vee-validate": "^4.5.11",
         "vue": "^3.2.41",
         "vue-router": "^4.0.12"
+      }
+    },
+    "node_modules/@prefecthq/orion-design/node_modules/@prefecthq/vue-compositions": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-0.2.9.tgz",
+      "integrity": "sha512-3MRzVoKRh6sR15kzI1gy8ksVQNedy4dYJQMVXO+QpOSCiONMZnv18uaHfFVuylw5XpDYoeWZSrZ4vgWvjPTOaA==",
+      "peerDependencies": {
+        "lodash.debounce": "^4.0.8",
+        "vue": "^3.2.36",
+        "vue-router": "^4.0.15"
+      },
+      "peerDependenciesMeta": {
+        "lodash.debounce": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@prefecthq/prefect-design": {
@@ -5104,21 +5122,29 @@
       }
     },
     "@prefecthq/orion-design": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.1.6.tgz",
-      "integrity": "sha512-4jcgPnZgfw9DhpZkVmPUyzV+N6caBFN90iStrE+p16GvA+JRYH0o779bKSQoB0EAXxoMAIqfdRxsPD2wHNZfMA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@prefecthq/orion-design/-/orion-design-1.1.10.tgz",
+      "integrity": "sha512-1JYtWIBUxhQeQukV4a4eOADf77biovxpveeN2hPlsA/oPcWdEefYXMARS3sokY/komt8RE6bbNb2k7oUjnzkBA==",
       "requires": {
         "@fontsource/inconsolata": "^4.5.9",
         "@fontsource/inter": "4.5.14",
         "@prefecthq/radar": "0.0.17",
         "@prefecthq/vue-charts": "0.0.19",
-        "@prefecthq/vue-compositions": "0.2.6",
+        "@prefecthq/vue-compositions": "0.2.9",
         "axios": "0.27.2",
         "cronstrue": "^2.14.0",
         "date-fns": "2.29.3",
         "date-fns-tz": "1.3.7",
         "prismjs": "1.29.0",
         "rrule": "^2.7.1"
+      },
+      "dependencies": {
+        "@prefecthq/vue-compositions": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-0.2.9.tgz",
+          "integrity": "sha512-3MRzVoKRh6sR15kzI1gy8ksVQNedy4dYJQMVXO+QpOSCiONMZnv18uaHfFVuylw5XpDYoeWZSrZ4vgWvjPTOaA==",
+          "requires": {}
+        }
       }
     },
     "@prefecthq/prefect-design": {

--- a/orion-ui/package.json
+++ b/orion-ui/package.json
@@ -10,7 +10,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@prefecthq/orion-design": "1.1.6",
+    "@prefecthq/orion-design": "1.1.10",
     "@prefecthq/prefect-design": "1.1.29",
     "@prefecthq/vue-compositions": "0.2.6",
     "@types/lodash.debounce": "4.0.7",

--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -73,7 +73,7 @@
   })
 
   const api = useWorkspaceApi()
-  const flowRunDetailsSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 5000 })
+  const flowRunDetailsSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 30000 })
   const flowRun = computed(() => flowRunDetailsSubscription.response)
 
   watch(flowRunId, (oldFlowRunId, newFlowRunId) => {

--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -1,7 +1,7 @@
 <template>
   <p-layout-well class="flow-run">
     <template #header>
-      <PageHeadingFlowRun v-if="flowRun" :flow-run="flowRun" @delete="goToFlowRuns" />
+      <PageHeadingFlowRun v-if="flowRun" :flow-run-id="flowRun.id" @delete="goToFlowRuns" />
     </template>
 
     <p-tabs v-model:selected="selectedTab" :tabs="tabs">

--- a/orion-ui/src/pages/TaskRun.vue
+++ b/orion-ui/src/pages/TaskRun.vue
@@ -1,7 +1,7 @@
 <template>
   <p-layout-well v-if="taskRun" class="task-run">
     <template #header>
-      <PageHeadingTaskRun :task-run="taskRun" @delete="goToFlowRun" />
+      <PageHeadingTaskRun :task-run-id="taskRun.id" @delete="goToFlowRun" />
     </template>
 
     <p-tabs :tabs="tabs">

--- a/orion-ui/src/pages/TaskRun.vue
+++ b/orion-ui/src/pages/TaskRun.vue
@@ -47,7 +47,7 @@
   })
 
   const taskRunIdArgs = computed<[string] | null>(() => taskRunId.value ? [taskRunId.value] : null)
-  const taskRunDetailsSubscription = useSubscriptionWithDependencies(api.taskRuns.getTaskRun, taskRunIdArgs)
+  const taskRunDetailsSubscription = useSubscriptionWithDependencies(api.taskRuns.getTaskRun, taskRunIdArgs, { interval: 30000 })
   const taskRun = computed(() => taskRunDetailsSubscription.response)
 
   const flowRunId = computed(() => taskRun.value?.flowRunId)


### PR DESCRIPTION
### Description
The issue came from this https://github.com/PrefectHQ/orion-design/pull/786 and here we switch WorkspaceFlowRun and WorkspaceTaskRun to pass ids as a prop instead full object to be able to refresh subscriptions on after change

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
