### PR TITLE
Add new "discourse" and "blog" admonition types

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -264,6 +264,7 @@ to force column width */
 }
 
 /* custom admonitions */
+/* cloud admonition */
 :root {
     --md-admonition-icon--cloud-ad: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 18H6a4 4 0 0 1-4-4 4 4 0 0 1 4-4h.71C7.37 7.69 9.5 6 12 6a5.5 5.5 0 0 1 5.5 5.5v.5H19a3 3 0 0 1 3 3 3 3 0 0 1-3 3m.35-7.97A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.03A6.004 6.004 0 0 0 0 14a6 6 0 0 0 6 6h13a5 5 0 0 0 5-5c0-2.64-2.05-4.78-4.65-4.97Z"/></svg>')
   }
@@ -282,3 +283,40 @@ to force column width */
             mask-image: var(--md-admonition-icon--cloud-ad);
   }
   
+  /* discourse admonition */
+:root {
+    --md-admonition-icon--discourse: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M225.9 32C103.3 32 0 130.5 0 252.1 0 256 .1 480 .1 480l225.8-.2c122.7 0 222.1-102.3 222.1-223.9C448 134.3 348.6 32 225.9 32zM224 384c-19.4 0-37.9-4.3-54.4-12.1L88.5 392l22.9-75c-9.8-18.1-15.4-38.9-15.4-61 0-70.7 57.3-128 128-128s128 57.3 128 128-57.3 128-128 128z"/></svg>')
+  }
+  .md-typeset .admonition.discourse,
+  .md-typeset details.discourse {
+    border-color: #cca701;
+  }
+  .md-typeset .discourse > .admonition-title,
+  .md-typeset .discourse > summary {
+    background-color: #cca70115;
+  }
+  .md-typeset .discourse > .admonition-title::before,
+  .md-typeset .discourse > summary::before {
+    background-color: #cca701;
+    -webkit-mask-image: var(--md-admonition-icon--discourse);
+            mask-image: var(--md-admonition-icon--discourse);
+  }
+
+    /* blog admonition */
+:root {
+    --md-admonition-icon--blog: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M249.6 471.5c10.8 3.8 22.4-4.1 22.4-15.5V78.6c0-4.2-1.6-8.4-5-11C247.4 52 202.4 32 144 32 87.5 32 35.1 48.6 9 59.9c-5.6 2.4-9 8-9 14v380.2c0 11.9 12.8 20.2 24.1 16.5C55.6 460.1 105.5 448 144 448c33.9 0 79 14 105.6 23.5zm76.8 0C353 462 398.1 448 432 448c38.5 0 88.4 12.1 119.9 22.6 11.3 3.8 24.1-4.6 24.1-16.5V73.9c0-6.1-3.4-11.6-9-14C540.9 48.6 488.5 32 432 32c-58.4 0-103.4 20-123 35.6-3.3 2.6-5 6.8-5 11V456c0 11.4 11.7 19.3 22.4 15.5z"/></svg>')
+  }
+  .md-typeset .admonition.blog,
+  .md-typeset details.blog {
+    border-color: #cca701;
+  }
+  .md-typeset .blog > .admonition-title,
+  .md-typeset .blog > summary {
+    background-color: #cca70115;
+  }
+  .md-typeset .blog > .admonition-title::before,
+  .md-typeset .blog > summary::before {
+    background-color: #cca701;
+    -webkit-mask-image: var(--md-admonition-icon--blog);
+            mask-image: var(--md-admonition-icon--blog);
+  }


### PR DESCRIPTION
Adds two new custom admonitions for calling out links to Discourse topics or blog/article/other content.

- "discourse" admonition uses a Discourse icon and is meant to call out a link to related content on Prefect Discourse.
- "blog" admonition uses a generalized book icon and may be used to call out any external content.

### Example

```
!!! discourse "Learn more about Secrets blocks"
    See Prefect Discourse topic [Pass ENV vars from Kubernetes to Job](https://discourse.prefect.io/t/pass-env-vars-from-kubernetes-agent-to-job/2218) for more information about using Secrets with Kubernetes Jobs.


!!! blog "Learn more about building modular dataflow applications"
    See the article [Modular Data Stack — Build a Data Platform with Prefect, dbt and Snowflake](https://www.prefect.io/guide/community-posts/modular-data-stack-build-a-data-platform-with-prefect-dbt-and-snowflake-pt2) for more information about building observable and composable workflows from lightweight modular components.
```

![newadmonitions](https://user-images.githubusercontent.com/370316/213310267-4fb52600-4adc-4fba-92c0-df98844b8319.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
