### PR TITLE
Fix error with empty paths using LocalFileSystem

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -92,13 +92,17 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
             return str(value)
         return value
 
-    def _resolve_path(self, path: str) -> Path:
-        # Only resolve the base path at runtime, default to the current directory
-        basepath = (
+    def _get_basepath(self):
+        """Get the resolved basepath if provided, otherwise use the current directory."""
+        return (
             Path(self.basepath).expanduser().resolve()
             if self.basepath
             else Path(".").resolve()
         )
+
+    def _resolve_path(self, path: str) -> Path:
+        # Only resolve the base path at runtime, default to the current directory
+        basepath = self._get_basepath()
 
         # Determine the path to access relative to the base path, ensuring that paths
         # outside of the base path are off limits
@@ -124,7 +128,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         Defaults to copying the entire contents of the block's basepath to the current working directory.
         """
         if not from_path:
-            from_path = Path(self.basepath).expanduser().resolve()
+            from_path = self._get_basepath()
         else:
             from_path = Path(from_path).resolve()
 
@@ -167,7 +171,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         An `ignore_file` path may be provided that can include gitignore style expressions for filepaths to ignore.
         """
         if not to_path:
-            to_path = Path(self.basepath).expanduser()
+            to_path = self._get_basepath()
 
         if not local_path:
             local_path = Path(".").absolute()

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -9,6 +9,7 @@ import prefect
 from prefect.exceptions import InvalidRepositoryURLError
 from prefect.filesystems import GitHub, LocalFileSystem, RemoteFileSystem
 from prefect.testing.utilities import AsyncMock
+from prefect.utilities.filesystem import tmpchdir
 
 TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
 
@@ -51,6 +52,132 @@ class TestLocalFileSystem:
     async def test_get_directory_duplicate_directory(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
         await fs.get_directory(".", ".")
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_get_directory_empty_local_path_uses_cwd(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that contents are copied to the CWD when no `local_path` is provided."""
+
+        # Construct the `from` directory
+        from_path = tmp_path / "from"
+        from_path.mkdir()
+        (from_path / "test").touch()
+
+        # Construct a clean working directory
+        cwd = tmp_path / "working"
+        cwd.mkdir()
+
+        fs = LocalFileSystem()
+        with tmpchdir(cwd):
+            await fs.get_directory(from_path=str(from_path), local_path=null_value)
+
+        assert (cwd / "test").exists()
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_get_directory_empty_from_path_uses_basepath(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that directory contents are copied from the basepath when no `from_path`
+        is provided.
+        """
+        # Construct a clean directory to copy to
+        local_path = tmp_path / "local"
+        local_path.mkdir()
+
+        # Construct a working directory with contents to copy
+        base_path = tmp_path / "base"
+        base_path.mkdir()
+        (base_path / "test").touch()
+
+        with tmpchdir(tmp_path):
+            fs = LocalFileSystem(basepath=base_path)
+            await fs.get_directory(from_path=null_value, local_path=local_path)
+        assert (local_path / "test").exists()
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_put_directory_empty_local_path_uses_cwd(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that CWD is used as the source when no `local_path` is provided."""
+
+        # Construct a clean directory to copy to
+        to_path = tmp_path / "to"
+        to_path.mkdir()
+
+        # Construct a working directory with contents to copy
+        cwd = tmp_path / "working"
+        cwd.mkdir()
+        (cwd / "test").touch()
+
+        fs = LocalFileSystem()
+        with tmpchdir(cwd):
+            await fs.put_directory(to_path=str(to_path), local_path=null_value)
+
+        assert (to_path / "test").exists()
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_put_directory_empty_from_path_uses_basepath(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that directory contents are copied to the basepath when no `to_path` is
+        provided.
+        """
+        # Construct a local path with contents to copy
+        local_path = tmp_path / "local"
+        local_path.mkdir()
+        (local_path / "test").touch()
+
+        # Construct a clean basepath directory
+        base_path = tmp_path / "base"
+        base_path.mkdir()
+
+        with tmpchdir(tmp_path):
+            fs = LocalFileSystem(basepath=base_path)
+            await fs.put_directory(to_path=null_value, local_path=local_path)
+        assert (local_path / "test").exists()
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_put_directory_basepath_is_cwd_if_not_provided(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that directory contents are copied to the CWD when no `to_path` is
+        provided and no `basepath` is provided.
+        """
+        # Construct a local path with contents to copy
+        local_path = tmp_path / "local"
+        local_path.mkdir()
+        (local_path / "test").touch()
+
+        # Construct a clean working directory
+        cwd = tmp_path / "working"
+        cwd.mkdir()
+
+        with tmpchdir(cwd):
+            fs = LocalFileSystem()
+            await fs.put_directory(to_path=null_value, local_path=local_path)
+        assert (cwd / "test").exists()
+
+    @pytest.mark.parametrize("null_value", {None, ""})
+    async def test_get_directory_basepath_is_cwd_if_not_provided(
+        self, tmp_path: Path, null_value
+    ):
+        """Check that directory contents are copied to the CWD when no `to_path` is
+        provided and no `basepath` is provided.
+        """
+        # Construct a local path with contents to copy
+        local_path = tmp_path / "local"
+        local_path.mkdir()
+
+        # Construct a clean working directory
+        cwd = tmp_path / "working"
+        cwd.mkdir()
+        (cwd / "test").touch()
+
+        with tmpchdir(cwd):
+            fs = LocalFileSystem()
+            await fs.get_directory(from_path=null_value, local_path=local_path)
+        assert (local_path / "test").exists()
 
 
 class TestRemoteFileSystem:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
This is a follow on PR to https://github.com/PrefectHQ/prefect/pull/7477
It adds tests for the changes made in that PR, and also adds handling for cases where a `basepath` was not provided to the `LocalFileSystem` which is necessary to address part of https://github.com/PrefectHQ/prefect/issues/7317 .

Previously we did a check like `if not from_path: from_path = Path(self.basepath).expanduser().resolve()` in `get_directory` and `put_directory`. This would error if the `basepath` was None. Now if an LFS block without a basepath calls get/put directory, it will treat the cwd as the basepath.

This currently CANNOT be merged until we change how temporary directories are created when running the engine.

The Process infrastructure block's run method currently spins up a subprocess in a random directory. Then from within that process, the storage block's get_directory method is called. put_directory is not called from this directory. This means that this isn't working correctly even when you resolve the paths if you don't supply as basepath.
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
