### PR TITLE
Update orchestration rule to wait for scheduled time to only apply to transition to running

### DIFF
--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -382,8 +382,8 @@ class WaitForScheduledTime(BaseOrchestrationRule):
     before attempting the transition again.
     """
 
-    FROM_STATES = [states.StateType.SCHEDULED]
-    TO_STATES = ALL_ORCHESTRATION_STATES
+    FROM_STATES = [states.StateType.SCHEDULED, states.StateType.PENDING]
+    TO_STATES = [states.StateType.RUNNING]
 
     async def before_transition(
         self,
@@ -393,7 +393,7 @@ class WaitForScheduledTime(BaseOrchestrationRule):
     ) -> None:
         scheduled_time = initial_state.state_details.scheduled_time
         if not scheduled_time:
-            raise ValueError("Received state without a scheduled time")
+            return
 
         # At this moment, we take the floor of the actual delay as the API schema
         # specifies an integer return value.

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -55,6 +55,7 @@ class CoreTaskPolicy(BaseOrchestrationPolicy):
             HandleTaskTerminalStateTransitions,
             PreventRedundantTransitions,
             SecureTaskConcurrencySlots,  # retrieve cached states even if slots are full
+            CopyScheduledTime,
             WaitForScheduledTime,
             RetryFailedTasks,
             RenameReruns,
@@ -371,9 +372,32 @@ class RenameReruns(BaseOrchestrationRule):
                 await self.rename_state("Rerunning")
 
 
+class CopyScheduledTime(BaseOrchestrationRule):
+    """
+    Ensures scheduled time is copied from scheduled states to pending states.
+
+    If a new scheduled time has been proposed on the pending state, the scheduled time
+    on the scheduled state will be ignored.
+    """
+
+    FROM_STATES = [states.StateType.SCHEDULED]
+    TO_STATES = [states.StateType.PENDING]
+
+    async def before_transition(
+        self,
+        initial_state: Optional[states.State],
+        proposed_state: Optional[states.State],
+        context: OrchestrationContext,
+    ) -> None:
+        if not proposed_state.state_details.scheduled_time:
+            proposed_state.state_details.scheduled_time = (
+                initial_state.state_details.scheduled_time
+            )
+
+
 class WaitForScheduledTime(BaseOrchestrationRule):
     """
-    Prevents transitions from scheduled states that happen too early.
+    Prevents transitions to running states from happening to early.
 
     This rule enforces that all scheduled states will only start with the machine clock
     used by the Orion instance. This rule will identify transitions from scheduled


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Currently, the orchestrator blocks transition from SCHEDULED -> ANY until the scheduled start time is reached. Here, the scope is reduced to -> RUNNING and transitions to PENDING are allowed so that runs can be presubmitted to infrastructure.

Closes https://github.com/PrefectHQ/prefect/issues/7584

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
