### PR TITLE
Bugfix: pauses will not sleep longer than the polling interval

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -723,7 +723,8 @@ async def pause_flow_run(timeout: int = 300, poll_interval: int = 10):
     with anyio.move_on_after(timeout):
 
         # attempt to check if a flow has resumed at least once
-        await anyio.sleep(timeout / 2)
+        initial_sleep = min(timeout / 2, poll_interval)
+        await anyio.sleep(initial_sleep)
         flow_run = await client.read_flow_run(frc.flow_run.id)
         if flow_run.state.is_running():
             logger.info("Resuming flow run execution!")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -158,9 +158,7 @@ class TestPausingFlows:
         assert min(sleep_intervals) == 2
         assert max(sleep_intervals) == 2
 
-    async def test_first_polling_is_smaller_than_the_timeout(
-        self, monkeypatch
-    ):
+    async def test_first_polling_is_smaller_than_the_timeout(self, monkeypatch):
         sleeper = AsyncMock(side_effect=[None, None, None, None, None])
         monkeypatch.setattr("prefect.engine.anyio.sleep", sleeper)
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -151,7 +151,7 @@ class TestPausingFlows:
             omega = doesnt_pause(wait_for=[x, y])
 
         with pytest.raises(StopAsyncIteration):
-            # the sleeper mock will exhaust its side effects after 5 calls
+            # the sleeper mock will exhaust its side effects after 6 calls
             pausing_flow()
 
         sleep_intervals = [c.args[0] for c in sleeper.await_args_list]
@@ -178,12 +178,12 @@ class TestPausingFlows:
             omega = doesnt_pause(wait_for=[x, y])
 
         with pytest.raises(StopAsyncIteration):
-            # the sleeper mock will exhaust its side effects after 5 calls
+            # the sleeper mock will exhaust its side effects after 6 calls
             pausing_flow()
 
         sleep_intervals = [c.args[0] for c in sleeper.await_args_list]
         assert sleep_intervals[0] == 2
-        assert sleep_intervals[1:] == [5, 5, 5, 5]
+        assert sleep_intervals[1:] == [5, 5, 5, 5, 5]
 
     async def test_paused_flows_block_execution_in_sync_flows(self, orion_client):
         @task


### PR DESCRIPTION
Fixes a bug in the pausing code that will result in a too-long initial poll when the timeout is large.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
