### PR TITLE
Add another cyclic import to CodeQL exclusions

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -3,6 +3,8 @@ query-filters:
       # this creates many false positives with our code
       id: py/unsafe-cyclic-import
   - exclude:
+      id: py/cyclic-import
+  - exclude:
       id: py/unreachable-statement
   - exclude:
       # catching base exceptions is required


### PR DESCRIPTION
Ignores another type of cyclic import warning e.g. https://github.com/PrefectHQ/prefect/security/code-scanning/1578