### PR TITLE
Add setting to toggle interpreting square brackets as style

### DIFF
--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -348,7 +348,7 @@ Then, the following will highlight "fancy" in red.
 from prefect import flow, get_run_logger
 
 @flow
-def log_email_flow():
+def my_flow():
     logger = get_run_logger()
     logger.info("This is [bold red]fancy[/]")
 

--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -333,6 +333,31 @@ def log_email_flow():
 log_email_flow()
 ```
 
+## Applying markup in logs
+
+To use [Rich's markup](https://rich.readthedocs.io/en/stable/markup.html#console-markup) in Prefect logs, first configure `PREFECT_LOGGING_MARKUP`.
+
+<div class='terminal'>
+```bash
+PREFECT_LOGGING_MARKUP=True
+```
+</div>
+
+Then, the following will highlight "fancy" in red.
+```python
+from prefect import flow, get_run_logger
+
+@flow
+def log_email_flow():
+    logger = get_run_logger()
+    logger.info("This is [bold red]fancy[/]")
+
+log_email_flow()
+```
+
+!!! warning "Inaccurate logs could result"
+    Although this can be convenient, the downside is, if enabled, strings that contain square brackets may be inaccurately interpreted and lead to incomplete output, e.g. `DROP TABLE [dbo].[SomeTable];"` outputs `DROP TABLE .[SomeTable];`.
+
 ## Log database schema
 
 Logged events are also persisted to the Orion database. A log record includes the following data:

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -21,6 +21,7 @@ from prefect.logging.highlighters import PrefectConsoleHighlighter
 from prefect.orion.schemas.actions import LogCreate
 from prefect.settings import (
     PREFECT_LOGGING_COLORS,
+    PREFECT_LOGGING_MARKUP,
     PREFECT_LOGGING_ORION_BATCH_INTERVAL,
     PREFECT_LOGGING_ORION_BATCH_SIZE,
     PREFECT_LOGGING_ORION_ENABLED,
@@ -381,6 +382,7 @@ class PrefectConsoleHandler(logging.StreamHandler):
         super().__init__(stream=stream)
 
         styled_console = PREFECT_LOGGING_COLORS.value()
+        markup_console = PREFECT_LOGGING_MARKUP.value()
         if styled_console:
             highlighter = highlighter()
             theme = Theme(styles, inherit=False)
@@ -389,7 +391,12 @@ class PrefectConsoleHandler(logging.StreamHandler):
             theme = Theme(inherit=False)
 
         self.level = level
-        self.console = Console(highlighter=highlighter, theme=theme, file=self.stream)
+        self.console = Console(
+            highlighter=highlighter,
+            theme=theme,
+            file=self.stream,
+            markup=markup_console,
+        )
 
     def emit(self, record: logging.LogRecord):
         try:

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -572,7 +572,7 @@ This allows styles to be conveniently added to log messages, e.g.
 `[red]This is a red message.[/red]`. However, the downside is,
 if enabled, strings that contain square brackets may be inaccurately
 interpreted and lead to incomplete output, e.g.
-`DROP TABLE [dbo].[SomeTable];"` results in `DROP TABLE .[SomeTable];`.
+`DROP TABLE [dbo].[SomeTable];"` outputs `DROP TABLE .[SomeTable];`.
 """
 
 PREFECT_AGENT_QUERY_INTERVAL = Setting(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -562,6 +562,19 @@ PREFECT_LOGGING_COLORS = Setting(
 )
 """Whether to style console logs with color."""
 
+PREFECT_LOGGING_MARKUP = Setting(
+    bool,
+    default=False,
+)
+"""
+Whether to interpret strings wrapped in square brackets as a style.
+This allows styles to be conveniently added to log messages, e.g.
+`[red]This is a red message.[/red]`. However, the downside is,
+if enabled, strings that contain square brackets may be inaccurately
+interpreted and lead to incomplete output, e.g.
+`DROP TABLE [dbo].[SomeTable];"` results in `DROP TABLE .[SomeTable];`.
+"""
+
 PREFECT_AGENT_QUERY_INTERVAL = Setting(
     float,
     default=10,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -47,6 +47,7 @@ from prefect.orion.schemas.actions import LogCreate
 from prefect.settings import (
     PREFECT_LOGGING_COLORS,
     PREFECT_LOGGING_LEVEL,
+    PREFECT_LOGGING_MARKUP,
     PREFECT_LOGGING_ORION_BATCH_INTERVAL,
     PREFECT_LOGGING_ORION_BATCH_SIZE,
     PREFECT_LOGGING_ORION_ENABLED,
@@ -1137,6 +1138,29 @@ class TestPrefectConsoleHandler:
         _, stderr = capsys.readouterr()
         # There will be newlines in the middle if cropped
         assert "x" * 1000 in stderr
+
+    def test_outputs_square_brackets_as_text(self, capsys):
+        logger = get_logger(uuid.uuid4().hex)
+        handler = PrefectConsoleHandler()
+        logger.handlers = [handler]
+
+        msg = "DROP TABLE [dbo].[SomeTable];"
+        logger.info(msg)
+
+        _, stderr = capsys.readouterr()
+        assert msg in stderr
+
+    def test_outputs_square_brackets_as_style(self, capsys):
+        with temporary_settings({PREFECT_LOGGING_MARKUP: True}):
+            logger = get_logger(uuid.uuid4().hex)
+            handler = PrefectConsoleHandler()
+            logger.handlers = [handler]
+
+            msg = "this applies [red]style[/red]!;"
+            logger.info(msg)
+
+            _, stderr = capsys.readouterr()
+            assert "this applies style" in stderr
 
 
 class TestJsonFormatter:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Sometimes, strings that contain brackets  [  ]  aren't being logged correctly because rich interprets them as styles. This adds a setting to allow toggling and defaults it to False:

"Whether to interpret strings wrapped in square brackets as a style.
This allows styles to be conveniently added to log messages, e.g.
`[red]This is a red message.[/red]`. However, the downside is,
if enabled, strings that contain square brackets may be inaccurately
interpreted and lead to incomplete output, e.g.
`DROP TABLE [dbo].[SomeTable];"` results in `DROP TABLE .[SomeTable];`."

Originally from [here](https://prefect-community.slack.com/archives/CL09KU1K7/p1670455860648239)

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
from prefect import flow, task, get_run_logger

@task
def execute_sql(sql: str):
    logger = get_run_logger()
    logger.info(f"Executing: {sql}")
    logger.info(sql)


@flow
def bracket_flow():
    execute_sql("DROP TABLE [dbo].[SomeTable];")
    execute_sql("EXEC [dbo].[usp_SomeProcedure];")


if __name__ == "__main__":
    bracket_flow()
```

![image](https://user-images.githubusercontent.com/15331990/206325319-f878c20b-2a4e-4961-88ee-4b206ac01678.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
