### PR TITLE
Rename Worker pools -> work pools

### DIFF
--- a/src/prefect/_internal/concurrency/executor.py
+++ b/src/prefect/_internal/concurrency/executor.py
@@ -36,14 +36,14 @@ class Executor(BaseExecutor):
     def __init__(
         self,
         worker_type: WorkerType = "thread",
-        **worker_pool_kwargs: Any,
+        **work_pool_kwargs: Any,
     ) -> None:
         super().__init__()
 
         if worker_type == "thread":
-            worker_pool_cls = ThreadPoolExecutor
+            work_pool_cls = ThreadPoolExecutor
         elif worker_type == "process":
-            worker_pool_cls = ProcessPoolExecutor
+            work_pool_cls = ProcessPoolExecutor
         else:
             raise ValueError(
                 f"Unknown worker type {worker_type}; "
@@ -51,15 +51,15 @@ class Executor(BaseExecutor):
             )
 
         self._worker_type = worker_type
-        self._worker_pool = worker_pool_cls(**worker_pool_kwargs)
+        self._work_pool = work_pool_cls(**work_pool_kwargs)
 
     def submit(
         self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> "Future[T]":
-        return self._worker_pool.submit(self._wrap_submitted_call(fn, *args, **kwargs))
+        return self._work_pool.submit(self._wrap_submitted_call(fn, *args, **kwargs))
 
     def shutdown(self, wait=True) -> None:
-        self._worker_pool.shutdown(wait=wait)
+        self._work_pool.shutdown(wait=wait)
 
     def _wrap_submitted_call(
         self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs

--- a/src/prefect/_internal/concurrency/executor.py
+++ b/src/prefect/_internal/concurrency/executor.py
@@ -36,14 +36,14 @@ class Executor(BaseExecutor):
     def __init__(
         self,
         worker_type: WorkerType = "thread",
-        **work_pool_kwargs: Any,
+        **worker_pool_kwargs: Any,
     ) -> None:
         super().__init__()
 
         if worker_type == "thread":
-            work_pool_cls = ThreadPoolExecutor
+            worker_pool_cls = ThreadPoolExecutor
         elif worker_type == "process":
-            work_pool_cls = ProcessPoolExecutor
+            worker_pool_cls = ProcessPoolExecutor
         else:
             raise ValueError(
                 f"Unknown worker type {worker_type}; "
@@ -51,15 +51,15 @@ class Executor(BaseExecutor):
             )
 
         self._worker_type = worker_type
-        self._work_pool = work_pool_cls(**work_pool_kwargs)
+        self._worker_pool = worker_pool_cls(**worker_pool_kwargs)
 
     def submit(
         self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> "Future[T]":
-        return self._work_pool.submit(self._wrap_submitted_call(fn, *args, **kwargs))
+        return self._worker_pool.submit(self._wrap_submitted_call(fn, *args, **kwargs))
 
     def shutdown(self, wait=True) -> None:
-        self._work_pool.shutdown(wait=wait)
+        self._worker_pool.shutdown(wait=wait)
 
     def _wrap_submitted_call(
         self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -316,8 +316,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            work_pool_filter: filter criteria for worker pools
-            work_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for work pools
+            work_pool_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flows
             limit: limit for the flow query
             offset: offset for the flow query
@@ -1437,8 +1437,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            work_pool_filter: filter criteria for worker pools
-            work_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for work pools
+            work_pool_queue_filter: filter criteria for work pool queues
             limit: a limit for the deployment query
             offset: an offset for the deployment query
 
@@ -1558,8 +1558,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            work_pool_filter: filter criteria for worker pools
-            work_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for work pools
+            work_pool_queue_filter: filter criteria for work pool queues
             sort: sort criteria for the flow runs
             limit: limit for the flow run query
             offset: offset for the flow run query
@@ -1951,10 +1951,10 @@ class OrionClient:
 
     async def send_worker_heartbeat(self, work_pool_name: str, worker_name: str):
         """
-        Sends a worker heartbeat for a given worker pool.
+        Sends a worker heartbeat for a given work pool.
 
         Args:
-            work_pool_name: The name of the worker pool to heartbeat against.
+            work_pool_name: The name of the work pool to heartbeat against.
             worker_name: The name of the worker sending the heartbeat.
         """
         await self._client.post(
@@ -1970,10 +1970,10 @@ class OrionClient:
         limit: Optional[int] = None,
     ) -> List[schemas.core.Worker]:
         """
-        Reads workers for a given worker pool.
+        Reads workers for a given work pool.
 
         Args:
-            work_pool_name: The name of the worker pool for which to get
+            work_pool_name: The name of the work pool for which to get
                 member workers.
             worker_filter: Criteria by which to filter workers.
             limit: Limit for the worker query.
@@ -1996,14 +1996,14 @@ class OrionClient:
 
     async def read_work_pool(self, work_pool_name: str) -> schemas.core.WorkPool:
         """
-        Reads information for a given worker pool
+        Reads information for a given work pool
 
         Args:
-            work_pool_name: The name of the worker pool to for which to get
+            work_pool_name: The name of the work pool to for which to get
                 information.
 
         Returns:
-            Information about the requested worker pool.
+            Information about the requested work pool.
         """
         try:
             response = await self._client.get(
@@ -2021,13 +2021,13 @@ class OrionClient:
         work_pool: schemas.actions.WorkPoolCreate,
     ) -> schemas.core.WorkPool:
         """
-        Creates a worker pool with the provided configuration.
+        Creates a work pool with the provided configuration.
 
         Args:
-            work_pool: Desired configuration for the new worker pool.
+            work_pool: Desired configuration for the new work pool.
 
         Returns:
-            Information about the newly created worker pool.
+            Information about the newly created work pool.
         """
         response = await self._client.post(
             "/experimental/work_pools/",
@@ -2040,13 +2040,13 @@ class OrionClient:
         self, work_pool_name: str
     ) -> List[schemas.core.WorkPoolQueue]:
         """
-        Retrieves queues for a worker pool.
+        Retrieves queues for a work pool.
 
         Args:
-            work_pool_name: Name of the worker pool for which to get queues.
+            work_pool_name: Name of the work pool for which to get queues.
 
         Returns:
-            List of queues for the specified worker pool.
+            List of queues for the specified work pool.
         """
         response = await self._client.get(
             f"/experimental/work_pools/{work_pool_name}/queues"
@@ -2060,10 +2060,10 @@ class OrionClient:
         work_pool_queue: schemas.actions.WorkPoolQueueCreate,
     ) -> schemas.core.WorkPoolQueue:
         """
-        Creates a queue for a given worker pool
+        Creates a queue for a given work pool
 
         Args:
-            work_pool_name: Name of the worker pool to create the queue under.
+            work_pool_name: Name of the work pool to create the queue under.
             work_pool_queue: Desired configuration for the new queue.
 
         Returns:
@@ -2083,11 +2083,11 @@ class OrionClient:
         work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
     ):
         """
-        Creates a queue for a given worker pool
+        Creates a queue for a given work pool
 
         Args:
-            work_pool_name: Name of the worker pool in which the queue resides.
-            work_pool_queue_name: Name of the worker pool queue to update
+            work_pool_name: Name of the work pool in which the queue resides.
+            work_pool_queue_name: Name of the work pool queue to update
             work_pool_queue: Desired updates for the queue.
 
         """
@@ -2103,12 +2103,12 @@ class OrionClient:
         scheduled_before: Optional[datetime.datetime] = None,
     ) -> List[WorkerFlowRunResponse]:
         """
-        Retrieves scheduled flow runs for the provided set of worker pool queues.
+        Retrieves scheduled flow runs for the provided set of work pool queues.
 
         Args:
-            work_pool_name: The name of the worker pool that the worker pool
+            work_pool_name: The name of the work pool that the work pool
                 queues are associated with.
-            work_pool_queue_names: The names of the worker pool queues from which
+            work_pool_queue_names: The names of the work pool queues from which
                 to get scheduled flow runs.
             scheduled_before: Datetime used to filter returned flow runs. Flow runs
                 scheduled for after the given datetime string will not be returned.

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -31,8 +31,8 @@ from prefect.orion.schemas.core import (
     BlockType,
     FlowRunNotificationPolicy,
     QueueFilter,
-    WorkerPool,
-    WorkerPoolQueue,
+    WorkPool,
+    WorkPoolQueue,
 )
 from prefect.orion.schemas.filters import FlowRunNotificationPolicyFilter, LogFilter
 from prefect.orion.schemas.responses import WorkerFlowRunResponse
@@ -301,8 +301,8 @@ class OrionClient:
         flow_run_filter: schemas.filters.FlowRunFilter = None,
         task_run_filter: schemas.filters.TaskRunFilter = None,
         deployment_filter: schemas.filters.DeploymentFilter = None,
-        worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-        worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+        work_pool_filter: schemas.filters.WorkPoolFilter = None,
+        work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
         sort: schemas.sorting.FlowSort = None,
         limit: int = None,
         offset: int = 0,
@@ -316,8 +316,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            worker_pool_filter: filter criteria for worker pools
-            worker_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for worker pools
+            work_pool_queue_filter: filter criteria for worker pool queues
             sort: sort criteria for the flows
             limit: limit for the flow query
             offset: offset for the flow query
@@ -338,14 +338,14 @@ class OrionClient:
                 if deployment_filter
                 else None
             ),
-            "worker_pools": (
-                worker_pool_filter.dict(json_compatible=True)
-                if worker_pool_filter
+            "work_pools": (
+                work_pool_filter.dict(json_compatible=True)
+                if work_pool_filter
                 else None
             ),
-            "worker_pool_queues": (
-                worker_pool_queue_filter.dict(json_compatible=True)
-                if worker_pool_queue_filter
+            "work_pool_queues": (
+                work_pool_queue_filter.dict(json_compatible=True)
+                if work_pool_queue_filter
                 else None
             ),
             "sort": sort,
@@ -1266,8 +1266,8 @@ class OrionClient:
         parameters: Dict[str, Any] = None,
         description: str = None,
         work_queue_name: str = None,
-        worker_pool_name: str = None,
-        worker_pool_queue_name: str = None,
+        work_pool_name: str = None,
+        work_pool_queue_name: str = None,
         tags: List[str] = None,
         storage_document_id: UUID = None,
         manifest_path: str = None,
@@ -1305,8 +1305,8 @@ class OrionClient:
             parameters=dict(parameters or {}),
             tags=list(tags or []),
             work_queue_name=work_queue_name,
-            worker_pool_name=worker_pool_name,
-            worker_pool_queue_name=worker_pool_queue_name,
+            work_pool_name=work_pool_name,
+            work_pool_queue_name=work_pool_queue_name,
             description=description,
             storage_document_id=storage_document_id,
             path=path,
@@ -1422,8 +1422,8 @@ class OrionClient:
         flow_run_filter: schemas.filters.FlowRunFilter = None,
         task_run_filter: schemas.filters.TaskRunFilter = None,
         deployment_filter: schemas.filters.DeploymentFilter = None,
-        worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-        worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+        work_pool_filter: schemas.filters.WorkPoolFilter = None,
+        work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
         limit: int = None,
         sort: schemas.sorting.DeploymentSort = None,
         offset: int = 0,
@@ -1437,8 +1437,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            worker_pool_filter: filter criteria for worker pools
-            worker_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for worker pools
+            work_pool_queue_filter: filter criteria for worker pool queues
             limit: a limit for the deployment query
             offset: an offset for the deployment query
 
@@ -1459,14 +1459,14 @@ class OrionClient:
                 if deployment_filter
                 else None
             ),
-            "worker_pools": (
-                worker_pool_filter.dict(json_compatible=True)
-                if worker_pool_filter
+            "work_pools": (
+                work_pool_filter.dict(json_compatible=True)
+                if work_pool_filter
                 else None
             ),
-            "worker_pool_queues": (
-                worker_pool_queue_filter.dict(json_compatible=True)
-                if worker_pool_queue_filter
+            "work_pool_queues": (
+                work_pool_queue_filter.dict(json_compatible=True)
+                if work_pool_queue_filter
                 else None
             ),
             "limit": limit,
@@ -1543,8 +1543,8 @@ class OrionClient:
         flow_run_filter: schemas.filters.FlowRunFilter = None,
         task_run_filter: schemas.filters.TaskRunFilter = None,
         deployment_filter: schemas.filters.DeploymentFilter = None,
-        worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-        worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+        work_pool_filter: schemas.filters.WorkPoolFilter = None,
+        work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
         sort: schemas.sorting.FlowRunSort = None,
         limit: int = None,
         offset: int = 0,
@@ -1558,8 +1558,8 @@ class OrionClient:
             flow_run_filter: filter criteria for flow runs
             task_run_filter: filter criteria for task runs
             deployment_filter: filter criteria for deployments
-            worker_pool_filter: filter criteria for worker pools
-            worker_pool_queue_filter: filter criteria for worker pool queues
+            work_pool_filter: filter criteria for worker pools
+            work_pool_queue_filter: filter criteria for worker pool queues
             sort: sort criteria for the flow runs
             limit: limit for the flow run query
             offset: offset for the flow run query
@@ -1581,14 +1581,14 @@ class OrionClient:
                 if deployment_filter
                 else None
             ),
-            "worker_pools": (
-                worker_pool_filter.dict(json_compatible=True)
-                if worker_pool_filter
+            "work_pools": (
+                work_pool_filter.dict(json_compatible=True)
+                if work_pool_filter
                 else None
             ),
-            "worker_pool_queues": (
-                worker_pool_queue_filter.dict(json_compatible=True)
-                if worker_pool_queue_filter
+            "work_pool_queues": (
+                work_pool_queue_filter.dict(json_compatible=True)
+                if work_pool_queue_filter
                 else None
             ),
             "sort": sort,
@@ -1949,22 +1949,22 @@ class OrionClient:
 
         return await resolve_inner(datadoc)
 
-    async def send_worker_heartbeat(self, worker_pool_name: str, worker_name: str):
+    async def send_worker_heartbeat(self, work_pool_name: str, worker_name: str):
         """
         Sends a worker heartbeat for a given worker pool.
 
         Args:
-            worker_pool_name: The name of the worker pool to heartbeat against.
+            work_pool_name: The name of the worker pool to heartbeat against.
             worker_name: The name of the worker sending the heartbeat.
         """
         await self._client.post(
-            f"/experimental/worker_pools/{worker_pool_name}/workers/heartbeat",
+            f"/experimental/work_pools/{work_pool_name}/workers/heartbeat",
             json={"name": worker_name},
         )
 
-    async def read_workers_for_worker_pool(
+    async def read_workers_for_work_pool(
         self,
-        worker_pool_name: str,
+        work_pool_name: str,
         worker_filter: Optional[schemas.filters.WorkerFilter] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
@@ -1973,14 +1973,14 @@ class OrionClient:
         Reads workers for a given worker pool.
 
         Args:
-            worker_pool_name: The name of the worker pool for which to get
+            work_pool_name: The name of the worker pool for which to get
                 member workers.
             worker_filter: Criteria by which to filter workers.
             limit: Limit for the worker query.
             offset: Limit for the worker query.
         """
         response = await self._client.post(
-            f"/experimental/worker_pools/{worker_pool_name}/workers/filter",
+            f"/experimental/work_pools/{work_pool_name}/workers/filter",
             json={
                 "worker_filter": (
                     worker_filter.dict(json_compatible=True, exclude_unset=True)
@@ -1994,12 +1994,12 @@ class OrionClient:
 
         return pydantic.parse_obj_as(List[schemas.core.Worker], response.json())
 
-    async def read_worker_pool(self, worker_pool_name: str) -> schemas.core.WorkerPool:
+    async def read_work_pool(self, work_pool_name: str) -> schemas.core.WorkPool:
         """
         Reads information for a given worker pool
 
         Args:
-            worker_pool_name: The name of the worker pool to for which to get
+            work_pool_name: The name of the worker pool to for which to get
                 information.
 
         Returns:
@@ -2007,108 +2007,108 @@ class OrionClient:
         """
         try:
             response = await self._client.get(
-                f"/experimental/worker_pools/{worker_pool_name}"
+                f"/experimental/work_pools/{work_pool_name}"
             )
-            return pydantic.parse_obj_as(WorkerPool, response.json())
+            return pydantic.parse_obj_as(WorkPool, response.json())
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:
                 raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
             else:
                 raise
 
-    async def create_worker_pool(
+    async def create_work_pool(
         self,
-        worker_pool: schemas.actions.WorkerPoolCreate,
-    ) -> schemas.core.WorkerPool:
+        work_pool: schemas.actions.WorkPoolCreate,
+    ) -> schemas.core.WorkPool:
         """
         Creates a worker pool with the provided configuration.
 
         Args:
-            worker_pool: Desired configuration for the new worker pool.
+            work_pool: Desired configuration for the new worker pool.
 
         Returns:
             Information about the newly created worker pool.
         """
         response = await self._client.post(
-            "/experimental/worker_pools/",
-            json=worker_pool.dict(json_compatible=True, exclude_unset=True),
+            "/experimental/work_pools/",
+            json=work_pool.dict(json_compatible=True, exclude_unset=True),
         )
 
-        return pydantic.parse_obj_as(WorkerPool, response.json())
+        return pydantic.parse_obj_as(WorkPool, response.json())
 
-    async def read_worker_pool_queues(
-        self, worker_pool_name: str
-    ) -> List[schemas.core.WorkerPoolQueue]:
+    async def read_work_pool_queues(
+        self, work_pool_name: str
+    ) -> List[schemas.core.WorkPoolQueue]:
         """
         Retrieves queues for a worker pool.
 
         Args:
-            worker_pool_name: Name of the worker pool for which to get queues.
+            work_pool_name: Name of the worker pool for which to get queues.
 
         Returns:
             List of queues for the specified worker pool.
         """
         response = await self._client.get(
-            f"/experimental/worker_pools/{worker_pool_name}/queues"
+            f"/experimental/work_pools/{work_pool_name}/queues"
         )
 
-        return pydantic.parse_obj_as(List[WorkerPoolQueue], response.json())
+        return pydantic.parse_obj_as(List[WorkPoolQueue], response.json())
 
-    async def create_worker_pool_queue(
+    async def create_work_pool_queue(
         self,
-        worker_pool_name: str,
-        worker_pool_queue: schemas.actions.WorkerPoolQueueCreate,
-    ) -> schemas.core.WorkerPoolQueue:
+        work_pool_name: str,
+        work_pool_queue: schemas.actions.WorkPoolQueueCreate,
+    ) -> schemas.core.WorkPoolQueue:
         """
         Creates a queue for a given worker pool
 
         Args:
-            worker_pool_name: Name of the worker pool to create the queue under.
-            worker_pool_queue: Desired configuration for the new queue.
+            work_pool_name: Name of the worker pool to create the queue under.
+            work_pool_queue: Desired configuration for the new queue.
 
         Returns:
             Information about the newly created queue.
         """
         response = await self._client.post(
-            f"/experimental/worker_pools/{worker_pool_name}/queues",
-            json=worker_pool_queue.dict(json_compatible=True, exclude_unset=True),
+            f"/experimental/work_pools/{work_pool_name}/queues",
+            json=work_pool_queue.dict(json_compatible=True, exclude_unset=True),
         )
 
-        return pydantic.parse_obj_as(WorkerPoolQueue, response.json())
+        return pydantic.parse_obj_as(WorkPoolQueue, response.json())
 
-    async def update_worker_pool_queue(
+    async def update_work_pool_queue(
         self,
-        worker_pool_name: str,
-        worker_pool_queue_name: str,
-        worker_pool_queue: schemas.actions.WorkerPoolQueueUpdate,
+        work_pool_name: str,
+        work_pool_queue_name: str,
+        work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
     ):
         """
         Creates a queue for a given worker pool
 
         Args:
-            worker_pool_name: Name of the worker pool in which the queue resides.
-            worker_pool_queue_name: Name of the worker pool queue to update
-            worker_pool_queue: Desired updates for the queue.
+            work_pool_name: Name of the worker pool in which the queue resides.
+            work_pool_queue_name: Name of the worker pool queue to update
+            work_pool_queue: Desired updates for the queue.
 
         """
         await self._client.patch(
-            f"/experimental/worker_pools/{worker_pool_name}/queues/{worker_pool_queue_name}",
-            json=worker_pool_queue.dict(json_compatible=True, exclude_unset=True),
+            f"/experimental/work_pools/{work_pool_name}/queues/{work_pool_queue_name}",
+            json=work_pool_queue.dict(json_compatible=True, exclude_unset=True),
         )
 
-    async def get_scheduled_flow_runs_for_worker_pool_queues(
+    async def get_scheduled_flow_runs_for_work_pool_queues(
         self,
-        worker_pool_name: str,
-        worker_pool_queue_names: Optional[List[str]] = None,
+        work_pool_name: str,
+        work_pool_queue_names: Optional[List[str]] = None,
         scheduled_before: Optional[datetime.datetime] = None,
     ) -> List[WorkerFlowRunResponse]:
         """
         Retrieves scheduled flow runs for the provided set of worker pool queues.
 
         Args:
-            worker_pool_name: The name of the worker pool that the worker pool
+            work_pool_name: The name of the worker pool that the worker pool
                 queues are associated with.
-            worker_pool_queue_names: The names of the worker pool queues from which
+            work_pool_queue_names: The names of the worker pool queues from which
                 to get scheduled flow runs.
             scheduled_before: Datetime used to filter returned flow runs. Flow runs
                 scheduled for after the given datetime string will not be returned.
@@ -2118,13 +2118,13 @@ class OrionClient:
             retrieved flow runs.
         """
         body: Dict[str, Any] = {}
-        if worker_pool_queue_names is not None:
-            body["worker_pool_queue_names"] = worker_pool_queue_names
+        if work_pool_queue_names is not None:
+            body["work_pool_queue_names"] = work_pool_queue_names
         if scheduled_before:
             body["scheduled_before"] = str(scheduled_before)
 
         response = await self._client.post(
-            f"/experimental/worker_pools/{worker_pool_name}/get_scheduled_flow_runs",
+            f"/experimental/work_pools/{work_pool_name}/get_scheduled_flow_runs",
             json=body,
         )
 

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -210,9 +210,9 @@ def load_deployments_from_yaml(
     return registry
 
 
-@experimental_field("worker_pool_name", group="workers", when=lambda x: x is not None)
+@experimental_field("work_pool_name", group="workers", when=lambda x: x is not None)
 @experimental_field(
-    "worker_pool_queue_name",
+    "work_pool_queue_name",
     group="workers",
     when=lambda x: x is not None,
     stacklevel=4,
@@ -288,8 +288,8 @@ class Deployment(BaseModel):
             "description",
             "version",
             "work_queue_name",
-            "worker_pool_name",
-            "worker_pool_queue_name",
+            "work_pool_name",
+            "work_pool_queue_name",
             "tags",
             "parameters",
             "schedule",
@@ -390,10 +390,10 @@ class Deployment(BaseModel):
         description="The work queue for the deployment.",
         yaml_comment="The work queue that will handle this deployment's runs",
     )
-    worker_pool_name: Optional[str] = Field(
+    work_pool_name: Optional[str] = Field(
         default=None, description="The worker pool for the deployment"
     )
-    worker_pool_queue_name: Optional[str] = Field(
+    work_pool_queue_name: Optional[str] = Field(
         default=None, description="The worker pool queue for the deployment."
     )
     # flow data
@@ -653,8 +653,8 @@ class Deployment(BaseModel):
                 flow_id=flow_id,
                 name=self.name,
                 work_queue_name=self.work_queue_name,
-                worker_pool_name=self.worker_pool_name,
-                worker_pool_queue_name=self.worker_pool_queue_name,
+                work_pool_name=self.work_pool_name,
+                work_pool_queue_name=self.work_pool_queue_name,
                 version=self.version,
                 schedule=self.schedule,
                 parameters=self.parameters,

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -391,10 +391,10 @@ class Deployment(BaseModel):
         yaml_comment="The work queue that will handle this deployment's runs",
     )
     work_pool_name: Optional[str] = Field(
-        default=None, description="The worker pool for the deployment"
+        default=None, description="The work pool for the deployment"
     )
     work_pool_queue_name: Optional[str] = Field(
-        default=None, description="The worker pool queue for the deployment."
+        default=None, description="The work pool queue for the deployment."
     )
     # flow data
     parameters: Dict[str, Any] = Field(default_factory=dict)

--- a/src/prefect/experimental/cli/worker.py
+++ b/src/prefect/experimental/cli/worker.py
@@ -27,7 +27,7 @@ async def start(
     worker_name: str = typer.Option(
         None, "-n", "--name", help="The name to give to the started worker."
     ),
-    worker_pool_name: str = typer.Option(
+    work_pool_name: str = typer.Option(
         ..., "-p", "--pool", help="The worker pool the started worker should join."
     ),
     worker_type: str = typer.Option(
@@ -52,7 +52,7 @@ async def start(
         )
     async with Worker(
         name=worker_name,
-        worker_pool_name=worker_pool_name,
+        work_pool_name=work_pool_name,
         limit=limit,
         prefetch_seconds=prefetch_seconds,
     ) as worker:

--- a/src/prefect/experimental/cli/worker.py
+++ b/src/prefect/experimental/cli/worker.py
@@ -28,7 +28,7 @@ async def start(
         None, "-n", "--name", help="The name to give to the started worker."
     ),
     work_pool_name: str = typer.Option(
-        ..., "-p", "--pool", help="The worker pool the started worker should join."
+        ..., "-p", "--pool", help="The work pool the started worker should join."
     ),
     worker_type: str = typer.Option(
         "process", "-t", "--type", help="The type of worker to start."

--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -166,9 +166,7 @@ class BaseWorker(abc.ABC):
                 )
                 self._logger.info(f"Worker pool {self._work_pool_name!r} created.")
             else:
-                self._logger.warning(
-                    f"Worker pool {self._work_pool_name!r} not found!"
-                )
+                self._logger.warning(f"Worker pool {self._work_pool_name!r} not found!")
                 return
 
         # if the remote config type changes (or if it's being loaded for the

--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -56,14 +56,14 @@ class BaseWorker(abc.ABC):
                 The name is used to identify the worker in the UI; if two
                 processes have the same name, they will be treated as the same
                 worker.
-            work_pool_name: The name of the worker pool to use. If not
+            work_pool_name: The name of the work pool to use. If not
                 provided, the default will be used.
             prefetch_seconds: The number of seconds to prefetch flow runs for.
             workflow_storage_path: The filesystem path to workflow storage for
                 this worker.
-            create_pool_if_not_found: Whether to create the worker pool
+            create_pool_if_not_found: Whether to create the work pool
                 if it is not found. Defaults to `True`, but can be set to `False` to
-                ensure that worker pools are not created accidentally.
+                ensure that work pools are not created accidentally.
             limit: The maximum number of flow runs this worker should be running at
                 a given time.
         """
@@ -188,7 +188,7 @@ class BaseWorker(abc.ABC):
 
     async def sync_with_backend(self):
         """
-        Updates the worker's local information about it's current worker pool and
+        Updates the worker's local information about it's current work pool and
         queues. Sends a worker heartbeat to the API.
         """
         await self._update_local_work_pool_info()
@@ -257,7 +257,7 @@ class BaseWorker(abc.ABC):
         self,
     ) -> List[schemas.responses.WorkerFlowRunResponse]:
         """
-        Retrieve scheduled flow runs from the worker pool's queues.
+        Retrieve scheduled flow runs from the work pool's queues.
         """
         scheduled_before = pendulum.now("utc").add(seconds=int(self._prefetch_seconds))
         self._logger.debug(
@@ -396,7 +396,7 @@ class BaseWorker(abc.ABC):
     def get_status(self):
         """
         Retrieves the status of the current worker including its name, current worker
-        pool, the worker pool queues it is polling, and its local settings.
+        pool, the work pool queues it is polling, and its local settings.
         """
         return {
             "name": self.name,

--- a/src/prefect/orion/api/admin.py
+++ b/src/prefect/orion/api/admin.py
@@ -44,7 +44,7 @@ async def clear_database(
         return
     async with db.session_context(begin_transaction=True) as session:
         # worker pool has a circular dependency on pool queue; delete it first
-        await session.execute(db.WorkerPool.__table__.delete())
+        await session.execute(db.WorkPool.__table__.delete())
         for table in reversed(db.Base.metadata.sorted_tables):
             await session.execute(table.delete())
 

--- a/src/prefect/orion/api/admin.py
+++ b/src/prefect/orion/api/admin.py
@@ -43,7 +43,7 @@ async def clear_database(
         response.status_code = status.HTTP_400_BAD_REQUEST
         return
     async with db.session_context(begin_transaction=True) as session:
-        # worker pool has a circular dependency on pool queue; delete it first
+        # work pool has a circular dependency on pool queue; delete it first
         await session.execute(db.WorkPool.__table__.delete())
         for table in reversed(db.Base.metadata.sorted_tables):
             await session.execute(table.delete())

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -44,7 +44,7 @@ async def create_deployment(
         )
         if deployment.work_pool_name and deployment.work_pool_queue_name:
             # If a specific pool name/queue name combination was provided, get the
-            # ID for that worker pool queue.
+            # ID for that work pool queue.
             deployment_dict[
                 "work_pool_queue_id"
             ] = await worker_lookups._get_work_pool_queue_id_from_name(
@@ -54,7 +54,7 @@ async def create_deployment(
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
-            # worker pool queue.
+            # work pool queue.
             deployment_dict[
                 "work_pool_queue_id"
             ] = await worker_lookups._get_default_work_pool_queue_id_from_work_pool_name(

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -40,26 +40,26 @@ async def create_deployment(
     async with db.session_context(begin_transaction=True) as session:
         # hydrate the input model into a full model
         deployment_dict = deployment.dict(
-            exclude={"worker_pool_name", "worker_pool_queue_name"}
+            exclude={"work_pool_name", "work_pool_queue_name"}
         )
-        if deployment.worker_pool_name and deployment.worker_pool_queue_name:
+        if deployment.work_pool_name and deployment.work_pool_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that worker pool queue.
             deployment_dict[
-                "worker_pool_queue_id"
-            ] = await worker_lookups._get_worker_pool_queue_id_from_name(
+                "work_pool_queue_id"
+            ] = await worker_lookups._get_work_pool_queue_id_from_name(
                 session=session,
-                worker_pool_name=deployment.worker_pool_name,
-                worker_pool_queue_name=deployment.worker_pool_queue_name,
+                work_pool_name=deployment.work_pool_name,
+                work_pool_queue_name=deployment.work_pool_queue_name,
             )
-        elif deployment.worker_pool_name:
+        elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
             # worker pool queue.
             deployment_dict[
-                "worker_pool_queue_id"
-            ] = await worker_lookups._get_default_worker_pool_queue_id_from_worker_pool_name(
+                "work_pool_queue_id"
+            ] = await worker_lookups._get_default_work_pool_queue_id_from_work_pool_name(
                 session=session,
-                worker_pool_name=deployment.worker_pool_name,
+                work_pool_name=deployment.work_pool_name,
             )
 
         deployment = schemas.core.Deployment(**deployment_dict)
@@ -163,8 +163,8 @@ async def read_deployments(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
-    worker_pools: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
+    work_pool_queues: schemas.filters.WorkPoolQueueFilter = None,
     sort: schemas.sorting.DeploymentSort = Body(
         schemas.sorting.DeploymentSort.NAME_ASC
     ),
@@ -183,8 +183,8 @@ async def read_deployments(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            worker_pool_filter=worker_pools,
-            worker_pool_queue_filter=worker_pool_queues,
+            work_pool_filter=work_pools,
+            work_pool_queue_filter=work_pool_queues,
         )
         return [
             schemas.responses.DeploymentResponse.from_orm(orm_deployment=deployment)
@@ -198,8 +198,8 @@ async def count_deployments(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
-    worker_pools: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
+    work_pool_queues: schemas.filters.WorkPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> int:
     """
@@ -212,8 +212,8 @@ async def count_deployments(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            worker_pool_filter=worker_pools,
-            worker_pool_queue_filter=worker_pool_queues,
+            work_pool_filter=work_pools,
+            work_pool_queue_filter=work_pool_queues,
         )
 
 
@@ -371,7 +371,7 @@ async def create_flow_run_from_deployment(
                 or deployment.infrastructure_document_id
             ),
             work_queue_name=deployment.work_queue_name,
-            worker_pool_queue_id=deployment.worker_pool_queue_id,
+            work_pool_queue_id=deployment.work_pool_queue_id,
         )
 
         if not flow_run.state:

--- a/src/prefect/orion/api/flow_runs.py
+++ b/src/prefect/orion/api/flow_runs.py
@@ -91,8 +91,8 @@ async def count_flow_runs(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
-    worker_pools: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
+    work_pool_queues: schemas.filters.WorkPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> int:
     """
@@ -105,8 +105,8 @@ async def count_flow_runs(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            worker_pool_filter=worker_pools,
-            worker_pool_queue_filter=worker_pool_queues,
+            work_pool_filter=work_pools,
+            work_pool_queue_filter=work_pool_queues,
         )
 
 
@@ -250,8 +250,8 @@ async def read_flow_runs(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
-    worker_pools: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queues: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
+    work_pool_queues: schemas.filters.WorkPoolQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.responses.FlowRunResponse]:
     """
@@ -264,8 +264,8 @@ async def read_flow_runs(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            worker_pool_filter=worker_pools,
-            worker_pool_queue_filter=worker_pool_queues,
+            work_pool_filter=work_pools,
+            work_pool_queue_filter=work_pool_queues,
             offset=offset,
             limit=limit,
             sort=sort,

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -24,7 +24,7 @@ def error_404_if_workers_not_enabled():
 
 
 router = OrionRouter(
-    prefix="/experimental/worker_pools",
+    prefix="/experimental/work_pools",
     tags=["Worker Pools"],
     dependencies=[Depends(error_404_if_workers_not_enabled)],
 )
@@ -40,66 +40,66 @@ router = OrionRouter(
 
 
 class WorkerLookups:
-    async def _get_worker_pool_id_from_name(
-        self, session: AsyncSession, worker_pool_name: str
+    async def _get_work_pool_id_from_name(
+        self, session: AsyncSession, work_pool_name: str
     ) -> UUID:
         """
         Given a worker pool name, return its ID. Used for translating
         user-facing APIs (which are name-based) to internal ones (which are
         id-based).
         """
-        worker_pool = await models.workers.read_worker_pool_by_name(
+        work_pool = await models.workers.read_work_pool_by_name(
             session=session,
-            worker_pool_name=worker_pool_name,
+            work_pool_name=work_pool_name,
         )
-        if not worker_pool:
+        if not work_pool:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Worker pool "{worker_pool_name}" not found.',
+                detail=f'Worker pool "{work_pool_name}" not found.',
             )
 
-        return worker_pool.id
+        return work_pool.id
 
-    async def _get_default_worker_pool_queue_id_from_worker_pool_name(
-        self, session: AsyncSession, worker_pool_name: str
+    async def _get_default_work_pool_queue_id_from_work_pool_name(
+        self, session: AsyncSession, work_pool_name: str
     ):
         """
         Given a worker pool name, return the ID of its default queue.
         Used for translating user-facing APIs (which are name-based)
         to internal ones (which are id-based).
         """
-        worker_pool = await models.workers.read_worker_pool_by_name(
+        work_pool = await models.workers.read_work_pool_by_name(
             session=session,
-            worker_pool_name=worker_pool_name,
+            work_pool_name=work_pool_name,
         )
-        if not worker_pool:
+        if not work_pool:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Worker pool "{worker_pool_name}" not found.',
+                detail=f'Worker pool "{work_pool_name}" not found.',
             )
 
-        return worker_pool.default_queue_id
+        return work_pool.default_queue_id
 
-    async def _get_worker_pool_queue_id_from_name(
-        self, session: AsyncSession, worker_pool_name: str, worker_pool_queue_name: str
+    async def _get_work_pool_queue_id_from_name(
+        self, session: AsyncSession, work_pool_name: str, work_pool_queue_name: str
     ) -> UUID:
         """
         Given a worker pool name and worker pool queue name, return the ID of the
         queue. Used for translating user-facing APIs (which are name-based) to
         internal ones (which are id-based).
         """
-        worker_pool_queue = await models.workers.read_worker_pool_queue_by_name(
+        work_pool_queue = await models.workers.read_work_pool_queue_by_name(
             session=session,
-            worker_pool_name=worker_pool_name,
-            worker_pool_queue_name=worker_pool_queue_name,
+            work_pool_name=work_pool_name,
+            work_pool_queue_name=work_pool_queue_name,
         )
-        if not worker_pool_queue:
+        if not work_pool_queue:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Worker queue '{worker_pool_name}/{worker_pool_queue_name}' not found.",
+                detail=f"Worker queue '{work_pool_name}/{work_pool_queue_name}' not found.",
             )
 
-        return worker_pool_queue.id
+        return work_pool_queue.id
 
 
 # -----------------------------------------------------
@@ -112,16 +112,16 @@ class WorkerLookups:
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
-async def create_worker_pool(
-    worker_pool: schemas.actions.WorkerPoolCreate,
+async def create_work_pool(
+    work_pool: schemas.actions.WorkPoolCreate,
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkerPool:
+) -> schemas.core.WorkPool:
     """
     Creates a new worker pool. If a worker pool with the same
     name already exists, an error will be raised.
     """
 
-    if worker_pool.name.lower().startswith("prefect"):
+    if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Worker pools starting with 'Prefect' are reserved for internal use.",
@@ -129,8 +129,8 @@ async def create_worker_pool(
 
     try:
         async with db.session_context(begin_transaction=True) as session:
-            model = await models.workers.create_worker_pool(
-                session=session, worker_pool=worker_pool, db=db
+            model = await models.workers.create_work_pool(
+                session=session, work_pool=work_pool, db=db
             )
     except sa.exc.IntegrityError:
         raise HTTPException(
@@ -142,48 +142,48 @@ async def create_worker_pool(
 
 
 @router.get("/{name}")
-async def read_worker_pool(
-    worker_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+async def read_work_pool(
+    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkerPool:
+) -> schemas.core.WorkPool:
     """
     Read a worker by name
     """
 
     async with db.session_context() as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
-        return await models.workers.read_worker_pool(
-            session=session, worker_pool_id=worker_pool_id, db=db
+        return await models.workers.read_work_pool(
+            session=session, work_pool_id=work_pool_id, db=db
         )
 
 
 @router.post("/filter")
-async def read_worker_pools(
-    worker_pools: schemas.filters.WorkerPoolFilter = None,
+async def read_work_pools(
+    work_pools: schemas.filters.WorkPoolFilter = None,
     limit: int = dependencies.LimitBody(),
     offset: int = Body(0, ge=0),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> List[schemas.core.WorkerPool]:
+) -> List[schemas.core.WorkPool]:
     """
     Read multiple workers
     """
     async with db.session_context() as session:
-        return await models.workers.read_worker_pools(
+        return await models.workers.read_work_pools(
             db=db,
             session=session,
-            worker_pool_filter=worker_pools,
+            work_pool_filter=work_pools,
             offset=offset,
             limit=limit,
         )
 
 
 @router.patch("/{name}", status_code=status.HTTP_204_NO_CONTENT)
-async def update_worker_pool(
-    worker_pool: schemas.actions.WorkerPoolUpdate,
-    worker_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+async def update_work_pool(
+    work_pool: schemas.actions.WorkPoolUpdate,
+    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
@@ -192,8 +192,8 @@ async def update_worker_pool(
     """
 
     # Reserved pools can only updated pause / concurrency
-    update_values = worker_pool.dict(exclude_unset=True)
-    if worker_pool_name.lower().startswith("prefect") and (
+    update_values = work_pool.dict(exclude_unset=True)
+    if work_pool_name.lower().startswith("prefect") and (
         set(update_values).difference({"is_paused", "concurrency_limit"})
     ):
         raise HTTPException(
@@ -203,20 +203,20 @@ async def update_worker_pool(
         )
 
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
-        await models.workers.update_worker_pool(
+        await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pool_id,
-            worker_pool=worker_pool,
+            work_pool_id=work_pool_id,
+            work_pool=work_pool,
             db=db,
         )
 
 
 @router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_worker_pool(
-    worker_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+async def delete_work_pool(
+    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
@@ -224,26 +224,26 @@ async def delete_worker_pool(
     Delete a worker pool
     """
 
-    if worker_pool_name.lower().startswith("prefect"):
+    if work_pool_name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Worker pools starting with 'Prefect' are reserved for internal use and can not be deleted.",
         )
 
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
 
-        await models.workers.delete_worker_pool(
-            session=session, worker_pool_id=worker_pool_id, db=db
+        await models.workers.delete_work_pool(
+            session=session, work_pool_id=work_pool_id, db=db
         )
 
 
 @router.post("/{name}/get_scheduled_flow_runs")
 async def get_scheduled_flow_runs(
-    worker_pool_name: str = Path(..., description="The worker pool name", alias="name"),
-    worker_pool_queue_names: List[str] = Body(
+    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+    work_pool_queue_names: List[str] = Body(
         None, description="The names of worker pool queues"
     ),
     scheduled_before: DateTimeTZ = Body(
@@ -260,28 +260,28 @@ async def get_scheduled_flow_runs(
     Load scheduled runs for a worker
     """
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
 
-        if worker_pool_queue_names is None:
-            worker_pool_queue_ids = None
+        if work_pool_queue_names is None:
+            work_pool_queue_ids = None
         else:
-            worker_pool_queue_ids = []
-            for qn in worker_pool_queue_names:
-                worker_pool_queue_ids.append(
-                    await worker_lookups._get_worker_pool_queue_id_from_name(
+            work_pool_queue_ids = []
+            for qn in work_pool_queue_names:
+                work_pool_queue_ids.append(
+                    await worker_lookups._get_work_pool_queue_id_from_name(
                         session=session,
-                        worker_pool_name=worker_pool_name,
-                        worker_pool_queue_name=qn,
+                        work_pool_name=work_pool_name,
+                        work_pool_queue_name=qn,
                     )
                 )
 
         queue_response = await models.workers.get_scheduled_flow_runs(
             session=session,
             db=db,
-            worker_pool_ids=[worker_pool_id],
-            worker_pool_queue_ids=worker_pool_queue_ids,
+            work_pool_ids=[work_pool_id],
+            work_pool_queue_ids=work_pool_queue_ids,
             scheduled_before=scheduled_before,
             scheduled_after=scheduled_after,
             limit=limit,
@@ -299,13 +299,13 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 
 
-@router.post("/{worker_pool_name}/queues", status_code=status.HTTP_201_CREATED)
-async def create_worker_pool_queue(
-    worker_pool_queue: schemas.actions.WorkerPoolQueueCreate,
-    worker_pool_name: str = Path(..., description="The worker pool name"),
+@router.post("/{work_pool_name}/queues", status_code=status.HTTP_201_CREATED)
+async def create_work_pool_queue(
+    work_pool_queue: schemas.actions.WorkPoolQueueCreate,
+    work_pool_name: str = Path(..., description="The worker pool name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkerPoolQueue:
+) -> schemas.core.WorkPoolQueue:
     """
     Creates a new worker pool queue. If a worker pool queue with the same
     name already exists, an error will be raised.
@@ -313,15 +313,15 @@ async def create_worker_pool_queue(
 
     try:
         async with db.session_context(begin_transaction=True) as session:
-            worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
+            work_pool_id = await worker_lookups._get_work_pool_id_from_name(
                 session=session,
-                worker_pool_name=worker_pool_name,
+                work_pool_name=work_pool_name,
             )
 
-            model = await models.workers.create_worker_pool_queue(
+            model = await models.workers.create_work_pool_queue(
                 session=session,
-                worker_pool_id=worker_pool_id,
-                worker_pool_queue=worker_pool_queue,
+                work_pool_id=work_pool_id,
+                work_pool_queue=work_pool_queue,
                 db=db,
             )
     except sa.exc.IntegrityError:
@@ -333,57 +333,57 @@ async def create_worker_pool_queue(
     return model
 
 
-@router.get("/{worker_pool_name}/queues/{name}")
-async def read_worker_pool_queue(
-    worker_pool_name: str = Path(..., description="The worker pool name"),
-    worker_pool_queue_name: str = Path(
+@router.get("/{work_pool_name}/queues/{name}")
+async def read_work_pool_queue(
+    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_queue_name: str = Path(
         ..., description="The worker pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkerPoolQueue:
+) -> schemas.core.WorkPoolQueue:
     """
     Read a worker pool queue
     """
 
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_queue_id = await worker_lookups._get_worker_pool_queue_id_from_name(
+        work_pool_queue_id = await worker_lookups._get_work_pool_queue_id_from_name(
             session=session,
-            worker_pool_name=worker_pool_name,
-            worker_pool_queue_name=worker_pool_queue_name,
+            work_pool_name=work_pool_name,
+            work_pool_queue_name=work_pool_queue_name,
         )
 
-        return await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue_id, db=db
+        return await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue_id, db=db
         )
 
 
-@router.get("/{worker_pool_name}/queues")
-async def read_worker_pool_queues(
-    worker_pool_name: str = Path(..., description="The worker pool name"),
+@router.get("/{work_pool_name}/queues")
+async def read_work_pool_queues(
+    work_pool_name: str = Path(..., description="The worker pool name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> List[schemas.core.WorkerPoolQueue]:
+) -> List[schemas.core.WorkPoolQueue]:
     """
     Read all worker pool queues
     """
     async with db.session_context() as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
             session=session,
-            worker_pool_name=worker_pool_name,
+            work_pool_name=work_pool_name,
         )
-        return await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool_id, db=db
+        return await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool_id, db=db
         )
 
 
 @router.patch(
-    "/{worker_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
+    "/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
 )
-async def update_worker_pool_queue(
-    worker_pool_queue: schemas.actions.WorkerPoolQueueUpdate,
-    worker_pool_name: str = Path(..., description="The worker pool name"),
-    worker_pool_queue_name: str = Path(
+async def update_work_pool_queue(
+    work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
+    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_queue_name: str = Path(
         ..., description="The worker pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
@@ -394,26 +394,26 @@ async def update_worker_pool_queue(
     """
 
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_queue_id = await worker_lookups._get_worker_pool_queue_id_from_name(
-            worker_pool_name=worker_pool_name,
-            worker_pool_queue_name=worker_pool_queue_name,
+        work_pool_queue_id = await worker_lookups._get_work_pool_queue_id_from_name(
+            work_pool_name=work_pool_name,
+            work_pool_queue_name=work_pool_queue_name,
             session=session,
         )
 
-        await models.workers.update_worker_pool_queue(
+        await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queue_id,
-            worker_pool_queue=worker_pool_queue,
+            work_pool_queue_id=work_pool_queue_id,
+            work_pool_queue=work_pool_queue,
             db=db,
         )
 
 
 @router.delete(
-    "/{worker_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
+    "/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
 )
-async def delete_worker_pool_queue(
-    worker_pool_name: str = Path(..., description="The worker pool name"),
-    worker_pool_queue_name: str = Path(
+async def delete_work_pool_queue(
+    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_queue_name: str = Path(
         ..., description="The worker pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
@@ -424,14 +424,14 @@ async def delete_worker_pool_queue(
     """
 
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_queue_id = await worker_lookups._get_worker_pool_queue_id_from_name(
+        work_pool_queue_id = await worker_lookups._get_work_pool_queue_id_from_name(
             session=session,
-            worker_pool_name=worker_pool_name,
-            worker_pool_queue_name=worker_pool_queue_name,
+            work_pool_name=work_pool_name,
+            work_pool_queue_name=work_pool_queue_name,
         )
 
-        await models.workers.delete_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue_id, db=db
+        await models.workers.delete_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue_id, db=db
         )
 
 
@@ -445,31 +445,31 @@ async def delete_worker_pool_queue(
 
 
 @router.post(
-    "/{worker_pool_name}/workers/heartbeat",
+    "/{work_pool_name}/workers/heartbeat",
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def worker_heartbeat(
-    worker_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The worker pool name"),
     name: str = Body(..., description="The worker process name", embed=True),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     async with db.session_context(begin_transaction=True) as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
 
         await models.workers.worker_heartbeat(
             session=session,
-            worker_pool_id=worker_pool_id,
+            work_pool_id=work_pool_id,
             worker_name=name,
             db=db,
         )
 
 
-@router.post("/{worker_pool_name}/workers/filter")
+@router.post("/{work_pool_name}/workers/filter")
 async def read_workers(
-    worker_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The worker pool name"),
     workers: schemas.filters.WorkerFilter = None,
     limit: int = dependencies.LimitBody(),
     offset: int = Body(0, ge=0),
@@ -480,12 +480,12 @@ async def read_workers(
     Read all worker processes
     """
     async with db.session_context() as session:
-        worker_pool_id = await worker_lookups._get_worker_pool_id_from_name(
-            session=session, worker_pool_name=worker_pool_name
+        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
+            session=session, work_pool_name=work_pool_name
         )
         return await models.workers.read_workers(
             session=session,
-            worker_pool_id=worker_pool_id,
+            work_pool_id=work_pool_id,
             worker_filter=workers,
             limit=limit,
             offset=offset,

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -377,9 +377,7 @@ async def read_work_pool_queues(
         )
 
 
-@router.patch(
-    "/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.patch("/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT)
 async def update_work_pool_queue(
     work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
     work_pool_name: str = Path(..., description="The worker pool name"),

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -44,7 +44,7 @@ class WorkerLookups:
         self, session: AsyncSession, work_pool_name: str
     ) -> UUID:
         """
-        Given a worker pool name, return its ID. Used for translating
+        Given a work pool name, return its ID. Used for translating
         user-facing APIs (which are name-based) to internal ones (which are
         id-based).
         """
@@ -64,7 +64,7 @@ class WorkerLookups:
         self, session: AsyncSession, work_pool_name: str
     ):
         """
-        Given a worker pool name, return the ID of its default queue.
+        Given a work pool name, return the ID of its default queue.
         Used for translating user-facing APIs (which are name-based)
         to internal ones (which are id-based).
         """
@@ -84,7 +84,7 @@ class WorkerLookups:
         self, session: AsyncSession, work_pool_name: str, work_pool_queue_name: str
     ) -> UUID:
         """
-        Given a worker pool name and worker pool queue name, return the ID of the
+        Given a work pool name and work pool queue name, return the ID of the
         queue. Used for translating user-facing APIs (which are name-based) to
         internal ones (which are id-based).
         """
@@ -117,7 +117,7 @@ async def create_work_pool(
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPool:
     """
-    Creates a new worker pool. If a worker pool with the same
+    Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
     """
 
@@ -143,7 +143,7 @@ async def create_work_pool(
 
 @router.get("/{name}")
 async def read_work_pool(
-    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+    work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPool:
@@ -183,12 +183,12 @@ async def read_work_pools(
 @router.patch("/{name}", status_code=status.HTTP_204_NO_CONTENT)
 async def update_work_pool(
     work_pool: schemas.actions.WorkPoolUpdate,
-    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+    work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     """
-    Update a worker pool
+    Update a work pool
     """
 
     # Reserved pools can only updated pause / concurrency
@@ -216,12 +216,12 @@ async def update_work_pool(
 
 @router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_work_pool(
-    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+    work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     """
-    Delete a worker pool
+    Delete a work pool
     """
 
     if work_pool_name.lower().startswith("prefect"):
@@ -242,9 +242,9 @@ async def delete_work_pool(
 
 @router.post("/{name}/get_scheduled_flow_runs")
 async def get_scheduled_flow_runs(
-    work_pool_name: str = Path(..., description="The worker pool name", alias="name"),
+    work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     work_pool_queue_names: List[str] = Body(
-        None, description="The names of worker pool queues"
+        None, description="The names of work pool queues"
     ),
     scheduled_before: DateTimeTZ = Body(
         None, description="The maximum time to look for scheduled flow runs"
@@ -302,12 +302,12 @@ async def get_scheduled_flow_runs(
 @router.post("/{work_pool_name}/queues", status_code=status.HTTP_201_CREATED)
 async def create_work_pool_queue(
     work_pool_queue: schemas.actions.WorkPoolQueueCreate,
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPoolQueue:
     """
-    Creates a new worker pool queue. If a worker pool queue with the same
+    Creates a new work pool queue. If a work pool queue with the same
     name already exists, an error will be raised.
     """
 
@@ -335,15 +335,15 @@ async def create_work_pool_queue(
 
 @router.get("/{work_pool_name}/queues/{name}")
 async def read_work_pool_queue(
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     work_pool_queue_name: str = Path(
-        ..., description="The worker pool queue name", alias="name"
+        ..., description="The work pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPoolQueue:
     """
-    Read a worker pool queue
+    Read a work pool queue
     """
 
     async with db.session_context(begin_transaction=True) as session:
@@ -360,12 +360,12 @@ async def read_work_pool_queue(
 
 @router.get("/{work_pool_name}/queues")
 async def read_work_pool_queues(
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.WorkPoolQueue]:
     """
-    Read all worker pool queues
+    Read all work pool queues
     """
     async with db.session_context() as session:
         work_pool_id = await worker_lookups._get_work_pool_id_from_name(
@@ -380,15 +380,15 @@ async def read_work_pool_queues(
 @router.patch("/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT)
 async def update_work_pool_queue(
     work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     work_pool_queue_name: str = Path(
-        ..., description="The worker pool queue name", alias="name"
+        ..., description="The work pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     """
-    Update a worker pool queue
+    Update a work pool queue
     """
 
     async with db.session_context(begin_transaction=True) as session:
@@ -410,15 +410,15 @@ async def update_work_pool_queue(
     "/{work_pool_name}/queues/{name}", status_code=status.HTTP_204_NO_CONTENT
 )
 async def delete_work_pool_queue(
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     work_pool_queue_name: str = Path(
-        ..., description="The worker pool queue name", alias="name"
+        ..., description="The work pool queue name", alias="name"
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     """
-    Delete a worker pool queue
+    Delete a work pool queue
     """
 
     async with db.session_context(begin_transaction=True) as session:
@@ -447,7 +447,7 @@ async def delete_work_pool_queue(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def worker_heartbeat(
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     name: str = Body(..., description="The worker process name", embed=True),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
@@ -467,7 +467,7 @@ async def worker_heartbeat(
 
 @router.post("/{work_pool_name}/workers/filter")
 async def read_workers(
-    work_pool_name: str = Path(..., description="The worker pool name"),
+    work_pool_name: str = Path(..., description="The work pool name"),
     workers: schemas.filters.WorkerFilter = None,
     limit: int = dependencies.LimitBody(),
     offset: int = Body(0, ge=0),

--- a/src/prefect/orion/database/interface.py
+++ b/src/prefect/orion/database/interface.py
@@ -150,12 +150,12 @@ class OrionDBInterface(metaclass=DBSingleton):
 
     @property
     def WorkPool(self):
-        """A worker pool orm model"""
+        """A work pool orm model"""
         return self.orm.WorkPool
 
     @property
     def WorkPoolQueue(self):
-        """A worker pool queue orm model"""
+        """A work pool queue orm model"""
         return self.orm.WorkPoolQueue
 
     @property

--- a/src/prefect/orion/database/interface.py
+++ b/src/prefect/orion/database/interface.py
@@ -149,14 +149,14 @@ class OrionDBInterface(metaclass=DBSingleton):
         return self.orm.SavedSearch
 
     @property
-    def WorkerPool(self):
+    def WorkPool(self):
         """A worker pool orm model"""
-        return self.orm.WorkerPool
+        return self.orm.WorkPool
 
     @property
-    def WorkerPoolQueue(self):
+    def WorkPoolQueue(self):
         """A worker pool queue orm model"""
-        return self.orm.WorkerPoolQueue
+        return self.orm.WorkPoolQueue
 
     @property
     def Worker(self):

--- a/src/prefect/orion/database/migrations/versions/postgresql/2023_01_08_180142_d481d5058a19_rename_worker_pools_to_work_pools.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2023_01_08_180142_d481d5058a19_rename_worker_pools_to_work_pools.py
@@ -1,0 +1,461 @@
+"""Rename Worker Pools to Work Pools
+
+Revision ID: d481d5058a19
+Revises: f7587d6c5776
+Create Date: 2023-01-08 18:01:42.559990
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import prefect
+
+
+# revision identifiers, used by Alembic.
+revision = "d481d5058a19"
+down_revision = "f7587d6c5776"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # delete old worker table structures
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_column("worker_pool_queue_id")
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_column("worker_pool_queue_id")
+    with op.batch_alter_table("worker_pool", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_worker_pool__default_queue_id__worker_pool_queue")
+    op.drop_table("worker_pool_queue")
+    op.drop_table("worker")
+    op.drop_table("worker_pool")
+
+    op.create_table(
+        "work_pool",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("type", sa.String(), nullable=True),
+        sa.Column(
+            "base_job_template",
+            prefect.orion.utilities.database.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column(
+            "default_queue_id", prefect.orion.utilities.database.UUID(), nullable=True
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_work_pool")),
+        sa.UniqueConstraint("name", name=op.f("uq_work_pool__name")),
+    )
+    op.create_index(
+        op.f("ix_work_pool__updated"), "work_pool", ["updated"], unique=False
+    )
+    op.create_index(op.f("ix_work_pool__type"), "work_pool", ["type"], unique=False)
+
+    op.create_table(
+        "worker",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "last_heartbeat_time",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "work_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_pool_id"],
+            ["work_pool.id"],
+            name=op.f("fk_worker__work_pool_id__work_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker")),
+        sa.UniqueConstraint(
+            "work_pool_id",
+            "name",
+            name=op.f("uq_worker__work_pool_id_name"),
+        ),
+    )
+    op.create_index(op.f("ix_worker__updated"), "worker", ["updated"], unique=False)
+    op.create_index(
+        op.f("ix_worker__work_pool_id"),
+        "worker",
+        ["work_pool_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_worker__work_pool_id_last_heartbeat_time"),
+        "worker",
+        ["work_pool_id", "last_heartbeat_time"],
+        unique=False,
+    )
+
+    op.create_table(
+        "work_pool_queue",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column(
+            "work_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_pool_id"],
+            ["work_pool.id"],
+            name=op.f("fk_work_pool_queue__work_pool_id__work_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_work_pool_queue")),
+        sa.UniqueConstraint(
+            "work_pool_id",
+            "name",
+            name=op.f("uq_work_pool_queue__work_pool_id_name"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_work_pool_queue__updated"),
+        "work_pool_queue",
+        ["updated"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_work_pool_queue__work_pool_id_priority"),
+        "work_pool_queue",
+        ["work_pool_id", "priority"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_work_pool_queue__work_pool_id"),
+        "work_pool_queue",
+        ["work_pool_id"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            batch_op.f("fk_work_pool__default_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["default_queue_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "work_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_deployment__work_pool_queue_id"),
+            ["work_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__work_pool_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["work_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "work_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__work_pool_queue_id"),
+            ["work_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_flow_run__work_pool_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["work_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_column("work_pool_queue_id")
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_column("work_pool_queue_id")
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_work_pool__default_queue_id__work_pool_queue")
+    op.drop_table("work_pool_queue")
+    op.drop_table("worker")
+    op.drop_table("work_pool")
+
+    # recreate old table structure
+    op.create_table(
+        "worker_pool",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("type", sa.String(), nullable=True),
+        sa.Column(
+            "base_job_template",
+            prefect.orion.utilities.database.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column(
+            "default_queue_id", prefect.orion.utilities.database.UUID(), nullable=True
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker_pool")),
+        sa.UniqueConstraint("name", name=op.f("uq_worker_pool__name")),
+    )
+    op.create_index(
+        op.f("ix_worker_pool__updated"), "worker_pool", ["updated"], unique=False
+    )
+    op.create_index(op.f("ix_worker_pool__type"), "worker_pool", ["type"], unique=False)
+
+    op.create_table(
+        "worker",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "last_heartbeat_time",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "worker_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["worker_pool_id"],
+            ["worker_pool.id"],
+            name=op.f("fk_worker__worker_pool_id__worker_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker")),
+        sa.UniqueConstraint(
+            "worker_pool_id",
+            "name",
+            name=op.f("uq_worker__worker_pool_id_name"),
+        ),
+    )
+    op.create_index(op.f("ix_worker__updated"), "worker", ["updated"], unique=False)
+    op.create_index(
+        op.f("ix_worker__worker_pool_id"),
+        "worker",
+        ["worker_pool_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_worker__worker_pool_id_last_heartbeat_time"),
+        "worker",
+        ["worker_pool_id", "last_heartbeat_time"],
+        unique=False,
+    )
+
+    op.create_table(
+        "worker_pool_queue",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text("(GEN_RANDOM_UUID())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column(
+            "worker_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["worker_pool_id"],
+            ["worker_pool.id"],
+            name=op.f("fk_worker_pool_queue__worker_pool_id__worker_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker_pool_queue")),
+        sa.UniqueConstraint(
+            "worker_pool_id",
+            "name",
+            name=op.f("uq_worker_pool_queue__worker_pool_id_name"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_worker_pool_queue__updated"),
+        "worker_pool_queue",
+        ["updated"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_worker_pool_queue__worker_pool_id_priority"),
+        "worker_pool_queue",
+        ["worker_pool_id", "priority"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_worker_pool_queue__worker_pool_id"),
+        "worker_pool_queue",
+        ["worker_pool_id"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("worker_pool", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            batch_op.f("fk_worker_pool__default_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["default_queue_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "worker_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_deployment__worker_pool_queue_id"),
+            ["worker_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__worker_pool_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["worker_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "worker_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__worker_pool_queue_id"),
+            ["worker_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_flow_run__worker_pool_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["worker_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )

--- a/src/prefect/orion/database/migrations/versions/postgresql/2023_01_08_180142_d481d5058a19_rename_worker_pools_to_work_pools.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2023_01_08_180142_d481d5058a19_rename_worker_pools_to_work_pools.py
@@ -5,10 +5,10 @@ Revises: f7587d6c5776
 Create Date: 2023-01-08 18:01:42.559990
 
 """
-from alembic import op
 import sqlalchemy as sa
-import prefect
+from alembic import op
 
+import prefect
 
 # revision identifiers, used by Alembic.
 revision = "d481d5058a19"

--- a/src/prefect/orion/database/migrations/versions/sqlite/2023_01_08_175327_bb38729c471a_rename_worker_pools_to_work_pools.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2023_01_08_175327_bb38729c471a_rename_worker_pools_to_work_pools.py
@@ -1,0 +1,497 @@
+"""Rename Worker Pools to Work Pools
+
+Revision ID: bb38729c471a
+Revises: fe77ad0dda06
+Create Date: 2023-01-08 17:53:27.444733
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import prefect
+
+
+# revision identifiers, used by Alembic.
+revision = "bb38729c471a"
+down_revision = "fe77ad0dda06"
+branch_labels = None
+depends_on = None
+
+
+### NOTE ###
+# This upgrade is destructive for anyone who has created a worker
+###
+
+
+def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    ## first we reset to a clean, no-worker slate
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_index("ix_deployment__worker_pool_queue_id")
+        batch_op.drop_constraint(
+            "fk_deployment__worker_pool_queue_id__worker_pool_queue"
+        )
+        batch_op.drop_column("worker_pool_queue_id")
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_flow_run__worker_pool_queue_id")
+        batch_op.drop_constraint("fk_flow_run__worker_pool_queue_id__worker_pool_queue")
+        batch_op.drop_column("worker_pool_queue_id")
+
+    with op.batch_alter_table("worker_pool", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_worker_pool__default_queue_id__worker_pool_queue")
+    op.drop_table("worker_pool_queue")
+    op.drop_table("worker")
+    op.drop_table("worker_pool")
+
+    ## then we recreate all tables and relationships
+    op.create_table(
+        "work_pool",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("type", sa.String(), nullable=True),
+        sa.Column(
+            "base_job_template",
+            prefect.orion.utilities.database.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column(
+            "default_queue_id", prefect.orion.utilities.database.UUID(), nullable=True
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_work_pool")),
+        sa.UniqueConstraint("name", name=op.f("uq_work_pool__name")),
+    )
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_work_pool__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(batch_op.f("ix_work_pool__type"), ["type"], unique=False)
+
+    op.create_table(
+        "worker",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "last_heartbeat_time",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "work_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_pool_id"],
+            ["work_pool.id"],
+            name=op.f("fk_worker__work_pool_id__work_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker")),
+        sa.UniqueConstraint(
+            "work_pool_id",
+            "name",
+            name=op.f("uq_worker__work_pool_id_name"),
+        ),
+    )
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_worker__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker__work_pool_id_last_heartbeat_time"),
+            ["work_pool_id", "last_heartbeat_time"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker__work_pool_id"),
+            ["work_pool_id"],
+            unique=False,
+        )
+
+    op.create_table(
+        "work_pool_queue",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column(
+            "work_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_pool_id"],
+            ["work_pool.id"],
+            name=op.f("fk_work_pool_queue__work_pool_id__work_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_work_pool_queue")),
+        sa.UniqueConstraint(
+            "work_pool_id",
+            "name",
+            name=op.f("uq_work_pool_queue__work_pool_id_name"),
+        ),
+    )
+    with op.batch_alter_table("work_pool_queue", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_work_pool_queue__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_work_pool_queue__work_pool_id_priority"),
+            ["work_pool_id", "priority"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_work_pool_queue__work_pool_id"),
+            ["work_pool_id"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            batch_op.f("fk_work_pool__default_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["default_queue_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "work_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_deployment__work_pool_queue_id"),
+            ["work_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__work_pool_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["work_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "work_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__work_pool_queue_id"),
+            ["work_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_flow_run__work_pool_queue_id__work_pool_queue"),
+            "work_pool_queue",
+            ["work_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")
+
+
+def downgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_index("ix_deployment__work_pool_queue_id")
+        batch_op.drop_constraint("fk_deployment__work_pool_queue_id__work_pool_queue")
+        batch_op.drop_column("work_pool_queue_id")
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index("ix_flow_run__work_pool_queue_id")
+        batch_op.drop_constraint("fk_flow_run__work_pool_queue_id__work_pool_queue")
+        batch_op.drop_column("work_pool_queue_id")
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_work_pool__default_queue_id__work_pool_queue")
+    op.drop_table("work_pool_queue")
+    op.drop_table("worker")
+    op.drop_table("work_pool")
+
+    op.create_table(
+        "worker_pool",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("type", sa.String(), nullable=True),
+        sa.Column(
+            "base_job_template",
+            prefect.orion.utilities.database.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column(
+            "default_queue_id", prefect.orion.utilities.database.UUID(), nullable=True
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker_pool")),
+        sa.UniqueConstraint("name", name=op.f("uq_worker_pool__name")),
+    )
+    with op.batch_alter_table("worker_pool", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_worker_pool__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker_pool__type"), ["type"], unique=False
+        )
+
+    op.create_table(
+        "worker",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "last_heartbeat_time",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "worker_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["worker_pool_id"],
+            ["worker_pool.id"],
+            name=op.f("fk_worker__worker_pool_id__worker_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker")),
+        sa.UniqueConstraint(
+            "worker_pool_id",
+            "name",
+            name=op.f("uq_worker__worker_pool_id_name"),
+        ),
+    )
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_worker__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker__worker_pool_id_last_heartbeat_time"),
+            ["worker_pool_id", "last_heartbeat_time"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker__worker_pool_id"),
+            ["worker_pool_id"],
+            unique=False,
+        )
+
+    op.create_table(
+        "worker_pool_queue",
+        sa.Column(
+            "id",
+            prefect.orion.utilities.database.UUID(),
+            server_default=sa.text(
+                "(\n    (\n        lower(hex(randomblob(4)))\n        || '-'\n        || lower(hex(randomblob(2)))\n        || '-4'\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || substr('89ab',abs(random()) % 4 + 1, 1)\n        || substr(lower(hex(randomblob(2))),2)\n        || '-'\n        || lower(hex(randomblob(6)))\n    )\n    )"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            prefect.orion.utilities.database.Timestamp(timezone=True),
+            server_default=sa.text("(strftime('%Y-%m-%d %H:%M:%f000', 'now'))"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("is_paused", sa.Boolean(), server_default="0", nullable=False),
+        sa.Column("concurrency_limit", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column(
+            "worker_pool_id", prefect.orion.utilities.database.UUID(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["worker_pool_id"],
+            ["worker_pool.id"],
+            name=op.f("fk_worker_pool_queue__worker_pool_id__worker_pool"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_worker_pool_queue")),
+        sa.UniqueConstraint(
+            "worker_pool_id",
+            "name",
+            name=op.f("uq_worker_pool_queue__worker_pool_id_name"),
+        ),
+    )
+    with op.batch_alter_table("worker_pool_queue", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_worker_pool_queue__updated"), ["updated"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker_pool_queue__worker_pool_id_priority"),
+            ["worker_pool_id", "priority"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_worker_pool_queue__worker_pool_id"),
+            ["worker_pool_id"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("worker_pool", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            batch_op.f("fk_worker_pool__default_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["default_queue_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "worker_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_deployment__worker_pool_queue_id"),
+            ["worker_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__worker_pool_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["worker_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "worker_pool_queue_id",
+                prefect.orion.utilities.database.UUID(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_flow_run__worker_pool_queue_id"),
+            ["worker_pool_queue_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_flow_run__worker_pool_queue_id__worker_pool_queue"),
+            "worker_pool_queue",
+            ["worker_pool_queue_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    op.execute("PRAGMA foreign_keys=ON")

--- a/src/prefect/orion/database/migrations/versions/sqlite/2023_01_08_175327_bb38729c471a_rename_worker_pools_to_work_pools.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2023_01_08_175327_bb38729c471a_rename_worker_pools_to_work_pools.py
@@ -5,10 +5,10 @@ Revises: fe77ad0dda06
 Create Date: 2023-01-08 17:53:27.444733
 
 """
-from alembic import op
 import sqlalchemy as sa
-import prefect
+from alembic import op
 
+import prefect
 
 # revision identifiers, used by Alembic.
 revision = "bb38729c471a"

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -1191,8 +1191,8 @@ class BaseORMConfiguration(ABC):
         deployment_mixin: deployment orm mixin, combined with Base orm class
         saved_search_mixin: saved search orm mixin, combined with Base orm class
         log_mixin: log orm mixin, combined with Base orm class
-        work_pool_mixin: worker pool orm mixin, combined with Base orm class
-        work_pool_queue_mixin: worker pool queue orm mixin, combined with Base orm class
+        work_pool_mixin: work pool orm mixin, combined with Base orm class
+        work_pool_queue_mixin: work pool queue orm mixin, combined with Base orm class
         worker_mixin: worker orm mixin, combined with Base orm class
         concurrency_limit_mixin: concurrency limit orm mixin, combined with Base orm class
         block_type_mixin: block_type orm mixin, combined with Base orm class

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -409,10 +409,10 @@ class ORMFlowRun(ORMRun):
         )
 
     @declared_attr
-    def worker_pool_queue_id(cls):
+    def work_pool_queue_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("worker_pool_queue.id", ondelete="SET NULL"),
+            sa.ForeignKey("work_pool_queue.id", ondelete="SET NULL"),
             nullable=True,
             index=True,
         )
@@ -479,11 +479,11 @@ class ORMFlowRun(ORMRun):
         )
 
     @declared_attr
-    def worker_pool_queue(cls):
+    def work_pool_queue(cls):
         return sa.orm.relationship(
-            "WorkerPoolQueue",
+            "WorkPoolQueue",
             lazy="joined",
-            foreign_keys=[cls.worker_pool_queue_id],
+            foreign_keys=[cls.work_pool_queue_id],
         )
 
     @declared_attr
@@ -715,10 +715,10 @@ class ORMDeployment:
         )
 
     @declared_attr
-    def worker_pool_queue_id(cls):
+    def work_pool_queue_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("worker_pool_queue.id", ondelete="SET NULL"),
+            sa.ForeignKey("work_pool_queue.id", ondelete="SET NULL"),
             nullable=True,
             index=True,
         )
@@ -766,9 +766,9 @@ class ORMDeployment:
         return sa.orm.relationship("Flow", back_populates="deployments", lazy="raise")
 
     @declared_attr
-    def worker_pool_queue(cls):
+    def work_pool_queue(cls):
         return sa.orm.relationship(
-            "WorkerPoolQueue", lazy="joined", foreign_keys=[cls.worker_pool_queue_id]
+            "WorkPoolQueue", lazy="joined", foreign_keys=[cls.work_pool_queue_id]
         )
 
     @declared_attr
@@ -1030,7 +1030,7 @@ class ORMWorkQueue:
 
 
 @declarative_mixin
-class ORMWorkerPool:
+class ORMWorkPool:
     """SQLAlchemy model of an worker"""
 
     name = sa.Column(sa.String, nullable=False)
@@ -1050,17 +1050,17 @@ class ORMWorkerPool:
 
 
 @declarative_mixin
-class ORMWorkerPoolQueue:
+class ORMWorkPoolQueue:
     """SQLAlchemy model of a Worker Queue"""
 
     name = sa.Column(sa.String, nullable=False)
     description = sa.Column(sa.String)
 
     @declared_attr
-    def worker_pool_id(cls):
+    def work_pool_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("worker_pool.id", ondelete="cascade"),
+            sa.ForeignKey("work_pool.id", ondelete="cascade"),
             nullable=False,
             index=True,
         )
@@ -1074,14 +1074,14 @@ class ORMWorkerPoolQueue:
 
     @declared_attr
     def __table_args__(cls):
-        return (sa.UniqueConstraint("worker_pool_id", "name"),)
+        return (sa.UniqueConstraint("work_pool_id", "name"),)
 
     @declared_attr
-    def worker_pool(cls):
+    def work_pool(cls):
         return sa.orm.relationship(
-            "WorkerPool",
+            "WorkPool",
             lazy="joined",
-            foreign_keys=[cls.worker_pool_id],
+            foreign_keys=[cls.work_pool_id],
         )
 
 
@@ -1090,10 +1090,10 @@ class ORMWorker:
     """SQLAlchemy model of an worker"""
 
     @declared_attr
-    def worker_pool_id(cls):
+    def work_pool_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("worker_pool.id", ondelete="cascade"),
+            sa.ForeignKey("work_pool.id", ondelete="cascade"),
             nullable=False,
             index=True,
         )
@@ -1109,7 +1109,7 @@ class ORMWorker:
 
     @declared_attr
     def __table_args__(cls):
-        return (sa.UniqueConstraint("worker_pool_id", "name"),)
+        return (sa.UniqueConstraint("work_pool_id", "name"),)
 
 
 @declarative_mixin
@@ -1191,8 +1191,8 @@ class BaseORMConfiguration(ABC):
         deployment_mixin: deployment orm mixin, combined with Base orm class
         saved_search_mixin: saved search orm mixin, combined with Base orm class
         log_mixin: log orm mixin, combined with Base orm class
-        worker_pool_mixin: worker pool orm mixin, combined with Base orm class
-        worker_pool_queue_mixin: worker pool queue orm mixin, combined with Base orm class
+        work_pool_mixin: worker pool orm mixin, combined with Base orm class
+        work_pool_queue_mixin: worker pool queue orm mixin, combined with Base orm class
         worker_mixin: worker orm mixin, combined with Base orm class
         concurrency_limit_mixin: concurrency limit orm mixin, combined with Base orm class
         block_type_mixin: block_type orm mixin, combined with Base orm class
@@ -1218,8 +1218,8 @@ class BaseORMConfiguration(ABC):
         saved_search_mixin=ORMSavedSearch,
         log_mixin=ORMLog,
         concurrency_limit_mixin=ORMConcurrencyLimit,
-        worker_pool_mixin=ORMWorkerPool,
-        worker_pool_queue_mixin=ORMWorkerPoolQueue,
+        work_pool_mixin=ORMWorkPool,
+        work_pool_queue_mixin=ORMWorkPoolQueue,
         worker_mixin=ORMWorker,
         block_type_mixin=ORMBlockType,
         block_schema_mixin=ORMBlockSchema,
@@ -1268,8 +1268,8 @@ class BaseORMConfiguration(ABC):
             saved_search_mixin=saved_search_mixin,
             log_mixin=log_mixin,
             concurrency_limit_mixin=concurrency_limit_mixin,
-            worker_pool_mixin=worker_pool_mixin,
-            worker_pool_queue_mixin=worker_pool_queue_mixin,
+            work_pool_mixin=work_pool_mixin,
+            work_pool_queue_mixin=work_pool_queue_mixin,
             worker_mixin=worker_mixin,
             work_queue_mixin=work_queue_mixin,
             agent_mixin=agent_mixin,
@@ -1312,8 +1312,8 @@ class BaseORMConfiguration(ABC):
         saved_search_mixin=ORMSavedSearch,
         log_mixin=ORMLog,
         concurrency_limit_mixin=ORMConcurrencyLimit,
-        worker_pool_mixin=ORMWorkerPool,
-        worker_pool_queue_mixin=ORMWorkerPoolQueue,
+        work_pool_mixin=ORMWorkPool,
+        work_pool_queue_mixin=ORMWorkPoolQueue,
         worker_mixin=ORMWorker,
         block_type_mixin=ORMBlockType,
         block_schema_mixin=ORMBlockSchema,
@@ -1361,10 +1361,10 @@ class BaseORMConfiguration(ABC):
         class ConcurrencyLimit(concurrency_limit_mixin, self.Base):
             pass
 
-        class WorkerPool(worker_pool_mixin, self.Base):
+        class WorkPool(work_pool_mixin, self.Base):
             pass
 
-        class WorkerPoolQueue(worker_pool_queue_mixin, self.Base):
+        class WorkPoolQueue(work_pool_queue_mixin, self.Base):
             pass
 
         class Worker(worker_mixin, self.Base):
@@ -1410,8 +1410,8 @@ class BaseORMConfiguration(ABC):
         self.SavedSearch = SavedSearch
         self.Log = Log
         self.ConcurrencyLimit = ConcurrencyLimit
-        self.WorkerPool = WorkerPool
-        self.WorkerPoolQueue = WorkerPoolQueue
+        self.WorkPool = WorkPool
+        self.WorkPoolQueue = WorkPoolQueue
         self.Worker = Worker
         self.WorkQueue = WorkQueue
         self.Agent = Agent

--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -272,33 +272,33 @@ class BaseQueryComponents(ABC):
     # -------------------------------------------------------
 
     @abstractproperty
-    def _get_scheduled_flow_runs_from_worker_pool_template_path(self):
+    def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
         Template for the query to get scheduled flow runs from a worker pool
         """
 
-    async def get_scheduled_flow_runs_from_worker_pool(
+    async def get_scheduled_flow_runs_from_work_pool(
         self,
         session,
         db: "OrionDBInterface",
         limit: Optional[int] = None,
         worker_limit: Optional[int] = None,
         queue_limit: Optional[int] = None,
-        worker_pool_ids: Optional[List[UUID]] = None,
-        worker_pool_queue_ids: Optional[List[UUID]] = None,
+        work_pool_ids: Optional[List[UUID]] = None,
+        work_pool_queue_ids: Optional[List[UUID]] = None,
         scheduled_before: Optional[datetime.datetime] = None,
         scheduled_after: Optional[datetime.datetime] = None,
         respect_queue_priorities: bool = False,
     ) -> List[schemas.responses.WorkerFlowRunResponse]:
 
         template = jinja_env.get_template(
-            self._get_scheduled_flow_runs_from_worker_pool_template_path
+            self._get_scheduled_flow_runs_from_work_pool_template_path
         )
 
         raw_query = sa.text(
             template.render(
-                worker_pool_ids=worker_pool_ids,
-                worker_pool_queue_ids=worker_pool_queue_ids,
+                work_pool_ids=work_pool_ids,
+                work_pool_queue_ids=work_pool_queue_ids,
                 respect_queue_priorities=respect_queue_priorities,
                 scheduled_before=scheduled_before,
                 scheduled_after=scheduled_after,
@@ -318,24 +318,24 @@ class BaseQueryComponents(ABC):
             )
 
         # if worker pool IDs were provided, bind them
-        if worker_pool_ids:
-            assert all(isinstance(i, UUID) for i in worker_pool_ids)
+        if work_pool_ids:
+            assert all(isinstance(i, UUID) for i in work_pool_ids)
             bindparams.append(
                 sa.bindparam(
-                    "worker_pool_ids",
-                    worker_pool_ids,
+                    "work_pool_ids",
+                    work_pool_ids,
                     expanding=True,
                     type_=UUIDTypeDecorator,
                 )
             )
 
         # if worker pool queue IDs were provided, bind them
-        if worker_pool_queue_ids:
-            assert all(isinstance(i, UUID) for i in worker_pool_queue_ids)
+        if work_pool_queue_ids:
+            assert all(isinstance(i, UUID) for i in work_pool_queue_ids)
             bindparams.append(
                 sa.bindparam(
-                    "worker_pool_queue_ids",
-                    worker_pool_queue_ids,
+                    "work_pool_queue_ids",
+                    work_pool_queue_ids,
                     expanding=True,
                     type_=UUIDTypeDecorator,
                 )
@@ -350,8 +350,8 @@ class BaseQueryComponents(ABC):
 
         orm_query = (
             sa.select(
-                sa.column("run_worker_pool_id"),
-                sa.column("run_worker_pool_queue_id"),
+                sa.column("run_work_pool_id"),
+                sa.column("run_work_pool_queue_id"),
                 db.FlowRun,
             ).from_statement(query)
             # indicate that the state relationship isn't being loaded
@@ -362,8 +362,8 @@ class BaseQueryComponents(ABC):
 
         return [
             schemas.responses.WorkerFlowRunResponse(
-                worker_pool_id=r.run_worker_pool_id,
-                worker_pool_queue_id=r.run_worker_pool_queue_id,
+                work_pool_id=r.run_work_pool_id,
+                work_pool_queue_id=r.run_work_pool_queue_id,
                 flow_run=schemas.core.FlowRun.from_orm(r.FlowRun),
             )
             for r in result
@@ -661,7 +661,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         return result.fetchall()
 
     @property
-    def _get_scheduled_flow_runs_from_worker_pool_template_path(self):
+    def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
         Template for the query to get scheduled flow runs from a worker pool
         """
@@ -911,7 +911,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
     # -------------------------------------------------------
 
     @property
-    def _get_scheduled_flow_runs_from_worker_pool_template_path(self):
+    def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
         Template for the query to get scheduled flow runs from a worker pool
         """

--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -274,7 +274,7 @@ class BaseQueryComponents(ABC):
     @abstractproperty
     def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
-        Template for the query to get scheduled flow runs from a worker pool
+        Template for the query to get scheduled flow runs from a work pool
         """
 
     async def get_scheduled_flow_runs_from_work_pool(
@@ -317,7 +317,7 @@ class BaseQueryComponents(ABC):
                 sa.bindparam("scheduled_after", scheduled_after, type_=Timestamp)
             )
 
-        # if worker pool IDs were provided, bind them
+        # if work pool IDs were provided, bind them
         if work_pool_ids:
             assert all(isinstance(i, UUID) for i in work_pool_ids)
             bindparams.append(
@@ -329,7 +329,7 @@ class BaseQueryComponents(ABC):
                 )
             )
 
-        # if worker pool queue IDs were provided, bind them
+        # if work pool queue IDs were provided, bind them
         if work_pool_queue_ids:
             assert all(isinstance(i, UUID) for i in work_pool_queue_ids)
             bindparams.append(
@@ -663,7 +663,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
     @property
     def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
-        Template for the query to get scheduled flow runs from a worker pool
+        Template for the query to get scheduled flow runs from a work pool
         """
         return "postgres/get-runs-from-worker-queues.sql.jinja"
 
@@ -913,6 +913,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
     @property
     def _get_scheduled_flow_runs_from_work_pool_template_path(self):
         """
-        Template for the query to get scheduled flow runs from a worker pool
+        Template for the query to get scheduled flow runs from a work pool
         """
         return "sqlite/get-runs-from-worker-queues.sql.jinja"

--- a/src/prefect/orion/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/orion/database/sql/postgres/get-runs-from-worker-queues.sql.jinja
@@ -4,9 +4,9 @@ WITH pool_slots AS (
         wp.id,
         GREATEST (0, wp.concurrency_limit - COUNT(fr.id)) AS available_slots
     FROM
-        worker_pool wp
-        JOIN worker_pool_queue wq ON wq.worker_pool_id = wp.id
-        LEFT JOIN flow_run fr ON wq.id = fr.worker_pool_queue_id
+        work_pool wp
+        JOIN work_pool_queue wq ON wq.work_pool_id = wp.id
+        LEFT JOIN flow_run fr ON wq.id = fr.work_pool_queue_id
             AND fr.state_type IN ('RUNNING', 'PENDING')
     WHERE
         wp.is_paused IS FALSE
@@ -22,8 +22,8 @@ queue_slots AS (
         wq.id,
         GREATEST (0, wq.concurrency_limit - COUNT(fr.id)) AS available_slots
     FROM
-        worker_pool_queue wq
-        LEFT JOIN flow_run fr ON wq.id = fr.worker_pool_queue_id
+        work_pool_queue wq
+        LEFT JOIN flow_run fr ON wq.id = fr.work_pool_queue_id
             AND fr.state_type IN ('RUNNING', 'PENDING')
     WHERE
         wq.is_paused IS FALSE
@@ -34,11 +34,11 @@ queue_slots AS (
 
 -- get all flow runs that match criteria
 SELECT
-    wp.id AS run_worker_pool_id,
-    fr_outer.worker_pool_queue_id AS run_worker_pool_queue_id,
+    wp.id AS run_work_pool_id,
+    fr_outer.work_pool_queue_id AS run_work_pool_queue_id,
     fr_outer.*
 FROM
-    worker_pool wp
+    work_pool wp
     LEFT JOIN pool_slots ON wp.id = pool_slots.id
     
 
@@ -48,9 +48,9 @@ FROM
     CROSS JOIN LATERAL (
         SELECT
             fr_inner.*,
-            wq.priority as worker_pool_queue_priority
+            wq.priority as work_pool_queue_priority
         FROM
-            worker_pool_queue wq
+            work_pool_queue wq
             LEFT JOIN queue_slots ON wq.id = queue_slots.id
     
 
@@ -63,7 +63,7 @@ FROM
                 FROM
                     flow_run fr
                 WHERE
-                    fr.worker_pool_queue_id = wq.id
+                    fr.work_pool_queue_id = wq.id
                     AND fr.state_type = 'SCHEDULED'
                     {% if scheduled_after %}
                     AND fr.next_scheduled_start_time >= :scheduled_after
@@ -79,12 +79,12 @@ FROM
                 ) fr_inner
         
         WHERE
-            wq.worker_pool_id = wp.id
+            wq.work_pool_id = wp.id
             AND wq.is_paused IS FALSE 
 
-            {% if worker_pool_queue_ids %}
+            {% if work_pool_queue_ids %}
             -- optionally filter for specific worker pool queue IDs
-            AND wq.id IN :worker_pool_queue_ids
+            AND wq.id IN :work_pool_queue_ids
             {% endif %}
         
         ORDER BY 
@@ -99,14 +99,14 @@ FROM
 WHERE
     wp.is_paused IS FALSE 
 
-    {% if worker_pool_ids %}
+    {% if work_pool_ids %}
     -- optionally filter for specific worker pool IDs
-    AND wp.id IN :worker_pool_ids
+    AND wp.id IN :work_pool_ids
     {% endif %}
 
 ORDER BY 
 {% if respect_queue_priorities %}
-worker_pool_queue_priority ASC,
+work_pool_queue_priority ASC,
 {% endif %}
 next_scheduled_start_time ASC
 

--- a/src/prefect/orion/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
+++ b/src/prefect/orion/database/sql/sqlite/get-runs-from-worker-queues.sql.jinja
@@ -4,9 +4,9 @@ WITH worker_slots AS (
         wp.id,
         MAX(0, wp.concurrency_limit - count(fr.id)) AS available_slots
     FROM
-        worker_pool wp
-        JOIN worker_pool_queue wq ON wq.worker_pool_id = wp.id
-        LEFT JOIN flow_run fr ON wq.id = fr.worker_pool_queue_id
+        work_pool wp
+        JOIN work_pool_queue wq ON wq.work_pool_id = wp.id
+        LEFT JOIN flow_run fr ON wq.id = fr.work_pool_queue_id
             AND fr.state_type in('RUNNING', 'PENDING')
     WHERE
         wp.is_paused IS FALSE
@@ -22,8 +22,8 @@ queue_slots AS (
         wq.id,
         MAX(0, wq.concurrency_limit - count(fr.id)) AS available_slots
     FROM
-        worker_pool_queue wq
-    LEFT JOIN flow_run fr ON wq.id = fr.worker_pool_queue_id
+        work_pool_queue wq
+    LEFT JOIN flow_run fr ON wq.id = fr.work_pool_queue_id
         AND fr.state_type in('RUNNING', 'PENDING')
 WHERE
     wq.is_paused IS FALSE
@@ -36,21 +36,21 @@ GROUP BY
 -- CTE that loads flow runs and applies worker pool queue limits
 scheduled_flow_runs AS (
     SELECT
-        wp.id AS run_worker_pool_id,
-        wq.id AS run_worker_pool_queue_id,
+        wp.id AS run_work_pool_id,
+        wq.id AS run_work_pool_queue_id,
         fr.*,
         worker_slots.available_slots as available_worker_slots,
-        ROW_NUMBER() OVER (PARTITION BY wp.id ORDER BY {% if respect_queue_priorities %}wq.priority ASC, {% endif %}fr.next_scheduled_start_time) AS worker_pool_rank
+        ROW_NUMBER() OVER (PARTITION BY wp.id ORDER BY {% if respect_queue_priorities %}wq.priority ASC, {% endif %}fr.next_scheduled_start_time) AS work_pool_rank
     FROM
-        worker_pool wp
-        JOIN worker_pool_queue wq ON wq.worker_pool_id = wp.id
+        work_pool wp
+        JOIN work_pool_queue wq ON wq.work_pool_id = wp.id
         LEFT JOIN worker_slots ON wp.id = worker_slots.id
         LEFT JOIN queue_slots ON wq.id = queue_slots.id
 
         JOIN (
             SELECT 
                 fr.*,
-                ROW_NUMBER() OVER (PARTITION BY worker_pool_queue_id ORDER BY next_scheduled_start_time) AS worker_pool_queue_rank
+                ROW_NUMBER() OVER (PARTITION BY work_pool_queue_id ORDER BY next_scheduled_start_time) AS work_pool_queue_rank
             FROM flow_run fr
             WHERE fr.state_type = 'SCHEDULED'
             {% if scheduled_after %}
@@ -61,19 +61,19 @@ scheduled_flow_runs AS (
             {% endif %}
             ) fr
         ON 
-            fr.worker_pool_queue_id = wq.id 
-            AND worker_pool_queue_rank <= MIN(COALESCE(queue_slots.available_slots, :queue_limit), :queue_limit)
+            fr.work_pool_queue_id = wq.id 
+            AND work_pool_queue_rank <= MIN(COALESCE(queue_slots.available_slots, :queue_limit), :queue_limit)
 
     WHERE
         wp.is_paused IS FALSE
         AND wq.is_paused IS FALSE
-        {% if worker_pool_ids %}
+        {% if work_pool_ids %}
         -- optionally filter for specific worker pool IDs
-        AND wp.id IN :worker_pool_ids
+        AND wp.id IN :work_pool_ids
         {% endif %}                    
-        {% if worker_pool_queue_ids %}
+        {% if work_pool_queue_ids %}
         -- optionally filter for specific worker pool queue IDs
-        AND wq.id IN :worker_pool_queue_ids
+        AND wq.id IN :work_pool_queue_ids
         {% endif %}
     )
 
@@ -81,11 +81,11 @@ SELECT
     *
 FROM scheduled_flow_runs
 WHERE
-    worker_pool_rank <= MIN(COALESCE(available_worker_slots, :worker_limit), :worker_limit)
+    work_pool_rank <= MIN(COALESCE(available_worker_slots, :worker_limit), :worker_limit)
 ORDER BY 
     {% if respect_queue_priorities %}
     
-    worker_pool_rank ASC,
+    work_pool_rank ASC,
     {% endif %}
     next_scheduled_start_time ASC
 LIMIT :limit

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -148,7 +148,7 @@ async def update_deployment(
     )
     if deployment.work_pool_name and deployment.work_pool_queue_name:
         # If a specific pool name/queue name combination was provided, get the
-        # ID for that worker pool queue.
+        # ID for that work pool queue.
         update_data[
             "work_pool_queue_id"
         ] = await WorkerLookups()._get_work_pool_queue_id_from_name(
@@ -158,7 +158,7 @@ async def update_deployment(
         )
     elif deployment.work_pool_name:
         # If just a pool name was provided, get the ID for its default
-        # worker pool queue.
+        # work pool queue.
         update_data[
             "work_pool_queue_id"
         ] = await WorkerLookups()._get_default_work_pool_queue_id_from_work_pool_name(
@@ -319,8 +319,8 @@ async def read_deployments(
         flow_run_filter: only select deployments whose flow runs match these criteria
         task_run_filter: only select deployments whose task runs match these criteria
         deployment_filter: only select deployment that match these filters
-        work_pool_filter: only select deployments whose worker pools match these criteria
-        work_pool_queue_filter: only select deployments whose worker pool queues match these criteria
+        work_pool_filter: only select deployments whose work pools match these criteria
+        work_pool_queue_filter: only select deployments whose work pool queues match these criteria
         sort: the sort criteria for selected deployments. Defaults to `name` ASC.
 
     Returns:
@@ -369,8 +369,8 @@ async def count_deployments(
         flow_run_filter: only count deployments whose flow runs match these criteria
         task_run_filter: only count deployments whose task runs match these criteria
         deployment_filter: only count deployment that match these filters
-        work_pool_filter: only count deployments that match these worker pool filters
-        work_pool_queue_filter: only count deployments that match these worker pool queue filters
+        work_pool_filter: only count deployments that match these work pool filters
+        work_pool_queue_filter: only count deployments that match these work pool queue filters
 
     Returns:
         int: the number of deployments matching filters

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -144,26 +144,26 @@ async def update_deployment(
     update_data = deployment.dict(
         shallow=True,
         exclude_unset=True,
-        exclude={"worker_pool_name", "worker_pool_queue_name"},
+        exclude={"work_pool_name", "work_pool_queue_name"},
     )
-    if deployment.worker_pool_name and deployment.worker_pool_queue_name:
+    if deployment.work_pool_name and deployment.work_pool_queue_name:
         # If a specific pool name/queue name combination was provided, get the
         # ID for that worker pool queue.
         update_data[
-            "worker_pool_queue_id"
-        ] = await WorkerLookups()._get_worker_pool_queue_id_from_name(
+            "work_pool_queue_id"
+        ] = await WorkerLookups()._get_work_pool_queue_id_from_name(
             session=session,
-            worker_pool_name=deployment.worker_pool_name,
-            worker_pool_queue_name=deployment.worker_pool_queue_name,
+            work_pool_name=deployment.work_pool_name,
+            work_pool_queue_name=deployment.work_pool_queue_name,
         )
-    elif deployment.worker_pool_name:
+    elif deployment.work_pool_name:
         # If just a pool name was provided, get the ID for its default
         # worker pool queue.
         update_data[
-            "worker_pool_queue_id"
-        ] = await WorkerLookups()._get_default_worker_pool_queue_id_from_worker_pool_name(
+            "work_pool_queue_id"
+        ] = await WorkerLookups()._get_default_work_pool_queue_id_from_work_pool_name(
             session=session,
-            worker_pool_name=deployment.worker_pool_name,
+            work_pool_name=deployment.work_pool_name,
         )
 
     update_stmt = (
@@ -241,8 +241,8 @@ async def _apply_deployment_filters(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
 ):
     """
     Applies filters to a deployment query as a combination of EXISTS subqueries.
@@ -274,20 +274,20 @@ async def _apply_deployment_filters(
 
         query = query.where(exists_clause.exists())
 
-    if worker_pool_filter or worker_pool_queue_filter:
-        exists_clause = select(db.WorkerPoolQueue).where(
-            db.Deployment.worker_pool_queue_id == db.WorkerPoolQueue.id
+    if work_pool_filter or work_pool_queue_filter:
+        exists_clause = select(db.WorkPoolQueue).where(
+            db.Deployment.work_pool_queue_id == db.WorkPoolQueue.id
         )
 
-        if worker_pool_queue_filter:
+        if work_pool_queue_filter:
             exists_clause = exists_clause.where(
-                worker_pool_queue_filter.as_sql_filter(db)
+                work_pool_queue_filter.as_sql_filter(db)
             )
 
-        if worker_pool_filter:
+        if work_pool_filter:
             exists_clause = exists_clause.join(
-                db.WorkerPool, db.WorkerPool.id == db.WorkerPoolQueue.worker_pool_id
-            ).where(worker_pool_filter.as_sql_filter(db))
+                db.WorkPool, db.WorkPool.id == db.WorkPoolQueue.work_pool_id
+            ).where(work_pool_filter.as_sql_filter(db))
 
         query = query.where(exists_clause.exists())
 
@@ -304,8 +304,8 @@ async def read_deployments(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
     sort: schemas.sorting.DeploymentSort = schemas.sorting.DeploymentSort.NAME_ASC,
 ):
     """
@@ -319,8 +319,8 @@ async def read_deployments(
         flow_run_filter: only select deployments whose flow runs match these criteria
         task_run_filter: only select deployments whose task runs match these criteria
         deployment_filter: only select deployment that match these filters
-        worker_pool_filter: only select deployments whose worker pools match these criteria
-        worker_pool_queue_filter: only select deployments whose worker pool queues match these criteria
+        work_pool_filter: only select deployments whose worker pools match these criteria
+        work_pool_queue_filter: only select deployments whose worker pool queues match these criteria
         sort: the sort criteria for selected deployments. Defaults to `name` ASC.
 
     Returns:
@@ -335,8 +335,8 @@ async def read_deployments(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        worker_pool_filter=worker_pool_filter,
-        worker_pool_queue_filter=worker_pool_queue_filter,
+        work_pool_filter=work_pool_filter,
+        work_pool_queue_filter=work_pool_queue_filter,
         db=db,
     )
 
@@ -357,8 +357,8 @@ async def count_deployments(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
 ) -> int:
     """
     Count deployments.
@@ -369,8 +369,8 @@ async def count_deployments(
         flow_run_filter: only count deployments whose flow runs match these criteria
         task_run_filter: only count deployments whose task runs match these criteria
         deployment_filter: only count deployment that match these filters
-        worker_pool_filter: only count deployments that match these worker pool filters
-        worker_pool_queue_filter: only count deployments that match these worker pool queue filters
+        work_pool_filter: only count deployments that match these worker pool filters
+        work_pool_queue_filter: only count deployments that match these worker pool queue filters
 
     Returns:
         int: the number of deployments matching filters
@@ -384,8 +384,8 @@ async def count_deployments(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        worker_pool_filter=worker_pool_filter,
-        worker_pool_queue_filter=worker_pool_queue_filter,
+        work_pool_filter=work_pool_filter,
+        work_pool_queue_filter=work_pool_queue_filter,
         db=db,
     )
 
@@ -557,7 +557,7 @@ async def _generate_scheduled_flow_runs(
                 "flow_id": deployment.flow_id,
                 "deployment_id": deployment_id,
                 "work_queue_name": deployment.work_queue_name,
-                "worker_pool_queue_id": deployment.worker_pool_queue_id,
+                "work_pool_queue_id": deployment.work_pool_queue_id,
                 "parameters": deployment.parameters,
                 "infrastructure_document_id": deployment.infrastructure_document_id,
                 "idempotency_key": f"scheduled {deployment.id} {date}",

--- a/src/prefect/orion/models/flow_runs.py
+++ b/src/prefect/orion/models/flow_runs.py
@@ -93,8 +93,8 @@ async def create_flow_run(
             .limit(1)
             .execution_options(populate_existing=True)
             .options(
-                joinedload(db.FlowRun.worker_pool_queue).joinedload(
-                    db.WorkerPoolQueue.worker_pool
+                joinedload(db.FlowRun.work_pool_queue).joinedload(
+                    db.WorkPoolQueue.work_pool
                 )
             )
         )
@@ -159,8 +159,8 @@ async def read_flow_run(session: AsyncSession, flow_run_id: UUID, db: OrionDBInt
         sa.select(db.FlowRun)
         .where(db.FlowRun.id == flow_run_id)
         .options(
-            joinedload(db.FlowRun.worker_pool_queue).joinedload(
-                db.WorkerPoolQueue.worker_pool
+            joinedload(db.FlowRun.work_pool_queue).joinedload(
+                db.WorkPoolQueue.work_pool
             )
         )
     )
@@ -175,8 +175,8 @@ async def _apply_flow_run_filters(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
 ):
     """
     Applies filters to a flow run query as a combination of EXISTS subqueries.
@@ -192,19 +192,19 @@ async def _apply_flow_run_filters(
         )
         query = query.where(exists_clause.exists())
 
-    if worker_pool_filter:
-        exists_clause = select(db.WorkerPool).where(
-            db.WorkerPoolQueue.id == db.FlowRun.worker_pool_queue_id,
-            db.WorkerPool.id == db.WorkerPoolQueue.worker_pool_id,
-            worker_pool_filter.as_sql_filter(db),
+    if work_pool_filter:
+        exists_clause = select(db.WorkPool).where(
+            db.WorkPoolQueue.id == db.FlowRun.work_pool_queue_id,
+            db.WorkPool.id == db.WorkPoolQueue.work_pool_id,
+            work_pool_filter.as_sql_filter(db),
         )
 
         query = query.where(exists_clause.exists())
 
-    if worker_pool_queue_filter:
-        exists_clause = select(db.WorkerPoolQueue).where(
-            db.WorkerPoolQueue.id == db.FlowRun.worker_pool_queue_id,
-            worker_pool_queue_filter.as_sql_filter(db),
+    if work_pool_queue_filter:
+        exists_clause = select(db.WorkPoolQueue).where(
+            db.WorkPoolQueue.id == db.FlowRun.work_pool_queue_id,
+            work_pool_queue_filter.as_sql_filter(db),
         )
         query = query.where(exists_clause.exists())
 
@@ -245,8 +245,8 @@ async def read_flow_runs(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
     offset: int = None,
     limit: int = None,
     sort: schemas.sorting.FlowRunSort = schemas.sorting.FlowRunSort.ID_DESC,
@@ -272,8 +272,8 @@ async def read_flow_runs(
         select(db.FlowRun)
         .order_by(sort.as_sql_sort(db))
         .options(
-            joinedload(db.FlowRun.worker_pool_queue).joinedload(
-                db.WorkerPoolQueue.worker_pool
+            joinedload(db.FlowRun.work_pool_queue).joinedload(
+                db.WorkPoolQueue.work_pool
             )
         )
     )
@@ -287,8 +287,8 @@ async def read_flow_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        worker_pool_filter=worker_pool_filter,
-        worker_pool_queue_filter=worker_pool_queue_filter,
+        work_pool_filter=work_pool_filter,
+        work_pool_queue_filter=work_pool_queue_filter,
         db=db,
     )
 
@@ -370,8 +370,8 @@ async def count_flow_runs(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
-    worker_pool_queue_filter: schemas.filters.WorkerPoolQueueFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_queue_filter: schemas.filters.WorkPoolQueueFilter = None,
 ) -> int:
     """
     Count flow runs.
@@ -395,8 +395,8 @@ async def count_flow_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        worker_pool_filter=worker_pool_filter,
-        worker_pool_queue_filter=worker_pool_queue_filter,
+        work_pool_filter=work_pool_filter,
+        work_pool_queue_filter=work_pool_queue_filter,
         db=db,
     )
 

--- a/src/prefect/orion/models/workers.py
+++ b/src/prefect/orion/models/workers.py
@@ -16,8 +16,8 @@ from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.database.orm_models import (
     ORMWorker,
-    ORMWorkerPool,
-    ORMWorkerPoolQueue,
+    ORMWorkPool,
+    ORMWorkPoolQueue,
 )
 
 # -----------------------------------------------------
@@ -30,33 +30,33 @@ from prefect.orion.database.orm_models import (
 
 
 @inject_db
-async def create_worker_pool(
+async def create_work_pool(
     session: AsyncSession,
-    worker_pool: schemas.core.WorkerPool,
+    work_pool: schemas.core.WorkPool,
     db: OrionDBInterface,
-) -> ORMWorkerPool:
+) -> ORMWorkPool:
     """
     Creates a worker pool.
 
-    If a WorkerPool with the same name exists, an error will be thrown.
+    If a WorkPool with the same name exists, an error will be thrown.
 
     Args:
         session (AsyncSession): a database session
-        worker_pool (schemas.core.WorkerPool): a WorkerPool model
+        work_pool (schemas.core.WorkPool): a WorkPool model
 
     Returns:
-        db.WorkerPool: the newly-created WorkerPool
+        db.WorkPool: the newly-created WorkPool
 
     """
 
-    pool = db.WorkerPool(**worker_pool.dict())
+    pool = db.WorkPool(**work_pool.dict())
     session.add(pool)
     await session.flush()
 
-    default_queue = await create_worker_pool_queue(
+    default_queue = await create_work_pool_queue(
         session=session,
-        worker_pool_id=pool.id,
-        worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+        work_pool_id=pool.id,
+        work_pool_queue=schemas.actions.WorkPoolQueueCreate(
             name="Default Queue", description="The worker pool's default queue."
         ),
     )
@@ -68,53 +68,53 @@ async def create_worker_pool(
 
 
 @inject_db
-async def read_worker_pool(
-    session: AsyncSession, worker_pool_id: UUID, db: OrionDBInterface
-) -> ORMWorkerPool:
+async def read_work_pool(
+    session: AsyncSession, work_pool_id: UUID, db: OrionDBInterface
+) -> ORMWorkPool:
     """
-    Reads a WorkerPool by id.
+    Reads a WorkPool by id.
 
     Args:
         session (AsyncSession): A database session
-        worker_pool_id (UUID): a WorkerPool id
+        work_pool_id (UUID): a WorkPool id
 
     Returns:
-        db.WorkerPool: the WorkerPool
+        db.WorkPool: the WorkPool
     """
-    query = sa.select(db.WorkerPool).where(db.WorkerPool.id == worker_pool_id).limit(1)
+    query = sa.select(db.WorkPool).where(db.WorkPool.id == work_pool_id).limit(1)
     result = await session.execute(query)
     return result.scalar()
 
 
 @inject_db
-async def read_worker_pool_by_name(
-    session: AsyncSession, worker_pool_name: str, db: OrionDBInterface
-) -> ORMWorkerPool:
+async def read_work_pool_by_name(
+    session: AsyncSession, work_pool_name: str, db: OrionDBInterface
+) -> ORMWorkPool:
     """
-    Reads a WorkerPool by name.
+    Reads a WorkPool by name.
 
     Args:
         session (AsyncSession): A database session
-        worker_pool_name (str): a WorkerPool name
+        work_pool_name (str): a WorkPool name
 
     Returns:
-        db.WorkerPool: the WorkerPool
+        db.WorkPool: the WorkPool
     """
     query = (
-        sa.select(db.WorkerPool).where(db.WorkerPool.name == worker_pool_name).limit(1)
+        sa.select(db.WorkPool).where(db.WorkPool.name == work_pool_name).limit(1)
     )
     result = await session.execute(query)
     return result.scalar()
 
 
 @inject_db
-async def read_worker_pools(
+async def read_work_pools(
     db: OrionDBInterface,
     session: AsyncSession,
-    worker_pool_filter: schemas.filters.WorkerPoolFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
     offset: int = None,
     limit: int = None,
-) -> List[ORMWorkerPool]:
+) -> List[ORMWorkPool]:
     """
     Read worker configs.
 
@@ -123,13 +123,13 @@ async def read_worker_pools(
         offset: Query offset
         limit: Query limit
     Returns:
-        List[db.WorkerPool]: worker configs
+        List[db.WorkPool]: worker configs
     """
 
-    query = select(db.WorkerPool).order_by(db.WorkerPool.name)
+    query = select(db.WorkPool).order_by(db.WorkPool.name)
 
-    if worker_pool_filter is not None:
-        query = query.where(worker_pool_filter.as_sql_filter(db))
+    if work_pool_filter is not None:
+        query = query.where(work_pool_filter.as_sql_filter(db))
     if offset is not None:
         query = query.offset(offset)
     if limit is not None:
@@ -140,18 +140,18 @@ async def read_worker_pools(
 
 
 @inject_db
-async def update_worker_pool(
+async def update_work_pool(
     session: AsyncSession,
-    worker_pool_id: UUID,
-    worker_pool: schemas.actions.WorkerPoolUpdate,
+    work_pool_id: UUID,
+    work_pool: schemas.actions.WorkPoolUpdate,
     db: OrionDBInterface,
 ) -> bool:
     """
-    Update a WorkerPool by id.
+    Update a WorkPool by id.
 
     Args:
         session (AsyncSession): A database session
-        worker_pool_id (UUID): a WorkerPool id
+        work_pool_id (UUID): a WorkPool id
         worker: the work queue data
 
     Returns:
@@ -159,11 +159,11 @@ async def update_worker_pool(
     """
     # exclude_unset=True allows us to only update values provided by
     # the user, ignoring any defaults on the model
-    update_data = worker_pool.dict(shallow=True, exclude_unset=True)
+    update_data = work_pool.dict(shallow=True, exclude_unset=True)
 
     update_stmt = (
-        sa.update(db.WorkerPool)
-        .where(db.WorkerPool.id == worker_pool_id)
+        sa.update(db.WorkPool)
+        .where(db.WorkPool.id == work_pool_id)
         .values(**update_data)
     )
     result = await session.execute(update_stmt)
@@ -171,22 +171,22 @@ async def update_worker_pool(
 
 
 @inject_db
-async def delete_worker_pool(
-    session: AsyncSession, worker_pool_id: UUID, db: OrionDBInterface
+async def delete_work_pool(
+    session: AsyncSession, work_pool_id: UUID, db: OrionDBInterface
 ) -> bool:
     """
-    Delete a WorkerPool by id.
+    Delete a WorkPool by id.
 
     Args:
         session (AsyncSession): A database session
-        worker_pool_id (UUID): a worker pool id
+        work_pool_id (UUID): a worker pool id
 
     Returns:
-        bool: whether or not the WorkerPool was deleted
+        bool: whether or not the WorkPool was deleted
     """
 
     result = await session.execute(
-        delete(db.WorkerPool).where(db.WorkerPool.id == worker_pool_id)
+        delete(db.WorkPool).where(db.WorkPool.id == work_pool_id)
     )
     return result.rowcount > 0
 
@@ -194,8 +194,8 @@ async def delete_worker_pool(
 @inject_db
 async def get_scheduled_flow_runs(
     session: AsyncSession,
-    worker_pool_ids: List[UUID] = None,
-    worker_pool_queue_ids: List[UUID] = None,
+    work_pool_ids: List[UUID] = None,
+    work_pool_queue_ids: List[UUID] = None,
     scheduled_before: datetime.datetime = None,
     scheduled_after: datetime.datetime = None,
     limit: int = None,
@@ -207,8 +207,8 @@ async def get_scheduled_flow_runs(
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_ids (List[UUID]): a list of worker pool ids
-        worker_pool_queue_ids (List[UUID]): a list of worker pool queue ids
+        work_pool_ids (List[UUID]): a list of worker pool ids
+        work_pool_queue_ids (List[UUID]): a list of worker pool queue ids
         scheduled_before (datetime.datetime): a datetime to filter runs scheduled before
         scheduled_after (datetime.datetime): a datetime to filter runs scheduled after
         respect_queue_priorities (bool): whether or not to respect queue priorities
@@ -223,11 +223,11 @@ async def get_scheduled_flow_runs(
     if respect_queue_priorities is None:
         respect_queue_priorities = True
 
-    return await db.queries.get_scheduled_flow_runs_from_worker_pool(
+    return await db.queries.get_scheduled_flow_runs_from_work_pool(
         session=session,
         db=db,
-        worker_pool_ids=worker_pool_ids,
-        worker_pool_queue_ids=worker_pool_queue_ids,
+        work_pool_ids=work_pool_ids,
+        work_pool_queue_ids=work_pool_queue_ids,
         scheduled_before=scheduled_before,
         scheduled_after=scheduled_after,
         respect_queue_priorities=respect_queue_priorities,
@@ -245,33 +245,33 @@ async def get_scheduled_flow_runs(
 
 
 @inject_db
-async def create_worker_pool_queue(
+async def create_work_pool_queue(
     session: AsyncSession,
-    worker_pool_id: UUID,
-    worker_pool_queue: schemas.actions.WorkerPoolQueueCreate,
+    work_pool_id: UUID,
+    work_pool_queue: schemas.actions.WorkPoolQueueCreate,
     db: OrionDBInterface,
-) -> ORMWorkerPoolQueue:
+) -> ORMWorkPoolQueue:
     """
     Creates a worker pool queue.
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_id (UUID): a worker pool id
-        worker_pool_queue (schemas.actions.WorkerPoolQueueCreate): a WorkerPoolQueue action model
+        work_pool_id (UUID): a worker pool id
+        work_pool_queue (schemas.actions.WorkPoolQueueCreate): a WorkPoolQueue action model
 
     Returns:
-        db.WorkerPoolQueue: the newly-created WorkerPoolQueue
+        db.WorkPoolQueue: the newly-created WorkPoolQueue
 
     """
 
     max_priority_query = sa.select(
-        sa.func.coalesce(sa.func.max(db.WorkerPoolQueue.priority), 0)
-    ).where(db.WorkerPoolQueue.worker_pool_id == worker_pool_id)
+        sa.func.coalesce(sa.func.max(db.WorkPoolQueue.priority), 0)
+    ).where(db.WorkPoolQueue.work_pool_id == work_pool_id)
     priority = (await session.execute(max_priority_query)).scalar()
 
-    model = db.WorkerPoolQueue(
-        **worker_pool_queue.dict(exclude={"priority"}),
-        worker_pool_id=worker_pool_id,
+    model = db.WorkPoolQueue(
+        **work_pool_queue.dict(exclude={"priority"}),
+        work_pool_id=work_pool_id,
         # initialize the priority as the current max priority + 1
         priority=priority + 1
     )
@@ -279,20 +279,20 @@ async def create_worker_pool_queue(
     session.add(model)
     await session.flush()
 
-    if worker_pool_queue.priority:
-        await bulk_update_worker_pool_queue_priorities(
+    if work_pool_queue.priority:
+        await bulk_update_work_pool_queue_priorities(
             session=session,
-            worker_pool_id=worker_pool_id,
-            new_priorities={model.id: worker_pool_queue.priority},
+            work_pool_id=work_pool_id,
+            new_priorities={model.id: work_pool_queue.priority},
             db=db,
         )
     return model
 
 
 @inject_db
-async def bulk_update_worker_pool_queue_priorities(
+async def bulk_update_work_pool_queue_priorities(
     session: AsyncSession,
-    worker_pool_id: UUID,
+    work_pool_id: UUID,
     new_priorities: Dict[UUID, int],
     db: OrionDBInterface,
 ):
@@ -312,98 +312,98 @@ async def bulk_update_worker_pool_queue_priorities(
     if len(set(new_priorities.values())) != len(new_priorities):
         raise ValueError("Duplicate target priorities provided")
 
-    worker_pool_queues_query = (
-        sa.select(db.WorkerPoolQueue)
-        .where(db.WorkerPoolQueue.worker_pool_id == worker_pool_id)
-        .order_by(db.WorkerPoolQueue.priority.asc())
+    work_pool_queues_query = (
+        sa.select(db.WorkPoolQueue)
+        .where(db.WorkPoolQueue.work_pool_id == work_pool_id)
+        .order_by(db.WorkPoolQueue.priority.asc())
     )
-    result = await session.execute(worker_pool_queues_query)
-    all_worker_pool_queues = result.scalars().all()
+    result = await session.execute(work_pool_queues_query)
+    all_work_pool_queues = result.scalars().all()
 
-    worker_pool_queues = [
-        wq for wq in all_worker_pool_queues if wq.id not in new_priorities
+    work_pool_queues = [
+        wq for wq in all_work_pool_queues if wq.id not in new_priorities
     ]
-    updated_queues = [wq for wq in all_worker_pool_queues if wq.id in new_priorities]
+    updated_queues = [wq for wq in all_work_pool_queues if wq.id in new_priorities]
 
     for queue in sorted(updated_queues, key=lambda wq: new_priorities[wq.id]):
-        worker_pool_queues.insert(new_priorities[queue.id] - 1, queue)
+        work_pool_queues.insert(new_priorities[queue.id] - 1, queue)
 
-    for i, queue in enumerate(worker_pool_queues):
+    for i, queue in enumerate(work_pool_queues):
         queue.priority = i + 1
 
     await session.flush()
 
 
 @inject_db
-async def read_worker_pool_queues(
+async def read_work_pool_queues(
     session: AsyncSession,
-    worker_pool_id: UUID,
+    work_pool_id: UUID,
     db: OrionDBInterface,
-) -> List[ORMWorkerPoolQueue]:
+) -> List[ORMWorkPoolQueue]:
     """
     Read all worker pool queues for a worker pool. Results are ordered by ascending priority.
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_id (UUID): a worker pool id
+        work_pool_id (UUID): a worker pool id
 
     Returns:
-        List[db.WorkerPoolQueue]: the WorkerPoolQueues
+        List[db.WorkPoolQueue]: the WorkPoolQueues
 
     """
     query = (
-        sa.select(db.WorkerPoolQueue)
-        .where(db.WorkerPoolQueue.worker_pool_id == worker_pool_id)
-        .order_by(db.WorkerPoolQueue.priority.asc())
+        sa.select(db.WorkPoolQueue)
+        .where(db.WorkPoolQueue.work_pool_id == work_pool_id)
+        .order_by(db.WorkPoolQueue.priority.asc())
     )
     result = await session.execute(query)
     return result.scalars().unique().all()
 
 
 @inject_db
-async def read_worker_pool_queue(
+async def read_work_pool_queue(
     session: AsyncSession,
-    worker_pool_queue_id: UUID,
+    work_pool_queue_id: UUID,
     db: OrionDBInterface,
-) -> ORMWorkerPoolQueue:
+) -> ORMWorkPoolQueue:
     """
     Read a specific worker pool queue.
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_queue_id (UUID): a worker pool queue id
+        work_pool_queue_id (UUID): a worker pool queue id
 
     Returns:
-        db.WorkerPoolQueue: the WorkerPoolQueue
+        db.WorkPoolQueue: the WorkPoolQueue
 
     """
-    return await session.get(db.WorkerPoolQueue, worker_pool_queue_id)
+    return await session.get(db.WorkPoolQueue, work_pool_queue_id)
 
 
 @inject_db
-async def read_worker_pool_queue_by_name(
+async def read_work_pool_queue_by_name(
     session: AsyncSession,
-    worker_pool_name: str,
-    worker_pool_queue_name: str,
+    work_pool_name: str,
+    work_pool_queue_name: str,
     db: OrionDBInterface,
-) -> ORMWorkerPoolQueue:
+) -> ORMWorkPoolQueue:
     """
-    Reads a WorkerPoolQueue by name.
+    Reads a WorkPoolQueue by name.
 
     Args:
         session (AsyncSession): A database session
-        worker_pool_name (str): a WorkerPool name
-        worker_pool_queue_name (str): a WorkerPoolQueue name
+        work_pool_name (str): a WorkPool name
+        work_pool_queue_name (str): a WorkPoolQueue name
 
     Returns:
-        db.WorkerPoolQueue: the WorkerPoolQueue
+        db.WorkPoolQueue: the WorkPoolQueue
     """
     query = (
-        sa.select(db.WorkerPoolQueue)
-        .join(db.WorkerPool, db.WorkerPool.id == db.WorkerPoolQueue.worker_pool_id)
+        sa.select(db.WorkPoolQueue)
+        .join(db.WorkPool, db.WorkPool.id == db.WorkPoolQueue.work_pool_id)
         .where(
-            db.WorkerPool.name == worker_pool_name,
-            db.WorkerPoolQueue.name == worker_pool_queue_name,
+            db.WorkPool.name == work_pool_name,
+            db.WorkPoolQueue.name == work_pool_queue_name,
         )
         .limit(1)
     )
@@ -412,10 +412,10 @@ async def read_worker_pool_queue_by_name(
 
 
 @inject_db
-async def update_worker_pool_queue(
+async def update_work_pool_queue(
     session: AsyncSession,
-    worker_pool_queue_id: UUID,
-    worker_pool_queue: schemas.actions.WorkerPoolQueueUpdate,
+    work_pool_queue_id: UUID,
+    work_pool_queue: schemas.actions.WorkPoolQueueUpdate,
     db: OrionDBInterface,
 ) -> bool:
     """
@@ -423,35 +423,35 @@ async def update_worker_pool_queue(
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_queue_id (UUID): a worker pool queue ID
-        worker_pool_queue (schemas.actions.WorkerPoolQueueUpdate): a WorkerPoolQueue model
+        work_pool_queue_id (UUID): a worker pool queue ID
+        work_pool_queue (schemas.actions.WorkPoolQueueUpdate): a WorkPoolQueue model
 
     Returns:
-        bool: whether or not the WorkerPoolQueue was updated
+        bool: whether or not the WorkPoolQueue was updated
 
     """
-    update_values = worker_pool_queue.dict(shallow=True, exclude_unset=True)
+    update_values = work_pool_queue.dict(shallow=True, exclude_unset=True)
     update_stmt = (
-        sa.update(db.WorkerPoolQueue)
-        .where(db.WorkerPoolQueue.id == worker_pool_queue_id)
+        sa.update(db.WorkPoolQueue)
+        .where(db.WorkPoolQueue.id == work_pool_queue_id)
         .values(update_values)
     )
     result = await session.execute(update_stmt)
 
     if result.rowcount > 0 and "priority" in update_values:
-        worker_pool_queue = await session.get(db.WorkerPoolQueue, worker_pool_queue_id)
-        await bulk_update_worker_pool_queue_priorities(
+        work_pool_queue = await session.get(db.WorkPoolQueue, work_pool_queue_id)
+        await bulk_update_work_pool_queue_priorities(
             session,
-            worker_pool_id=worker_pool_queue.worker_pool_id,
-            new_priorities={worker_pool_queue_id: update_values["priority"]},
+            work_pool_id=work_pool_queue.work_pool_id,
+            new_priorities={work_pool_queue_id: update_values["priority"]},
         )
     return result.rowcount > 0
 
 
 @inject_db
-async def delete_worker_pool_queue(
+async def delete_work_pool_queue(
     session: AsyncSession,
-    worker_pool_queue_id: UUID,
+    work_pool_queue_id: UUID,
     db: OrionDBInterface,
 ) -> bool:
     """
@@ -459,17 +459,17 @@ async def delete_worker_pool_queue(
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_queue_id (UUID): a worker pool queue ID
+        work_pool_queue_id (UUID): a worker pool queue ID
 
     Returns:
-        bool: whether or not the WorkerPoolQueue was deleted
+        bool: whether or not the WorkPoolQueue was deleted
 
     """
-    worker_pool_queue = await session.get(db.WorkerPoolQueue, worker_pool_queue_id)
-    if worker_pool_queue is None:
+    work_pool_queue = await session.get(db.WorkPoolQueue, work_pool_queue_id)
+    if work_pool_queue is None:
         return False
 
-    await session.delete(worker_pool_queue)
+    await session.delete(work_pool_queue)
     try:
         await session.flush()
 
@@ -479,9 +479,9 @@ async def delete_worker_pool_queue(
             raise ValueError("Can't delete a pool's default queue.")
         raise
 
-    await bulk_update_worker_pool_queue_priorities(
+    await bulk_update_work_pool_queue_priorities(
         session,
-        worker_pool_id=worker_pool_queue.worker_pool_id,
+        work_pool_id=work_pool_queue.work_pool_id,
         new_priorities={},
     )
     return True
@@ -499,7 +499,7 @@ async def delete_worker_pool_queue(
 @inject_db
 async def read_workers(
     session: AsyncSession,
-    worker_pool_id: UUID,
+    work_pool_id: UUID,
     worker_filter: schemas.filters.WorkerFilter = None,
     limit: int = None,
     offset: int = None,
@@ -508,7 +508,7 @@ async def read_workers(
 
     query = (
         sa.select(db.Worker)
-        .where(db.Worker.worker_pool_id == worker_pool_id)
+        .where(db.Worker.work_pool_id == work_pool_id)
         .order_by(db.Worker.last_heartbeat_time.desc())
         .limit(limit)
     )
@@ -529,7 +529,7 @@ async def read_workers(
 @inject_db
 async def worker_heartbeat(
     session: AsyncSession,
-    worker_pool_id: UUID,
+    work_pool_id: UUID,
     worker_name: str,
     db: OrionDBInterface,
 ) -> bool:
@@ -538,7 +538,7 @@ async def worker_heartbeat(
 
     Args:
         session (AsyncSession): a database session
-        worker_pool_id (UUID): a worker pool ID
+        work_pool_id (UUID): a worker pool ID
         worker_name (str): a worker name
 
     Returns:
@@ -549,13 +549,13 @@ async def worker_heartbeat(
     insert_stmt = (
         (await db.insert(db.Worker))
         .values(
-            worker_pool_id=worker_pool_id,
+            work_pool_id=work_pool_id,
             name=worker_name,
             last_heartbeat_time=now,
         )
         .on_conflict_do_update(
             index_elements=[
-                db.Worker.worker_pool_id,
+                db.Worker.work_pool_id,
                 db.Worker.name,
             ],
             set_=dict(last_heartbeat_time=now),

--- a/src/prefect/orion/models/workers.py
+++ b/src/prefect/orion/models/workers.py
@@ -14,11 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.orion.schemas as schemas
 from prefect.orion.database.dependencies import inject_db
 from prefect.orion.database.interface import OrionDBInterface
-from prefect.orion.database.orm_models import (
-    ORMWorker,
-    ORMWorkPool,
-    ORMWorkPoolQueue,
-)
+from prefect.orion.database.orm_models import ORMWorker, ORMWorkPool, ORMWorkPoolQueue
 
 # -----------------------------------------------------
 # --
@@ -100,9 +96,7 @@ async def read_work_pool_by_name(
     Returns:
         db.WorkPool: the WorkPool
     """
-    query = (
-        sa.select(db.WorkPool).where(db.WorkPool.name == work_pool_name).limit(1)
-    )
+    query = sa.select(db.WorkPool).where(db.WorkPool.name == work_pool_name).limit(1)
     result = await session.execute(query)
     return result.scalar()
 

--- a/src/prefect/orion/models/workers.py
+++ b/src/prefect/orion/models/workers.py
@@ -32,7 +32,7 @@ async def create_work_pool(
     db: OrionDBInterface,
 ) -> ORMWorkPool:
     """
-    Creates a worker pool.
+    Creates a work pool.
 
     If a WorkPool with the same name exists, an error will be thrown.
 
@@ -53,7 +53,7 @@ async def create_work_pool(
         session=session,
         work_pool_id=pool.id,
         work_pool_queue=schemas.actions.WorkPoolQueueCreate(
-            name="Default Queue", description="The worker pool's default queue."
+            name="Default Queue", description="The work pool's default queue."
         ),
     )
 
@@ -173,7 +173,7 @@ async def delete_work_pool(
 
     Args:
         session (AsyncSession): A database session
-        work_pool_id (UUID): a worker pool id
+        work_pool_id (UUID): a work pool id
 
     Returns:
         bool: whether or not the WorkPool was deleted
@@ -197,12 +197,12 @@ async def get_scheduled_flow_runs(
     db: OrionDBInterface = None,
 ) -> List[schemas.responses.WorkerFlowRunResponse]:
     """
-    Get runs from queues in a specific worker pool.
+    Get runs from queues in a specific work pool.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_ids (List[UUID]): a list of worker pool ids
-        work_pool_queue_ids (List[UUID]): a list of worker pool queue ids
+        work_pool_ids (List[UUID]): a list of work pool ids
+        work_pool_queue_ids (List[UUID]): a list of work pool queue ids
         scheduled_before (datetime.datetime): a datetime to filter runs scheduled before
         scheduled_after (datetime.datetime): a datetime to filter runs scheduled after
         respect_queue_priorities (bool): whether or not to respect queue priorities
@@ -210,7 +210,7 @@ async def get_scheduled_flow_runs(
         db (OrionDBInterface): a database interface
 
     Returns:
-        List[WorkerFlowRunResponse]: the runs, as well as related worker pool details
+        List[WorkerFlowRunResponse]: the runs, as well as related work pool details
 
     """
 
@@ -232,7 +232,7 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 # --
 # --
-# -- worker pool queues
+# -- work pool queues
 # --
 # --
 # -----------------------------------------------------
@@ -246,11 +246,11 @@ async def create_work_pool_queue(
     db: OrionDBInterface,
 ) -> ORMWorkPoolQueue:
     """
-    Creates a worker pool queue.
+    Creates a work pool queue.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_id (UUID): a worker pool id
+        work_pool_id (UUID): a work pool id
         work_pool_queue (schemas.actions.WorkPoolQueueCreate): a WorkPoolQueue action model
 
     Returns:
@@ -291,7 +291,7 @@ async def bulk_update_work_pool_queue_priorities(
     db: OrionDBInterface,
 ):
     """
-    This is a brute force update of all worker pool queue priorities for a given worker
+    This is a brute force update of all work pool queue priorities for a given worker
     pool.
 
     It loads all queues fully into memory, sorts them, and flushes the update to
@@ -335,11 +335,11 @@ async def read_work_pool_queues(
     db: OrionDBInterface,
 ) -> List[ORMWorkPoolQueue]:
     """
-    Read all worker pool queues for a worker pool. Results are ordered by ascending priority.
+    Read all work pool queues for a work pool. Results are ordered by ascending priority.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_id (UUID): a worker pool id
+        work_pool_id (UUID): a work pool id
 
     Returns:
         List[db.WorkPoolQueue]: the WorkPoolQueues
@@ -361,11 +361,11 @@ async def read_work_pool_queue(
     db: OrionDBInterface,
 ) -> ORMWorkPoolQueue:
     """
-    Read a specific worker pool queue.
+    Read a specific work pool queue.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_queue_id (UUID): a worker pool queue id
+        work_pool_queue_id (UUID): a work pool queue id
 
     Returns:
         db.WorkPoolQueue: the WorkPoolQueue
@@ -413,11 +413,11 @@ async def update_work_pool_queue(
     db: OrionDBInterface,
 ) -> bool:
     """
-    Update a worker pool queue.
+    Update a work pool queue.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_queue_id (UUID): a worker pool queue ID
+        work_pool_queue_id (UUID): a work pool queue ID
         work_pool_queue (schemas.actions.WorkPoolQueueUpdate): a WorkPoolQueue model
 
     Returns:
@@ -449,11 +449,11 @@ async def delete_work_pool_queue(
     db: OrionDBInterface,
 ) -> bool:
     """
-    Delete a worker pool queue.
+    Delete a work pool queue.
 
     Args:
         session (AsyncSession): a database session
-        work_pool_queue_id (UUID): a worker pool queue ID
+        work_pool_queue_id (UUID): a work pool queue ID
 
     Returns:
         bool: whether or not the WorkPoolQueue was deleted
@@ -532,7 +532,7 @@ async def worker_heartbeat(
 
     Args:
         session (AsyncSession): a database session
-        work_pool_id (UUID): a worker pool ID
+        work_pool_id (UUID): a work pool ID
         worker_name (str): a worker name
 
     Returns:

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -85,15 +85,15 @@ class DeploymentCreate(ActionBaseModel):
 
     manifest_path: Optional[str] = FieldFrom(schemas.core.Deployment)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
-    worker_pool_name: Optional[str] = Field(
+    work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool.",
-        example="my-worker-pool",
+        example="my-work-pool",
     )
-    worker_pool_queue_name: Optional[str] = Field(
+    work_pool_queue_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool queue.",
-        example="my-worker-pool-queue",
+        example="my-work-pool-queue",
     )
     storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
@@ -123,15 +123,15 @@ class DeploymentUpdate(ActionBaseModel):
     parameters: Dict[str, Any] = FieldFrom(schemas.core.Deployment)
     tags: List[str] = FieldFrom(schemas.core.Deployment)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
-    worker_pool_name: Optional[str] = Field(
+    work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool.",
-        example="my-worker-pool",
+        example="my-work-pool",
     )
-    worker_pool_queue_name: Optional[str] = Field(
+    work_pool_queue_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool queue.",
-        example="my-worker-pool-queue",
+        example="my-work-pool-queue",
     )
     path: Optional[str] = FieldFrom(schemas.core.Deployment)
     infra_overrides: Optional[Dict[str, Any]] = FieldFrom(schemas.core.Deployment)
@@ -362,47 +362,47 @@ class LogCreate(ActionBaseModel):
 
 
 @copy_model_fields
-class WorkerPoolCreate(ActionBaseModel):
+class WorkPoolCreate(ActionBaseModel):
     """Data used by the Orion API to create a worker pool."""
 
-    name: str = FieldFrom(schemas.core.WorkerPool)
-    description: Optional[str] = FieldFrom(schemas.core.WorkerPool)
-    type: Optional[str] = FieldFrom(schemas.core.WorkerPool)
-    base_job_template: Dict[str, Any] = FieldFrom(schemas.core.WorkerPool)
-    is_paused: bool = FieldFrom(schemas.core.WorkerPool)
-    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkerPool)
+    name: str = FieldFrom(schemas.core.WorkPool)
+    description: Optional[str] = FieldFrom(schemas.core.WorkPool)
+    type: Optional[str] = FieldFrom(schemas.core.WorkPool)
+    base_job_template: Dict[str, Any] = FieldFrom(schemas.core.WorkPool)
+    is_paused: bool = FieldFrom(schemas.core.WorkPool)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkPool)
 
 
 @copy_model_fields
-class WorkerPoolUpdate(ActionBaseModel):
+class WorkPoolUpdate(ActionBaseModel):
     """Data used by the Orion API to update a worker pool."""
 
-    description: Optional[str] = FieldFrom(schemas.core.WorkerPool)
-    is_paused: Optional[bool] = FieldFrom(schemas.core.WorkerPool)
-    base_job_template: Optional[Dict[str, Any]] = FieldFrom(schemas.core.WorkerPool)
-    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkerPool)
+    description: Optional[str] = FieldFrom(schemas.core.WorkPool)
+    is_paused: Optional[bool] = FieldFrom(schemas.core.WorkPool)
+    base_job_template: Optional[Dict[str, Any]] = FieldFrom(schemas.core.WorkPool)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkPool)
 
 
 @copy_model_fields
-class WorkerPoolQueueCreate(ActionBaseModel):
+class WorkPoolQueueCreate(ActionBaseModel):
     """Data used by the Orion API to create a worker pool queue."""
 
-    name: str = FieldFrom(schemas.core.WorkerPoolQueue)
-    description: Optional[str] = FieldFrom(schemas.core.WorkerPoolQueue)
-    is_paused: bool = FieldFrom(schemas.core.WorkerPoolQueue)
-    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkerPoolQueue)
-    priority: Optional[int] = FieldFrom(schemas.core.WorkerPoolQueue)
+    name: str = FieldFrom(schemas.core.WorkPoolQueue)
+    description: Optional[str] = FieldFrom(schemas.core.WorkPoolQueue)
+    is_paused: bool = FieldFrom(schemas.core.WorkPoolQueue)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkPoolQueue)
+    priority: Optional[int] = FieldFrom(schemas.core.WorkPoolQueue)
 
 
 @copy_model_fields
-class WorkerPoolQueueUpdate(ActionBaseModel):
+class WorkPoolQueueUpdate(ActionBaseModel):
     """Data used by the Orion API to update a worker pool queue."""
 
-    name: str = FieldFrom(schemas.core.WorkerPoolQueue)
-    description: Optional[str] = FieldFrom(schemas.core.WorkerPoolQueue)
-    is_paused: Optional[bool] = FieldFrom(schemas.core.WorkerPoolQueue)
-    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkerPoolQueue)
-    priority: Optional[int] = FieldFrom(schemas.core.WorkerPoolQueue)
+    name: str = FieldFrom(schemas.core.WorkPoolQueue)
+    description: Optional[str] = FieldFrom(schemas.core.WorkPoolQueue)
+    is_paused: Optional[bool] = FieldFrom(schemas.core.WorkPoolQueue)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkPoolQueue)
+    priority: Optional[int] = FieldFrom(schemas.core.WorkPoolQueue)
 
 
 @copy_model_fields

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -2,6 +2,8 @@
 Reduced schemas for accepting API actions.
 """
 import re
+import warnings
+from copy import deepcopy
 from typing import Any, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
@@ -77,6 +79,33 @@ class FlowUpdate(ActionBaseModel):
 class DeploymentCreate(ActionBaseModel):
     """Data used by the Orion API to create a deployment."""
 
+    @root_validator(pre=True)
+    def remove_old_fields(cls, values):
+        # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
+        # worker_pool_queue_name. Those fields were later renamed to work_pool_name
+        # and work_pool_queue_name. This validator removes old fields provided
+        # by older clients to avoid 422 errors.
+        values_copy = deepcopy(values)
+        worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        worker_pool_name = values_copy.pop("worker_pool_name", None)
+        worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
+        if worker_pool_queue_id:
+            warnings.warn(
+                "`worker_pool_queue_id` is no longer supported for creating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        if worker_pool_name or worker_pool_queue_name:
+            warnings.warn(
+                "`worker_pool_name` and `worker_pool_queue_name` are "
+                "no longer supported for creating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        return values_copy
+
     name: str = FieldFrom(schemas.core.Deployment)
     flow_id: UUID = FieldFrom(schemas.core.Deployment)
     is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
@@ -113,6 +142,33 @@ class DeploymentCreate(ActionBaseModel):
 @copy_model_fields
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Orion API to update a deployment."""
+
+    @root_validator(pre=True)
+    def remove_old_fields(cls, values):
+        # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
+        # worker_pool_queue_name. Those fields were later renamed to work_pool_name
+        # and work_pool_queue_name. This validator removes old fields provided
+        # by older clients to avoid 422 errors.
+        values_copy = deepcopy(values)
+        worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        worker_pool_name = values_copy.pop("worker_pool_name", None)
+        worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
+        if worker_pool_queue_id:
+            warnings.warn(
+                "`worker_pool_queue_id` is no longer supported for updating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        if worker_pool_name or worker_pool_queue_name:
+            warnings.warn(
+                "`worker_pool_name` and `worker_pool_queue_name` are "
+                "no longer supported for updating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        return values_copy
 
     version: Optional[str] = FieldFrom(schemas.core.Deployment)
     schedule: Optional[schemas.schedules.SCHEDULE_TYPES] = FieldFrom(

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -87,12 +87,12 @@ class DeploymentCreate(ActionBaseModel):
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
     work_pool_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool.",
+        description="The name of the deployment's work pool.",
         example="my-work-pool",
     )
     work_pool_queue_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool queue.",
+        description="The name of the deployment's work pool queue.",
         example="my-work-pool-queue",
     )
     storage_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
@@ -125,12 +125,12 @@ class DeploymentUpdate(ActionBaseModel):
     work_queue_name: Optional[str] = FieldFrom(schemas.core.Deployment)
     work_pool_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool.",
+        description="The name of the deployment's work pool.",
         example="my-work-pool",
     )
     work_pool_queue_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool queue.",
+        description="The name of the deployment's work pool queue.",
         example="my-work-pool-queue",
     )
     path: Optional[str] = FieldFrom(schemas.core.Deployment)
@@ -363,7 +363,7 @@ class LogCreate(ActionBaseModel):
 
 @copy_model_fields
 class WorkPoolCreate(ActionBaseModel):
-    """Data used by the Orion API to create a worker pool."""
+    """Data used by the Orion API to create a work pool."""
 
     name: str = FieldFrom(schemas.core.WorkPool)
     description: Optional[str] = FieldFrom(schemas.core.WorkPool)
@@ -375,7 +375,7 @@ class WorkPoolCreate(ActionBaseModel):
 
 @copy_model_fields
 class WorkPoolUpdate(ActionBaseModel):
-    """Data used by the Orion API to update a worker pool."""
+    """Data used by the Orion API to update a work pool."""
 
     description: Optional[str] = FieldFrom(schemas.core.WorkPool)
     is_paused: Optional[bool] = FieldFrom(schemas.core.WorkPool)
@@ -385,7 +385,7 @@ class WorkPoolUpdate(ActionBaseModel):
 
 @copy_model_fields
 class WorkPoolQueueCreate(ActionBaseModel):
-    """Data used by the Orion API to create a worker pool queue."""
+    """Data used by the Orion API to create a work pool queue."""
 
     name: str = FieldFrom(schemas.core.WorkPoolQueue)
     description: Optional[str] = FieldFrom(schemas.core.WorkPoolQueue)
@@ -396,7 +396,7 @@ class WorkPoolQueueCreate(ActionBaseModel):
 
 @copy_model_fields
 class WorkPoolQueueUpdate(ActionBaseModel):
-    """Data used by the Orion API to update a worker pool queue."""
+    """Data used by the Orion API to update a work pool queue."""
 
     name: str = FieldFrom(schemas.core.WorkPoolQueue)
     description: Optional[str] = FieldFrom(schemas.core.WorkPoolQueue)

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -258,7 +258,7 @@ class FlowRun(ORMBaseModel):
         default=None,
         description="Optional information about the creator of this flow run.",
     )
-    worker_pool_queue_id: Optional[UUID] = Field(
+    work_pool_queue_id: Optional[UUID] = Field(
         default=None, description="The id of the run's worker pool queue."
     )
 
@@ -548,7 +548,7 @@ class Deployment(ORMBaseModel):
         default=None,
         description="Optional information about the updater of this deployment.",
     )
-    worker_pool_queue_id: UUID = Field(
+    work_pool_queue_id: UUID = Field(
         default=None,
         description="The id of the worker pool queue to which this deployment is assigned.",
     )
@@ -944,7 +944,7 @@ class Agent(ORMBaseModel):
     )
 
 
-class WorkerPool(ORMBaseModel):
+class WorkPool(ORMBaseModel):
     """An ORM representation of a worker pool"""
 
     name: str = Field(
@@ -981,18 +981,18 @@ class WorkerPool(ORMBaseModel):
         """
         Default queue ID is required because all pools must have a default queue
         ID, but it represents a circular foreign key relationship to a
-        WorkerPoolQueue (which can't be created until the worker pool exists).
+        WorkPoolQueue (which can't be created until the worker pool exists).
         Therefore, while this field can *technically* be null, it shouldn't be.
         This should only be an issue when creating new pools, as reading
         existing ones will always have this field populated. This custom error
         message will help users understand that they should use the
-        `actions.WorkerPoolCreate` model in that case.
+        `actions.WorkPoolCreate` model in that case.
         """
         if v is None:
             raise ValueError(
                 "`default_queue_id` is a required field. If you are "
-                "creating a new WorkerPool and don't have a queue "
-                "ID yet, use the `actions.WorkerPoolCreate` model instead."
+                "creating a new WorkPool and don't have a queue "
+                "ID yet, use the `actions.WorkPoolCreate` model instead."
             )
         return v
 
@@ -1001,7 +1001,7 @@ class Worker(ORMBaseModel):
     """An ORM representation of a worker"""
 
     name: str = Field(description="The name of the worker.")
-    worker_pool_id: UUID = Field(
+    work_pool_id: UUID = Field(
         description="The worker pool with which the queue is associated."
     )
     last_heartbeat_time: datetime.datetime = Field(
@@ -1009,10 +1009,10 @@ class Worker(ORMBaseModel):
     )
 
 
-class WorkerPoolQueue(ORMBaseModel):
+class WorkPoolQueue(ORMBaseModel):
     """An ORM representation of a worker pool queue"""
 
-    worker_pool_id: UUID = Field(
+    work_pool_id: UUID = Field(
         description="The worker pool with which the queue is associated."
     )
     name: str = Field(

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -259,7 +259,7 @@ class FlowRun(ORMBaseModel):
         description="Optional information about the creator of this flow run.",
     )
     work_pool_queue_id: Optional[UUID] = Field(
-        default=None, description="The id of the run's worker pool queue."
+        default=None, description="The id of the run's work pool queue."
     )
 
     # relationships
@@ -550,7 +550,7 @@ class Deployment(ORMBaseModel):
     )
     work_pool_queue_id: UUID = Field(
         default=None,
-        description="The id of the worker pool queue to which this deployment is assigned.",
+        description="The id of the work pool queue to which this deployment is assigned.",
     )
 
     @validator("name", check_fields=False)
@@ -945,24 +945,24 @@ class Agent(ORMBaseModel):
 
 
 class WorkPool(ORMBaseModel):
-    """An ORM representation of a worker pool"""
+    """An ORM representation of a work pool"""
 
     name: str = Field(
-        description="The name of the worker pool.",
+        description="The name of the work pool.",
     )
     description: Optional[str] = Field(
-        default=None, description="A description of the worker pool."
+        default=None, description="A description of the work pool."
     )
-    type: Optional[str] = Field(None, description="The worker pool type.")
+    type: Optional[str] = Field(None, description="The work pool type.")
     base_job_template: Dict[str, Any] = Field(
-        default_factory=dict, description="The worker pool's base job template."
+        default_factory=dict, description="The work pool's base job template."
     )
     is_paused: bool = Field(
         default=False,
-        description="Pausing the worker pool stops the delivery of all work.",
+        description="Pausing the work pool stops the delivery of all work.",
     )
     concurrency_limit: Optional[conint(ge=0)] = Field(
-        default=None, description="A concurrency limit for the worker pool."
+        default=None, description="A concurrency limit for the work pool."
     )
 
     # this required field has a default of None so that the custom validator
@@ -981,7 +981,7 @@ class WorkPool(ORMBaseModel):
         """
         Default queue ID is required because all pools must have a default queue
         ID, but it represents a circular foreign key relationship to a
-        WorkPoolQueue (which can't be created until the worker pool exists).
+        WorkPoolQueue (which can't be created until the work pool exists).
         Therefore, while this field can *technically* be null, it shouldn't be.
         This should only be an issue when creating new pools, as reading
         existing ones will always have this field populated. This custom error
@@ -1002,7 +1002,7 @@ class Worker(ORMBaseModel):
 
     name: str = Field(description="The name of the worker.")
     work_pool_id: UUID = Field(
-        description="The worker pool with which the queue is associated."
+        description="The work pool with which the queue is associated."
     )
     last_heartbeat_time: datetime.datetime = Field(
         None, description="The last time the worker process sent a heartbeat."
@@ -1010,10 +1010,10 @@ class Worker(ORMBaseModel):
 
 
 class WorkPoolQueue(ORMBaseModel):
-    """An ORM representation of a worker pool queue"""
+    """An ORM representation of a work pool queue"""
 
     work_pool_id: UUID = Field(
-        description="The worker pool with which the queue is associated."
+        description="The work pool with which the queue is associated."
     )
     name: str = Field(
         description="The name of the queue.",

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -1285,8 +1285,8 @@ class WorkQueueFilter(PrefectOperatorFilterBaseModel):
         return filters
 
 
-class WorkerPoolFilterId(PrefectFilterBaseModel):
-    """Filter by `WorkerPool.id`."""
+class WorkPoolFilterId(PrefectFilterBaseModel):
+    """Filter by `WorkPool.id`."""
 
     any_: Optional[List[UUID]] = Field(
         default=None, description="A list of worker pool ids to include"
@@ -1295,12 +1295,12 @@ class WorkerPoolFilterId(PrefectFilterBaseModel):
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkerPool.id.in_(self.any_))
+            filters.append(db.WorkPool.id.in_(self.any_))
         return filters
 
 
-class WorkerPoolFilterName(PrefectFilterBaseModel):
-    """Filter by `WorkerPool.name`."""
+class WorkPoolFilterName(PrefectFilterBaseModel):
+    """Filter by `WorkPool.name`."""
 
     any_: Optional[List[str]] = Field(
         default=None, description="A list of worker pool names to include"
@@ -1309,12 +1309,12 @@ class WorkerPoolFilterName(PrefectFilterBaseModel):
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkerPool.name.in_(self.any_))
+            filters.append(db.WorkPool.name.in_(self.any_))
         return filters
 
 
-class WorkerPoolFilterType(PrefectFilterBaseModel):
-    """Filter by `WorkerPool.type`."""
+class WorkPoolFilterType(PrefectFilterBaseModel):
+    """Filter by `WorkPool.type`."""
 
     any_: Optional[List[str]] = Field(
         default=None, description="A list of worker pool types to include"
@@ -1323,20 +1323,20 @@ class WorkerPoolFilterType(PrefectFilterBaseModel):
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkerPool.type.in_(self.any_))
+            filters.append(db.WorkPool.type.in_(self.any_))
         return filters
 
 
-class WorkerPoolFilter(PrefectOperatorFilterBaseModel):
+class WorkPoolFilter(PrefectOperatorFilterBaseModel):
 
-    id: Optional[WorkerPoolFilterId] = Field(
-        default=None, description="Filter criteria for `WorkerPool.id`"
+    id: Optional[WorkPoolFilterId] = Field(
+        default=None, description="Filter criteria for `WorkPool.id`"
     )
-    name: Optional[WorkerPoolFilterName] = Field(
-        default=None, description="Filter criteria for `WorkerPool.name`"
+    name: Optional[WorkPoolFilterName] = Field(
+        default=None, description="Filter criteria for `WorkPool.name`"
     )
-    type: Optional[WorkerPoolFilterType] = Field(
-        default=None, description="Filter criteria for `WorkerPool.type`"
+    type: Optional[WorkPoolFilterType] = Field(
+        default=None, description="Filter criteria for `WorkPool.type`"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1352,8 +1352,8 @@ class WorkerPoolFilter(PrefectOperatorFilterBaseModel):
         return filters
 
 
-class WorkerPoolQueueFilterId(PrefectFilterBaseModel):
-    """Filter by `WorkerPoolQueue.id`."""
+class WorkPoolQueueFilterId(PrefectFilterBaseModel):
+    """Filter by `WorkPoolQueue.id`."""
 
     any_: Optional[List[UUID]] = Field(
         default=None, description="A list of worker pool queue ids to include"
@@ -1362,12 +1362,12 @@ class WorkerPoolQueueFilterId(PrefectFilterBaseModel):
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkerPoolQueue.id.in_(self.any_))
+            filters.append(db.WorkPoolQueue.id.in_(self.any_))
         return filters
 
 
-class WorkerPoolQueueFilterName(PrefectFilterBaseModel):
-    """Filter by `WorkerPoolQueue.name`."""
+class WorkPoolQueueFilterName(PrefectFilterBaseModel):
+    """Filter by `WorkPoolQueue.name`."""
 
     any_: Optional[List[str]] = Field(
         default=None, description="A list of worker pool queue names to include"
@@ -1376,17 +1376,17 @@ class WorkerPoolQueueFilterName(PrefectFilterBaseModel):
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkerPoolQueue.name.in_(self.any_))
+            filters.append(db.WorkPoolQueue.name.in_(self.any_))
         return filters
 
 
-class WorkerPoolQueueFilter(PrefectOperatorFilterBaseModel):
+class WorkPoolQueueFilter(PrefectOperatorFilterBaseModel):
 
-    id: Optional[WorkerPoolQueueFilterId] = Field(
-        default=None, description="Filter criteria for `WorkerPoolQueue.id`"
+    id: Optional[WorkPoolQueueFilterId] = Field(
+        default=None, description="Filter criteria for `WorkPoolQueue.id`"
     )
-    name: Optional[WorkerPoolQueueFilterName] = Field(
-        default=None, description="Filter criteria for `WorkerPoolQueue.name`"
+    name: Optional[WorkPoolQueueFilterName] = Field(
+        default=None, description="Filter criteria for `WorkPoolQueue.name`"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1400,7 +1400,7 @@ class WorkerPoolQueueFilter(PrefectOperatorFilterBaseModel):
         return filters
 
 
-class WorkerFilterWorkerPoolId(PrefectFilterBaseModel):
+class WorkerFilterWorkPoolId(PrefectFilterBaseModel):
     """Filter by `Worker.worker_config_id`."""
 
     any_: Optional[List[UUID]] = Field(
@@ -1437,7 +1437,7 @@ class WorkerFilterLastHeartbeatTime(PrefectFilterBaseModel):
 
 class WorkerFilter(PrefectOperatorFilterBaseModel):
 
-    # worker_config_id: Optional[WorkerFilterWorkerPoolId] = Field(
+    # worker_config_id: Optional[WorkerFilterWorkPoolId] = Field(
     #     default=None, description="Filter criteria for `Worker.worker_config_id`"
     # )
 

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -1289,7 +1289,7 @@ class WorkPoolFilterId(PrefectFilterBaseModel):
     """Filter by `WorkPool.id`."""
 
     any_: Optional[List[UUID]] = Field(
-        default=None, description="A list of worker pool ids to include"
+        default=None, description="A list of work pool ids to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1303,7 +1303,7 @@ class WorkPoolFilterName(PrefectFilterBaseModel):
     """Filter by `WorkPool.name`."""
 
     any_: Optional[List[str]] = Field(
-        default=None, description="A list of worker pool names to include"
+        default=None, description="A list of work pool names to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1317,7 +1317,7 @@ class WorkPoolFilterType(PrefectFilterBaseModel):
     """Filter by `WorkPool.type`."""
 
     any_: Optional[List[str]] = Field(
-        default=None, description="A list of worker pool types to include"
+        default=None, description="A list of work pool types to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1356,7 +1356,7 @@ class WorkPoolQueueFilterId(PrefectFilterBaseModel):
     """Filter by `WorkPoolQueue.id`."""
 
     any_: Optional[List[UUID]] = Field(
-        default=None, description="A list of worker pool queue ids to include"
+        default=None, description="A list of work pool queue ids to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1370,7 +1370,7 @@ class WorkPoolQueueFilterName(PrefectFilterBaseModel):
     """Filter by `WorkPoolQueue.name`."""
 
     any_: Optional[List[str]] = Field(
-        default=None, description="A list of worker pool queue names to include"
+        default=None, description="A list of work pool queue names to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
@@ -1404,7 +1404,7 @@ class WorkerFilterWorkPoolId(PrefectFilterBaseModel):
     """Filter by `Worker.worker_config_id`."""
 
     any_: Optional[List[UUID]] = Field(
-        default=None, description="A list of worker pool ids to include"
+        default=None, description="A list of work pool ids to include"
     )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -136,8 +136,8 @@ class WorkerFlowRunResponse(PrefectBaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    worker_pool_id: UUID
-    worker_pool_queue_id: UUID
+    work_pool_id: UUID
+    work_pool_queue_id: UUID
     flow_run: schemas.core.FlowRun
 
 
@@ -170,24 +170,24 @@ class FlowRunResponse(ORMBaseModel):
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
     infrastructure_pid: Optional[str] = FieldFrom(schemas.core.FlowRun)
     created_by: Optional[CreatedBy] = FieldFrom(schemas.core.FlowRun)
-    worker_pool_name: Optional[str] = Field(
+    work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's worker pool.",
-        example="my-worker-pool",
+        example="my-work-pool",
     )
-    worker_pool_queue_name: Optional[str] = Field(
+    work_pool_queue_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's worker pool queue.",
-        example="my-worker-pool-queue",
+        example="my-work-pool-queue",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
     def from_orm(cls, orm_flow_run: "prefect.orion.database.orm_models.ORMFlowRun"):
         response = super().from_orm(orm_flow_run)
-        if orm_flow_run.worker_pool_queue:
-            response.worker_pool_queue_name = orm_flow_run.worker_pool_queue.name
-            response.worker_pool_name = orm_flow_run.worker_pool_queue.worker_pool.name
+        if orm_flow_run.work_pool_queue:
+            response.work_pool_queue_name = orm_flow_run.work_pool_queue.name
+            response.work_pool_name = orm_flow_run.work_pool_queue.work_pool.name
 
         return response
 
@@ -230,11 +230,11 @@ class DeploymentResponse(ORMBaseModel):
     infrastructure_document_id: Optional[UUID] = FieldFrom(schemas.core.Deployment)
     created_by: Optional[CreatedBy] = FieldFrom(schemas.core.Deployment)
     updated_by: Optional[UpdatedBy] = FieldFrom(schemas.core.Deployment)
-    worker_pool_name: Optional[str] = Field(
+    work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool.",
     )
-    worker_pool_queue_name: Optional[str] = Field(
+    work_pool_queue_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's worker pool queue.",
     )
@@ -244,10 +244,10 @@ class DeploymentResponse(ORMBaseModel):
         cls, orm_deployment: "prefect.orion.database.orm_models.ORMDeployment"
     ):
         response = super().from_orm(orm_deployment)
-        if orm_deployment.worker_pool_queue:
-            response.worker_pool_queue_name = orm_deployment.worker_pool_queue.name
-            response.worker_pool_name = (
-                orm_deployment.worker_pool_queue.worker_pool.name
+        if orm_deployment.work_pool_queue:
+            response.work_pool_queue_name = orm_deployment.work_pool_queue.name
+            response.work_pool_name = (
+                orm_deployment.work_pool_queue.work_pool.name
             )
 
         return response

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -172,12 +172,12 @@ class FlowRunResponse(ORMBaseModel):
     created_by: Optional[CreatedBy] = FieldFrom(schemas.core.FlowRun)
     work_pool_name: Optional[str] = Field(
         default=None,
-        description="The name of the flow run's worker pool.",
+        description="The name of the flow run's work pool.",
         example="my-work-pool",
     )
     work_pool_queue_name: Optional[str] = Field(
         default=None,
-        description="The name of the flow run's worker pool queue.",
+        description="The name of the flow run's work pool queue.",
         example="my-work-pool-queue",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
@@ -232,11 +232,11 @@ class DeploymentResponse(ORMBaseModel):
     updated_by: Optional[UpdatedBy] = FieldFrom(schemas.core.Deployment)
     work_pool_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool.",
+        description="The name of the deployment's work pool.",
     )
     work_pool_queue_name: Optional[str] = Field(
         default=None,
-        description="The name of the deployment's worker pool queue.",
+        description="The name of the deployment's work pool queue.",
     )
 
     @classmethod

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -246,8 +246,6 @@ class DeploymentResponse(ORMBaseModel):
         response = super().from_orm(orm_deployment)
         if orm_deployment.work_pool_queue:
             response.work_pool_queue_name = orm_deployment.work_pool_queue.name
-            response.work_pool_name = (
-                orm_deployment.work_pool_queue.work_pool.name
-            )
+            response.work_pool_name = orm_deployment.work_pool_queue.work_pool.name
 
         return response

--- a/tests/agent/test_agent_run_cancellation.py
+++ b/tests/agent/test_agent_run_cancellation.py
@@ -29,7 +29,7 @@ async def _create_test_deployment_from_orm(
                     "is_schedule_active",
                     "created_by",
                     "updated_by",
-                    "worker_pool_queue_id",
+                    "work_pool_queue_id",
                 }
             )
         )

--- a/tests/experimental/cli/test_worker.py
+++ b/tests/experimental/cli/test_worker.py
@@ -29,7 +29,7 @@ def test_start_worker_run_once_with_name():
             "start",
             "--run-once",
             "-p",
-            "test-worker-pool",
+            "test-work-pool",
             "-n",
             "test-worker",
         ],
@@ -41,7 +41,7 @@ def test_start_worker_run_once_with_name():
     )
 
 
-async def test_start_worker_creates_worker_pool(orion_client: OrionClient):
+async def test_start_worker_creates_work_pool(orion_client: OrionClient):
     await run_sync_in_worker_thread(
         invoke_and_assert,
         command=["worker", "start", "--run-once", "-p", "not-yet-created-pool"],
@@ -49,10 +49,10 @@ async def test_start_worker_creates_worker_pool(orion_client: OrionClient):
         expected_output_contains=["Worker", "stopped!", "Worker", "started!"],
     )
 
-    worker_pool = await orion_client.read_worker_pool("not-yet-created-pool")
-    assert worker_pool is not None
-    assert worker_pool.name == "not-yet-created-pool"
-    assert worker_pool.default_queue_id is not None
+    work_pool = await orion_client.read_work_pool("not-yet-created-pool")
+    assert work_pool is not None
+    assert work_pool.name == "not-yet-created-pool"
+    assert work_pool.default_queue_id is not None
 
 
 def test_start_worker_with_prefetch_seconds(monkeypatch):
@@ -74,7 +74,7 @@ def test_start_worker_with_prefetch_seconds(monkeypatch):
     )
     mock_worker.assert_called_once_with(
         name=None,
-        worker_pool_name="test",
+        work_pool_name="test",
         prefetch_seconds=30,
         limit=None,
     )
@@ -98,7 +98,7 @@ def test_start_worker_with_prefetch_seconds_from_setting_by_default(monkeypatch)
         )
     mock_worker.assert_called_once_with(
         name=None,
-        worker_pool_name="test",
+        work_pool_name="test",
         prefetch_seconds=100,
         limit=None,
     )
@@ -123,13 +123,13 @@ def test_start_worker_with_limit(monkeypatch):
     )
     mock_worker.assert_called_once_with(
         name=None,
-        worker_pool_name="test",
+        work_pool_name="test",
         prefetch_seconds=10,
         limit=5,
     )
 
 
-async def test_worker_joins_existing_pool(worker_pool, orion_client: OrionClient):
+async def test_worker_joins_existing_pool(work_pool, orion_client: OrionClient):
     await run_sync_in_worker_thread(
         invoke_and_assert,
         command=[
@@ -137,7 +137,7 @@ async def test_worker_joins_existing_pool(worker_pool, orion_client: OrionClient
             "start",
             "--run-once",
             "-p",
-            worker_pool.name,
+            work_pool.name,
             "-n",
             "test-worker",
         ],
@@ -148,7 +148,7 @@ async def test_worker_joins_existing_pool(worker_pool, orion_client: OrionClient
         ],
     )
 
-    workers = await orion_client.read_workers_for_worker_pool(
-        worker_pool_name=worker_pool.name
+    workers = await orion_client.read_workers_for_work_pool(
+        work_pool_name=work_pool.name
     )
     assert workers[0].name == "test-worker"

--- a/tests/experimental/workers/test_base_worker.py
+++ b/tests/experimental/workers/test_base_worker.py
@@ -99,9 +99,7 @@ async def test_worker_respects_settings(setting, attr):
 async def test_worker_sends_heartbeat_messages(
     orion_client: OrionClient,
 ):
-    async with WorkerTestImpl(
-        name="test", work_pool_name="test-work-pool"
-    ) as worker:
+    async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
         await worker.sync_with_backend()
 
         workers = await orion_client.read_workers_for_work_pool(

--- a/tests/experimental/workers/test_process_worker.py
+++ b/tests/experimental/workers/test_process_worker.py
@@ -80,7 +80,7 @@ def mock_open_process(monkeypatch):
 async def test_worker_process_run_flow_run(flow_run, patch_run_process):
     mock: AsyncMock = patch_run_process()
 
-    async with ProcessWorker(worker_pool_name="test-worker-pool") as worker:
+    async with ProcessWorker(work_pool_name="test-work-pool") as worker:
         result = await worker.run(flow_run)
 
         assert isinstance(result, ProcessWorkerResult)
@@ -98,7 +98,7 @@ async def test_process_created_then_marked_as_started(flow_run, mock_open_proces
     fake_status.started.side_effect = RuntimeError("Started called!")
 
     with pytest.raises(RuntimeError, match="Started called!"):
-        async with ProcessWorker(worker_pool_name="test-worker-pool") as worker:
+        async with ProcessWorker(work_pool_name="test-work-pool") as worker:
             await worker.run(flow_run=flow_run, task_status=fake_status)
 
     fake_status.started.assert_called_once()
@@ -120,7 +120,7 @@ async def test_process_worker_logs_exit_code_help_message(
 ):
 
     patch_run_process(returncode=exit_code)
-    async with ProcessWorker(worker_pool_name="test-worker-pool") as worker:
+    async with ProcessWorker(work_pool_name="test-work-pool") as worker:
         result = await worker.run(flow_run=flow_run)
 
         assert result.status_code == exit_code
@@ -139,7 +139,7 @@ async def test_windows_process_worker_run_sets_process_group_creation_flag(
 ):
     mock = patch_run_process()
 
-    async with ProcessWorker(worker_pool_name="test-worker-pool") as worker:
+    async with ProcessWorker(work_pool_name="test-work-pool") as worker:
         await worker.run(flow_run=flow_run)
 
     mock.assert_awaited_once()
@@ -155,7 +155,7 @@ async def test_unix_process_worker_run_does_not_set_creation_flag(
     patch_run_process, flow_run
 ):
     mock = patch_run_process()
-    async with ProcessWorker(worker_pool_name="test-worker-pool") as worker:
+    async with ProcessWorker(work_pool_name="test-work-pool") as worker:
         await worker.run(flow_run=flow_run)
 
     mock.assert_awaited_once()

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -63,7 +63,7 @@ async def clear_db(db):
     """
     yield
     async with db.session_context(begin_transaction=True) as session:
-        # worker pool has a circular dependency on pool queue; delete it first
+        # work pool has a circular dependency on pool queue; delete it first
         await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(db.Base.metadata.sorted_tables):

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -64,7 +64,7 @@ async def clear_db(db):
     yield
     async with db.session_context(begin_transaction=True) as session:
         # worker pool has a circular dependency on pool queue; delete it first
-        await session.execute(db.WorkerPool.__table__.delete())
+        await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(db.Base.metadata.sorted_tables):
             await session.execute(table.delete())
@@ -330,7 +330,7 @@ async def deployment(
     flow_function,
     infrastructure_document_id,
     storage_document_id,
-    worker_pool_queue,
+    work_pool_queue,
 ):
     def hello(name: str):
         pass
@@ -351,7 +351,7 @@ async def deployment(
             infrastructure_document_id=infrastructure_document_id,
             work_queue_name="wq",
             parameter_openapi_schema=parameter_schema(hello),
-            worker_pool_queue_id=worker_pool_queue.id,
+            work_pool_queue_id=work_pool_queue.id,
         ),
     )
     await session.commit()
@@ -372,21 +372,21 @@ async def work_queue(session):
 
 
 @pytest.fixture
-async def worker_pool(session):
-    model = await models.workers.create_worker_pool(
+async def work_pool(session):
+    model = await models.workers.create_work_pool(
         session=session,
-        worker_pool=schemas.actions.WorkerPoolCreate(name="Test Worker Pool"),
+        work_pool=schemas.actions.WorkPoolCreate(name="Test Worker Pool"),
     )
     await session.commit()
     return model
 
 
 @pytest.fixture
-async def worker_pool_queue(session, worker_pool):
-    model = await models.workers.create_worker_pool_queue(
+async def work_pool_queue(session, work_pool):
+    model = await models.workers.create_work_pool_queue(
         session=session,
-        worker_pool_id=worker_pool.id,
-        worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="Test Queue"),
+        work_pool_id=work_pool.id,
+        work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="Test Queue"),
     )
     await session.commit()
     return model

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -360,8 +360,8 @@ class TestCreateDeployment:
         flow,
         session,
         infrastructure_document_id,
-        worker_pool,
-        worker_pool_queue,
+        work_pool,
+        work_pool_queue,
     ):
         data = DeploymentCreate(
             name="My Deployment",
@@ -373,8 +373,8 @@ class TestCreateDeployment:
             parameters={"foo": "bar"},
             infrastructure_document_id=infrastructure_document_id,
             infra_overrides={"cpu": 24},
-            worker_pool_name=worker_pool.name,
-            worker_pool_queue_name=worker_pool_queue.name,
+            work_pool_name=work_pool.name,
+            work_pool_queue_name=work_pool_queue.name,
         ).dict(json_compatible=True)
         response = await client.post("/deployments/", json=data)
         assert response.status_code == status.HTTP_201_CREATED
@@ -386,8 +386,8 @@ class TestCreateDeployment:
             infrastructure_document_id
         )
         assert response.json()["infra_overrides"] == {"cpu": 24}
-        assert response.json()["worker_pool_name"] == worker_pool.name
-        assert response.json()["worker_pool_queue_name"] == worker_pool_queue.name
+        assert response.json()["work_pool_name"] == work_pool.name
+        assert response.json()["work_pool_queue_name"] == work_pool_queue.name
         deployment_id = response.json()["id"]
 
         deployment = await models.deployments.read_deployment(
@@ -399,18 +399,18 @@ class TestCreateDeployment:
         assert deployment.flow_id == flow.id
         assert deployment.parameters == {"foo": "bar"}
         assert deployment.infrastructure_document_id == infrastructure_document_id
-        assert deployment.worker_pool_queue_id == worker_pool_queue.id
+        assert deployment.work_pool_queue_id == work_pool_queue.id
 
-    async def test_create_deployment_with_only_worker_pool(
+    async def test_create_deployment_with_only_work_pool(
         self,
         client,
         flow,
         session,
         infrastructure_document_id,
-        worker_pool,
+        work_pool,
     ):
-        default_queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        default_queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         data = DeploymentCreate(
             name="My Deployment",
@@ -422,7 +422,7 @@ class TestCreateDeployment:
             parameters={"foo": "bar"},
             infrastructure_document_id=infrastructure_document_id,
             infra_overrides={"cpu": 24},
-            worker_pool_name=worker_pool.name,
+            work_pool_name=work_pool.name,
         ).dict(json_compatible=True)
         response = await client.post("/deployments/", json=data)
         assert response.status_code == status.HTTP_201_CREATED
@@ -434,8 +434,8 @@ class TestCreateDeployment:
             infrastructure_document_id
         )
         assert response.json()["infra_overrides"] == {"cpu": 24}
-        assert response.json()["worker_pool_name"] == worker_pool.name
-        assert response.json()["worker_pool_queue_name"] == default_queue.name
+        assert response.json()["work_pool_name"] == work_pool.name
+        assert response.json()["work_pool_queue_name"] == default_queue.name
         deployment_id = response.json()["id"]
 
         deployment = await models.deployments.read_deployment(
@@ -447,7 +447,7 @@ class TestCreateDeployment:
         assert deployment.flow_id == flow.id
         assert deployment.parameters == {"foo": "bar"}
         assert deployment.infrastructure_document_id == infrastructure_document_id
-        assert deployment.worker_pool_queue_id == worker_pool.default_queue_id
+        assert deployment.work_pool_queue_id == work_pool.default_queue_id
 
 
 class TestReadDeployment:

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -353,7 +353,7 @@ class TestCreateDeployment:
             in response.json()["detail"]
         ), "Error message identifies storage block could not be found."
 
-    # TODO: update this test as more changes are made to worker pool deployments
+    # TODO: update this test as more changes are made to work pool deployments
     async def test_create_deployment_with_pool_and_queue(
         self,
         client,

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -281,7 +281,7 @@ class TestReadFlowRun:
 
 class TestReadFlowRuns:
     @pytest.fixture
-    async def flow_runs(self, flow, worker_pool_queue, session):
+    async def flow_runs(self, flow, work_pool_queue, session):
         flow_2 = await models.flows.create_flow(
             session=session,
             flow=actions.FlowCreate(name="another-test"),
@@ -301,7 +301,7 @@ class TestReadFlowRuns:
                 flow_id=flow_2.id,
                 name="fr3",
                 tags=["blue", "red"],
-                worker_pool_queue_id=worker_pool_queue.id,
+                work_pool_queue_id=work_pool_queue.id,
             ),
         )
         await session.commit()
@@ -316,8 +316,8 @@ class TestReadFlowRuns:
             List[schemas.responses.FlowRunResponse], response.json()
         )
 
-    async def test_read_flow_runs_worker_pool_fields(
-        self, flow_runs, client, worker_pool, worker_pool_queue
+    async def test_read_flow_runs_work_pool_fields(
+        self, flow_runs, client, work_pool, work_pool_queue
     ):
         response = await client.post("/flow_runs/filter")
         assert response.status_code == status.HTTP_200_OK
@@ -328,8 +328,8 @@ class TestReadFlowRuns:
             ),
             key=lambda fr: fr.name,
         )
-        assert response[2].worker_pool_name == worker_pool.name
-        assert response[2].worker_pool_queue_name == worker_pool_queue.name
+        assert response[2].work_pool_name == work_pool.name
+        assert response[2].work_pool_queue_name == work_pool_queue.name
 
     async def test_read_flow_runs_applies_flow_filter(self, flow, flow_runs, client):
         flow_run_filter = dict(
@@ -375,31 +375,31 @@ class TestReadFlowRuns:
         assert len(response.json()) == 1
         assert response.json()[0]["id"] == str(flow_runs[1].id)
 
-    async def test_read_flow_runs_applies_worker_pool_name_filter(
-        self, flow_runs, client, worker_pool
+    async def test_read_flow_runs_applies_work_pool_name_filter(
+        self, flow_runs, client, work_pool
     ):
-        worker_pool_filter = dict(
-            worker_pools=schemas.filters.WorkerPoolFilter(
-                name=schemas.filters.WorkerPoolFilterName(any_=[worker_pool.name])
+        work_pool_filter = dict(
+            work_pools=schemas.filters.WorkPoolFilter(
+                name=schemas.filters.WorkPoolFilterName(any_=[work_pool.name])
             ).dict(json_compatible=True)
         )
-        response = await client.post("/flow_runs/filter", json=worker_pool_filter)
+        response = await client.post("/flow_runs/filter", json=work_pool_filter)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 1
         assert response.json()[0]["id"] == str(flow_runs[2].id)
 
-    async def test_read_flow_runs_applies_worker_pool_queue_id_filter(
+    async def test_read_flow_runs_applies_work_pool_queue_id_filter(
         self,
         flow_runs,
-        worker_pool_queue,
+        work_pool_queue,
         client,
     ):
-        worker_pool_filter = dict(
-            worker_pool_queues=schemas.filters.WorkerPoolQueueFilter(
-                id=schemas.filters.WorkerPoolQueueFilterId(any_=[worker_pool_queue.id])
+        work_pool_filter = dict(
+            work_pool_queues=schemas.filters.WorkPoolQueueFilter(
+                id=schemas.filters.WorkPoolQueueFilterId(any_=[work_pool_queue.id])
             ).dict(json_compatible=True)
         )
-        response = await client.post("/flow_runs/filter", json=worker_pool_filter)
+        response = await client.post("/flow_runs/filter", json=work_pool_filter)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()) == 1
         assert response.json()[0]["id"] == str(flow_runs[2].id)

--- a/tests/orion/api/test_workers.py
+++ b/tests/orion/api/test_workers.py
@@ -278,7 +278,7 @@ class TestCreateWorkPoolQueue:
 
 class TestReadWorkPoolQueue:
     async def test_read_work_pool_queue(self, client, work_pool):
-        # Create worker pool queue
+        # Create work pool queue
         create_response = await client.post(
             f"/experimental/work_pools/{work_pool.name}/queues",
             json=dict(name="test-queue", description="test queue"),
@@ -296,7 +296,7 @@ class TestReadWorkPoolQueue:
 
 class TestUpdateWorkPoolQueue:
     async def test_update_work_pool_queue(self, client, work_pool):
-        # Create worker pool queue
+        # Create work pool queue
         create_response = await client.post(
             f"/experimental/work_pools/{work_pool.name}/queues",
             json=dict(name="test-queue", description="test queue"),
@@ -305,7 +305,7 @@ class TestUpdateWorkPoolQueue:
         create_result = pydantic.parse_obj_as(WorkPoolQueue, create_response.json())
         assert not create_result.is_paused
 
-        # Update worker pool queue
+        # Update work pool queue
         update_response = await client.patch(
             f"/experimental/work_pools/{work_pool.name}/queues/test-queue",
             json=dict(
@@ -316,7 +316,7 @@ class TestUpdateWorkPoolQueue:
         )
         assert update_response.status_code == status.HTTP_204_NO_CONTENT
 
-        # Read updated worker pool queue
+        # Read updated work pool queue
         read_response = await client.get(
             f"/experimental/work_pools/{work_pool.name}/queues/updated-test-queue"
         )
@@ -391,12 +391,12 @@ class TestGetScheduledRuns:
     async def setup(self, session, flow):
         """
         Creates:
-        - Three different worker pools ("A", "B", "C")
+        - Three different work pools ("A", "B", "C")
         - Three different queues in each pool ("AA", "AB", "AC", "BA", "BB", "BC", "CA", "CB", "CC")
         - One pending run, one running run, and 5 scheduled runs in each queue
         """
 
-        # create three different worker pools
+        # create three different work pools
         wp_a = await models.workers.create_work_pool(
             session=session,
             work_pool=schemas.actions.WorkPoolCreate(name="A"),

--- a/tests/orion/api/test_workers.py
+++ b/tests/orion/api/test_workers.py
@@ -90,9 +90,7 @@ class TestCreateWorkPool:
 
     @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
     async def test_create_work_pool_with_invalid_name(self, client, name):
-        response = await client.post(
-            "/experimental/work_pools/", json=dict(name=name)
-        )
+        response = await client.post("/experimental/work_pools/", json=dict(name=name))
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     @pytest.mark.parametrize("type", [None, "PROCESS", "K8S", "AGENT"])
@@ -106,9 +104,7 @@ class TestCreateWorkPool:
 
     @pytest.mark.parametrize("name", RESERVED_POOL_NAMES)
     async def test_create_reserved_pool_fails(self, session, client, name):
-        response = await client.post(
-            "/experimental/work_pools/", json=dict(name=name)
-        )
+        response = await client.post("/experimental/work_pools/", json=dict(name=name))
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "reserved for internal use" in response.json()["detail"]
 
@@ -558,9 +554,7 @@ class TestGetScheduledRuns:
         )
         assert len(data) == 5
 
-    async def test_get_all_runs_wq_aa_wq_ab(
-        self, client, work_pools, work_pool_queues
-    ):
+    async def test_get_all_runs_wq_aa_wq_ab(self, client, work_pools, work_pool_queues):
         response = await client.post(
             f"/experimental/work_pools/{work_pools['wp_a'].name}/get_scheduled_flow_runs",
             json=dict(

--- a/tests/orion/database/test_dependencies.py
+++ b/tests/orion/database/test_dependencies.py
@@ -121,7 +121,7 @@ async def test_injecting_really_dumb_query_components():
         ):
             ...
 
-        def _get_scheduled_flow_runs_from_worker_pool_template_path(self):
+        def _get_scheduled_flow_runs_from_work_pool_template_path(self):
             ...
 
     with dependencies.temporary_query_components(ReallyBrokenQueries()):

--- a/tests/orion/database/test_queries.py
+++ b/tests/orion/database/test_queries.py
@@ -229,12 +229,12 @@ class TestGetRunsFromWorkPoolQueueQuery:
     async def setup(self, session, flow):
         """
         Creates:
-        - Three different worker pools ("A", "B", "C")
+        - Three different work pools ("A", "B", "C")
         - Three different queues in each pool ("AA", "AB", "AC", "BA", "BB", "BC", "CA", "CB", "CC")
         - One pending run, one running run, and 5 scheduled runs in each queue
         """
 
-        # create three different worker pools
+        # create three different work pools
         wp_a = await models.workers.create_work_pool(
             session=session,
             work_pool=schemas.actions.WorkPoolCreate(name="A"),

--- a/tests/orion/database/test_queries.py
+++ b/tests/orion/database/test_queries.py
@@ -415,9 +415,7 @@ class TestGetRunsFromWorkPoolQueueQuery:
             work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 5
-        assert all(
-            r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs
-        )
+        assert all(r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs)
 
     async def test_get_wq_aa_runs_with_all_wc_also_provided(
         self, session, db: OrionDBInterface, work_pools, work_pool_queues
@@ -433,9 +431,7 @@ class TestGetRunsFromWorkPoolQueueQuery:
             work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 5
-        assert all(
-            r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs
-        )
+        assert all(r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs)
 
     async def test_get_wq_aa_runs_when_queue_is_paused(
         self, session, db: OrionDBInterface, work_pools, work_pool_queues
@@ -599,11 +595,7 @@ class TestGetRunsFromWorkPoolQueueQuery:
         )
         assert len(runs) == 24
         assert (
-            sum(
-                1
-                for r in runs
-                if r.work_pool_queue_id == work_pool_queues["wq_aa"].id
-            )
+            sum(1 for r in runs if r.work_pool_queue_id == work_pool_queues["wq_aa"].id)
             == 0
         )
 
@@ -691,13 +683,9 @@ class TestGetRunsFromWorkPoolQueueQuery:
         # first 10 runs are from wq_aa or wq_ba
         assert all([r.work_pool_queue_id in (wq_aa.id, wq_ba.id) for r in runs[:10]])
         # next 10 runs are from wq_ab or wq_bb
-        assert all(
-            [r.work_pool_queue_id in (wq_ab.id, wq_bb.id) for r in runs[10:20]]
-        )
+        assert all([r.work_pool_queue_id in (wq_ab.id, wq_bb.id) for r in runs[10:20]])
         # next 10 runs are from wq_ac or wq_bc
-        assert all(
-            [r.work_pool_queue_id in (wq_ac.id, wq_bc.id) for r in runs[20:30]]
-        )
+        assert all([r.work_pool_queue_id in (wq_ac.id, wq_bc.id) for r in runs[20:30]])
 
         # runs are not in time order
         assert sorted(runs, key=lambda r: r.flow_run.next_scheduled_start_time) != runs

--- a/tests/orion/database/test_queries.py
+++ b/tests/orion/database/test_queries.py
@@ -224,7 +224,7 @@ class TestGetRunsInQueueQuery:
         assert len(result2) == 0
 
 
-class TestGetRunsFromWorkerPoolQueueQuery:
+class TestGetRunsFromWorkPoolQueueQuery:
     @pytest.fixture(autouse=True)
     async def setup(self, session, flow):
         """
@@ -235,64 +235,64 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         """
 
         # create three different worker pools
-        wp_a = await models.workers.create_worker_pool(
+        wp_a = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="A"),
+            work_pool=schemas.actions.WorkPoolCreate(name="A"),
         )
-        wp_b = await models.workers.create_worker_pool(
+        wp_b = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="B"),
+            work_pool=schemas.actions.WorkPoolCreate(name="B"),
         )
-        wp_c = await models.workers.create_worker_pool(
+        wp_c = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="C"),
+            work_pool=schemas.actions.WorkPoolCreate(name="C"),
         )
 
         # create three different work queues for each config
-        wq_aa = await models.workers.create_worker_pool_queue(
+        wq_aa = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AA"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AA"),
         )
-        wq_ab = await models.workers.create_worker_pool_queue(
+        wq_ab = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AB"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AB"),
         )
-        wq_ac = await models.workers.create_worker_pool_queue(
+        wq_ac = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AC"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AC"),
         )
-        wq_ba = await models.workers.create_worker_pool_queue(
+        wq_ba = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BA"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BA"),
         )
-        wq_bb = await models.workers.create_worker_pool_queue(
+        wq_bb = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BB"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BB"),
         )
-        wq_bc = await models.workers.create_worker_pool_queue(
+        wq_bc = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BC"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BC"),
         )
-        wq_ca = await models.workers.create_worker_pool_queue(
+        wq_ca = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CA"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CA"),
         )
-        wq_cb = await models.workers.create_worker_pool_queue(
+        wq_cb = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CB"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CB"),
         )
-        wq_cc = await models.workers.create_worker_pool_queue(
+        wq_cc = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CC"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CC"),
         )
 
         # create flow runs
@@ -303,7 +303,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
                 flow_run=schemas.core.FlowRun(
                     flow_id=flow.id,
                     state=prefect.states.Running(),
-                    worker_pool_queue_id=wq.id,
+                    work_pool_queue_id=wq.id,
                 ),
             )
 
@@ -313,7 +313,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
                 flow_run=schemas.core.FlowRun(
                     flow_id=flow.id,
                     state=prefect.states.Pending(),
-                    worker_pool_queue_id=wq.id,
+                    work_pool_queue_id=wq.id,
                 ),
             )
 
@@ -328,14 +328,14 @@ class TestGetRunsFromWorkerPoolQueueQuery:
                         state=prefect.states.Scheduled(
                             scheduled_time=pendulum.now().add(hours=i)
                         ),
-                        worker_pool_queue_id=wq.id,
+                        work_pool_queue_id=wq.id,
                     ),
                 )
         await session.commit()
 
         return dict(
-            worker_pools=dict(wp_a=wp_a, wp_b=wp_b, wp_c=wp_c),
-            worker_pool_queues=dict(
+            work_pools=dict(wp_a=wp_a, wp_b=wp_b, wp_c=wp_c),
+            work_pool_queues=dict(
                 wq_aa=wq_aa,
                 wq_ab=wq_ab,
                 wq_ac=wq_ac,
@@ -349,17 +349,17 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         )
 
     @pytest.fixture
-    def worker_pools(self, setup):
-        return setup["worker_pools"]
+    def work_pools(self, setup):
+        return setup["work_pools"]
 
     @pytest.fixture
-    def worker_pool_queues(self, setup):
-        return setup["worker_pool_queues"]
+    def work_pool_queues(self, setup):
+        return setup["work_pool_queues"]
 
     async def test_get_all_runs(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db
         )
         assert len(runs) == 45
@@ -369,12 +369,12 @@ class TestGetRunsFromWorkerPoolQueueQuery:
 
     @pytest.mark.parametrize("limit", [100, 10, 0])
     async def test_get_all_runs_with_limit(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues, limit
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues, limit
     ):
-        all_runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        all_runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db, limit=min(limit, 45)
         )
         assert len(runs) == min(limit, 45)
@@ -385,85 +385,85 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         ]
 
     async def test_get_wc_a_runs(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
-            session=session, db=db, worker_pool_ids=[worker_pools["wp_a"].id]
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
+            session=session, db=db, work_pool_ids=[work_pools["wp_a"].id]
         )
         assert len(runs) == 15
 
     async def test_get_wc_a_b_and_c_runs(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[
-                worker_pools["wp_a"].id,
-                worker_pools["wp_b"].id,
-                worker_pools["wp_c"].id,
+            work_pool_ids=[
+                work_pools["wp_a"].id,
+                work_pools["wp_b"].id,
+                work_pools["wp_c"].id,
             ],
         )
         assert len(runs) == 45
 
     async def test_get_wq_aa_runs(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 5
         assert all(
-            r.worker_pool_queue_id == worker_pool_queues["wq_aa"].id for r in runs
+            r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs
         )
 
     async def test_get_wq_aa_runs_with_all_wc_also_provided(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[
-                worker_pools["wp_a"].id,
-                worker_pools["wp_b"].id,
-                worker_pools["wp_c"].id,
+            work_pool_ids=[
+                work_pools["wp_a"].id,
+                work_pools["wp_b"].id,
+                work_pools["wp_c"].id,
             ],
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 5
         assert all(
-            r.worker_pool_queue_id == worker_pool_queues["wq_aa"].id for r in runs
+            r.work_pool_queue_id == work_pool_queues["wq_aa"].id for r in runs
         )
 
     async def test_get_wq_aa_runs_when_queue_is_paused(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queues["wq_aa"].id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(is_paused=True),
+            work_pool_queue_id=work_pool_queues["wq_aa"].id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(is_paused=True),
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 0
 
     async def test_get_wq_aa_runs_when_worker_is_paused(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        assert await models.workers.update_worker_pool(
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pools["wp_a"].id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(is_paused=True),
+            work_pool_id=work_pools["wp_a"].id,
+            work_pool=schemas.actions.WorkPoolUpdate(is_paused=True),
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 0
 
@@ -472,23 +472,23 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         self,
         session,
         db: OrionDBInterface,
-        worker_pools,
-        worker_pool_queues,
+        work_pools,
+        work_pool_queues,
         concurrency_limit,
         expected,
     ):
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queues["wq_aa"].id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(
+            work_pool_queue_id=work_pool_queues["wq_aa"].id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(
                 concurrency_limit=concurrency_limit
             ),
         )
         await session.commit()
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == expected
 
@@ -499,22 +499,22 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         self,
         session,
         db: OrionDBInterface,
-        worker_pools,
-        worker_pool_queues,
+        work_pools,
+        work_pool_queues,
         concurrency_limit,
         expected,
     ):
-        assert await models.workers.update_worker_pool(
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pools["wp_a"].id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(
+            work_pool_id=work_pools["wp_a"].id,
+            work_pool=schemas.actions.WorkPoolUpdate(
                 concurrency_limit=concurrency_limit
             ),
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == expected
 
@@ -525,76 +525,76 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         self,
         session,
         db: OrionDBInterface,
-        worker_pools,
-        worker_pool_queues,
+        work_pools,
+        work_pool_queues,
         concurrency_limit,
         expected,
     ):
-        assert await models.workers.update_worker_pool(
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pools["wp_a"].id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(
+            work_pool_id=work_pools["wp_a"].id,
+            work_pool=schemas.actions.WorkPoolUpdate(
                 concurrency_limit=concurrency_limit
             ),
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[worker_pools["wp_a"].id],
+            work_pool_ids=[work_pools["wp_a"].id],
         )
         assert len(runs) == expected
 
     @pytest.mark.parametrize("limit", [100, 7, 0])
     async def test_worker_limit(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues, limit
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues, limit
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db, worker_limit=limit
         )
         assert len(runs) == min(15, limit) * 3
-        for wc in worker_pools.values():
-            assert sum(1 for r in runs if r.worker_pool_id == wc.id) == min(15, limit)
+        for wc in work_pools.values():
+            assert sum(1 for r in runs if r.work_pool_id == wc.id) == min(15, limit)
 
     async def test_worker_limit_with_pause(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        assert await models.workers.update_worker_pool(
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pools["wp_a"].id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(is_paused=True),
+            work_pool_id=work_pools["wp_a"].id,
+            work_pool=schemas.actions.WorkPoolUpdate(is_paused=True),
         )
 
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db, worker_limit=7
         )
 
         assert len(runs) == 14
-        assert sum(1 for r in runs if r.worker_pool_id == worker_pools["wp_a"].id) == 0
-        assert sum(1 for r in runs if r.worker_pool_id == worker_pools["wp_b"].id) == 7
-        assert sum(1 for r in runs if r.worker_pool_id == worker_pools["wp_c"].id) == 7
+        assert sum(1 for r in runs if r.work_pool_id == work_pools["wp_a"].id) == 0
+        assert sum(1 for r in runs if r.work_pool_id == work_pools["wp_b"].id) == 7
+        assert sum(1 for r in runs if r.work_pool_id == work_pools["wp_c"].id) == 7
 
     @pytest.mark.parametrize("limit", [100, 3, 0])
     async def test_queue_limit(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues, limit
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues, limit
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db, queue_limit=limit
         )
         assert len(runs) == min(5, limit) * 9
-        for wq in worker_pool_queues.values():
-            assert sum(1 for r in runs if r.worker_pool_queue_id == wq.id) == min(
+        for wq in work_pool_queues.values():
+            assert sum(1 for r in runs if r.work_pool_queue_id == wq.id) == min(
                 5, limit
             )
 
     async def test_queue_limit_with_pause(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queues["wq_aa"].id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(is_paused=True),
+            work_pool_queue_id=work_pool_queues["wq_aa"].id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(is_paused=True),
         )
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session, db=db, queue_limit=3
         )
         assert len(runs) == 24
@@ -602,7 +602,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
             sum(
                 1
                 for r in runs
-                if r.worker_pool_queue_id == worker_pool_queues["wq_aa"].id
+                if r.work_pool_queue_id == work_pool_queues["wq_aa"].id
             )
             == 0
         )
@@ -613,20 +613,20 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         self,
         session,
         db: OrionDBInterface,
-        worker_pools,
-        worker_pool_queues,
+        work_pools,
+        work_pool_queues,
         respect_priorities,
     ):
         wq_aa, wq_ab, wq_ac = (
-            worker_pool_queues["wq_aa"],
-            worker_pool_queues["wq_ab"],
-            worker_pool_queues["wq_ac"],
+            work_pool_queues["wq_aa"],
+            work_pool_queues["wq_ab"],
+            work_pool_queues["wq_ac"],
         )
 
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[worker_pools["wp_a"].id],
+            work_pool_ids=[work_pools["wp_a"].id],
             respect_queue_priorities=respect_priorities,
         )
 
@@ -634,69 +634,69 @@ class TestGetRunsFromWorkerPoolQueueQuery:
 
         # first 3 runs are from all three queues
         assert all(
-            [r.worker_pool_queue_id in (wq_aa.id, wq_ab.id, wq_ac.id) for r in runs[:3]]
+            [r.work_pool_queue_id in (wq_aa.id, wq_ab.id, wq_ac.id) for r in runs[:3]]
         )
         # runs are in time order
         assert sorted(runs, key=lambda r: r.flow_run.next_scheduled_start_time) == runs
 
     async def test_runs_are_returned_from_queues_according_to_priority(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
         wq_aa, wq_ab, wq_ac = (
-            worker_pool_queues["wq_aa"],
-            worker_pool_queues["wq_ab"],
-            worker_pool_queues["wq_ac"],
+            work_pool_queues["wq_aa"],
+            work_pool_queues["wq_ab"],
+            work_pool_queues["wq_ac"],
         )
 
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[worker_pools["wp_a"].id],
+            work_pool_ids=[work_pools["wp_a"].id],
             respect_queue_priorities=True,
         )
 
         assert len(runs) == 15
 
         # first 5 runs are from wq_aa
-        assert all([r.worker_pool_queue_id == wq_aa.id for r in runs[:5]])
+        assert all([r.work_pool_queue_id == wq_aa.id for r in runs[:5]])
         # next 5 runs are from wq_ab
-        assert all([r.worker_pool_queue_id == wq_ab.id for r in runs[5:10]])
+        assert all([r.work_pool_queue_id == wq_ab.id for r in runs[5:10]])
         # next 5 runs are from wq_ac
-        assert all([r.worker_pool_queue_id == wq_ac.id for r in runs[10:15]])
+        assert all([r.work_pool_queue_id == wq_ac.id for r in runs[10:15]])
 
         # runs are not in time order
         assert sorted(runs, key=lambda r: r.flow_run.next_scheduled_start_time) != runs
 
     async def test_runs_are_returned_from_queues_according_to_priority_across_multiple_pools(
-        self, session, db: OrionDBInterface, worker_pools, worker_pool_queues
+        self, session, db: OrionDBInterface, work_pools, work_pool_queues
     ):
         wq_aa, wq_ab, wq_ac, wq_ba, wq_bb, wq_bc = (
-            worker_pool_queues["wq_aa"],
-            worker_pool_queues["wq_ab"],
-            worker_pool_queues["wq_ac"],
-            worker_pool_queues["wq_ba"],
-            worker_pool_queues["wq_bb"],
-            worker_pool_queues["wq_bc"],
+            work_pool_queues["wq_aa"],
+            work_pool_queues["wq_ab"],
+            work_pool_queues["wq_ac"],
+            work_pool_queues["wq_ba"],
+            work_pool_queues["wq_bb"],
+            work_pool_queues["wq_bc"],
         )
 
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
-            worker_pool_ids=[worker_pools["wp_a"].id, worker_pools["wp_b"].id],
+            work_pool_ids=[work_pools["wp_a"].id, work_pools["wp_b"].id],
             respect_queue_priorities=True,
         )
 
         assert len(runs) == 30
 
         # first 10 runs are from wq_aa or wq_ba
-        assert all([r.worker_pool_queue_id in (wq_aa.id, wq_ba.id) for r in runs[:10]])
+        assert all([r.work_pool_queue_id in (wq_aa.id, wq_ba.id) for r in runs[:10]])
         # next 10 runs are from wq_ab or wq_bb
         assert all(
-            [r.worker_pool_queue_id in (wq_ab.id, wq_bb.id) for r in runs[10:20]]
+            [r.work_pool_queue_id in (wq_ab.id, wq_bb.id) for r in runs[10:20]]
         )
         # next 10 runs are from wq_ac or wq_bc
         assert all(
-            [r.worker_pool_queue_id in (wq_ac.id, wq_bc.id) for r in runs[20:30]]
+            [r.work_pool_queue_id in (wq_ac.id, wq_bc.id) for r in runs[20:30]]
         )
 
         # runs are not in time order
@@ -715,10 +715,10 @@ class TestGetRunsFromWorkerPoolQueueQuery:
 
         async with db.session_context(begin_transaction=True) as session1:
             async with db.session_context(begin_transaction=True) as session2:
-                runs1 = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+                runs1 = await db.queries.get_scheduled_flow_runs_from_work_pool(
                     session=session1, db=db, limit=35
                 )
-                runs2 = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+                runs2 = await db.queries.get_scheduled_flow_runs_from_work_pool(
                     session=session2, db=db
                 )
 
@@ -738,10 +738,10 @@ class TestGetRunsFromWorkerPoolQueueQuery:
 
         async with db.session_context(begin_transaction=True) as session1:
             async with db.session_context(begin_transaction=True) as session2:
-                runs1 = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+                runs1 = await db.queries.get_scheduled_flow_runs_from_work_pool(
                     session=session1, db=db, queue_limit=2
                 )
-                runs2 = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+                runs2 = await db.queries.get_scheduled_flow_runs_from_work_pool(
                     session=session2, db=db
                 )
 
@@ -754,7 +754,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
     async def test_scheduled_before(
         self, session, db: OrionDBInterface, hours, expected
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
             scheduled_before=pendulum.now("UTC").add(hours=hours),
@@ -767,7 +767,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
     async def test_scheduled_after(
         self, session, db: OrionDBInterface, hours, expected
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
             scheduled_after=pendulum.now("UTC").add(hours=hours),
@@ -775,7 +775,7 @@ class TestGetRunsFromWorkerPoolQueueQuery:
         assert len(runs) == expected
 
     async def test_scheduled_before_and_after(self, session, db: OrionDBInterface):
-        runs = await db.queries.get_scheduled_flow_runs_from_worker_pool(
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
             db=db,
             # criteria should match no runs

--- a/tests/orion/models/test_deployments.py
+++ b/tests/orion/models/test_deployments.py
@@ -76,19 +76,19 @@ class TestCreateDeployment:
         )
         await session.commit()
 
-    async def test_create_deployment_with_worker_pool(
-        self, session, flow, worker_pool_queue
+    async def test_create_deployment_with_work_pool(
+        self, session, flow, work_pool_queue
     ):
         deployment = await models.deployments.create_deployment(
             session=session,
             deployment=schemas.core.Deployment(
                 name="My Deployment",
                 flow_id=flow.id,
-                worker_pool_queue_id=worker_pool_queue.id,
+                work_pool_queue_id=work_pool_queue.id,
             ),
         )
 
-        assert deployment.worker_pool_queue_id == worker_pool_queue.id
+        assert deployment.work_pool_queue_id == work_pool_queue.id
 
     async def test_create_deployment_updates_existing_deployment(
         self,
@@ -975,38 +975,38 @@ class TestUpdateDeployment:
         )
         assert wq is not None
 
-    async def test_update_worker_pool_deployment(
-        self, session, deployment, worker_pool, worker_pool_queue
+    async def test_update_work_pool_deployment(
+        self, session, deployment, work_pool, work_pool_queue
     ):
         await models.deployments.update_deployment(
             session=session,
             deployment_id=deployment.id,
             deployment=schemas.actions.DeploymentUpdate(
-                worker_pool_name=worker_pool.name,
-                worker_pool_queue_name=worker_pool_queue.name,
+                work_pool_name=work_pool.name,
+                work_pool_queue_name=work_pool_queue.name,
             ),
         )
 
         updated_deployment = await models.deployments.read_deployment(
             session=session, deployment_id=deployment.id
         )
-        assert updated_deployment.worker_pool_queue_id == worker_pool_queue.id
+        assert updated_deployment.work_pool_queue_id == work_pool_queue.id
 
-    async def test_update_worker_pool_deployment_with_only_pool(
-        self, session, deployment, worker_pool, worker_pool_queue
+    async def test_update_work_pool_deployment_with_only_pool(
+        self, session, deployment, work_pool, work_pool_queue
     ):
-        default_queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        default_queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         await models.deployments.update_deployment(
             session=session,
             deployment_id=deployment.id,
             deployment=schemas.actions.DeploymentUpdate(
-                worker_pool_name=worker_pool.name,
+                work_pool_name=work_pool.name,
             ),
         )
 
         updated_deployment = await models.deployments.read_deployment(
             session=session, deployment_id=deployment.id
         )
-        assert updated_deployment.worker_pool_queue_id == default_queue.id
+        assert updated_deployment.work_pool_queue_id == default_queue.id

--- a/tests/orion/models/test_filters.py
+++ b/tests/orion/models/test_filters.py
@@ -574,9 +574,7 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                )
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"]))
             ),
             1,
         ],
@@ -590,9 +588,7 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                ),
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
@@ -612,9 +608,7 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                ),
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["a queue that doesn't exist"])
                 ),
@@ -919,9 +913,7 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                )
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"]))
             ),
             1,
         ],
@@ -935,9 +927,7 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                ),
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
@@ -957,9 +947,7 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                work_pool_filter=filters.WorkPoolFilter(
-                    name=dict(any_=["Test Pool"])
-                ),
+                work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["a queue that doesn't exist"])
                 ),

--- a/tests/orion/models/test_filters.py
+++ b/tests/orion/models/test_filters.py
@@ -285,7 +285,7 @@ async def data(flow_function, db):
     # ----------------- clear data
 
     async with db.session_context(begin_transaction=True) as session:
-        # worker pool has a circular dependency on pool queue; delete it first
+        # work pool has a circular dependency on pool queue; delete it first
         await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(db.Base.metadata.sorted_tables):

--- a/tests/orion/models/test_filters.py
+++ b/tests/orion/models/test_filters.py
@@ -33,10 +33,10 @@ def adjust_kwargs_for_client(kwargs):
             k = "task_runs"
         elif k == "deployment_filter":
             k = "deployments"
-        elif k == "worker_pool_filter":
-            k = "worker_pools"
-        elif k == "worker_pool_queue_filter":
-            k = "worker_pool_queues"
+        elif k == "work_pool_filter":
+            k = "work_pools"
+        elif k == "work_pool_queue_filter":
+            k = "work_pool_queues"
         else:
             raise ValueError("Unrecognized filter")
         adjusted_kwargs[k] = v
@@ -62,8 +62,8 @@ async def data(flow_function, db):
             session=session, task_run=task_run
         )
 
-        wp = await models.workers.create_worker_pool(
-            session=session, worker_pool=actions.WorkerPoolCreate(name="Test Pool")
+        wp = await models.workers.create_work_pool(
+            session=session, work_pool=actions.WorkPoolCreate(name="Test Pool")
         )
 
         f_1 = await create_flow(flow=core.Flow(name="f-1", tags=["db", "blue"]))
@@ -99,7 +99,7 @@ async def data(flow_function, db):
                 flow_id=f_3.id,
                 schedule=schedules.IntervalSchedule(interval=timedelta(days=1)),
                 is_schedule_active=True,
-                worker_pool_queue_id=wp.default_queue_id,
+                work_pool_queue_id=wp.default_queue_id,
             )
         )
 
@@ -182,7 +182,7 @@ async def data(flow_function, db):
                 tags=[],
                 state=states.Completed(),
                 deployment_id=d_3_1.id,
-                worker_pool_queue_id=wp.default_queue_id,
+                work_pool_queue_id=wp.default_queue_id,
             )
         )
 
@@ -286,7 +286,7 @@ async def data(flow_function, db):
 
     async with db.session_context(begin_transaction=True) as session:
         # worker pool has a circular dependency on pool queue; delete it first
-        await session.execute(db.WorkerPool.__table__.delete())
+        await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(db.Base.metadata.sorted_tables):
             await session.execute(table.delete())
@@ -574,7 +574,7 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 )
             ),
@@ -582,7 +582,7 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 )
             ),
@@ -590,10 +590,10 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
             ),
@@ -601,10 +601,10 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["A pool that doesn't exist"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
             ),
@@ -612,10 +612,10 @@ class TestCountFlowRunModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["a queue that doesn't exist"])
                 ),
             ),
@@ -919,7 +919,7 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 )
             ),
@@ -927,7 +927,7 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 )
             ),
@@ -935,10 +935,10 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
             ),
@@ -946,10 +946,10 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["A pool that doesn't exist"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["Default Queue"])
                 ),
             ),
@@ -957,10 +957,10 @@ class TestCountDeploymentModels:
         ],
         [
             dict(
-                worker_pool_filter=filters.WorkerPoolFilter(
+                work_pool_filter=filters.WorkPoolFilter(
                     name=dict(any_=["Test Pool"])
                 ),
-                worker_pool_queue_filter=filters.WorkerPoolQueueFilter(
+                work_pool_queue_filter=filters.WorkPoolQueueFilter(
                     name=dict(any_=["a queue that doesn't exist"])
                 ),
             ),

--- a/tests/orion/models/test_flow_runs.py
+++ b/tests/orion/models/test_flow_runs.py
@@ -1016,16 +1016,16 @@ class TestReadFlowRuns:
         )
         assert len(result) == 0
 
-    async def test_read_flow_runs_filters_by_worker_pool_name(self, flow, session):
-        worker_pool = await models.workers.create_worker_pool(
+    async def test_read_flow_runs_filters_by_work_pool_name(self, flow, session):
+        work_pool = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="worker-pool"),
+            work_pool=schemas.actions.WorkPoolCreate(name="work-pool"),
         )
-        worker_pool_queue = await models.workers.create_worker_pool_queue(
+        work_pool_queue = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
-                name="worker-pool-queue"
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
+                name="work-pool-queue"
             ),
         )
         flow_run_1 = await models.flow_runs.create_flow_run(
@@ -1035,28 +1035,28 @@ class TestReadFlowRuns:
         flow_run_2 = await models.flow_runs.create_flow_run(
             session=session,
             flow_run=schemas.core.FlowRun(
-                flow_id=flow.id, worker_pool_queue_id=worker_pool_queue.id
+                flow_id=flow.id, work_pool_queue_id=work_pool_queue.id
             ),
         )
 
         result = await models.flow_runs.read_flow_runs(
             session=session,
-            worker_pool_filter=schemas.filters.WorkerPoolFilter(
-                name=schemas.filters.WorkerPoolFilterName(any_=[worker_pool.name])
+            work_pool_filter=schemas.filters.WorkPoolFilter(
+                name=schemas.filters.WorkPoolFilterName(any_=[work_pool.name])
             ),
         )
         assert {res.id for res in result} == {flow_run_2.id}
 
-    async def test_read_flow_runs_filters_by_worker_pool_queue_id(self, session, flow):
-        worker_pool = await models.workers.create_worker_pool(
+    async def test_read_flow_runs_filters_by_work_pool_queue_id(self, session, flow):
+        work_pool = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="worker-pool"),
+            work_pool=schemas.actions.WorkPoolCreate(name="work-pool"),
         )
-        worker_pool_queue = await models.workers.create_worker_pool_queue(
+        work_pool_queue = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
-                name="worker-pool-queue"
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
+                name="work-pool-queue"
             ),
         )
         flow_run_1 = await models.flow_runs.create_flow_run(
@@ -1066,14 +1066,14 @@ class TestReadFlowRuns:
         flow_run_2 = await models.flow_runs.create_flow_run(
             session=session,
             flow_run=schemas.core.FlowRun(
-                flow_id=flow.id, worker_pool_queue_id=worker_pool_queue.id
+                flow_id=flow.id, work_pool_queue_id=work_pool_queue.id
             ),
         )
 
         result = await models.flow_runs.read_flow_runs(
             session=session,
-            worker_pool_queue_filter=schemas.filters.WorkerPoolQueueFilter(
-                id=schemas.filters.WorkerPoolQueueFilterId(any_=[worker_pool_queue.id])
+            work_pool_queue_filter=schemas.filters.WorkPoolQueueFilter(
+                id=schemas.filters.WorkPoolQueueFilterId(any_=[work_pool_queue.id])
             ),
         )
         assert {res.id for res in result} == {flow_run_2.id}

--- a/tests/orion/models/test_flow_runs.py
+++ b/tests/orion/models/test_flow_runs.py
@@ -1024,9 +1024,7 @@ class TestReadFlowRuns:
         work_pool_queue = await models.workers.create_work_pool_queue(
             session=session,
             work_pool_id=work_pool.id,
-            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
-                name="work-pool-queue"
-            ),
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="work-pool-queue"),
         )
         flow_run_1 = await models.flow_runs.create_flow_run(
             session=session,
@@ -1055,9 +1053,7 @@ class TestReadFlowRuns:
         work_pool_queue = await models.workers.create_work_pool_queue(
             session=session,
             work_pool_id=work_pool.id,
-            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
-                name="work-pool-queue"
-            ),
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="work-pool-queue"),
         )
         flow_run_1 = await models.flow_runs.create_flow_run(
             session=session,

--- a/tests/orion/models/test_workers.py
+++ b/tests/orion/models/test_workers.py
@@ -9,21 +9,21 @@ import prefect
 from prefect.orion import models, schemas
 
 
-class TestCreateWorkerPool:
-    async def test_create_worker_pool(self, session):
-        result = await models.workers.create_worker_pool(
+class TestCreateWorkPool:
+    async def test_create_work_pool(self, session):
+        result = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="My Test Pool"),
+            work_pool=schemas.actions.WorkPoolCreate(name="My Test Pool"),
         )
 
         assert result.name == "My Test Pool"
         assert result.is_paused is False
         assert result.concurrency_limit is None
 
-    async def test_create_worker_pool_with_options(self, session):
-        result = await models.workers.create_worker_pool(
+    async def test_create_work_pool_with_options(self, session):
+        result = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(
+            work_pool=schemas.actions.WorkPoolCreate(
                 name="My Test Pool", is_paused=True, concurrency_limit=5
             ),
         )
@@ -32,23 +32,23 @@ class TestCreateWorkerPool:
         assert result.is_paused is True
         assert result.concurrency_limit == 5
 
-    async def test_create_duplicate_worker_pool(self, session, worker_pool):
+    async def test_create_duplicate_work_pool(self, session, work_pool):
         with pytest.raises(sa.exc.IntegrityError):
-            await models.workers.create_worker_pool(
+            await models.workers.create_work_pool(
                 session=session,
-                worker_pool=schemas.actions.WorkerPoolCreate(name=worker_pool.name),
+                work_pool=schemas.actions.WorkPoolCreate(name=work_pool.name),
             )
 
     @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
     async def test_create_invalid_name(self, session, name):
         with pytest.raises(pydantic.ValidationError, match="(invalid character)"):
-            schemas.core.WorkerPool(name=name)
+            schemas.core.WorkPool(name=name)
 
     @pytest.mark.parametrize("type", [None, "PROCESS", "K8S", "AGENT"])
     async def test_create_typed_worker(self, session, type):
-        result = await models.workers.create_worker_pool(
+        result = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(
+            work_pool=schemas.actions.WorkPoolCreate(
                 name="Typed Worker",
                 type=type,
             ),
@@ -58,253 +58,253 @@ class TestCreateWorkerPool:
 
 class TestDefaultQueues:
     async def test_creating_a_pool_creates_default_queue(self, session):
-        result = await models.workers.create_worker_pool(
+        result = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="My Test Pool"),
+            work_pool=schemas.actions.WorkPoolCreate(name="My Test Pool"),
         )
 
         # read the default queue
-        queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=result.default_queue_id
+        queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=result.default_queue_id
         )
 
         assert queue.name == "Default Queue"
         assert queue.priority == 1
 
         # check that it is the only queue for the pool
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=result.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=result.id
         )
         assert len(all_queues) == 1
         assert all_queues[0].id == result.default_queue_id
 
-    async def test_cant_delete_default_queue(self, session, worker_pool):
+    async def test_cant_delete_default_queue(self, session, work_pool):
         with pytest.raises(ValueError, match="(Can't delete a pool's default queue.)"):
-            await models.workers.delete_worker_pool_queue(
-                session=session, worker_pool_queue_id=worker_pool.default_queue_id
+            await models.workers.delete_work_pool_queue(
+                session=session, work_pool_queue_id=work_pool.default_queue_id
             )
 
-    async def test_cant_delete_default_queue_even_in_db(self, session, worker_pool, db):
+    async def test_cant_delete_default_queue_even_in_db(self, session, work_pool, db):
         """Deleting the default queue is not allowed in the db, even if you bypass the model"""
         with pytest.raises(sa.exc.IntegrityError):
             await session.execute(
-                sa.delete(db.WorkerPoolQueue).where(
-                    db.WorkerPoolQueue.id == worker_pool.default_queue_id
+                sa.delete(db.WorkPoolQueue).where(
+                    db.WorkPoolQueue.id == work_pool.default_queue_id
                 )
             )
 
-    async def test_can_rename_default_queue(self, session, worker_pool):
-        queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+    async def test_can_rename_default_queue(self, session, work_pool):
+        queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         assert queue.name == "Default Queue"
 
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool.default_queue_id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(name="New Name"),
+            work_pool_queue_id=work_pool.default_queue_id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(name="New Name"),
         )
         await session.commit()
         session.expunge_all()
 
-        queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         assert queue.name == "New Name"
 
-    async def test_can_reprioritize_default_queue(self, session, worker_pool):
-        queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+    async def test_can_reprioritize_default_queue(self, session, work_pool):
+        queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         assert queue.priority == 1
 
         # create a new queue so we can reprioritize them
-        await models.workers.create_worker_pool_queue(
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="New Queue"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="New Queue"),
         )
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool.default_queue_id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(priority=2),
+            work_pool_queue_id=work_pool.default_queue_id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(priority=2),
         )
         await session.commit()
         session.expunge_all()
 
-        queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         assert queue.priority == 2
 
 
-class TestUpdateWorkerPool:
-    async def test_update_worker_pool(self, session, worker_pool):
-        assert await models.workers.update_worker_pool(
+class TestUpdateWorkPool:
+    async def test_update_work_pool(self, session, work_pool):
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(
+            work_pool_id=work_pool.id,
+            work_pool=schemas.actions.WorkPoolUpdate(
                 is_paused=True, concurrency_limit=5
             ),
         )
 
-        result = await models.workers.read_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
+        result = await models.workers.read_work_pool(
+            session=session, work_pool_id=work_pool.id
         )
         assert result.is_paused is True
         assert result.concurrency_limit == 5
 
-    async def test_update_worker_pool_invalid_concurrency(self, session, worker_pool):
+    async def test_update_work_pool_invalid_concurrency(self, session, work_pool):
         with pytest.raises(pydantic.ValidationError):
-            await models.workers.update_worker_pool(
+            await models.workers.update_work_pool(
                 session=session,
-                worker_pool_id=worker_pool.id,
-                worker_pool=schemas.actions.WorkerPoolUpdate(concurrency_limit=-5),
+                work_pool_id=work_pool.id,
+                work_pool=schemas.actions.WorkPoolUpdate(concurrency_limit=-5),
             )
 
-    async def test_update_worker_pool_zero_concurrency(self, session, worker_pool):
-        assert await models.workers.update_worker_pool(
+    async def test_update_work_pool_zero_concurrency(self, session, work_pool):
+        assert await models.workers.update_work_pool(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool=schemas.actions.WorkerPoolUpdate(concurrency_limit=0),
+            work_pool_id=work_pool.id,
+            work_pool=schemas.actions.WorkPoolUpdate(concurrency_limit=0),
         )
-        result = await models.workers.read_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
+        result = await models.workers.read_work_pool(
+            session=session, work_pool_id=work_pool.id
         )
         assert result.concurrency_limit == 0
 
 
-class TestReadWorkerPool:
-    async def test_read_worker_pool(self, session, worker_pool):
-        result = await models.workers.read_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
+class TestReadWorkPool:
+    async def test_read_work_pool(self, session, work_pool):
+        result = await models.workers.read_work_pool(
+            session=session, work_pool_id=work_pool.id
         )
-        assert result.name == worker_pool.name
-        assert result.is_paused is worker_pool.is_paused
-        assert result.concurrency_limit == worker_pool.concurrency_limit
+        assert result.name == work_pool.name
+        assert result.is_paused is work_pool.is_paused
+        assert result.concurrency_limit == work_pool.concurrency_limit
 
 
-class TestDeleteWorkerPool:
-    async def test_delete_worker_pool(self, session, worker_pool):
-        assert await models.workers.delete_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
+class TestDeleteWorkPool:
+    async def test_delete_work_pool(self, session, work_pool):
+        assert await models.workers.delete_work_pool(
+            session=session, work_pool_id=work_pool.id
         )
-        assert not await models.workers.read_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
-        )
-
-    async def test_delete_worker_pool_non_existent(self, session, worker_pool):
-        assert await models.workers.delete_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
-        )
-        assert not await models.workers.delete_worker_pool(
-            session=session, worker_pool_id=worker_pool.id
+        assert not await models.workers.read_work_pool(
+            session=session, work_pool_id=work_pool.id
         )
 
+    async def test_delete_work_pool_non_existent(self, session, work_pool):
+        assert await models.workers.delete_work_pool(
+            session=session, work_pool_id=work_pool.id
+        )
+        assert not await models.workers.delete_work_pool(
+            session=session, work_pool_id=work_pool.id
+        )
 
-class TestCreateWorkerPoolQueue:
-    async def test_create_worker_pool_queue(self, session, worker_pool, db):
-        result = await models.workers.create_worker_pool_queue(
+
+class TestCreateWorkPoolQueue:
+    async def test_create_work_pool_queue(self, session, work_pool, db):
+        result = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="A"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A"),
         )
 
         assert result.name == "A"
-        assert result.worker_pool_id == worker_pool.id
+        assert result.work_pool_id == work_pool.id
         assert result.is_paused is False
         assert result.concurrency_limit is None
 
         # this is the second queue created after the default, so it should have priority 2
         assert result.priority == 2
 
-    async def test_create_worker_pool_queue_with_options(self, session, worker_pool):
-        result = await models.workers.create_worker_pool_queue(
+    async def test_create_work_pool_queue_with_options(self, session, work_pool):
+        result = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
                 name="A", is_paused=True, concurrency_limit=5
             ),
         )
 
         assert result.name == "A"
-        assert result.worker_pool_id == worker_pool.id
+        assert result.work_pool_id == work_pool.id
         assert result.is_paused is True
         assert result.concurrency_limit == 5
 
-    async def test_create_worker_pool_queue_with_priority(self, session, worker_pool):
-        result = await models.workers.create_worker_pool_queue(
+    async def test_create_work_pool_queue_with_priority(self, session, work_pool):
+        result = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
                 name="A", priority=1
             ),
         )
 
         assert result.priority == 1
 
-        default_queue = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        default_queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         assert default_queue.priority == 2
 
-    async def test_queues_initialize_with_correct_priority(self, session, worker_pool):
-        result_1 = await models.workers.create_worker_pool_queue(
+    async def test_queues_initialize_with_correct_priority(self, session, work_pool):
+        result_1 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="A"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A"),
         )
-        result_2 = await models.workers.create_worker_pool_queue(
+        result_2 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="B"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="B"),
         )
-        result_3 = await models.workers.create_worker_pool_queue(
+        result_3 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="C"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="C"),
         )
 
         assert result_1.priority == 2
         assert result_2.priority == 3
         assert result_3.priority == 4
 
-    async def test_create_duplicate_worker_pool_queue(self, session, worker_pool_queue):
+    async def test_create_duplicate_work_pool_queue(self, session, work_pool_queue):
         with pytest.raises(sa.exc.IntegrityError):
-            await models.workers.create_worker_pool_queue(
+            await models.workers.create_work_pool_queue(
                 session=session,
-                worker_pool_id=worker_pool_queue.worker_pool_id,
-                worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(
-                    name=worker_pool_queue.name
+                work_pool_id=work_pool_queue.work_pool_id,
+                work_pool_queue=schemas.actions.WorkPoolQueueCreate(
+                    name=work_pool_queue.name
                 ),
             )
 
     @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
-    async def test_create_invalid_name(self, session, worker_pool, name):
+    async def test_create_invalid_name(self, session, work_pool, name):
         with pytest.raises(pydantic.ValidationError, match="(invalid character)"):
-            schemas.actions.WorkerPoolQueueCreate(name=name)
+            schemas.actions.WorkPoolQueueCreate(name=name)
 
 
-class TestReadWorkerPoolQueues:
-    async def test_read_worker_pool_queues(self, session, worker_pool):
-        await models.workers.create_worker_pool_queue(
+class TestReadWorkPoolQueues:
+    async def test_read_work_pool_queues(self, session, work_pool):
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="C"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="C"),
         )
-        await models.workers.create_worker_pool_queue(
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="A"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A"),
         )
-        await models.workers.create_worker_pool_queue(
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="B"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="B"),
         )
 
-        result = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        result = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert len(result) == 4
         assert (result[0].name, result[0].priority) == ("Default Queue", 1)
@@ -312,32 +312,32 @@ class TestReadWorkerPoolQueues:
         assert (result[2].name, result[2].priority) == ("A", 3)
         assert (result[3].name, result[3].priority) == ("B", 4)
 
-    async def test_read_worker_pool_queues_sorts_by_priority(
-        self, session, worker_pool
+    async def test_read_work_pool_queues_sorts_by_priority(
+        self, session, work_pool
     ):
-        await models.workers.create_worker_pool_queue(
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="C"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="C"),
         )
-        result_2 = await models.workers.create_worker_pool_queue(
+        result_2 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="A"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A"),
         )
-        await models.workers.create_worker_pool_queue(
+        await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="B"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="B"),
         )
-        await models.workers.update_worker_pool_queue(
+        await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=result_2.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(priority=100),
+            work_pool_queue_id=result_2.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(priority=100),
         )
 
-        result = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        result = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert len(result) == 4
         assert (result[0].name, result[0].priority) == ("Default Queue", 1)
@@ -346,80 +346,80 @@ class TestReadWorkerPoolQueues:
         assert (result[3].name, result[3].priority) == ("A", 4)
 
 
-class TestUpdateWorkerPoolQueue:
-    async def test_update_worker_pool_queue(self, session, worker_pool_queue):
-        assert await models.workers.update_worker_pool_queue(
+class TestUpdateWorkPoolQueue:
+    async def test_update_work_pool_queue(self, session, work_pool_queue):
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queue.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(
+            work_pool_queue_id=work_pool_queue.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(
                 is_paused=True, concurrency_limit=5
             ),
         )
 
-        result = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
+        result = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
         assert result.is_paused is True
         assert result.concurrency_limit == 5
 
-    async def test_update_worker_pool_queue_invalid_concurrency(
-        self, session, worker_pool_queue
+    async def test_update_work_pool_queue_invalid_concurrency(
+        self, session, work_pool_queue
     ):
         with pytest.raises(pydantic.ValidationError):
-            await models.workers.update_worker_pool_queue(
+            await models.workers.update_work_pool_queue(
                 session=session,
-                worker_pool_queue_id=worker_pool_queue.id,
-                worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(
+                work_pool_queue_id=work_pool_queue.id,
+                work_pool_queue=schemas.actions.WorkPoolQueueUpdate(
                     concurrency_limit=-5
                 ),
             )
 
-    async def test_update_worker_pool_queue_zero_concurrency(
-        self, session, worker_pool_queue
+    async def test_update_work_pool_queue_zero_concurrency(
+        self, session, work_pool_queue
     ):
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queue.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(
+            work_pool_queue_id=work_pool_queue.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(
                 concurrency_limit=0
             ),
         )
-        result = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
+        result = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
         assert result.concurrency_limit == 0
 
-    async def test_update_worker_pool_queue_priority_is_normalized_for_number_of_queues(
-        self, session, worker_pool_queue
+    async def test_update_work_pool_queue_priority_is_normalized_for_number_of_queues(
+        self, session, work_pool_queue
     ):
-        assert await models.workers.update_worker_pool_queue(
+        assert await models.workers.update_work_pool_queue(
             session=session,
-            worker_pool_queue_id=worker_pool_queue.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueUpdate(priority=100),
+            work_pool_queue_id=work_pool_queue.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(priority=100),
         )
-        result = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
+        result = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
         assert result.priority == 2
 
 
-class TestUpdateWorkerPoolQueuePriorities:
+class TestUpdateWorkPoolQueuePriorities:
     @pytest.fixture(autouse=True)
-    async def queues(self, session, worker_pool):
+    async def queues(self, session, work_pool):
         queues = {}
         # rename the default queue "A"
 
-        queues["A"] = await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool.default_queue_id
+        queues["A"] = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool.default_queue_id
         )
         queues["A"].name = "A"
 
         # create B-E
         for name in "BCDE":
-            queues[name] = await models.workers.create_worker_pool_queue(
+            queues[name] = await models.workers.create_work_pool_queue(
                 session=session,
-                worker_pool_id=worker_pool.id,
-                worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name=name),
+                work_pool_id=work_pool.id,
+                work_pool_queue=schemas.actions.WorkPoolQueueCreate(name=name),
             )
         await session.commit()
         return queues
@@ -436,23 +436,23 @@ class TestUpdateWorkerPoolQueuePriorities:
         ],
     )
     async def test_bulk_update_priorities(
-        self, session, worker_pool, queues, new_priorities
+        self, session, work_pool, queues, new_priorities
     ):
 
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert len(all_queues) == 5
 
-        await models.workers.bulk_update_worker_pool_queue_priorities(
+        await models.workers.bulk_update_work_pool_queue_priorities(
             session=session,
-            worker_pool_id=worker_pool.id,
+            work_pool_id=work_pool.id,
             new_priorities={queues[k].id: v for k, v in new_priorities.items()},
         )
         await session.commit()
 
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert len(all_queues) == 5
 
@@ -461,38 +461,38 @@ class TestUpdateWorkerPoolQueuePriorities:
             assert all_queues[k].priority == v
 
     async def test_update_priorities_with_invalid_target_id(
-        self, session, worker_pool, queues
+        self, session, work_pool, queues
     ):
-        await models.workers.bulk_update_worker_pool_queue_priorities(
+        await models.workers.bulk_update_work_pool_queue_priorities(
             session=session,
-            worker_pool_id=worker_pool.id,
+            work_pool_id=work_pool.id,
             new_priorities={uuid4(): 3, queues["A"].id: 4},
         )
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert next(q.priority for q in all_queues if q.name == "A") == 4
 
     async def test_update_priorities_with_duplicate_priorities(
-        self, session, worker_pool, queues
+        self, session, work_pool, queues
     ):
         with pytest.raises(ValueError, match="(Duplicate target priorities provided)"):
-            await models.workers.bulk_update_worker_pool_queue_priorities(
+            await models.workers.bulk_update_work_pool_queue_priorities(
                 session=session,
-                worker_pool_id=worker_pool.id,
+                work_pool_id=work_pool.id,
                 new_priorities={queues["A"]: 3, queues["B"].id: 3},
             )
 
     async def test_update_priorities_with_empty_new_priority(
-        self, session, worker_pool, queues
+        self, session, work_pool, queues
     ):
-        await models.workers.bulk_update_worker_pool_queue_priorities(
+        await models.workers.bulk_update_work_pool_queue_priorities(
             session=session,
-            worker_pool_id=worker_pool.id,
+            work_pool_id=work_pool.id,
             new_priorities={},
         )
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert {q.name: q.priority for q in all_queues} == {
             "A": 1,
@@ -503,16 +503,16 @@ class TestUpdateWorkerPoolQueuePriorities:
         }
 
     async def test_update_priorities_with_empty_new_priority_to_recompute(
-        self, session, db, worker_pool, queues
+        self, session, db, work_pool, queues
     ):
         # manually delete a queue (this won't trigger the automatic priority update)
         await session.execute(
-            sa.delete(db.WorkerPoolQueue).where(db.WorkerPoolQueue.id == queues["C"].id)
+            sa.delete(db.WorkPoolQueue).where(db.WorkPoolQueue.id == queues["C"].id)
         )
         await session.commit()
 
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert {q.name: q.priority for q in all_queues} == {
             "A": 1,
@@ -521,13 +521,13 @@ class TestUpdateWorkerPoolQueuePriorities:
             "E": 5,
         }
 
-        await models.workers.bulk_update_worker_pool_queue_priorities(
+        await models.workers.bulk_update_work_pool_queue_priorities(
             session=session,
-            worker_pool_id=worker_pool.id,
+            work_pool_id=work_pool.id,
             new_priorities={},
         )
-        all_queues = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        all_queues = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
         assert {q.name: q.priority for q in all_queues} == {
             "A": 1,
@@ -537,48 +537,48 @@ class TestUpdateWorkerPoolQueuePriorities:
         }
 
 
-class TestDeleteWorkerPoolQueue:
-    async def test_delete_worker_pool_queue(self, session, worker_pool_queue):
-        assert await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
+class TestDeleteWorkPoolQueue:
+    async def test_delete_work_pool_queue(self, session, work_pool_queue):
+        assert await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
-        assert await models.workers.delete_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
+        assert await models.workers.delete_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
-        assert not await models.workers.read_worker_pool_queue(
-            session=session, worker_pool_queue_id=worker_pool_queue.id
-        )
-
-    async def test_nonexistent_delete_worker_pool_queue(self, session):
-        assert not await models.workers.delete_worker_pool_queue(
-            session=session, worker_pool_queue_id=uuid4()
+        assert not await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=work_pool_queue.id
         )
 
-    async def test_delete_queue_updates_priorities(self, session, worker_pool):
-        result_1 = await models.workers.create_worker_pool_queue(
-            session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="A"),
+    async def test_nonexistent_delete_work_pool_queue(self, session):
+        assert not await models.workers.delete_work_pool_queue(
+            session=session, work_pool_queue_id=uuid4()
         )
-        result_2 = await models.workers.create_worker_pool_queue(
+
+    async def test_delete_queue_updates_priorities(self, session, work_pool):
+        result_1 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="B"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A"),
         )
-        result_3 = await models.workers.create_worker_pool_queue(
+        result_2 = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=worker_pool.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="C"),
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="B"),
+        )
+        result_3 = await models.workers.create_work_pool_queue(
+            session=session,
+            work_pool_id=work_pool.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="C"),
         )
 
         # delete queue 2
-        assert await models.workers.delete_worker_pool_queue(
-            session=session, worker_pool_queue_id=result_2.id
+        assert await models.workers.delete_work_pool_queue(
+            session=session, work_pool_queue_id=result_2.id
         )
 
         # read queues
-        result = await models.workers.read_worker_pool_queues(
-            session=session, worker_pool_id=worker_pool.id
+        result = await models.workers.read_work_pool_queues(
+            session=session, work_pool_id=work_pool.id
         )
 
         assert len(result) == 3
@@ -588,58 +588,58 @@ class TestDeleteWorkerPoolQueue:
 
 
 class TestWorkerHeartbeat:
-    async def test_worker_heartbeat(self, session, worker_pool):
+    async def test_worker_heartbeat(self, session, work_pool):
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert not processes
 
         result = await models.workers.worker_heartbeat(
-            session=session, worker_pool_id=worker_pool.id, worker_name="process X"
+            session=session, work_pool_id=work_pool.id, worker_name="process X"
         )
 
         assert result is True
 
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert len(processes) == 1
         assert processes[0].name == "process X"
 
-    async def test_worker_heartbeat_upsert(self, session, worker_pool):
+    async def test_worker_heartbeat_upsert(self, session, work_pool):
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert not processes
 
         for _ in range(3):
             await models.workers.worker_heartbeat(
                 session=session,
-                worker_pool_id=worker_pool.id,
+                work_pool_id=work_pool.id,
                 worker_name="process X",
             )
 
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert len(processes) == 1
         assert processes[0].name == "process X"
 
-    async def test_multiple_worker_heartbeats(self, session, worker_pool):
+    async def test_multiple_worker_heartbeats(self, session, work_pool):
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert not processes
 
         for name in ["X", "Y", "Z"]:
             await models.workers.worker_heartbeat(
                 session=session,
-                worker_pool_id=worker_pool.id,
+                work_pool_id=work_pool.id,
                 worker_name=name,
             )
 
         processes = await models.workers.read_workers(
-            session=session, worker_pool_id=worker_pool.id
+            session=session, work_pool_id=work_pool.id
         )
         assert len(processes) == 3
         assert processes[0].name == "Z"
@@ -658,64 +658,64 @@ class TestGetScheduledRuns:
         """
 
         # create three different worker pools
-        wp_a = await models.workers.create_worker_pool(
+        wp_a = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="A"),
+            work_pool=schemas.actions.WorkPoolCreate(name="A"),
         )
-        wp_b = await models.workers.create_worker_pool(
+        wp_b = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="B"),
+            work_pool=schemas.actions.WorkPoolCreate(name="B"),
         )
-        wp_c = await models.workers.create_worker_pool(
+        wp_c = await models.workers.create_work_pool(
             session=session,
-            worker_pool=schemas.actions.WorkerPoolCreate(name="C"),
+            work_pool=schemas.actions.WorkPoolCreate(name="C"),
         )
 
         # create three different work queues for each config
-        wq_aa = await models.workers.create_worker_pool_queue(
+        wq_aa = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AA"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AA"),
         )
-        wq_ab = await models.workers.create_worker_pool_queue(
+        wq_ab = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AB"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AB"),
         )
-        wq_ac = await models.workers.create_worker_pool_queue(
+        wq_ac = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_a.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="AC"),
+            work_pool_id=wp_a.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="AC"),
         )
-        wq_ba = await models.workers.create_worker_pool_queue(
+        wq_ba = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BA"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BA"),
         )
-        wq_bb = await models.workers.create_worker_pool_queue(
+        wq_bb = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BB"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BB"),
         )
-        wq_bc = await models.workers.create_worker_pool_queue(
+        wq_bc = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_b.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="BC"),
+            work_pool_id=wp_b.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="BC"),
         )
-        wq_ca = await models.workers.create_worker_pool_queue(
+        wq_ca = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CA"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CA"),
         )
-        wq_cb = await models.workers.create_worker_pool_queue(
+        wq_cb = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CB"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CB"),
         )
-        wq_cc = await models.workers.create_worker_pool_queue(
+        wq_cc = await models.workers.create_work_pool_queue(
             session=session,
-            worker_pool_id=wp_c.id,
-            worker_pool_queue=schemas.actions.WorkerPoolQueueCreate(name="CC"),
+            work_pool_id=wp_c.id,
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="CC"),
         )
 
         # create flow runs
@@ -726,7 +726,7 @@ class TestGetScheduledRuns:
                 flow_run=schemas.core.FlowRun(
                     flow_id=flow.id,
                     state=prefect.states.Running(),
-                    worker_pool_queue_id=wq.id,
+                    work_pool_queue_id=wq.id,
                 ),
             )
 
@@ -736,7 +736,7 @@ class TestGetScheduledRuns:
                 flow_run=schemas.core.FlowRun(
                     flow_id=flow.id,
                     state=prefect.states.Pending(),
-                    worker_pool_queue_id=wq.id,
+                    work_pool_queue_id=wq.id,
                 ),
             )
 
@@ -751,14 +751,14 @@ class TestGetScheduledRuns:
                         state=prefect.states.Scheduled(
                             scheduled_time=pendulum.now().add(hours=i)
                         ),
-                        worker_pool_queue_id=wq.id,
+                        work_pool_queue_id=wq.id,
                     ),
                 )
         await session.commit()
 
         return dict(
-            worker_pools=dict(wp_a=wp_a, wp_b=wp_b, wp_c=wp_c),
-            worker_pool_queues=dict(
+            work_pools=dict(wp_a=wp_a, wp_b=wp_b, wp_c=wp_c),
+            work_pool_queues=dict(
                 wq_aa=wq_aa,
                 wq_ab=wq_ab,
                 wq_ac=wq_ac,
@@ -772,12 +772,12 @@ class TestGetScheduledRuns:
         )
 
     @pytest.fixture
-    def worker_pools(self, setup):
-        return setup["worker_pools"]
+    def work_pools(self, setup):
+        return setup["work_pools"]
 
     @pytest.fixture
-    def worker_pool_queues(self, setup):
-        return setup["worker_pool_queues"]
+    def work_pool_queues(self, setup):
+        return setup["work_pool_queues"]
 
     async def test_get_all_runs(self, session):
         runs = await models.workers.get_scheduled_flow_runs(session=session)
@@ -811,56 +811,56 @@ class TestGetScheduledRuns:
         )
         assert len(runs) == 27
 
-    async def test_get_all_runs_wq_aa(self, session, worker_pools, worker_pool_queues):
+    async def test_get_all_runs_wq_aa(self, session, work_pools, work_pool_queues):
         runs = await models.workers.get_scheduled_flow_runs(
-            session=session, worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id]
+            session=session, work_pool_queue_ids=[work_pool_queues["wq_aa"].id]
         )
         assert len(runs) == 5
 
     async def test_get_all_runs_wq_aa_wq_ba_wq_cb(
-        self, session, worker_pools, worker_pool_queues
+        self, session, work_pools, work_pool_queues
     ):
         runs = await models.workers.get_scheduled_flow_runs(
             session=session,
-            worker_pool_queue_ids=[
-                worker_pool_queues["wq_aa"].id,
-                worker_pool_queues["wq_ba"].id,
-                worker_pool_queues["wq_cb"].id,
+            work_pool_queue_ids=[
+                work_pool_queues["wq_aa"].id,
+                work_pool_queues["wq_ba"].id,
+                work_pool_queues["wq_cb"].id,
             ],
         )
         assert len(runs) == 15
 
-    async def test_get_all_runs_wp_a(self, session, worker_pools, worker_pool_queues):
+    async def test_get_all_runs_wp_a(self, session, work_pools, work_pool_queues):
         runs = await models.workers.get_scheduled_flow_runs(
-            session=session, worker_pool_ids=[worker_pools["wp_a"].id]
+            session=session, work_pool_ids=[work_pools["wp_a"].id]
         )
         assert len(runs) == 15
 
     async def test_get_all_runs_wp_a_wp_b(
-        self, session, worker_pools, worker_pool_queues
+        self, session, work_pools, work_pool_queues
     ):
         runs = await models.workers.get_scheduled_flow_runs(
             session=session,
-            worker_pool_ids=[worker_pools["wp_a"].id, worker_pools["wp_b"].id],
+            work_pool_ids=[work_pools["wp_a"].id, work_pools["wp_b"].id],
         )
         assert len(runs) == 30
 
     async def test_get_all_runs_pools_and_queues_combined(
-        self, session, worker_pools, worker_pool_queues
+        self, session, work_pools, work_pool_queues
     ):
         runs = await models.workers.get_scheduled_flow_runs(
             session=session,
-            worker_pool_ids=[worker_pools["wp_a"].id],
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_ids=[work_pools["wp_a"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 5
 
     async def test_get_all_runs_pools_and_queues_incompatible(
-        self, session, worker_pools, worker_pool_queues
+        self, session, work_pools, work_pool_queues
     ):
         runs = await models.workers.get_scheduled_flow_runs(
             session=session,
-            worker_pool_ids=[worker_pools["wp_b"].id],
-            worker_pool_queue_ids=[worker_pool_queues["wq_aa"].id],
+            work_pool_ids=[work_pools["wp_b"].id],
+            work_pool_queue_ids=[work_pool_queues["wq_aa"].id],
         )
         assert len(runs) == 0

--- a/tests/orion/models/test_workers.py
+++ b/tests/orion/models/test_workers.py
@@ -236,9 +236,7 @@ class TestCreateWorkPoolQueue:
         result = await models.workers.create_work_pool_queue(
             session=session,
             work_pool_id=work_pool.id,
-            work_pool_queue=schemas.actions.WorkPoolQueueCreate(
-                name="A", priority=1
-            ),
+            work_pool_queue=schemas.actions.WorkPoolQueueCreate(name="A", priority=1),
         )
 
         assert result.priority == 1
@@ -312,9 +310,7 @@ class TestReadWorkPoolQueues:
         assert (result[2].name, result[2].priority) == ("A", 3)
         assert (result[3].name, result[3].priority) == ("B", 4)
 
-    async def test_read_work_pool_queues_sorts_by_priority(
-        self, session, work_pool
-    ):
+    async def test_read_work_pool_queues_sorts_by_priority(self, session, work_pool):
         await models.workers.create_work_pool_queue(
             session=session,
             work_pool_id=work_pool.id,
@@ -380,9 +376,7 @@ class TestUpdateWorkPoolQueue:
         assert await models.workers.update_work_pool_queue(
             session=session,
             work_pool_queue_id=work_pool_queue.id,
-            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(
-                concurrency_limit=0
-            ),
+            work_pool_queue=schemas.actions.WorkPoolQueueUpdate(concurrency_limit=0),
         )
         result = await models.workers.read_work_pool_queue(
             session=session, work_pool_queue_id=work_pool_queue.id
@@ -836,9 +830,7 @@ class TestGetScheduledRuns:
         )
         assert len(runs) == 15
 
-    async def test_get_all_runs_wp_a_wp_b(
-        self, session, work_pools, work_pool_queues
-    ):
+    async def test_get_all_runs_wp_a_wp_b(self, session, work_pools, work_pool_queues):
         runs = await models.workers.get_scheduled_flow_runs(
             session=session,
             work_pool_ids=[work_pools["wp_a"].id, work_pools["wp_b"].id],

--- a/tests/orion/models/test_workers.py
+++ b/tests/orion/models/test_workers.py
@@ -646,12 +646,12 @@ class TestGetScheduledRuns:
     async def setup(self, session, flow):
         """
         Creates:
-        - Three different worker pools ("A", "B", "C")
+        - Three different work pools ("A", "B", "C")
         - Three different queues in each pool ("AA", "AB", "AC", "BA", "BB", "BC", "CA", "CB", "CC")
         - One pending run, one running run, and 5 scheduled runs in each queue
         """
 
-        # create three different worker pools
+        # create three different work pools
         wp_a = await models.workers.create_work_pool(
             session=session,
             work_pool=schemas.actions.WorkPoolCreate(name="A"),

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -2,7 +2,11 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.orion.schemas.actions import FlowRunCreate
+from prefect.orion.schemas.actions import (
+    DeploymentCreate,
+    DeploymentUpdate,
+    FlowRunCreate,
+)
 
 
 @pytest.mark.parametrize(
@@ -24,3 +28,61 @@ class TestFlowRunCreate:
         frc = FlowRunCreate(flow_id=uuid4(), flow_version="0.1", parameters=test_params)
         res = frc.dict(json_compatible=True)
         assert res["parameters"] == expected_dict
+
+
+class TestDeploymentCreate:
+    def test_create_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for creating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_create = DeploymentCreate(
+                **dict(name="test-deployment", worker_pool_queue_id=uuid4())
+            )
+
+        assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0
+
+    def test_create_with_worker_pool_name_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            "no longer supported for creating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_create = DeploymentCreate(
+                **dict(
+                    name="test-deployment", worker_pool_queue_name="test-worker-pool"
+                )
+            )
+
+        assert getattr(deployment_create, "worker_pool_name", 0) == 0
+
+
+class TestDeploymentUpdate:
+    def test_update_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for updating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_update = DeploymentUpdate(**dict(worker_pool_queue_id=uuid4()))
+
+        assert getattr(deployment_update, "worker_pool_queue_id", 0) == 0
+
+    def test_update_with_worker_pool_name_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            "no longer supported for creating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_update = DeploymentCreate(
+                **dict(worker_pool_queue_name="test-worker-pool")
+            )
+
+        assert getattr(deployment_update, "worker_pool_name", 0) == 0

--- a/tests/orion/schemas/test_core.py
+++ b/tests/orion/schemas/test_core.py
@@ -292,14 +292,14 @@ class TestWorkQueueHealthPolicy:
         )
 
 
-class TestWorkerPool:
-    def test_more_helpful_validation_message_for_worker_pools(self):
+class TestWorkPool:
+    def test_more_helpful_validation_message_for_work_pools(self):
         with pytest.raises(
             pydantic.ValidationError, match="`default_queue_id` is a required field."
         ):
-            schemas.core.WorkerPool(name="test")
+            schemas.core.WorkPool(name="test")
 
-    async def test_valid_worker_pool_default_queue_id(self):
+    async def test_valid_work_pool_default_queue_id(self):
         qid = uuid4()
-        wp = schemas.core.WorkerPool(name="test", default_queue_id=qid)
+        wp = schemas.core.WorkPool(name="test", default_queue_id=qid)
         assert wp.default_queue_id == qid

--- a/tests/orion/utilities/test_database.py
+++ b/tests/orion/utilities/test_database.py
@@ -87,7 +87,7 @@ async def clear_database_models(db):
     """
     yield
     async with db.session_context(begin_transaction=True) as session:
-        # worker pool has a circular dependency on pool queue; delete it first
+        # work pool has a circular dependency on pool queue; delete it first
         await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(DBBase.metadata.sorted_tables):

--- a/tests/orion/utilities/test_database.py
+++ b/tests/orion/utilities/test_database.py
@@ -88,7 +88,7 @@ async def clear_database_models(db):
     yield
     async with db.session_context(begin_transaction=True) as session:
         # worker pool has a circular dependency on pool queue; delete it first
-        await session.execute(db.WorkerPool.__table__.delete())
+        await session.execute(db.WorkPool.__table__.delete())
 
         for table in reversed(DBBase.metadata.sorted_tables):
             await session.execute(table.delete())


### PR DESCRIPTION
This PR renames Worker Pools to work pools in all the relevant places.

**NOTE:** this feature is still experimental; therefore, for simplicity I chose to destructively delete all tables and references to worker pools and recreate them from scratch within the migration logic.  This allowed me to maintain our naming conventions easily and clearly instead of surgically renaming things in the migration.