### PR TITLE
Monitor process after kill and return early when possible

### DIFF
--- a/src/prefect/infrastructure/process.py
+++ b/src/prefect/infrastructure/process.py
@@ -171,18 +171,17 @@ class Process(Infrastructure):
             # Throttle how often we check if the process is still alive to keep
             # from making too many system calls in a short period of time.
             check_interval = max(grace_seconds / 10, 1)
-            waited_seconds = 0
 
-            while waited_seconds < grace_seconds:
-                await anyio.sleep(check_interval)
-                waited_seconds += check_interval
+            with anyio.move_on_after(grace_seconds):
+                while True:
+                    await anyio.sleep(check_interval)
 
-                # Detect if the process is still alive. If not do an early
-                # return as the process respected the SIGTERM from above.
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    return
+                    # Detect if the process is still alive. If not do an early
+                    # return as the process respected the SIGTERM from above.
+                    try:
+                        os.kill(pid, 0)
+                    except ProcessLookupError:
+                        return
 
             try:
                 os.kill(pid, signal.SIGKILL)

--- a/tests/infrastructure/test_process.py
+++ b/tests/infrastructure/test_process.py
@@ -201,7 +201,7 @@ async def test_process_kill_mismatching_hostname(monkeypatch):
     process = Process(command=["noop"])
 
     with pytest.raises(InfrastructureNotAvailable):
-        await process.kill(infrastructure_pid=infrastructure_pid, grace_seconds=15)
+        await process.kill(infrastructure_pid=infrastructure_pid)
 
     os_kill.assert_not_called()
 
@@ -215,7 +215,7 @@ async def test_process_kill_no_matching_pid(monkeypatch):
     process = Process(command=["noop"])
 
     with pytest.raises(InfrastructureNotFound):
-        await process.kill(infrastructure_pid=infrastructure_pid, grace_seconds=15)
+        await process.kill(infrastructure_pid=infrastructure_pid)
 
 
 @pytest.mark.skipif(
@@ -224,12 +224,10 @@ async def test_process_kill_no_matching_pid(monkeypatch):
 )
 async def test_process_kill_sends_sigterm_then_sigkill(monkeypatch):
     os_kill = MagicMock()
-    anyio_sleep = AsyncMock()
     monkeypatch.setattr("os.kill", os_kill)
-    monkeypatch.setattr("prefect.infrastructure.process.anyio.sleep", anyio_sleep)
 
     infrastructure_pid = f"{socket.gethostname()}:12345"
-    grace_seconds = 15
+    grace_seconds = 2
 
     process = Process(command=["noop"])
     await process.kill(
@@ -240,20 +238,9 @@ async def test_process_kill_sends_sigterm_then_sigkill(monkeypatch):
         [
             call(12345, signal.SIGTERM),
             call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
-            call(12345, 0),
             call(12345, signal.SIGKILL),
         ]
     )
-
-    anyio_sleep.assert_has_calls([call(1.5)] * 10)
 
 
 @pytest.mark.skipif(

--- a/tests/infrastructure/test_process.py
+++ b/tests/infrastructure/test_process.py
@@ -229,7 +229,7 @@ async def test_process_kill_sends_sigterm_then_sigkill(monkeypatch):
     monkeypatch.setattr("prefect.infrastructure.process.anyio.sleep", anyio_sleep)
 
     infrastructure_pid = f"{socket.gethostname()}:12345"
-    grace_seconds = 3
+    grace_seconds = 15
 
     process = Process(command=["noop"])
     await process.kill(
@@ -242,11 +242,18 @@ async def test_process_kill_sends_sigterm_then_sigkill(monkeypatch):
             call(12345, 0),
             call(12345, 0),
             call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
+            call(12345, 0),
             call(12345, signal.SIGKILL),
         ]
     )
 
-    assert anyio_sleep.call_count == 3
+    anyio_sleep.assert_has_calls([call(1.5)] * 10)
 
 
 @pytest.mark.skipif(
@@ -274,7 +281,7 @@ async def test_process_kill_early_return(monkeypatch):
         ]
     )
 
-    assert anyio_sleep.call_count == 1
+    anyio_sleep.assert_called_once_with(3)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This updates the `Process.kill` method. Instead of sleeping for the full `grace_seconds` and then attempting a kill, it sleeps for 1 second `grace_seconds` times. This allows it to check if the process still exists and do an early return when possible.

Closes #7734 

### Example

https://user-images.githubusercontent.com/354286/205357158-9f4ec671-0a08-401f-a397-804075befb51.mov


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
