### PR TITLE
Add work queue name coverage to `test_create_flow_run_from_deployment`

### DIFF
--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -921,11 +921,13 @@ async def test_read_flow_by_name(orion_client):
     assert the_flow.id == flow_id
 
 
-async def test_create_flow_run_from_deployment(orion_client, deployment):
+async def test_create_flow_run_from_deployment(orion_client: OrionClient, deployment):
     flow_run = await orion_client.create_flow_run_from_deployment(deployment.id)
     # Deployment details attached
     assert flow_run.deployment_id == deployment.id
     assert flow_run.flow_id == deployment.flow_id
+    assert flow_run.work_queue_name == deployment.work_queue_name
+    assert flow_run.work_queue_name  # not empty
 
     # Flow version is not populated yet
     assert flow_run.flow_version is None


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
In an attempt to reproduce the issue at https://github.com/PrefectHQ/prefect/issues/8186 I added a check that the work queue name is populated on the returned flow run.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
