### PR TITLE
Add `project_urls` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     author_email="help@prefect.io",
     url="https://www.prefect.io",
     project_urls={
+        "Changelog": "https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md",
         "Documentation": "https://docs.prefect.io",
         "Source": "https://github.com/PrefectHQ/prefect",
         "Tracker": "https://github.com/PrefectHQ/prefect/issues",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,12 @@ setup(
     description="Workflow orchestration and management.",
     author="Prefect Technologies, Inc.",
     author_email="help@prefect.io",
-    url="https://github.com/PrefectHQ/prefect/",
+    url="https://www.prefect.io",
+    project_urls={
+        "Documentation": "https://docs.prefect.io",
+        "Source": "https://github.com/PrefectHQ/prefect",
+        "Tracker": "https://github.com/PrefectHQ/prefect/issues",
+    },
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     # Versioning


### PR DESCRIPTION
Today we only use `url` parameter. This PR add relevant project links to `setup.py` as well. 

Today:
![image](https://user-images.githubusercontent.com/5853172/213898722-19e3f557-3f5c-48ad-bca1-14fbb4b5322f.png)

After this change:
![image](https://user-images.githubusercontent.com/5853172/213898715-c2c0d29a-8c2a-4a1e-a72e-c8337d88c31a.png)
