### PR TITLE
Add documentation for pausing flow runs

### DIFF
--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -625,7 +625,7 @@ async def marvin_punchline():
     return "it's a wonder none of them ducked!"
 @flow
 async def inspiring_joke():
-    await marvin_set()
+    await marvin_setup()
     await pause_flow_run(timeout=600)  # pauses for 10 minutes
     await marvin_punchline()
 ```
@@ -653,16 +653,16 @@ The paused flow run will then finish!
 ```
 </div>
 
-Here is an example of a flow that stops executing in a paused state after one task, and will be rescheduled upon resuming. The stored result of the first task is retrieved instead of being rerun.
+Here is an example of a flow that does not block flow execution while paused. This flow will exit after one task, and will be rescheduled upon resuming. The stored result of the first task is retrieved instead of being rerun.
 
 ```python
 from prefect import flow, pause_flow_run, task
 
-@task
+@task(persist_result=True)
 def foo():
     return 42
 
-@flow
+@flow(persist_result=True)
 def noblock_pausing():
     x = foo.submit()
     pause_flow_run(timeout=30, reschedule=True)
@@ -692,7 +692,7 @@ async def longrunning():
 ```
 
 !!! tip "Pausing flow runs is blocking by default"
-    By default, pausing a flow run blocks the agent &mdash; the flow is still running inside the `pause_flow_run` function. However, you may pause any flow run in this fashion, including non-deployment local flow runs.
+    By default, pausing a flow run blocks the agent &mdash; the flow is still running inside the `pause_flow_run` function. However, you may pause any flow run in this fashion, including non-deployment local flow runs and subflows.
 
     Alternatively, flow runs can be paused without blocking the flow run process. This is particularly useful when running the flow via an agent and you want the agent to be able to pick up other flows while the paused flow is paused. 
     


### PR DESCRIPTION
Adds a new "Pause a flow run" section to Flows documentation documenting flow run pause and resume.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
