### PR TITLE
Make stale action more likely to close issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,11 +11,10 @@ jobs:
         with:
           stale-issue-message: "This issue is stale because it has been open 30 days with no activity. To keep this issue open remove stale label or comment."
           stale-issue-label: "status:stale"
-          close-issue-message: "This issue was closed because it has been stale for 7 days with no activity. If this issue is important or you have more to add feel free to re-open it."
-          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. To keep this pull request open remove stale label or comment."
-          stale-pr-label: "status:stale"
-          close-pr-message: "This pull request was closed because it has been stale for 7 days with no activity. If this pull request is important or you have more to add feel free to re-open it."
+          close-issue-message: "This issue was closed because it has been stale for 14 days with no activity. If this issue is important or you have more to add feel free to re-open it."
           days-before-stale: 30
+          days-before-pr-stale: -1 # Disable stale-ing PRs
           days-before-close: 14
-          exempt-draft-pr: true
           exempt-issue-labels: "status:in-progress,status:roadmap,status:accepted"
+          ascending: true # https://github.com/actions/stale#ascending
+          operations-per-run: 60


### PR DESCRIPTION
This makes several small changes to the stale action:

- Disables PR stale-ing. When debug / analytics were turned on a lot of operations were spent (over half) checking PRs and given the relatively small set of PRs it's likely not a great use of those operations.
- Sets `ascending` to `true`. If I'm reading the docs correctly this should result in in looking at old issues first.
- Doubles the number of operations it can perform, default is 30, this gives it 60.
- Updates messaging.