### PR TITLE
Docs: Add create a flow run from deployment with Prefect client to Concepts

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -496,25 +496,21 @@ The `prefect deployment` CLI command provides commands for managing and running 
 | `preview` | Prints a preview of a deployment. |
 | `run`     | Create a flow run for the given flow and deployment. |
 
-### Create a flow run with Prefect client
+### Create a flow run in a Python script 
 
-To create a flow run from a deployment with Prefect client, start with retrieve the deployment ID corresponding to the the flow you try to trigger by running `prefect deployment ls`.
-
-After obtaining the deployment ID, use Prefect client to create a flow run from a deployment:
+You can create a flow run from a deployment in a Python script with the `run_deployment` method.
 
 ```python
-import asyncio
-from prefect.client import get_client
+from prefect.deployments import run_deployment
 
 
-async def main():
-    async with get_client() as client:
-        depl_id = "your-deployment-id"
-        response = await client.create_flow_run_from_deployment(depl_id)
+def main():
+    response = run_deployment(name="flow-name/deployment-name")
+    print(response)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+   main()
 ``` 
 
 !!! tip "`PREFECT_API_URL` setting for agents"

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -478,8 +478,10 @@ $ prefect deployment inspect 'Cat Facts/catfact'
 
 ## Create a flow run from a deployment
 
+### Create a flow run with a schedule
 If you specify a schedule for a deployment, the deployment will execute its flow automatically on that schedule as long as a Prefect Orion API server and agent is running. Prefect Cloud created scheduled flow runs automatically, and they will run on schedule if an agent is configured to pick up flow runs for the deployment.
 
+### Create a flow run with Prefect UI
 In the [Prefect UI](/ui/deployments/), you can click the **Run** button next to any deployment to execute an ad hoc flow run for that deployment.
 
 The `prefect deployment` CLI command provides commands for managing and running deployments locally.
@@ -493,6 +495,27 @@ The `prefect deployment` CLI command provides commands for managing and running 
 | `ls`      | View all deployments or deployments for specific flows. |
 | `preview` | Prints a preview of a deployment. |
 | `run`     | Create a flow run for the given flow and deployment. |
+
+### Create a flow run with Prefect client
+
+To create a flow run from a deployment with Prefect client, start with retrieve the deployment ID corresponding to the the flow you try to trigger by running `prefect deployment ls`.
+
+After obtaining the deployment ID, use Prefect client to create a flow run from a deployment:
+
+```python
+import asyncio
+from prefect.client import get_client
+
+
+async def main():
+    async with get_client() as client:
+        depl_id = "your-deployment-id"
+        response = await client.create_flow_run_from_deployment(depl_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+``` 
 
 !!! tip "`PREFECT_API_URL` setting for agents"
     You'll need to configure [agents and work queues](/concepts/work-queues/) that can create flow runs for deployments in remote environments. [`PREFECT_API_URL`](/concepts/settings/#prefect_api_url) must be set for the environment in which your agent is running.

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -302,7 +302,7 @@ To create an ad-hoc flow run with different parameter values, go the the details
 
 ![Configuring custom parameter values for an ad-hoc flow run](/img/concepts/custom-parameters.png)
 
-## Create a deployment with the CLI
+### Create a deployment
 
 When you've configured `deployment.yaml` for a deployment, you can create the deployment on the API by running the `prefect deployment apply` Prefect CLI command.
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
There are two commits in this PR. 

The first one is to indent the `Create a deployment` section under `Create a deployment on the CLI`. Without this fix, there are two `Create a deployment with CLI` sections at the same level. 

![Screenshot 2022-11-30 at 11 34 43 AM](https://user-images.githubusercontent.com/49108771/204868238-bb14c05a-590f-4c9c-9ab8-a6583ffc7cd3.png)

The second one is to add creating a flow run from deployment with Prefect client to the Concepts page. This closes #7680

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
