### PR TITLE
Fixes read worker pool queue endpoint

### DIFF
--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -333,7 +333,7 @@ async def read_worker_pool_queue(
             worker_pool_queue_name=worker_pool_queue_name,
         )
 
-        return await models.workers.create_worker_pool_queue(
+        return await models.workers.read_worker_pool_queue(
             session=session, worker_pool_queue_id=worker_pool_queue_id, db=db
         )
 

--- a/tests/orion/api/test_workers.py
+++ b/tests/orion/api/test_workers.py
@@ -280,6 +280,24 @@ class TestCreateWorkerPoolQueue:
         assert result.description == "test queue"
 
 
+class TestReadWorkerPoolQueue:
+    async def test_read_worker_pool_queue(self, client, worker_pool):
+        # Create worker pool queue
+        create_response = await client.post(
+            f"/experimental/worker_pools/{worker_pool.name}/queues",
+            json=dict(name="test-queue", description="test queue"),
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+
+        read_response = await client.get(
+            f"/experimental/worker_pools/{worker_pool.name}/queues/test-queue"
+        )
+        assert read_response.status_code == status.HTTP_200_OK
+        result = pydantic.parse_obj_as(WorkerPoolQueue, read_response.json())
+        assert result.name == "test-queue"
+        assert result.description == "test queue"
+
+
 class TestWorkerProcess:
     async def test_heartbeat_worker(self, client, worker_pool):
         workers_response = await client.post(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
@marichka-offen encountered the following error when developing the workers UI:
<img width="1624" alt="Screenshot 2022-12-27 at 5 50 00 PM" src="https://user-images.githubusercontent.com/12350579/209830648-ae4c693b-42bb-47e9-a0cf-fd389f36fcae.png">

@marichka-offen was able to determine that the get worker pool queue endpoint was using the wrong model. This PR updates the endpoint to use the correct model and adds a test for coverage.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
