### PR TITLE
Fix integration tests with v2.6 client images

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -116,6 +116,10 @@ jobs:
           - prefect-version: "2.5"
             server-incompatible: true
 
+          # 2.6 containers have a bad version of httpcore installed
+          - prefect-version: "2.6"
+            extra_docker_run_options: '--env PIP_EXTRA_PACKAGES="httpcore>=0.16.2"'
+
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -144,6 +148,7 @@ jobs:
           --name "orion-server-${{ matrix.prefect-version }}"
           --detach
           --publish 4200:4200
+          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           prefect orion start --host 0.0.0.0
 
@@ -177,5 +182,6 @@ jobs:
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts
           --network host
+          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

2.6 integration tests are failing due to a bad httpcore release in the image: https://github.com/PrefectHQ/prefect/actions/runs/3678823904/jobs/6222542729

I've resolved this by upgrading the httpcore package on container startup.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Fixed run at https://github.com/PrefectHQ/prefect/actions/runs/3678881759/jobs/6222672158

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
