### PR TITLE
Update Python tests to use a single test matrix for both databases

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       matrix:
         database:
-          - "postgres"
+          - "postgres:13"
+          - "postgres:14"
           - "sqlite"
         os:
           - ubuntu-latest
@@ -67,17 +68,15 @@ jobs:
           - pytest-options: "--only-services"
             build-docker-images: true
 
-          # Test against Postgres 13 and 14
-          - database: "postgres"
-            postgres-version: "13"
-
-          - database: "postgres"
-            postgres-version: "14"
-
         exclude:
           # Do not run service tests with postgres
-          - database: "postgres"
+          - database: "postgres:13"
             pytest-options: "--only-services"
+
+          # Do not run service tests with postgres
+          - database: "postgres:14"
+            pytest-options: "--only-services"
+
 
       fail-fast: false
 
@@ -164,8 +163,8 @@ jobs:
           # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
           pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      - name: Start PostgreSQL ${{ matrix.postgres-version }}
-        if: ${{ matrix.database == 'postgres' }}
+      - name: Start database container
+        if: ${{ matrix.database.startsWith('postgres') }}
         run: >
           docker run
           --name "postgres"
@@ -184,7 +183,7 @@ jobs:
           --env LC_ALL="C.UTF-8"
           --env LC_COLLATE="C.UTF-8"
           --env LC_CTYPE="C.UTF-8"
-          postgres:${{ matrix.postgres-version }}
+          ${{ matrix.database }}
 
           ./scripts/wait-for-healthy-container.sh postgres 30
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -192,7 +192,7 @@ jobs:
         # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
         env: 
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
-          PREFECT_ORION_DATABASE_CONNECTION_URL: ${{ 'postgresql+asyncpg://prefect:prefect@localhost/orion' && matrix.database == "postgres" || '' }} 
+          PREFECT_ORION_DATABASE_CONNECTION_URL: ${{ 'postgresql+asyncpg://prefect:prefect@localhost/orion' && matrix.database == 'postgres' || '' }} 
         run: |
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -200,7 +200,8 @@ jobs:
           pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 -x ${{ matrix.pytest-options }}
 
       - name: Check database container
-        if: always() && ${{ startsWith(matrix.database, 'postgres') }}
-        run: |
+        if: always()
+        run: >
           docker container inspect postgres
-          docker container logs postgres
+          && docker container logs postgres
+          || echo "Ok"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   run-tests:
-    name: Python ${{ matrix.python-version }} / ${{ matrix.database }} / ${{ matrix.pytest-options }}
+    name: ${{ matrix.database }}, Py${{ matrix.python-version }}, ${{ matrix.pytest-options }}
 
     strategy:
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -165,7 +165,7 @@ jobs:
           pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
       - name: Start PostgreSQL ${{ matrix.postgres-version }}
-        if: ${{ matrix.database == "postgres" }}
+        if: ${{ matrix.database == 'postgres' }}
         run: >
           docker run
           --name "postgres"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   run-tests:
-    name: Python ${{ matrix.python-version }} (${{ matrix.database }} / ${{ matrix.pytest-options }})
+    name: Python ${{ matrix.python-version }} / ${{ matrix.database }} / ${{ matrix.pytest-options }}
 
     strategy:
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -187,7 +187,7 @@ jobs:
 
           ./scripts/wait-for-healthy-container.sh postgres 30
 
-          echo "PREFECT_ORION_DATABASE_CONNECTION_URL='postgresql+asyncpg://prefect:prefect@localhost/orion'" >> $GITHUB_ENV
+          echo "PREFECT_ORION_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/orion" >> $GITHUB_ENV
 
       - name: Run tests
         # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   run-tests:
-    name: ${{ matrix.database }}, Py${{ matrix.python-version }}, ${{ matrix.pytest-options }}
+    name: python:${{ matrix.python-version }}, ${{ matrix.database }}, ${{ matrix.pytest-options }}
 
     strategy:
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -200,7 +200,7 @@ jobs:
           pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 -x ${{ matrix.pytest-options }}
 
       - name: Check database container
-        if: failure() && ${{ startsWith(matrix.database, 'postgres') }}
+        if: always() && ${{ startsWith(matrix.database, 'postgres') }}
         run: |
           docker container inspect postgres
           docker container logs postgres

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -200,8 +200,9 @@ jobs:
           pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 ${{ matrix.pytest-options }}
 
       - name: Check database container
+        # Only applicable for Postgres, but we want this to run even when tests fail
         if: always()
         run: >
           docker container inspect postgres
           && docker container logs postgres
-          || echo "Ok"
+          || echo "Ignoring bad exit code"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -188,11 +188,12 @@ jobs:
 
           ./scripts/wait-for-healthy-container.sh postgres 30
 
+          echo "PREFECT_ORION_DATABASE_CONNECTION_URL='postgresql+asyncpg://prefect:prefect@localhost/orion'" >> $GITHUB_ENV
+
       - name: Run tests
         # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
         env: 
-          SQLALCHEMY_SILENCE_UBER_WARNING: 1
-          PREFECT_ORION_DATABASE_CONNECTION_URL: ${{ 'postgresql+asyncpg://prefect:prefect@localhost/orion' && matrix.database == 'postgres' || '' }} 
+          SQLALCHEMY_SILENCE_UBER_WARNING: 1 
         run: |
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -197,7 +197,7 @@ jobs:
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
-          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 -x ${{ matrix.pytest-options }}
+          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 ${{ matrix.pytest-options }}
 
       - name: Check database container
         if: always()

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,4 +1,4 @@
-name: Python tests
+name: Unit tests
 
 # Note: Conda support for 3.11 is pending. See https://github.com/ContinuumIO/anaconda-issues/issues/13082
 
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   run-tests:
-    name: Test
+    name: Python ${{ matrix.python-version }} (${{ matrix.database }} / ${{ matrix.pytest-options }})
 
     strategy:
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -198,3 +198,9 @@ jobs:
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 -x ${{ matrix.pytest-options }}
+
+      - name: Check database container
+        if: failure() && ${{ startsWith(matrix.database, 'postgres') }}
+        run: |
+          docker container inspect postgres
+          docker container logs postgres

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -198,4 +198,4 @@ jobs:
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
-          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 ${{ matrix.pytest-options }}
+          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 -x ${{ matrix.pytest-options }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -37,11 +37,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  run-tests-sqlite:
-    name: Test with SQLite
+  run-tests:
+    name: Test
 
     strategy:
       matrix:
+        database:
+          - "postgres"
+          - "sqlite"
         os:
           - ubuntu-latest
         python-version:
@@ -63,6 +66,18 @@ jobs:
           # suite from building images automaticlly in fixtures
           - pytest-options: "--only-services"
             build-docker-images: true
+
+          # Test against Postgres 13 and 14
+          - database: "postgres"
+            postgres-version: "13"
+
+          - database: "postgres"
+            postgres-version: "14"
+
+        exclude:
+          # Do not run service tests with postgres
+          - database: "postgres"
+            pytest-options: "--only-services"
 
       fail-fast: false
 
@@ -149,44 +164,8 @@ jobs:
           # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
           pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      - name: Run tests
-        # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
-        env: 
-          SQLALCHEMY_SILENCE_UBER_WARNING: 1
-        run: |
-          # Parallelize tests by scope to reduce expensive service fixture duplication
-          # Do not allow the test suite to build images, as we want the prebuilt images to be tested
-          # Do not run Kubernetes service tests, we do not have a cluster available
-          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 ${{ matrix.pytest-options }}
-
-  run-tests-postgres:
-    name: Test with Postgres
-
-    strategy:
-      matrix:
-        postgres-version:
-          - "13"
-          - "14"
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-        pytest-options:
-          - "--exclude-services"
-
-      fail-fast: false
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
       - name: Start PostgreSQL ${{ matrix.postgres-version }}
+        if: ${{ matrix.database == "postgres" }}
         run: >
           docker run
           --name "postgres"
@@ -209,22 +188,13 @@ jobs:
 
           ./scripts/wait-for-healthy-container.sh postgres 30
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "requirements*.txt"
-
-      - name: Install packages
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -e .[dev]
-
       - name: Run tests
-        env:
-          PREFECT_ORION_DATABASE_CONNECTION_URL: "postgresql+asyncpg://prefect:prefect@localhost/orion"
-          # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
+        # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
+        env: 
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
+          PREFECT_ORION_DATABASE_CONNECTION_URL: ${{ 'postgresql+asyncpg://prefect:prefect@localhost/orion' && matrix.database == "postgres" || '' }} 
         run: |
-          pytest tests --numprocesses auto --dist loadscope ${{ matrix.pytest-options }} --durations 30
+          # Parallelize tests by scope to reduce expensive service fixture duplication
+          # Do not allow the test suite to build images, as we want the prebuilt images to be tested
+          # Do not run Kubernetes service tests, we do not have a cluster available
+          pytest tests --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 ${{ matrix.pytest-options }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -164,7 +164,7 @@ jobs:
           pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
       - name: Start database container
-        if: ${{ matrix.database.startsWith('postgres') }}
+        if: ${{ startsWith(matrix.database, 'postgres') }}
         run: >
           docker run
           --name "postgres"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pytz >= 2021.1
 pyyaml >= 5.4.1
 readchar >= 4.0.0
 rich >= 11.0
-sqlalchemy[asyncio] >= 1.4.20, != 1.4.33, < 2.0
+sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0
 toml >= 0.10.0
 typer >= 0.4.2
 typing_extensions >= 4.1.0

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -450,7 +450,7 @@ class TaskRunnerStandardTestSuite(ABC):
 
         if sys.platform != "darwin":
             # CI machines are slow
-            sleep_time += 2.0
+            sleep_time += 2.5
 
         if sys.version_info < (3, 8):
             # Python 3.7 is slower

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,8 @@ async def generate_test_database_connection_url(
         yield None
         return
 
+    print(f"Generating test database connection URL from {original_url!r}")
+
     scheme, netloc, database, query, fragment = urlsplit(original_url)
     if scheme == "sqlite+aiosqlite":
         # SQLite databases will be scoped by the PREFECT_HOME setting, which will
@@ -374,8 +376,11 @@ async def generate_test_database_connection_url(
         postgres_url = urlunsplit(("postgres", netloc, "postgres", query, fragment))
 
         # Create an empty temporary database for use in the tests
+
+        print(f"Connecting to postgres at {postgres_url!r}")
         connection = await asyncpg.connect(postgres_url)
         try:
+            print(f"Creating test postgres database {quoted_db_name!r}")
             # remove any connections to the test database. For example if a SQL IDE
             # is being used to investigate it, it will block the drop database command.
             await connection.execute(
@@ -394,7 +399,10 @@ async def generate_test_database_connection_url(
 
         new_url = urlunsplit((scheme, netloc, test_db_name, query, fragment))
 
+        print(f"Using test database connection URL {new_url!r}")
         yield new_url
+
+        print("Cleaning up test postgres database")
 
         # Now drop the temporary database we created
         connection = await asyncpg.connect(postgres_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,7 +402,6 @@ async def generate_test_database_connection_url(
         yield new_url
 
         print("Cleaning up test postgres database")
-
         # Now drop the temporary database we created
         connection = await asyncpg.connect(postgres_url)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,68 +361,66 @@ async def generate_test_database_connection_url(
         return
 
     print(f"Generating test database connection URL from {original_url!r}")
-    try:
-        scheme, netloc, database, query, fragment = urlsplit(original_url)
-        if scheme == "sqlite+aiosqlite":
-            # SQLite databases will be scoped by the PREFECT_HOME setting, which will
-            # be in an isolated temporary directory
-            yield None
-            return
+    scheme, netloc, database, query, fragment = urlsplit(original_url)
+    if scheme == "sqlite+aiosqlite":
+        # SQLite databases will be scoped by the PREFECT_HOME setting, which will
+        # be in an isolated temporary directory
+        yield None
+        return
 
-        if scheme == "postgresql+asyncpg":
-            test_db_name = database.strip("/") + f"_tests_{worker_id}"
-            quoted_db_name = postgres_dialect().identifier_preparer.quote(test_db_name)
+    elif scheme == "postgresql+asyncpg":
+        test_db_name = database.strip("/") + f"_tests_{worker_id}"
+        quoted_db_name = postgres_dialect().identifier_preparer.quote(test_db_name)
 
-            postgres_url = urlunsplit(("postgres", netloc, "postgres", query, fragment))
+        postgres_url = urlunsplit(("postgres", netloc, "postgres", query, fragment))
 
-            # Create an empty temporary database for use in the tests
+        # Create an empty temporary database for use in the tests
 
-            print(f"Connecting to postgres at {postgres_url!r}")
-            connection = await asyncpg.connect(postgres_url)
-            try:
-                print(f"Creating test postgres database {quoted_db_name!r}")
-                # remove any connections to the test database. For example if a SQL IDE
-                # is being used to investigate it, it will block the drop database command.
-                await connection.execute(
-                    f"""
-                    SELECT pg_terminate_backend(pg_stat_activity.pid)
-                    FROM pg_stat_activity
-                    WHERE pg_stat_activity.datname = '{quoted_db_name}'
-                    AND pid <> pg_backend_pid();
-                    """
-                )
+        print(f"Connecting to postgres at {postgres_url!r}")
+        connection = await asyncpg.connect(postgres_url)
+        try:
+            print(f"Creating test postgres database {quoted_db_name!r}")
+            # remove any connections to the test database. For example if a SQL IDE
+            # is being used to investigate it, it will block the drop database command.
+            await connection.execute(
+                f"""
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = '{quoted_db_name}'
+                AND pid <> pg_backend_pid();
+                """
+            )
 
-                await connection.execute(f"DROP DATABASE IF EXISTS {quoted_db_name}")
-                await connection.execute(f"CREATE DATABASE {quoted_db_name}")
-            finally:
-                await connection.close()
+            await connection.execute(f"DROP DATABASE IF EXISTS {quoted_db_name}")
+            await connection.execute(f"CREATE DATABASE {quoted_db_name}")
+        finally:
+            await connection.close()
 
-            new_url = urlunsplit((scheme, netloc, test_db_name, query, fragment))
+        new_url = urlunsplit((scheme, netloc, test_db_name, query, fragment))
 
-            print(f"Using test database connection URL {new_url!r}")
-            yield new_url
+        print(f"Using test database connection URL {new_url!r}")
+        yield new_url
 
-            print("Cleaning up test postgres database")
+        print("Cleaning up test postgres database")
 
-            # Now drop the temporary database we created
-            connection = await asyncpg.connect(postgres_url)
-            try:
-                await connection.execute(f"DROP DATABASE IF EXISTS {quoted_db_name}")
-            except asyncpg.exceptions.ObjectInUseError:
-                # If we aren't able to drop the database because there's still a connection,
-                # open, that's okay.  If we're in CI, then this DB is going away permanently
-                # anyway, and if we're testing locally, in the beginning of this fixture,
-                # we drop the database prior to creating it.  The worst case is that we
-                # leave a DB catalog lying around on your local Postgres, which will get
-                # cleaned up before the next test suite run.
-                pass
-            finally:
-                await connection.close()
-    except:
-        import traceback
-
-        traceback.print_exc()
-        raise
+        # Now drop the temporary database we created
+        connection = await asyncpg.connect(postgres_url)
+        try:
+            await connection.execute(f"DROP DATABASE IF EXISTS {quoted_db_name}")
+        except asyncpg.exceptions.ObjectInUseError:
+            # If we aren't able to drop the database because there's still a connection,
+            # open, that's okay.  If we're in CI, then this DB is going away permanently
+            # anyway, and if we're testing locally, in the beginning of this fixture,
+            # we drop the database prior to creating it.  The worst case is that we
+            # leave a DB catalog lying around on your local Postgres, which will get
+            # cleaned up before the next test suite run.
+            pass
+        finally:
+            await connection.close()
+    else:
+        raise ValueError(
+            f"Unknown scheme {scheme!r} parsed from database url {original_url!r}."
+        )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1312,12 +1312,12 @@ class TestFlowRunLogs:
 
     async def test_repeated_flow_calls_send_logs_to_orion(self, orion_client):
         @flow
-        def my_flow(i):
+        async def my_flow(i):
             logger = get_run_logger()
             logger.info(f"Hello {i}")
 
-        my_flow(1)
-        my_flow(2)
+        await my_flow(1)
+        await my_flow(2)
 
         logs = await orion_client.read_logs()
         assert {"Hello 1", "Hello 2"}.issubset({log.message for log in logs})


### PR DESCRIPTION
Following #8125 we can consolidate the Postgres and SQLite tests into a single matrix for maintainability :)

This also creates an avenue for splitting tests further for speedups (as we have recently done in Cloud)