### PR TITLE
Create a `CANCELLING` state type

### DIFF
--- a/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add `CANCELLING` to StateType enum
+SQLite: None
+Postgres: `9326a6aee18b`
+
 # Add infrastructure_pid to flow runs
 SQLite: `7201de756d85`
 Postgres: `5d526270ddb4`

--- a/src/prefect/orion/database/migrations/versions/postgresql/2022_12_06_164028_9326a6aee18b_add_cancelling_to_state_type_enum.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2022_12_06_164028_9326a6aee18b_add_cancelling_to_state_type_enum.py
@@ -1,0 +1,22 @@
+"""Add CANCELLING to state type enum
+
+Revision ID: 9326a6aee18b
+Revises: 5e4f924ff96c
+Create Date: 2022-12-06 16:40:28.282753
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9326a6aee18b"
+down_revision = "5e4f924ff96c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE state_type ADD VALUE IF NOT EXISTS 'CANCELLING';")
+
+
+def downgrade():
+    pass

--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -166,7 +166,7 @@ class BaseQueryComponents(ABC):
                 db.FlowRun,
                 sa.and_(
                     self._flow_run_work_queue_join_clause(db.FlowRun, db.WorkQueue),
-                    db.FlowRun.state_type.in_(["RUNNING", "PENDING"]),
+                    db.FlowRun.state_type.in_(["RUNNING", "PENDING", "CANCELLING"]),
                 ),
                 isouter=True,
             )

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -702,10 +702,23 @@ class PreventRedundantTransitions(BaseOrchestrationRule):
         StateType.SCHEDULED: 1,
         StateType.PENDING: 2,
         StateType.RUNNING: 3,
+        StateType.CANCELLING: 4,
     }
 
-    FROM_STATES = [StateType.SCHEDULED, StateType.PENDING, StateType.RUNNING, None]
-    TO_STATES = [StateType.SCHEDULED, StateType.PENDING, StateType.RUNNING, None]
+    FROM_STATES = [
+        StateType.SCHEDULED,
+        StateType.PENDING,
+        StateType.RUNNING,
+        StateType.CANCELLING,
+        None,
+    ]
+    TO_STATES = [
+        StateType.SCHEDULED,
+        StateType.PENDING,
+        StateType.RUNNING,
+        StateType.CANCELLING,
+        None,
+    ]
 
     async def before_transition(
         self,
@@ -715,6 +728,7 @@ class PreventRedundantTransitions(BaseOrchestrationRule):
     ) -> None:
         initial_state_type = initial_state.type if initial_state else None
         proposed_state_type = proposed_state.type if proposed_state else None
+
         if (
             self.STATE_PROGRESS[proposed_state_type]
             <= self.STATE_PROGRESS[initial_state_type]

--- a/src/prefect/orion/schemas/states.py
+++ b/src/prefect/orion/schemas/states.py
@@ -27,6 +27,7 @@ class StateType(AutoEnum):
     CANCELLED = AutoEnum.auto()
     CRASHED = AutoEnum.auto()
     PAUSED = AutoEnum.auto()
+    CANCELLING = AutoEnum.auto()
 
 
 TERMINAL_STATES = {
@@ -265,6 +266,15 @@ def Crashed(cls: Type[State] = State, **kwargs) -> State:
         State: a Crashed state
     """
     return cls(type=StateType.CRASHED, **kwargs)
+
+
+def Cancelling(cls: Type[State] = State, **kwargs) -> State:
+    """Convenience function for creating `Cancelling` states.
+
+    Returns:
+        State: a Cancelling state
+    """
+    return cls(type=StateType.CANCELLING, **kwargs)
 
 
 def Cancelled(cls: Type[State] = State, **kwargs) -> State:

--- a/tests/orion/models/test_work_queues.py
+++ b/tests/orion/models/test_work_queues.py
@@ -242,7 +242,6 @@ class TestGetRunsInWorkQueue:
         schemas.states.StateType.PENDING,
         schemas.states.StateType.CANCELLING,
         schemas.states.StateType.RUNNING,
-        schemas.states.StateType.RUNNING,
     ]
 
     @pytest.fixture

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -968,6 +968,7 @@ class TestTransitionsFromTerminalStatesRule:
 @pytest.mark.parametrize("run_type", ["task", "flow"])
 class TestPreventingRedundantTransitionsRule:
     active_states = (
+        states.StateType.CANCELLING,
         states.StateType.RUNNING,
         states.StateType.PENDING,
         states.StateType.SCHEDULED,

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -1682,7 +1682,12 @@ class TestTaskConcurrencyLimits:
                 mutated_state.type = random.choice(
                     list(
                         set(states.StateType)
-                        - {initial_state.type, proposed_state.type}
+                        - {
+                            initial_state.type,
+                            proposed_state.type,
+                            states.StateType.RUNNING,
+                            states.StateType.CANCELLING,
+                        }
                     )
                 )
                 await self.reject_transition(

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -1772,7 +1772,11 @@ class TestTaskConcurrencyLimits:
                 mutated_state.type = random.choice(
                     list(
                         set(states.StateType)
-                        - {initial_state.type, proposed_state.type}
+                        - {
+                            initial_state.type,
+                            proposed_state.type,
+                            states.StateType.CANCELLING,
+                        }
                     )
                 )
                 await self.reject_transition(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

The MVP for cancellation used a `CANCELLED` state with a name of `Cancelling` for the agent to decide which flows need to be cancelled. The main issue with this is that concurrency slots are immediately released when that transition happens even though the tasks/flows are still technically running. There is also some general 'ick' factor in using a state name for an important operation like cancellation.

This introduces a `CANCELLING` state type and sets it up so that it maintains / occupies concurrency limit slots, both for tag-based task usage as well as work queues. 

Related to #7735 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
