### PR TITLE
Fix notification query bug caused by postgresql

### DIFF
--- a/src/prefect/orion/database/query_components.py
+++ b/src/prefect/orion/database/query_components.py
@@ -606,7 +606,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                 db.FlowRunNotificationQueue.flow_run_state_id,
             )
             .where(
-                db.FlowRunNotificationQueue.id.in_(
+                db.FlowRunNotificationQueue.id.eq_(
                     sa.select(db.FlowRunNotificationQueue.id)
                     .select_from(db.FlowRunNotificationQueue)
                     .order_by(db.FlowRunNotificationQueue.updated)


### PR DESCRIPTION
[Postgres Forum](https://www.postgresql.org/message-id/16497.1553640836%40sss.pgh.pa.us)

[Issue 7568](https://github.com/PrefectHQ/prefect/issues/7568)

The notifications query is supposed to return 1 record, but returns multiple. This change to the query should enforce 1 record returning.

I ran the notification service locally against our prefect database. Without the change, the query returned multiple records. With the change, only 1 record returned.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
