### PR TITLE
Add Python dependency scanning for the 1.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
     schedule:
       interval: "daily"
     labels: ["maintenance"]
+
+  # Check for Python updates 
+  - package-ecosystem: "pip"
+    target-branch: "1.x"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["maintenance", "v1"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       interval: "daily"
     labels: ["maintenance"]
 
-  # Check for Python updates 
+  # Check for Python updates in v1
   - package-ecosystem: "pip"
     target-branch: "1.x"
     directory: "/"


### PR DESCRIPTION
This was removed when we moved the default branch to `main`.

I have not enabled npm scanning since it is only used for legacy documentation, the security alerts are always false positives, and the requirements should stay frozen for consistent builds.