### PR TITLE
Added params to run deployment for  #7237 and #7522

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -7,7 +7,7 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from uuid import UUID
 
 import anyio
@@ -49,6 +49,8 @@ async def run_deployment(
     flow_run_name: str = None,
     timeout: float = None,
     poll_interval: float = 5,
+    tags: Optional[Iterable[str]] = None,
+    idempotency_key: str = None,
 ):
     """
     Create a flow run for a deployment and return it after completion or a timeout.
@@ -115,9 +117,11 @@ async def run_deployment(
 
     flow_run = await client.create_flow_run_from_deployment(
         deployment.id,
-        state=Scheduled(scheduled_time=scheduled_time),
         parameters=parameters,
+        state=Scheduled(scheduled_time=scheduled_time),
         name=flow_run_name,
+        tags=tags,
+        idempotency_key=idempotency_key,
         parent_task_run_id=parent_task_run_id,
     )
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -738,6 +738,31 @@ class TestRunDeployment:
 
         assert flow_run.name == "a custom flow run name"
 
+    def test_accepts_tags(self, test_deployment):
+        d, deployment_id = test_deployment
+
+        flow_run = run_deployment(
+            f"{d.flow_name}/{d.name}",
+            tags=["I", "love", "prefect"],
+            timeout=0,
+            poll_interval=0
+        )
+
+        assert sorted(flow_run.tags) == ["I", "love", "prefect"]
+
+
+    def test_accepts_idempotency_key(self, test_deployment):
+        d, deployment_id = test_deployment
+
+        flow_run = run_deployment(
+            f"{d.flow_name}/{d.name}",
+            idempotency_key="12345",
+            timeout=0,
+            poll_interval=0
+        )
+
+        assert flow_run.idempotency_key == "12345"
+
     async def test_links_to_parent_flow_run_when_used_in_flow(
         self, test_deployment, use_hosted_orion, orion_client: OrionClient
     ):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Exposes the `tags` and `idempotency_key` parameters within the `run_deployment` method. Closes #7237 and #7522.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Example use of `run_deployment`:

```
await run_deployment(
    name=f"{flow_name}/default",
    parameters={'q', 42},
    scheduled_time = my_time,
    flow_run_name = my_run_name,
    timeout = 0,
    tags=["I", "love", "prefect"],
    idempotency_key = my_external_id,
  )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
