### PR TITLE
Allow deployment creation and update to create work pool queues

### DIFF
--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -65,6 +65,7 @@ async def create_deployment(
                 session=session,
                 work_pool_name=deployment.work_pool_name,
                 work_pool_queue_name=deployment.work_pool_queue_name,
+                create_queue_if_not_found=True,
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default

--- a/src/prefect/orion/api/deployments.py
+++ b/src/prefect/orion/api/deployments.py
@@ -44,6 +44,11 @@ async def create_deployment(
             work_pool = await models.workers.read_work_pool_by_name(
                 session=session, work_pool_name=deployment.work_pool_name
             )
+            if work_pool is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f'Work pool "{deployment.work_pool_name}" not found.',
+                )
             try:
                 deployment.check_valid_configuration(work_pool.base_job_template)
             except (MissingVariableError, jsonschema.exceptions.ValidationError) as exc:

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -55,7 +55,7 @@ class WorkerLookups:
         if not work_pool:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Worker pool "{work_pool_name}" not found.',
+                detail=f'Work pool "{work_pool_name}" not found.',
             )
 
         return work_pool.id
@@ -75,7 +75,7 @@ class WorkerLookups:
         if not work_pool:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Worker pool "{work_pool_name}" not found.',
+                detail=f'Work pool "{work_pool_name}" not found.',
             )
 
         return work_pool.default_queue_id
@@ -101,7 +101,7 @@ class WorkerLookups:
             if not create_queue_if_not_found:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Worker queue '{work_pool_name}/{work_pool_queue_name}' not found.",
+                    detail=f"Work pool queue '{work_pool_name}/{work_pool_queue_name}' not found.",
                 )
             work_pool_id = await self._get_work_pool_id_from_name(
                 session=session, work_pool_name=work_pool_name

--- a/src/prefect/orion/models/deployments.py
+++ b/src/prefect/orion/models/deployments.py
@@ -155,6 +155,7 @@ async def update_deployment(
             session=session,
             work_pool_name=deployment.work_pool_name,
             work_pool_queue_name=deployment.work_pool_queue_name,
+            create_queue_if_not_found=True,
         )
     elif deployment.work_pool_name:
         # If just a pool name was provided, get the ID for its default

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -654,6 +654,31 @@ class TestCreateDeployment:
 
         assert deployment.work_pool_queue_id == work_pool_queue.id
 
+    async def test_create_deployment_returns_404_for_non_existent_work_pool(
+        self,
+        client,
+        flow,
+        session,
+        infrastructure_document_id,
+        work_pool,
+    ):
+        data = DeploymentCreate(
+            name="My Deployment",
+            version="mint",
+            path="/",
+            entrypoint="/file.py:flow",
+            flow_id=flow.id,
+            tags=["foo"],
+            parameters={"foo": "bar"},
+            infrastructure_document_id=infrastructure_document_id,
+            infra_overrides={"cpu": 24},
+            work_pool_name="imaginary-work-pool",
+            work_pool_queue_name="default",
+        ).dict(json_compatible=True)
+        response = await client.post("/deployments/", json=data)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == 'Work pool "imaginary-work-pool" not found.'
+
 
 class TestReadDeployment:
     async def test_read_deployment(

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -634,7 +634,7 @@ class TestCreateDeployment:
             infrastructure_document_id=infrastructure_document_id,
             infra_overrides={"cpu": 24},
             work_pool_name=work_pool.name,
-            work_pool_queue_name="new-work-queue",
+            work_pool_queue_name="new-work-pool-queue",
         ).dict(json_compatible=True)
         response = await client.post("/deployments/", json=data)
         assert response.status_code == status.HTTP_201_CREATED

--- a/tests/orion/models/test_deployments.py
+++ b/tests/orion/models/test_deployments.py
@@ -1010,3 +1010,23 @@ class TestUpdateDeployment:
             session=session, deployment_id=deployment.id
         )
         assert updated_deployment.work_pool_queue_id == default_queue.id
+
+    async def test_update_work_pool_can_create_work_pool_queue(
+        self, session, deployment, work_pool
+    ):
+        await models.deployments.update_deployment(
+            session=session,
+            deployment_id=deployment.id,
+            deployment=schemas.actions.DeploymentUpdate(
+                work_pool_name=work_pool.name,
+                work_pool_queue_name="new-work-pool-queue",
+            ),
+        )
+
+        updated_deployment = await models.deployments.read_deployment(
+            session=session, deployment_id=deployment.id
+        )
+        work_pool_queue = await models.workers.read_work_pool_queue(
+            session=session, work_pool_queue_id=updated_deployment.work_pool_queue_id
+        )
+        assert work_pool_queue.name == "new-work-pool-queue"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the ability to create a work pool queue during deployment creation and update. If the work pool exists, but the work pool queue does not, the queue will be created under the specified work pool. If the work pool does not exist, a 404 error is returned and no work pool queue is created.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
