### PR TITLE
Update experimental utilities to require kwarg for group

### DIFF
--- a/src/prefect/_internal/compatibility/experimental.py
+++ b/src/prefect/_internal/compatibility/experimental.py
@@ -82,7 +82,12 @@ def _warn_setting_for_group(group: str) -> Setting[bool]:
 
 
 def experimental(
-    group: str, feature: str, help: str = "", stacklevel: int = 2, opt_in: bool = False
+    feature: str,
+    *,
+    group: str,
+    help: str = "",
+    stacklevel: int = 2,
+    opt_in: bool = False,
 ) -> Callable[[T], T]:
     group = group.upper()
 
@@ -124,6 +129,7 @@ def experiment_enabled(group: str) -> bool:
 
 def experimental_parameter(
     name: str,
+    *,
     group: str,
     help: str = "",
     stacklevel: int = 2,

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -78,7 +78,9 @@ def enable_prefect_experimental_test_opt_in_setting(
 
 
 def test_experimental_marker_on_function():
-    @experimental("TEST", "A test function", help="This is just a test, don't worry.")
+    @experimental(
+        "A test function", group="test", help="This is just a test, don't worry."
+    )
     def foo():
         return 1
 
@@ -96,7 +98,9 @@ def test_experimental_marker_on_function():
 
 
 def test_experimental_marker_on_class():
-    @experimental("TEST", "A test class", help="This is just a test, don't worry.")
+    @experimental(
+        "A test class", group="test", help="This is just a test, don't worry."
+    )
     class Foo:
         pass
 
@@ -116,7 +120,7 @@ def test_experimental_marker_on_class():
 def test_experimental_parameter_warning():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
     )
     def foo(return_value: int = 1):
@@ -138,7 +142,7 @@ def test_experimental_parameter_warning():
 def test_experimental_parameter_no_warning_when_not_passed():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
     )
     def foo(return_value: int = 1):
@@ -150,7 +154,7 @@ def test_experimental_parameter_no_warning_when_not_passed():
 def test_experimental_parameter_positional():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
     )
     def foo(return_value: int = 1):
@@ -163,7 +167,7 @@ def test_experimental_parameter_positional():
 def test_experimental_parameter_when():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
         when=lambda x: x == 3,
     )
@@ -180,7 +184,7 @@ def test_experimental_parameter_when():
 def test_experimental_parameter_opt_in():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
         opt_in=True,
     )
@@ -194,7 +198,7 @@ def test_experimental_parameter_opt_in():
 def test_experimental_parameter_retains_error_with_invalid_arguments():
     @experimental_parameter(
         "return_value",
-        group="TEST",
+        group="test",
         help="This is just a test, don't worry.",
     )
     def foo(return_value: int = 1):
@@ -207,7 +211,7 @@ def test_experimental_parameter_retains_error_with_invalid_arguments():
 
 
 def test_experimental_warning_without_help():
-    @experimental("TEST", "A test function")
+    @experimental("A test function", group="test")
     def foo():
         return 1
 
@@ -226,7 +230,9 @@ def test_experimental_warning_without_help():
 
 @pytest.mark.usefixtures("disable_prefect_experimental_test_setting")
 def test_experimental_marker_does_not_warn_with_group_setting():
-    @experimental("TEST", "A test function", help="This is just a test, don't worry.")
+    @experimental(
+        "A test function", group="test", help="This is just a test, don't worry."
+    )
     def foo():
         return 1
 
@@ -234,7 +240,9 @@ def test_experimental_marker_does_not_warn_with_group_setting():
 
 
 def test_experimental_marker_does_not_warn_with_global_setting():
-    @experimental("TEST", "A test function", help="This is just a test, don't worry.")
+    @experimental(
+        "A test function", group="test", help="This is just a test, don't worry."
+    )
     def foo():
         return 1
 
@@ -244,7 +252,10 @@ def test_experimental_marker_does_not_warn_with_global_setting():
 
 def test_experimental_marker_raises_without_opt_in():
     @experimental(
-        "TEST", "A test function", help="This is just a test, don't worry.", opt_in=True
+        "A test function",
+        group="test",
+        help="This is just a test, don't worry.",
+        opt_in=True,
     )
     def foo():
         return 1
@@ -263,8 +274,8 @@ def test_experimental_marker_raises_without_opt_in():
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
 def test_experimental_marker_does_not_raise_with_opt_in():
     @experimental(
-        "TEST",
         "A test function",
+        group="test",
         help="This is just a test, don't worry.",
         opt_in=True,
     )
@@ -308,8 +319,8 @@ def test_experimental_marker_cannot_be_used_without_warn_setting():
     ):
 
         @experimental(
-            "ANOTHER_GROUP",
             feature="A test feature",
+            group="ANOTHER_GROUP",
         )
         def foo():
             return 1
@@ -325,6 +336,6 @@ def test_experimental_marker_cannot_be_used_without_opt_in_setting_if_required()
         ),
     ):
 
-        @experimental("ANOTHER_GROUP", feature="A test feature", opt_in=True)
+        @experimental(feature="A test feature", group="ANOTHER_GROUP", opt_in=True)
         def foo():
             return 1


### PR DESCRIPTION
For consistency in the API surface for these, the "feature" blurb comes first then the "group" is specified as a kwarg.