### PR TITLE
Return 404 on missing flow run

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -81,12 +81,6 @@ class MissingFlowError(PrefectException):
     """
 
 
-class MissingFlowRunError(PrefectException):
-    """
-    Raised when a flow run cannot be found.
-    """
-
-
 class UnspecifiedFlowError(PrefectException):
     """
     Raised when multiple flows are found in the expected script and no name is given.

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -12,10 +12,10 @@ import sqlalchemy as sa
 from packaging.version import Version
 from sqlalchemy import select
 
-from prefect.exceptions import MissingFlowRunError
 from prefect.orion import models
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
+from prefect.orion.exceptions import ObjectNotFoundError
 from prefect.orion.models import concurrency_limits
 from prefect.orion.orchestration.policies import BaseOrchestrationPolicy
 from prefect.orion.orchestration.rules import (
@@ -422,7 +422,7 @@ class UpdateFlowRunTrackerOnTasks(BaseOrchestrationRule):
         if self.flow_run:
             context.run.flow_run_run_count = self.flow_run.run_count
         else:
-            raise MissingFlowRunError(
+            raise ObjectNotFoundError(
                 f"Unable to read flow run associated with task run: {context.run.id}, this flow run might have been deleted",
             )
 

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -409,6 +409,19 @@ class TestSetTaskRunState:
         assert api_response.status == responses.SetStateStatus.ACCEPT
         assert api_response.state.type == states.StateType.FAILED
 
+    async def test_set_task_run_state_returns_404_on_missing_flow_run(
+        self, task_run, client, session
+    ):
+        await models.flow_runs.delete_flow_run(
+            session=session, flow_run_id=task_run.flow_run_id
+        )
+        await session.commit()
+        response = await client.post(
+            f"/task_runs/{task_run.id}/set_state",
+            json=dict(state=dict(type="RUNNING", name="Test State")),
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
 
 class TestTaskRunHistory:
     async def test_history_interval_must_be_one_second_or_larger(self, client):

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 import pendulum
 import pytest
 
-from prefect.exceptions import MissingFlowRunError
 from prefect.orion import schemas
+from prefect.orion.exceptions import ObjectNotFoundError
 from prefect.orion.models import concurrency_limits
 from prefect.orion.orchestration.core_policy import (
     CacheInsertion,
@@ -510,7 +510,7 @@ class TestUpdatingFlowRunTrackerOnTasks:
         async def missing_flow_run(self):
             return None
 
-        with pytest.raises(MissingFlowRunError, match="Unable to read flow run"):
+        with pytest.raises(ObjectNotFoundError, match="Unable to read flow run"):
             async with contextlib.AsyncExitStack() as stack:
                 for rule in update_policy:
                     ctx = await stack.enter_async_context(


### PR DESCRIPTION
If a flow run is not found when orchestrating a task run, ensure we return a 404. Previously, `MissingFlowRunError` was unhandled, resulting in a 500 error.

Closes https://github.com/PrefectHQ/nebula/issues/2685

### Example
```
async def test_set_task_run_state_returns_404_on_missing_flow_run(
        self, task_run, client, session
    ):
        await models.flow_runs.delete_flow_run(
            session=session, flow_run_id=task_run.flow_run_id
        )
        await session.commit()
        response = await client.post(
            f"/task_runs/{task_run.id}/set_state",
            json=dict(state=dict(type="RUNNING", name="Test State")),
        )
        assert response.status_code == status.HTTP_404_NOT_FOUND
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
