### PR TITLE
Disable cache on result retrieval if disabled on creation

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -401,6 +401,8 @@ class PersistedResult(BaseResult):
     storage_block_id: uuid.UUID
     storage_key: str
 
+    _should_cache_object: bool = True
+
     @sync_compatible
     @inject_client
     async def get(self, client: "OrionClient") -> R:
@@ -412,7 +414,9 @@ class PersistedResult(BaseResult):
 
         blob = await self._read_blob(client=client)
         obj = blob.serializer.loads(blob.data)
-        self._cache_object(obj)
+
+        if self._should_cache_object:
+            self._cache_object(obj)
 
         return obj
 
@@ -455,6 +459,8 @@ class PersistedResult(BaseResult):
         if cache_object:
             # Attach the object to the result so it's available without deserialization
             result._cache_object(obj)
+
+        result._should_cache_object = cache_object
 
         return result
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -401,7 +401,7 @@ class PersistedResult(BaseResult):
     storage_block_id: uuid.UUID
     storage_key: str
 
-    _should_cache_object: bool = True
+    _should_cache_object: bool = pydantic.PrivateAttr(default=True)
 
     @sync_compatible
     @inject_client

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -460,7 +460,7 @@ class PersistedResult(BaseResult):
             # Attach the object to the result so it's available without deserialization
             result._cache_object(obj)
 
-        result._should_cache_object = cache_object
+        object.__setattr__(result, "_should_cache_object", cache_object)
 
         return result
 

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -28,8 +28,8 @@ async def test_result_reference_create_and_get(cache_object, storage_block):
 
     assert await result.get() == "test"
 
-    # After retrieval, it should be cached again
-    assert result.has_cached_object()
+    # Only cached after retrieval if enabled during initialization
+    assert result.has_cached_object() == cache_object
 
 
 async def test_result_reference_create_uses_storage(storage_block):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Alternative to https://github.com/PrefectHQ/prefect/pull/7625

Closes #7624 

Result caching can be disabled on creation, but if you retrieve the result downstream it will be cached on the state. There's not a great way for a user to release this cached object and it's not an intuitive result for the feature. Here, we stash the cache setting on creation. If caching was disabled at creation time, we do not cache the result on future retrievals. This setting will only be stashed locally and will not be persisted on later retrievals of the state.

Unlike  https://github.com/PrefectHQ/prefect/pull/7625, if a task enables caching in a flow that disables caching, the result will continue to cached as intended.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
