### PR TITLE
Adds worker pool and worker pool queue filters to count flow runs endpoint

### DIFF
--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -91,6 +91,8 @@ async def count_flow_runs(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
+    worker_pools: schemas.filters.WorkerPoolFilter = None,
+    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> int:
     """
@@ -103,6 +105,8 @@ async def count_flow_runs(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
+            worker_pool_filter=worker_pools,
+            worker_pool_queue_filter=worker_pool_queues,
         )
 
 

--- a/src/prefect/orion/models/flow_runs.py
+++ b/src/prefect/orion/models/flow_runs.py
@@ -348,6 +348,8 @@ async def count_flow_runs(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
+    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
 ) -> int:
     """
     Count flow runs.
@@ -371,6 +373,8 @@ async def count_flow_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
+        worker_pool_filter=worker_pool_filter,
+        worker_pool_queue_filter=worker_pool_queue_filter,
         db=db,
     )
 

--- a/tests/orion/models/test_filters.py
+++ b/tests/orion/models/test_filters.py
@@ -182,6 +182,7 @@ async def data(flow_function, db):
                 tags=[],
                 state=states.Completed(),
                 deployment_id=d_3_1.id,
+                worker_pool_queue_id=wp.default_queue_id,
             )
         )
 
@@ -570,6 +571,55 @@ class TestCountFlowRunModels:
                 flow_run_filter=filters.FlowRunFilter(),
             ),
             12,
+        ],
+        [
+            dict(
+                worker_pool_filter=filters.WorkerPoolFilter(
+                    name=dict(any_=["Test Pool"])
+                )
+            ),
+            1,
+        ],
+        [
+            dict(
+                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                    name=dict(any_=["Default Queue"])
+                )
+            ),
+            1,
+        ],
+        [
+            dict(
+                worker_pool_filter=filters.WorkerPoolFilter(
+                    name=dict(any_=["Test Pool"])
+                ),
+                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                    name=dict(any_=["Default Queue"])
+                ),
+            ),
+            1,
+        ],
+        [
+            dict(
+                worker_pool_filter=filters.WorkerPoolFilter(
+                    name=dict(any_=["A pool that doesn't exist"])
+                ),
+                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                    name=dict(any_=["Default Queue"])
+                ),
+            ),
+            0,
+        ],
+        [
+            dict(
+                worker_pool_filter=filters.WorkerPoolFilter(
+                    name=dict(any_=["Test Pool"])
+                ),
+                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                    name=dict(any_=["a queue that doesn't exist"])
+                ),
+            ),
+            0,
         ],
     ]
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds worker pool and worker pool queue filters to the `/flow_runs/count` endpoint to restore filter parity with the `/flow_runs/filter` endpoint.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
