### PR TITLE
Add cloud icons and admonitions

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -262,3 +262,23 @@ to force column width */
 [data-md-color-scheme="slate"] .prefect-table th {
     background-color: #3b3d54;
 }
+
+/* custom admonitions */
+:root {
+    --md-admonition-icon--cloud-ad: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 18H6a4 4 0 0 1-4-4 4 4 0 0 1 4-4h.71C7.37 7.69 9.5 6 12 6a5.5 5.5 0 0 1 5.5 5.5v.5H19a3 3 0 0 1 3 3 3 3 0 0 1-3 3m.35-7.97A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.03A6.004 6.004 0 0 0 0 14a6 6 0 0 0 6 6h13a5 5 0 0 0 5-5c0-2.64-2.05-4.78-4.65-4.97Z"/></svg>')
+  }
+  .md-typeset .admonition.cloud-ad,
+  .md-typeset details.cloud-ad {
+    border-color: #799AF7;
+  }
+  .md-typeset .cloud-ad > .admonition-title,
+  .md-typeset .cloud-ad > summary {
+    background-color: #799bf715;
+  }
+  .md-typeset .cloud-ad > .admonition-title::before,
+  .md-typeset .cloud-ad > summary::before {
+    background-color: #799AF7;
+    -webkit-mask-image: var(--md-admonition-icon--cloud-ad);
+            mask-image: var(--md-admonition-icon--cloud-ad);
+  }
+  

--- a/docs/ui/audit-log.md
+++ b/docs/ui/audit-log.md
@@ -1,5 +1,6 @@
 ---
 description: Monitor user access and activity with Audit Logs in Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard

--- a/docs/ui/automations.md
+++ b/docs/ui/automations.md
@@ -1,5 +1,6 @@
 ---
 description: Configure automations based on flow state from the Prefect UI and Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - Orion
     - UI

--- a/docs/ui/cloud-getting-started.md
+++ b/docs/ui/cloud-getting-started.md
@@ -1,5 +1,6 @@
 ---
 description: Get started using Prefect Cloud, including creating a workspace and running a flow deployment.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard
@@ -107,7 +108,7 @@ Now you're ready to run flows locally and have the results displayed in the Pref
 
 You can log out of Prefect Cloud by switching to a different profile.
 
-!!! tip "Interactive login"
+!!! cloud-ad "Interactive login to Prefect Cloud"
     The `prefect cloud login` command, used on its own, provides an interactive login experience. Using this command, you may log in with either an API key or through a browser.
 
     <div class="terminal">

--- a/docs/ui/cloud.md
+++ b/docs/ui/cloud.md
@@ -1,5 +1,6 @@
 ---
 description: Prefect Cloud provides a hosted coordination-as-a-service platform for your workflows.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard
@@ -24,7 +25,7 @@ Prefect Cloud is a workflow coordination-as-a-service platform. Prefect Cloud pr
 - [Blocks](/ui/blocks/) configured for storage or infrastructure used by your flow runs.
 - [Notifications](/ui/notifications/) configured to alert on flow run state changes.
 
-!!! info "Prefect Cloud features"
+!!! cloud-ad "Prefect Cloud features"
     Features only available on Prefect Cloud include:
 
     - [User accounts](#user-accounts) &mdash; personal accounts for working in Prefect Cloud. 
@@ -34,7 +35,7 @@ Prefect Cloud is a workflow coordination-as-a-service platform. Prefect Cloud pr
     - [Custom role-based access controls (RBAC)](/ui/roles/) &mdash; assign users granular permissions to perform certain activities within an organization or a workspace.
     - [Single Sign-on (SSO)](/ui/sso/) authentication using your identity provider.
     - [Audit Log](/ui/audit-log/) record of user activities to monitor security and compliance.
-    - Collaborators &mdash; invite others to work in your workspace or organization.
+    - Collaborators &mdash; invite others to work in your [workspace](/ui/workspaces/#workspace-collaborators) or [organization](/ui/organizations/#organization-members).
     - [Email notifications](/ui/notifications/) &mdash; configure email alerts based on flow run states and tags.
     - [Automations](/ui/automations/) &mdash; configure triggers and actions in response to real-time monitoring events.
 
@@ -51,7 +52,7 @@ As a personal account owner, you can create a [workspace](#workspaces) and invit
 
 [Organizations](#organizations) in Prefect Cloud enable you to invite users to collaborate in your workspaces with the ability to set [role-based access controls (RBAC)](#roles-and-custom-permissions) for organization members. Organizations may also configure [service accounts](#service-accounts) with API keys for non-user access to the Prefect Cloud API.
 
-!!! tip "Prefect Cloud plans for teams of every size"
+!!! cloud-ad "Prefect Cloud plans for teams of every size"
     See the [Prefect Cloud plans](https://www.prefect.io/pricing/) for details on options for individual users and teams.
 
 ## Workspaces

--- a/docs/ui/organizations.md
+++ b/docs/ui/organizations.md
@@ -1,5 +1,6 @@
 ---
 description: Manage teams and organizations in Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard

--- a/docs/ui/roles.md
+++ b/docs/ui/roles.md
@@ -1,5 +1,6 @@
 ---
 description: Configure user workspace roles in Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard

--- a/docs/ui/service-accounts.md
+++ b/docs/ui/service-accounts.md
@@ -1,5 +1,6 @@
 ---
 description: Workspaces are isolated environments for flows and deployments within Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - UI
     - Prefect Cloud

--- a/docs/ui/sso.md
+++ b/docs/ui/sso.md
@@ -1,5 +1,6 @@
 ---
 description: Configure single sign-on (SSO) for your Prefect Cloud users.
+icon: material/cloud-outline
 tags:
     - UI
     - dashboard

--- a/docs/ui/workspaces.md
+++ b/docs/ui/workspaces.md
@@ -1,5 +1,6 @@
 ---
 description: Workspaces are isolated environments for flows and deployments within Prefect Cloud.
+icon: material/cloud-outline
 tags:
     - UI
     - Prefect Cloud
@@ -29,7 +30,7 @@ Your list of available workspaces may include:
 - Workspaces owned by other users, who have invited you to their workspace as a collaborator.
 - Workspaces in an [organization](/ui/organizations/) to which you've been invited and have been given access to organization workspaces.
 
-!!! info "Workspace-specific features"
+!!! cloud-ad "Workspace-specific features"
     Each workspace keeps track of its own:
 
     - [Flow runs](/ui/flow-runs/) and task runs executed in an environment that is [syncing with the workspace](/ui/cloud/#workspaces)

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,5 +1,6 @@
 INHERIT: mkdocs.yml
 plugins:
+    meta:
     social: 
         cards_color:
             fill: "#115AF4"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,10 @@ markdown_extensions:
     - toc:
         permalink: true
     - pymdownx.snippets
+    - pymdownx.emoji:
+        emoji_index: !!python/name:materialx.emoji.twemoji
+        emoji_generator: !!python/name:materialx.emoji.to_svg
+
 theme:
     name: material
     custom_dir: docs/overrides
@@ -130,24 +134,23 @@ nav:
         - Database: concepts/database.md
         - Settings: concepts/settings.md
     - Prefect UI & Prefect Cloud:
-        - Overview: ui/overview.md
+        - Orion UI Overview: ui/overview.md
         - ui/flow-runs.md
         - ui/flows.md
         - ui/deployments.md
         - ui/work-queues.md
         - ui/blocks.md
         - ui/notifications.md
-        - Prefect Cloud:
-            - Prefect Cloud Overview: ui/cloud.md
-            - Prefect Cloud Quickstart: ui/cloud-getting-started.md
-            - Workspaces: ui/workspaces.md
-            - Automations: ui/automations.md
-            - Organizations: ui/organizations.md
-            - Service Accounts: ui/service-accounts.md
-            - Roles (RBAC): ui/roles.md
-            - Single Sign-on (SSO): ui/sso.md
-            - Audit Log: ui/audit-log.md
-            - Troubleshooting: ui/troubleshooting.md
+        - Prefect Cloud Overview: ui/cloud.md
+        - Prefect Cloud Quickstart: ui/cloud-getting-started.md
+        - Workspaces: ui/workspaces.md
+        - Automations: ui/automations.md
+        - Organizations: ui/organizations.md
+        - Service Accounts: ui/service-accounts.md
+        - Roles (RBAC): ui/roles.md
+        - Single Sign-on (SSO): ui/sso.md
+        - Audit Log: ui/audit-log.md
+        - Troubleshooting: ui/troubleshooting.md
     - Integrations:
         - Collections Catalog: collections/catalog.md
         - Using Collections: collections/usage.md


### PR DESCRIPTION
Styling changes to increase visibility of Prefect Cloud features.

- Add cloud icon next to Cloud-specific topics in left nav
- Move all Cloud topics up one level so they're not hidden
- Add a cloud admonition type
- Icons are compatible with dark theme

### Example

![icons-admonitions](https://user-images.githubusercontent.com/370316/207457908-181ca966-f06c-47d8-989e-0cf6ee77064a.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
