### PR TITLE
chore: add k8s kube-system permissions to prefect agent template

### DIFF
--- a/src/prefect/cli/templates/kubernetes-agent.yaml
+++ b/src/prefect/cli/templates/kubernetes-agent.yaml
@@ -60,7 +60,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/prefect/cli/templates/kubernetes-agent.yaml
+++ b/src/prefect/cli/templates/kubernetes-agent.yaml
@@ -16,28 +16,28 @@ spec:
         app: prefect-agent
     spec:
       containers:
-      - name: agent
-        image: ${image_name}
-        command: ["prefect", "agent", "start", "-q", "${work_queue}"]
-        imagePullPolicy: "IfNotPresent"
-        env:
-          - name: PREFECT_API_URL
-            value: ${api_url}
-          - name: PREFECT_API_KEY
-            value: ${api_key}
+        - name: agent
+          image: ${image_name}
+          command: ["prefect", "agent", "start", "-q", "${work_queue}"]
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: PREFECT_API_URL
+              value: ${api_url}
+            - name: PREFECT_API_KEY
+              value: ${api_key}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: ${namespace}
   name: prefect-agent
+  namespace: ${namespace}
 rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/log", "pods/status"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["batch"]
-  resources: ["jobs"]
-  verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -45,10 +45,32 @@ metadata:
   name: prefect-agent-role-binding
   namespace: ${namespace}
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: ${namespace}
+  - kind: ServiceAccount
+    name: default
+    namespace: ${namespace}
 roleRef:
   kind: Role
+  name: prefect-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prefect-agent
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prefect-agent-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ${namespace}
+roleRef:
+  kind: ClusterRole
   name: prefect-agent
   apiGroup: rbac.authorization.k8s.io

--- a/tests/cli/test_kubernetes_manifest.py
+++ b/tests/cli/test_kubernetes_manifest.py
@@ -161,7 +161,8 @@ def test_printing_the_agent_manifest_with_namespace():
     assert manifests
 
     for manifest in manifests:
-        assert manifest["metadata"]["namespace"] == "test_namespace"
+        if manifest["kind"] not in ["ClusterRole", "ClusterRoleBinding"]:
+            assert manifest["metadata"]["namespace"] == "test_namespace"
 
 
 def test_printing_the_job_base_manifest():

--- a/tests/cli/test_kubernetes_manifest.py
+++ b/tests/cli/test_kubernetes_manifest.py
@@ -95,7 +95,8 @@ def test_printing_the_agent_manifest_with_no_args():
     assert manifests
 
     for manifest in manifests:
-        assert manifest["metadata"]["namespace"] == "default"
+        if manifest["kind"] not in ["ClusterRole","ClusterRoleBinding"]:
+            assert manifest["metadata"]["namespace"] == "default"
 
         if manifest["kind"] == "Deployment":
             assert manifest["metadata"]["name"] == "prefect-agent"

--- a/tests/cli/test_kubernetes_manifest.py
+++ b/tests/cli/test_kubernetes_manifest.py
@@ -95,7 +95,7 @@ def test_printing_the_agent_manifest_with_no_args():
     assert manifests
 
     for manifest in manifests:
-        if manifest["kind"] not in ["ClusterRole","ClusterRoleBinding"]:
+        if manifest["kind"] not in ["ClusterRole", "ClusterRoleBinding"]:
             assert manifest["metadata"]["namespace"] == "default"
 
         if manifest["kind"] == "Deployment":


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Relates to #8120; Defines the required cluster permissions to enable the Prefect agent to query the `kube-system` namespace to retrieve a UUID


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
