### PR TITLE
Makes rename safe for deployments API

### DIFF
--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -2,6 +2,8 @@
 Reduced schemas for accepting API actions.
 """
 import re
+import warnings
+from copy import deepcopy
 from typing import Any, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
@@ -78,17 +80,28 @@ class DeploymentCreate(ActionBaseModel):
     """Data used by the Orion API to create a deployment."""
 
     @root_validator(pre=True)
-    def remove_worker_pool_queue_id(cls, values):
+    def remove_old_fields(cls, values):
         # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
-        # worker_pool_queue_name. This validator removes worker_pool_queue_id
-        # to avoid 422 errors when it is provided by older clients.
+        # worker_pool_queue_name. Those fields were later renamed to work_pool_name
+        # and work_pool_queue_name. This validator removes old fields provided
+        # by older clients to avoid 422 errors.
         values_copy = deepcopy(values)
         worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        worker_pool_name = values_copy.pop("worker_pool_name", None)
+        worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
         if worker_pool_queue_id:
             warnings.warn(
                 "`worker_pool_queue_id` is no longer supported for creating "
-                "deployments. Please use `worker_pool_name` and "
-                "`worker_pool_queue_name` instead.",
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        if worker_pool_name or worker_pool_queue_name:
+            warnings.warn(
+                "`worker_pool_name` and `worker_pool_queue_name` are "
+                "no longer supported for creating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
                 UserWarning,
             )
         return values_copy
@@ -131,17 +144,28 @@ class DeploymentUpdate(ActionBaseModel):
     """Data used by the Orion API to update a deployment."""
 
     @root_validator(pre=True)
-    def remove_worker_pool_queue_id(cls, values):
+    def remove_old_fields(cls, values):
         # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
-        # worker_pool_queue_name. This validator removes worker_pool_queue_id
-        # to avoid 422 errors when it is provided by older clients.
+        # worker_pool_queue_name. Those fields were later renamed to work_pool_name
+        # and work_pool_queue_name. This validator removes old fields provided
+        # by older clients to avoid 422 errors.
         values_copy = deepcopy(values)
         worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        worker_pool_name = values_copy.pop("worker_pool_name", None)
+        worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
         if worker_pool_queue_id:
             warnings.warn(
                 "`worker_pool_queue_id` is no longer supported for updating "
-                "deployments. Please use `worker_pool_name` and "
-                "`worker_pool_queue_name` instead.",
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
+                UserWarning,
+            )
+        if worker_pool_name or worker_pool_queue_name:
+            warnings.warn(
+                "`worker_pool_name` and `worker_pool_queue_name` are "
+                "no longer supported for updating "
+                "deployments. Please use `work_pool_name` and "
+                "`work_pool_queue_name` instead.",
                 UserWarning,
             )
         return values_copy

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -77,6 +77,22 @@ class FlowUpdate(ActionBaseModel):
 class DeploymentCreate(ActionBaseModel):
     """Data used by the Orion API to create a deployment."""
 
+    @root_validator(pre=True)
+    def remove_worker_pool_queue_id(cls, values):
+        # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
+        # worker_pool_queue_name. This validator removes worker_pool_queue_id
+        # to avoid 422 errors when it is provided by older clients.
+        values_copy = deepcopy(values)
+        worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        if worker_pool_queue_id:
+            warnings.warn(
+                "`worker_pool_queue_id` is no longer supported for creating "
+                "deployments. Please use `worker_pool_name` and "
+                "`worker_pool_queue_name` instead.",
+                UserWarning,
+            )
+        return values_copy
+
     name: str = FieldFrom(schemas.core.Deployment)
     flow_id: UUID = FieldFrom(schemas.core.Deployment)
     is_schedule_active: bool = FieldFrom(schemas.core.Deployment)
@@ -113,6 +129,22 @@ class DeploymentCreate(ActionBaseModel):
 @copy_model_fields
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Orion API to update a deployment."""
+
+    @root_validator(pre=True)
+    def remove_worker_pool_queue_id(cls, values):
+        # 2.7.7 removed worker_pool_queue_id in lieu of worker_pool_name and
+        # worker_pool_queue_name. This validator removes worker_pool_queue_id
+        # to avoid 422 errors when it is provided by older clients.
+        values_copy = deepcopy(values)
+        worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
+        if worker_pool_queue_id:
+            warnings.warn(
+                "`worker_pool_queue_id` is no longer supported for updating "
+                "deployments. Please use `worker_pool_name` and "
+                "`worker_pool_queue_name` instead.",
+                UserWarning,
+            )
+        return values_copy
 
     version: Optional[str] = FieldFrom(schemas.core.Deployment)
     schedule: Optional[schemas.schedules.SCHEDULE_TYPES] = FieldFrom(

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -2,7 +2,11 @@ from uuid import uuid4
 
 import pytest
 
-from prefect.orion.schemas.actions import FlowRunCreate
+from prefect.orion.schemas.actions import (
+    DeploymentCreate,
+    DeploymentUpdate,
+    FlowRunCreate,
+)
 
 
 @pytest.mark.parametrize(
@@ -24,3 +28,31 @@ class TestFlowRunCreate:
         frc = FlowRunCreate(flow_id=uuid4(), flow_version="0.1", parameters=test_params)
         res = frc.dict(json_compatible=True)
         assert res["parameters"] == expected_dict
+
+
+class TestDeploymentCreate:
+    def test_create_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for creating "
+            "deployments. Please use `worker_pool_name` and "
+            "`worker_pool_queue_name` instead.",
+        ):
+            deployment_create = DeploymentCreate(
+                **dict(name="test-deployment", worker_pool_queue_id=uuid4())
+            )
+
+        assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0
+
+
+class TestDeploymentUpdate:
+    def test_update_with_worker_pool_queue_id_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_queue_id` is no longer supported for updating "
+            "deployments. Please use `worker_pool_name` and "
+            "`worker_pool_queue_name` instead.",
+        ):
+            deployment_update = DeploymentUpdate(**dict(worker_pool_queue_id=uuid4()))
+
+        assert getattr(deployment_update, "worker_pool_queue_id", 0) == 0

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -35,8 +35,8 @@ class TestDeploymentCreate:
         with pytest.warns(
             UserWarning,
             match="`worker_pool_queue_id` is no longer supported for creating "
-            "deployments. Please use `worker_pool_name` and "
-            "`worker_pool_queue_name` instead.",
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
         ):
             deployment_create = DeploymentCreate(
                 **dict(name="test-deployment", worker_pool_queue_id=uuid4())
@@ -44,15 +44,45 @@ class TestDeploymentCreate:
 
         assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0
 
+    def test_create_with_worker_pool_name_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            "no longer supported for creating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_create = DeploymentCreate(
+                **dict(
+                    name="test-deployment", worker_pool_queue_name="test-worker-pool"
+                )
+            )
+
+        assert getattr(deployment_create, "worker_pool_name", 0) == 0
+
 
 class TestDeploymentUpdate:
     def test_update_with_worker_pool_queue_id_warns(self):
         with pytest.warns(
             UserWarning,
             match="`worker_pool_queue_id` is no longer supported for updating "
-            "deployments. Please use `worker_pool_name` and "
-            "`worker_pool_queue_name` instead.",
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
         ):
             deployment_update = DeploymentUpdate(**dict(worker_pool_queue_id=uuid4()))
 
         assert getattr(deployment_update, "worker_pool_queue_id", 0) == 0
+
+    def test_update_with_worker_pool_name_warns(self):
+        with pytest.warns(
+            UserWarning,
+            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            "no longer supported for creating "
+            "deployments. Please use `work_pool_name` and "
+            "`work_pool_queue_name` instead.",
+        ):
+            deployment_update = DeploymentCreate(
+                **dict(worker_pool_queue_name="test-worker-pool")
+            )
+
+        assert getattr(deployment_update, "worker_pool_name", 0) == 0


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Ports changes in #8110 and adds support for `worker_pool_name` and `worker_pool_queue_name` to make rename safe for older clients.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
