### PR TITLE
Move /health to root router

### DIFF
--- a/src/prefect/orion/api/server.py
+++ b/src/prefect/orion/api/server.py
@@ -160,7 +160,7 @@ def create_orion_api(
     fast_api_app_kwargs = fast_api_app_kwargs or {}
     api_app = FastAPI(title=API_TITLE, **fast_api_app_kwargs)
 
-    @api_app.get(health_check_path)
+    @api_app.get(health_check_path, tags=["Root"])
     async def health_check():
         return True
 


### PR DESCRIPTION
Very minor change -- currently the `/health` endpoint shows up as the only element of the `default` category in the API docs; this moves it to the `root` category along with `/hello`.