### PR TITLE
Make the final state of a flow `Cancelled` when any task finishes in a `Cancelled` state

### DIFF
--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -233,6 +233,21 @@ class TestStateGroup:
 
         assert not StateGroup(states).all_completed()
 
+    def test_any_cancelled(self):
+        states = [
+            Cancelled(),
+            Failed(data=ValueError("1")),
+        ]
+
+        assert StateGroup(states).any_cancelled()
+
+        states = [
+            Completed(data="test"),
+            Failed(data=ValueError("1")),
+        ]
+
+        assert not StateGroup(states).any_cancelled()
+
     def test_any_failed(self):
         states = [
             Completed(data="test"),


### PR DESCRIPTION
In issue #6789 it was called out that returning a `Cancelled` state from a task resulted in an exception. This updates the handling in `return_value_to_state` to set the final state of a flow to `Cancelled` if any subflow/task returns a `Cancelled` state. Examples:

This shows a flow that will run a task 10 times and get 5 Cancelled states and 5 Completed states. The final state of the flow will be `Cancelled`.
```python
from prefect import flow, task
from prefect.orion.schemas.states import Cancelled


@task
def process(n):
    if n % 2 == 0:
        return Cancelled(message="I want to skip this")
    else:
        return n


@flow
def my_flow():
    for n in range(10):
        process(n)
```
Which has the final state of `Cancelled('5/10 states cancelled.')`

The same is true about subflows:
```python
from prefect import flow, task
from prefect.orion.schemas.states import Cancelled


@task
def subflow():
    return Cancelled(message="I want to skip this")


@flow
def my_flow():
    subflow()
```
Which has the final state of `Cancelled('1/1 states cancelled.')`

and you can return a `Cancelled` state directly from a flow itself:

```python
from prefect import flow
from prefect.orion.schemas.states import Cancelled


@flow
def my_flow():
    return Cancelled(message="I want to skip this")


if __name__ == "__main__":
    my_flow()
```

Which has the final state of `Cancelled('I want to skip this')`


Closes #6789 