### PR TITLE
Add `PrefectFormatter` to reduce logging configuration duplication

### DIFF
--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -63,8 +63,6 @@ handlers:
 loggers:
     prefect:
         level: "${PREFECT_LOGGING_LEVEL}"
-        handlers: [console]
-        propagate: no
 
     prefect.extra:
         level: "${PREFECT_LOGGING_LEVEL}"
@@ -89,13 +87,9 @@ loggers:
 
     uvicorn:
         level: "${PREFECT_LOGGING_SERVER_LEVEL}"
-        handlers: [console]
-        propagate: no
 
     fastapi:
         level: "${PREFECT_LOGGING_SERVER_LEVEL}"
-        handlers: [console]
-        propagate: no
 
 # The root logger: any logger without propagation disabled sends to here as well
 root:

--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -14,15 +14,10 @@ formatters:
         datefmt: "%H:%M:%S"
 
     standard:
+        (): prefect.logging.formatters.PrefectFormatter
         format: "%(asctime)s.%(msecs)03d | %(levelname)-7s | %(name)s - %(message)s"
-        datefmt: "%H:%M:%S"
-
-    flow_runs:
-        format: "%(asctime)s.%(msecs)03d | %(levelname)-7s | Flow run %(flow_run_name)r - %(message)s"
-        datefmt: "%H:%M:%S"
-
-    task_runs:
-        format: "%(asctime)s.%(msecs)03d | %(levelname)-7s | Task run %(task_run_name)r - %(message)s"
+        flow_run_fmt: "%(asctime)s.%(msecs)03d | %(levelname)-7s | Flow run %(flow_run_name)r - %(message)s"
+        task_run_fmt: "%(asctime)s.%(msecs)03d | %(levelname)-7s | Task run %(task_run_name)r - %(message)s"
         datefmt: "%H:%M:%S"
 
     json:
@@ -61,42 +56,6 @@ handlers:
             log.flow_run_name: magenta
             log.flow_name: bold magenta
 
-    console_flow_runs:
-        level: 0
-        class: prefect.logging.handlers.PrefectConsoleHandler
-        formatter: flow_runs
-        styles:
-            log.web_url: bright_blue
-            log.local_url: bright_blue
-
-            log.info_level: cyan
-            log.warning_level: yellow3
-            log.error_level: red3
-            log.critical_level: bright_red
-
-            log.completed_state: green
-            log.cancelled_state: yellow3
-            log.failed_state: red3
-            log.crashed_state: bright_red
-
-    console_task_runs:
-        level: 0
-        class: prefect.logging.handlers.PrefectConsoleHandler
-        formatter: task_runs
-        styles:
-            log.web_url: bright_blue
-            log.local_url: bright_blue
-
-            log.info_level: cyan
-            log.warning_level: yellow3
-            log.error_level: red3
-            log.critical_level: bright_red
-
-            log.completed_state: green
-            log.cancelled_state: yellow3
-            log.failed_state: red3
-            log.state_crashed: bright_red
-
     orion:
         level: 0
         class: prefect.logging.handlers.OrionHandler
@@ -109,18 +68,15 @@ loggers:
 
     prefect.extra:
         level: "${PREFECT_LOGGING_LEVEL}"
-        handlers: [orion, console]
-        propagate: no
+        handlers: [orion]
 
     prefect.flow_runs:
         level: NOTSET
-        handlers: [orion, console_flow_runs]
-        propagate: no
+        handlers: [orion]
 
     prefect.task_runs:
         level: NOTSET
-        handlers: [orion, console_task_runs]
-        propagate: no
+        handlers: [orion]
 
     prefect.orion:
         level: "${PREFECT_LOGGING_SERVER_LEVEL}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ pytest.register_assert_rewrite("prefect.testing.utilities")
 
 import prefect
 import prefect.settings
-from prefect.logging import get_logger
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
     PREFECT_API_URL,
@@ -465,7 +464,8 @@ def caplog(caplog):
 
     for name, logger_config in config["loggers"].items():
         if not logger_config.get("propagate", True):
-            logger = get_logger(name)
-            logger.handlers.append(caplog.handler)
+            logger = logging.getLogger(name)
+            if caplog.handler not in logger.handlers:
+                logger.handlers.append(caplog.handler)
 
     yield caplog

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -153,13 +153,13 @@ def test_setup_logging_uses_env_var_overrides(tmp_path, dictConfigMock, monkeypa
     expected_config["root"]["level"] = "ROOT_LEVEL_VAL"
 
     # Test setting a value where the a key contains underscores
-    env["PREFECT_LOGGING_FORMATTERS_FLOW_RUNS_DATEFMT"] = "UNDERSCORE_KEY_VAL"
-    expected_config["formatters"]["flow_runs"]["datefmt"] = "UNDERSCORE_KEY_VAL"
+    env["PREFECT_LOGGING_FORMATTERS_STANDARD_FLOW_RUN_FMT"] = "UNDERSCORE_KEY_VAL"
+    expected_config["formatters"]["standard"]["flow_run_fmt"] = "UNDERSCORE_KEY_VAL"
 
     # Test setting a value where the key contains a period
-    env["PREFECT_LOGGING_LOGGERS_PREFECT_FLOW_RUNS_LEVEL"] = "FLOW_RUN_VAL"
+    env["PREFECT_LOGGING_LOGGERS_PREFECT_EXTRA_LEVEL"] = "VAL"
 
-    expected_config["loggers"]["prefect.flow_runs"]["level"] = "FLOW_RUN_VAL"
+    expected_config["loggers"]["prefect.extra"]["level"] = "VAL"
 
     # Test setting a value that does not exist in the yaml config and should not be
     # set in the expected_config since there is no value to override


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Previously, flow run and task run loggers required their own formatters and did not propagate to the `prefect` logger. We did this to allow customization of formatting for flow and task run logs. However, this makes it difficult to change the behavior of Prefect's loggers since you need to adjust multiple handlers. We can accomplish this same feature with a single formatter that has support for flow and task run formats.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Now, since there are not separate formatters for flow and task runs, you can change the format with a single setting e.g. to use JSON logging

```
PREFECT_LOGGING_HANDLERS_CONSOLE_FORMATTER="json" python example.py
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
