### PR TITLE
Update logging setup to support incremental configuration

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -20,6 +20,7 @@ __ui_static_path__ = __module_path__ / "orion" / "ui"
 
 del _version, pathlib
 
+
 # Import user-facing API
 from prefect.states import State
 from prefect.logging import get_run_logger
@@ -61,6 +62,12 @@ prefect.client.schemas.State.update_forward_refs(
 import prefect.plugins
 
 prefect.plugins.load_prefect_collections()
+
+
+# Configure logging
+import prefect.logging.configuration
+
+prefect.logging.configuration.setup_logging()
 
 
 # Ensure moved names are accessible at old locations

--- a/src/prefect/logging/configuration.py
+++ b/src/prefect/logging/configuration.py
@@ -60,7 +60,12 @@ def load_logging_config(path: Path) -> dict:
     return flatdict_to_dict(flat_config)
 
 
-def setup_logging() -> None:
+def setup_logging() -> dict:
+    """
+    Sets up logging.
+
+    Returns the config used.
+    """
     global PROCESS_LOGGING_CONFIG
 
     # If the user has specified a logging path and it exists we will ignore the
@@ -73,15 +78,8 @@ def setup_logging() -> None:
         )
     )
 
-    if PROCESS_LOGGING_CONFIG:
-        # Do not allow repeated configuration calls, only warn if the config differs
-        if PROCESS_LOGGING_CONFIG != config:
-            warnings.warn(
-                "Logging can only be setup once per process, the new logging config "
-                f"will be ignored.",
-                stacklevel=2,
-            )
-        return
+    # Perform an incremental update if setup has already been run
+    config.setdefault("incremental", bool(PROCESS_LOGGING_CONFIG))
 
     logging.config.dictConfig(config)
 
@@ -91,9 +89,12 @@ def setup_logging() -> None:
     for logger_name in PREFECT_LOGGING_EXTRA_LOGGERS.value():
         logger = logging.getLogger(logger_name)
         for handler in extra_config.handlers:
-            logger.addHandler(handler)
+            if not config["incremental"]:
+                logger.addHandler(handler)
             if logger.level == logging.NOTSET:
                 logger.setLevel(extra_config.level)
             logger.propagate = extra_config.propagate
 
     PROCESS_LOGGING_CONFIG = config
+
+    return config

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -15,7 +15,7 @@ from rich.highlighter import Highlighter, NullHighlighter
 from rich.theme import Theme
 
 import prefect.context
-from prefect.client import get_client
+from prefect.client.orion import get_client
 from prefect.exceptions import MissingContextError
 from prefect.logging.highlighters import PrefectConsoleHighlighter
 from prefect.orion.schemas.actions import LogCreate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ pytest.register_assert_rewrite("prefect.testing.utilities")
 
 import prefect
 import prefect.settings
+from prefect.logging import get_logger
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
     PREFECT_API_URL,
@@ -451,3 +452,20 @@ def reset_registered_blocks():
 
     registry.clear()
     registry.update(before)
+
+
+@pytest.fixture
+def caplog(caplog):
+    """
+    Overrides caplog to apply to all of our loggers that do not propagate and
+    consequently would not be captured by caplog.
+    """
+
+    config = setup_logging()
+
+    for name, logger_config in config["loggers"].items():
+        if not logger_config.get("propagate", True):
+            logger = get_logger(name)
+            logger.handlers.append(caplog.handler)
+
+    yield caplog

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -73,24 +73,6 @@ def parameterized_flow():
 
 
 @pytest.fixture
-def flow_run_caplog(caplog):
-    """
-    Capture logging from flow runs to ensure messages are correct.
-    """
-    import logging
-
-    logger = logging.getLogger("prefect.flow_runs")
-    logger2 = logging.getLogger("prefect")
-    logger.propagate = True
-    logger2.propagate = True
-
-    try:
-        yield caplog
-    finally:
-        logger.propagate = False
-
-
-@pytest.fixture
 async def get_flow_run_context(orion_client, result_factory, local_filesystem):
     partial_ctx = PartialModel(FlowRunContext)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Closes #5850, https://github.com/PrefectHQ/prefect-dask/issues/10, https://github.com/PrefectHQ/prefect-dask/issues/40
Related #6872 
<!-- Include an overview here -->

Previously, `setup_logging` was deferred until the a flow or task run started. A global variable was used to detect if it had been called already; if so, we'd exit so subsequent calls had no affect. Now, subsequent calls will trigger an "incremental" update. See the [standard library logging documentation](https://docs.python.org/3/library/logging.config.html#incremental-configuration) for details on incremental configuration.

This allows us to call `setup_logging` on import of Prefect. This is very convenient as there are other edge-cases where we want logging to be configured:
- CLI commands
- Uvicorn starting the server
- Dask workers
- Tests

We had to keep adding `setup_logging` calls to support these, but now logging will just be properly configured at all times.

The downside to this, is that only logging levels will be changed after import of Prefect. This means that changes to logging in profiles will not work if they attempt to change the _loggers_ used. This is a limitation of the Python logging libarary and we would roughly respect this previously anyway. This caveat does not apply to the profile that is in use when the process starts, just dynamic profile changes.

### Examples

Prefect logs are now displayed by the server; previously only Uvicorn logs were displayed
```
PREFECT_LOGGING_SERVER_LEVEL=DEBUG prefect orion start
```

Prefect run logs for tasks on Dask workers are now sent to the API
```python
from prefect import flow, get_run_logger, task
from prefect_dask.task_runners import DaskTaskRunner


@task
def bar():
    get_run_logger().info("bar")


# Also works with existing cluster e.g. `address="tcp://192.168.1.17:8786"`
@flow(task_runner=DaskTaskRunner)
def foo():
    get_run_logger().info("foo")
    bar.submit()


if __name__ == "__main__":
    foo()
```



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
