### PR TITLE
Add explicit time zone to test datetime constant

### DIFF
--- a/tests/orion/api/test_run_history.py
+++ b/tests/orion/api/test_run_history.py
@@ -10,7 +10,7 @@ from prefect.orion import models
 from prefect.orion.schemas import core, responses, states
 from prefect.orion.schemas.states import StateType
 
-dt = pendulum.datetime(2021, 7, 1)
+dt = pendulum.datetime(2021, 7, 1, tz=pendulum.tz.timezone("UTC"))
 
 
 def parse_response(response: Response, include=None):


### PR DESCRIPTION
Attempting to fix flake in https://github.com/PrefectHQ/prefect/actions/runs/3644245163/jobs/6153302014

Test fails with:
```
  -  {'interval_end': DateTime(2021, 6, 30, 0, 0, 0, tzinfo=Timezone('UTC')),
  ?                                                                   ^^^
  +  {'interval_end': DateTime(2021, 6, 30, 0, 0, 0, tzinfo=Timezone('+00:00')),
```