### PR TITLE
Stop blocks from referencing themselves

### DIFF
--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -750,6 +750,16 @@ class BlockDocumentReference(ORMBaseModel):
         default=..., description="The name that the reference is nested under"
     )
 
+    @root_validator
+    def validate_parent_and_ref_are_different(cls, values):
+        parent_id = values.get("parent_block_document_id")
+        ref_id = values.get("reference_block_document_id")
+        if parent_id and ref_id and parent_id == ref_id:
+            raise ValueError(
+                "`parent_block_document_id` and `reference_block_document_id` cannot be the same"
+            )
+        return values
+
 
 class Configuration(ORMBaseModel):
     """An ORM representation of account info."""

--- a/tests/orion/schemas/test_core.py
+++ b/tests/orion/schemas/test_core.py
@@ -68,6 +68,20 @@ class TestBlockDocument:
         )
 
 
+class TestBlockDocumentReference:
+    async def test_block_document_reference_different_parent_and_ref(self):
+        same_id = uuid4()
+        with pytest.raises(
+            ValueError,
+            match="`parent_block_document_id` and `reference_block_document_id` cannot be the same",
+        ):
+            schemas.core.BlockDocumentReference(
+                parent_block_document_id=same_id,
+                reference_block_document_id=same_id,
+                name="name",
+            )
+
+
 class TestFlowRunNotificationPolicy:
     async def test_message_template_variables_are_validated(self):
         with pytest.raises(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:


Happy engineering!
-->
<!-- Include an overview here -->

closes: https://github.com/PrefectHQ/nebula/issues/3190

### Example
It is currently possible to get a block to create a `BlockDocumentReference` where the `parent_block_document_id` and `reference_block_document_id` are the same. This will lead to an infinite loop when trying to query the database for blocks using `WITH RECURSIVE ...` which looks to extract nested blocks. This pr will guard against this self referential loop from occurring. 

Note: There currently is not an MRE for actually getting into this state using the block interface. Once that exists, more changes and better validation might need to be added. Until then this ensures that the server cannot get into an undesired state.

```bash
# Before
>>> same_id = uuid4()
>>> BlockDocumentReference(parent_block_document_id=same_id, reference_block_document_id=same_id, name="name")

# Now
>>> same_id = uuid4()
>>> BlockDocumentReference(parent_block_document_id=same_id, reference_block_document_id=same_id, name="name")
Traceback (most recent call last):
  File "/Users/jakekaplan/PycharmProjects/prefect/jake-test2.py", line 5, in <module>
    BlockDocumentReference(parent_block_document_id=same_id, reference_block_document_id=same_id, name="name")
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for BlockDocumentReference
__root__
  `parent_block_document_id` and `reference_block_document_id` cannot be the same (type=value_error)

```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
