### PR TITLE
Fix CLI ability to spawn subprocesses on Windows

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -84,6 +84,19 @@ def main(
         # during tests.
         setup_logging()
 
+    # When running on Windows we need to use a non-default loop for subprocess support
+    # this is most important for the agent but we need to set the policy before a loop
+    # is created
+    if sys.platform == "win32":
+        if sys.version_info >= (3, 8):
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        else:
+            app.console.print(
+                "WARNING: Prefect does not support Python 3.7 on Windows. "
+                "We recommend using Python 3.8+. "
+                "Functionality that requires subprocess spawning may fail."
+            )
+
 
 @app.command()
 async def version():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
In  some cases, an external library can change the default event loop policy (see https://github.com/PrefectHQ/prefect/issues/8206). This pull request adds update of the event loop policy to the CLI entrypoint. This is ideal because it is

1. Before any event loop is created
2. Always in a context where we are in full control of the process — this will not change the policy for any user code

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
