### PR TITLE
Bugfix: Fullscreen layouts on screens < `lg` should take up all the available space

### DIFF
--- a/orion-ui/src/App.vue
+++ b/orion-ui/src/App.vue
@@ -12,7 +12,7 @@
     </template>
     <ContextSidebar v-if="showMenu" class="app__sidebar" @click="close" />
     <suspense>
-      <AppRouterView />
+      <AppRouterView class="app__router-view" />
     </suspense>
   </div>
 </template>
@@ -58,10 +58,14 @@
 
 .app { @apply
   text-slate-900
+  flex
+  flex-col
 }
 
 .app {
   --prefect-scroll-margin: theme('spacing.20');
+  min-height: 100vh;
+  min-width: 100vw;
 }
 
 .app__prefect-icon { @apply
@@ -79,9 +83,14 @@
 @screen lg {
   .app {
     --prefect-scroll-margin: theme('spacing.2');
-
     display: grid;
     grid-template-columns: max-content minmax(0, 1fr);
   }
+}
+
+.app__router-view {
+  /* The 1px flex-basis is important because it allows us to use height: 100% without additional flexing */
+  flex: 1 0 1px;
+  height: 100%;
 }
 </style>

--- a/orion-ui/src/App.vue
+++ b/orion-ui/src/App.vue
@@ -65,7 +65,6 @@
 .app {
   --prefect-scroll-margin: theme('spacing.20');
   min-height: 100vh;
-  min-width: 100vw;
 }
 
 .app__prefect-icon { @apply


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This PR fixes a long-standing bug where views like Radar that are full screen used a min-content height on screen sizes under the lg breakpoint.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Before:
<img width="907" alt="Screen Shot 2022-12-06 at 2 50 16 PM" src="https://user-images.githubusercontent.com/27291717/206008987-4e926d23-a420-417f-b006-dc9041038450.png">

After:
<img width="907" alt="Screen Shot 2022-12-06 at 2 49 44 PM" src="https://user-images.githubusercontent.com/27291717/206008985-31773cb0-fb7b-4933-a8aa-d4260905495c.png">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
