### PR TITLE
Fix state display bug when state message is empty

### DIFF
--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -187,15 +187,15 @@ class State(IDBaseModel, Generic[R]):
         `MyCompletedState("my message", type=COMPLETED)`
         """
 
-        display_message = f"{self.message!r}" if self.message else ""
+        display = []
 
-        display_type = (
-            f", type={self.type.value}"
-            if self.type.value.lower() != self.name.lower()
-            else ""
-        )
+        if self.message:
+            display.append(repr(self.message))
 
-        return f"{self.name}({display_message}{display_type})"
+        if self.type.value.lower() != self.name.lower():
+            display.append(f"type={self.type.value}")
+
+        return f"{self.name}({', '.join(display)})"
 
     def __hash__(self) -> int:
         return hash(

--- a/tests/orion/schemas/test_states.py
+++ b/tests/orion/schemas/test_states.py
@@ -177,6 +177,9 @@ class TestRepresentation:
     async def test_state_str_excludes_null_message(self):
         assert str(Failed(message=None)) == "Failed()"
 
+    async def test_state_str_excludes_null_message_with_name(self):
+        assert str(Failed(message=None, name="Test")) == "Test(type=FAILED)"
+
     async def test_state_str_includes_type_if_name_is_custom(self):
         assert str(Failed(message="abc", name="Foo")) == "Foo('abc', type=FAILED)"
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
state = Failed(message=None, name="Test")
print(state)
```
Previously: `Test(, type=FAILED)`
Now: `Test(type=FAILED)`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
