### PR TITLE
Add `log_prints` option to redirect print to logs

### DIFF
--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -159,7 +159,7 @@ from prefect import task, flow
 
 @task
 def my_task(log_prints=False):
-    print("we're logging print statements from a task")
+    print("not logging print statements in this task")
 
 @flow(log_prints=True)
 def my_flow():
@@ -175,15 +175,15 @@ Using `log_prints=False` at the task level will output:
 15:52:11.812 | INFO    | Flow run 'emerald-gharial' - we're logging print statements from a flow
 15:52:11.926 | INFO    | Flow run 'emerald-gharial' - Created task run 'my_task-20c6ece6-0' for task 'my_task'
 15:52:11.927 | INFO    | Flow run 'emerald-gharial' - Executing 'my_task-20c6ece6-0' immediately...
-we're logging print statements from a task
+not logging print statements in this task
 ```
 </div>
 
-You can also set this at the system level for all Prefect flows, tasks, and subflows.
+You can also configure this behavior globally for all Prefect flows, tasks, and subflows.
 
 <div class='terminal'>
 ```bash
-PREFECT_LOGGING_LOG_PRINTS=True
+prefect config set PREFECT_LOGGING_LOG_PRINTS=True
 ```
 </div>
 

--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -125,6 +125,68 @@ Prefect automatically uses the task run logger based on the task context. The de
 
 The underlying log model for task runs captures the task name, task run ID, and parent flow run ID, which are persisted to the database for reporting and may also be used in custom message formatting.
 
+### Logging print statements
+
+Prefect provides the `log_prints` option to enable logging of print statements at the task or flow level. By default, tasks and subflows will inherit the print logging behavior from their parent flow, unless opted out with their own `log_print=False`.
+
+```python
+from prefect import task, flow
+
+@task
+def my_task():
+    print("we're logging print statements from a task")
+
+@flow(log_prints=True)
+def my_flow():
+    print("we're logging print statements from a flow")
+    my_task()
+```
+
+Will output:
+
+<div class='terminal'>
+```bash
+15:52:11.244 | INFO    | prefect.engine - Created flow run 'emerald-gharial' for flow 'my-flow'
+15:52:11.812 | INFO    | Flow run 'emerald-gharial' - we're logging print statements from a flow
+15:52:11.926 | INFO    | Flow run 'emerald-gharial' - Created task run 'my_task-20c6ece6-0' for task 'my_task'
+15:52:11.927 | INFO    | Flow run 'emerald-gharial' - Executing 'my_task-20c6ece6-0' immediately...
+15:52:12.217 | INFO    | Task run 'my_task-20c6ece6-0' - we're logging print statements from a task
+```
+</div>
+
+```python
+from prefect import task, flow
+
+@task
+def my_task(log_prints=False):
+    print("we're logging print statements from a task")
+
+@flow(log_prints=True)
+def my_flow():
+    print("we're logging print statements from a flow")
+    my_task()
+```
+
+Using `log_prints=False` at the task level will output:
+
+<div class='terminal'>
+```bash
+15:52:11.244 | INFO    | prefect.engine - Created flow run 'emerald-gharial' for flow 'my-flow'
+15:52:11.812 | INFO    | Flow run 'emerald-gharial' - we're logging print statements from a flow
+15:52:11.926 | INFO    | Flow run 'emerald-gharial' - Created task run 'my_task-20c6ece6-0' for task 'my_task'
+15:52:11.927 | INFO    | Flow run 'emerald-gharial' - Executing 'my_task-20c6ece6-0' immediately...
+we're logging print statements from a task
+```
+</div>
+
+You can also set this at the system level for all Prefect flows, tasks, and subflows.
+
+<div class='terminal'>
+```bash
+PREFECT_LOGGING_LOG_PRINTS=True
+```
+</div>
+
 ## Formatters
 
 Prefect log formatters specify the format of log messages. You can see details of message formatting for different loggers in [`logging.yml`](https://github.com/PrefectHQ/prefect/blob/orion/src/prefect/logging/logging.yml). For example, the default formatting for task run log records is:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -221,8 +221,7 @@ class FlowRunContext(RunContext):
     flow: "Flow"
     flow_run: FlowRun
     task_runner: BaseTaskRunner
-
-    log_print: bool = True
+    log_prints: bool = False
 
     # Result handling
     result_factory: ResultFactory
@@ -261,11 +260,10 @@ class TaskRunContext(RunContext):
     task: "Task"
     task_run: TaskRun
     timeout_scope: Optional[anyio.abc.CancelScope] = None
+    log_prints: bool = False
 
     # Result handling
     result_factory: ResultFactory
-
-    log_print: bool = True
 
     __var__ = ContextVar("task_run")
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -222,6 +222,8 @@ class FlowRunContext(RunContext):
     flow_run: FlowRun
     task_runner: BaseTaskRunner
 
+    log_print: bool = True
+
     # Result handling
     result_factory: ResultFactory
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -265,6 +265,8 @@ class TaskRunContext(RunContext):
     # Result handling
     result_factory: ResultFactory
 
+    log_print: bool = True
+
     __var__ = ContextVar("task_run")
 
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -555,6 +555,12 @@ async def orchestrate_flow_run(
     )
     flow_run_context = None
 
+    import builtins
+
+    from prefect.logging.loggers import print_as_log
+
+    builtins.print = print_as_log
+
     try:
         # Resolve futures in any non-data dependencies to ensure they are ready
         if wait_for is not None:

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -411,6 +411,7 @@ async def create_and_begin_subflow_run(
     """
     parent_flow_run_context = FlowRunContext.get()
     parent_logger = get_run_logger(parent_flow_run_context)
+    log_prints = should_log_prints(flow)
 
     parent_logger.debug(f"Resolving inputs to {flow.name!r}")
     task_inputs = {k: await collect_task_run_inputs(v) for k, v in parameters.items()}
@@ -490,6 +491,10 @@ async def create_and_begin_subflow_run(
                 report_flow_run_crashes(flow_run=flow_run, client=client)
             )
             task_runner = await stack.enter_async_context(flow.task_runner.start())
+
+            if log_prints:
+                stack.enter_context(patch_print())
+
             terminal_state = await orchestrate_flow_run(
                 flow,
                 flow_run=flow_run,
@@ -505,6 +510,7 @@ async def create_and_begin_subflow_run(
                     task_runner=task_runner,
                     background_tasks=parent_flow_run_context.background_tasks,
                     result_factory=result_factory,
+                    log_prints=log_prints,
                 ),
             )
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -329,7 +329,8 @@ async def begin_flow_run(
     """
     logger = flow_run_logger(flow_run, flow)
 
-    flow_run_context = PartialModel(FlowRunContext, log_prints=should_log_prints(flow))
+    log_prints = should_log_prints(flow)
+    flow_run_context = PartialModel(FlowRunContext, log_prints=log_prints)
 
     async with AsyncExitStack() as stack:
 
@@ -359,7 +360,7 @@ async def begin_flow_run(
             flow, client=client
         )
 
-        if flow.log_prints:
+        if log_prints:
             stack.enter_context(patch_print())
 
         terminal_state = await orchestrate_flow_run(

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -224,6 +224,7 @@ class Flow(Generic[P, R]):
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
         cache_result_in_memory: bool = None,
+        log_prints: Optional[bool] = NotSet,
     ):
         """
         Create a new flow from the current object, updating provided options.
@@ -304,6 +305,7 @@ class Flow(Generic[P, R]):
                 if cache_result_in_memory is not None
                 else self.cache_result_in_memory
             ),
+            log_prints=log_prints if log_prints is not NotSet else self.log_prints,
         )
 
     def validate_parameters(self, parameters: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -582,7 +582,7 @@ def flow(
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
         log_prints: If set, `print` statements in the flow will be redirected to the
-            Prefect logger for the flow run. Defaults to `None` which indicates that
+            Prefect logger for the flow run. Defaults to `None`, which indicates that
             the value from the parent flow should be used. If this is a parent flow,
             the default is pulled from the `PREFECT_LOGGING_LOG_PRINTS` setting.
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -130,6 +130,7 @@ class Flow(Generic[P, R]):
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
         cache_result_in_memory: bool = True,
+        log_prints: Optional[bool] = None,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -143,6 +144,8 @@ class Flow(Generic[P, R]):
         self.task_runner = (
             task_runner() if isinstance(task_runner, type) else task_runner
         )
+
+        self.log_prints = log_prints
 
         self.description = description or inspect.getdoc(fn)
         update_wrapper(self, fn)
@@ -512,6 +515,7 @@ def flow(
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
+    log_prints: Optional[bool] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
 
@@ -531,6 +535,7 @@ def flow(
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
+    log_prints: Optional[bool] = None,
 ):
     """
     Decorator to designate a function as a Prefect workflow.
@@ -574,6 +579,10 @@ def flow(
             in this flow. If not provided, the value of `PREFECT_RESULTS_DEFAULT_SERIALIZER`
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
+        log_prints: If set, `print` statements in the flow will be redirected to the
+            Prefect logger for the flow run. Defaults to `None` which indicates that
+            the value from the parent flow should be used. If this is a parent flow,
+            the default is pulled from the `PREFECT_LOGGING_LOG_PRINTS` setting.
 
     Returns:
         A callable `Flow` object which, when called, will run the flow and return its
@@ -630,6 +639,7 @@ def flow(
                 result_storage=result_storage,
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
+                log_prints=log_prints,
             ),
         )
     else:
@@ -649,6 +659,7 @@ def flow(
                 result_storage=result_storage,
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
+                log_prints=log_prints,
             ),
         )
 

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -199,21 +199,39 @@ def disable_run_logger():
 
 
 def print_as_log(*args, **kwargs):
+    """
+    A patch for `print` to send printed messages to the Prefect run logger.
 
+    If no run is active, `print` will behave as if it were not patched.
+    """
     from prefect.context import FlowRunContext, TaskRunContext
 
     context = TaskRunContext.get() or FlowRunContext.get()
-    if not context or not context.log_print:
+    if not context or not context.log_prints:
         return print(*args, **kwargs)
 
     logger = get_run_logger()
+
+    # Print to an in-memory buffer; so we do not need to implement `print`
     buffer = io.StringIO()
     kwargs["file"] = buffer
     print(*args, **kwargs)
+
+    # Remove trailing whitespace to prevent duplicates
     logger.info(buffer.getvalue().rstrip())
 
 
+@contextmanager
 def patch_print():
+    """
+    Patches the Python builtin `print` method to use `print_as_log`
+    """
     import builtins
 
-    builtins.print = print_as_log
+    original = builtins.print
+
+    try:
+        builtins.print = print_as_log
+        yield
+    finally:
+        builtins.print = original

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -200,9 +200,9 @@ def disable_run_logger():
 
 def print_as_log(*args, **kwargs):
 
-    from prefect.context import FlowRunContext
+    from prefect.context import FlowRunContext, TaskRunContext
 
-    context = FlowRunContext.get()
+    context = TaskRunContext.get() or FlowRunContext.get()
     if not context or not context.log_print:
         return print(*args, **kwargs)
 
@@ -211,3 +211,9 @@ def print_as_log(*args, **kwargs):
     kwargs["file"] = buffer
     print(*args, **kwargs)
     logger.info(buffer.getvalue().rstrip())
+
+
+def patch_print():
+    import builtins
+
+    builtins.print = print_as_log

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -1,4 +1,6 @@
+import io
 import logging
+from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -194,3 +196,18 @@ def disable_run_logger():
     """
     with disable_logger("prefect.flow_run"), disable_logger("prefect.task_run"):
         yield
+
+
+def print_as_log(*args, **kwargs):
+
+    from prefect.context import FlowRunContext
+
+    context = FlowRunContext.get()
+    if not context or not context.log_print:
+        return print(*args, **kwargs)
+
+    logger = get_run_logger()
+    buffer = io.StringIO()
+    kwargs["file"] = buffer
+    print(*args, **kwargs)
+    logger.info(buffer.getvalue().rstrip())

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -511,6 +511,15 @@ will be added to these loggers. Additionally, if the level is not set, it will
 be set to the same level as the 'prefect' logger.
 """
 
+PREFECT_LOGGING_LOG_PRINTS = Setting(
+    bool,
+    default=False,
+)
+"""
+If set, `print` statements in flows and tasks will be redirected to the Prefect logger
+for the given run. This setting ca be overriden by individual tasks and flows.
+"""
+
 PREFECT_LOGGING_ORION_ENABLED = Setting(
     bool,
     default=True,

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -517,7 +517,7 @@ PREFECT_LOGGING_LOG_PRINTS = Setting(
 )
 """
 If set, `print` statements in flows and tasks will be redirected to the Prefect logger
-for the given run. This setting ca be overriden by individual tasks and flows.
+for the given run. This setting can be overriden by individual tasks and flows.
 """
 
 PREFECT_LOGGING_ORION_ENABLED = Setting(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -122,7 +122,7 @@ class Task(Generic[P, R]):
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the
             Prefect logger for the task run. Defaults to `None`, which indicates
-            that the value from the flow should be used.s
+            that the value from the flow should be used.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -120,6 +120,9 @@ class Task(Generic[P, R]):
             called in.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
+        log_prints: If set, `print` statements in the task will be redirected to the
+            Prefect logger for the task run. Defaults to `None`, which indicates
+            that the value from the flow should be used.s
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -142,6 +145,7 @@ class Task(Generic[P, R]):
         result_serializer: Optional[ResultSerializer] = None,
         cache_result_in_memory: bool = True,
         timeout_seconds: Union[int, float] = None,
+        log_prints: Optional[bool] = False,
     ):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -160,6 +164,7 @@ class Task(Generic[P, R]):
             self.name = name
 
         self.version = version
+        self.log_prints = log_prints
 
         raise_for_reserved_arguments(self.fn, ["return_state", "wait_for"])
 
@@ -222,6 +227,7 @@ class Task(Generic[P, R]):
         result_serializer: Optional[ResultSerializer] = NotSet,
         cache_result_in_memory: Optional[bool] = None,
         timeout_seconds: Union[int, float] = None,
+        log_prints: Optional[bool] = NotSet,
     ):
         """
         Create a new task from the current object, updating provided options.
@@ -309,6 +315,7 @@ class Task(Generic[P, R]):
             timeout_seconds=(
                 timeout_seconds if timeout_seconds is not None else self.timeout_seconds
             ),
+            log_prints=(log_prints if log_prints is not NotSet else self.log_prints),
         )
 
     @overload
@@ -755,6 +762,7 @@ def task(
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
+    log_prints: Optional[bool] = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 
@@ -775,6 +783,7 @@ def task(
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
+    log_prints: Optional[bool] = None,
 ):
     """
     Decorator to designate a function as a task in a Prefect workflow.
@@ -807,6 +816,11 @@ def task(
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
             called in.
+        timeout_seconds: An optional number of seconds indicating a maximum runtime for
+            the task. If the task exceeds this runtime, it will be marked as failed.
+        log_prints: If set, `print` statements in the task will be redirected to the
+            Prefect logger for the task run. Defaults to `None`, which indicates
+            that the value from the flow should be used.
 
     Returns:
         A callable `Task` object which, when called, will submit the task for execution.
@@ -874,6 +888,7 @@ def task(
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
+                log_prints=log_prints,
             ),
         )
     else:
@@ -894,5 +909,6 @@ def task(
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
+                log_prints=log_prints,
             ),
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,6 +132,7 @@ class TestOrchestrateTaskRun:
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
+                log_prints=False,
             )
 
         assert state.is_completed()
@@ -164,6 +165,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         mock_anyio_sleep.assert_not_called()
@@ -203,6 +205,7 @@ class TestOrchestrateTaskRun:
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
+                log_prints=False,
             )
 
         # Check for a proper final result
@@ -276,6 +279,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task did not run
@@ -317,6 +321,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task ran with the unqoted data
@@ -360,6 +365,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task ran with the state as its input

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -200,6 +200,7 @@ class TestFlowWithOptions:
             result_serializer="json",
             result_storage=LocalFileSystem(),
             cache_result_in_memory=False,
+            log_prints=False,
         )
         def initial_flow():
             pass
@@ -218,6 +219,7 @@ class TestFlowWithOptions:
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem()
         assert flow_with_options.cache_result_in_memory is False
+        assert flow_with_options.log_prints is False
 
     def test_with_options_can_unset_timeout_seconds_with_zero(self):
         @flow(timeout_seconds=1)

--- a/tests/test_log_prints.py
+++ b/tests/test_log_prints.py
@@ -1,0 +1,388 @@
+import builtins
+
+from prefect import flow, task
+from prefect.context import get_run_context
+from prefect.logging.loggers import print_as_log
+
+
+def test_log_prints_task_setting_is_context_managed():
+    @task(log_prints=True)
+    def get_builtin_print():
+        return builtins.print
+
+    @flow
+    def wrapper():
+        return builtins.print, get_builtin_print()
+
+    caller_builtin_print, user_builtin_print = wrapper()
+
+    assert caller_builtin_print is builtins.print
+    assert user_builtin_print is print_as_log
+
+
+def test_log_prints_subflow_setting_is_context_managed():
+    @flow(log_prints=True)
+    def get_builtin_print():
+        return builtins.print
+
+    @flow
+    def wrapper():
+        return builtins.print, get_builtin_print()
+
+    caller_builtin_print, user_builtin_print = wrapper()
+
+    assert caller_builtin_print is builtins.print
+    assert user_builtin_print is print_as_log
+
+
+def test_task_inherits_log_prints_setting(caplog):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def log_prints_flow():
+        return test_log_task()
+
+    printing_task_name = log_prints_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_subflow_inherits_log_prints_setting(caplog):
+    @flow
+    def test_subflow():
+        subflow_run_name = get_run_context().flow_run.name
+        print(f"test message from {subflow_run_name}")
+        return subflow_run_name
+
+    @flow(log_prints=True)
+    def test_flow():
+        return test_subflow()
+
+    printing_subflow_name = test_flow()
+
+    assert f"test message from {printing_subflow_name}" in caplog.text
+
+
+def test_task_can_opt_in_when_parent_not_set(caplog):
+    @task(log_prints=True)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_subflow_can_opt_in_when_parent_not_set(caplog):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
+def test_task_log_prints_with_options(caplog):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow
+    def log_prints_flow():
+        return test_log_task.with_options(log_prints=True)()
+
+    printing_task_name = log_prints_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_flow_log_prints_with_options(caplog):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def log_prints_flow():
+        return test_log_flow.with_options(log_prints=True)()
+
+    printing_subflow_name = log_prints_flow()
+
+    assert f"test print from {printing_subflow_name}" in caplog.text
+
+
+def test_task_inherits_log_prints_setting_with_options(caplog):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow
+    def simple_flow():
+        return test_log_task()
+
+    modified_flow = simple_flow.with_options(log_prints=True)
+
+    printing_task_name = modified_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_task_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @task(log_prints=False)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" not in caplog.text
+    assert f"test print from {printing_task_name}" in capsys.readouterr().out
+
+
+def test_subflow_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow(log_prints=False)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_task_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @task(log_prints=True)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+    assert f"test print from {printing_task_name}" not in capsys.readouterr().out
+
+
+def test_subflow_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_task_with_options_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_task.with_options(log_prints=False)()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" not in caplog.text
+    assert f"test print from {printing_task_name}" in capsys.readouterr().out
+
+
+def test_subflow_with_options_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_flow.with_options(log_prints=False)()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_task_with_options_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_task.with_options(log_prints=True)()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+    assert f"test print from {printing_task_name}" not in capsys.readouterr().out
+
+
+def test_subflow_with_options_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_flow.with_options(log_prints=True)()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_subsubflow_inherits_log_prints_setting(caplog):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=True)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
+def test_subsubflow_inherits_log_prints_setting_with_options(caplog):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent.with_options(log_prints=True)()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
+def test_subsubflow_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow(log_prints=False)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=True)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_subsubflow_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=False)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_subsubflow_can_opt_in_when_root_parent_not_set(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -40,6 +40,7 @@ from prefect.logging.loggers import (
     flow_run_logger,
     get_logger,
     get_run_logger,
+    patch_print,
     task_run_logger,
 )
 from prefect.orion.schemas.actions import LogCreate
@@ -1291,3 +1292,67 @@ def test_disable_run_logger(caplog):
     assert not flow_run_logger.disabled
     assert task_run_logger.disabled  # was already disabled beforehand
     assert caplog.record_tuples == [("null", logging.CRITICAL, "wont show")]
+
+
+def test_patch_print_writes_to_stdout_without_run_context(caplog, capsys):
+    with patch_print():
+        print("foo")
+
+    assert "foo" in capsys.readouterr().out
+    assert "foo" not in caplog.text
+
+
+@pytest.mark.parametrize("run_context_cls", [TaskRunContext, FlowRunContext])
+def test_patch_print_writes_to_stdout_with_run_context_and_no_log_prints(
+    caplog, capsys, run_context_cls
+):
+    with patch_print():
+        with run_context_cls.construct(log_prints=False):
+            print("foo")
+
+    assert "foo" in capsys.readouterr().out
+    assert "foo" not in caplog.text
+
+
+def test_patch_print_writes_to_logger_with_task_run_context(caplog, capsys, task_run):
+    @task
+    def my_task():
+        pass
+
+    with patch_print():
+        with TaskRunContext.construct(log_prints=True, task_run=task_run, task=my_task):
+            print("foo")
+
+    assert "foo" not in capsys.readouterr().out
+    assert "foo" in caplog.text
+
+    for record in caplog.records:
+        if record.message == "foo":
+            break
+
+    assert record.levelname == "INFO"
+    assert record.name == "prefect.task_runs"
+    assert record.task_run_id == str(task_run.id)
+    assert record.task_name == my_task.name
+
+
+def test_patch_print_writes_to_logger_with_flow_run_context(caplog, capsys, flow_run):
+    @flow
+    def my_flow():
+        pass
+
+    with patch_print():
+        with FlowRunContext.construct(log_prints=True, flow_run=flow_run, flow=my_flow):
+            print("foo")
+
+    assert "foo" not in capsys.readouterr().out
+    assert "foo" in caplog.text
+
+    for record in caplog.records:
+        if record.message == "foo":
+            break
+
+    assert record.levelname == "INFO"
+    assert record.name == "prefect.flow_runs"
+    assert record.flow_run_id == str(flow_run.id)
+    assert record.flow_name == my_flow.name


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Addresses the much requested `log_stdout` feature from v1 in v2 by adding a `log_prints` option. It is very hard for us to log standard output from _within_ the run as we have no way to tell where the bytes are coming from (i.e. you cannot disable capturing per task or flow). We can, however, patch the builtin `print` method, allowing us to identify the flow or task run the message comes from. 

This pull request introduces temporary patching of `print` to accomplish logging of prints from within tasks or flows. This will also apply to any functions within the scope of a task or a flow e.g. if they call into another library. If a flow or task run context is not present, we will just `print` as normal.

There are options at the flow, task, and settings level. Defaults for children (subflows and tasks) are pulled from the parent flow.

Closes https://github.com/PrefectHQ/prefect/issues/7117
### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Play with the following, try `None`, `False` and `True` for values:
```python
import prefect


@prefect.flow(log_prints=False)
def foo():
    print("foo")
    bar()


@prefect.task(log_prints=True)
def bar():
    print("bar")


foo()
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->

### Future work

We may add a `log_stdout` feature but it would operate at the infrastructure level where we actually have access to the full standard output stream.