### PR TITLE
Use new session to send each notification

### DIFF
--- a/src/prefect/orion/services/flow_run_notifications.py
+++ b/src/prefect/orion/services/flow_run_notifications.py
@@ -27,8 +27,8 @@ class FlowRunNotifications(LoopService):
 
     @inject_db
     async def run_once(self, db: OrionDBInterface):
-        async with db.session_context(begin_transaction=True) as session:
-            while True:
+        while True:
+            async with db.session_context(begin_transaction=True) as session:
                 # Drain the queue one entry at a time, because if a transient
                 # database error happens while sending a notification, the whole
                 # transaction will be rolled back, which effectively re-queues any


### PR DESCRIPTION
Curious for comment on this change -- currently we're using a single session to load and send every queued notification. This means that if anything happens to the session (due to misconfigured block or something), all subsequent notifications won't get sent because the session is rolled back. Notifications themselves do *not* use the session to send, so it's only the _loading_ of the notifications that presents a surface area for errors. This PR avoids this potentially long-lived session and opens a new session for each notification. 