### PR TITLE
Add thread-safe async primitives `Event` and `Future`

### DIFF
--- a/src/prefect/_internal/concurrency/event_loop.py
+++ b/src/prefect/_internal/concurrency/event_loop.py
@@ -1,0 +1,49 @@
+"""
+Utilities for working with asynchronous event loops.
+"""
+
+import asyncio
+import concurrent.futures
+import functools
+from typing import Callable, Optional, TypeVar
+
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def get_running_loop() -> Optional[asyncio.BaseEventLoop]:
+    """
+    Get the current running loop.
+
+    Returns `None` if there is no running loop.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
+def run_in_loop_thread(
+    __loop: asyncio.AbstractEventLoop,
+    __fn: Callable[P, T],
+    *args: P.args,
+    **kwargs: P.kwargs
+) -> T:
+    """
+    Run a synchronous call in event loop's thread from another thread.
+    """
+    future = concurrent.futures.Future()
+
+    @functools.wraps(__fn)
+    def wrapper() -> None:
+        try:
+            future.set_result(__fn(*args, **kwargs))
+        except BaseException as exc:
+            future.set_exception(exc)
+            if not isinstance(exc, Exception):
+                raise
+
+    __loop.call_soon_threadsafe(wrapper)
+    return future.result()

--- a/src/prefect/_internal/concurrency/primitives.py
+++ b/src/prefect/_internal/concurrency/primitives.py
@@ -1,0 +1,91 @@
+"""
+Thread-safe async primitives.
+"""
+
+import asyncio
+import concurrent.futures
+from typing import Any
+
+from prefect._internal.concurrency.event_loop import (
+    get_running_loop,
+    run_in_loop_thread,
+)
+
+
+class Event:
+    """
+    A thread-safe async event.
+    """
+
+    def __init__(self) -> None:
+        self._loop = get_running_loop()
+
+        # For compatibility with Python <3.10, do not create the event until a loop
+        # is present
+        if self._loop:
+            self._event = asyncio.Event()
+
+        self._is_set = False
+
+    def set(self):
+        """Set the flag, notifying all listeners."""
+        self._is_set = True
+        if self._loop:
+            if self._loop != get_running_loop():
+                return run_in_loop_thread(self._loop, self._event.set)
+            else:
+                return self._event.set()
+
+    def is_set(self) -> bool:
+        """Return ``True`` if the flag is set, ``False`` if not."""
+        return self._is_set
+
+    async def wait(self) -> None:
+        """
+        Wait until the flag has been set.
+
+        If the flag has already been set when this method is called, it returns immediately.
+        """
+        if self._is_set:
+            return
+
+        if not self._loop:
+            self._loop = get_running_loop()
+            self._event = asyncio.Event()
+
+        return await self._event.wait()
+
+    def __repr__(self) -> str:
+        return f"Event<loop={id(self._loop)}, is_set={self._is_set}>"
+
+
+class Future:
+    """
+    A thread-safe async future.
+    """
+
+    def __init__(self, __sync_future: concurrent.futures.Future = None):
+        self._done_event = Event()
+        self._future = __sync_future or concurrent.futures.Future()
+        self._future.add_done_callback(self._set_done_event)
+
+    def _set_done_event(self, future: "concurrent.futures.Future"):
+        assert future is self._future
+        self._done_event.set()
+
+    async def result(self):
+        """Get the result of the future."""
+        await self._done_event.wait()
+        return self._future.result(timeout=0)
+
+    def cancel(self) -> bool:
+        return self._future.cancel()
+
+    def set_running_or_notify_cancel(self):
+        return self._future.set_running_or_notify_cancel()
+
+    def set_result(self, result: Any):
+        return self._future.set_result(result)
+
+    def set_exception(self, exception: BaseException):
+        return self._future.set_exception(exception)

--- a/src/prefect/_internal/concurrency/primitives.py
+++ b/src/prefect/_internal/concurrency/primitives.py
@@ -27,14 +27,14 @@ class Event:
 
         self._is_set = False
 
-    def set(self):
+    def set(self) -> None:
         """Set the flag, notifying all listeners."""
         self._is_set = True
         if self._loop:
             if self._loop != get_running_loop():
-                return run_in_loop_thread(self._loop, self._event.set)
+                run_in_loop_thread(self._loop, self._event.set)
             else:
-                return self._event.set()
+                self._event.set()
 
     def is_set(self) -> bool:
         """Return ``True`` if the flag is set, ``False`` if not."""
@@ -53,7 +53,7 @@ class Event:
             self._loop = get_running_loop()
             self._event = asyncio.Event()
 
-        return await self._event.wait()
+        await self._event.wait()
 
     def __repr__(self) -> str:
         return f"Event<loop={id(self._loop)}, is_set={self._is_set}>"
@@ -69,11 +69,11 @@ class Future:
         self._future = __sync_future or concurrent.futures.Future()
         self._future.add_done_callback(self._set_done_event)
 
-    def _set_done_event(self, future: "concurrent.futures.Future"):
+    def _set_done_event(self, future: "concurrent.futures.Future") -> None:
         assert future is self._future
         self._done_event.set()
 
-    async def result(self):
+    async def result(self) -> Any:
         """Get the result of the future."""
         await self._done_event.wait()
         return self._future.result(timeout=0)
@@ -81,11 +81,11 @@ class Future:
     def cancel(self) -> bool:
         return self._future.cancel()
 
-    def set_running_or_notify_cancel(self):
+    def set_running_or_notify_cancel(self) -> bool:
         return self._future.set_running_or_notify_cancel()
 
-    def set_result(self, result: Any):
-        return self._future.set_result(result)
+    def set_result(self, result: Any) -> None:
+        self._future.set_result(result)
 
-    def set_exception(self, exception: BaseException):
-        return self._future.set_exception(exception)
+    def set_exception(self, exception: BaseException) -> None:
+        self._future.set_exception(exception)

--- a/src/prefect/_internal/concurrency/primitives.py
+++ b/src/prefect/_internal/concurrency/primitives.py
@@ -1,15 +1,16 @@
 """
 Thread-safe async primitives.
 """
-
 import asyncio
 import concurrent.futures
-from typing import Any
+from typing import Generic, TypeVar
 
 from prefect._internal.concurrency.event_loop import (
     get_running_loop,
     run_in_loop_thread,
 )
+
+T = TypeVar("T")
 
 
 class Event:
@@ -59,33 +60,42 @@ class Event:
         return f"Event<loop={id(self._loop)}, is_set={self._is_set}>"
 
 
-class Future:
+class Future(concurrent.futures.Future, Generic[T]):
     """
     A thread-safe async future.
+
+    See `concurrent.futures.Future` documentation for details.
+        https://docs.python.org/3/library/concurrent.futures.html#future-objects
+
+    This implemention adds an `aresult` method to wait for results asynchronously.
     """
 
-    def __init__(self, __sync_future: concurrent.futures.Future = None):
-        self._done_event = Event()
-        self._future = __sync_future or concurrent.futures.Future()
-        self._future.add_done_callback(self._set_done_event)
+    def __init__(self):
+        super().__init__()
+        self._attach_async_callback()
 
-    def _set_done_event(self, future: "concurrent.futures.Future") -> None:
-        assert future is self._future
+    def _attach_async_callback(self):
+        self._done_event = Event()
+        self.add_done_callback(self._set_done_event)
+
+    def _set_done_event(self, _: "concurrent.futures.Future") -> None:
         self._done_event.set()
 
-    async def result(self) -> Any:
-        """Get the result of the future."""
+    async def aresult(self: "Future[T]") -> T:
+        """
+        Wait for the result from the future and return it.
+
+        If the future encountered an exception, it will be raised.
+        """
         await self._done_event.wait()
-        return self._future.result(timeout=0)
+        return self.result(timeout=0)
 
-    def cancel(self) -> bool:
-        return self._future.cancel()
-
-    def set_running_or_notify_cancel(self) -> bool:
-        return self._future.set_running_or_notify_cancel()
-
-    def set_result(self, result: Any) -> None:
-        self._future.set_result(result)
-
-    def set_exception(self, exception: BaseException) -> None:
-        self._future.set_exception(exception)
+    @classmethod
+    def from_existing(cls, future: "concurrent.futures.Future") -> "Future":
+        """
+        Create an async future from an existing future.
+        """
+        new = cls.__new__(cls)
+        new.__dict__ = future.__dict__
+        new._attach_async_callback()
+        return new

--- a/src/prefect/_internal/concurrency/primitives.py
+++ b/src/prefect/_internal/concurrency/primitives.py
@@ -81,6 +81,14 @@ class Future(concurrent.futures.Future, Generic[T]):
     def _set_done_event(self, _: "concurrent.futures.Future") -> None:
         self._done_event.set()
 
+    def result(self: "Future[T]") -> T:
+        if get_running_loop() is not None:
+            raise RuntimeError(
+                "Future.result() cannot be called from an async thread; "
+                "use `aresult()` instead to avoid blocking the event loop."
+            )
+        return super().result()
+
     async def aresult(self: "Future[T]") -> T:
         """
         Wait for the result from the future and return it.

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -1,0 +1,181 @@
+import anyio
+import pytest
+
+from prefect._internal.concurrency.primitives import Event, Future
+
+
+def test_event_set_in_sync_context_before_wait():
+
+    event = Event()
+    event.set()
+
+    async def main():
+        with anyio.fail_after(1):
+            await event.wait()
+
+    anyio.run(main)
+
+
+async def test_event_set_in_async_context_before_wait():
+    event = Event()
+    event.set()
+    await event.wait()
+
+
+async def test_event_set_from_async_task():
+    event = Event()
+
+    async def set_event():
+        event.set()
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(event.wait)
+            tg.start_soon(set_event)
+
+
+async def test_event_set_from_sync_thread():
+    event = Event()
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(event.wait)
+            tg.start_soon(anyio.to_thread.run_sync, event.set)
+
+
+async def test_event_set_from_sync_thread_before_wait():
+    event = Event()
+
+    async def set_event(task_status):
+        await anyio.to_thread.run_sync(event.set)
+        task_status.started()
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            await tg.start(set_event)
+            tg.start_soon(event.wait)
+
+
+async def test_event_created_and_set_from_sync_threadt():
+    def create_event():
+        return Event()
+
+    async def create_and_set_event(task_status):
+        event = await anyio.to_thread.run_sync(create_event)
+        task_status.started(event)
+        await anyio.to_thread.run_sync(event.set)
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            event = await tg.start(create_and_set_event)
+            tg.start_soon(event.wait)
+
+
+async def test_event_set_from_async_thread():
+    event = Event()
+
+    async def set_event():
+        event.set()
+
+    def set_event_in_new_loop():
+        anyio.run(set_event)
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(event.wait)
+            tg.start_soon(anyio.to_thread.run_sync, set_event_in_new_loop)
+
+
+async def test_event_set_from_async_thread_before_wait():
+    event = Event()
+
+    async def set_event():
+        event.set()
+
+    def set_event_in_new_loop():
+        anyio.run(set_event)
+
+    await anyio.to_thread.run_sync(set_event_in_new_loop)
+    with anyio.fail_after(1):
+        await event.wait()
+
+
+def test_event_is_set():
+    event = Event()
+    assert not event.is_set()
+    event.set()
+    assert event.is_set()
+
+
+async def test_future_result_set_in_same_async_context():
+    future = Future()
+    future.set_result("test")
+    assert await future.result() == "test"
+
+
+async def test_future_result_set_from_async_task():
+    future = Future()
+    result = None
+
+    async def set_result():
+        future.set_result("test")
+
+    async def get_result():
+        nonlocal result
+        result = await future.result()
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(get_result)
+            tg.start_soon(set_result)
+
+    assert result == "test"
+    assert await future.result() == "test"
+
+
+async def test_future_result_set_from_sync_thread():
+    future = Future()
+    result = None
+
+    async def get_result():
+        nonlocal result
+        result = await future.result()
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(get_result)
+            tg.start_soon(anyio.to_thread.run_sync, future.set_result, "test")
+
+    assert result == "test"
+    assert await future.result() == "test"
+
+
+async def test_future_result_set_to_exception():
+    future = Future()
+    future.set_result(Exception("test"))
+    with pytest.raises(Exception, match="test"):
+        await future.result()
+
+
+async def test_future_cancel():
+    future = Future()
+    assert future.cancel() is True
+    with pytest.raises(Exception, match="test"):
+        await future.result()
+
+
+async def test_future_cancel_after_running():
+    future = Future()
+    assert future.set_running_or_notify_cancel() is True
+    assert future.cancel() is False
+
+
+async def test_future_set_running_or_notify_cancel():
+    future = Future()
+    assert future.set_running_or_notify_cancel() is True
+    future.set_result("test")
+    await future.result() == "test"
+
+    future = Future()
+    future.cancel()
+    assert future.set_running_or_notify_cancel() is False

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -59,7 +59,7 @@ async def test_event_set_from_sync_thread_before_wait():
             tg.start_soon(event.wait)
 
 
-async def test_event_created_and_set_from_sync_threadt():
+async def test_event_created_and_set_from_sync_thread():
     def create_event():
         return Event()
 

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -116,6 +116,19 @@ async def test_future_result_set_in_same_async_context():
     assert await future.aresult() == "test"
 
 
+async def test_future_result_from_async_context():
+    future = Future()
+    future.set_result("test")
+    with pytest.raises(RuntimeError, match="cannot be called from an async thread"):
+        future.result()
+
+
+async def test_future_result_from_sync_context():
+    future = Future()
+    future.set_result("test")
+    assert await anyio.to_thread.run_sync(future.result) == "test"
+
+
 async def test_future_result_set_from_async_task():
     future = Future()
     result = None

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -113,7 +113,7 @@ def test_event_is_set():
 async def test_future_result_set_in_same_async_context():
     future = Future()
     future.set_result("test")
-    assert await future.result() == "test"
+    assert await future.aresult() == "test"
 
 
 async def test_future_result_set_from_async_task():
@@ -125,7 +125,7 @@ async def test_future_result_set_from_async_task():
 
     async def get_result():
         nonlocal result
-        result = await future.result()
+        result = await future.aresult()
 
     with anyio.fail_after(1):
         async with anyio.create_task_group() as tg:
@@ -133,7 +133,7 @@ async def test_future_result_set_from_async_task():
             tg.start_soon(set_result)
 
     assert result == "test"
-    assert await future.result() == "test"
+    assert await future.aresult() == "test"
 
 
 async def test_future_result_set_from_sync_thread():
@@ -142,7 +142,7 @@ async def test_future_result_set_from_sync_thread():
 
     async def get_result():
         nonlocal result
-        result = await future.result()
+        result = await future.aresult()
 
     with anyio.fail_after(1):
         async with anyio.create_task_group() as tg:
@@ -150,20 +150,20 @@ async def test_future_result_set_from_sync_thread():
             tg.start_soon(anyio.to_thread.run_sync, future.set_result, "test")
 
     assert result == "test"
-    assert await future.result() == "test"
+    assert await future.aresult() == "test"
 
 
 async def test_future_result_set_to_exception():
     future = Future()
     future.set_exception(ValueError("test"))
     with pytest.raises(ValueError, match="test"):
-        await future.result()
+        await future.aresult()
 
 
 async def test_future_result_set_to_exception_instance():
     future = Future()
     future.set_result(ValueError("test"))
-    result = await future.result()
+    result = await future.aresult()
     assert exceptions_equal(result, ValueError("test"))
 
 
@@ -171,7 +171,7 @@ async def test_future_cancel():
     future = Future()
     assert future.cancel() is True
     with pytest.raises(concurrent.futures.CancelledError):
-        await future.result()
+        await future.aresult()
 
 
 async def test_future_cancel_after_running():
@@ -184,7 +184,7 @@ async def test_future_set_running_or_notify_cancel():
     future = Future()
     assert future.set_running_or_notify_cancel() is True
     future.set_result("test")
-    await future.result() == "test"
+    await future.aresult() == "test"
 
     future = Future()
     future.cancel()
@@ -193,6 +193,6 @@ async def test_future_set_running_or_notify_cancel():
 
 async def test_future_from_existing_sync_future():
     sync_future = concurrent.futures.Future()
-    future = Future(sync_future)
+    future = Future.from_existing(sync_future)
     sync_future.set_result("test")
-    assert await future.result() == "test"
+    assert await future.aresult() == "test"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

In preparation for changes in engine behavior, adds async but threadsafe `Event` and `Future` concurrency primitives. We may add other primitives like `Lock` in the future.

Note these implementations are specific to asyncio.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
