### PR TITLE
Ignore vcs directories git, hg (mercurial) in .prefectignore

### DIFF
--- a/src/prefect/.prefectignore
+++ b/src/prefect/.prefectignore
@@ -35,3 +35,7 @@ dask-worker-space/
 # Editors
 .idea/
 .vscode/
+
+# VCS
+.git/
+.hg/


### PR DESCRIPTION
vcs directories tend to be relatively big and make deployment slow, so they should be ignored by default. Added `.git` and `.hg` here as those are the ones I use.

Right now every deployment of a repository would also upload it's version control history although that's generally not needed or expected. This makes uploads quite a bit faster & cheaper.

I'm not aware of any already existing issue I could link here and it's a small fix.

### Example

Deploy a flow e.g. with to observe the time difference and also check the storage to see there is less data saved:

```
time prefect deployment build foobar.py:foobar --name dev -ib kubernetes-job/foobar-dev -sb gcs/foobar-dev -q kubernetes -a
```

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
