### PR TITLE
Fixes cross version compatibility issues for deployments

### DIFF
--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -88,7 +88,7 @@ class DeploymentCreate(ActionBaseModel):
         worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
         if worker_pool_queue_id:
             warnings.warn(
-                "`worker_pool_queue_id` is no longer supported for creating. "
+                "`worker_pool_queue_id` is no longer supported for creating "
                 "deployments. Please use `worker_pool_name` and "
                 "`worker_pool_queue_name` instead.",
                 UserWarning,
@@ -131,6 +131,22 @@ class DeploymentCreate(ActionBaseModel):
 @copy_model_fields
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Orion API to update a deployment."""
+
+    @root_validator(pre=True)
+    def remove_worker_pool_queue_id(cls, values):
+        # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
+        # worker_pool_queue_name. This validator removes worker_pool_queue_id
+        # to avoid 422 errors when it is provided by older clients.
+        values_copy = deepcopy(values)
+        worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        if worker_pool_queue_id:
+            warnings.warn(
+                "`worker_pool_queue_id` is no longer supported for updating "
+                "deployments. Please use `worker_pool_name` and "
+                "`worker_pool_queue_name` instead.",
+                UserWarning,
+            )
+        return values_copy
 
     version: Optional[str] = FieldFrom(schemas.core.Deployment)
     schedule: Optional[schemas.schedules.SCHEDULE_TYPES] = FieldFrom(

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -2,7 +2,11 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.orion.schemas.actions import DeploymentCreate, FlowRunCreate
+from prefect.orion.schemas.actions import (
+    DeploymentCreate,
+    DeploymentUpdate,
+    FlowRunCreate,
+)
 
 
 @pytest.mark.parametrize(
@@ -26,11 +30,11 @@ class TestFlowRunCreate:
         assert res["parameters"] == expected_dict
 
 
-class TestDeployeCreate:
+class TestDeploymentCreate:
     def test_create_with_worker_pool_queue_id_warns(self):
         with pytest.warns(
             UserWarning,
-            match="`worker_pool_queue_id` is no longer supported for creating. "
+            match="`worker_pool_queue_id` is no longer supported for creating "
             "deployments. Please use `worker_pool_name` and "
             "`worker_pool_queue_name` instead.",
         ):
@@ -39,3 +43,16 @@ class TestDeployeCreate:
             )
 
         assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0
+
+
+class TestDeploymentUpdate:
+    def test_update_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for updating "
+            "deployments. Please use `worker_pool_name` and "
+            "`worker_pool_queue_name` instead.",
+        ):
+            deployment_update = DeploymentUpdate(**dict(worker_pool_queue_id=uuid4()))
+
+        assert getattr(deployment_update, "worker_pool_queue_id", 0) == 0

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.orion.schemas.actions import FlowRunCreate
+from prefect.orion.schemas.actions import DeploymentCreate, FlowRunCreate
 
 
 @pytest.mark.parametrize(
@@ -24,3 +24,18 @@ class TestFlowRunCreate:
         frc = FlowRunCreate(flow_id=uuid4(), flow_version="0.1", parameters=test_params)
         res = frc.dict(json_compatible=True)
         assert res["parameters"] == expected_dict
+
+
+class TestDeployeCreate:
+    def test_create_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for creating. "
+            "deployments. Please use `worker_pool_name` and "
+            "`worker_pool_queue_name` instead.",
+        ):
+            deployment_create = DeploymentCreate(
+                **dict(name="test-deployment", worker_pool_queue_id=uuid4())
+            )
+
+        assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
In 2.7.7 `worker_pool_queue_id` was removed from `DeploymentCreate` and `DeploymentUpdate` in lieu of `worker_pool_queue_name` and `worker_pool_name`. Because extra fields are rejected on action models, this resulted in 422 errors for users with mismatched server and client versions.

This PR adds the following validators to restore compatibility:
- Adds validator to remove `worker_pool_queue_id` from `DeploymentCreate` payloads
- Adds validator to remove `worker_pool_queue_id` from `DeploymentUpdate` payloads

Closes #8102 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Tested with the following script run by a 2.7.6 client:
```python
import asyncio

from prefect import flow


@flow
def a_flow_for_ants():
    print("what is this?")


async def apply_deployment():
    from prefect.deployments import Deployment

    deployment = await Deployment.build_from_flow(flow=a_flow_for_ants, name="test2")
    await deployment.apply()


if __name__ == "__main__":
    asyncio.run(apply_deployment())
```

It fails when run against a 2.7.7 Orion server and succeeds against a Orion server running this branch.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
