### PR TITLE
add detail on `log_prints` patching

### DIFF
--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -127,7 +127,7 @@ The underlying log model for task runs captures the task name, task run ID, and 
 
 ### Logging print statements
 
-Prefect provides the `log_prints` option to enable the logging of `print` statements at the task or flow level. When `log_prints=True` for a given task or flow, the Python builtin `print` will be patched with the Prefect logger for the scope of that task or flow.
+Prefect provides the `log_prints` option to enable the logging of `print` statements at the task or flow level. When `log_prints=True` for a given task or flow, the Python builtin `print` will be patched to redirect to the Prefect logger for the scope of that task or flow.
 
 By default, tasks and subflows will inherit their `log_prints` setting from their parent flow, unless opted out with their own explicit `log_prints` setting.
 

--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -129,7 +129,7 @@ The underlying log model for task runs captures the task name, task run ID, and 
 
 Prefect provides the `log_prints` option to enable the logging of `print` statements at the task or flow level. When `log_prints=True` for a given task or flow, the Python builtin `print` will be patched to redirect to the Prefect logger for the scope of that task or flow.
 
-By default, tasks and subflows will inherit their `log_prints` setting from their parent flow, unless opted out with their own explicit `log_prints` setting.
+By default, tasks and subflows will inherit the `log_prints` setting from their parent flow, unless opted out with their own explicit `log_prints` setting.
 
 
 ```python

--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -127,7 +127,10 @@ The underlying log model for task runs captures the task name, task run ID, and 
 
 ### Logging print statements
 
-Prefect provides the `log_prints` option to enable logging of print statements at the task or flow level. By default, tasks and subflows will inherit the print logging behavior from their parent flow, unless opted out with their own `log_print=False`.
+Prefect provides the `log_prints` option to enable the logging of `print` statements at the task or flow level. When `log_prints=True` for a given task or flow, the Python builtin `print` will be patched with the Prefect logger for the scope of that task or flow.
+
+By default, tasks and subflows will inherit their `log_prints` setting from their parent flow, unless opted out with their own explicit `log_prints` setting.
+
 
 ```python
 from prefect import task, flow


### PR DESCRIPTION
adds a little detail on the implementation of `log_prints` with respect to the patching of `print`