### PR TITLE
Use cluster uid and namespace instead of cluster "name" for Kubernetes job identifiers

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -221,7 +221,7 @@ A real-world example might include the flow run ID from the context in the cache
 
 ```python
 def cache_within_flow_run(context, parameters):
-    return f"{context.flow_run_id}-{task_input_hash(context, parameters)}"
+    return f"{context.task_run.flow_run_id}-{task_input_hash(context, parameters)}"
 
 @task(cache_key_fn=cache_within_flow_run)
 def cached_task():

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -305,6 +305,9 @@ class KubernetesJob(Infrastructure):
                     name=job_name,
                     namespace=job_namespace,
                     grace_period_seconds=grace_seconds,
+                    # Foreground propagation deletes dependent objects before deleting owner objects.
+                    # This ensures that the pods are cleaned up before the job is marked as deleted.
+                    # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
                     propagation_policy="Foreground",
                 )
             except kubernetes.client.exceptions.ApiException as exc:

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -266,39 +266,48 @@ class KubernetesJob(Infrastructure):
 
         self._configure_kubernetes_library_client()
         manifest = self.build_job()
-        job_name = await run_sync_in_worker_thread(self._create_job, manifest)
+        job = await run_sync_in_worker_thread(self._create_job, manifest)
 
-        job_pid = self._get_infrastructure_pid(job_name)
+        pid = await run_sync_in_worker_thread(self._get_infrastructure_pid, job)
         # Indicate that the job has started
         if task_status is not None:
-            task_status.started(job_pid)
+            task_status.started(pid)
 
         # Monitor the job
-        return await run_sync_in_worker_thread(self._watch_job, job_name)
+        return await run_sync_in_worker_thread(self._watch_job, job)
 
     async def kill(self, infrastructure_pid: str, grace_seconds: int = 30):
         self._configure_kubernetes_library_client()
-        job_cluster, job_name = self._parse_infrastructure_pid(infrastructure_pid)
-        current_cluster = self._get_active_cluster_name()
-        if job_cluster != current_cluster:
+        job_cluster_uid, job_namespace, job_name = self._parse_infrastructure_pid(
+            infrastructure_pid
+        )
+
+        if not job_namespace == self.namespace:
             raise InfrastructureNotAvailable(
-                f"Unable to stop job {job_name!r}: the job is running on cluster ",
-                f"{job_cluster!r}, but your current context is attached to cluster ",
-                f"{current_cluster!r}.",
+                f"Unable to kill job {job_name!r}: The job is running in namespace "
+                f"{job_namespace!r} but this block is configured to use "
+                f"{self.namespace!r}."
+            )
+
+        current_cluster_uid = self._get_cluster_uid()
+        if job_cluster_uid != current_cluster_uid:
+            raise InfrastructureNotAvailable(
+                f"Unable to kill job {job_name!r}: The job is running on another "
+                "cluster."
             )
 
         with self.get_batch_client() as batch_client:
             try:
                 batch_client.delete_namespaced_job(
                     name=job_name,
-                    namespace=self.namespace,
+                    namespace=job_namespace,
                     grace_period_seconds=grace_seconds,
                     propagation_policy="Foreground",
                 )
             except kubernetes.client.exceptions.ApiException as exc:
                 if exc.status == 404:
                     raise InfrastructureNotFound(
-                        f"Unable to stop job {job_name!r}: The job was not found."
+                        f"Unable to kill job {job_name!r}: The job was not found."
                     ) from exc
                 else:
                     raise
@@ -329,32 +338,51 @@ class KubernetesJob(Infrastructure):
             finally:
                 client.rest_client.pool_manager.clear()
 
-    def _get_infrastructure_pid(self, job_name: str) -> str:
-        """Generates a kubernetes pid string in the form of `<cluster_name>:<job_name>`."""
-        try:
-            cluster_name = self._get_active_cluster_name()
-        except kubernetes.config.config_exception.ConfigException:
-            cluster_name = "in-cluster-config"
-        job_pid = f"{cluster_name}:{job_name}"
-        return job_pid
+    def _get_infrastructure_pid(self, job: "V1Job") -> str:
+        """
+        Generates a Kubernetes infrastructure PID.
 
-    def _parse_infrastructure_pid(self, infrastructure_pid: str) -> Tuple[str, str]:
-        """Splits a kubernetes infrastructure pid into its component parts."""
-        cluster_name, job_name = infrastructure_pid.rsplit(":", 1)
-        return cluster_name, job_name
+        The PID is in the format: "<cluster uid>:<namespace>:<job name>".
+        """
+        cluster_uid = self._get_cluster_uid()
+        pid = f"{cluster_uid}:{self.namespace}:{job.metadata.name}"
+        return pid
 
-    def _get_active_cluster_name(self) -> str:
-        _, active_context = kubernetes.config.list_kube_config_contexts()
-        cluster_name = active_context["context"]["cluster"]
-        return cluster_name
+    def _parse_infrastructure_pid(
+        self, infrastructure_pid: str
+    ) -> Tuple[str, str, str]:
+        """
+        Parse a Kubernetes infrastructure PID into its component parts.
+
+        Returns a cluster UID, namespace, and job name.
+        """
+        cluster_uid, namespace, job_name = infrastructure_pid.split(":", 2)
+        return cluster_uid, namespace, job_name
+
+    def _get_cluster_uid(self) -> str:
+        """
+        Gets a unique id for the current cluster being used.
+
+        There is no real unique identifier for a cluster. However, the `kube-system`
+        namespace is immutable and has a persistence UID that we use instead.
+
+        See https://github.com/kubernetes/kubernetes/issues/44954
+        """
+        with self.get_client() as client:
+            namespace = client.read_namespace("kube-system")
+        cluster_uid = namespace.metadata.uid
+        return cluster_uid
 
     def _configure_kubernetes_library_client(self) -> None:
-        """Set the correct kubernetes client configuration.
-
-        Important: this is NOT threadsafe.
-
-        TODO: investigate returning a client
         """
+        Set the correct kubernetes client configuration.
+
+        WARNING: This action is not threadsafe and may override the configuration
+                  specified by another `KubernetesJob` instance.
+        """
+        # TODO: Investigate returning a configured client so calls on other threads
+        #       will not invalidate the config needed here
+
         # if a k8s cluster block is provided to the flow runner, use that
         if self.cluster_config:
             self.cluster_config.configure_client()
@@ -507,7 +535,8 @@ class KubernetesJob(Infrastructure):
 
         self.logger.error(f"Job {job_name!r}: Pod never started.")
 
-    def _watch_job(self, job_name: str) -> bool:
+    def _watch_job(self, job: "V1Job") -> KubernetesJobResult:
+        job_name = job.metadata.name
         job = self._get_job(job_name)
         if not job:
             return KubernetesJobResult(status_code=-1, identifier=job_name)
@@ -555,14 +584,14 @@ class KubernetesJob(Infrastructure):
             identifier=job.metadata.name,
         )
 
-    def _create_job(self, job_manifest: KubernetesManifest) -> str:
+    def _create_job(self, job_manifest: KubernetesManifest) -> "V1Job":
         """
         Given a Kubernetes Job Manifest, create the Job on the configured Kubernetes
         cluster and return its name.
         """
         with self.get_batch_client() as batch_client:
             job = batch_client.create_namespaced_job(self.namespace, job_manifest)
-        return job.metadata.name
+        return job
 
     def _slugify_name(self, name: str) -> str:
         """

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -705,7 +705,7 @@ def test_get_infrastructure_pid_handles_config_exceptions(monkeypatch):
         "prefect.infrastructure.kubernetes.KubernetesJob._get_active_cluster_name", mock
     )
     job = KubernetesJob()
-    job_pid = job._get_infrastructure_pid("my-job")
+    job_pid = job._get_infrastructure_identifier("my-job")
     assert job_pid == "in-cluster-config:my-job"
 
 

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -215,9 +215,6 @@ class TestKill:
             name="mock-k8s-v1-job",
             namespace="default",
             grace_period_seconds=0,
-            # Foreground propagation deletes dependent objects before deleting owner objects.
-            # This ensures that the pods are cleaned up before the job is marked as deleted.
-            # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
             propagation_policy="Foreground",
         )
 

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -150,114 +150,208 @@ def test_task_status_receives_job_pid(
     mock_k8s_batch_client,
     mock_k8s_client,
     mock_watch,
+    monkeypatch,
 ):
+    MOCK_CLUSTER_UID = "1234"
+    mock_func = MagicMock()
+    mock_func.return_value = MOCK_CLUSTER_UID
+
+    monkeypatch.setattr(
+        "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid", mock_func
+    )
+
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
     result = KubernetesJob(command=["echo", "hello"]).run(task_status=fake_status)
-    fake_status.started.assert_called_once_with(f"{FAKE_CLUSTER}:{result.identifier}")
+    expected_value = f"{MOCK_CLUSTER_UID}:default:{'mock-k8s-v1-job'}"
+    fake_status.started.assert_called_once_with(expected_value)
 
 
 async def test_task_group_start_returns_job_pid(
     mock_k8s_batch_client,
     mock_k8s_client,
     mock_watch,
+    monkeypatch,
 ):
+    MOCK_CLUSTER_UID = "1234"
+    mock_func = MagicMock()
+    mock_func.return_value = MOCK_CLUSTER_UID
+
+    monkeypatch.setattr(
+        "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid", mock_func
+    )
+
+    expected_value = f"{MOCK_CLUSTER_UID}:default:{'mock-k8s-v1-job'}"
     async with anyio.create_task_group() as tg:
-        status_result = await tg.start(
+        result = await tg.start(
             KubernetesJob(command=["echo", "hello"], name="test").run
         )
-        assert status_result == f"{FAKE_CLUSTER}:mock-k8s-v1-job"
+        assert result == expected_value
 
 
-async def test_kill_calls_delete_namespaced_job(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    await KubernetesJob(command=["echo", "hello"], name="test").kill(
-        infrastructure_pid=f"{FAKE_CLUSTER}:mock-k8s-v1-job", grace_seconds=0
-    )
-
-    assert len(mock_k8s_batch_client.mock_calls) == 1
-    mock_k8s_batch_client.delete_namespaced_job.assert_called_once_with(
-        name="mock-k8s-v1-job",
-        namespace="default",
-        grace_period_seconds=0,
-        # Foreground propagation deletes dependent objects before deleting owner objects.
-        # This ensures that the pods are cleaned up before the job is marked as deleted.
-        # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-        propagation_policy="Foreground",
-    )
-
-
-async def test_kill_uses_foreground_propagation_policy(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    await KubernetesJob(command=["echo", "hello"], name="test").kill(
-        infrastructure_pid=f"{FAKE_CLUSTER}:mock-k8s-v1-job", grace_seconds=0
-    )
-
-    assert len(mock_k8s_batch_client.mock_calls) == 1
-    mock_call = mock_k8s_batch_client.mock_calls[0]
-    assert "propagation_policy='Foreground'" in str(mock_call)
-
-
-async def test_kill_uses_correct_grace_seconds(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    await KubernetesJob(command=["echo", "hello"], name="test").kill(
-        infrastructure_pid=f"{FAKE_CLUSTER}:mock-k8s-v1-job", grace_seconds=42
-    )
-
-    assert len(mock_k8s_batch_client.mock_calls) == 1
-    mock_call = mock_k8s_batch_client.mock_calls[0]
-    assert "grace_period_seconds=42" in str(mock_call)
-
-
-async def test_kill_raises_infra_not_available_on_mismatched_cluster_name(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    BAD_CLUSTER = "bad-cluster"
-    with pytest.raises(
-        InfrastructureNotAvailable,
+class TestKill:
+    async def test_kill_calls_delete_namespaced_job(
+        self,
+        mock_k8s_batch_client,
+        mock_k8s_client,
+        mock_watch,
+        monkeypatch,
     ):
-        await KubernetesJob(command=["echo", "hello"], name="test").kill(
-            infrastructure_pid=f"{BAD_CLUSTER}:mock-k8s-v1-job", grace_seconds=0
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
         )
 
-
-async def test_kill_raises_infrastructure_not_found_on_404(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    mock_k8s_batch_client.delete_namespaced_job.side_effect = [ApiException(status=404)]
-    with pytest.raises(
-        InfrastructureNotFound,
-        match="Unable to stop job 'mock-k8s-v1-job': The job was not found.",
-    ):
         await KubernetesJob(command=["echo", "hello"], name="test").kill(
-            infrastructure_pid=f"{FAKE_CLUSTER}:mock-k8s-v1-job", grace_seconds=0
+            infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
+            grace_seconds=0,
         )
 
-
-async def test_kill_passes_other_k8s_api_errors_through(
-    mock_k8s_batch_client,
-    mock_k8s_client,
-    mock_watch,
-):
-    mock_k8s_batch_client.delete_namespaced_job.side_effect = [ApiException(status=400)]
-    with pytest.raises(
-        ApiException,
-    ):
-        await KubernetesJob(command=["echo", "hello"], name="test").kill(
-            infrastructure_pid=f"{FAKE_CLUSTER}:mock-k8s-v1-job", grace_seconds=0
+        assert len(mock_k8s_batch_client.mock_calls) == 1
+        mock_k8s_batch_client.delete_namespaced_job.assert_called_once_with(
+            name="mock-k8s-v1-job",
+            namespace="default",
+            grace_period_seconds=0,
+            # Foreground propagation deletes dependent objects before deleting owner objects.
+            # This ensures that the pods are cleaned up before the job is marked as deleted.
+            # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+            propagation_policy="Foreground",
         )
+
+    async def test_kill_uses_foreground_propagation_policy(
+        self,
+        mock_k8s_batch_client,
+        mock_k8s_client,
+        mock_watch,
+        monkeypatch,
+    ):
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
+        )
+
+        await KubernetesJob(command=["echo", "hello"], name="test").kill(
+            infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
+            grace_seconds=0,
+        )
+
+        assert len(mock_k8s_batch_client.mock_calls) == 1
+        assert len(mock_k8s_batch_client.mock_calls) == 1
+        mock_k8s_batch_client.delete_namespaced_job.assert_called_once_with(
+            name="mock-k8s-v1-job",
+            namespace="default",
+            grace_period_seconds=0,
+            propagation_policy="Foreground",
+        )
+
+    async def test_kill_uses_correct_grace_seconds(
+        self, mock_k8s_batch_client, mock_k8s_client, mock_watch, monkeypatch
+    ):
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
+        )
+
+        GRACE_SECONDS = 42
+        await KubernetesJob(command=["echo", "hello"], name="test").kill(
+            infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
+            grace_seconds=GRACE_SECONDS,
+        )
+
+        assert len(mock_k8s_batch_client.mock_calls) == 1
+        mock_k8s_batch_client.delete_namespaced_job.assert_called_once_with(
+            name="mock-k8s-v1-job",
+            namespace="default",
+            grace_period_seconds=GRACE_SECONDS,
+            propagation_policy="Foreground",
+        )
+
+    async def test_kill_raises_infra_not_available_on_mismatched_cluster_name(
+        self, mock_k8s_batch_client, mock_k8s_client, mock_watch, monkeypatch
+    ):
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
+        )
+        BAD_CLUSTER = "4321"
+        with pytest.raises(
+            InfrastructureNotAvailable,
+        ):
+            await KubernetesJob(command=["echo", "hello"], name="test").kill(
+                infrastructure_pid=f"{BAD_CLUSTER}:default:mock-k8s-v1-job",
+                grace_seconds=0,
+            )
+
+    async def test_kill_raises_infrastructure_not_found_on_404(
+        self,
+        mock_k8s_batch_client,
+        mock_k8s_client,
+        mock_watch,
+        monkeypatch,
+    ):
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
+        )
+
+        mock_k8s_batch_client.delete_namespaced_job.side_effect = [
+            ApiException(status=404)
+        ]
+
+        with pytest.raises(
+            InfrastructureNotFound,
+            match="Unable to kill job 'mock-k8s-v1-job': The job was not found.",
+        ):
+            await KubernetesJob(command=["echo", "hello"], name="test").kill(
+                infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
+                grace_seconds=0,
+            )
+
+    async def test_kill_passes_other_k8s_api_errors_through(
+        self,
+        mock_k8s_batch_client,
+        mock_k8s_client,
+        mock_watch,
+        monkeypatch,
+    ):
+
+        MOCK_CLUSTER_UID = "1234"
+        mock_func = MagicMock()
+        mock_func.return_value = MOCK_CLUSTER_UID
+
+        monkeypatch.setattr(
+            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
+            mock_func,
+        )
+
+        mock_k8s_batch_client.delete_namespaced_job.side_effect = [
+            ApiException(status=400)
+        ]
+        with pytest.raises(
+            ApiException,
+        ):
+            await KubernetesJob(command=["echo", "hello"], name="test").kill(
+                infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:dog", grace_seconds=0
+            )
 
 
 @pytest.mark.parametrize(
@@ -696,17 +790,6 @@ def test_watches_the_right_namespace(
             ),
         ]
     )
-
-
-def test_get_infrastructure_pid_handles_config_exceptions(monkeypatch):
-    mock = MagicMock()
-    mock.side_effect = k8s.config.config_exception.ConfigException("Error")
-    monkeypatch.setattr(
-        "prefect.infrastructure.kubernetes.KubernetesJob._get_active_cluster_name", mock
-    )
-    job = KubernetesJob()
-    job_pid = job._get_infrastructure_identifier("my-job")
-    assert job_pid == "in-cluster-config:my-job"
 
 
 class TestCustomizingBaseJob:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Co-authored with @peytonrunyan 
Closes https://github.com/PrefectHQ/prefect/issues/7739

Converts Kubernetes job PIDs from `{cluster_name}:{job_name}` to `{cluster_uid}:{namespace}:{job_name}`. Cluster names can be arbitrarily set in the Kubernetes config and are not a reliable unique identifier. Additionally, the config does not exist when using an in-cluster agent or in cases like #7739. We generate a stable cluster UID from the `kube-system` namespace UID as described in https://github.com/kubernetes/kubernetes/issues/44954 — which tracks the lack of a Kubernetes API for retrieving a cluster identifier. I attempted to use the job UID instead of the job name because it is guaranteed to be unique across namespaces. However, there is not a clear way to look up a job by its UID later without listing all jobs. Instead, we include the namespace in the PID to ensure we do not kill jobs in the wrong namespace.

Additionally, in #7701 the `KubernetesJobResult` returns were not updated to include the new identifier. Here, I do some minor refactoring to fix this.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
 
 ```python
 from prefect.infrastructure import KubernetesJob
import anyio


async def main():
    async with anyio.create_task_group() as tg:
        job = KubernetesJob(
            command=["sleep", "1000"], pod_watch_timeout_seconds=5
        )

        pid = await tg.start(job.run)
        print("PID:", pid)

        await job.kill(pid)
        print("Killed :)")


anyio.run(main)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
