### PR TITLE
Include final state logs in logs sent to API

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -375,7 +375,6 @@ async def begin_flow_run(
     logger.log(
         level=logging.INFO if terminal_state.is_completed() else logging.ERROR,
         msg=f"Finished in state {display_state}",
-        extra={"send_to_orion": False},
     )
 
     # When a "root" flow run finishes, flush logs so we do not have to rely on handling
@@ -508,7 +507,6 @@ async def create_and_begin_subflow_run(
     logger.log(
         level=logging.INFO if terminal_state.is_completed() else logging.ERROR,
         msg=f"Finished in state {display_state}",
-        extra={"send_to_orion": False},
     )
 
     # Track the subflow state so the parent flow can use it to determine its final state
@@ -1305,7 +1303,6 @@ async def orchestrate_task_run(
     logger.log(
         level=logging.INFO if state.is_completed() else logging.ERROR,
         msg=f"Finished in state {display_state}",
-        extra={"send_to_orion": False},
     )
 
     return state

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1245,7 +1245,11 @@ class TestFlowRunLogs:
             my_flow()
 
         logs = await orion_client.read_logs()
-        error_log = [log.message for log in logs if log.level == 40].pop()
+        error_log = [
+            log.message
+            for log in logs
+            if log.level == 40 and "Encountered exception" in log.message
+        ].pop()
         assert "Traceback" in error_log
         assert "ValueError: Hello!" in error_log, "References the exception"
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect/issues/7494

cc @zhen0 

Sends final state logs to the API. Previously, these were logged locally but not sent to the API. Some logs will still not be sent to the API; for example, logs indicating that the API rejected a proposed state.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
