### PR TITLE
Improve `Event` implementation consistency and fix deadlock

### DIFF
--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -133,7 +133,7 @@ async def test_dependent_events_in_two_loops_do_not_deadlock():
         event_one.set()
         await event_two.wait()
 
-    with anyio.fail_after(1):
+    with anyio.fail_after(2):
         async with anyio.create_task_group() as tg:
             tg.start_soon(anyio.to_thread.run_sync, anyio.run, one)
             tg.start_soon(anyio.to_thread.run_sync, anyio.run, two)

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -113,7 +113,7 @@ async def test_event_wait_in_different_loop():
     async def wait_for_event():
         await event.wait()
 
-    with pytest.raises(RuntimeError, match="different loop"):
+    with pytest.raises(RuntimeError, match="different .* loop"):
         await anyio.to_thread.run_sync(anyio.run, wait_for_event)
 
 

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -8,9 +8,8 @@ from prefect.testing.utilities import exceptions_equal
 
 
 def test_event_created_in_sync_context():
-
-    with pytest.raises(RuntimeError, match="no running event loop"):
-        event = Event()
+    with pytest.raises(RuntimeError, match="no .* event loop"):
+        Event()
 
 
 async def test_event_set_in_async_context_before_wait():

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -133,7 +133,7 @@ async def test_dependent_events_in_two_loops_do_not_deadlock():
         event_one.set()
         await event_two.wait()
 
-    with anyio.fail_after(2):
+    with anyio.fail_after(5):
         async with anyio.create_task_group() as tg:
             tg.start_soon(anyio.to_thread.run_sync, anyio.run, one)
             tg.start_soon(anyio.to_thread.run_sync, anyio.run, two)

--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -61,6 +61,16 @@ async def test_event_set_from_sync_thread():
             tg.start_soon(anyio.to_thread.run_sync, event.set)
 
 
+async def test_event_many_set_and_wait():
+    event = Event()
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as tg:
+            for _ in range(100):
+                # Interleave many set and wait operations
+                tg.start_soon(event.wait)
+                tg.start_soon(anyio.to_thread.run_sync, event.set)
+
+
 async def test_event_set_from_sync_thread_before_wait():
     event = Event()
 

--- a/tests/_internal/concurrency/test_workers.py
+++ b/tests/_internal/concurrency/test_workers.py
@@ -19,9 +19,12 @@ async def test_submit():
 
 async def test_submit_many():
     async with WorkerThreadPool() as pool:
-        futures = [await pool.submit(identity, i) for i in range(100)]
+        futures = [await pool.submit(identity, i) for i in range(1000)]
         results = await asyncio.gather(*[future.aresult() for future in futures])
-        assert results == list(range(100))
+        assert results == list(range(1000))
+
+        # Note: We need to submit an order of magnitude more than the max worker count
+        #       to actually saturate the pool.
         assert len(pool._workers) == pool._max_workers
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Follow-up to #7865 — extends https://github.com/PrefectHQ/prefect/pull/7875 

I attempted to simplify the `Event` implementation by inheriting from `asyncio.Event`, but it turns out there is significant variation in how they handle binding to event loops across our supported Python versions. I went with a backport of the latest CPython implementation and cleaned up our comments covering the differences.

We no longer bind an event to a single loop at startup. Instead, each `wait()` call creates a future bound to the current event loop. Then, during `set()` calls, we will notify each waiter. This is nearly verbatim the implementation from CPython, with thread safety added in.

The primary motivation for revisiting the `Event` implementation was a hard to find deadlock that occurred when two threaded event loops waited on each other. The offending line 😠 was:

https://github.com/PrefectHQ/prefect/blob/3aa447a5bea28d58907bb1dae30f1c8b3ff98217/src/prefect/_internal/concurrency/primitives.py#L36

This line blocked `Event.set()` calls until the loop got around to running it. For example:
- Thread A creates an event and passes it to Thread B to set when something is done
- Thread A waits for Thread B to finish (without calling `await` and unblocking the event loop)
- Thread B sets the event, _this blocks until Thread A notifies listeners_
- Thread A is busy waiting for Thread B, so we deadlock

`test_events_in_two_loops_do_not_deadlock` reproduces this scenario.

By updating the problematic line to use "call soon" instead, setting an event no longer blocks and there's no deadlock :) This implementation is significantly faster as well.

I've also taken this opportunity to clarify when loop utilities are safe to use by adding documentation.