### PR TITLE
update `prefect cloud login` when no workspaces exist

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -426,7 +426,14 @@ async def login(
                 [(workspace, workspace.handle) for workspace in workspaces],
             )
         else:
-            workspace = current_workspace or workspaces[0]
+            if current_workspace:
+                workspace = current_workspace
+            elif len(workspaces) > 0:
+                workspace = workspaces[0]
+            else:
+                exit_with_error(
+                    f"No workspaces found! Create a workspace at {PREFECT_CLOUD_UI_URL.value()} and try again."
+                )
 
     update_current_profile(
         {

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -144,23 +144,6 @@ def test_login_with_key_and_workspace_with_no_workspaces(respx_mock):
     )
 
 
-def test_login_with_key_and_no_workspaces(respx_mock):
-    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-        return_value=httpx.Response(
-            status.HTTP_200_OK,
-            json=[],
-        )
-    )
-    invoke_and_assert(
-        ["cloud", "login", "--key", "foo"],
-        expected_code=1,
-        user_input=readchar.key.ENTER,
-        expected_output_contains=[
-            f"No workspaces found! Create a workspace at {PREFECT_CLOUD_UI_URL.value()} and try again."
-        ],
-    )
-
-
 def test_login_with_key_and_workspace(respx_mock):
     foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
     bar_workspace = gen_test_workspace(account_handle="test", workspace_handle="bar")
@@ -192,6 +175,24 @@ def test_login_with_non_interactive_missing_args(args):
         ["cloud", "login", *args],
         expected_code=1,
         expected_output="When not using an interactive terminal, you must supply a `--key` and `--workspace`.",
+    )
+
+
+@pytest.mark.usefixtures("interactive_console")
+def test_login_with_key_and_no_workspaces(respx_mock):
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[],
+        )
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo"],
+        expected_code=1,
+        user_input=readchar.key.ENTER,
+        expected_output_contains=[
+            f"No workspaces found! Create a workspace at {PREFECT_CLOUD_UI_URL.value()} and try again."
+        ],
     )
 
 

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -133,6 +133,17 @@ def test_login_with_key_and_missing_workspace(respx_mock):
     )
 
 
+def test_login_with_key_and_workspace_with_no_workspaces(respx_mock):
+    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json=[])
+    )
+    invoke_and_assert(
+        ["cloud", "login", "--key", "foo", "--workspace", "bar"],
+        expected_code=1,
+        expected_output="Workspace 'bar' not found.",
+    )
+
+
 def test_login_with_key_and_no_workspaces(respx_mock):
     respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
         return_value=httpx.Response(

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -17,6 +17,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_CLOUD_UI_URL,
     PREFECT_PROFILES_PATH,
     Profile,
     ProfilesCollection,
@@ -134,12 +135,18 @@ def test_login_with_key_and_missing_workspace(respx_mock):
 
 def test_login_with_key_and_no_workspaces(respx_mock):
     respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-        return_value=httpx.Response(status.HTTP_200_OK, json=[])
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[],
+        )
     )
     invoke_and_assert(
-        ["cloud", "login", "--key", "foo", "--workspace", "bar"],
+        ["cloud", "login", "--key", "foo"],
         expected_code=1,
-        expected_output="Workspace 'bar' not found.",
+        user_input=readchar.key.ENTER,
+        expected_output_contains=[
+            f"No workspaces found! Create a workspace at {PREFECT_CLOUD_UI_URL.value()} and try again."
+        ],
     )
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->



<!-- Include an overview here -->
Previously when running `prefect cloud login` without any workspaces existing, an `IndexError` would occur. This pr adds messaging when that occurs to indicate to the user that no workspaces exist and directs them to create one.

Closes: https://github.com/PrefectHQ/prefect/issues/7952

### Example
When logging in when no workspaces exist:

<img width="863" alt="Screenshot 2023-01-03 at 10 24 16 AM" src="https://user-images.githubusercontent.com/40362401/210387727-b890b911-3348-4392-8306-b57a1e0d0c05.png">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
