### PR TITLE
Defer imports for performance

### DIFF
--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -98,9 +98,9 @@ class OrionClient:
         httpx_settings.setdefault("headers", {})
         if api_version is None:
             # deferred import to avoid importing the entire server unless needed
-            import prefect.orion.api.server
+            from prefect.orion.api.server import ORION_API_VERSION
 
-            api_version = prefect.orion.api.server.ORION_API_VERSION
+            api_version = ORION_API_VERSION
         httpx_settings["headers"].setdefault("X-PREFECT-API-VERSION", api_version)
         if api_key:
             httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -19,7 +19,6 @@ import prefect.states
 from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
 from prefect.deprecated.data_documents import DataDocument
 from prefect.logging import get_logger
-from prefect.orion.api.server import ORION_API_VERSION, create_app
 from prefect.orion.schemas.actions import (
     FlowRunNotificationPolicyCreate,
     LogCreate,
@@ -51,8 +50,15 @@ from prefect.client.base import PrefectHttpxClient, app_lifespan_context
 
 def get_client(httpx_settings: dict = None) -> "OrionClient":
     ctx = prefect.context.get_settings_context()
+    api = PREFECT_API_URL.value()
+    if not api:
+        # create an ephemeral API if none was provided
+        from prefect.orion.api.server import create_app
+
+        api = create_app(ctx.settings, ephemeral=True)
+
     return OrionClient(
-        PREFECT_API_URL.value() or create_app(ctx.settings, ephemeral=True),
+        api,
         api_key=PREFECT_API_KEY.value(),
         httpx_settings=httpx_settings,
     )
@@ -85,13 +91,17 @@ class OrionClient:
         api: Union[str, FastAPI],
         *,
         api_key: str = None,
-        api_version: str = ORION_API_VERSION,
+        api_version: str = None,
         httpx_settings: dict = None,
     ) -> None:
         httpx_settings = httpx_settings.copy() if httpx_settings else {}
         httpx_settings.setdefault("headers", {})
-        if api_version:
-            httpx_settings["headers"].setdefault("X-PREFECT-API-VERSION", api_version)
+        if api_version is None:
+            # deferred import to avoid importing the entire server unless needed
+            import prefect.orion.api.server
+
+            api_version = prefect.orion.api.server.ORION_API_VERSION
+        httpx_settings["headers"].setdefault("X-PREFECT-API-VERSION", api_version)
         if api_key:
             httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
 

--- a/src/prefect/infrastructure/docker.py
+++ b/src/prefect/infrastructure/docker.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple
 
 import anyio.abc
-import docker
 import packaging.version
 from pydantic import Field, validator
 from typing_extensions import Literal

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -7,16 +7,19 @@ Each filter schema includes logic for transforming itself into a SQL `where` cla
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
-import sqlalchemy as sa
 from pydantic import Field
-from sqlalchemy.sql.elements import BooleanClauseList
 
 import prefect.orion.schemas as schemas
 from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
 from prefect.utilities.collections import AutoEnum
+from prefect.utilities.importtools import lazy_import
 
 if TYPE_CHECKING:
+    from sqlalchemy.sql.elements import BooleanClauseList
+
     from prefect.orion.database.interface import OrionDBInterface
+
+sa = lazy_import("sqlalchemy")
 
 # TOOD: Consider moving the `as_sql_filter` functions out of here since they are a
 #       database model level function and do not properly separate concerns when
@@ -36,7 +39,7 @@ class PrefectFilterBaseModel(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    def as_sql_filter(self, db: "OrionDBInterface") -> BooleanClauseList:
+    def as_sql_filter(self, db: "OrionDBInterface") -> "BooleanClauseList":
         """Generate SQL filter from provided filter parameters. If no filters parameters are available, return a TRUE filter."""
         filters = self._get_filter_list(db)
         if not filters:
@@ -56,7 +59,7 @@ class PrefectOperatorFilterBaseModel(PrefectFilterBaseModel):
         description="Operator for combining filter criteria. Defaults to 'and_'.",
     )
 
-    def as_sql_filter(self, db: "OrionDBInterface") -> BooleanClauseList:
+    def as_sql_filter(self, db: "OrionDBInterface") -> "BooleanClauseList":
         filters = self._get_filter_list(db)
         if not filters:
             return True

--- a/src/prefect/orion/schemas/sorting.py
+++ b/src/prefect/orion/schemas/sorting.py
@@ -4,12 +4,11 @@ Schemas for sorting Orion API objects.
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy.sql.expression import ColumnElement
-from sqlalchemy.sql.functions import coalesce
-
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:
+    from sqlalchemy.sql.expression import ColumnElement
+
     from prefect.orion.database.interface import OrionDBInterface
 
 # TOOD: Consider moving the `as_sql_sort` functions out of here since they are a
@@ -30,7 +29,9 @@ class FlowRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "OrionDBInterface") -> ColumnElement:
+    def as_sql_sort(self, db: "OrionDBInterface") -> "ColumnElement":
+        from sqlalchemy.sql.functions import coalesce
+
         """Return an expression used to sort flow runs"""
         sort_mapping = {
             "ID_DESC": db.FlowRun.id.desc(),
@@ -61,7 +62,7 @@ class TaskRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "OrionDBInterface") -> ColumnElement:
+    def as_sql_sort(self, db: "OrionDBInterface") -> "ColumnElement":
         """Return an expression used to sort task runs"""
         sort_mapping = {
             "ID_DESC": db.TaskRun.id.desc(),
@@ -87,7 +88,7 @@ class LogSort(AutoEnum):
     TASK_RUN_ID_ASC = AutoEnum.auto()
     TASK_RUN_ID_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "OrionDBInterface") -> ColumnElement:
+    def as_sql_sort(self, db: "OrionDBInterface") -> "ColumnElement":
         """Return an expression used to sort task runs"""
         sort_mapping = {
             "TIMESTAMP_ASC": db.Log.timestamp.asc(),
@@ -110,7 +111,7 @@ class FlowSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "OrionDBInterface") -> ColumnElement:
+    def as_sql_sort(self, db: "OrionDBInterface") -> "ColumnElement":
         """Return an expression used to sort flows"""
         sort_mapping = {
             "CREATED_DESC": db.Flow.created.desc(),
@@ -129,7 +130,7 @@ class DeploymentSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "OrionDBInterface") -> ColumnElement:
+    def as_sql_sort(self, db: "OrionDBInterface") -> "ColumnElement":
         """Return an expression used to sort deployments"""
         sort_mapping = {
             "CREATED_DESC": db.Deployment.created.desc(),


### PR DESCRIPTION
I used [Tuna](https://github.com/nschloe/tuna) to profile import times and noticed a few easy wins:
- eager imports of `sqlalchemy` in `schemas/filters.py`
- eager import of `docker` in `docker.py` (this looks like an accident; it's lazily loaded a couple lines later)
- eager imports of the entire ephemeral server in `client/orion.py`

I deferred these imports and reduced import times by roughly 25-30%. For anyone using Prefect only for workflow development or as a client, these aren't needed (obviously working on or with the server would require them)

One other low-hanging fruit is the eager import of `apprise` in `blocks/notifications.py`. Unfortunately an Apprise class is used as a base class in the file, so deferring the import isn't possible. It would be straightforward to simply not import `prefect.blocks.notifications` on startup, but it would technically be a breaking change.

------------

Quick instructions for replicating (after `pip install tuna`):
```bash
python -X importtime -c "import prefect" 2> import.log
tuna import.log
```
