### PR TITLE
Refactor `pause_flow_run` for consistency with engine state handling

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1599,11 +1599,8 @@ async def report_task_run_crashes(task_run: TaskRun, client: OrionClient):
     """
     try:
         yield
-    except PausedRun:
-        # Do not capture PausedRuns as crashes
-        raise
-    except Abort:
-        # Do not capture aborts as crashes
+    except (Abort, Pause):
+        # Do not capture internal signals as crashes
         raise
     except BaseException as exc:
         state = await exception_to_crashed_state(exc)
@@ -1772,7 +1769,7 @@ async def propose_state(
 
     elif response.status == SetStateStatus.REJECT:
         if response.state.is_paused():
-            raise PausedRun(response.details.reason)
+            raise Pause(response.details.reason)
         return response.state
 
     else:

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -45,7 +45,7 @@ from prefect.exceptions import (
     MappingLengthMismatch,
     MappingMissingIterable,
     NotPausedError,
-    PausedRun,
+    Pause,
     UpstreamTaskError,
 )
 from prefect.flows import Flow
@@ -638,10 +638,6 @@ async def orchestrate_flow_run(
                 waited_for_task_runs = await wait_for_task_runs_and_report_crashes(
                     flow_run_context.task_run_futures, client=client
                 )
-        except PausedRun:
-            paused_flow_run = await client.read_flow_run(flow_run.id)
-            paused_flow_run_state = paused_flow_run.state
-            return paused_flow_run_state
         except Exception as exc:
             name = message = None
             if (
@@ -721,7 +717,7 @@ async def pause_flow_run(
     flow_run_id: UUID = None,
     timeout: int = 300,
     poll_interval: int = 10,
-    reschedule=False,
+    reschedule: bool = False,
     key: str = None,
 ):
     """
@@ -774,48 +770,62 @@ async def _in_process_pause(
     if TaskRunContext.get():
         raise RuntimeError("Cannot pause task runs.")
 
-    frc = FlowRunContext.get()
-    logger = get_run_logger(context=frc)
-    client = get_client()
+    context = FlowRunContext.get()
+    if not context:
+        raise RuntimeError("Flow runs can only be paused from within a flow run.")
 
-    pause_counter = _observed_flow_pauses(frc)
+    logger = get_run_logger(context=context)
+
+    pause_counter = _observed_flow_pauses(context)
     pause_key = key or str(pause_counter)
 
     logger.info("Pausing flow, execution will continue when this flow run is resumed.")
-    response = await client.set_flow_run_state(
-        frc.flow_run.id,
-        Paused(timeout_seconds=timeout, reschedule=reschedule, pause_key=pause_key),
-    )
 
-    if response.status == SetStateStatus.REJECT:
-        if response.state.type == StateType.RUNNING:
-            return
-        raise RuntimeError(response.details.reason)
-    elif response.status == SetStateStatus.ABORT:
-        raise RuntimeError(response.details.reason)
+    try:
+        state = await propose_state(
+            client=context.client,
+            state=Paused(
+                timeout_seconds=timeout, reschedule=reschedule, pause_key=pause_key
+            ),
+            flow_run_id=context.flow_run.id,
+        )
+    except Abort as exc:
+        # Aborted pause requests mean the pause is not allowed
+        raise RuntimeError(f"Flow run cannot be paused: {exc}")
+
+    if state.is_running():
+        # The orchestrator requests that this paused be ignored
+        return
+
+    if not state.is_paused():
+        # If we receive anything but a PAUSED state, we are unable to continue
+        raise RuntimeError(
+            f"Flow run cannot be paused. Received non-paused state from API: {state}"
+        )
 
     if reschedule:
-        raise PausedRun()
+        # If a rescheduled pause, exit this process so the run can be resubmitted later
+        raise Pause()
 
+    # Otherwise, block and check for completion on an interval
     with anyio.move_on_after(timeout):
-
         # attempt to check if a flow has resumed at least once
         initial_sleep = min(timeout / 2, poll_interval)
         await anyio.sleep(initial_sleep)
-        flow_run = await client.read_flow_run(frc.flow_run.id)
+        flow_run = await context.client.read_flow_run(context.flow_run.id)
         if flow_run.state.is_running():
             logger.info("Resuming flow run execution!")
             return
 
         while True:
             await anyio.sleep(poll_interval)
-            flow_run = await client.read_flow_run(frc.flow_run.id)
+            flow_run = await context.client.read_flow_run(context.flow_run.id)
             if flow_run.state.is_running():
                 logger.info("Resuming flow run execution!")
                 return
 
     # check one last time before failing the flow
-    flow_run = await client.read_flow_run(frc.flow_run.id)
+    flow_run = await context.client.read_flow_run(context.flow_run.id)
     if flow_run.state.is_running():
         logger.info("Resuming flow run execution!")
         return
@@ -857,9 +867,7 @@ async def resume_flow_run(flow_run_id):
     if not flow_run.state.is_paused():
         raise NotPausedError("Cannot resume a run that isn't paused!")
 
-    response = await client.resume_flow_run(
-        flow_run_id,
-    )
+    response = await client.resume_flow_run(flow_run_id)
 
     if response.status == SetStateStatus.REJECT:
         if response.state.type == StateType.FAILED:
@@ -1559,8 +1567,8 @@ async def report_flow_run_crashes(flow_run: FlowRun, client: OrionClient):
     """
     try:
         yield
-    except Abort:
-        # Do not capture aborts as crashes
+    except (Abort, Pause):
+        # Do not capture internal signals as crashes
         raise
     except BaseException as exc:
         state = await exception_to_crashed_state(exc)
@@ -1891,7 +1899,7 @@ if __name__ == "__main__":
             f"Engine execution of flow run '{flow_run_id}' aborted by orchestrator: {exc}"
         )
         exit(0)
-    except PausedRun as exc:
+    except Pause as exc:
         engine_logger.info(
             f"Engine execution of flow run '{flow_run_id}' is paused: {exc}"
         )

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -794,7 +794,7 @@ async def _in_process_pause(
         raise RuntimeError(f"Flow run cannot be paused: {exc}")
 
     if state.is_running():
-        # The orchestrator requests that this paused be ignored
+        # The orchestrator requests that this pause be ignored
         return
 
     if not state.is_paused():

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -85,6 +85,12 @@ class CancelledRun(PrefectException):
     """
 
 
+class PausedRun(PrefectException):
+    """
+    Raised when the result from a paused run is retrieved.
+    """
+
+
 class MissingFlowError(PrefectException):
     """
     Raised when a given flow name is not found in the expected script.
@@ -264,6 +270,12 @@ class Abort(PrefectSignal):
     """
 
 
+class Pause(PrefectSignal):
+    """
+    Raised when a flow run is PAUSED and needs to exit for resubmission.
+    """
+
+
 class PrefectHTTPStatusError(HTTPStatusError):
     """
     Raised when client receives a `Response` that contains an HTTPStatusError.
@@ -349,7 +361,3 @@ class NotPausedError(PrefectException):
 
 class FlowPauseTimeout(PrefectException):
     """Raised when a flow pause times out"""
-
-
-class PausedRun(PrefectSignal):
-    """Signal raised when exiting a flow early for nonblocking pauses"""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 import prefect.flows
 from prefect import engine, flow, task
-from prefect.context import FlowRunContext
+from prefect.context import FlowRunContext, get_run_context
 from prefect.engine import (
     begin_flow_run,
     create_and_begin_subflow_run,
@@ -30,7 +30,7 @@ from prefect.exceptions import (
     CrashedRun,
     FailedRun,
     ParameterTypeError,
-    PausedRun,
+    Pause,
     SignatureMismatchError,
 )
 from prefect.futures import PrefectFuture
@@ -298,6 +298,7 @@ class TestNonblockingPause:
     ):
         frc = partial(FlowRunCreate, deployment_id=deployment.id)
         monkeypatch.setattr("prefect.client.orion.schemas.actions.FlowRunCreate", frc)
+        flow_run_id = None
 
         @task
         async def foo():
@@ -305,16 +306,21 @@ class TestNonblockingPause:
 
         @flow(task_runner=SequentialTaskRunner())
         async def pausing_flow_without_blocking():
+            nonlocal flow_run_id
+            flow_run_id = get_run_context().flow_run.id
             x = await foo.submit()
             y = await foo.submit()
             await pause_flow_run(timeout=20, reschedule=True)
             z = await foo(wait_for=[x])
             alpha = await foo(wait_for=[y])
             omega = await foo(wait_for=[x, y])
+            assert False, "This line should not be reached"
 
-        flow_run_state = await pausing_flow_without_blocking(return_state=True)
-        assert flow_run_state.is_paused()
-        flow_run_id = flow_run_state.state_details.flow_run_id
+        with pytest.raises(Pause):
+            await pausing_flow_without_blocking(return_state=True)
+
+        flow_run = await orion_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused()
         task_runs = await orion_client.read_task_runs(
             flow_run_filter=FlowRunFilter(id={"any_": [flow_run_id]})
         )
@@ -339,7 +345,7 @@ class TestNonblockingPause:
             alpha = await foo(wait_for=[y])
             omega = await foo(wait_for=[x, y])
 
-        with pytest.raises(PausedRun):
+        with pytest.raises(Pause):
             await pausing_flow_without_blocking()
 
     async def test_paused_flows_can_be_resumed_then_rescheduled(
@@ -347,6 +353,7 @@ class TestNonblockingPause:
     ):
         frc = partial(FlowRunCreate, deployment_id=deployment.id)
         monkeypatch.setattr("prefect.client.orion.schemas.actions.FlowRunCreate", frc)
+        flow_run_id = None
 
         @task
         async def foo():
@@ -354,6 +361,8 @@ class TestNonblockingPause:
 
         @flow(task_runner=SequentialTaskRunner())
         async def pausing_flow_without_blocking():
+            nonlocal flow_run_id
+            flow_run_id = get_run_context().flow_run.id
             x = await foo.submit()
             y = await foo.submit()
             await pause_flow_run(timeout=20, reschedule=True)
@@ -361,9 +370,11 @@ class TestNonblockingPause:
             alpha = await foo(wait_for=[y])
             omega = await foo(wait_for=[x, y])
 
-        flow_run_state = await pausing_flow_without_blocking(return_state=True)
-        assert flow_run_state.is_paused()
-        flow_run_id = flow_run_state.state_details.flow_run_id
+        with pytest.raises(Pause):
+            await pausing_flow_without_blocking()
+
+        flow_run = await orion_client.read_flow_run(flow_run_id)
+        assert flow_run.state.is_paused()
 
         await resume_flow_run(flow_run_id)
         flow_run = await orion_client.read_flow_run(flow_run_id)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -489,7 +489,7 @@ class TestOutOfProcessPause:
             alpha = await foo(wait_for=[y])
             omega = await foo(wait_for=[x, y])
 
-        with pytest.raises(PausedRun):
+        with pytest.raises(Pause):
             flow_run_state = await pausing_flow_without_blocking()
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,6 +31,7 @@ from prefect.exceptions import (
     FailedRun,
     ParameterTypeError,
     Pause,
+    PausedRun,
     SignatureMismatchError,
 )
 from prefect.futures import PrefectFuture
@@ -489,7 +490,7 @@ class TestOutOfProcessPause:
             alpha = await foo(wait_for=[y])
             omega = await foo(wait_for=[x, y])
 
-        with pytest.raises(Pause):
+        with pytest.raises(PausedRun):
             flow_run_state = await pausing_flow_without_blocking()
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Follow-up to #7738 

- Creates a separate `Pause(PrefectSignal)` instead of `PausedRun(BaseException)` for signalling exit on pause. This is inline with our plans for `Cancel` and our other state-exception types.
- Uses `propose_state` in `pause_flow_run` so all orchestration result types are handled.

I've attempted to avoid stylistic changes. I have not changed `resume_flow_run`, but we may want to in a separate PR.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
