### PR TITLE
Add version_group_id property to flow view

### DIFF
--- a/src/prefect/backend/flow.py
+++ b/src/prefect/backend/flow.py
@@ -34,6 +34,7 @@ class FlowView:
         - storage: The deserialized Storage object used to store this flow
         - name: The name of the flow
         - flow_group_labels: Labels that are assigned to the parent flow group
+        - version_group_id: The group version used to register the flow
     """
 
     flow_id: str
@@ -46,6 +47,7 @@ class FlowView:
     storage: prefect.storage.Storage
     name: str
     flow_group_labels: List[str]
+    version_group_id: str
 
     @property
     def flow(self) -> "prefect.Flow":
@@ -282,6 +284,7 @@ class FlowView:
                     "core_version": True,
                     "storage": True,
                     "flow_group": {"labels"},
+                    "version_group_id": True,
                 }
             }
         }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
I need to create cloud hooks programmatically via API however currently, there is no clean way to pull out the `version_group_id` using the client. In my scenario, upon registering the flows I need to get the `group_version_id` and put it in the mutation request:

```
mutation {
  create_cloud_hook(
    input: {
      type: EMAIL,
      version_group_id: <= The key is mandatory,
      ...
      ) {
    id
  }
}
```

In order to address that issue I simply updated the flow query and introduced a new property in the codebase. That way we could simply call the function `from_flow_name` and get the result through the newly added property.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
