### PR TITLE
Makes agents work pool aware

### DIFF
--- a/orion-ui/src/components/ContextSidebar.vue
+++ b/orion-ui/src/components/ContextSidebar.vue
@@ -3,7 +3,7 @@
     <p-context-nav-item title="Flow Runs" icon="FlowRun" :to="routes.flowRuns()" />
     <p-context-nav-item title="Flows" icon="Flow" :to="routes.flows()" />
     <p-context-nav-item title="Deployments" icon="LocationMarkerIcon" :to="routes.deployments()" />
-    <p-context-nav-item v-if="canSeeWorkers" title="Workers" icon="DatabaseIcon" :to="routes.workPools()" />
+    <p-context-nav-item v-if="canSeeWorkers" title="Work Pools" icon="DatabaseIcon" :to="routes.workPools()" />
     <p-context-nav-item title="Work Queues" icon="DatabaseIcon" :to="routes.workQueues()" />
     <p-context-nav-item title="Blocks" icon="CubeIcon" :to="routes.blocks()" />
     <p-context-nav-item title="Notifications" icon="BellIcon" :to="routes.notifications()" />

--- a/orion-ui/src/pages/WorkPool.vue
+++ b/orion-ui/src/pages/WorkPool.vue
@@ -17,9 +17,6 @@
         <WorkPoolQueuesTable :work-pool-name="workPoolName" />
       </template>
 
-      <template #workers>
-        <WorkersTable :work-pool-filter="workPool.name" />
-      </template>
     </p-tabs>
 
     <template #well>
@@ -29,7 +26,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { useWorkspaceApi, PageHeadingWorkPool, WorkPoolDetails, WorkersTable, useRecentFlowRunFilter, FlowRunFilteredList, WorkPoolQueuesTable } from '@prefecthq/orion-design'
+  import { useWorkspaceApi, PageHeadingWorkPool, WorkPoolDetails, useRecentFlowRunFilter, FlowRunFilteredList, WorkPoolQueuesTable } from '@prefecthq/orion-design'
   import { media } from '@prefecthq/prefect-design'
   import { useRouteParam, useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
@@ -39,7 +36,7 @@
   const workPoolName = useRouteParam('workPoolName')
 
   const tabs = computed(() => {
-    const values = ['Runs', 'Queues', 'Workers']
+    const values = ['Runs', 'Queues']
 
     if (!media.xl) {
       values.unshift('Details')

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -194,42 +194,44 @@ class OrionAgent:
 
         submittable_runs: List[FlowRun] = []
 
-        if self.work_pool_name and not self.work_queues:
+        if self.work_pool_name:
             responses = await self.client.get_scheduled_flow_runs_for_work_pool_queues(
                 work_pool_name=self.work_pool_name,
+                work_pool_queue_names=[wq.name async for wq in self.get_work_queues()],
                 scheduled_before=before,
             )
             submittable_runs.extend([response.flow_run for response in responses])
 
-        # load runs from each work queue
-        async for work_queue in self.get_work_queues():
+        else:
+            # load runs from each work queue
+            async for work_queue in self.get_work_queues():
 
-            # print a nice message if the work queue is paused
-            if work_queue.is_paused:
-                self.logger.info(
-                    f"Work queue {work_queue.name!r} ({work_queue.id}) is paused."
-                )
-
-            else:
-                try:
-                    if isinstance(work_queue, WorkPoolQueue):
-                        responses = await self.client.get_scheduled_flow_runs_for_work_pool_queues(
-                            work_pool_name=self.work_pool_name,
-                            work_pool_queue_names=[work_queue.name],
-                            scheduled_before=before,
-                        )
-                        queue_runs = [response.flow_run for response in responses]
-                    else:
-                        queue_runs = await self.client.get_runs_in_work_queue(
-                            id=work_queue.id, limit=10, scheduled_before=before
-                        )
-                    submittable_runs.extend(queue_runs)
-                except ObjectNotFound:
-                    self.logger.error(
-                        f"Work queue {work_queue.name!r} ({work_queue.id}) not found."
+                # print a nice message if the work queue is paused
+                if work_queue.is_paused:
+                    self.logger.info(
+                        f"Work queue {work_queue.name!r} ({work_queue.id}) is paused."
                     )
-                except Exception as exc:
-                    self.logger.exception(exc)
+
+                else:
+                    try:
+                        if isinstance(work_queue, WorkPoolQueue):
+                            responses = await self.client.get_scheduled_flow_runs_for_work_pool_queues(
+                                work_pool_name=self.work_pool_name,
+                                work_pool_queue_names=[work_queue.name],
+                                scheduled_before=before,
+                            )
+                            queue_runs = [response.flow_run for response in responses]
+                        else:
+                            queue_runs = await self.client.get_runs_in_work_queue(
+                                id=work_queue.id, limit=10, scheduled_before=before
+                            )
+                        submittable_runs.extend(queue_runs)
+                    except ObjectNotFound:
+                        self.logger.error(
+                            f"Work queue {work_queue.name!r} ({work_queue.id}) not found."
+                        )
+                    except Exception as exc:
+                        self.logger.exception(exc)
 
         submittable_runs.sort(key=lambda run: run.next_scheduled_start_time)
 

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -60,6 +60,12 @@ async def start(
             "for example `dev-` will match all work queues with a name that starts with `dev-`"
         ),
     ),
+    work_pool_name: str = typer.Option(
+        None,
+        "-p",
+        "--pool",
+        help="A work pool name for the agent to pull from.",
+    ),
     hide_welcome: bool = typer.Option(False, "--hide-welcome"),
     api: str = SettingsOption(PREFECT_API_URL),
     run_once: bool = typer.Option(
@@ -145,6 +151,7 @@ async def start(
     async with OrionAgent(
         work_queues=work_queues,
         work_queue_prefix=work_queue_prefix,
+        work_pool_name=work_pool_name,
         prefetch_seconds=prefetch_seconds,
         limit=limit,
     ) as agent:

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -161,7 +161,12 @@ async def start(
     ) as agent:
         if not hide_welcome:
             app.console.print(ascii_name)
-            if work_queue_prefix:
+            if work_pool_name:
+                app.console.print(
+                    "Agent started! Looking for work from "
+                    f"work pool '{work_pool_name}'..."
+                )
+            elif work_queue_prefix:
                 app.console.print(
                     "Agent started! Looking for work from "
                     f"queue(s) that start with the prefix: {work_queue_prefix}..."

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -107,12 +107,16 @@ async def start(
             style="blue",
         )
 
-    if not work_queues and not tags and not work_queue_prefix:
+    if not work_queues and not tags and not work_queue_prefix and not work_pool_name:
         exit_with_error("No work queues provided!", style="red")
     elif bool(work_queues) + bool(tags) + bool(work_queue_prefix) > 1:
         exit_with_error(
             "Only one of `work_queues`, `match`, or `tags` can be provided.",
             style="red",
+        )
+    if work_pool_name and tags:
+        exit_with_error(
+            "`tag` and `pool` options cannot be used together.", style="red"
         )
 
     if tags:

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -610,6 +610,15 @@ async def apply(
             app.console.print(
                 f"$ prefect agent start -q {deployment.work_queue_name!r}", style="blue"
             )
+        elif deployment.work_pool_name is not None:
+            app.console.print(
+                "\nTo execute flow runs from this deployment, start an agent "
+                f"that pulls work from the {deployment.work_pool_name!r} work pool:"
+            )
+            app.console.print(
+                f"$ prefect agent start --pool {deployment.work_pool_name!r}",
+                style="blue",
+            )
         else:
             app.console.print(
                 "\nThis deployment does not specify a work queue name, which means agents "

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2189,7 +2189,7 @@ class OrionClient:
         """
         body: Dict[str, Any] = {}
         if work_pool_queue_names is not None:
-            body["work_pool_queue_names"] = work_pool_queue_names
+            body["work_pool_queue_names"] = list(work_pool_queue_names)
         if scheduled_before:
             body["scheduled_before"] = str(scheduled_before)
 

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2104,7 +2104,7 @@ class OrionClient:
         self, work_pool_name: str, work_pool_queue_name: str
     ) -> schemas.core.WorkPoolQueue:
         """
-        Retrieves queues for a work pool.
+        Retrieves a given queue for a work pool.
 
         Args:
             work_pool_name: Name of the work pool the queue belong to.

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2113,11 +2113,16 @@ class OrionClient:
         Returns:
             The specified work pool queue.
         """
-        response = await self._client.get(
-            f"/experimental/work_pools/{work_pool_name}/queues/{work_pool_queue_name}"
-        )
-
-        return pydantic.parse_obj_as(WorkPoolQueue, response.json())
+        try:
+            response = await self._client.get(
+                f"/experimental/work_pools/{work_pool_name}/queues/{work_pool_queue_name}"
+            )
+            return pydantic.parse_obj_as(WorkPoolQueue, response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
 
     async def create_work_pool_queue(
         self,

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2078,6 +2078,25 @@ class OrionClient:
 
         return pydantic.parse_obj_as(List[WorkPoolQueue], response.json())
 
+    async def read_work_pool_queue(
+        self, work_pool_name: str, work_pool_queue_name: str
+    ) -> schemas.core.WorkPoolQueue:
+        """
+        Retrieves queues for a work pool.
+
+        Args:
+            work_pool_name: Name of the work pool the queue belong to.
+            work_pool_queue_name: Name of the work pool queue to get.
+
+        Returns:
+            The specified work pool queue.
+        """
+        response = await self._client.get(
+            f"/experimental/work_pools/{work_pool_name}/queues/{work_pool_queue_name}"
+        )
+
+        return pydantic.parse_obj_as(WorkPoolQueue, response.json())
+
     async def create_work_pool_queue(
         self,
         work_pool_name: str,

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -139,7 +139,7 @@ async def create_work_pool(
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use.",
+            detail="Work pools starting with 'Prefect' are reserved for internal use.",
         )
 
     try:
@@ -150,7 +150,7 @@ async def create_work_pool(
     except sa.exc.IntegrityError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="A worker with this name already exists.",
+            detail="A work pool with this name already exists.",
         )
 
     return model
@@ -163,7 +163,7 @@ async def read_work_pool(
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPool:
     """
-    Read a worker by name
+    Read a work pool by name
     """
 
     async with db.session_context() as session:
@@ -183,7 +183,7 @@ async def read_work_pools(
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.WorkPool]:
     """
-    Read multiple workers
+    Read multiple work pools
     """
     async with db.session_context() as session:
         return await models.workers.read_work_pools(
@@ -213,7 +213,7 @@ async def update_work_pool(
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use "
+            detail="Work pools starting with 'Prefect' are reserved for internal use "
             "and can only be updated to set concurrency limits or pause.",
         )
 
@@ -242,7 +242,7 @@ async def delete_work_pool(
     if work_pool_name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use and can not be deleted.",
+            detail="Work pools starting with 'Prefect' are reserved for internal use and can not be deleted.",
         )
 
     async with db.session_context(begin_transaction=True) as session:
@@ -308,7 +308,7 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 # --
 # --
-# -- Worker Queues
+# -- Work Pool Queues
 # --
 # --
 # -----------------------------------------------------
@@ -342,7 +342,7 @@ async def create_work_pool_queue(
     except sa.exc.IntegrityError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="A worker with this name already exists.",
+            detail="A work pool queue with this name already exists.",
         )
 
     return model

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -373,9 +373,12 @@ async def read_work_pool_queue(
         )
 
 
-@router.get("/{work_pool_name}/queues")
+@router.post("/{work_pool_name}/queues/filter")
 async def read_work_pool_queues(
     work_pool_name: str = Path(..., description="The work pool name"),
+    work_pool_queues: schemas.filters.WorkPoolQueueFilter = None,
+    limit: int = dependencies.LimitBody(),
+    offset: int = Body(0, ge=0),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.WorkPoolQueue]:
@@ -388,7 +391,12 @@ async def read_work_pool_queues(
             work_pool_name=work_pool_name,
         )
         return await models.workers.read_work_pool_queues(
-            session=session, work_pool_id=work_pool_id, db=db
+            session=session,
+            work_pool_id=work_pool_id,
+            work_pool_queue_filter=work_pool_queues,
+            limit=limit,
+            offset=offset,
+            db=db,
         )
 
 

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -342,7 +342,7 @@ async def create_work_pool_queue(
     except sa.exc.IntegrityError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="A work pool queue with this name already exists.",
+            detail="A work queue with this name already exists in work pool {work_pool_name!r}.",
         )
 
     return model

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -144,12 +144,13 @@ class DeploymentCreate(ActionBaseModel):
         and infra_overrides conforms to the specified schema.
         """
         variables_schema = base_job_template.get("variables")
-        schema = {
-            "type": "object",
-            "properties": variables_schema["properties"],
-            "required": variables_schema["required"],
-        }
-        jsonschema.validate(self.infra_overrides, schema)
+        if variables_schema is not None:
+            schema = {
+                "type": "object",
+                "properties": variables_schema["properties"],
+                "required": variables_schema["required"],
+            }
+            jsonschema.validate(self.infra_overrides, schema)
 
 
 @copy_model_fields
@@ -213,18 +214,14 @@ class DeploymentUpdate(ActionBaseModel):
         """Check that the combination of base_job_template defaults
         and infra_overrides conforms to the specified schema.
         """
-
-    def check_valid_configuration(self, base_job_template: dict):
-        """Check that the combination of base_job_template defaults
-        and infra_overrides conforms to the specified schema.
-        """
         variables_schema = base_job_template.get("variables")
-        schema = {
-            "type": "object",
-            "properties": variables_schema["properties"],
-            "required": variables_schema["required"],
-        }
-        jsonschema.validate(self.infra_overrides, schema)
+        if variables_schema is not None:
+            schema = {
+                "type": "object",
+                "properties": variables_schema["properties"],
+                "required": variables_schema["required"],
+            }
+            jsonschema.validate(self.infra_overrides, schema)
 
 
 @copy_model_fields

--- a/src/prefect/orion/schemas/filters.py
+++ b/src/prefect/orion/schemas/filters.py
@@ -1372,11 +1372,29 @@ class WorkPoolQueueFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None, description="A list of work pool queue names to include"
     )
+    startswith_: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "A list of case-insensitive starts-with matches. For example, "
+            " passing 'marvin' will match "
+            "'marvin', and 'Marvin-robot', but not 'sad-marvin'."
+        ),
+        example=["marvin", "Marvin-robot"],
+    )
 
     def _get_filter_list(self, db: "OrionDBInterface") -> List:
         filters = []
         if self.any_ is not None:
             filters.append(db.WorkPoolQueue.name.in_(self.any_))
+        if self.startswith_ is not None:
+            filters.append(
+                sa.or_(
+                    *[
+                        db.WorkPoolQueue.name.ilike(f"{item}%")
+                        for item in self.startswith_
+                    ]
+                )
+            )
         return filters
 
 

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -8,6 +8,7 @@ import pytest
 from prefect import flow
 from prefect.agent import OrionAgent
 from prefect.blocks.core import Block
+from prefect.client.orion import OrionClient
 from prefect.exceptions import Abort, CrashedRun, FailedRun
 from prefect.infrastructure.base import Infrastructure
 from prefect.orion import models, schemas
@@ -886,3 +887,203 @@ async def test_agent_displays_message_on_work_queue_pause(
         await agent.get_and_submit_flow_runs()
 
         assert f"Work queue 'wq' ({work_queue.id}) is paused." in prefect_caplog.text
+
+
+async def test_agent_with_work_pool_queue(
+    orion_client: OrionClient,
+    deployment: schemas.core.Deployment,
+    work_pool: schemas.core.WorkPool,
+    work_pool_queue: schemas.core.WorkPoolQueue,
+    enable_workers,
+):
+    @flow
+    def foo():
+        pass
+
+    create_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment.id, state=state
+        )
+    )
+
+    flow_runs = [
+        await create_run_with_deployment(Pending()),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=20))
+        ),
+        await create_run_with_deployment(Running()),
+        await create_run_with_deployment(Completed()),
+        await orion_client.create_flow_run(foo, state=Scheduled()),
+    ]
+    flow_run_ids = [run.id for run in flow_runs]
+
+    # Pull runs from the work queue to get expected runs
+    work_pool_queue = await orion_client.read_work_pool_queue(
+        work_pool_name=work_pool.name,
+        work_pool_queue_name=work_pool_queue.name,
+    )
+    responses = await orion_client.get_scheduled_flow_runs_for_work_pool_queues(
+        work_pool_name=work_pool.name,
+        work_pool_queue_names=[work_pool_queue.name],
+        scheduled_before=pendulum.now().add(seconds=10),
+    )
+    work_queue_flow_run_ids = {response.flow_run.id for response in responses}
+
+    # Should only include scheduled runs in the past or next prefetch seconds
+    # Should not include runs without deployments
+    assert work_queue_flow_run_ids == set(flow_run_ids[1:4])
+
+    agent = OrionAgent(
+        work_queues=[work_pool_queue.name],
+        work_pool_name=work_pool.name,
+        prefetch_seconds=10,
+    )
+
+    async with agent:
+        agent.submit_run = AsyncMock()  # do not actually run anything
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+
+    submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+    assert submitted_flow_run_ids == work_queue_flow_run_ids
+
+
+async def test_agent_with_work_pool(
+    orion_client: OrionClient,
+    deployment: schemas.core.Deployment,
+    work_pool: schemas.core.WorkPool,
+    work_pool_queue: schemas.core.WorkPoolQueue,
+    enable_workers,
+):
+    @flow
+    def foo():
+        pass
+
+    create_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment.id, state=state
+        )
+    )
+
+    flow_runs = [
+        await create_run_with_deployment(Pending()),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=20))
+        ),
+        await create_run_with_deployment(Running()),
+        await create_run_with_deployment(Completed()),
+        await orion_client.create_flow_run(foo, state=Scheduled()),
+    ]
+    flow_run_ids = [run.id for run in flow_runs]
+
+    # Pull runs from the work queue to get expected runs
+    work_pool_queue = await orion_client.read_work_pool_queue(
+        work_pool_name=work_pool.name,
+        work_pool_queue_name=work_pool_queue.name,
+    )
+    responses = await orion_client.get_scheduled_flow_runs_for_work_pool_queues(
+        work_pool_name=work_pool.name,
+        work_pool_queue_names=[work_pool_queue.name],
+        scheduled_before=pendulum.now().add(seconds=10),
+    )
+    work_queue_flow_run_ids = {response.flow_run.id for response in responses}
+
+    # Should only include scheduled runs in the past or next prefetch seconds
+    # Should not include runs without deployments
+    assert work_queue_flow_run_ids == set(flow_run_ids[1:4])
+
+    agent = OrionAgent(
+        work_pool_name=work_pool.name,
+        prefetch_seconds=10,
+    )
+
+    async with agent:
+        agent.submit_run = AsyncMock()  # do not actually run anything
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+
+    submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+    assert submitted_flow_run_ids == work_queue_flow_run_ids
+
+
+async def test_agent_with_work_pool_and_work_queue_prefix(
+    orion_client: OrionClient,
+    deployment: schemas.core.Deployment,
+    work_pool: schemas.core.WorkPool,
+    work_pool_queue: schemas.core.WorkPoolQueue,
+    enable_workers,
+):
+    @flow
+    def foo():
+        pass
+
+    create_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment.id, state=state
+        )
+    )
+
+    flow_runs = [
+        await create_run_with_deployment(Pending()),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=20))
+        ),
+        await create_run_with_deployment(Running()),
+        await create_run_with_deployment(Completed()),
+        await orion_client.create_flow_run(foo, state=Scheduled()),
+    ]
+    flow_run_ids = [run.id for run in flow_runs]
+
+    # Pull runs from the work queue to get expected runs
+    work_pool_queue = await orion_client.read_work_pool_queue(
+        work_pool_name=work_pool.name,
+        work_pool_queue_name=work_pool_queue.name,
+    )
+    responses = await orion_client.get_scheduled_flow_runs_for_work_pool_queues(
+        work_pool_name=work_pool.name,
+        work_pool_queue_names=[work_pool_queue.name],
+        scheduled_before=pendulum.now().add(seconds=10),
+    )
+    work_queue_flow_run_ids = {response.flow_run.id for response in responses}
+
+    # Should only include scheduled runs in the past or next prefetch seconds
+    # Should not include runs without deployments
+    assert work_queue_flow_run_ids == set(flow_run_ids[1:4])
+
+    agent = OrionAgent(
+        work_pool_name=work_pool.name,
+        work_queue_prefix="test",
+        prefetch_seconds=10,
+    )
+
+    async with agent:
+        agent.submit_run = AsyncMock()  # do not actually run anything
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+
+    submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+    assert submitted_flow_run_ids == work_queue_flow_run_ids

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -69,6 +69,7 @@ def test_start_agent_with_prefetch_seconds(monkeypatch):
     mock_agent.assert_called_once_with(
         work_queues=["test"],
         work_queue_prefix=ANY,
+        work_pool_name=None,
         prefetch_seconds=30,
         limit=None,
     )
@@ -91,6 +92,7 @@ def test_start_agent_with_prefetch_seconds_from_setting_by_default(monkeypatch):
     mock_agent.assert_called_once_with(
         work_queues=ANY,
         work_queue_prefix=ANY,
+        work_pool_name=None,
         prefetch_seconds=100,
         limit=None,
     )
@@ -106,6 +108,7 @@ def test_start_agent_respects_work_queue_names(monkeypatch):
     mock_agent.assert_called_once_with(
         work_queues=["a", "b"],
         work_queue_prefix=[],
+        work_pool_name=None,
         prefetch_seconds=ANY,
         limit=None,
     )
@@ -121,6 +124,7 @@ def test_start_agent_respects_work_queue_prefixes(monkeypatch):
     mock_agent.assert_called_once_with(
         work_queues=[],
         work_queue_prefix=["a", "b"],
+        work_pool_name=None,
         prefetch_seconds=ANY,
         limit=None,
     )
@@ -136,8 +140,25 @@ def test_start_agent_respects_limit(monkeypatch):
     mock_agent.assert_called_once_with(
         work_queues=["test"],
         work_queue_prefix=[],
+        work_pool_name=None,
         prefetch_seconds=ANY,
         limit=10,
+    )
+
+
+def test_start_agent_respects_work_pool_name(monkeypatch):
+    mock_agent = MagicMock()
+    monkeypatch.setattr(prefect.cli.agent, "OrionAgent", mock_agent)
+    invoke_and_assert(
+        command=["agent", "start", "--pool", "test-pool", "--run-once", "-q", "test"],
+        expected_code=0,
+    )
+    mock_agent.assert_called_once_with(
+        work_queues=["test"],
+        work_queue_prefix=[],
+        work_pool_name="test-pool",
+        prefetch_seconds=ANY,
+        limit=None,
     )
 
 

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -174,3 +174,35 @@ def test_start_agent_with_work_queue_match_and_work_queue():
         expected_output_contains="Only one of `work_queues`, `match`, or `tags` can be provided.",
         expected_code=1,
     )
+
+
+def test_start_agent_with_just_work_pool(monkeypatch):
+    mock_agent = MagicMock()
+    monkeypatch.setattr(prefect.cli.agent, "OrionAgent", mock_agent)
+    invoke_and_assert(
+        command=["agent", "start", "--pool", "test-pool", "--run-once"],
+        expected_code=0,
+    )
+    mock_agent.assert_called_once_with(
+        work_queues=[],
+        work_queue_prefix=[],
+        work_pool_name="test-pool",
+        prefetch_seconds=ANY,
+        limit=None,
+    )
+
+
+def test_start_agent_errors_with_work_pool_and_tags():
+    invoke_and_assert(
+        command=[
+            "agent",
+            "start",
+            "--pool",
+            "test-pool",
+            "--run-once",
+            "--tag",
+            "test",
+        ],
+        expected_output_contains="`tag` and `pool` options cannot be used together.",
+        expected_code=1,
+    )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the option to specify a work pool when starting an agent. The normally functionality is left untouched. 

The following functionality is added:
- If a work pool is specified with a queue or a queue prefix, the agent will poll for runs from the matching queues under the specified work pool.
- If only a work pool is provided, the agent will poll for runs from all queues in that work pool.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Start an agent to poll from a specific queues in a work pool:
```bash
prefect agent start --pool test-pool --queue test-queue-1 --queue test-queue-2
```

Start an agent to poll from a queues in a work pool:
```bash
prefect agent start --pool test-pool
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
