### PR TITLE
Fix path argument for LocalFileSystem block

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -161,11 +161,16 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         Copies a directory from one place to another on the local filesystem.
 
         Defaults to copying the entire contents of the current working directory to the block's basepath.
-
         An `ignore_file` path may be provided that can include gitignore style expressions for filepaths to ignore.
         """
-        if not to_path:
-            to_path = Path(self.basepath).expanduser()
+        # If to_path is provided as an exact destination, use that instead of the basepath
+        if to_path and Path(to_path).expanduser().is_absolute():
+            destination_path = to_path
+        else:
+            # to_path should modify the basepath
+            destination_path = Path(self.basepath).expanduser()
+            if to_path:
+                destination_path = destination_path / to_path
 
         if not local_path:
             local_path = Path(".").absolute()
@@ -177,11 +182,14 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         else:
             ignore_func = None
 
-        if local_path == to_path:
+        if local_path == destination_path:
             pass
         else:
             copytree(
-                src=local_path, dst=to_path, ignore=ignore_func, dirs_exist_ok=True
+                src=local_path,
+                dst=destination_path,
+                ignore=ignore_func,
+                dirs_exist_ok=True,
             )
 
     @sync_compatible

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -100,7 +100,11 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         # Determine the path to access relative to the base path, ensuring that paths
         # outside of the base path are off limits
+        if path is None:
+            return basepath
+
         path: Path = Path(path).expanduser()
+
         if not path.is_absolute():
             path = basepath / path
         else:
@@ -163,14 +167,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         Defaults to copying the entire contents of the current working directory to the block's basepath.
         An `ignore_file` path may be provided that can include gitignore style expressions for filepaths to ignore.
         """
-        # If to_path is provided as an exact destination, use that instead of the basepath
-        if to_path and Path(to_path).expanduser().is_absolute():
-            destination_path = to_path
-        else:
-            # to_path should modify the basepath
-            destination_path = Path(self.basepath).expanduser()
-            if to_path:
-                destination_path = destination_path / to_path
+        destination_path = self._resolve_path(to_path)
 
         if not local_path:
             local_path = Path(".").absolute()

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -148,6 +148,22 @@ class TestLocalFileSystem:
                     child_contents
                 )
 
+    async def test_to_path_raises_error_when_not_in_basepath(self):
+
+        with TemporaryDirectory() as tmp_basepath:
+            f = LocalFileSystem(basepath=tmp_basepath)
+            outside_path = "~/puppy"
+            with pytest.raises(
+                ValueError, match="Provided path .* is outside of the base path.*"
+            ):
+                await f.put_directory(to_path=outside_path)
+
+                # Make sure that correct destination was reached at <basepath>/<to_path>
+                assert set(os.listdir(tmp_dst)) == set(parent_contents)
+                assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == set(
+                    child_contents
+                )
+
     async def test_dir_contents_copied_correctly_with_put_directory_and_file_pattern(
         self,
     ):

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -111,14 +111,38 @@ class TestLocalFileSystem:
             )
             # move file contents to tmp_dst
             with TemporaryDirectory() as tmp_dst:
-
-                f = LocalFileSystem()
+                f = LocalFileSystem(basepath=Path(tmp_dst).parent)
 
                 await f.put_directory(
                     local_path=tmp_src,
                     to_path=tmp_dst,
                 )
 
+                assert set(os.listdir(tmp_dst)) == set(parent_contents)
+                assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == set(
+                    child_contents
+                )
+
+    async def test_to_path_modifies_base_path_correctly(self):
+
+        sub_dir_name = "puppy"
+
+        with TemporaryDirectory() as tmp_src:
+            parent_contents, child_contents = setup_test_directory(
+                tmp_src, sub_dir_name
+            )
+            # move file contents to tmp_dst
+            with TemporaryDirectory() as tmp_dst:
+                # Do not include final destination dir in the basepath
+                f = LocalFileSystem(basepath=Path(tmp_dst).parent)
+
+                # add final destination_dir
+                await f.put_directory(
+                    local_path=tmp_src,
+                    to_path=Path(tmp_dst).name,
+                )
+
+                # Make sure that correct destination was reached at <basepath>/<to_path>
                 assert set(os.listdir(tmp_dst)) == set(parent_contents)
                 assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == set(
                     child_contents
@@ -154,7 +178,7 @@ class TestLocalFileSystem:
             # move file contents to tmp_dst
             with TemporaryDirectory() as tmp_dst:
 
-                f = LocalFileSystem()
+                f = LocalFileSystem(basepath=Path(tmp_dst).parent)
 
                 await f.put_directory(
                     local_path=tmp_src, to_path=tmp_dst, ignore_file=ignore_fpath
@@ -195,7 +219,7 @@ class TestLocalFileSystem:
             # move file contents to tmp_dst
             with TemporaryDirectory() as tmp_dst:
 
-                f = LocalFileSystem()
+                f = LocalFileSystem(basepath=Path(tmp_dst).parent)
 
                 await f.put_directory(
                     local_path=tmp_src, to_path=tmp_dst, ignore_file=ignore_fpath


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Closes https://github.com/PrefectHQ/prefect/issues/7853

The `--path` argument for deployments wasn't being used to modify the `LocalFileSystem.basepath` when calling the `put_directory` method.

This PR updates the logic of `LFS._resolve_path` and updates `LFS.put_directory` to use the `_resolve_path` method to fix the bug. This makes the implementation comparable to the implementation in the `RemoteFileSystem`.

A little bit of refactoring also happened in filesystem tests (see last commit) to remove some clunky temporary directory setup.
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
fs = LocalFileSystem(basepath="~/my/dog")
fs._resolve_path("skip")
Out[14]: PosixPath('/Users/peytonrunyan/my/dog/skip')
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
