### PR TITLE
Check for missing Pydantic extra fields in `visit_collection`

### DIFF
--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -328,7 +328,9 @@ def visit_collection(
         # Pydantic does not expose extras in `__fields__` so we use `__fields_set__`
         # as well to get all of the relevant attributes
         # Check for presence of attrs even if they're in the field set due to pydantic#4916
-        model_fields = {f for f in expr.__fields_set__.union(expr.__fields__) if hasattr(expr, f)}
+        model_fields = {
+            f for f in expr.__fields_set__.union(expr.__fields__) if hasattr(expr, f)
+        }
         items = [visit_nested(getattr(expr, key)) for key in model_fields]
 
         if return_data:

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -295,7 +295,7 @@ def visit_collection(
         # Pydantic does not expose extras in `__fields__` so we use `__fields_set__`
         # as well to get all of the relevant attributes
         model_fields = expr.__fields_set__.union(expr.__fields__)
-        items = [visit_nested(getattr(expr, key)) for key in model_fields]
+        items = [visit_nested(getattr(expr, key)) for key in model_fields if hasattr(expr, key)]
 
         if return_data:
             # Collect fields with aliases so reconstruction can use the correct field name

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -294,8 +294,8 @@ def visit_collection(
         # NOTE: This implementation *does not* traverse private attributes
         # Pydantic does not expose extras in `__fields__` so we use `__fields_set__`
         # as well to get all of the relevant attributes
-        model_fields = expr.__fields_set__.union(expr.__fields__)
-        items = [visit_nested(getattr(expr, key)) for key in model_fields if hasattr(expr, key)]
+        model_fields = {f for f in expr.__fields_set__.union(expr.__fields__) if hasattr(expr, f)}
+        items = [visit_nested(getattr(expr, key)) for key in model_fields]
 
         if return_data:
             # Collect fields with aliases so reconstruction can use the correct field name

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -294,6 +294,7 @@ def visit_collection(
         # NOTE: This implementation *does not* traverse private attributes
         # Pydantic does not expose extras in `__fields__` so we use `__fields_set__`
         # as well to get all of the relevant attributes
+        # Check for presence of attrs even if they're in the field set due to pydantic#4916
         model_fields = {f for f in expr.__fields_set__.union(expr.__fields__) if hasattr(expr, f)}
         items = [visit_nested(getattr(expr, key)) for key in model_fields]
 

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -234,6 +234,7 @@ class TestVisitCollection:
             (SimpleDataclass(x=1, y=2), {2}),
             (SimplePydantic(x=1, y=2), {2}),
             (ExtraPydantic(x=1, y=2, z=4), {2, 4}),
+            (ExtraPydantic(x=1, y=2, z=4).copy(exclude={"z"}), {2}),
         ],
     )
     def test_visit_collection(self, inp, expected):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Closes #8082 by adding a `hasattr` check on the fields of the Pydantic object

### Example

The following code now runs without error.

```python
from pydantic import BaseModel, Extra

from prefect import flow


class Something(BaseModel, extra=Extra.allow):
    a: int


@flow(name="main")
def main_flow() -> Something:
    o1 = Something(a=1, b=2)
    o2 = o1.copy(exclude={"b"})
    return o2


if __name__ == "__main__":
    main_flow()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
