### PR TITLE
Introducing the `PREFECT_API_ENABLE_HTTP2` setting to give users a choice

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -35,6 +35,7 @@ from prefect.orion.schemas.core import (
 )
 from prefect.orion.schemas.filters import FlowRunNotificationPolicyFilter, LogFilter
 from prefect.settings import (
+    PREFECT_API_ENABLE_HTTP2,
     PREFECT_API_KEY,
     PREFECT_API_REQUEST_TIMEOUT,
     PREFECT_API_URL,
@@ -133,7 +134,7 @@ class OrionClient:
             # and responses will be transported over HTTP/2, since both the client and the server
             # need to support HTTP/2. If you connect to a server that only supports HTTP/1.1 the
             # client will use a standard HTTP/1.1 connection instead.
-            httpx_settings.setdefault("http2", True)
+            httpx_settings.setdefault("http2", PREFECT_API_ENABLE_HTTP2.value())
 
         # Connect to an in-process application
         elif isinstance(api, FastAPI):

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -390,6 +390,9 @@ PREFECT_API_KEY = Setting(
 )
 """API key used to authenticate against Orion API. Defaults to `None`."""
 
+PREFECT_API_ENABLE_HTTP2 = Setting(bool, default=True)
+"""If True, enable support for HTTP/2 for communicating with a remote Orion API"""
+
 PREFECT_CLOUD_API_URL = Setting(
     str,
     default="https://api.prefect.cloud/api",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -391,7 +391,10 @@ PREFECT_API_KEY = Setting(
 """API key used to authenticate against Orion API. Defaults to `None`."""
 
 PREFECT_API_ENABLE_HTTP2 = Setting(bool, default=True)
-"""If True, enable support for HTTP/2 for communicating with a remote Orion API"""
+"""If True, enable support for HTTP/2 for communicating with a remote Orion API.
+
+If the remote Orion API does not support HTTP/2, this will have no effect and
+connections will be made via HTTP/1.1"""
 
 PREFECT_CLOUD_API_URL = Setting(
     str,


### PR DESCRIPTION
We've seen enough folks having trouble with HTTP/2 connectivity, and we want to give them the option to disable it if they are experiencing difficulty with it with their workloads and environments.