### PR TITLE
Add release notes for 2.7.8

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,11 +3,8 @@
 ## Release 2.8.0
 
 ### Flow run timeline view
-A timeline graph (beta) has been added to the Flow Run details page. This graph is intended to help visualize flow run details as they occur over time.
+A timeline graph (beta) has been added to the Flow Run details page. This graph is intended to help visualize flow run details as they occur over time. See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
 ![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
-
-
-See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
 
 ### Enhancements
 - Add task option `refresh_cache` to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ A timeline graph (beta) has been added to the Flow Run details page. This graph 
 ![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
 
 ### Enhancements
-- Add task option `refresh_cache` to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
+- Add [task option `refresh_cache`](https://docs.prefect.io/concepts/tasks/#refreshing-the-cache) to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
 - Add logs when a task run receives an abort signal and is in a non-final state — https://github.com/PrefectHQ/prefect/pull/8097
 - Add [publishing of multiarchitecture Docker images](https://hub.docker.com/r/prefecthq/prefect-dev) for development builds  — https://github.com/PrefectHQ/prefect/pull/7900
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Release 2.8.0
 
 ### Flow run timeline view
+![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
 
 
 See https://github.com/PrefectHQ/prefect/pull/8153 for more details.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@ A timeline graph (beta) has been added to the Flow Run details page. This graph 
 - Add [task option `refresh_cache`](https://docs.prefect.io/concepts/tasks/#refreshing-the-cache) to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
 - Add logs when a task run receives an abort signal and is in a non-final state — https://github.com/PrefectHQ/prefect/pull/8097
 - Add [publishing of multiarchitecture Docker images](https://hub.docker.com/r/prefecthq/prefect-dev) for development builds  — https://github.com/PrefectHQ/prefect/pull/7900
+- Add `httpx.WriteError` to client retryable exceptions — https://github.com/PrefectHQ/prefect/pull/8145
 
 ### Fixes
 - Add support for `allow_failure` to mapped task arguments — https://github.com/PrefectHQ/prefect/pull/8135

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,11 @@ A timeline graph (beta) has been added to the Flow Run details page. This graph 
 - Add worker configuration — https://github.com/PrefectHQ/prefect/pull/8100
 - Add `BaseWorker` and `ProcessWorker` — https://github.com/PrefectHQ/prefect/pull/7996
 
+### Documentation
+- Add YouTube video to welcome page - https://github.com/PrefectHQ/prefect/pull/8090
+- Add social links - https://github.com/PrefectHQ/prefect/pull/8088
+- Increase visibility of Prefect Cloud and Orion REST API documentation - https://github.com/PrefectHQ/prefect/pull/8134
+
 ## New Contributors
 * @muddi900 made their first contribution in https://github.com/PrefectHQ/prefect/pull/8101
 * @ddelange made their first contribution in https://github.com/PrefectHQ/prefect/pull/7900

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@ A timeline graph (beta) has been added to the Flow Run details page. This graph 
 
 ### Enhancements
 - Add task option `refresh_cache` to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
-- Add logs when task run receives abort signal and is in non-final state — https://github.com/PrefectHQ/prefect/pull/8097
+- Add logs when a task run receives an abort signal and is in a non-final state — https://github.com/PrefectHQ/prefect/pull/8097
 - Add [publishing of multiarchitecture Docker images](https://hub.docker.com/r/prefecthq/prefect-dev) for development builds  — https://github.com/PrefectHQ/prefect/pull/7900
 
 ### Fixes

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,37 @@
 # Prefect Release Notes
 
+## Release 2.8.0
+
+### Flow run timeline view
+
+
+See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
+
+### Enhancements
+- Add task option `refresh_cache` to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
+- Add logs when task run receives abort signal and is in non-final state — https://github.com/PrefectHQ/prefect/pull/8097
+- Add [publishing of multiarchitecture Docker images](https://hub.docker.com/r/prefecthq/prefect-dev) for development builds  — https://github.com/PrefectHQ/prefect/pull/7900
+
+### Fixes
+- Add support for `allow_failure` to mapped task arguments — https://github.com/PrefectHQ/prefect/pull/8135
+- Update conda requirement regex to support channel and build hashes — https://github.com/PrefectHQ/prefect/pull/8137
+- Add numpy array support to orjson serialization — https://github.com/PrefectHQ/prefect/pull/7912
+
+### Experimental
+- Rename "Worker pools" to "Work pools" — https://github.com/PrefectHQ/prefect/pull/8107
+- Rename default work pool queue — https://github.com/PrefectHQ/prefect/pull/8117
+- Add worker configuration — https://github.com/PrefectHQ/prefect/pull/8100
+- Add `BaseWorker` and `ProcessWorker` — https://github.com/PrefectHQ/prefect/pull/7996
+
+## New Contributors
+* @muddi900 made their first contribution in https://github.com/PrefectHQ/prefect/pull/8101
+* @ddelange made their first contribution in https://github.com/PrefectHQ/prefect/pull/7900
+* @toro-berlin made their first contribution in https://github.com/PrefectHQ/prefect/pull/7856
+* @Ewande made their first contribution in https://github.com/PrefectHQ/prefect/pull/7912
+* @brandonreid made their first contribution in https://github.com/PrefectHQ/prefect/pull/8153
+
+**All changes**: https://github.com/PrefectHQ/prefect/compare/2.7.7...2.8.0
+
 ## Release 2.7.7
 
 ### Improved reference documentation

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,7 @@ This feature is currently in beta and we have lots of improvements planned in th
 - Add logs when a task run receives an abort signal and is in a non-final state — https://github.com/PrefectHQ/prefect/pull/8097
 - Add [publishing of multiarchitecture Docker images](https://hub.docker.com/r/prefecthq/prefect-dev) for development builds  — https://github.com/PrefectHQ/prefect/pull/7900
 - Add `httpx.WriteError` to client retryable exceptions — https://github.com/PrefectHQ/prefect/pull/8145
+- Add support for memory limits and privileged containers to `DockerContainer` — https://github.com/PrefectHQ/prefect/pull/8033
 
 ### Fixes
 - Add support for `allow_failure` to mapped task arguments — https://github.com/PrefectHQ/prefect/pull/8135

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@
 ### Flow run timeline view
 
 We're excited to announce that a new timeline graph has been added to the flow run page. 
-This view helps visualize how execution of your flow run takes place in time, opposed to the radar view that focuses on the structure of dependencies between task runs.
+This view helps visualize how execution of your flow run takes place in time, an alternative to the radar view that focuses on the structure of dependencies between task runs.
 
 ![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@
 We're excited to announce that a new timeline graph has been added to the flow run page. 
 This view helps visualize how execution of your flow run takes place in time, an alternative to the radar view that focuses on the structure of dependencies between task runs.
 
-![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
+![The timeline view visualizes execution of your flow run over time](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
 
 We've marked this as a beta feature for now and have lots of improvements planned in the near future! We're looking forward to your feedback.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,8 +3,15 @@
 ## Release 2.8.0
 
 ### Flow run timeline view
-A timeline graph (beta) has been added to the Flow Run details page. This graph is intended to help visualize flow run details as they occur over time. See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
+
+We're excited to announce that a new timeline graph has been added to the flow run page. 
+This view helps visualize how execution of your flow run takes place in time, opposed to the radar view that focuses on the structure of dependencies between task runs.
+
 ![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
+
+We've marked this as a beta feature for now and have lots of improvements planned in the near future! We're looking forward to your feedback.
+
+See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
 
 ### Enhancements
 - Add [task option `refresh_cache`](https://docs.prefect.io/concepts/tasks/#refreshing-the-cache) to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,17 +1,15 @@
 # Prefect Release Notes
 
-## Release 2.8.0
+## Release 2.7.8
 
 ### Flow run timeline view
 
 We're excited to announce that a new timeline graph has been added to the flow run page. 
 This view helps visualize how execution of your flow run takes place in time, an alternative to the radar view that focuses on the structure of dependencies between task runs.
 
+This feature is currently in beta and we have lots of improvements planned in the near future! We're looking forward to your feedback.
+
 ![The timeline view visualizes execution of your flow run over time](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
-
-We've marked this as a beta feature for now and have lots of improvements planned in the near future! We're looking forward to your feedback.
-
-See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
 
 ### Enhancements
 - Add [task option `refresh_cache`](https://docs.prefect.io/concepts/tasks/#refreshing-the-cache) to update the cached data for a task run — https://github.com/PrefectHQ/prefect/pull/7856
@@ -42,7 +40,7 @@ See https://github.com/PrefectHQ/prefect/pull/8153 for more details.
 * @Ewande made their first contribution in https://github.com/PrefectHQ/prefect/pull/7912
 * @brandonreid made their first contribution in https://github.com/PrefectHQ/prefect/pull/8153
 
-**All changes**: https://github.com/PrefectHQ/prefect/compare/2.7.7...2.8.0
+**All changes**: https://github.com/PrefectHQ/prefect/compare/2.7.7...2.7.8
 
 ## Release 2.7.7
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Release 2.8.0
 
 ### Flow run timeline view
+A timeline graph (beta) has been added to the Flow Run details page. This graph is intended to help visualize flow run details as they occur over time.
 ![image](https://user-images.githubusercontent.com/6200442/212138540-78586356-89bc-4401-a700-b80b15a17020.png)
 
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% block announce %}
 <div style="color: white;">
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-280" style="color: #07e798;">
-    <strong>Prefect 2.8.0 is live!</strong>
+  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-278" style="color: #07e798;">
+    <strong>Prefect 2.7.8 is live!</strong>
   </a> Includes a new flow run timeline view, refreshing cached task data, and
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-280" style="color: #07e798;">
+  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-278" style="color: #07e798;">
     <strong>many fixes & enhancements!</strong>
   </a>
 </div>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% block announce %}
 <div style="color: white;">
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-277" style="color: #07e798;">
-    <strong>Prefect 2.7.7 is live!</strong>
-  </a> New reference documentation, better support for block schema changes, and 
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-277" style="color: #07e798;">
+  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-280" style="color: #07e798;">
+    <strong>Prefect 2.8.0 is live!</strong>
+  </a> Includes a new flow run timeline view, refreshing cached task data, and
+  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-280" style="color: #07e798;">
     <strong>many fixes & enhancements!</strong>
   </a>
 </div>


### PR DESCRIPTION
Replaces https://github.com/PrefectHQ/prefect/pull/8155

[Rendered](https://github.com/PrefectHQ/prefect/blob/release-notes-2.7.8/RELEASE-NOTES.md#release-278)