### PR TITLE
Changing default hash_algo to sha512 instead of md5

### DIFF
--- a/src/prefect/utilities/hashing.py
+++ b/src/prefect/utilities/hashing.py
@@ -7,7 +7,7 @@ import cloudpickle
 from prefect.serializers import JSONSerializer
 
 
-def stable_hash(*args: Union[str, bytes], hash_algo=hashlib.md5) -> str:
+def stable_hash(*args: Union[str, bytes], hash_algo=hashlib.sha512) -> str:
     """Given some arguments, produces a stable 64-bit hash of their contents.
 
     Supports bytes and strings. Strings will be UTF-8 encoded.
@@ -27,7 +27,7 @@ def stable_hash(*args: Union[str, bytes], hash_algo=hashlib.md5) -> str:
     return h.hexdigest()
 
 
-def file_hash(path: str, hash_algo=hashlib.md5) -> str:
+def file_hash(path: str, hash_algo=hashlib.sha512) -> str:
     """Given a path to a file, produces a stable hash of the file contents.
 
     Args:
@@ -41,7 +41,7 @@ def file_hash(path: str, hash_algo=hashlib.md5) -> str:
     return stable_hash(contents, hash_algo=hash_algo)
 
 
-def hash_objects(*args, hash_algo=hashlib.md5, **kwargs) -> Optional[str]:
+def hash_objects(*args, hash_algo=hashlib.sha512, **kwargs) -> Optional[str]:
     """
     Attempt to hash objects by dumping to JSON or serializing with cloudpickle.
     On failure of both, `None` will be returned

--- a/tests/utilities/test_hashing.py
+++ b/tests/utilities/test_hashing.py
@@ -8,12 +8,36 @@ from prefect.utilities.hashing import file_hash, stable_hash
 @pytest.mark.parametrize(
     "inputs,hash_algo,expected",
     [
-        (("hello",), None, "5d41402abc4b2a76b9719d911017c592"),
-        (("goodbye",), None, "69faab6268350295550de7d587bc323d"),
-        ((b"goodbye",), None, "69faab6268350295550de7d587bc323d"),
-        (("hello", "goodbye"), None, "441add4718519b71e42d329a834d6d5e"),
-        (("hello", b"goodbye"), None, "441add4718519b71e42d329a834d6d5e"),
-        (("goodbye", "hello"), None, "c04d8ccb6b9368703e62be93358094f9"),
+        (
+            ("hello",),
+            None,
+            "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+        ),
+        (
+            ("goodbye",),
+            None,
+            "de2c0320cdff37271049dfa8cb835ffd54200216253a1dfbad75a1ae51bd30bb499e14e37fe993ba2ea57b863fc56304de94073d880c9c18eb0a469cde211d02",
+        ),
+        (
+            (b"goodbye",),
+            None,
+            "de2c0320cdff37271049dfa8cb835ffd54200216253a1dfbad75a1ae51bd30bb499e14e37fe993ba2ea57b863fc56304de94073d880c9c18eb0a469cde211d02",
+        ),
+        (
+            ("hello", "goodbye"),
+            None,
+            "be68ed8f7c48c3c78af4ab2a1c8ba497f469a55c171a6d81e9386f0f2245ed4c8bc85a2135ef8d839151dad1361522cdfbb25d0f252395c29b81a9445b52ca83",
+        ),
+        (
+            ("hello", b"goodbye"),
+            None,
+            "be68ed8f7c48c3c78af4ab2a1c8ba497f469a55c171a6d81e9386f0f2245ed4c8bc85a2135ef8d839151dad1361522cdfbb25d0f252395c29b81a9445b52ca83",
+        ),
+        (
+            ("goodbye", "hello"),
+            None,
+            "b779b909718f0c4d9b85f0a1a71bb58cec74e6deece4eadb522261e0cee267a7eb7f4d57327bc369c1774c0cf7d5185db0d5e3f04cc88aff78d1899249bd26d5",
+        ),
         (
             ("goodbye", "hello"),
             hashlib.sha256,
@@ -52,6 +76,9 @@ class TestFileHash:
             f.write("0")
 
         val = file_hash(tmp_path.joinpath("test.py"))
-        assert val == hashlib.md5(b"0").hexdigest()
+        assert val == hashlib.sha512(b"0").hexdigest()
         # Check if the hash is stable
-        assert val == "cfcd208495d565ef66e7dff9f98764da"
+        assert (
+            val
+            == "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+        )


### PR DESCRIPTION
To allow Prefect to run in FIPS 140-2 environments, it cannot use the md5 algorithm. For Python 3.9+ it's possible to add an extra parameter to the md5 call, but there's no firm need to have this as md5 AFAIK. So adjusting this to sha512 will resolve this issue for Python 3.7+

closes #7615 

### Example
Changes are transparent to developer, simply changing the hash_algo from md5 to sha512

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
