### PR TITLE
fixup: set `oauth` prefix to git clone string

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@ base = ""
 command = """
 pip install --upgrade pip \
 && pip install --upgrade --upgrade-strategy eager  -e ".[dev]" \
-&& pip install git+https://${MKDOCS_INSIDERS_PAT}@github.com/PrefectHQ/mkdocs-material-insiders.git; \
+&& pip install git+https://oauth:${MKDOCS_INSIDERS_PAT}@github.com/PrefectHQ/mkdocs-material-insiders.git; \
 prefect dev build-docs  \
 && mkdocs build --config-file mkdocs.insiders.yml \
 || mkdocs build --config-file mkdocs.yml \


### PR DESCRIPTION
attempting to fix the docsite build failure - my hunch is that the subshell will prompt for a password without this prefix (bc the git client assumes this is a username/password authentication) + hang/fail