### PR TITLE
Tweaks to agents <-> work pools

### DIFF
--- a/orion-ui/src/components/ContextSidebar.vue
+++ b/orion-ui/src/components/ContextSidebar.vue
@@ -3,7 +3,7 @@
     <p-context-nav-item title="Flow Runs" icon="FlowRun" :to="routes.flowRuns()" />
     <p-context-nav-item title="Flows" icon="Flow" :to="routes.flows()" />
     <p-context-nav-item title="Deployments" icon="LocationMarkerIcon" :to="routes.deployments()" />
-    <p-context-nav-item v-if="canSeeWorkers" title="Workers" icon="DatabaseIcon" :to="routes.workPools()" />
+    <p-context-nav-item v-if="canSeeWorkers" title="Work Pools" icon="DatabaseIcon" :to="routes.workPools()" />
     <p-context-nav-item title="Work Queues" icon="DatabaseIcon" :to="routes.workQueues()" />
     <p-context-nav-item title="Blocks" icon="CubeIcon" :to="routes.blocks()" />
     <p-context-nav-item title="Notifications" icon="BellIcon" :to="routes.notifications()" />

--- a/orion-ui/src/pages/WorkPool.vue
+++ b/orion-ui/src/pages/WorkPool.vue
@@ -17,9 +17,6 @@
         <WorkPoolQueuesTable :work-pool-name="workPoolName" />
       </template>
 
-      <template #workers>
-        <WorkersTable :work-pool-filter="workPool.name" />
-      </template>
     </p-tabs>
 
     <template #well>
@@ -29,7 +26,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { useWorkspaceApi, PageHeadingWorkPool, WorkPoolDetails, WorkersTable, useRecentFlowRunFilter, FlowRunFilteredList, WorkPoolQueuesTable } from '@prefecthq/orion-design'
+  import { useWorkspaceApi, PageHeadingWorkPool, WorkPoolDetails, useRecentFlowRunFilter, FlowRunFilteredList, WorkPoolQueuesTable } from '@prefecthq/orion-design'
   import { media } from '@prefecthq/prefect-design'
   import { useRouteParam, useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
@@ -39,7 +36,7 @@
   const workPoolName = useRouteParam('workPoolName')
 
   const tabs = computed(() => {
-    const values = ['Runs', 'Queues', 'Workers']
+    const values = ['Runs', 'Queues']
 
     if (!media.xl) {
       values.unshift('Details')

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -197,7 +197,7 @@ class OrionAgent:
         if self.work_pool_name:
             responses = await self.client.get_scheduled_flow_runs_for_work_pool_queues(
                 work_pool_name=self.work_pool_name,
-                work_pool_queue_names=self.work_queues,
+                work_pool_queue_names=[wq.name async for wq in self.get_work_queues()],
                 scheduled_before=before,
             )
             submittable_runs.extend([response.flow_run for response in responses])

--- a/src/prefect/cli/agent.py
+++ b/src/prefect/cli/agent.py
@@ -161,7 +161,12 @@ async def start(
     ) as agent:
         if not hide_welcome:
             app.console.print(ascii_name)
-            if work_queue_prefix:
+            if work_pool_name:
+                app.console.print(
+                    "Agent started! Looking for work from "
+                    f"work pool '{work_pool_name}'..."
+                )
+            elif work_queue_prefix:
                 app.console.print(
                     "Agent started! Looking for work from "
                     f"queue(s) that start with the prefix: {work_queue_prefix}..."

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -610,6 +610,15 @@ async def apply(
             app.console.print(
                 f"$ prefect agent start -q {deployment.work_queue_name!r}", style="blue"
             )
+        elif deployment.work_pool_name is not None:
+            app.console.print(
+                "\nTo execute flow runs from this deployment, start an agent "
+                f"that pulls work from the {deployment.work_pool_name!r} work pool:"
+            )
+            app.console.print(
+                f"$ prefect agent start --pool {deployment.work_pool_name!r}",
+                style="blue",
+            )
         else:
             app.console.print(
                 "\nThis deployment does not specify a work queue name, which means agents "

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2189,7 +2189,7 @@ class OrionClient:
         """
         body: Dict[str, Any] = {}
         if work_pool_queue_names is not None:
-            body["work_pool_queue_names"] = work_pool_queue_names
+            body["work_pool_queue_names"] = list(work_pool_queue_names)
         if scheduled_before:
             body["scheduled_before"] = str(scheduled_before)
 

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -139,7 +139,7 @@ async def create_work_pool(
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use.",
+            detail="Work pools starting with 'Prefect' are reserved for internal use.",
         )
 
     try:
@@ -150,7 +150,7 @@ async def create_work_pool(
     except sa.exc.IntegrityError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="A worker with this name already exists.",
+            detail="A work pool with this name already exists.",
         )
 
     return model
@@ -163,7 +163,7 @@ async def read_work_pool(
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.WorkPool:
     """
-    Read a worker by name
+    Read a work pool by name
     """
 
     async with db.session_context() as session:
@@ -183,7 +183,7 @@ async def read_work_pools(
     db: OrionDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.WorkPool]:
     """
-    Read multiple workers
+    Read multiple work pools
     """
     async with db.session_context() as session:
         return await models.workers.read_work_pools(
@@ -213,7 +213,7 @@ async def update_work_pool(
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use "
+            detail="Work pools starting with 'Prefect' are reserved for internal use "
             "and can only be updated to set concurrency limits or pause.",
         )
 
@@ -242,7 +242,7 @@ async def delete_work_pool(
     if work_pool_name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Worker pools starting with 'Prefect' are reserved for internal use and can not be deleted.",
+            detail="Work pools starting with 'Prefect' are reserved for internal use and can not be deleted.",
         )
 
     async with db.session_context(begin_transaction=True) as session:
@@ -308,7 +308,7 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 # --
 # --
-# -- Worker Queues
+# -- Work Pool Queues
 # --
 # --
 # -----------------------------------------------------
@@ -342,7 +342,7 @@ async def create_work_pool_queue(
     except sa.exc.IntegrityError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="A worker with this name already exists.",
+            detail="A work pool queue with this name already exists.",
         )
 
     return model

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -144,12 +144,13 @@ class DeploymentCreate(ActionBaseModel):
         and infra_overrides conforms to the specified schema.
         """
         variables_schema = base_job_template.get("variables")
-        schema = {
-            "type": "object",
-            "properties": variables_schema["properties"],
-            "required": variables_schema["required"],
-        }
-        jsonschema.validate(self.infra_overrides, schema)
+        if variables_schema is not None:
+            schema = {
+                "type": "object",
+                "properties": variables_schema["properties"],
+                "required": variables_schema["required"],
+            }
+            jsonschema.validate(self.infra_overrides, schema)
 
 
 @copy_model_fields
@@ -213,18 +214,14 @@ class DeploymentUpdate(ActionBaseModel):
         """Check that the combination of base_job_template defaults
         and infra_overrides conforms to the specified schema.
         """
-
-    def check_valid_configuration(self, base_job_template: dict):
-        """Check that the combination of base_job_template defaults
-        and infra_overrides conforms to the specified schema.
-        """
         variables_schema = base_job_template.get("variables")
-        schema = {
-            "type": "object",
-            "properties": variables_schema["properties"],
-            "required": variables_schema["required"],
-        }
-        jsonschema.validate(self.infra_overrides, schema)
+        if variables_schema is not None:
+            schema = {
+                "type": "object",
+                "properties": variables_schema["properties"],
+                "required": variables_schema["required"],
+            }
+            jsonschema.validate(self.infra_overrides, schema)
 
 
 @copy_model_fields


### PR DESCRIPTION
A few tweaks to:
- hide some warnings
- update some console output
- fix a deployment creation error
- simplify run-gathering logic for work pools
- renames 'Workers' UI sidebar header
- removes Workers tab from Work Pool page