### PR TITLE
Prompt workspace selection if API key is set but API URL is not set

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -410,7 +410,7 @@ async def login(
 
         # Confirm that we want to switch if the current profile is already logged in
         if (
-            current_profile_is_logged_in or current_workspace is not None
+            current_profile_is_logged_in and current_workspace is not None
         ) and prompt_switch_workspace:
             app.console.print(
                 f"You are currently using workspace {current_workspace.handle!r}."

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -553,6 +553,69 @@ def test_login_already_logged_in_to_current_profile_yes_reauth(respx_mock):
 
 
 @pytest.mark.usefixtures("interactive_console")
+def test_login_already_logged_in_with_invalid_api_url_prompts_workspace_change(
+    respx_mock,
+):
+    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
+    bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
+
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                foo_workspace.dict(json_compatible=True),
+                bar_workspace.dict(json_compatible=True),
+            ],
+        )
+    )
+
+    save_profiles(
+        ProfilesCollection(
+            [
+                Profile(
+                    name="logged-in-profile",
+                    settings={
+                        PREFECT_API_URL: "oh-no",
+                        PREFECT_API_KEY: "foo",
+                    },
+                )
+            ],
+            active=None,
+        )
+    )
+
+    with use_profile("logged-in-profile"):
+        invoke_and_assert(
+            ["cloud", "login"],
+            expected_code=0,
+            user_input=(
+                # Yes, reauth
+                "y"
+                + readchar.key.ENTER
+                # Enter a key
+                + readchar.key.DOWN
+                + readchar.key.ENTER
+                + "bar"
+                + readchar.key.ENTER
+                # Select the first workspace
+                + readchar.key.ENTER
+            ),
+            expected_output_contains=[
+                "It looks like you're already authenticated on this profile.",
+                "? Which workspace would you like to use?",
+                "test/foo",
+                "test/bar",
+                "Authenticated with Prefect Cloud! Using workspace 'test/foo'.",
+            ],
+        )
+
+        settings = load_current_profile().settings
+
+    assert settings[PREFECT_API_KEY] == "bar"
+    assert settings[PREFECT_API_URL] == foo_workspace.api_url()
+
+
+@pytest.mark.usefixtures("interactive_console")
 def test_login_already_logged_in_to_another_profile(respx_mock):
     foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

If the `PREFECT_API_URL` does not contain a valid workspace but the `PREFECT_API_KEY` is set during `prefect cloud login` re-authentication will fail during display of the current workspace.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Encountered in https://prefecthq.slack.com/archives/C029PBS5JVB/p1669233780065449

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
