### PR TITLE
Bump timeout in flaky test

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -820,7 +820,7 @@ class TestFlowTimeouts:
         assert "exceeded timeout of 0.1 seconds" in state.message
 
     def test_timeout_only_applies_if_exceeded(self):
-        @flow(timeout_seconds=0.5)
+        @flow(timeout_seconds=1)
         def my_flow():
             time.sleep(0.1)
 


### PR DESCRIPTION
See example failure at https://github.com/PrefectHQ/prefect/actions/runs/3589607088/jobs/6042201822 — if the runner is slow it is possible to timeout