### PR TITLE
Pin httpx==0.23.1 to fix tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ docker >= 4.0
 fastapi >= 0.70
 fsspec >= 2022.5.0
 griffe >= 0.20.0
-httpx[http2] >= 0.23
+httpx[http2] == 0.23.1  # https://github.com/PrefectHQ/prefect/pull/8004#issuecomment-1369457371
 importlib_metadata >= 4.4; python_version < '3.10'
 jinja2 >= 3.0.0
 jsonpatch >= 1.32


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Since httpx==0.23.2 is raising TypeError on UUID, maybe we should pin it temporarily?
https://github.com/PrefectHQ/prefect/pull/8004#issuecomment-1369457371

Or perhaps the better fix is to cast the UUID into string?

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```

        # Check expected state transitions
>       states = await orion_client.read_flow_run_states(flow_run.id)

tests/test_engine.py:1101: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/prefect/client/orion.py:1589: in read_flow_run_states
    response = await self._client.get(
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_client.py:1757: in get
    return await self.request(
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_client.py:1520: in request
    request = self.build_request(
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_client.py:351: in build_request
    params = self._merge_queryparams(params)
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_client.py:428: in _merge_queryparams
    return merged_queryparams.merge(params)
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_urls.py:723: in merge
    q = QueryParams(params)
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_urls.py:585: in __init__
    self._dict = {
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_urls.py:586: in <dictcomp>
    str(k): [primitive_value_to_str(item) for item in v]
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/httpx/_urls.py:586: in <listcomp>
    str(k): [primitive_value_to_str(item) for item in v]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

value = UUID('be4f74f2-8d51-4ff4-927e-707641bc498f')

    def primitive_value_to_str(value: "PrimitiveData") -> str:
        """
        Coerce a primitive data type into a string value.
    
        Note that we prefer JSON-style 'true'/'false' for boolean values here.
        """
        if value is True:
            return "true"
        elif value is False:
            return "false"
        elif value is None:
            return ""
        elif isinstance(value, (str, float, int)):
            return str(value)
>       raise TypeError(
            f"Expected str, int, float, bool, or None. Got {type(value).__name__!r}."
        )
E       TypeError: Expected str, int, float, bool, or None. Got 'UUID'.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
