### PR TITLE
Release task concurrency slots when transition is rejected as long as the task is not in a running state

### DIFF
--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -22,6 +22,7 @@ from prefect.orion.orchestration.rules import (
     ALL_ORCHESTRATION_STATES,
     TERMINAL_STATES,
     BaseOrchestrationRule,
+    BaseUniversalTransform,
     FlowOrchestrationContext,
     OrchestrationContext,
     TaskOrchestrationContext,
@@ -154,31 +155,26 @@ class SecureTaskConcurrencySlots(BaseOrchestrationRule):
             cl.active_slots = list(active_slots)
 
 
-class ReleaseTaskConcurrencySlots(BaseOrchestrationRule):
+class ReleaseTaskConcurrencySlots(BaseUniversalTransform):
     """
     Releases any concurrency slots held by a run upon exiting a Running state.
     """
 
-    FROM_STATES = [states.StateType.RUNNING]
-    TO_STATES = ALL_ORCHESTRATION_STATES
-
     async def after_transition(
         self,
-        initial_state: Optional[states.State],
-        validated_state: Optional[states.State],
-        context: TaskOrchestrationContext,
-    ) -> None:
-
-        filtered_limits = (
-            await concurrency_limits.filter_concurrency_limits_for_orchestration(
-                context.session, tags=context.run.tags
+        context: OrchestrationContext,
+    ):
+        if not context.validated_state.is_running():
+            filtered_limits = (
+                await concurrency_limits.filter_concurrency_limits_for_orchestration(
+                    context.session, tags=context.run.tags
+                )
             )
-        )
-        run_limits = {limit.tag: limit for limit in filtered_limits}
-        for tag, cl in run_limits.items():
-            active_slots = set(cl.active_slots)
-            active_slots.discard(str(context.run.id))
-            cl.active_slots = list(active_slots)
+            run_limits = {limit.tag: limit for limit in filtered_limits}
+            for tag, cl in run_limits.items():
+                active_slots = set(cl.active_slots)
+                active_slots.discard(str(context.run.id))
+                cl.active_slots = list(active_slots)
 
 
 class CacheInsertion(BaseOrchestrationRule):

--- a/src/prefect/orion/orchestration/core_policy.py
+++ b/src/prefect/orion/orchestration/core_policy.py
@@ -164,6 +164,9 @@ class ReleaseTaskConcurrencySlots(BaseUniversalTransform):
         self,
         context: OrchestrationContext,
     ):
+        if self.nullified_transition():
+            return
+
         if not context.validated_state.is_running():
             filtered_limits = (
                 await concurrency_limits.filter_concurrency_limits_for_orchestration(

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -1494,7 +1494,6 @@ class TestTaskConcurrencyLimits:
         task2_running_ctx = await initialize_orchestration(
             session, "task", *running_transition, run_tags=["shrinking limit"]
         )
-
         async with contextlib.AsyncExitStack() as stack:
             for rule in concurrency_policy:
                 task2_running_ctx = await stack.enter_async_context(
@@ -1553,3 +1552,321 @@ class TestTaskConcurrencyLimits:
         # the concurrency slot is released as expected
         assert task1_completed_ctx.response_status == SetStateStatus.ACCEPT
         assert (await self.count_concurrency_slots(session, "shrinking limit")) == 0
+
+    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle_with_release_first(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        """Make sure that we return the concurrency slot when even on a fizzle as long as we transition
+        out of running, with ReleaseTaskConcurrencySlots listed first in priority.
+        """
+
+        class StateMutatingRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                mutated_state = proposed_state.copy()
+                mutated_state.type = random.choice(
+                    list(
+                        set(states.StateType)
+                        - {initial_state.type, proposed_state.type}
+                    )
+                )
+                await self.reject_transition(
+                    mutated_state, reason="gotta fizzle some rules, for fun"
+                )
+
+            async def after_transition(self, initial_state, validated_state, context):
+                pass
+
+            async def cleanup(self, initial_state, validated_state, context):
+                pass
+
+        accept_concurrency_policy = [
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        reject_concurrency_policy = [
+            ReleaseTaskConcurrencySlots,
+            SecureTaskConcurrencySlots,
+            StateMutatingRule,
+        ]
+
+        await self.create_concurrency_limit(session, "small", 1)
+
+        # Fill the concurrency slot by transitioning into a running state
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+
+        ctx = await initialize_orchestration(
+            session, "task", *running_transition, run_tags=["small"]
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in accept_concurrency_policy:
+                task1_running_ctx = await stack.enter_async_context(
+                    rule(ctx, *running_transition)
+                )
+            await task1_running_ctx.validate_proposed_state()
+
+        assert task1_running_ctx.response_status == SetStateStatus.ACCEPT
+        assert (await self.count_concurrency_slots(session, "small")) == 1
+
+        # Make sure that the concurrency slot is released even though the transition was
+        # rejected, because the task was still moved out of a RUNNING state
+        pending_transition = (states.StateType.RUNNING, states.StateType.PENDING)
+
+        task1_pending_ctx = await initialize_orchestration(
+            session,
+            "task",
+            *pending_transition,
+            run_override=task1_running_ctx.run,
+            run_tags=["small"],
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in reject_concurrency_policy:
+                task1_pending_ctx = await stack.enter_async_context(
+                    rule(task1_pending_ctx, *pending_transition)
+                )
+            await task1_pending_ctx.validate_proposed_state()
+
+        assert task1_pending_ctx.response_status == SetStateStatus.REJECT
+        assert task1_pending_ctx.validated_state == states.StateType.PENDING
+        assert (await self.count_concurrency_slots(session, "small")) == 0
+
+    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle_with_release_last(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        """Make sure that we return the concurrency slot when even on a fizzle as long as we transition
+        out of running, with ReleaseTaskConcurrencySlots listed last in priority.
+        """
+
+        class StateMutatingRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                mutated_state = proposed_state.copy()
+                mutated_state.type = random.choice(
+                    list(
+                        set(states.StateType)
+                        - {initial_state.type, proposed_state.type}
+                    )
+                )
+                await self.reject_transition(
+                    mutated_state, reason="gotta fizzle some rules, for fun"
+                )
+
+            async def after_transition(self, initial_state, validated_state, context):
+                pass
+
+            async def cleanup(self, initial_state, validated_state, context):
+                pass
+
+        accept_concurrency_policy = [
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        reject_concurrency_policy = [
+            StateMutatingRule,
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        await self.create_concurrency_limit(session, "small", 1)
+
+        # Fill the concurrency slot by transitioning into a running state
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+
+        ctx = await initialize_orchestration(
+            session, "task", *running_transition, run_tags=["small"]
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in accept_concurrency_policy:
+                task1_running_ctx = await stack.enter_async_context(
+                    rule(ctx, *running_transition)
+                )
+            await task1_running_ctx.validate_proposed_state()
+
+        assert task1_running_ctx.response_status == SetStateStatus.ACCEPT
+        assert (await self.count_concurrency_slots(session, "small")) == 1
+
+        # Make sure that the concurrency slot is released even though the transition was
+        # rejected, because the task was still moved out of a RUNNING state
+        pending_transition = (states.StateType.RUNNING, states.StateType.PENDING)
+
+        task1_pending_ctx = await initialize_orchestration(
+            session,
+            "task",
+            *pending_transition,
+            run_override=task1_running_ctx.run,
+            run_tags=["small"],
+        )
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in reject_concurrency_policy:
+                task1_pending_ctx = await stack.enter_async_context(
+                    rule(task1_pending_ctx, *pending_transition)
+                )
+            await task1_pending_ctx.validate_proposed_state()
+
+        assert task1_pending_ctx.response_status == SetStateStatus.REJECT
+        assert task1_pending_ctx.validated_state == states.StateType.PENDING
+        assert (await self.count_concurrency_slots(session, "small")) == 0
+
+    async def test_releasing_concurrency_slots_does_not_happen_if_nullified_with_release_first(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        """Make sure that concurrency slots are not released if the transition is nullified,
+        with ReleaseTaskConcurrencySlots listed first in priority
+        """
+
+        class NullifiedTransition(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                await self.abort_transition(reason="For testing purposes")
+
+            async def after_transition(self, initial_state, validated_state, context):
+                pass
+
+            async def cleanup(self, initial_state, validated_state, context):
+                pass
+
+        accept_concurrency_policy = [
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        abort_concurrency_policy = [
+            ReleaseTaskConcurrencySlots,
+            SecureTaskConcurrencySlots,
+            NullifiedTransition,
+        ]
+
+        await self.create_concurrency_limit(session, "small", 1)
+
+        # Fill the concurrency slot by transitioning into a running state
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+
+        ctx = await initialize_orchestration(
+            session, "task", *running_transition, run_tags=["small"]
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in accept_concurrency_policy:
+                task1_running_ctx = await stack.enter_async_context(
+                    rule(ctx, *running_transition)
+                )
+            await task1_running_ctx.validate_proposed_state()
+
+        assert task1_running_ctx.response_status == SetStateStatus.ACCEPT
+        assert (await self.count_concurrency_slots(session, "small")) == 1
+
+        # Make sure that the concurrency slot is not released because the transition
+        # was aborted
+        pending_transition = (states.StateType.RUNNING, states.StateType.PENDING)
+
+        task1_pending_ctx = await initialize_orchestration(
+            session,
+            "task",
+            *pending_transition,
+            run_override=task1_running_ctx.run,
+            run_tags=["small"],
+        )
+
+        async with contextlib.AsyncExitStack() as stack:  # Here
+            for rule in abort_concurrency_policy:
+                task1_pending_ctx = await stack.enter_async_context(
+                    rule(task1_pending_ctx, *pending_transition)
+                )
+            await task1_pending_ctx.validate_proposed_state()
+
+        assert task1_pending_ctx.response_status == SetStateStatus.ABORT
+        assert (await self.count_concurrency_slots(session, "small")) == 1
+
+    async def test_releasing_concurrency_slots_does_not_happen_if_nullified_with_release_last(
+        self,
+        session,
+        run_type,
+        initialize_orchestration,
+    ):
+        """Make sure that concurrency slots are not released if the transition is nullified,
+        with ReleaseTaskConcurrencySlots listed last in priority
+        """
+
+        class NullifiedTransition(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                await self.abort_transition(reason="For testing purposes")
+
+            async def after_transition(self, initial_state, validated_state, context):
+                pass
+
+            async def cleanup(self, initial_state, validated_state, context):
+                pass
+
+        accept_concurrency_policy = [
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        abort_concurrency_policy = [
+            NullifiedTransition,
+            SecureTaskConcurrencySlots,
+            ReleaseTaskConcurrencySlots,
+        ]
+
+        await self.create_concurrency_limit(session, "small", 1)
+
+        # Fill the concurrency slot by transitioning into a running state
+        running_transition = (states.StateType.PENDING, states.StateType.RUNNING)
+
+        ctx = await initialize_orchestration(
+            session, "task", *running_transition, run_tags=["small"]
+        )
+
+        async with contextlib.AsyncExitStack() as stack:
+            for rule in accept_concurrency_policy:
+                task1_running_ctx = await stack.enter_async_context(
+                    rule(ctx, *running_transition)
+                )
+            await task1_running_ctx.validate_proposed_state()
+
+        assert task1_running_ctx.response_status == SetStateStatus.ACCEPT
+        assert (await self.count_concurrency_slots(session, "small")) == 1
+
+        # Make sure that the concurrency slot is not released because the transition
+        # was aborted
+        pending_transition = (states.StateType.RUNNING, states.StateType.PENDING)
+
+        task1_pending_ctx = await initialize_orchestration(
+            session,
+            "task",
+            *pending_transition,
+            run_override=task1_running_ctx.run,
+            run_tags=["small"],
+        )
+
+        async with contextlib.AsyncExitStack() as stack:  # Here
+            for rule in abort_concurrency_policy:
+                task1_pending_ctx = await stack.enter_async_context(
+                    rule(task1_pending_ctx, *pending_transition)
+                )
+            await task1_pending_ctx.validate_proposed_state()
+
+        assert task1_pending_ctx.response_status == SetStateStatus.ABORT
+        assert (await self.count_concurrency_slots(session, "small")) == 1

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -1553,7 +1553,7 @@ class TestTaskConcurrencyLimits:
         assert task1_completed_ctx.response_status == SetStateStatus.ACCEPT
         assert (await self.count_concurrency_slots(session, "shrinking limit")) == 0
 
-    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle_with_release_first(
+    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle(
         self,
         session,
         run_type,
@@ -1637,7 +1637,7 @@ class TestTaskConcurrencyLimits:
         assert task1_pending_ctx.validated_state.type != states.StateType.RUNNING
         assert (await self.count_concurrency_slots(session, "small")) == 0
 
-    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle_with_release_last(
+    async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_invalidation(
         self,
         session,
         run_type,

--- a/tests/orion/orchestration/test_core_policy.py
+++ b/tests/orion/orchestration/test_core_policy.py
@@ -1634,7 +1634,7 @@ class TestTaskConcurrencyLimits:
             await task1_pending_ctx.validate_proposed_state()
 
         assert task1_pending_ctx.response_status == SetStateStatus.REJECT
-        assert task1_pending_ctx.validated_state == states.StateType.PENDING
+        assert task1_pending_ctx.validated_state.type != states.StateType.RUNNING
         assert (await self.count_concurrency_slots(session, "small")) == 0
 
     async def test_returning_concurrency_slots_when_transitioning_out_of_running_even_on_fizzle_with_release_last(
@@ -1718,7 +1718,7 @@ class TestTaskConcurrencyLimits:
             await task1_pending_ctx.validate_proposed_state()
 
         assert task1_pending_ctx.response_status == SetStateStatus.REJECT
-        assert task1_pending_ctx.validated_state == states.StateType.PENDING
+        assert task1_pending_ctx.validated_state.type != states.StateType.RUNNING
         assert (await self.count_concurrency_slots(session, "small")) == 0
 
     async def test_releasing_concurrency_slots_does_not_happen_if_nullified_with_release_first(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Closes https://github.com/PrefectHQ/prefect/issues/7752.
Massive shoutout to @anticorrelator for the help.

Task concurrency slots are released according to `ReleaseTaskConcurrencySlots` which is currently a child class of `BaseOrchestrationRule`. Orchestration rules have `before_transition`, `after_transition`, and `cleanup` methods. The `cleanup` method is fired instead of the `after_transition` method if, at any point in the series of calls in the orchestration rules, a transition is rejected. `ReleaseTaskConcurrencySlots` releases the concurrency slot in the `after_transition` method.

This was causing a problem when retrying tasks, because a retry rejects a proposed final state and sets the state to `SCHEDULED` instead. This meant that `ReleaseTaskConcurrencySlots` was not able to release the concurrency slot.

 After discussing this with @anticorrelator there appeared to be two possible solutions. One was to make the `cleanup` method mirror the `after_transition` method. This would also require modifying the priority of `ReleaseTaskConcurrencySlots`. The alternative was changing `ReleaseTaskConcurrencySlots` from a `BaseOrchestrationRule` to a `BaseUniversalTransform`.

The `after_transition` method on a `BaseUniversalTransform` will fire on each state transition regardless of `ACCEPT` or `REJECT` status. `ABORT` is handled by a check at the start of the method. 

We elected to make it a `BaseUniversalTransform`. This newly modified `ReleaseTaskConcurrencySlots` will release a concurrency slot as long as the task transitions out of running.

I'd appreciate a second set of eyes on these tests. Yesterday was my first time looking at the orchestration rules, so I might be missing something. 
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
