### PR TITLE
maintenance: Add github token to remove labels action

### DIFF
--- a/.github/workflows/remove-issue-labels.yaml
+++ b/.github/workflows/remove-issue-labels.yaml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - name: Remove label
         run: gh issue edit ${{ github.event.issue.number }} --remove-label "status:triage"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Our GitHub Action for auto-removing labels appears to be failing; [concrete example here](https://github.com/PrefectHQ/prefect/actions/runs/3869458533/jobs/6595565332) and [long list here](https://github.com/PrefectHQ/prefect/actions/workflows/remove-issue-labels.yaml).

This PR adds the relevant environment variable that should resolve the issue

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
