### PR TITLE
Add descriptions to flows

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -228,14 +228,17 @@ class OrionClient:
         Returns:
             the ID of the flow in the backend
         """
-        return await self.create_flow_from_name(flow.name)
+        return await self.create_flow_from_name(flow.name, flow.description)
 
-    async def create_flow_from_name(self, flow_name: str) -> UUID:
+    async def create_flow_from_name(
+        self, flow_name: str, flow_description: str
+    ) -> UUID:
         """
         Create a flow in Orion.
 
         Args:
             flow_name: the name of the new flow
+            flow_description: the description of the new flow
 
         Raises:
             httpx.RequestError: if a flow was not created for any reason
@@ -243,7 +246,9 @@ class OrionClient:
         Returns:
             the ID of the flow in the backend
         """
-        flow_data = schemas.actions.FlowCreate(name=flow_name)
+        flow_data = schemas.actions.FlowCreate(
+            name=flow_name, description=flow_description
+        )
         response = await self._client.post(
             "/flows/", json=flow_data.dict(json_compatible=True)
         )

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -272,6 +272,26 @@ class OrionClient:
         # Return the id of the created flow
         return UUID(flow_id)
 
+    async def update_flow(self, flow_id: UUID, description: Optional[str] = None):
+        """
+        Update a flow.
+
+        Args:
+            flow_id: the id of the flow to update
+            description: the new description of the flow
+
+        Returns:
+            a [Flow model][prefect.orion.schemas.core.Flow] representation of the updated flow
+        """
+        params = {"description": description}
+
+        flow_data = schemas.actions.FlowUpdate(**params)
+
+        return await self._client.patch(
+            f"/flows/{flow_id}",
+            json=flow_data.dict(json_compatible=True, exclude_unset=True),
+        )
+
     async def read_flow(self, flow_id: UUID) -> schemas.core.Flow:
         """
         Query Orion for a flow by id.

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -232,14 +232,14 @@ class OrionClient:
         return await self.create_flow_from_name(flow.name, flow.description)
 
     async def create_flow_from_name(
-        self, flow_name: str, flow_description: str
+        self, flow_name: str, description: Optional[str] = None
     ) -> UUID:
         """
         Create a flow in Orion.
 
         Args:
             flow_name: the name of the new flow
-            flow_description: the description of the new flow
+            description: the description of the new flow
 
         Raises:
             httpx.RequestError: if a flow was not created for any reason
@@ -248,7 +248,8 @@ class OrionClient:
             the ID of the flow in the backend
         """
         flow_data = schemas.actions.FlowCreate(
-            name=flow_name, description=flow_description
+            name=flow_name,
+            description=description,
         )
         response = await self._client.post(
             "/flows/", json=flow_data.dict(json_compatible=True)

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_12_05_185028_adabad235795_add_description_to_flow.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_12_05_185028_adabad235795_add_description_to_flow.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: adabad235795
+Revises: 5e4f924ff96c
+Create Date: 2022-12-05 18:50:28.800545
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "adabad235795"
+down_revision = "5e4f924ff96c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("flow", sa.Column("description", sa.TEXT(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("flow", schema=None) as batch_op:
+        batch_op.drop_column("description")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2022_12_05_184519_dc729e5c0448_add_description_to_flow.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2022_12_05_184519_dc729e5c0448_add_description_to_flow.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: dc729e5c0448
+Revises: 7201de756d85
+Create Date: 2022-12-05 18:45:19.631375
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dc729e5c0448"
+down_revision = "7201de756d85"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("flow", sa.Column("description", sa.TEXT(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("flow", schema=None) as batch_op:
+        batch_op.drop_column("description")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -89,6 +89,7 @@ class ORMFlow:
     """SQLAlchemy mixin of a flow."""
 
     name = sa.Column(sa.String, nullable=False)
+    description = sa.Column(sa.Text(), nullable=False)
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
 
     @declared_attr

--- a/src/prefect/orion/models/flows.py
+++ b/src/prefect/orion/models/flows.py
@@ -2,7 +2,6 @@
 Functions for interacting with flow ORM objects.
 Intended for internal use by the Orion API.
 """
-
 from uuid import UUID
 
 import sqlalchemy as sa

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -39,6 +39,14 @@ def validate_block_document_name(value):
     return value
 
 
+def validate_description_length(cls, description):
+    if description is not None and len(description) > MAX_FLOW_DESCRIPTION_LENGTH:
+        raise ValueError(
+            f"Description is over the maximum length of {MAX_FLOW_DESCRIPTION_LENGTH}."
+        )
+    return description
+
+
 class ActionBaseModel(PrefectBaseModel):
     class Config:
         extra = "forbid"
@@ -68,13 +76,9 @@ class FlowCreate(ActionBaseModel):
     description: Optional[str] = FieldFrom(schemas.core.Flow)
     tags: List[str] = FieldFrom(schemas.core.Flow)
 
-    @validator("description")
-    def validate_description_length(cls, description):
-        if description is not None and len(description) > MAX_FLOW_DESCRIPTION_LENGTH:
-            raise ValueError(
-                f"Description is over the maximum length of {MAX_FLOW_DESCRIPTION_LENGTH}."
-            )
-        return description
+    _validate_description_length = validator("description", allow_reuse=True)(
+        validate_description_length
+    )
 
 
 @copy_model_fields
@@ -83,6 +87,10 @@ class FlowUpdate(ActionBaseModel):
 
     description: Optional[str] = FieldFrom(schemas.core.Flow)
     tags: List[str] = FieldFrom(schemas.core.Flow)
+
+    _validate_description_length = validator("description", allow_reuse=True)(
+        validate_description_length
+    )
 
 
 @copy_model_fields

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -63,6 +63,7 @@ class FlowCreate(ActionBaseModel):
     """Data used by the Orion API to create a flow."""
 
     name: str = FieldFrom(schemas.core.Flow)
+    description: Optional[str] = FieldFrom(schemas.core.Flow)
     tags: List[str] = FieldFrom(schemas.core.Flow)
 
 
@@ -70,6 +71,7 @@ class FlowCreate(ActionBaseModel):
 class FlowUpdate(ActionBaseModel):
     """Data used by the Orion API to update a flow."""
 
+    description: Optional[str] = FieldFrom(schemas.core.Flow)
     tags: List[str] = FieldFrom(schemas.core.Flow)
 
 

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -18,6 +18,8 @@ from prefect.orion.utilities.schemas import (
 
 LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
 
+MAX_FLOW_DESCRIPTION_LENGTH = 200
+
 
 def validate_block_type_slug(value):
     if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
@@ -65,6 +67,14 @@ class FlowCreate(ActionBaseModel):
     name: str = FieldFrom(schemas.core.Flow)
     description: Optional[str] = FieldFrom(schemas.core.Flow)
     tags: List[str] = FieldFrom(schemas.core.Flow)
+
+    @validator("description")
+    def validate_description_length(cls, description):
+        if description is not None and len(description) > MAX_FLOW_DESCRIPTION_LENGTH:
+            raise ValueError(
+                f"Description is over the maximum length of {MAX_FLOW_DESCRIPTION_LENGTH}."
+            )
+        return description
 
 
 @copy_model_fields

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -77,6 +77,9 @@ class Flow(ORMBaseModel):
     name: str = Field(
         default=..., description="The name of the flow", example="my-flow"
     )
+    description: Optional[str] = Field(
+        default=None, description="The description of the flow."
+    )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -593,6 +593,20 @@ async def test_create_then_read_flow(orion_client):
     assert lookup.name == foo.name
 
 
+async def test_create_then_read_flow_with_description(orion_client):
+    @flow(name="foo", description="foo description.")
+    def foo():
+        pass
+
+    flow_id = await orion_client.create_flow(foo)
+    assert isinstance(flow_id, UUID)
+
+    lookup = await orion_client.read_flow(flow_id)
+    assert isinstance(lookup, schemas.core.Flow)
+    assert lookup.name == foo.name
+    assert lookup.description == foo.description
+
+
 async def test_create_then_read_deployment(
     orion_client, infrastructure_document_id, storage_document_id
 ):

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -607,6 +607,32 @@ async def test_create_then_read_flow_with_description(orion_client):
     assert lookup.description == foo.description
 
 
+@pytest.mark.parametrize(
+    "init_desc, updated_desc",
+    [
+        (None, "new description"),
+        ("initial description", "updated description"),
+        ("remove description", None),
+    ],
+)
+async def test_update_flow_description(init_desc, updated_desc, orion_client):
+    @flow(name="foo", description=init_desc)
+    def foo():
+        pass
+
+    flow_id = await orion_client.create_flow(foo)
+
+    initial_lookup = await orion_client.read_flow(flow_id)
+    assert initial_lookup.name == foo.name
+    assert initial_lookup.description == foo.description
+
+    await orion_client.update_flow(initial_lookup.id, description=updated_desc)
+
+    second_lookup = await orion_client.read_flow(flow_id)
+    assert second_lookup.name == foo.name
+    assert second_lookup.description == updated_desc
+
+
 async def test_create_then_read_deployment(
     orion_client, infrastructure_document_id, storage_document_id
 ):

--- a/tests/orion/api/test_flows.py
+++ b/tests/orion/api/test_flows.py
@@ -20,6 +20,17 @@ class TestCreateFlow:
         flow = await models.flows.read_flow(session=session, flow_id=flow_id)
         assert str(flow.id) == flow_id
 
+    async def test_create_flow_with_description(self, session, client):
+        flow_data = {"name": "my-flow", "description": "my-flow description."}
+        response = await client.post("/flows/", json=flow_data)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["name"] == "my-flow"
+        assert response.json()["description"] == "my-flow description."
+        flow_id = response.json()["id"]
+
+        flow = await models.flows.read_flow(session=session, flow_id=flow_id)
+        assert str(flow.id) == flow_id
+
     async def test_create_flow_populates_and_returned_created(self, client):
         now = pendulum.now(tz="UTC")
         flow_data = {"name": "my-flow"}
@@ -122,6 +133,19 @@ class TestReadFlow:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["id"] == flow_id
         assert response.json()["name"] == "my-flow"
+
+    async def test_read_flow_with_description(self, client):
+        # first create a flow to read
+        flow_data = {"name": "my-flow", "description": "my-flow description."}
+        response = await client.post("/flows/", json=flow_data)
+        flow_id = response.json()["id"]
+
+        # make sure we we can read the flow correctly
+        response = await client.get(f"/flows/{flow_id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == flow_id
+        assert response.json()["name"] == "my-flow"
+        assert response.json()["description"] == "my-flow description."
 
     async def test_read_flow_returns_404_if_does_not_exist(self, client):
         response = await client.get(f"/flows/{uuid4()}")

--- a/tests/orion/models/test_flows.py
+++ b/tests/orion/models/test_flows.py
@@ -8,9 +8,11 @@ from prefect.orion import models, schemas
 class TestCreateFlow:
     async def test_create_flow_succeeds(self, session):
         flow = await models.flows.create_flow(
-            session=session, flow=schemas.core.Flow(name="my-flow")
+            session=session,
+            flow=schemas.core.Flow(name="my-flow", description="my-flow-description"),
         )
         assert flow.name == "my-flow"
+        assert flow.description == "my-flow-description"
         assert flow.id
 
     async def test_create_flow_does_not_upsert(self, session):
@@ -39,12 +41,15 @@ class TestUpdateFlow:
         update_result = await models.flows.update_flow(
             session=session,
             flow_id=flow_id,
-            flow=schemas.actions.FlowUpdate(tags=["TB12"]),
+            flow=schemas.actions.FlowUpdate(
+                tags=["TB12"], description="Updated description."
+            ),
         )
         assert update_result
 
         updated_flow = await models.flows.read_flow(session=session, flow_id=flow_id)
         assert updated_flow.tags == ["TB12"]
+        assert updated_flow.description == "Updated description."
         assert flow_id == flow.id == updated_flow.id
 
     async def test_update_flow_does_not_update_if_nothing_set(self, session):

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -2,7 +2,35 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.orion.schemas.actions import FlowRunCreate
+from prefect.orion.schemas.actions import (
+    MAX_FLOW_DESCRIPTION_LENGTH,
+    FlowCreate,
+    FlowRunCreate,
+)
+
+
+@pytest.mark.parametrize(
+    "test_flow, expected_dict",
+    [
+        (
+            {"name": "valid_flow", "description": "short_valid_description"},
+            {"name": "valid_flow", "description": "short_valid_description"},
+        ),
+        pytest.param(
+            {
+                "name": "invalid_flow",
+                "description": "long invalid description" * MAX_FLOW_DESCRIPTION_LENGTH,
+            },
+            None,
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+class TestFlowCreate:
+    def test_flow_create_validates_description(self, test_flow, expected_dict):
+        fc = FlowCreate(name=test_flow["name"], description=test_flow["description"])
+        assert fc.name == test_flow["name"]
+        assert fc.description == test_flow["description"]
 
 
 @pytest.mark.parametrize(

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -6,6 +6,7 @@ from prefect.orion.schemas.actions import (
     MAX_FLOW_DESCRIPTION_LENGTH,
     FlowCreate,
     FlowRunCreate,
+    FlowUpdate,
 )
 
 
@@ -28,9 +29,29 @@ from prefect.orion.schemas.actions import (
 )
 class TestFlowCreate:
     def test_flow_create_validates_description(self, test_flow, expected_dict):
+        # Fix this test
         fc = FlowCreate(name=test_flow["name"], description=test_flow["description"])
         assert fc.name == test_flow["name"]
         assert fc.description == test_flow["description"]
+
+
+@pytest.mark.parametrize(
+    "test_flow, expected_dict",
+    [
+        ({"description": "flow_description"}, {"description": "flow_description"}),
+        pytest.param(
+            {
+                "description": "long invalid description" * MAX_FLOW_DESCRIPTION_LENGTH,
+            },
+            None,
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+class TestFlowUpdate:
+    def test_flow_update_validates_description(self, test_flow, expected_dict):
+        fu = FlowUpdate(description=test_flow["description"])
+        assert fu.description == expected_dict["description"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The [flow and task configuration docs](https://docs.prefect.io/tutorials/flow-task-config/#flow-and-task-configuration) indicate that users should be able to set descriptions via decorator attribute or docstring of the flow function. It looks like those docs don't reflect the actual behavior of the code, as outlined in the issue #7774.

I am evaluating the use of Prefect at work and I have minimal experience with this codebase, but I am happy to continue working on this PR if someone can confirm that I am on the right track. For now, this PR should demonstrate roughly what needs to happen in order to implement this behavior as indicated by the docs. 

Additions/Alterations:
- migrations for added column in flow table to hold description
- model and schema code altered to account for description field
- some fairly minimal tests 


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect import flow, task

# Very simple flow demonstrating the working code
@task(name="My Test Task")
def my_task():
    print("In the task")


@flow(name="My Test Flow.",
      description="A minimal flow for verifying description problem updated."
      )
def my_flow():
    """Flow description from docstring."""
    print("In the flow")
    my_task()


if __name__ == '__main__':
    my_flow()

```


flow page and description label after running:
![Screenshot from 2022-12-05 19-20-37](https://user-images.githubusercontent.com/7216850/205784965-f24e1014-4242-4f95-9b62-ddb2817751f4.png)

**This code is a WIP and as such is not ready to be merged. It'd be great if someone could have a look and make sure I am on the right track here. If someone on the engineering team wants to take this over that is fine too.**

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
