### PR TITLE
Fix captured Kubernetes error type in `get_job`

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -22,6 +22,7 @@ from prefect.utilities.slugify import slugify
 if TYPE_CHECKING:
     import kubernetes
     import kubernetes.client
+    import kubernetes.client.exceptions
     import kubernetes.config
     from kubernetes.client import BatchV1Api, CoreV1Api, V1Job, V1Pod
 else:
@@ -530,7 +531,7 @@ class KubernetesJob(Infrastructure):
             try:
                 job = batch_client.read_namespaced_job(job_id, self.namespace)
             except kubernetes.client.exceptions.ApiException:
-                self.logger.error(f"Job{job_id!r} was removed.", exc_info=True)
+                self.logger.error(f"Job {job_id!r} was removed.", exc_info=True)
                 return None
             return job
 

--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -529,7 +529,7 @@ class KubernetesJob(Infrastructure):
         with self.get_batch_client() as batch_client:
             try:
                 job = batch_client.read_namespaced_job(job_id, self.namespace)
-            except kubernetes.ApiException:
+            except kubernetes.client.exceptions.ApiException:
                 self.logger.error(f"Job{job_id!r} was removed.", exc_info=True)
                 return None
             return job

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -203,7 +203,7 @@ async def test_missing_job_returns_bad_status_code(
     k8s_job = KubernetesJob(command=["echo", "hello"])
     result = await k8s_job.run()
 
-    _, _, job_name = KubernetesJob._parse_infrastructure_pid(result.identifier)
+    _, _, job_name = k8s_job._parse_infrastructure_pid(result.identifier)
 
     assert result.status_code == -1
     assert f"Job {job_name!r} was removed" in caplog.text

--- a/tests/infrastructure/test_kubernetes_job.py
+++ b/tests/infrastructure/test_kubernetes_job.py
@@ -203,8 +203,10 @@ async def test_missing_job_returns_bad_status_code(
     k8s_job = KubernetesJob(command=["echo", "hello"])
     result = await k8s_job.run()
 
+    _, _, job_name = KubernetesJob._parse_infrastructure_pid(result.identifier)
+
     assert result.status_code == -1
-    assert f"Job {result.identifier!r} was removed" in caplog.text
+    assert f"Job {job_name!r} was removed" in caplog.text
 
 
 class TestKill:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

As reported in https://prefecthq.slack.com/archives/C02J2QEHXAR/p1672429355523049?thread_ts=1672429297.984519&cid=C02J2QEHXAR — this path was incorrect.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/prefect/agent.py", line 257, in _submit_run_and_capture_errors
    result = await infrastructure.run(task_status=task_status)
  File "/usr/local/lib/python3.10/site-packages/prefect/infrastructure/kubernetes.py", line 249, in run
    return await run_sync_in_worker_thread(self._watch_job, job_name)
  File "/usr/local/lib/python3.10/site-packages/prefect/utilities/asyncutils.py", line 68, in run_sync_in_worker_thread
    return await anyio.to_thread.run_sync(call, cancellable=True)
  File "/usr/local/lib/python3.10/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/usr/local/lib/python3.10/site-packages/prefect/infrastructure/kubernetes.py", line 410, in _watch_job
    job = self._get_job(job_name)
  File "/usr/local/lib/python3.10/site-packages/prefect/infrastructure/kubernetes.py", line 378, in _get_job
    except kubernetes.ApiException:
AttributeError: module 'kubernetes' has no attribute 'ApiException'
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
