### PR TITLE
Mark `test_process_streams_stderr` as flaky on Python 3.11

### DIFF
--- a/tests/infrastructure/test_process.py
+++ b/tests/infrastructure/test_process.py
@@ -49,6 +49,7 @@ def test_process_stream_output(capsys, stream_output):
         assert "hello world" in out
 
 
+@pytest.mark.flaky(max_runs=2 if sys.version_info > (3, 10) else 1)
 @pytest.mark.skipif(
     sys.platform == "win32", reason="stderr redirect does not work on Windows"
 )


### PR DESCRIPTION
Example failure at https://github.com/PrefectHQ/prefect/actions/runs/3905183643/jobs/6671882248