### PR TITLE
use `should_log_prints` in `create_and_begin_subflow_run` and add `test_log_prints.py`

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -411,6 +411,7 @@ async def create_and_begin_subflow_run(
     """
     parent_flow_run_context = FlowRunContext.get()
     parent_logger = get_run_logger(parent_flow_run_context)
+    log_prints = should_log_prints(flow)
 
     parent_logger.debug(f"Resolving inputs to {flow.name!r}")
     task_inputs = {k: await collect_task_run_inputs(v) for k, v in parameters.items()}
@@ -490,6 +491,10 @@ async def create_and_begin_subflow_run(
                 report_flow_run_crashes(flow_run=flow_run, client=client)
             )
             task_runner = await stack.enter_async_context(flow.task_runner.start())
+
+            if log_prints:
+                stack.enter_context(patch_print())
+
             terminal_state = await orchestrate_flow_run(
                 flow,
                 flow_run=flow_run,
@@ -505,6 +510,7 @@ async def create_and_begin_subflow_run(
                     task_runner=task_runner,
                     background_tasks=parent_flow_run_context.background_tasks,
                     result_factory=result_factory,
+                    log_prints=log_prints,
                 ),
             )
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -224,6 +224,7 @@ class Flow(Generic[P, R]):
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
         cache_result_in_memory: bool = None,
+        log_prints: Optional[bool] = NotSet,
     ):
         """
         Create a new flow from the current object, updating provided options.
@@ -304,6 +305,7 @@ class Flow(Generic[P, R]):
                 if cache_result_in_memory is not None
                 else self.cache_result_in_memory
             ),
+            log_prints=log_prints if log_prints is not NotSet else self.log_prints,
         )
 
     def validate_parameters(self, parameters: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -517,7 +517,7 @@ PREFECT_LOGGING_LOG_PRINTS = Setting(
 )
 """
 If set, `print` statements in flows and tasks will be redirected to the Prefect logger
-for the given run. This setting ca be overriden by individual tasks and flows.
+for the given run. This setting can be overriden by individual tasks and flows.
 """
 
 PREFECT_LOGGING_ORION_ENABLED = Setting(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -150,6 +150,7 @@ class TestOrchestrateTaskRun:
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
+                log_prints=False,
             )
 
         assert state.is_completed()
@@ -182,6 +183,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         mock_anyio_sleep.assert_not_called()
@@ -221,6 +223,7 @@ class TestOrchestrateTaskRun:
                 result_factory=result_factory,
                 interruptible=False,
                 client=orion_client,
+                log_prints=False,
             )
 
         # Check for a proper final result
@@ -294,6 +297,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task did not run
@@ -335,6 +339,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task ran with the unqoted data
@@ -378,6 +383,7 @@ class TestOrchestrateTaskRun:
             result_factory=result_factory,
             interruptible=False,
             client=orion_client,
+            log_prints=False,
         )
 
         # The task ran with the state as its input

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -173,7 +173,6 @@ class TestFlowWithOptions:
             result_serializer="json",
             result_storage=LocalFileSystem(basepath="bar"),
             cache_result_in_memory=True,
-            log_prints=True,
         )
 
         assert flow_with_options.name == "Copied flow"

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -157,6 +157,7 @@ class TestFlowWithOptions:
             result_serializer="pickle",
             result_storage=LocalFileSystem(basepath="foo"),
             cache_result_in_memory=False,
+            log_prints=False,
         )
         def initial_flow():
             pass
@@ -173,6 +174,7 @@ class TestFlowWithOptions:
             result_serializer="json",
             result_storage=LocalFileSystem(basepath="bar"),
             cache_result_in_memory=True,
+            log_prints=True,
         )
 
         assert flow_with_options.name == "Copied flow"
@@ -186,6 +188,7 @@ class TestFlowWithOptions:
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem(basepath="bar")
         assert flow_with_options.cache_result_in_memory is True
+        assert flow_with_options.log_prints is True
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         @flow(
@@ -200,6 +203,7 @@ class TestFlowWithOptions:
             result_serializer="json",
             result_storage=LocalFileSystem(),
             cache_result_in_memory=False,
+            log_prints=False,
         )
         def initial_flow():
             pass
@@ -218,6 +222,7 @@ class TestFlowWithOptions:
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem()
         assert flow_with_options.cache_result_in_memory is False
+        assert flow_with_options.log_prints is False
 
     def test_with_options_can_unset_timeout_seconds_with_zero(self):
         @flow(timeout_seconds=1)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -157,7 +157,6 @@ class TestFlowWithOptions:
             result_serializer="pickle",
             result_storage=LocalFileSystem(basepath="foo"),
             cache_result_in_memory=False,
-            log_prints=False,
         )
         def initial_flow():
             pass
@@ -188,7 +187,6 @@ class TestFlowWithOptions:
         assert flow_with_options.result_serializer == "json"
         assert flow_with_options.result_storage == LocalFileSystem(basepath="bar")
         assert flow_with_options.cache_result_in_memory is True
-        assert flow_with_options.log_prints is True
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         @flow(

--- a/tests/test_log_prints.py
+++ b/tests/test_log_prints.py
@@ -67,6 +67,38 @@ def test_subflow_inherits_log_prints_setting(caplog):
     assert f"test message from {printing_subflow_name}" in caplog.text
 
 
+def test_task_can_opt_in_when_parent_not_set(caplog):
+    @task(log_prints=True)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_subflow_can_opt_in_when_parent_not_set(caplog):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
 def test_task_log_prints_with_options(caplog):
     @task
     def test_log_task():
@@ -115,3 +147,242 @@ def test_task_inherits_log_prints_setting_with_options(caplog):
     printing_task_name = modified_flow()
 
     assert f"test print from {printing_task_name}" in caplog.text
+
+
+def test_task_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @task(log_prints=False)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" not in caplog.text
+    assert f"test print from {printing_task_name}" in capsys.readouterr().out
+
+
+def test_subflow_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow(log_prints=False)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_task_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @task(log_prints=True)
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_task()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+    assert f"test print from {printing_task_name}" not in capsys.readouterr().out
+
+
+def test_subflow_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_flow()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_task_with_options_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_task.with_options(log_prints=False)()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" not in caplog.text
+    assert f"test print from {printing_task_name}" in capsys.readouterr().out
+
+
+def test_subflow_with_options_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=True)
+    def simple_flow():
+        return test_log_flow.with_options(log_prints=False)()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_task_with_options_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_task.with_options(log_prints=True)()
+
+    printing_task_name = simple_flow()
+
+    assert f"test print from {printing_task_name}" in caplog.text
+    assert f"test print from {printing_task_name}" not in capsys.readouterr().out
+
+
+def test_subflow_with_options_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow(log_prints=False)
+    def simple_flow():
+        return test_log_flow.with_options(log_prints=True)()
+
+    printing_flow_name = simple_flow()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_subsubflow_inherits_log_prints_setting(caplog):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=True)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
+def test_subsubflow_inherits_log_prints_setting_with_options(caplog):
+    @flow
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent.with_options(log_prints=True)()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+
+
+def test_subsubflow_can_opt_out_of_inherited_on_setting(caplog, capsys):
+    @flow(log_prints=False)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=True)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" not in caplog.text
+    assert f"test print from {printing_flow_name}" in capsys.readouterr().out
+
+
+def test_subsubflow_can_opt_out_of_inherited_off_setting(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow(log_prints=False)
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out
+
+
+def test_subsubflow_can_opt_in_when_root_parent_not_set(caplog, capsys):
+    @flow(log_prints=True)
+    def test_log_flow():
+        flow_run_name = get_run_context().flow_run.name
+        print(f"test print from {flow_run_name}")
+        return flow_run_name
+
+    @flow
+    def wrapper():
+        return test_log_flow()
+
+    @flow
+    def parent():
+        return wrapper()
+
+    printing_flow_name = parent()
+
+    assert f"test print from {printing_flow_name}" in caplog.text
+    assert f"test print from {printing_flow_name}" not in capsys.readouterr().out

--- a/tests/test_log_prints.py
+++ b/tests/test_log_prints.py
@@ -1,0 +1,72 @@
+import builtins
+
+import pytest
+
+from prefect import flow, task
+from prefect.context import get_run_context
+from prefect.logging.loggers import print_as_log
+
+
+def test_log_prints_task_setting_is_context_managed():
+    @task(log_prints=True)
+    def get_builtin_print():
+        return builtins.print
+
+    @flow
+    def wrapper():
+        return builtins.print, get_builtin_print()
+
+    caller_builtin_print, user_builtin_print = wrapper()
+
+    assert caller_builtin_print is builtins.print
+    assert user_builtin_print is print_as_log
+
+
+def test_log_prints_flow_setting_is_context_managed():
+    @flow(log_prints=True)
+    def get_builtin_print():
+        return builtins.print
+
+    @flow
+    def wrapper():
+        return builtins.print, get_builtin_print()
+
+    caller_builtin_print, user_builtin_print = wrapper()
+
+    assert caller_builtin_print is builtins.print
+    assert user_builtin_print is print_as_log
+
+
+def test_task_inherits_log_prints_setting(caplog):
+    @task
+    def test_log_task():
+        task_run_name = get_run_context().task_run.name
+        print(f"test print from {task_run_name}")
+        return task_run_name
+
+    @flow(log_prints=True)
+    def log_prints_flow():
+        return test_log_task()
+
+    with caplog.at_level("INFO"):
+        task_run_name = log_prints_flow()
+
+    assert f"test print from {task_run_name}" in caplog.text
+
+
+@pytest.mark.xfail(reason="known bug")
+def test_subflow_inherits_log_prints_setting(caplog):
+    @flow
+    def test_subflow():
+        subflow_run_name = get_run_context().flow_run.name
+        print(f"test message from {subflow_run_name}")
+        return subflow_run_name
+
+    @flow(log_prints=True)
+    def test_flow():
+        return test_subflow()
+
+    with caplog.at_level("INFO"):
+        subflow_run_name = test_flow()
+
+    assert f"test message from {subflow_run_name}" in caplog.text


### PR DESCRIPTION
this PR updates `create_and_begin_flow_run` to use `should_log_prints` in a similar way to how its currently used by `begin_flow_run`, where the result of `should_log_prints` decides:
- whether to enter `patch_print` before calling `orchestrate_flow_run`
-  what `log_prints` setting should be passed to `orchestrate_flow_run`

and adds test coverage checking task and subflow (and subsubflow) inheritance of this setting, and checking the ability for tasks or subflows to opt out of their parent's `log_prints` setting by defining their own `log_prints` setting