### PR TITLE
Rename default work pool queue

### DIFF
--- a/src/prefect/orion/models/workers.py
+++ b/src/prefect/orion/models/workers.py
@@ -53,7 +53,7 @@ async def create_work_pool(
         session=session,
         work_pool_id=pool.id,
         work_pool_queue=schemas.actions.WorkPoolQueueCreate(
-            name="Default Queue", description="The work pool's default queue."
+            name="default", description="The work pool's default queue."
         ),
     )
 

--- a/tests/orion/models/test_filters.py
+++ b/tests/orion/models/test_filters.py
@@ -581,7 +581,7 @@ class TestCountFlowRunModels:
         [
             dict(
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 )
             ),
             1,
@@ -590,7 +590,7 @@ class TestCountFlowRunModels:
             dict(
                 work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 ),
             ),
             1,
@@ -601,7 +601,7 @@ class TestCountFlowRunModels:
                     name=dict(any_=["A pool that doesn't exist"])
                 ),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 ),
             ),
             0,
@@ -920,7 +920,7 @@ class TestCountDeploymentModels:
         [
             dict(
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 )
             ),
             1,
@@ -929,7 +929,7 @@ class TestCountDeploymentModels:
             dict(
                 work_pool_filter=filters.WorkPoolFilter(name=dict(any_=["Test Pool"])),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 ),
             ),
             1,
@@ -940,7 +940,7 @@ class TestCountDeploymentModels:
                     name=dict(any_=["A pool that doesn't exist"])
                 ),
                 work_pool_queue_filter=filters.WorkPoolQueueFilter(
-                    name=dict(any_=["Default Queue"])
+                    name=dict(any_=["default"])
                 ),
             ),
             0,

--- a/tests/orion/models/test_workers.py
+++ b/tests/orion/models/test_workers.py
@@ -68,7 +68,7 @@ class TestDefaultQueues:
             session=session, work_pool_queue_id=result.default_queue_id
         )
 
-        assert queue.name == "Default Queue"
+        assert queue.name == "default"
         assert queue.priority == 1
 
         # check that it is the only queue for the pool
@@ -97,7 +97,7 @@ class TestDefaultQueues:
         queue = await models.workers.read_work_pool_queue(
             session=session, work_pool_queue_id=work_pool.default_queue_id
         )
-        assert queue.name == "Default Queue"
+        assert queue.name == "default"
 
         assert await models.workers.update_work_pool_queue(
             session=session,
@@ -305,7 +305,7 @@ class TestReadWorkPoolQueues:
             session=session, work_pool_id=work_pool.id
         )
         assert len(result) == 4
-        assert (result[0].name, result[0].priority) == ("Default Queue", 1)
+        assert (result[0].name, result[0].priority) == ("default", 1)
         assert (result[1].name, result[1].priority) == ("C", 2)
         assert (result[2].name, result[2].priority) == ("A", 3)
         assert (result[3].name, result[3].priority) == ("B", 4)
@@ -336,7 +336,7 @@ class TestReadWorkPoolQueues:
             session=session, work_pool_id=work_pool.id
         )
         assert len(result) == 4
-        assert (result[0].name, result[0].priority) == ("Default Queue", 1)
+        assert (result[0].name, result[0].priority) == ("default", 1)
         assert (result[1].name, result[1].priority) == ("C", 2)
         assert (result[2].name, result[2].priority) == ("B", 3)
         assert (result[3].name, result[3].priority) == ("A", 4)
@@ -576,7 +576,7 @@ class TestDeleteWorkPoolQueue:
         )
 
         assert len(result) == 3
-        assert (result[0].name, result[0].priority) == ("Default Queue", 1)
+        assert (result[0].name, result[0].priority) == ("default", 1)
         assert (result[1].name, result[1].priority) == ("A", 2)
         assert (result[2].name, result[2].priority) == ("C", 3)
 


### PR DESCRIPTION
Supersedes #8108 

Renames the default worker pool queue to a slugified, one word `default`