### PR TITLE
Avoid creating an extra client instance during result factory creation

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -254,7 +254,9 @@ class ResultFactory(pydantic.BaseModel):
                 storage_block._block_document_id
                 # TODO: Overwrite is true to avoid issues where the save collides with
                 #       a previously saved document with a matching hash
-                or await storage_block._save(is_anonymous=True, overwrite=True)
+                or await storage_block._save(
+                    is_anonymous=True, overwrite=True, client=client
+                )
             )
         elif isinstance(result_storage, str):
             storage_block = await Block.load(result_storage, client=client)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -128,7 +128,7 @@ class TestRaiseStateException:
 
 class TestReturnValueToState:
     @pytest.fixture
-    async def factory(orion_client):
+    async def factory(self, orion_client):
         return await ResultFactory.default_factory(client=orion_client)
 
     async def test_returns_single_state_unaltered(self, factory):


### PR DESCRIPTION
Without this change, you can see an extra client is created during result factory creation

```
❯ python example.py
12:22:42.162 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
Stack (most recent call last):
  File "/Users/mz/dev/prefect/example.py", line 16, in <module>
    anyio.run(test_flow)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 634, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 601, in run_forever
    self._run_once()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 1905, in _run_once
    handle._run()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
12:22:42.208 | INFO    | prefect.engine - Created flow run 'famous-bulldog' for flow 'test-flow'
12:22:42.209 | DEBUG   | Flow run 'famous-bulldog' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
12:22:42.210 | DEBUG   | prefect.task_runner.concurrent - Starting task runner...
12:22:42.211 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
Stack (most recent call last):
  File "/Users/mz/dev/prefect/example.py", line 16, in <module>
    anyio.run(test_flow)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 634, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 601, in run_forever
    self._run_once()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/base_events.py", line 1905, in _run_once
    handle._run()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-39/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "/Users/mz/dev/prefect/src/prefect/client/utilities.py", line 47, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 237, in create_then_begin_flow_run
    state = await begin_flow_run(
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 365, in begin_flow_run
    flow_run_context.result_factory = await ResultFactory.from_flow(
  File "/Users/mz/dev/prefect/src/prefect/client/utilities.py", line 47, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/results.py", line 161, in from_flow
    return await cls.default_factory(
  File "/Users/mz/dev/prefect/src/prefect/client/utilities.py", line 47, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/results.py", line 123, in default_factory
    return await cls.from_settings(**kwargs, client=client)
  File "/Users/mz/dev/prefect/src/prefect/client/utilities.py", line 47, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/results.py", line 229, in from_settings
    storage_block_id, storage_block = await cls.resolve_storage_block(
  File "/Users/mz/dev/prefect/src/prefect/results.py", line 258, in resolve_storage_block
    or await storage_block._save(is_anonymous=True, overwrite=True)
12:22:42.289 | DEBUG   | Flow run 'famous-bulldog' - Executing flow 'test-flow' for flow run 'famous-bulldog'...
```

To reduce the overhead of creating additional connections to the database (when ephemeral) and new connection pools (when using a hosted API) we should avoid this wherever possible.