### PR TITLE
Increase default database query timeout to 10s

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -650,10 +650,11 @@ PREFECT_ORION_DATABASE_MIGRATE_ON_START = Setting(
 
 PREFECT_ORION_DATABASE_TIMEOUT = Setting(
     Optional[float],
-    default=5.0,
+    default=10.0,
 )
-"""A statement timeout, in seconds, applied to all database
-interactions made by the API. Defaults to `1`.
+"""
+A statement timeout, in seconds, applied to all database interactions made by the API.
+Defaults to 10 seconds.
 """
 
 PREFECT_ORION_DATABASE_CONNECTION_TIMEOUT = Setting(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,6 @@ from prefect.settings import (
     PREFECT_ORION_ANALYTICS_ENABLED,
     PREFECT_ORION_BLOCKS_REGISTER_ON_START,
     PREFECT_ORION_DATABASE_CONNECTION_URL,
-    PREFECT_ORION_DATABASE_TIMEOUT,
     PREFECT_ORION_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED,
     PREFECT_ORION_SERVICES_LATE_RUNS_ENABLED,
     PREFECT_ORION_SERVICES_SCHEDULER_ENABLED,
@@ -296,8 +295,6 @@ def pytest_sessionstart(session):
             PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION: False,
             # Disable auto-registration of block types as they can conflict
             PREFECT_ORION_BLOCKS_REGISTER_ON_START: False,
-            # Use more aggressive database timeouts during testing
-            PREFECT_ORION_DATABASE_TIMEOUT: 1,
         },
         source=__file__,
     )


### PR DESCRIPTION
Also increases the timeout in tests. This is in line with the Cloud timeout setting. We have seen user reports that this needs to be bumped and I have a preference for stability over early failure
