### PR TITLE
Add --match flag to work queues documentation

### DIFF
--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -49,7 +49,7 @@ Configuration parameters you can specify when starting an agent include:
 | --run-once           | Only run agent polling once. By default, the agent runs forever.                                                                           |
 | --prefetch-seconds   | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
 | --hide-welcome       | Do not display the startup ASCII art for the agent process.                                                                                |
-| --match QUEUE_PREFIX | Polls for queues matching the given QUEUE_PREFIX. Note: this option overrides anything passed with `-q` or `--work-queue`.                     |                  
+| --match QUEUE_PREFIX | Polls for queues matching the given QUEUE_PREFIX. Note: this option overrides anything passed with `-q` or `--work-queue`.                 |                  
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.
 

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -65,10 +65,13 @@ You must start an agent within an environment that can access or create the infr
 
 Use the `prefect agent start` CLI command to start an agent. You must pass at least one work queue name or match string that the agent will poll for work. If the work queue does not exist, it will be created.
 
+<div class="terminal">
 
 ```bash
 $ prefect agent start -q [work queue name]
 ```
+
+</div>
 
 For example:
 

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -42,14 +42,14 @@ Agents are configured to pull work from one or more work queues. If the agent re
 
 Configuration parameters you can specify when starting an agent include:
 
-| Option           | Description  |
-| --- | --- |
-| -q, --work-queue | One or more work queues that the agent will poll for work. |
-| --api TEXT       | The API URL for the Prefect Orion server. Default is the value of `PREFECT_API_URL`. |
-| --run-once        | Only run agent polling once. By default, the agent runs forever. |
-| --prefetch-seconds | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
-| --hide-welcome   | Do not display the startup ASCII art for the agent process.                          |
-| --match | Start all queues that match the given match string
+| Option               | Description                                                                                                                                |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| -q, --work-queue     | One or more work queues that the agent will poll for work.                                                                                 |
+| --api TEXT           | The API URL for the Prefect Orion server. Default is the value of `PREFECT_API_URL`.                                                       |
+| --run-once           | Only run agent polling once. By default, the agent runs forever.                                                                           |
+| --prefetch-seconds   | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
+| --hide-welcome       | Do not display the startup ASCII art for the agent process.                                                                                |
+| --match QUEUE_PREFIX | Polls for queues matching the given QUEUE_PREFIX. Note: this option overrides anything passed with `-q` or `--work-queue`.                     |                  
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.
 
@@ -97,7 +97,7 @@ In this case, Prefect automatically created a new `my-queue` work queue.
 
 By default, the agent polls the API specified by the `PREFECT_API_URL` environment variable. To configure the agent to poll from a different server location, use the `--api` flag, specifying the URL of the server.
 
-In addition, Agents can match multiple work queues by providing a --match string instead of specifying all of the work queues. The agent will poll every work queue with a name that starts with the given string.
+In addition, agents can match multiple work queues by providing a --match string instead of specifying all of the work queues. The agent will poll every work queue with a name that starts with the given string. New queues matching this prefix will be found by the agent without needing to restart it.
 
 For example:
 <div class="terminal">
@@ -105,7 +105,9 @@ For example:
 ```bash
 $ prefect agent start --match "foo-"
 ```
+
 </div>
+
 This example will poll every work queue that starts with "foo-".
 
 ### Configuring prefetch

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -49,6 +49,7 @@ Configuration parameters you can specify when starting an agent include:
 | --run-once        | Only run agent polling once. By default, the agent runs forever. |
 | --prefetch-seconds | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
 | --hide-welcome   | Do not display the startup ASCII art for the agent process.                          |
+| --match | Start all queues that match the given match string
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.
 
@@ -62,13 +63,12 @@ You must start an agent within an environment that can access or create the infr
 
 ### Starting an agent
 
-Use the `prefect agent start` CLI command to start an agent. You must pass at least one work queue name that the agent will poll for work. If the work queue does not exist, it will be created.
+Use the `prefect agent start` CLI command to start an agent. You must pass at least one work queue name or match string that the agent will poll for work. If the work queue does not exist, it will be created.
 
-<div class="terminal">
+
 ```bash
 $ prefect agent start -q [work queue name]
 ```
-</div>
 
 For example:
 
@@ -93,6 +93,17 @@ Agent started! Looking for work from queue(s): my-queue...
 In this case, Prefect automatically created a new `my-queue` work queue.
 
 By default, the agent polls the API specified by the `PREFECT_API_URL` environment variable. To configure the agent to poll from a different server location, use the `--api` flag, specifying the URL of the server.
+
+In addition, Agents can match multiple work queues by providing a --match string instead of specifying all of the work queues. The agent will poll every work queue with a name that starts with the given string.
+
+For example:
+<div class="terminal">
+
+```bash
+$ prefect agent start --match "foo-"
+```
+</div>
+This example will poll every work queue that starts with "foo-"
 
 ### Configuring prefetch
 

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -42,8 +42,8 @@ Agents are configured to pull work from one or more work queues. If the agent re
 
 Configuration parameters you can specify when starting an agent include:
 
-| Option               | Description                                                                                                                                |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| Option               | Description |
+|---|---|
 | -q, --work-queue     | One or more work queues that the agent will poll for work.                                                                                 |
 | --api TEXT           | The API URL for the Prefect Orion server. Default is the value of `PREFECT_API_URL`.                                                       |
 | --run-once           | Only run agent polling once. By default, the agent runs forever.                                                                           |
@@ -97,7 +97,7 @@ In this case, Prefect automatically created a new `my-queue` work queue.
 
 By default, the agent polls the API specified by the `PREFECT_API_URL` environment variable. To configure the agent to poll from a different server location, use the `--api` flag, specifying the URL of the server.
 
-In addition, agents can match multiple work queues by providing a --match string instead of specifying all of the work queues. The agent will poll every work queue with a name that starts with the given string. New queues matching this prefix will be found by the agent without needing to restart it.
+In addition, agents can match multiple work queues by providing a `--match` string instead of specifying all of the work queues. The agent will poll every work queue with a name that starts with the given string. New queues matching this prefix will be found by the agent without needing to restart it.
 
 For example:
 <div class="terminal">

--- a/docs/concepts/work-queues.md
+++ b/docs/concepts/work-queues.md
@@ -106,7 +106,7 @@ For example:
 $ prefect agent start --match "foo-"
 ```
 </div>
-This example will poll every work queue that starts with "foo-"
+This example will poll every work queue that starts with "foo-".
 
 ### Configuring prefetch
 


### PR DESCRIPTION
Added documentation about the --match flag in agent configuration to work-queues.md. 
Preview here: https://deploy-preview-7768--prefect-orion.netlify.app/concepts/work-queues
Closes https://github.com/PrefectHQ/prefect/issues/7511

- [X] This pull request references any related issue by including "closes `<link to issue>`"
- [X] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
