### PR TITLE
SecretDict is not JSONSerializable in Deployment

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -16,6 +16,7 @@ import yaml
 from pydantic import BaseModel, Field, parse_obj_as, validator
 
 from prefect.blocks.core import Block
+from prefect.blocks.fields import SecretDict
 from prefect.client.orion import OrionClient, get_client
 from prefect.client.utilities import inject_client
 from prefect.context import FlowRunContext, PrefectObjectRegistry
@@ -265,6 +266,7 @@ class Deployment(BaseModel):
     """
 
     class Config:
+        json_encoders = {SecretDict: lambda v: v.dict()}
         validate_assignment = True
         extra = "forbid"
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -10,6 +10,7 @@ from pydantic.error_wrappers import ValidationError
 
 from prefect import flow, task
 from prefect.blocks.core import Block
+from prefect.blocks.fields import SecretDict
 from prefect.client.orion import OrionClient
 from prefect.deployments import Deployment, run_deployment
 from prefect.exceptions import BlockMissingCapabilities
@@ -435,6 +436,56 @@ class TestYAML:
         new_d = await Deployment.load_from_yaml(yaml_path)
         assert new_d.storage.aws_access_key_id.get_secret_value() == "fake"
         assert new_d.storage.aws_secret_access_key.get_secret_value() == "faker"
+
+    def test_yaml_comment_for_work_queue(self, tmp_path):
+        d = Deployment(name="yaml", flow_name="test")
+        yaml_path = str(tmp_path / "dep.yaml")
+        d.to_yaml(yaml_path)
+        with open(yaml_path, "r") as f:
+            contents = f.readlines()
+
+        comment_index = contents.index(
+            "# The work queue that will handle this deployment's runs\n"
+        )
+        assert contents[comment_index + 1] == "work_queue_name: default\n"
+
+    async def test_deployment_yaml_roundtrip_handles_secret_dict(self, tmp_path):
+        class CustomCredentials(Block):
+
+            auth_info: SecretDict
+
+        class CustomInfra(Infrastructure):
+            type = "CustomInfra"
+            credentials: CustomCredentials
+
+            def run(self):  # needed because abstract method
+                return 42
+
+            def preview(self):  # abstract method
+                return "woof!"
+
+        custom_creds = CustomCredentials(auth_info={"key": "val"})
+        custom_infra = CustomInfra(credentials=custom_creds)
+        await custom_infra.save("test-me-with-secrets")
+
+        d = Deployment(
+            name="yaml",
+            infrastructure=custom_infra,
+        )
+        yaml_path = str(tmp_path / "dep.yaml")
+        await d.to_yaml(yaml_path)
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        # ensure secret values are hidden
+        auth_info = data["infrastructure"]["credentials"]["auth_info"]
+        assert len(auth_info) == 1
+        assert set(auth_info["key"]) == {"*"}
+
+        # ensure secret values are re-hydrated
+        new_d = await Deployment.load_from_yaml(yaml_path)
+        auth_info = new_d.infrastructure.credentials.auth_info
+        assert auth_info.get_secret_value() == {"key": "val"}
 
     def test_yaml_comment_for_work_queue(self, tmp_path):
         d = Deployment(name="yaml", flow_name="test")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

User reports that: `prefect deployment build sky-pipe/flows/test_flow.py:test_flow -n testaroo -q sky-pipe --skip-upload -a -ib "cloud-run-job/test"` does not work in prefect_gcp==0.2.2, a version that introduces `SecretDict` inside `GcpCredentials`.

However, during my testing, I found this works, with plain blocks.
```
from prefect_gcp import GcpCredentials
from prefect_gcp.cloud_run import CloudRunJob
job = CloudRunJob(image="myimage", region="region", credentials=GcpCredentials.load("gcp-credentials"))
job.json()
```

The reason it works with blocks is because `Block` class has special handling; it does not work in a `Deployment` because `Deployment` inherits from `BaseModel` and not `Block`,  
```
    class Config:
        extra = "allow"

        json_encoders = {SecretDict: lambda v: v.dict()}
```
So this PR copies over the Config to Deployment to make it work.

Closes https://github.com/PrefectHQ/prefect-gcp/issues/102

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect.blocks.fields import SecretDict
from prefect_gcp.cloud_run import CloudRunJob, GcpCredentials
from prefect.deployments import Deployment

creds = GcpCredentials.load("gcp-credentials")  # must set service_account_info
crj = CloudRunJob(credentials=creds, image="abc", region="abc")
Deployment(name="abc", infrastructure=crj).to_yaml("my.yaml")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
