### PR TITLE
Add jitter to the agent core loop

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,53 @@
 # Prefect Release Notes
 
+
+## Release 2.6.9
+
+### Features
+
+Logging into Prefect Cloud from the CLI has been given a serious upgrade!
+
+<img width="748" alt="Login example" src="https://user-images.githubusercontent.com/2586601/199800241-c1b3691b-f18c-43ee-85e9-53cc3e5b1d48.png">
+
+The `prefect cloud login` command now:
+
+- Can be used non-interactively
+- Can open the browser to generate a new API key for you
+- Uses a new workspace selector
+- Always uses your current profile
+- Only prompts for workspace selection when you have more than one workspace
+
+It also detects existing authentication:
+
+- If logged in on the current profile, we will check that you want to reauthenticate
+- If logged in on another profile, we will suggest a profile switch
+
+There's also a new `prefect cloud logout` command (contributed by @hallenmaia) to remove credentials from the current profile.
+
+### Enhancements
+- Add automatic upper-casing of string log level settings — https://github.com/PrefectHQ/prefect/pull/7592
+- Add `infrastructure_pid` to flow run — https://github.com/PrefectHQ/prefect/pull/7595
+- Add `PrefectFormatter` to reduce logging configuration duplication — https://github.com/PrefectHQ/prefect/pull/7588
+- Update `CloudClient.read_workspaces` to return a model — https://github.com/PrefectHQ/prefect/pull/7332
+- Update hashing utilities to allow execution in FIPS 140-2 environments — https://github.com/PrefectHQ/prefect/pull/7620
+
+### Fixes
+- Update logging setup to support incremental configuration — https://github.com/PrefectHQ/prefect/pull/7569
+- Update logging `JsonFormatter` to output valid JSON — https://github.com/PrefectHQ/prefect/pull/7567
+- Remove `inter` CSS import, which blocked UI loads in air-gapped environments — https://github.com/PrefectHQ/prefect/pull/7586
+- Return 404 when a flow run is missing during `set_task_run_state` — https://github.com/PrefectHQ/prefect/pull/7603
+- Fix directory copy errors with `LocalFileSystem` deployments on Python 3.7 — https://github.com/PrefectHQ/prefect/pull/7441
+- Add flush of task run logs when on remote workers — https://github.com/PrefectHQ/prefect/pull/7626
+
+### Documentation
+- Add docs about CPU and memory allocation on agent deploying ECS infrastructure blocks — https://github.com/PrefectHQ/prefect/pull/7597
+
+### Contributors
+- @hallenmaia 
+- @szelenka
+
+**All changes**: https://github.com/PrefectHQ/prefect/compare/2.6.8...2.6.9
+
 ## Release 2.6.8
 
 ### Enhancements

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -156,6 +156,7 @@ async def start(
             PREFECT_AGENT_QUERY_INTERVAL.value(),
             printer=app.console.print,
             run_once=run_once,
+            jitter_range=0.3,
         )
 
     app.console.print("Agent stopped!")

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -3,7 +3,7 @@ import random
 
 
 def poisson_interval(average_interval):
-    # note that we ensure the argument to the logarithm is stabilized to prevented
+    # note that we ensure the argument to the logarithm is stabilized to prevent
     # calling log(0), which results in a DomainError
     return -math.log(max(1 - random.random(), 1e-10)) * average_interval
 

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -1,0 +1,17 @@
+import math
+import random
+
+
+def poisson_interval(average_interval):
+    return -math.log(1 - random.random()) * average_interval
+
+
+def clamped_poisson_interval(average_interval, clamping_factor=0.3):
+    interval = poisson_interval(average_interval)
+    while not (
+        average_interval * (1 - clamping_factor)
+        < interval
+        < average_interval * (1 + clamping_factor)
+    ):
+        interval = poisson_interval(average_interval)
+    return interval

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -7,6 +7,13 @@ def poisson_interval(average_interval):
 
 
 def clamped_poisson_interval(average_interval, clamping_factor=0.3):
+    """
+    Clamps Poisson intervals to a range defined by the clamping_factor
+
+    Note that because the distribution of Poisson intervals is not symmetric around the
+    average interval, a symmetric clamp with slightly skew the mean interval.
+    """
+
     interval = poisson_interval(average_interval)
     while not (
         average_interval * (1 - clamping_factor)

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -3,7 +3,9 @@ import random
 
 
 def poisson_interval(average_interval):
-    return -math.log(1 - random.random()) * average_interval
+    # note that we ensure the argument to the logarithm is stabilized to prevented
+    # calling log(0), which results in a DomainError
+    return -math.log(max(1 - random.random(), 1e-10)) * average_interval
 
 
 def clamped_poisson_interval(average_interval, clamping_factor=0.3):

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -8,6 +8,7 @@ import anyio
 import httpx
 
 from prefect.utilities.collections import distinct
+from prefect.utilities.math import clamped_poisson_interval
 
 
 async def critical_service_loop(
@@ -17,6 +18,7 @@ async def critical_service_loop(
     consecutive: int = 3,
     printer: Callable[..., None] = print,
     run_once: bool = False,
+    jitter_range: float = None,
 ):
     """
     Runs the given `workload` function on the specified `interval`, while being
@@ -31,6 +33,9 @@ async def critical_service_loop(
         consecutive: how many consecutive errors must we see before we exit
         printer: a `print`-like function where errors will be reported
         run_once: if set, the loop will only run once then return
+        jitter_range: if set, the interval will be a random variable (rv) drawn from
+            a clamped Poisson distribution where lambda = interval and bound between
+            `interval * (1 - range) < rv < interval * (1 + range)`
     """
 
     track_record: Deque[bool] = deque([True] * consecutive, maxlen=consecutive)
@@ -101,5 +106,10 @@ async def critical_service_loop(
 
         if run_once:
             return
+
+        if jitter_range is not None:
+            sleep = clamped_poisson_interval(interval, clamping_factor=jitter_range)
+        else:
+            sleep = interval
 
         await anyio.sleep(interval)

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -34,8 +34,8 @@ async def critical_service_loop(
         printer: a `print`-like function where errors will be reported
         run_once: if set, the loop will only run once then return
         jitter_range: if set, the interval will be a random variable (rv) drawn from
-            a clamped Poisson distribution where lambda = interval and bound between
-            `interval * (1 - range) < rv < interval * (1 + range)`
+            a clamped Poisson distribution where lambda = interval and the rv is bound
+            between `interval * (1 - range) < rv < interval * (1 + range)`
     """
 
     track_record: Deque[bool] = deque([True] * consecutive, maxlen=consecutive)

--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -112,4 +112,4 @@ async def critical_service_loop(
         else:
             sleep = interval
 
-        await anyio.sleep(interval)
+        await anyio.sleep(sleep)

--- a/tests/utilities/test_math.py
+++ b/tests/utilities/test_math.py
@@ -1,0 +1,42 @@
+from prefect.utilities.math import clamped_poisson_interval, poisson_interval
+
+
+def test_poisson_intervals():
+    expected_average = 42
+    bunch_of_intervals = [poisson_interval(expected_average) for _ in range(100_000)]
+    observed_average = sum(bunch_of_intervals) / len(bunch_of_intervals)
+    assert expected_average * 0.95 < observed_average < expected_average * 1.05
+
+
+def test_clamped_poisson_intervals():
+    expected_average = 42
+    bunch_of_intervals = [
+        clamped_poisson_interval(expected_average, clamping_factor=0.3)
+        for _ in range(100_000)
+    ]
+    observed_average = sum(bunch_of_intervals) / len(bunch_of_intervals)
+
+    assert expected_average * 0.9 < observed_average < expected_average * 1.1
+
+    assert (
+        len(
+            list(
+                filter(
+                    lambda interval: expected_average > expected_average * (1 + 0.3),
+                    bunch_of_intervals,
+                )
+            )
+        )
+        == 0
+    ), "no intervals should exceed the upper clamp limit"
+    assert (
+        len(
+            list(
+                filter(
+                    lambda interval: expected_average < expected_average * (1 - 0.3),
+                    bunch_of_intervals,
+                )
+            )
+        )
+        == 0
+    ), "no intervals should exceed the lower clamp limit"

--- a/tests/utilities/test_math.py
+++ b/tests/utilities/test_math.py
@@ -18,25 +18,10 @@ def test_clamped_poisson_intervals():
 
     assert expected_average * 0.9 < observed_average < expected_average * 1.1
 
-    assert (
-        len(
-            list(
-                filter(
-                    lambda interval: expected_average > expected_average * (1 + 0.3),
-                    bunch_of_intervals,
-                )
-            )
-        )
-        == 0
+    assert max(bunch_of_intervals) < expected_average * (
+        1 + 0.3
     ), "no intervals should exceed the upper clamp limit"
-    assert (
-        len(
-            list(
-                filter(
-                    lambda interval: expected_average < expected_average * (1 - 0.3),
-                    bunch_of_intervals,
-                )
-            )
-        )
-        == 0
-    ), "no intervals should exceed the lower clamp limit"
+
+    assert min(bunch_of_intervals) > expected_average * (
+        1 - 0.3
+    ), "no intervals should be smaller than the lower clamp limit"

--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -1,5 +1,4 @@
 import statistics
-from unittest.mock import call
 
 import httpx
 import pytest

--- a/tests/utilities/test_services.py
+++ b/tests/utilities/test_services.py
@@ -1,3 +1,4 @@
+import statistics
 from unittest.mock import call
 
 import httpx
@@ -98,7 +99,7 @@ async def test_quits_after_3_consecutive_errors(capsys: pytest.CaptureFixture):
     assert "httpx.TimeoutException: boo" in result.out
 
 
-async def test_sleeps_between_loops(monkeypatch):
+async def test_consistent_sleeps_between_loops(monkeypatch):
     workload = AsyncMock(
         side_effect=[
             None,
@@ -114,10 +115,35 @@ async def test_sleeps_between_loops(monkeypatch):
     monkeypatch.setattr("prefect.utilities.services.anyio.sleep", sleeper)
     await critical_service_loop(workload, 0.0)
     assert workload.await_count == 6
-    assert sleeper.await_args_list == [
-        call(0.0),
-        call(0.0),
-        call(0.0),
-        call(0.0),
-        call(0.0),
+
+    sleep_times = [call.args[0] for call in sleeper.await_args_list]
+    assert sleep_times == [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     ]
+
+
+async def test_jittered_sleeps_between_loops(monkeypatch):
+    workload = AsyncMock(
+        side_effect=[
+            None,
+            None,
+            None,
+            None,
+            None,
+            KeyboardInterrupt,
+        ]
+    )
+    sleeper = AsyncMock()
+
+    monkeypatch.setattr("prefect.utilities.services.anyio.sleep", sleeper)
+    await critical_service_loop(workload, 42, jitter_range=0.3)
+    assert workload.await_count == 6
+
+    sleep_times = [call.args[0] for call in sleeper.await_args_list]
+    assert statistics.variance(sleep_times) > 0
+    assert min(sleep_times) > 42 * (1 - 0.3)
+    assert max(sleep_times) < 42 * (1 + 0.3)


### PR DESCRIPTION
Jitters agent loop intervals. This change modifies the agent loop sleep time so it is drawn from a clamped Poisson distribution. The average sleep time is approximately the same as it was before, only now it's allowed to vary within 30% of the old value (5 seconds). In setups that use many agents, it's possible for agents to enter race conditions that cascade into correlated errors. By adding jitter to the agent loops, multi-agent setups can be more distributed in time, guarding against these failure modes.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
