### PR TITLE
Add agent reporting of crashed flow run infrastructure

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -291,9 +291,8 @@ class OrionAgent:
             task_status.started()
 
         if result.status_code != 0:
-            self.logger.warning(
-                f"Infrastructure for flow run '{flow_run.id}' exited with non-zero "
-                f"status code {result.status_code}."
+            self.logger.info(
+                f"Reporting flow run '{flow_run.id}' as crashed due to non-zero status code."
             )
             await self._propose_crashed_state(
                 flow_run,

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -18,7 +18,7 @@ from prefect.infrastructure import Infrastructure, InfrastructureResult, Process
 from prefect.logging import get_logger
 from prefect.orion.schemas.core import BlockDocument, FlowRun, WorkQueue
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
-from prefect.states import Pending, exception_to_failed_state
+from prefect.states import Crashed, Pending, exception_to_failed_state
 
 
 class OrionAgent:
@@ -290,8 +290,16 @@ class OrionAgent:
             # Mark the task as started to prevent agent crash
             task_status.started()
 
-        # TODO: Check the result for a bad exit code and proposing a crashed state for the
-        #       run
+        if result.status_code != 0:
+            self.logger.warning(
+                f"Infrastructure for flow run '{flow_run.id}' exited with non-zero "
+                f"status code {result.status_code}."
+            )
+            await self._propose_crashed_state(
+                flow_run,
+                f"Flow run infrastructure exited with non-zero status code {result.status_code}.",
+            )
+
         return result
 
     async def _propose_pending_state(self, flow_run: FlowRun) -> bool:
@@ -336,6 +344,19 @@ class OrionAgent:
                 f"Failed to update state of flow run '{flow_run.id}'",
                 exc_info=True,
             )
+
+    async def _propose_crashed_state(self, flow_run: FlowRun, message: str) -> None:
+        try:
+            await propose_state(
+                self.client,
+                Crashed(message=message),
+                flow_run_id=flow_run.id,
+            )
+        except Abort:
+            # Flow run already marked as failed
+            pass
+        except Exception:
+            self.logger.exception(f"Failed to update state of flow run '{flow_run.id}'")
 
     # Context management ---------------------------------------------------------------
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,3 +1,4 @@
+import inspect
 from unittest.mock import MagicMock
 
 import pendulum
@@ -6,10 +7,10 @@ import pytest
 from prefect import flow
 from prefect.agent import OrionAgent
 from prefect.blocks.core import Block
-from prefect.exceptions import Abort, FailedRun
+from prefect.exceptions import Abort, CrashedRun, FailedRun
 from prefect.infrastructure.base import Infrastructure
 from prefect.orion import models, schemas
-from prefect.states import Completed, Pending, Running, Scheduled
+from prefect.states import Completed, Pending, Running, Scheduled, State, StateType
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dispatch import get_registry_for_type
 
@@ -357,19 +358,25 @@ class TestInfrastructureIntegration:
         mock.pre_start_side_effect = lambda: None
         mock.post_start_side_effect = lambda: None
         mock.mark_as_started = True
+        mock.result_status_code = 0
 
         async def mock_run(self, task_status=None):
             # Record the call immediately
             result = mock(self.dict())
+            result.status_code = mock.result_status_code
 
             # Perform side-effects for testing error handling
 
-            mock.pre_start_side_effect()
+            pre = mock.pre_start_side_effect()
+            if inspect.iscoroutine(pre):
+                await pre
 
             if mock.mark_as_started:
                 task_status.started()
 
-            mock.post_start_side_effect()
+            post = mock.post_start_side_effect()
+            if inspect.iscoroutine(post):
+                await post
 
             return result
 
@@ -668,6 +675,90 @@ class TestInfrastructureIntegration:
             "generally indicates improper implementation of infrastructure. The "
             "flow run will not be marked as failed, but an issue may have occurred."
         )
+
+    async def test_agent_crashes_flow_if_infrastructure_returns_nonzero_status_code(
+        self, orion_client, deployment, mock_infrastructure_run, caplog
+    ):
+        infra_doc_id = deployment.infrastructure_document_id
+        infra_document = await orion_client.read_block_document(infra_doc_id)
+        infrastructure = Block._from_block_document(infra_document)
+
+        flow_run = await orion_client.create_flow_run_from_deployment(
+            deployment.id,
+            state=Scheduled(scheduled_time=pendulum.now("utc")),
+        )
+        flow = await orion_client.read_flow(deployment.flow_id)
+
+        mock_infrastructure_run.result_status_code = 9
+
+        async with OrionAgent(
+            [deployment.work_queue_name], prefetch_seconds=10
+        ) as agent:
+            await agent.get_and_submit_flow_runs()
+
+        mock_infrastructure_run.assert_called_once_with(
+            infrastructure.prepare_for_flow_run(
+                flow_run, deployment=deployment, flow=flow
+            ).dict()
+        )
+        assert (
+            f"flow run '{flow_run.id}' exited with non-zero status code 9"
+            in caplog.text
+        )
+
+        state = (await orion_client.read_flow_run(flow_run.id)).state
+        assert state.is_crashed()
+        with pytest.raises(CrashedRun, match="exited with non-zero status code 9"):
+            await state.result()
+
+    @pytest.mark.parametrize(
+        "terminal_state_type",
+        [StateType.CRASHED, StateType.FAILED, StateType.COMPLETED],
+    )
+    async def test_agent_does_not_crashes_flow_if_already_in_terminal_state(
+        self,
+        orion_client,
+        deployment,
+        mock_infrastructure_run,
+        caplog,
+        terminal_state_type,
+    ):
+        infra_doc_id = deployment.infrastructure_document_id
+        infra_document = await orion_client.read_block_document(infra_doc_id)
+        infrastructure = Block._from_block_document(infra_document)
+
+        flow_run = await orion_client.create_flow_run_from_deployment(
+            deployment.id,
+            state=Scheduled(scheduled_time=pendulum.now("utc")),
+        )
+        flow = await orion_client.read_flow(deployment.flow_id)
+
+        async def update_flow_run_state():
+            await orion_client.set_flow_run_state(
+                flow_run.id, State(type=terminal_state_type, message="test")
+            )
+
+        mock_infrastructure_run.result_status_code = 9
+        mock_infrastructure_run.post_start_side_effect = update_flow_run_state
+
+        async with OrionAgent(
+            [deployment.work_queue_name], prefetch_seconds=10
+        ) as agent:
+            await agent.get_and_submit_flow_runs()
+
+        mock_infrastructure_run.assert_called_once_with(
+            infrastructure.prepare_for_flow_run(
+                flow_run, deployment=deployment, flow=flow
+            ).dict()
+        )
+        assert (
+            f"flow run '{flow_run.id}' exited with non-zero status code 9"
+            in caplog.text
+        )
+
+        state = (await orion_client.read_flow_run(flow_run.id)).state
+        assert state.type == terminal_state_type
+        assert state.message == "test"
 
 
 async def test_agent_displays_message_on_work_queue_pause(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -702,7 +702,7 @@ class TestInfrastructureIntegration:
             ).dict()
         )
         assert (
-            f"flow run '{flow_run.id}' exited with non-zero status code 9"
+            f"Reporting flow run '{flow_run.id}' as crashed due to non-zero status code"
             in caplog.text
         )
 
@@ -752,7 +752,7 @@ class TestInfrastructureIntegration:
             ).dict()
         )
         assert (
-            f"flow run '{flow_run.id}' exited with non-zero status code 9"
+            f"Reporting flow run '{flow_run.id}' as crashed due to non-zero status code"
             in caplog.text
         )
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds reporting for crashed flow runs to the agent when the infrastructure status code is non-zero.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Agent logs:
```
15:31:34.018 | ERROR   | prefect.infrastructure.process - Process 'chirpy-bison' exited with status code: 2
15:31:34.018 | INFO | prefect.agent - Reporting flow run '568261ef-049c-40a1-a562-05dcbc3d6306' as crashed due to non-zero status code.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
