### PR TITLE
Allow `reject_transition` to use current state

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -349,3 +349,7 @@ class NotPausedError(PrefectException):
 
 class FlowPauseTimeout(PrefectException):
     """Raised when a flow pause times out"""
+
+
+class OrchestrationError(PrefectException):
+    """An error raised while orchestrating a state transition"""

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -349,7 +349,3 @@ class NotPausedError(PrefectException):
 
 class FlowPauseTimeout(PrefectException):
     """Raised when a flow pause times out"""
-
-
-class OrchestrationError(PrefectException):
-    """An error raised while orchestrating a state transition"""

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -256,6 +256,8 @@ async def set_flow_run_state(
     # pass the request version to the orchestration engine to support compatibility code
     orchestration_parameters.update({"api-version": api_version})
 
+    now = pendulum.now()
+
     # create the state
     async with db.session_context(begin_transaction=True) as session:
         orchestration_result = await models.flow_runs.set_flow_run_state(
@@ -268,12 +270,10 @@ async def set_flow_run_state(
             orchestration_parameters=orchestration_parameters,
         )
 
-    # set the 201 because a new state was created
-    if orchestration_result.status == schemas.responses.SetStateStatus.WAIT:
-        response.status_code = status.HTTP_200_OK
-    elif orchestration_result.status == schemas.responses.SetStateStatus.ABORT:
-        response.status_code = status.HTTP_200_OK
-    else:
+    # set the 201 if a new state was created
+    if orchestration_result.state and orchestration_result.state.created >= now:
         response.status_code = status.HTTP_201_CREATED
+    else:
+        response.status_code = status.HTTP_200_OK
 
     return orchestration_result

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -271,7 +271,7 @@ async def set_flow_run_state(
         )
 
     # set the 201 if a new state was created
-    if orchestration_result.state and orchestration_result.state.created >= now:
+    if orchestration_result.state and orchestration_result.state.timestamp >= now:
         response.status_code = status.HTTP_201_CREATED
     else:
         response.status_code = status.HTTP_200_OK

--- a/src/prefect/orion/exceptions.py
+++ b/src/prefect/orion/exceptions.py
@@ -8,3 +8,7 @@ class ObjectNotFoundError(PrefectException):
     If thrown during a request, this exception will be caught and
     a 404 response will be returned.
     """
+
+
+class OrchestrationError(PrefectException):
+    """An error raised while orchestrating a state transition"""

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -228,8 +228,7 @@ class FlowOrchestrationContext(OrchestrationContext):
         state. The state on the run is set to the validated state as well.
 
         If the proposed state is `None` when this method is called, no state will be
-        written. If the response type is REJECT, `self.validated_state` will be set to
-        the run's current state.
+        written and `self.validated_state` will be set to the run's current state.
 
         Returns:
             None
@@ -364,8 +363,10 @@ class TaskOrchestrationContext(OrchestrationContext):
         After the `TaskOrchestrationContext` is governed by orchestration rules, the
         proposed state can be validated: the proposed state is added to the current
         SQLAlchemy session and is flushed. `self.validated_state` set to the flushed
-        state. The state on the run is set to the validated state as well. If the
-        proposed state is `None` when this method is called, nothing happens.
+        state. The state on the run is set to the validated state as well.
+
+        If the proposed state is `None` when this method is called, no state will be
+        written and `self.validated_state` will be set to the run's current state.
 
         Returns:
             None
@@ -747,8 +748,8 @@ class BaseOrchestrationRule(contextlib.AbstractAsyncContextManager):
         despite the proposed state type changing.
 
         Args:
-            state: The new proposed state. If `None`, the current run state will
-                be used instead.
+            state: The new proposed state. If `None`, the current run state will be
+                returned in the result instead.
             reason: The reason for rejecting the transition
         """
 

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -25,10 +25,10 @@ import sqlalchemy as sa
 from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prefect.exceptions import OrchestrationError
 from prefect.logging import get_logger
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
+from prefect.orion.exceptions import OrchestrationError
 from prefect.orion.models import flow_runs
 from prefect.orion.schemas import states
 from prefect.orion.schemas.responses import (

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -25,6 +25,7 @@ import sqlalchemy as sa
 from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect.exceptions import OrchestrationError
 from prefect.logging import get_logger
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
@@ -771,6 +772,10 @@ class BaseOrchestrationRule(contextlib.AbstractAsyncContextManager):
         #     state = states.State.from_orm(self.context.run.state)
 
         if state is None:
+            if self.from_state_type is None:
+                raise OrchestrationError(
+                    "The current run has no state and this transition cannot be null rejected."
+                )
             self.to_state_type = None
             self.context.proposed_state = None
         else:

--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -766,15 +766,12 @@ class BaseOrchestrationRule(contextlib.AbstractAsyncContextManager):
         if self.context.validated_state:
             raise RuntimeError("The transition is already validated")
 
-        # # use the current state if a new one is not provided
-        # if state is None:
-        #     # cast from orm state class to api state type
-        #     state = states.State.from_orm(self.context.run.state)
-
+        # the current state will be used if a new one is not provided
         if state is None:
             if self.from_state_type is None:
                 raise OrchestrationError(
-                    "The current run has no state and this transition cannot be null rejected."
+                    "The current run has no state; this transition cannot be "
+                    "rejected without providing a new state."
                 )
             self.to_state_type = None
             self.context.proposed_state = None

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 
-from prefect.exceptions import OrchestrationError
 from prefect.orion import schemas
 from prefect.orion.database.dependencies import provide_database_interface
+from prefect.orion.exceptions import OrchestrationError
 from prefect.orion.orchestration.rules import (
     ALL_ORCHESTRATION_STATES,
     BaseOrchestrationRule,

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -1723,7 +1723,7 @@ class TestNullRejection:
             await ctx.validate_proposed_state()
 
         assert side_effects == 0
-        assert await minimal_rule.fizzled() is True
+        assert await minimal_rule.invalid() is True
         assert await null_rejector.invalid() is False
         assert await null_rejector.fizzled() is False
         minimal_after_hook.assert_not_called()

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -379,59 +379,6 @@ class TestBaseOrchestrationRule:
         assert after_transition_hook.call_count == 1
         assert cleanup_step.call_count == 0
 
-    async def test_rules_that_reject_state_with_null_do_not_fizzle_themselves(
-        self, session, task_run
-    ):
-        before_transition_hook = MagicMock()
-        after_transition_hook = MagicMock()
-        cleanup_step = MagicMock()
-
-        class StateMutatingRule(BaseOrchestrationRule):
-            FROM_STATES = ALL_ORCHESTRATION_STATES
-            TO_STATES = ALL_ORCHESTRATION_STATES
-
-            async def before_transition(self, initial_state, proposed_state, context):
-                # this rule mutates the proposed state type, but won't fizzle itself
-                # upon exiting
-                before_transition_hook()
-                # `BaseOrchestrationRule` provides hooks designed to mutate the proposed state
-                await self.reject_transition(None, reason="for testing, of course")
-
-            async def after_transition(self, initial_state, validated_state, context):
-                after_transition_hook()
-
-            async def cleanup(self, initial_state, validated_state, context):
-                cleanup_step()
-
-        # this rule seems valid because the initial and proposed states match the intended transition
-        initial_state_type = states.StateType.PENDING
-        proposed_state_type = states.StateType.RUNNING
-        intended_transition = (initial_state_type, proposed_state_type)
-        initial_state = await commit_task_run_state(
-            session, task_run, initial_state_type
-        )
-        proposed_state = (
-            states.State(type=proposed_state_type) if proposed_state_type else None
-        )
-
-        ctx = TaskOrchestrationContext(
-            session=session,
-            initial_state=initial_state,
-            proposed_state=proposed_state,
-            run=task_run,
-        )
-
-        mutating_rule = StateMutatingRule(ctx, *intended_transition)
-        async with mutating_rule as ctx:
-            pass
-        assert await mutating_rule.invalid() is False
-        assert await mutating_rule.fizzled() is False
-
-        # despite the mutation, this rule is valid so before and after hooks will fire
-        assert before_transition_hook.call_count == 1
-        assert after_transition_hook.call_count == 1
-        assert cleanup_step.call_count == 0
-
     async def test_rules_that_wait_do_not_fizzle_themselves(self, session, task_run):
         before_transition_hook = MagicMock()
         after_transition_hook = MagicMock()
@@ -1344,31 +1291,6 @@ class TestOrchestrationContext:
                 ctx = await stack.enter_async_context(the_tardy_hero)
                 await ctx.validate_proposed_state()
 
-    async def test_context_will_not_write_new_state_with_null_reject(
-        self, session, run_type, initialize_orchestration
-    ):
-        class RejectNoWriteRule(BaseOrchestrationRule):
-            FROM_STATES = ALL_ORCHESTRATION_STATES
-            TO_STATES = ALL_ORCHESTRATION_STATES
-
-            async def before_transition(self, initial_state, proposed_state, context):
-                await self.reject_transition(None, reason="its okay")
-
-        initial_state_type = states.StateType.PENDING
-        proposed_state_type = states.StateType.RUNNING
-        intended_transition = (initial_state_type, proposed_state_type)
-        ctx = await initialize_orchestration(session, run_type, *intended_transition)
-
-        async with contextlib.AsyncExitStack() as stack:
-            reject_no_write = RejectNoWriteRule(ctx, *intended_transition)
-            ctx = await stack.enter_async_context(reject_no_write)
-            intial_state = ctx.run.state
-            await ctx.validate_proposed_state()
-
-        assert ctx.proposed_state is None
-        assert ctx.validated_state == states.State.from_orm(intial_state)
-        assert ctx.response_status == schemas.responses.SetStateStatus.REJECT
-
     @pytest.mark.parametrize("delay", [42, 424242])
     async def test_context_will_propose_no_state_if_asked_to_wait(
         self, session, run_type, initialize_orchestration, delay
@@ -1627,3 +1549,262 @@ class TestOrchestrationContext:
             before_transition_hook.assert_called_once()
             after_transition_hook.assert_called_once()
             cleanup_hook.assert_not_called()
+
+
+class TestNullRejection:
+    @pytest.mark.parametrize(
+        "intended_transition",
+        list(product([*states.StateType], [*states.StateType])),
+        ids=transition_names,
+    )
+    async def test_null_rejects_fizzle_all_prior_rules(
+        self, session, initialize_orchestration, intended_transition
+    ):
+        run_type = "flow"
+
+        side_effects = 0
+        minimal_before_hook = MagicMock()
+        null_rejection_before_hook = MagicMock()
+        minimal_after_hook = MagicMock()
+        null_rejection_after_hook = MagicMock()
+        minimal_cleanup_hook = MagicMock()
+        null_rejection_cleanup = MagicMock()
+
+        class MinimalRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                nonlocal side_effects
+                side_effects += 1
+                minimal_before_hook()
+
+            async def after_transition(self, initial_state, validated_state, context):
+                nonlocal side_effects
+                side_effects += 1
+                first_after_hook()
+
+            async def cleanup(self, initial_state, validated_state, context):
+                nonlocal side_effects
+                side_effects -= 1
+                minimal_cleanup_hook()
+
+        class NullRejectionRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                null_rejection_before_hook()
+                await self.reject_transition(None, reason="its okay")
+
+            async def after_transition(self, initial_state, validated_state, context):
+                null_rejection_after_hook()
+
+            async def cleanup(self, initial_state, validated_state, context):
+                null_rejection_cleanup()
+
+        ctx = await initialize_orchestration(session, run_type, *intended_transition)
+
+        async with contextlib.AsyncExitStack() as stack:
+
+            # first enter a minimal rule that fires its pre-transition hook
+            minimal_rule = MinimalRule(ctx, *intended_transition)
+            ctx = await stack.enter_async_context(minimal_rule)
+
+            assert side_effects == 1
+            minimal_before_hook.assert_called_once()
+            minimal_after_hook.assert_not_called()
+            minimal_cleanup_hook.assert_not_called()
+            null_rejection_before_hook.assert_not_called()
+            null_rejection_after_hook.assert_not_called()
+            null_rejection_cleanup.assert_not_called()
+
+            # the null rejection rule rejects the transition
+            null_rejector = NullRejectionRule(ctx, *intended_transition)
+            ctx = await stack.enter_async_context(null_rejector)
+
+            assert side_effects == 1
+            minimal_before_hook.assert_called_once()
+            minimal_after_hook.assert_not_called()
+            minimal_cleanup_hook.assert_not_called()
+            null_rejection_before_hook.assert_called_once()
+            null_rejection_after_hook.assert_not_called()
+            null_rejection_cleanup.assert_not_called()
+
+            await ctx.validate_proposed_state()
+
+        assert side_effects == 0
+        assert await minimal_rule.fizzled() is True
+        assert await null_rejector.invalid() is False
+        assert await null_rejector.fizzled() is False
+        minimal_after_hook.assert_not_called()
+        minimal_cleanup_hook.assert_called_once()
+        assert ctx.response_status == schemas.responses.SetStateStatus.REJECT
+
+    @pytest.mark.parametrize(
+        "intended_transition",
+        list(product([*states.StateType], [*states.StateType])),
+        ids=transition_names,
+    )
+    async def test_null_rejects_abort_all_subsequent_rules(
+        self, session, initialize_orchestration, intended_transition
+    ):
+        run_type = "flow"
+
+        side_effects = 0
+        minimal_before_hook = MagicMock()
+        null_rejection_before_hook = MagicMock()
+        minimal_after_hook = MagicMock()
+        null_rejection_after_hook = MagicMock()
+        minimal_cleanup_hook = MagicMock()
+        null_rejection_cleanup = MagicMock()
+
+        class MinimalRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                nonlocal side_effects
+                side_effects += 1
+                minimal_before_hook()
+
+            async def after_transition(self, initial_state, validated_state, context):
+                nonlocal side_effects
+                side_effects += 1
+                first_after_hook()
+
+            async def cleanup(self, initial_state, validated_state, context):
+                nonlocal side_effects
+                side_effects -= 1
+                minimal_cleanup_hook()
+
+        class NullRejectionRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                null_rejection_before_hook()
+                await self.reject_transition(None, reason="its okay")
+
+            async def after_transition(self, initial_state, validated_state, context):
+                null_rejection_after_hook()
+
+            async def cleanup(self, initial_state, validated_state, context):
+                null_rejection_cleanup()
+
+        ctx = await initialize_orchestration(session, run_type, *intended_transition)
+
+        async with contextlib.AsyncExitStack() as stack:
+
+            # the null rejection rule rejects the transition
+            null_rejector = NullRejectionRule(ctx, *intended_transition)
+            ctx = await stack.enter_async_context(null_rejector)
+
+            assert side_effects == 0
+            null_rejection_before_hook.assert_called_once()
+            null_rejection_after_hook.assert_not_called()
+            null_rejection_cleanup.assert_not_called()
+            minimal_before_hook.assert_not_called()
+            minimal_after_hook.assert_not_called()
+            minimal_cleanup_hook.assert_not_called()
+
+            # first enter a minimal rule that fires its pre-transition hook
+            minimal_rule = MinimalRule(ctx, *intended_transition)
+            ctx = await stack.enter_async_context(minimal_rule)
+
+            assert side_effects == 0
+            null_rejection_before_hook.assert_called_once()
+            null_rejection_after_hook.assert_not_called()
+            null_rejection_cleanup.assert_not_called()
+            minimal_before_hook.assert_not_called()
+            minimal_after_hook.assert_not_called()
+            minimal_cleanup_hook.assert_not_called()
+
+            await ctx.validate_proposed_state()
+
+        assert side_effects == 0
+        assert await minimal_rule.fizzled() is True
+        assert await null_rejector.invalid() is False
+        assert await null_rejector.fizzled() is False
+        minimal_after_hook.assert_not_called()
+        minimal_cleanup_hook.assert_not_called()
+        assert ctx.response_status == schemas.responses.SetStateStatus.REJECT
+
+    @pytest.mark.parametrize("run_type", ["task", "flow"])
+    async def test_context_will_not_write_new_state_with_null_reject(
+        self, session, run_type, initialize_orchestration
+    ):
+        class NullRejectionRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                await self.reject_transition(None, reason="its okay")
+
+        initial_state_type = states.StateType.PENDING
+        proposed_state_type = states.StateType.RUNNING
+        intended_transition = (initial_state_type, proposed_state_type)
+        ctx = await initialize_orchestration(session, run_type, *intended_transition)
+
+        async with contextlib.AsyncExitStack() as stack:
+            reject_no_write = NullRejectionRule(ctx, *intended_transition)
+            ctx = await stack.enter_async_context(reject_no_write)
+            intial_state = ctx.run.state
+            await ctx.validate_proposed_state()
+
+        assert ctx.proposed_state is None
+        assert ctx.validated_state == states.State.from_orm(intial_state)
+        assert ctx.response_status == schemas.responses.SetStateStatus.REJECT
+
+    async def test_rules_that_reject_state_with_null_do_not_fizzle_themselves(
+        self, session, task_run
+    ):
+        before_transition_hook = MagicMock()
+        after_transition_hook = MagicMock()
+        cleanup_step = MagicMock()
+
+        class NullRejectionRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                # this rule mutates the proposed state type, but won't fizzle itself
+                # upon exiting
+                before_transition_hook()
+                # `BaseOrchestrationRule` provides hooks designed to mutate the proposed state
+                await self.reject_transition(None, reason="for testing, of course")
+
+            async def after_transition(self, initial_state, validated_state, context):
+                after_transition_hook()
+
+            async def cleanup(self, initial_state, validated_state, context):
+                cleanup_step()
+
+        # this rule seems valid because the initial and proposed states match the intended transition
+        initial_state_type = states.StateType.PENDING
+        proposed_state_type = states.StateType.RUNNING
+        intended_transition = (initial_state_type, proposed_state_type)
+        initial_state = await commit_task_run_state(
+            session, task_run, initial_state_type
+        )
+        proposed_state = (
+            states.State(type=proposed_state_type) if proposed_state_type else None
+        )
+
+        ctx = TaskOrchestrationContext(
+            session=session,
+            initial_state=initial_state,
+            proposed_state=proposed_state,
+            run=task_run,
+        )
+
+        null_rejector = NullRejectionRule(ctx, *intended_transition)
+        async with null_rejector as ctx:
+            pass
+        assert await null_rejector.invalid() is False
+        assert await null_rejector.fizzled() is False
+
+        # despite the mutation, this rule is valid so before and after hooks will fire
+        assert before_transition_hook.call_count == 1
+        assert after_transition_hook.call_count == 1
+        assert cleanup_step.call_count == 0


### PR DESCRIPTION
Co-authored with @anticorrelator 

Previously a REJECT response required a new state which was then always written to the database. Here, the `OrchestrationRule.reject_transition` utility is updated to accept `state=None`. When this is used, the REJECT orchestration response will contain the current state of the run and a new state will not be appended to the run's states. This allows REJECT semantics to be used to prevent transition to a proposed state without providing an explicit alternative. This is useful when a client is proposing a state with the assumption that they are in a different starting state than the orchestrator has.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Required for #7738 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
