### PR TITLE
Bugfix: Remove inter import blocking UI loads in airgapped environments

### DIFF
--- a/orion-ui/src/styles/style.css
+++ b/orion-ui/src/styles/style.css
@@ -1,4 +1,2 @@
-@import "https://rsms.me/inter/inter.css";
-
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This PR removes the inter font import. This font is already bundled in an upstream dependency and should be applied accordingly. 

Closes: https://github.com/PrefectHQ/prefect/issues/7582

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
