### PR TITLE
Fix benchmarks exit codes

### DIFF
--- a/benches/__main__.py
+++ b/benches/__main__.py
@@ -15,7 +15,7 @@ for arg in sys.argv[1:] if len(sys.argv) > 1 else []:
         targets.append(arg)
 
 
-subprocess.run(
+process = subprocess.run(
     [
         "pytest",
         "--no-cov",
@@ -29,3 +29,6 @@ subprocess.run(
     stdout=sys.stdout,
     stderr=sys.stderr,
 )
+
+
+sys.exit(process.returncode)


### PR DESCRIPTION
We were not reraising the subprocess exit code so CI always succeeded unless it deadlocked.