### PR TITLE
Add support for variadic keyword arguments to `Task.map`

### DIFF
--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -132,7 +132,8 @@ def collapse_variadic_parameters(
         )
 
     new_parameters = parameters.copy()
-    new_parameters[variadic_key] = {}
+    if variadic_key:
+        new_parameters[variadic_key] = {}
 
     for key in missing_parameters:
         new_parameters[variadic_key][key] = new_parameters.pop(key)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2967,7 +2967,7 @@ class TestTaskMap:
             [4, 5, 6, 7],
         ]
 
-    def test_with_default_kwargs(self):
+    def test_with_keyword_with_default(self):
         @task
         def add_some(x, y=5):
             return x + y
@@ -2979,6 +2979,32 @@ class TestTaskMap:
 
         task_states = my_flow()
         assert [state.result() for state in task_states] == [6, 7, 8]
+
+    def test_with_variadic_keywords_and_iterable(self):
+        @task
+        def add_some(x, **kwargs):
+            return x + kwargs["y"]
+
+        @flow
+        def my_flow():
+            numbers = [1, 2, 3]
+            return add_some.map(numbers, y=[4, 5, 6])
+
+        task_states = my_flow()
+        assert [state.result() for state in task_states] == [5, 7, 9]
+
+    def test_with_variadic_keywords_and_noniterable(self):
+        @task
+        def add_some(x, **kwargs):
+            return x + kwargs["y"]
+
+        @flow
+        def my_flow():
+            numbers = [1, 2, 3]
+            return add_some.map(numbers, y=1)
+
+        task_states = my_flow()
+        assert [state.result() for state in task_states] == [2, 3, 4]
 
 
 class TestTaskConstructorValidation:


### PR DESCRIPTION
Prompted by https://prefect-community.slack.com/archives/CL09KU1K7/p1673994869243719

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Currently, if you have a task with variadic keyword arguments (i.e. `**kwargs`) it cannot be used with mapping: a mapping length mismatch error will be raised. This occurs because when we cast the call arguments and keyword arguments to _parameters_, we capture the variadic options in a "kwargs" key. 

To resolve this, we need to expand the parameter key (i.e. "kwargs") during length checks. This pull request adds utilities to explode and collapse variadic parameters which are used during mapping to ensure that we are performing length checks on the actual arguments that would be passed to the function.

Instead of checking the lengths of `{'x': [1, 2], 'kwargs': {}}` we check `{'x': [1, 2]}` and  instead of `{'x': [1, 2], 'kwargs': {'y': 3}}` we check `{'x': [1, 2], 'y': 3}`.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->


```python
from prefect import task, flow

@task
def add(x: int, **kwargs):
    return x + kwargs.get("y", 0)


@flow
def my_flow():
    results = add.map(x=[1, 2])

my_flow()

# Previously:
# MappingLengthMismatch: Received iterable parameters with different lengths.
# Parameters for map must all be the same length. Got lengths: {'x': 2, 'kwargs': 0}

# In this implementation
# `y` can be excluded, a noniterable value, or an iterable of the same length as `x`
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
