### PR TITLE
Fix `PrefectConsoleHandler` bug where log tracebacks were excluded

### DIFF
--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -123,3 +123,14 @@ def invoke_and_assert(
         ), f"Expected {expected_line_count} lines of CLI output, only {line_count} lines present"
 
     return result
+
+
+@contextlib.contextmanager
+def temporary_console_width(console, width):
+    original = console.width
+
+    try:
+        console._width = width
+        yield
+    finally:
+        console._width = original

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -140,37 +140,33 @@ def test_register_fails_on_multiple_options():
 
 
 def test_listing_blocks_when_none_are_registered():
-    expected_output = (
-        "ID",
-        "Type",
-        "Name",
-        "Slug",
-    )
-
     invoke_and_assert(
         ["block", "ls"],
-        expected_code=0,
-        expected_output_contains=expected_output,
-        expected_line_count=10,
+        expected_output_contains=(
+            f"""                           
+           ┏━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
+           ┃ ID ┃ Type ┃ Name ┃ Slug ┃
+           ┡━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩
+           └────┴──────┴──────┴──────┘
+            """
+        ),
     )
 
 
 def test_listing_blocks_after_saving_a_block():
-    system.JSON(value="a casual test block").save("wildblock")
-
-    expected_output = (
-        "ID",
-        "Type",
-        "Name",
-        "Slug",
-        "wildblock",
-    )
+    block_id = system.JSON(value="a casual test block").save("wildblock")
 
     invoke_and_assert(
         ["block", "ls"],
-        expected_code=0,
-        expected_output_contains=expected_output,
-        expected_line_count=11,
+        expected_output_contains=(
+            f"""                           
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+            ┃ ID                                   ┃ Type ┃ Name      ┃ Slug           ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
+            │ {block_id} │ JSON │ wildblock │ json/wildblock │
+            └──────────────────────────────────────┴──────┴───────────┴────────────────┘  
+            """
+        ),
     )
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1094,6 +1094,50 @@ class TestPrefectConsoleHandler:
         ]
         assert handler.level == logging.DEBUG
 
+    def test_uses_stderr_by_default(self, capsys):
+        logger = get_logger()
+        logger.handlers = [PrefectConsoleHandler()]
+        logger.info("Test!")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert "Test!" in stderr
+
+    def test_respects_given_stream(self, capsys):
+        logger = get_logger()
+        logger.handlers = [PrefectConsoleHandler(stream=sys.stdout)]
+        logger.info("Test!")
+        stdout, stderr = capsys.readouterr()
+        assert stderr == ""
+        assert "Test!" in stdout
+
+    def test_includes_tracebacks_during_exceptions(self, capsys):
+        logger = get_logger()
+        logger.handlers = [PrefectConsoleHandler()]
+
+        try:
+            raise ValueError("oh my")
+        except:
+            logger.exception("Helpful context!")
+
+        _, stderr = capsys.readouterr()
+        assert "Helpful context!" in stderr
+        assert "Traceback" in stderr
+        assert 'raise ValueError("oh my")' in stderr
+        assert "ValueError: oh my" in stderr
+
+    def test_does_not_word_wrap_or_crop_messages(self, capsys):
+        logger = get_logger()
+        handler = PrefectConsoleHandler()
+        # Pretend we have a narrow little console
+        handler.console._width = 10
+        logger.handlers = [handler]
+
+        logger.info("x" * 1000)
+
+        _, stderr = capsys.readouterr()
+        # There will be newlines in the middle if cropped
+        assert "x" * 1000 in stderr
+
 
 @pytest.fixture
 def flow_run_caplog(caplog):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -51,6 +51,7 @@ from prefect.settings import (
     PREFECT_LOGGING_SETTINGS_PATH,
     temporary_settings,
 )
+from prefect.testing.cli import temporary_console_width
 from prefect.testing.utilities import AsyncMock
 
 
@@ -1128,11 +1129,11 @@ class TestPrefectConsoleHandler:
     def test_does_not_word_wrap_or_crop_messages(self, capsys):
         logger = get_logger()
         handler = PrefectConsoleHandler()
-        # Pretend we have a narrow little console
-        handler.console._width = 10
         logger.handlers = [handler]
 
-        logger.info("x" * 1000)
+        # Pretend we have a narrow little console
+        with temporary_console_width(handler.console, 10):
+            logger.info("x" * 1000)
 
         _, stderr = capsys.readouterr()
         # There will be newlines in the middle if cropped

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1096,7 +1096,7 @@ class TestPrefectConsoleHandler:
         assert handler.level == logging.DEBUG
 
     def test_uses_stderr_by_default(self, capsys):
-        logger = get_logger()
+        logger = get_logger(uuid.uuid4().hex)
         logger.handlers = [PrefectConsoleHandler()]
         logger.info("Test!")
         stdout, stderr = capsys.readouterr()
@@ -1104,7 +1104,7 @@ class TestPrefectConsoleHandler:
         assert "Test!" in stderr
 
     def test_respects_given_stream(self, capsys):
-        logger = get_logger()
+        logger = get_logger(uuid.uuid4().hex)
         logger.handlers = [PrefectConsoleHandler(stream=sys.stdout)]
         logger.info("Test!")
         stdout, stderr = capsys.readouterr()
@@ -1112,7 +1112,7 @@ class TestPrefectConsoleHandler:
         assert "Test!" in stdout
 
     def test_includes_tracebacks_during_exceptions(self, capsys):
-        logger = get_logger()
+        logger = get_logger(uuid.uuid4().hex)
         logger.handlers = [PrefectConsoleHandler()]
 
         try:
@@ -1127,7 +1127,7 @@ class TestPrefectConsoleHandler:
         assert "ValueError: oh my" in stderr
 
     def test_does_not_word_wrap_or_crop_messages(self, capsys):
-        logger = get_logger()
+        logger = get_logger(uuid.uuid4().hex)
         handler = PrefectConsoleHandler()
         logger.handlers = [handler]
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

The logging handler added in #6101 did not include the proper formatting and consequently dropped tracebacks from `logger.exception(...)`. This pull request:
- Fixes the bug, restoring tracebacks
- Disables word-wrapping/cropping at the same time because log output should not be wrapped
- Restores usage of stderr for logs instead of stdout

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
