### PR TITLE
feature: get flow run logs from CLI

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -143,15 +143,13 @@ async def logs(id: UUID):
     """
     View logs for a flow run.
     """
-    page_size = 50
+    page_size = 200
     offset = 0
     more_logs = True
     log_filter = LogFilter(flow_run_id={"any_": [id]})
 
     async with get_client() as client:
         while more_logs:
-            print()
-
             # Get the next page of logs
             page_logs = await client.read_logs(
                 log_filter=log_filter, limit=page_size, offset=offset
@@ -172,7 +170,6 @@ async def logs(id: UUID):
 
             # Wait for the user to press enter to get the next page
             if len(page_logs) == page_size:
-                app.console.input(f"Press any key to to see more logs...")
                 offset += page_size
             else:
                 # No more logs to show, exit

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -169,7 +169,6 @@ async def logs(id: UUID):
                     soft_wrap=True,
                 )
 
-            # Wait for the user to press enter to get the next page
             if len(page_logs) == page_size:
                 offset += page_size
             else:

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -314,7 +314,7 @@ class TestFlowRunLogs:
             ],
             expected_code=0,
             expected_output_contains=[
-                f"Log {i} from flow_run {flow_run.id}."
+                f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
                 for i in range(self.PAGE_SIZE - 1)
             ],
         )
@@ -351,7 +351,8 @@ class TestFlowRunLogs:
             ],
             expected_code=0,
             expected_output_contains=[
-                f"Log {i} from flow_run {flow_run.id}." for i in range(self.PAGE_SIZE)
+                f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
+                for i in range(self.PAGE_SIZE)
             ],
         )
 
@@ -365,4 +366,21 @@ class TestFlowRunLogs:
             ["flow-run", "logs", bad_id],
             expected_code=0,
             expected_output="",
+        )
+
+    @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
+    async def test_when_flow_run_not_found_then_exit_with_error(self, state):
+        # Given
+        bad_id = str(uuid4())
+
+        # When/Then
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=[
+                "flow-run",
+                "logs",
+                bad_id,
+            ],
+            expected_code=1,
+            expected_output_contains=f"Flow run '{bad_id}' not found!\n",
         )

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -283,7 +283,7 @@ class TestFlowRunLogs:
     PAGE_SIZE = 200
 
     @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
-    async def test_when_less_than_page_size_logs_exists_then_no_pagination(
+    async def test_when_num_logs_smaller_than_page_size_then_no_pagination(
         self, orion_client, state
     ):
         # Given
@@ -291,7 +291,7 @@ class TestFlowRunLogs:
             name="scheduled_flow_run", flow=hello_flow, state=state()
         )
 
-        # Create less than page size flow run logs
+        # Create not enough flow run logs to result in pagination (page_size <= 200)
         logs = [
             LogCreate(
                 name="prefect.flow_runs",
@@ -320,7 +320,7 @@ class TestFlowRunLogs:
         )
 
     @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
-    async def test_when_more_than_page_size_logs_exists_then_pagination(
+    async def test_when_num_logs_greater_than_page_size_then_pagination(
         self, orion_client, state
     ):
         # Given
@@ -328,7 +328,7 @@ class TestFlowRunLogs:
             name="scheduled_flow_run", flow=hello_flow, state=state()
         )
 
-        # Create more than page size flow run logs
+        # Create enough flow run logs to result in pagination (page_size > 200)
         logs = [
             LogCreate(
                 name="prefect.flow_runs",
@@ -352,7 +352,7 @@ class TestFlowRunLogs:
             expected_code=0,
             expected_output_contains=[
                 f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
-                for i in range(self.PAGE_SIZE)
+                for i in range(self.PAGE_SIZE + 1)
             ],
         )
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1,9 +1,11 @@
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
 
 import prefect.exceptions
 from prefect import flow
+from prefect.orion.schemas.actions import LogCreate
 from prefect.states import (
     AwaitingRetry,
     Cancelled,
@@ -274,4 +276,42 @@ class TestCancelFlowRun:
             ["flow-run", "cancel", bad_id],
             expected_code=1,
             expected_output_contains=f"Flow run '{bad_id}' not found!\n",
+        )
+
+
+class TestFlowRunLogs:
+    @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
+    async def test_get_flow_run_logs_by_id(self, orion_client, state):
+        # Given
+        flow_run = await orion_client.create_flow_run(
+            name="scheduled_flow_run", flow=hello_flow, state=state()
+        )
+
+        # Create a log entry
+        logs = [
+            LogCreate(
+                name="prefect.flow_runs",
+                level=20,
+                message=f"Log from flow_run {flow_run.id}.",
+                timestamp=datetime.now(tz=timezone.utc),
+                flow_run_id=flow_run.id,
+            )
+        ]
+        await orion_client.create_logs(logs)
+
+        # When
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=[
+                "flow-run",
+                "logs",
+                str(flow_run.id),
+            ],
+            expected_code=0,
+        )
+
+        # Then
+        assert (
+            f"{logs[0].timestamp.isoformat()}  | INFO  | Log from flow_run {flow_run.id}."
+            in res.stdout
         )

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -280,7 +280,7 @@ class TestCancelFlowRun:
 
 
 class TestFlowRunLogs:
-    PAGE_SIZE = 50
+    PAGE_SIZE = 200
 
     @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
     async def test_when_less_than_page_size_logs_exists_then_no_pagination(
@@ -317,7 +317,6 @@ class TestFlowRunLogs:
                 f"Log {i} from flow_run {flow_run.id}."
                 for i in range(self.PAGE_SIZE - 1)
             ],
-            expected_output_does_not_contain=["Press any key to to see more logs..."],
         )
 
     @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
@@ -351,14 +350,8 @@ class TestFlowRunLogs:
                 str(flow_run.id),
             ],
             expected_code=0,
-            # Press any key to see more logs
-            user_input=" ",
             expected_output_contains=[
-                "Press any key to to see more logs...",
-                *[
-                    f"Log {i} from flow_run {flow_run.id}."
-                    for i in range(self.PAGE_SIZE)
-                ],
+                f"Log {i} from flow_run {flow_run.id}." for i in range(self.PAGE_SIZE)
             ],
         )
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -357,18 +357,6 @@ class TestFlowRunLogs:
         )
 
     @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
-    def test_when_logs_not_found_then_output_is_empty(self, state):
-        # Given
-        bad_id = str(uuid4())
-
-        # When/Then
-        invoke_and_assert(
-            ["flow-run", "logs", bad_id],
-            expected_code=0,
-            expected_output="",
-        )
-
-    @pytest.mark.parametrize("state", [Completed, Failed, Crashed, Cancelled])
     async def test_when_flow_run_not_found_then_exit_with_error(self, state):
         # Given
         bad_id = str(uuid4())


### PR DESCRIPTION
Usage: prefect flow-run logs <flow-run-id>
closes #7814

<!-- Include an overview here -->

This PR attempts to resolve issue #7814 .

It adds a new `logs` command to the `flow-runs` command in the CLI.

### Example

Usage is as follows:

```
prefect flow-run logs <flow-run-id>
```

The CLI responds as follows:

```
2022-12-23T14:44:16.847706+00:00  | INFO  | Finished in state Completed()
```

This is my first PR here. Waiting for your review and opinions :)

Ohad

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
