### PR TITLE
Fix bug where flows with names that do not match the function name cannot not be loaded

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -751,11 +751,9 @@ async def build(
             raise exc
     try:
         flow = await run_sync_in_worker_thread(load_flow_from_entrypoint, entrypoint)
-        app.console.print(f"Found flow {flow.name!r}", style="green")
-    except AttributeError as exc:
-        exit_with_error(f"{obj_name!r} not found in {fpath!r}.")
     except Exception as exc:
         exit_with_error(exc)
+    app.console.print(f"Found flow {flow.name!r}", style="green")
     infra_overrides = {}
     for override in overrides or []:
         key, value = override.split("=", 1)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -752,6 +752,8 @@ async def build(
     try:
         flow = await run_sync_in_worker_thread(load_flow_from_entrypoint, entrypoint)
         app.console.print(f"Found flow {flow.name!r}", style="green")
+    except AttributeError as exc:
+        exit_with_error(f"{obj_name!r} not found in {fpath!r}.")
     except Exception as exc:
         exit_with_error(exc)
     infra_overrides = {}

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -770,12 +770,12 @@ def load_flow_from_entrypoint(entrypoint: str) -> Flow:
         path, func_name = entrypoint.split(":")
         try:
             return import_object(entrypoint)
-        except AttributeError:
+        except AttributeError as exc:
             raise MissingFlowError(
                 f"Flow function with name {func_name!r} not found in {path!r}. "
                 "If the function exists in the script at that path, check to make "
                 "sure that it is decorated with '@flow'."
-            )
+            ) from exc
 
 
 def load_flow_from_text(script_contents: AnyStr, flow_name: str):

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -680,9 +680,6 @@ def select_flow(
         MissingFlowError: If a flow name is provided and that flow does not exist
         UnspecifiedFlowError: If multiple flows exist but no flow name was provided
     """
-    # We search for the flow's underlying function, so any dashes must be
-    #   replaced with underscores
-    flow_name = flow_name.replace("-", "_")
     # Get underlying flow_function names
     flows = {f.fn.__name__: f for f in flows}
     # Add a leading space if given, otherwise use an empty string

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -680,15 +680,13 @@ def select_flow(
         MissingFlowError: If a flow name is provided and that flow does not exist
         UnspecifiedFlowError: If multiple flows exist but no flow name was provided
     """
-
-    # flow names have underscores replaced with dashes
-    flow_name = flow_name.replace("_", "-")
-
-    # Just get flow names
-    flows = {f.name: f for f in flows}
+    # We search for the flow's underlying function, so any dashes must be
+    #   replaced with underscores
+    flow_name = flow_name.replace("-", "_")
+    # Get underlying flow_function names
+    flows = {f.fn.__name__: f for f in flows}
     # Add a leading space if given, otherwise use an empty string
     from_message = (" " + from_message) if from_message else ""
-
     if not flows:
         raise MissingFlowError(f"No flows found{from_message}.")
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -769,13 +769,19 @@ def load_flow_from_entrypoint(entrypoint: str) -> Flow:
     ) as registry:
         path, func_name = entrypoint.split(":")
         try:
-            return import_object(entrypoint)
+            flow = import_object(entrypoint)
         except AttributeError as exc:
             raise MissingFlowError(
                 f"Flow function with name {func_name!r} not found in {path!r}. "
-                "If the function exists in the script at that path, check to make "
-                "sure that it is decorated with '@flow'."
             ) from exc
+
+        if not isinstance(flow, Flow):
+            raise MissingFlowError(
+                f"Function with name {func_name!r} is not a flow. Make sure that it is "
+                "decorated with '@flow'."
+            )
+
+        return flow
 
 
 def load_flow_from_text(script_contents: AnyStr, flow_name: str):

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -681,9 +681,8 @@ def select_flow(
         MissingFlowError: If a flow name is provided and that flow does not exist
         UnspecifiedFlowError: If multiple flows exist but no flow name was provided
     """
-    # Get underlying flow_function names
-    flows = {f.fn.__name__: f for f in flows}
-    # Add a leading space if given, otherwise use an empty string
+    flows = {f.name: f for f in flows}
+
     from_message = (" " + from_message) if from_message else ""
     if not flows:
         raise MissingFlowError(f"No flows found{from_message}.")
@@ -771,7 +770,9 @@ def load_flow_from_entrypoint(entrypoint: str) -> Flow:
             return import_object(entrypoint)
         except AttributeError:
             raise MissingFlowError(
-                f"Function with name {func_name!r} not found in {path!r}"
+                f"Flow function with name {func_name!r} not found in {path!r}. "
+                "If the function exists in the script at that path, check to make "
+                "sure that it is decorated with '@flow'."
             )
 
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -680,9 +680,12 @@ def select_flow(
         MissingFlowError: If a flow name is provided and that flow does not exist
         UnspecifiedFlowError: If multiple flows exist but no flow name was provided
     """
-    # Convert to flows by name
-    flows = {f.name: f for f in flows}
 
+    # flow names have underscores replaced with dashes
+    flow_name = flow_name.replace("_", "-")
+
+    # Just get flow names
+    flows = {f.name: f for f in flows}
     # Add a leading space if given, otherwise use an empty string
     from_message = (" " + from_message) if from_message else ""
 
@@ -719,7 +722,6 @@ def load_flows_from_script(path: str) -> List[Flow]:
     Raises:
         FlowScriptError: If an exception is encountered while running the script
     """
-
     return registry_from_script(path).get_instances(Flow)
 
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -681,8 +681,10 @@ def select_flow(
         MissingFlowError: If a flow name is provided and that flow does not exist
         UnspecifiedFlowError: If multiple flows exist but no flow name was provided
     """
+    # Convert to flows by name
     flows = {f.name: f for f in flows}
 
+    # Add a leading space if given, otherwise use an empty string
     from_message = (" " + from_message) if from_message else ""
     if not flows:
         raise MissingFlowError(f"No flows found{from_message}.")

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -536,7 +536,7 @@ class TestEntrypoint:
         res = invoke_and_assert(
             cmd,
             expected_code=1,
-            # expected_output_contains=f"The provided path does not point to a python file: {str(fpath)!r}",
+            expected_output_contains=f"No module named ",
         )
 
     def test_entrypoint_works_with_flow_with_custom_name(self):

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -495,7 +495,7 @@ class TestEntrypoint:
         res = invoke_and_assert(
             cmd,
             expected_code=1,
-            expected_output_contains=f"No flows found in script {str(fpath)!r}",
+            expected_output_contains=f"'fn' not found in {str(fpath)!r}",
         )
 
     def test_entrypoint_that_points_to_wrong_flow_raises_error(self, tmp_path):
@@ -517,10 +517,10 @@ class TestEntrypoint:
         res = invoke_and_assert(
             cmd,
             expected_code=1,
-            expected_output_contains=f"Flow 'fn' not found in script {str(fpath)!r}",
+            expected_output_contains=f"Flow function with name 'fn' not found in {str(fpath)!r}",
         )
 
-    def test_entrypoint_that_does_not_point_to_python_file_raises_error(self):
+    def test_entrypoint_that_does_not_point_to_python_file_raises_error(self, tmp_path):
         code = """
         def fn():
             pass
@@ -536,7 +536,7 @@ class TestEntrypoint:
         res = invoke_and_assert(
             cmd,
             expected_code=1,
-            expected_output_contains=f"The provided path does not point to a python file: {str(fpath)!r}",
+            # expected_output_contains=f"The provided path does not point to a python file: {str(fpath)!r}",
         )
 
     def test_entrypoint_works_with_flow_with_custom_name(self):

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -495,7 +495,7 @@ class TestEntrypoint:
         res = invoke_and_assert(
             cmd,
             expected_code=1,
-            expected_output_contains=f"'fn' not found in {str(fpath)!r}",
+            expected_output_contains=f"Function with name 'fn' is not a flow. Make sure that it is decorated with '@flow'",
         )
 
     def test_entrypoint_that_points_to_wrong_flow_raises_error(self, tmp_path):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1959,7 +1959,8 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert len(flow_runs) == 1
 
 
-def test_select_flows_finds_flows_with_underscores_or_dashes():
+def test_select_flows_finds_flows_with_underscores_and_dashes():
+    # underscores and dashes
     @flow
     def dog_flow():
         pass
@@ -1968,3 +1969,14 @@ def test_select_flows_finds_flows_with_underscores_or_dashes():
     found_flow_1 = select_flow([dog_flow], "dog_flow")
     found_flow_2 = select_flow([dog_flow], "dog-flow")
     assert found_flow_1 == found_flow_2 == dog_flow
+
+
+def test_select_flows_finds_flows_with_custom_names():
+    @flow(name="not-a-cat")
+    def cat_flow():
+        pass
+
+    assert cat_flow.name == "not-a-cat"
+    found_flow_1 = select_flow([cat_flow], "cat_flow")
+    found_flow_2 = select_flow([cat_flow], "cat-flow")
+    assert found_flow_1 == found_flow_2 == cat_flow

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -23,7 +23,7 @@ from prefect.exceptions import (
     ReservedArgumentError,
 )
 from prefect.filesystems import LocalFileSystem
-from prefect.flows import Flow, load_flow_from_entrypoint, select_flow
+from prefect.flows import Flow, load_flow_from_entrypoint
 from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.orion.schemas.sorting import FlowRunSort
@@ -1957,24 +1957,3 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert res == "woof!"
     flow_runs = await orion_client.read_flows()
     assert len(flow_runs) == 1
-
-
-def test_select_flows_finds_flows_with_underscores():
-    # underscores and dashes
-    @flow
-    def dog_flow():
-        pass
-
-    assert dog_flow.name == "dog-flow"
-    found_flow_1 = select_flow([dog_flow], "dog_flow")
-    assert found_flow_1 == dog_flow
-
-
-def test_select_flows_finds_flows_with_custom_names():
-    @flow(name="not-a-cat")
-    def cat_flow():
-        pass
-
-    assert cat_flow.name == "not-a-cat"
-    found_flow_1 = select_flow([cat_flow], "cat_flow")
-    assert found_flow_1 == cat_flow

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1959,7 +1959,7 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert len(flow_runs) == 1
 
 
-def test_select_flows_finds_flows_with_underscores_and_dashes():
+def test_select_flows_finds_flows_with_underscores():
     # underscores and dashes
     @flow
     def dog_flow():
@@ -1967,8 +1967,7 @@ def test_select_flows_finds_flows_with_underscores_and_dashes():
 
     assert dog_flow.name == "dog-flow"
     found_flow_1 = select_flow([dog_flow], "dog_flow")
-    found_flow_2 = select_flow([dog_flow], "dog-flow")
-    assert found_flow_1 == found_flow_2 == dog_flow
+    assert found_flow_1 == dog_flow
 
 
 def test_select_flows_finds_flows_with_custom_names():
@@ -1978,5 +1977,4 @@ def test_select_flows_finds_flows_with_custom_names():
 
     assert cat_flow.name == "not-a-cat"
     found_flow_1 = select_flow([cat_flow], "cat_flow")
-    found_flow_2 = select_flow([cat_flow], "cat-flow")
-    assert found_flow_1 == found_flow_2 == cat_flow
+    assert found_flow_1 == cat_flow

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -23,7 +23,7 @@ from prefect.exceptions import (
     ReservedArgumentError,
 )
 from prefect.filesystems import LocalFileSystem
-from prefect.flows import Flow, load_flow_from_entrypoint
+from prefect.flows import Flow, load_flow_from_entrypoint, select_flow
 from prefect.orion.schemas.core import TaskRunResult
 from prefect.orion.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.orion.schemas.sorting import FlowRunSort
@@ -1957,3 +1957,14 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert res == "woof!"
     flow_runs = await orion_client.read_flows()
     assert len(flow_runs) == 1
+
+
+def test_select_flows_finds_flows_with_underscores_or_dashes():
+    @flow
+    def dog_flow():
+        pass
+
+    assert dog_flow.name == "dog-flow"
+    found_flow_1 = select_flow([dog_flow], "dog_flow")
+    found_flow_2 = select_flow([dog_flow], "dog-flow")
+    assert found_flow_1 == found_flow_2 == dog_flow


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Closes https://github.com/PrefectHQ/prefect/issues/7918

The `select_flows` function was checking to see if flow names found in a module matched a desired function name. This was causing problems in two cases:
1. the flow function had underscores, which were converted to dashes in the flow name
2. the flow had a custom name, which would not relate to the underlying function

This is now addressed by checking the underlying function name. 

The parameter `flow_name` in `select_flows` is now also sanitized to make sure that any dashes are converted to underscores, so that it will match the underlying flow function name.  
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
