### PR TITLE
Correct spelling in Results page

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -32,7 +32,7 @@ result = my_flow()
 assert result == 2
 ```
 
-When working with flow and task states, the result can be retreived with the `State.result()` method:
+When working with flow and task states, the result can be retrieved with the `State.result()` method:
 
 ```python
 from prefect import flow, task
@@ -50,7 +50,7 @@ state = my_flow(return_state=True)
 assert state.result() == 2
 ```
 
-When submitting tasks to a runner, the result can be retreived with the `Future.result()` method:
+When submitting tasks to a runner, the result can be retrieved with the `Future.result()` method:
 
 ```python
 from prefect import flow, task
@@ -215,7 +215,7 @@ result = asyncio.run(my_flow())
 assert result == 2
 ```
 
-When working with flow and task states, the result can be retreived with the `State.result()` method:
+When working with flow and task states, the result can be retrieved with the `State.result()` method:
 
 ```python
 import asyncio
@@ -250,7 +250,7 @@ asyncio.run(main())
     You may also opt-out by setting `fetch=False`.
     This will silence the warning, but you will need to retrieve your result manually from the result type.
 
-When submitting tasks to a runner, the result can be retreived with the `Future.result()` method:
+When submitting tasks to a runner, the result can be retrieved with the `Future.result()` method:
 
 ```python
 import asyncio


### PR DESCRIPTION
Small spelling fix: `retreived` -> `retrieved`


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
