### PR TITLE
use prefect_ui_url for notifications

### DIFF
--- a/src/prefect/orion/services/flow_run_notifications.py
+++ b/src/prefect/orion/services/flow_run_notifications.py
@@ -10,7 +10,7 @@ from prefect.orion import models, schemas
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.services.loop_service import LoopService
-from prefect.settings import PREFECT_API_URL
+from prefect.settings import PREFECT_UI_URL
 
 
 class FlowRunNotifications(LoopService):
@@ -141,8 +141,7 @@ class FlowRunNotifications(LoopService):
         Args:
             flow_run_id: the flow run id.
         """
-        api_url = PREFECT_API_URL.value() or "http://ephemeral-orion/api"
-        ui_url = api_url.strip("/api")
+        ui_url = PREFECT_UI_URL.value() or "http://ephemeral-orion/api"
         return f"{ui_url}/flow-runs/flow-run/{flow_run_id}"
 
 


### PR DESCRIPTION
This change makes prefect use the prefect_ui_url when sending a flow run notification
closes `https://github.com/PrefectHQ/prefect/issues/7693`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [] This pull request includes tests or only affects documentation.
- [] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
