### PR TITLE
Raise `CancelledRun` when retrieving a Cancelled state's Result

### DIFF
--- a/src/prefect/deprecated/data_documents.py
+++ b/src/prefect/deprecated/data_documents.py
@@ -228,7 +228,9 @@ def result_from_state_with_data_document(state, raise_on_failure: bool) -> Any:
 
     from prefect.states import State
 
-    if (state.is_failed() or state.is_crashed()) and raise_on_failure:
+    if (
+        state.is_failed() or state.is_crashed() or state.is_cancelled()
+    ) and raise_on_failure:
         if isinstance(data, Exception):
             raise data
         elif isinstance(data, BaseException):

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -75,6 +75,16 @@ class FailedRun(PrefectException):
     """
 
 
+class CancelledRun(PrefectException):
+    """
+    Raised when the result from a cancelled run is retrieved and an exception
+    is not attached.
+
+    This occurs when a string is attached to the state instead of an exception
+    or if the state's data is null.
+    """
+
+
 class MissingFlowError(PrefectException):
     """
     Raised when a given flow name is not found in the expected script.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -15,6 +15,7 @@ from prefect.client.orion import OrionClient
 from prefect.context import PrefectObjectRegistry
 from prefect.deprecated.data_documents import DataDocument
 from prefect.exceptions import (
+    CancelledRun,
     InvalidNameError,
     MissingResult,
     ParameterTypeError,
@@ -551,6 +552,9 @@ class TestFlowCall:
         assert first.is_cancelled()
         assert second.is_completed()
         assert third.is_failed()
+
+        with pytest.raises(CancelledRun):
+            first.result()
 
     def test_flow_with_cancelled_subflow_has_cancelled_state(self):
         @task


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

As a follow-on to #7694 this causes getting the result of a `Cancelled` state to raise `CancelledRun`. This brings it in line with `Failed` and `Crashed` states.

### Example
```python
from prefect import flow
from prefect.orion.schemas.states import Cancelled


@flow
def my_flow():
    return Cancelled(message="I want to skip this")


state = my_flow()
state.result()
```

Which results in this traceback:

```
13:33:08.615 | INFO    | prefect.engine - Created flow run 'polite-sidewinder' for flow 'my-flow'
13:33:08.721 | ERROR   | Flow run 'polite-sidewinder' - Finished in state Cancelled('I want to skip this')
Traceback (most recent call last):
  File "/Users/chrispickett/src/flows/issue_6789.py", line 10, in <module>
    state = my_flow()
  File "/Users/chrispickett/src/prefect/src/prefect/flows.py", line 442, in __call__
    return enter_flow_run_engine_from_flow_call(
  File "/Users/chrispickett/src/prefect/src/prefect/engine.py", line 161, in enter_flow_run_engine_from_flow_call
    return anyio.run(begin_run)
  File "/opt/anaconda3/lib/python3.9/site-packages/anyio/_core/_eventloop.py", line 56, in run
    return asynclib.run(func, *args, **backend_options)
  File "/opt/anaconda3/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 233, in run
    return native_run(wrapper(), debug=debug)
  File "/opt/anaconda3/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/anaconda3/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/opt/anaconda3/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 228, in wrapper
    return await func(*args)
  File "/Users/chrispickett/src/prefect/src/prefect/client/utilities.py", line 47, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/chrispickett/src/prefect/src/prefect/engine.py", line 241, in create_then_begin_flow_run
    return await state.result(fetch=True)
  File "/Users/chrispickett/src/prefect/src/prefect/states.py", line 77, in _get_state_result
    raise await get_state_exception(state)
prefect.exceptions.CancelledRun: I want to skip this
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
