### PR TITLE
Include worker pool name and worker pool queue name in flow run API responses

### DIFF
--- a/src/prefect/client/schemas.py
+++ b/src/prefect/client/schemas.py
@@ -125,7 +125,7 @@ class State(schemas.states.State.subclass(exclude_fields=["data"]), Generic[R]):
         )
 
 
-class FlowRun(schemas.core.FlowRun.subclass()):
+class FlowRun(schemas.responses.FlowRunResponse.subclass()):
     state: Optional[State] = Field(default=None)
 
 

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -353,9 +353,7 @@ async def create_flow_run_from_deployment(
         )
         if model.created >= now:
             response.status_code = status.HTTP_201_CREATED
-        return await schemas.responses.FlowRunResponse.from_orm_model(
-            session=session, orm_flow_run=model
-        )
+        return model
 
 
 # DEPRECATED

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -353,7 +353,7 @@ async def create_flow_run_from_deployment(
         )
         if model.created >= now:
             response.status_code = status.HTTP_201_CREATED
-        return model
+        return schemas.responses.FlowRunResponse.from_orm(model)
 
 
 # DEPRECATED

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -300,7 +300,7 @@ async def create_flow_run_from_deployment(
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
     db: OrionDBInterface = Depends(provide_database_interface),
     response: Response = None,
-) -> schemas.core.FlowRun:
+) -> schemas.responses.FlowRunResponse:
     """
     Create a flow run from a deployment.
 
@@ -353,7 +353,9 @@ async def create_flow_run_from_deployment(
         )
         if model.created >= now:
             response.status_code = status.HTTP_201_CREATED
-        return model
+        return await schemas.responses.FlowRunResponse.from_orm_model(
+            session=session, orm_flow_run=model
+        )
 
 
 # DEPRECATED

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -272,7 +272,9 @@ async def read_flow_runs(
     # In particular, the FastAPI encoder is very slow for large, nested objects.
     # See: https://github.com/tiangolo/fastapi/issues/1224
     encoded = [
-        schemas.core.FlowRun.from_orm(fr).dict(json_compatible=True)
+        schemas.responses.FlowRunResponse.from_orm_model(session, fr).dict(
+            json_compatible=True
+        )
         for fr in db_flow_runs
     ]
     return ORJSONResponse(content=encoded)

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -38,7 +38,7 @@ async def create_flow_run(
         orchestration_dependencies.provide_flow_orchestration_parameters
     ),
     api_version=Depends(dependencies.provide_request_api_version),
-) -> schemas.core.FlowRun:
+) -> schemas.responses.FlowRunResponse:
     """
     Create a flow run. If a flow run with the same flow_id and
     idempotency key already exists, the existing flow run will be returned.
@@ -65,7 +65,7 @@ async def create_flow_run(
     if model.created >= now:
         response.status_code = status.HTTP_201_CREATED
 
-    return model
+    return await schemas.responses.FlowRunResponse.from_orm_model(model, session)
 
 
 @router.patch("/{id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -148,7 +148,7 @@ async def flow_run_history(
 async def read_flow_run(
     flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.FlowRun:
+) -> schemas.responses.FlowRunResponse:
     """
     Get a flow run by id.
     """
@@ -158,7 +158,7 @@ async def read_flow_run(
         )
     if not flow_run:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Flow run not found")
-    return flow_run
+    return await schemas.responses.FlowRunResponse.from_orm_model(flow_run, session)
 
 
 @router.get("/{id}/graph")
@@ -249,7 +249,7 @@ async def read_flow_runs(
     worker_pools: schemas.filters.WorkerPoolFilter = None,
     worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> List[schemas.core.FlowRun]:
+) -> List[schemas.responses.FlowRunResponse]:
     """
     Query for flow runs.
     """
@@ -267,17 +267,17 @@ async def read_flow_runs(
             sort=sort,
         )
 
-    # Instead of relying on fastapi.encoders.jsonable_encoder to convert the
-    # response to JSON, we do so more efficiently ourselves.
-    # In particular, the FastAPI encoder is very slow for large, nested objects.
-    # See: https://github.com/tiangolo/fastapi/issues/1224
-    encoded = [
-        schemas.responses.FlowRunResponse.from_orm_model(session, fr).dict(
-            json_compatible=True
-        )
-        for fr in db_flow_runs
-    ]
-    return ORJSONResponse(content=encoded)
+        # Instead of relying on fastapi.encoders.jsonable_encoder to convert the
+        # response to JSON, we do so more efficiently ourselves.
+        # In particular, the FastAPI encoder is very slow for large, nested objects.
+        # See: https://github.com/tiangolo/fastapi/issues/1224
+        encoded = [
+            (await schemas.responses.FlowRunResponse.from_orm_model(session, fr)).dict(
+                json_compatible=True
+            )
+            for fr in db_flow_runs
+        ]
+        return ORJSONResponse(content=encoded)
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -62,12 +62,10 @@ async def create_flow_run(
             flow_run=flow_run,
             orchestration_parameters=orchestration_parameters,
         )
-        if model.created >= now:
-            response.status_code = status.HTTP_201_CREATED
+    if model.created >= now:
+        response.status_code = status.HTTP_201_CREATED
 
-        return await schemas.responses.FlowRunResponse.from_orm_model(
-            session=session, orm_flow_run=model
-        )
+    return model
 
 
 @router.patch("/{id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -246,6 +246,8 @@ async def read_flow_runs(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
+    worker_pools: schemas.filters.WorkerPoolFilter = None,
+    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.FlowRun]:
     """
@@ -258,6 +260,8 @@ async def read_flow_runs(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
+            worker_pool_filter=worker_pools,
+            worker_pool_queue_filter=worker_pool_queues,
             offset=offset,
             limit=limit,
             sort=sort,

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -62,10 +62,10 @@ async def create_flow_run(
             flow_run=flow_run,
             orchestration_parameters=orchestration_parameters,
         )
-    if model.created >= now:
-        response.status_code = status.HTTP_201_CREATED
+        if model.created >= now:
+            response.status_code = status.HTTP_201_CREATED
 
-    return model
+        return schemas.responses.FlowRunResponse.from_orm(model)
 
 
 @router.patch("/{id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -156,9 +156,9 @@ async def read_flow_run(
         flow_run = await models.flow_runs.read_flow_run(
             session=session, flow_run_id=flow_run_id
         )
-    if not flow_run:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Flow run not found")
-    return flow_run
+        if not flow_run:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Flow run not found")
+        return schemas.responses.FlowRunResponse.from_orm(flow_run)
 
 
 @router.get("/{id}/graph")
@@ -267,15 +267,15 @@ async def read_flow_runs(
             sort=sort,
         )
 
-    # Instead of relying on fastapi.encoders.jsonable_encoder to convert the
-    # response to JSON, we do so more efficiently ourselves.
-    # In particular, the FastAPI encoder is very slow for large, nested objects.
-    # See: https://github.com/tiangolo/fastapi/issues/1224
-    encoded = [
-        schemas.responses.FlowRunResponse.from_orm(fr).dict(json_compatible=True)
-        for fr in db_flow_runs
-    ]
-    return ORJSONResponse(content=encoded)
+        # Instead of relying on fastapi.encoders.jsonable_encoder to convert the
+        # response to JSON, we do so more efficiently ourselves.
+        # In particular, the FastAPI encoder is very slow for large, nested objects.
+        # See: https://github.com/tiangolo/fastapi/issues/1224
+        encoded = [
+            schemas.responses.FlowRunResponse.from_orm(fr).dict(json_compatible=True)
+            for fr in db_flow_runs
+        ]
+        return ORJSONResponse(content=encoded)
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -132,22 +132,17 @@ async def read_work_queue_runs(
             limit=limit,
         )
 
-        # The Prefect UI often calls this route to see which runs are enqueued.
-        # We do not want to record this as an actual poll event.
-        if not x_prefect_ui:
-            background_tasks.add_task(
-                _record_work_queue_polls,
-                db=db,
-                work_queue_id=work_queue_id,
-                agent_id=agent_id,
-            )
+    # The Prefect UI often calls this route to see which runs are enqueued.
+    # We do not want to record this as an actual poll event.
+    if not x_prefect_ui:
+        background_tasks.add_task(
+            _record_work_queue_polls,
+            db=db,
+            work_queue_id=work_queue_id,
+            agent_id=agent_id,
+        )
 
-        return [
-            await schemas.responses.FlowRunResponse.from_orm_model(
-                session=session, orm_flow_run=fr
-            )
-            for fr in flow_runs
-        ]
+    return flow_runs
 
 
 async def _record_work_queue_polls(

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -479,6 +479,14 @@ class ORMFlowRun(ORMRun):
         )
 
     @declared_attr
+    def worker_pool_queue(cls):
+        return sa.orm.relationship(
+            "WorkerPoolQueue",
+            lazy="joined",
+            foreign_keys=[cls.worker_pool_queue_id],
+        )
+
+    @declared_attr
     def __table_args__(cls):
         return (
             sa.Index(
@@ -1061,6 +1069,14 @@ class ORMWorkerPoolQueue:
     @declared_attr
     def __table_args__(cls):
         return (sa.UniqueConstraint("worker_pool_id", "name"),)
+
+    @declared_attr
+    def worker_pool(cls):
+        return sa.orm.relationship(
+            "WorkerPool",
+            lazy="joined",
+            foreign_keys=[cls.worker_pool_id],
+        )
 
 
 @declarative_mixin

--- a/src/prefect/orion/models/flow_runs.py
+++ b/src/prefect/orion/models/flow_runs.py
@@ -161,6 +161,8 @@ async def _apply_flow_run_filters(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
+    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
 ):
     """
     Applies filters to a flow run query as a combination of EXISTS subqueries.
@@ -173,6 +175,22 @@ async def _apply_flow_run_filters(
         exists_clause = select(db.Deployment).where(
             db.Deployment.id == db.FlowRun.deployment_id,
             deployment_filter.as_sql_filter(db),
+        )
+        query = query.where(exists_clause.exists())
+
+    if worker_pool_filter:
+        exists_clause = select(db.WorkerPool).where(
+            db.WorkerPoolQueue.id == db.FlowRun.worker_pool_queue_id,
+            db.WorkerPool.id == db.WorkerPoolQueue.worker_pool_id,
+            worker_pool_filter.as_sql_filter(db),
+        )
+
+        query = query.where(exists_clause.exists())
+
+    if worker_pool_queue_filter:
+        exists_clause = select(db.WorkerPoolQueue).where(
+            db.WorkerPoolQueue.id == db.FlowRun.worker_pool_queue_id,
+            worker_pool_queue_filter.as_sql_filter(db),
         )
         query = query.where(exists_clause.exists())
 
@@ -213,6 +231,8 @@ async def read_flow_runs(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
+    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
     offset: int = None,
     limit: int = None,
     sort: schemas.sorting.FlowRunSort = schemas.sorting.FlowRunSort.ID_DESC,
@@ -245,6 +265,8 @@ async def read_flow_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
+        worker_pool_filter=worker_pool_filter,
+        worker_pool_queue_filter=worker_pool_queue_filter,
         db=db,
     )
 

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -183,10 +183,8 @@ class FlowRunResponse(ORMBaseModel):
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
-    async def from_orm_model(
-        cls, session, orm_flow_run: "prefect.orion.database.orm_models.ORMFlowRun"
-    ):
-        response = cls.from_orm(orm_flow_run)
+    def from_orm(cls, orm_flow_run: "prefect.orion.database.orm_models.ORMFlowRun"):
+        response = super().from_orm(orm_flow_run)
         if orm_flow_run.worker_pool_queue:
             response.worker_pool_queue_name = orm_flow_run.worker_pool_queue.name
             response.worker_pool_name = orm_flow_run.worker_pool_queue.worker_pool.name

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 from uuid import UUID
 
 from pydantic import Field
-from typing_extensions import Literal
+from typing_extensions import TYPE_CHECKING, Literal
 
 import prefect.orion.models as models
 import prefect.orion.schemas as schemas
@@ -19,6 +19,9 @@ from prefect.orion.utilities.schemas import (
     PrefectBaseModel,
 )
 from prefect.utilities.collections import AutoEnum
+
+if TYPE_CHECKING:
+    import prefect.orion.database.orm_models
 
 
 class SetStateStatus(AutoEnum):
@@ -176,9 +179,12 @@ class FlowRunResponse(ORMBaseModel):
         description="The name of the flow run's worker pool queue.",
         example="my-worker-pool-queue",
     )
+    state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
-    async def from_orm_model(cls, session, orm_flow_run):
+    async def from_orm_model(
+        cls, session, orm_flow_run: "prefect.orion.database.orm_models.ORMFlowRun"
+    ):
         response = cls.from_orm(orm_flow_run)
         if orm_flow_run.worker_pool_queue_id:
             worker_pool_queue = await models.workers.read_worker_pool_queue(

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -17,6 +17,7 @@ from prefect.orion.utilities.schemas import (
     FieldFrom,
     ORMBaseModel,
     PrefectBaseModel,
+    copy_model_fields,
 )
 from prefect.utilities.collections import AutoEnum
 
@@ -141,6 +142,7 @@ class WorkerFlowRunResponse(PrefectBaseModel):
     flow_run: schemas.core.FlowRun
 
 
+@copy_model_fields
 class FlowRunResponse(ORMBaseModel):
 
     name: str = FieldFrom(schemas.core.FlowRun)

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -3,7 +3,7 @@ Schemas for special responses from the Orion API.
 """
 
 import datetime
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import UUID
 
 from pydantic import Field
@@ -197,3 +197,17 @@ class FlowRunResponse(ORMBaseModel):
             response.worker_pool_name = worker_pool.name
 
         return response
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Check for "equality" to another flow run schema
+
+        Estimates times are rolling and will always change with repeated queries for
+        a flow run so we ignore them during equality checks.
+        """
+        if isinstance(other, FlowRunResponse):
+            exclude_fields = {"estimated_run_time", "estimated_start_time_delta"}
+            return self.dict(exclude=exclude_fields) == other.dict(
+                exclude=exclude_fields
+            )
+        return super().__eq__(other)

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from pydantic import Field
 from typing_extensions import TYPE_CHECKING, Literal
 
-import prefect.orion.models as models
 import prefect.orion.schemas as schemas
 from prefect.orion.schemas.core import CreatedBy, FlowRunPolicy
 from prefect.orion.utilities.schemas import (
@@ -188,15 +187,9 @@ class FlowRunResponse(ORMBaseModel):
         cls, session, orm_flow_run: "prefect.orion.database.orm_models.ORMFlowRun"
     ):
         response = cls.from_orm(orm_flow_run)
-        if orm_flow_run.worker_pool_queue_id:
-            worker_pool_queue = await models.workers.read_worker_pool_queue(
-                session=session, worker_pool_queue_id=orm_flow_run.worker_pool_queue_id
-            )
-            response.worker_pool_queue_name = worker_pool_queue.name
-            worker_pool = await models.workers.read_worker_pool(
-                session=session, worker_pool_id=worker_pool_queue.worker_pool_id
-            )
-            response.worker_pool_name = worker_pool.name
+        if orm_flow_run.worker_pool_queue:
+            response.worker_pool_queue_name = orm_flow_run.worker_pool_queue.name
+            response.worker_pool_name = orm_flow_run.worker_pool_queue.worker_pool.name
 
         return response
 

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import Depends, FastAPI, status
 from fastapi.security import HTTPBearer
 
+import prefect.client.schemas as client_schemas
 import prefect.context
 import prefect.exceptions
 from prefect import flow, tags
@@ -750,7 +751,7 @@ async def test_create_then_read_flow_run(orion_client):
         foo,
         name="zachs-flow-run",
     )
-    assert isinstance(flow_run, schemas.core.FlowRun)
+    assert isinstance(flow_run, client_schemas.FlowRun)
 
     lookup = await orion_client.read_flow_run(flow_run.id)
     # Estimates will not be equal since time has passed
@@ -827,7 +828,7 @@ async def test_read_flow_runs_without_filter(orion_client):
 
     flow_runs = await orion_client.read_flow_runs()
     assert len(flow_runs) == 2
-    assert all(isinstance(flow_run, schemas.core.FlowRun) for flow_run in flow_runs)
+    assert all(isinstance(flow_run, client_schemas.FlowRun) for flow_run in flow_runs)
     assert {flow_run.id for flow_run in flow_runs} == {fr_id_1, fr_id_2}
 
 
@@ -861,7 +862,7 @@ async def test_read_flow_runs_with_filtering(orion_client):
         ),
     )
     assert len(flow_runs) == 2
-    assert all(isinstance(flow, schemas.core.FlowRun) for flow in flow_runs)
+    assert all(isinstance(flow, client_schemas.FlowRun) for flow in flow_runs)
     assert {flow_run.id for flow_run in flow_runs} == {fr_id_4, fr_id_5}
 
 
@@ -1408,7 +1409,7 @@ async def test_delete_flow_run(orion_client, flow_run):
 
     # Make sure our flow exists (the read flow is of type `s.c.FlowRun`)
     lookup = await orion_client.read_flow_run(flow_run.id)
-    assert isinstance(lookup, schemas.core.FlowRun)
+    assert isinstance(lookup, client_schemas.FlowRun)
 
     # Check delete works
     await orion_client.delete_flow_run(flow_run.id)

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -217,7 +217,9 @@ class TestUpdateFlowRun:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         response = await client.get(f"flow_runs/{flow_run.id}")
-        updated_flow_run = pydantic.parse_obj_as(schemas.core.FlowRun, response.json())
+        updated_flow_run = pydantic.parse_obj_as(
+            schemas.responses.FlowRunResponse, response.json()
+        )
         assert updated_flow_run.flow_version == "The next one"
         assert updated_flow_run.name == "not yellow salamander"
         assert updated_flow_run.updated > now
@@ -238,7 +240,9 @@ class TestUpdateFlowRun:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         response = await client.get(f"flow_runs/{flow_run.id}")
-        updated_flow_run = pydantic.parse_obj_as(schemas.core.FlowRun, response.json())
+        updated_flow_run = pydantic.parse_obj_as(
+            schemas.responses.FlowRunResponse, response.json()
+        )
         assert updated_flow_run.flow_version == "1.0"
 
     async def test_update_flow_run_raises_error_if_flow_run_not_found(self, client):
@@ -328,7 +332,9 @@ class TestReadFlowRuns:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 3
         # return type should be correct
-        assert pydantic.parse_obj_as(List[schemas.core.FlowRun], response.json())
+        assert pydantic.parse_obj_as(
+            List[schemas.responses.FlowRunResponse], response.json()
+        )
 
     async def test_read_flow_runs_applies_flow_filter(self, flow, flow_runs, client):
         flow_run_filter = dict(

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -322,8 +322,11 @@ class TestReadFlowRuns:
         response = await client.post("/flow_runs/filter")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 3
-        response = pydantic.parse_obj_as(
-            List[schemas.responses.FlowRunResponse], response.json()
+        response = sorted(
+            pydantic.parse_obj_as(
+                List[schemas.responses.FlowRunResponse], response.json()
+            ),
+            key=lambda fr: fr.name,
         )
         assert response[2].worker_pool_name == worker_pool.name
         assert response[2].worker_pool_queue_name == worker_pool_queue.name

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -277,7 +277,27 @@ class TestReadFlowRun:
 
 class TestReadFlowRuns:
     @pytest.fixture
-    async def flow_runs(self, flow, session):
+    async def worker_pool(self, session):
+        worker_pool = await models.workers.create_worker_pool(
+            session=session,
+            worker_pool=schemas.actions.WorkerPoolCreate(name="worker-pool"),
+        )
+        await session.commit()
+        return worker_pool
+
+    async def worker_pool_queue(self, worker_pool, session):
+        worker_pool_queue = await models.workers.create_worker_pool_queue(
+            session=session,
+            worker_pool_id=worker_pool.id,
+            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+                name="worker-pool-queue"
+            ),
+        )
+        await session.commit()
+        return worker_pool_queue
+
+    @pytest.fixture
+    async def flow_runs(self, flow, worker_pool_queue, session):
         flow_2 = await models.flows.create_flow(
             session=session,
             flow=actions.FlowCreate(name="another-test"),
@@ -293,8 +313,11 @@ class TestReadFlowRuns:
         )
         flow_run_3 = await models.flow_runs.create_flow_run(
             session=session,
-            flow_run=actions.FlowRunCreate(
-                flow_id=flow_2.id, name="fr3", tags=["blue", "red"]
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow_2.id,
+                name="fr3",
+                tags=["blue", "red"],
+                worker_pool_queue_id=worker_pool_queue.id,
             ),
         )
         await session.commit()
@@ -350,6 +373,37 @@ class TestReadFlowRuns:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 1
         assert response.json()[0]["id"] == str(flow_runs[1].id)
+
+    async def test_read_flow_runs_applies_worker_pool_name_filter(
+        self,
+        flow_runs,
+        client,
+    ):
+        worker_pool_filter = dict(
+            worker_pools=schemas.filters.WorkerPoolFilter(
+                name=schemas.filters.WorkerPoolFilterName(any_=["worker-pool"])
+            ).dict(json_compatible=True)
+        )
+        response = await client.post("/flow_runs/filter", json=worker_pool_filter)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+        assert response.json()[0]["id"] == str(flow_runs[2].id)
+
+    async def test_read_flow_runs_applies_worker_pool_queue_id_filter(
+        self,
+        flow_runs,
+        worker_pool_queue,
+        client,
+    ):
+        worker_pool_filter = dict(
+            worker_pool_queues=schemas.filters.WorkerPoolQueueFilter(
+                id=schemas.filters.WorkerPoolQueueFilterId(any_=[worker_pool_queue.id])
+            ).dict(json_compatible=True)
+        )
+        response = await client.post("/flow_runs/filter", json=worker_pool_filter)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+        assert response.json()[0]["id"] == str(flow_runs[2].id)
 
     async def test_read_flow_runs_multi_filter(self, flow, flow_runs, client):
         flow_run_filter = dict(

--- a/tests/orion/api/test_work_queues.py
+++ b/tests/orion/api/test_work_queues.py
@@ -260,8 +260,12 @@ class TestGetRunsInWorkQueue:
         response2 = await client.post(f"/work_queues/{work_queue_2.id}/get_runs")
         assert response2.status_code == status.HTTP_200_OK
 
-        runs_wq1 = pydantic.parse_obj_as(List[schemas.core.FlowRun], response1.json())
-        runs_wq2 = pydantic.parse_obj_as(List[schemas.core.FlowRun], response2.json())
+        runs_wq1 = pydantic.parse_obj_as(
+            List[schemas.responses.FlowRunResponse], response1.json()
+        )
+        runs_wq2 = pydantic.parse_obj_as(
+            List[schemas.responses.FlowRunResponse], response2.json()
+        )
 
         assert len(runs_wq1) == len(runs_wq2) == 3
         assert all(r.work_queue_name == work_queue.name for r in runs_wq1)
@@ -280,7 +284,9 @@ class TestGetRunsInWorkQueue:
         response1 = await client.post(
             f"/work_queues/{work_queue.id}/get_runs", json=dict(limit=limit)
         )
-        runs_wq1 = pydantic.parse_obj_as(List[schemas.core.FlowRun], response1.json())
+        runs_wq1 = pydantic.parse_obj_as(
+            List[schemas.responses.FlowRunResponse], response1.json()
+        )
         assert len(runs_wq1) == limit
 
     async def test_get_runs_in_queue_scheduled_before(
@@ -290,7 +296,9 @@ class TestGetRunsInWorkQueue:
             f"/work_queues/{work_queue.id}/get_runs",
             json=dict(scheduled_before=pendulum.now().isoformat()),
         )
-        runs_wq1 = pydantic.parse_obj_as(List[schemas.core.FlowRun], response1.json())
+        runs_wq1 = pydantic.parse_obj_as(
+            List[schemas.responses.FlowRunResponse], response1.json()
+        )
         assert len(runs_wq1) == 1
 
     async def test_get_runs_in_queue_nonexistant(

--- a/tests/orion/models/test_flow_runs.py
+++ b/tests/orion/models/test_flow_runs.py
@@ -1016,6 +1016,68 @@ class TestReadFlowRuns:
         )
         assert len(result) == 0
 
+    async def test_read_flow_runs_filters_by_worker_pool_name(self, flow, session):
+        worker_pool = await models.workers.create_worker_pool(
+            session=session,
+            worker_pool=schemas.actions.WorkerPoolCreate(name="worker-pool"),
+        )
+        worker_pool_queue = await models.workers.create_worker_pool_queue(
+            session=session,
+            worker_pool_id=worker_pool.id,
+            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+                name="worker-pool-queue"
+            ),
+        )
+        flow_run_1 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(flow_id=flow.id),
+        )
+        flow_run_2 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id, worker_pool_queue_id=worker_pool_queue.id
+            ),
+        )
+
+        result = await models.flow_runs.read_flow_runs(
+            session=session,
+            worker_pool_filter=schemas.filters.WorkerPoolFilter(
+                name=schemas.filters.WorkerPoolFilterName(any_=[worker_pool.name])
+            ),
+        )
+        assert {res.id for res in result} == {flow_run_2.id}
+
+    async def test_read_flow_runs_filters_by_worker_pool_queue_id(self, session, flow):
+        worker_pool = await models.workers.create_worker_pool(
+            session=session,
+            worker_pool=schemas.actions.WorkerPoolCreate(name="worker-pool"),
+        )
+        worker_pool_queue = await models.workers.create_worker_pool_queue(
+            session=session,
+            worker_pool_id=worker_pool.id,
+            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+                name="worker-pool-queue"
+            ),
+        )
+        flow_run_1 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(flow_id=flow.id),
+        )
+        flow_run_2 = await models.flow_runs.create_flow_run(
+            session=session,
+            flow_run=schemas.core.FlowRun(
+                flow_id=flow.id, worker_pool_queue_id=worker_pool_queue.id
+            ),
+        )
+
+        result = await models.flow_runs.read_flow_runs(
+            session=session,
+            worker_pool_queue_filter=schemas.filters.WorkerPoolQueueFilter(
+                id=schemas.filters.WorkerPoolQueueFilterId(any_=[worker_pool_queue.id])
+            ),
+        )
+        assert {res.id for res in result} == {flow_run_2.id}
+
     async def test_read_flow_runs_applies_sort(self, flow, session):
         now = pendulum.now()
         flow_run_1 = await models.flow_runs.create_flow_run(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Introduces a `FlowRunResponse` model to replace a `worker_pool_queue_id` with the `worker_pool_name` and `worker_pool_queue_name` for the flow run. This update is for use in the UI and also to better align with the worker pool routes that operate with names instead of IDs. I'm not sure if this is the optimal implementation, so please let me know if there is a better way to approach this. I intend to implement a similar pattern for the deployments routes.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
