### PR TITLE
Add `PREFECT_KUBERNETES_CLUSTER_UID` to allow bypass of `kube-system` namespace read

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -1,5 +1,6 @@
 import copy
 import enum
+import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union
 
@@ -378,11 +379,21 @@ class KubernetesJob(Infrastructure):
         There is no real unique identifier for a cluster. However, the `kube-system`
         namespace is immutable and has a persistence UID that we use instead.
 
+        PREFECT_KUBERNETES_CLUSTER_UID can be set in cases where the `kube-system`
+        namespace cannot be read e.g. when a cluster role cannot be created.
+
         See https://github.com/kubernetes/kubernetes/issues/44954
         """
+        # Default to an environment variablle
+        env_cluster_uid = os.environ.get("PREFECT_KUBERNETES_CLUSTER_UID")
+        if env_cluster_uid:
+            return env_cluster_uid
+
+        # Read the UID from the cluster namespace
         with self.get_client() as client:
             namespace = client.read_namespace("kube-system")
         cluster_uid = namespace.metadata.uid
+
         return cluster_uid
 
     def _configure_kubernetes_library_client(self) -> None:

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -25,6 +25,7 @@ from prefect.infrastructure.kubernetes import (
 )
 
 FAKE_CLUSTER = "fake-cluster"
+MOCK_CLUSTER_UID = "1234"
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +71,7 @@ def mock_k8s_client(monkeypatch, mock_cluster_config):
     pytest.importorskip("kubernetes")
 
     mock = MagicMock(spec=k8s.client.CoreV1Api)
+    mock.read_namespace.return_value.metadata.uid = MOCK_CLUSTER_UID
 
     @contextmanager
     def get_client(_):
@@ -152,17 +154,25 @@ def test_task_status_receives_job_pid(
     mock_watch,
     monkeypatch,
 ):
-    MOCK_CLUSTER_UID = "1234"
-    mock_func = MagicMock()
-    mock_func.return_value = MOCK_CLUSTER_UID
-
-    monkeypatch.setattr(
-        "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid", mock_func
-    )
-
     fake_status = MagicMock(spec=anyio.abc.TaskStatus)
     result = KubernetesJob(command=["echo", "hello"]).run(task_status=fake_status)
-    expected_value = f"{MOCK_CLUSTER_UID}:default:{'mock-k8s-v1-job'}"
+    expected_value = f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job"
+    fake_status.started.assert_called_once_with(expected_value)
+
+
+def test_cluster_uid_uses_env_var_if_set(
+    mock_k8s_batch_client,
+    mock_k8s_client,
+    mock_watch,
+    monkeypatch,
+):
+    monkeypatch.setenv("PREFECT_KUBERNETES_CLUSTER_UID", "test-uid")
+    fake_status = MagicMock(spec=anyio.abc.TaskStatus)
+    result = KubernetesJob(command=["echo", "hello"]).run(task_status=fake_status)
+
+    mock_k8s_client.read_namespace.assert_not_called()
+    expected_value = "test-uid:default:mock-k8s-v1-job"
+    assert result.identifier == expected_value
     fake_status.started.assert_called_once_with(expected_value)
 
 
@@ -172,15 +182,7 @@ async def test_task_group_start_returns_job_pid(
     mock_watch,
     monkeypatch,
 ):
-    MOCK_CLUSTER_UID = "1234"
-    mock_func = MagicMock()
-    mock_func.return_value = MOCK_CLUSTER_UID
-
-    monkeypatch.setattr(
-        "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid", mock_func
-    )
-
-    expected_value = f"{MOCK_CLUSTER_UID}:default:{'mock-k8s-v1-job'}"
+    expected_value = f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job"
     async with anyio.create_task_group() as tg:
         result = await tg.start(
             KubernetesJob(command=["echo", "hello"], name="test").run
@@ -196,14 +198,6 @@ class TestKill:
         mock_watch,
         monkeypatch,
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
 
         await KubernetesJob(command=["echo", "hello"], name="test").kill(
             infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
@@ -225,14 +219,6 @@ class TestKill:
         mock_watch,
         monkeypatch,
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
 
         await KubernetesJob(command=["echo", "hello"], name="test").kill(
             infrastructure_pid=f"{MOCK_CLUSTER_UID}:default:mock-k8s-v1-job",
@@ -251,14 +237,6 @@ class TestKill:
     async def test_kill_uses_correct_grace_seconds(
         self, mock_k8s_batch_client, mock_k8s_client, mock_watch, monkeypatch
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
 
         GRACE_SECONDS = 42
         await KubernetesJob(command=["echo", "hello"], name="test").kill(
@@ -277,14 +255,6 @@ class TestKill:
     async def test_kill_raises_infra_not_available_on_mismatched_cluster_namespace(
         self, mock_k8s_batch_client, mock_k8s_client, mock_watch, monkeypatch
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
         BAD_NAMESPACE = "dog"
         with pytest.raises(
             InfrastructureNotAvailable,
@@ -298,15 +268,8 @@ class TestKill:
     async def test_kill_raises_infra_not_available_on_mismatched_cluster_uid(
         self, mock_k8s_batch_client, mock_k8s_client, mock_watch, monkeypatch
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
         BAD_CLUSTER = "4321"
+
         with pytest.raises(
             InfrastructureNotAvailable,
             match=f"Unable to kill job 'mock-k8s-v1-job': The job is running on another "
@@ -324,14 +287,6 @@ class TestKill:
         mock_watch,
         monkeypatch,
     ):
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
 
         mock_k8s_batch_client.delete_namespaced_job.side_effect = [
             ApiException(status=404)
@@ -353,15 +308,6 @@ class TestKill:
         mock_watch,
         monkeypatch,
     ):
-
-        MOCK_CLUSTER_UID = "1234"
-        mock_func = MagicMock()
-        mock_func.return_value = MOCK_CLUSTER_UID
-
-        monkeypatch.setattr(
-            "prefect.infrastructure.kubernetes.KubernetesJob._get_cluster_uid",
-            mock_func,
-        )
 
         mock_k8s_batch_client.delete_namespaced_job.side_effect = [
             ApiException(status=400)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
