### PR TITLE
Ignore latest httpx version during development

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ autoflake8
 cairosvg
 flake8
 flaky
+httpx != 0.23.1
 ipython
 jinja2
 mkdocs


### PR DESCRIPTION
We are seeing failures in CI, likely due to incompatibility with `respx`