### PR TITLE
Support Pydantic BaseModel secrets

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -100,6 +100,37 @@ def _get_non_block_reference_definitions(object_definition: Dict, definitions: D
     return non_block_definitions
 
 
+def _is_subclass(cls, parent_cls) -> bool:
+    """
+    Checks if a given class is a subclass of another class.
+    """
+    return inspect.isclass(cls) and issubclass(cls, parent_cls)
+
+
+def _collect_secret_fields(name: str, type_: Type, secrets: List[str]) -> None:
+    """
+    Collects all secret fields from a given type.
+    Note, this function mutates the input secrets list, thus does not return anything.
+    """
+    if get_origin(type_) is Union:
+        for union_type in get_args(type_):
+            _collect_secret_fields(name, union_type, secrets)
+        return
+    elif _is_subclass(type_, BaseModel):
+        for field in type_.__fields__.values():
+            _collect_secret_fields(f"{name}.{field.name}", field.type_, secrets)
+        return
+
+    if type_ in (SecretStr, SecretBytes):
+        secrets.append(name)
+    elif type_ == SecretDict:
+        # Append .* to field name to signify that all values under this
+        # field are secret and should be obfuscated.
+        secrets.append(f"{name}.*")
+    elif Block.is_block_class(type_):
+        secrets.extend(f"{name}.{s}" for s in type_.schema()["secret_fields"])
+
+
 @register_base_type
 class Block(BaseModel, ABC):
     """
@@ -145,17 +176,7 @@ class Block(BaseModel, ABC):
             # nested under the "child" key are all secret. There is no limit to nesting.
             secrets = schema["secret_fields"] = []
             for field in model.__fields__.values():
-                if field.type_ in [SecretStr, SecretBytes]:
-                    secrets.append(field.name)
-                elif field.type_ == SecretDict:
-                    # Append .* to field name to signify that all values under this
-                    # field are secret and should be obfuscated.
-                    secrets.append(f"{field.name}.*")
-                elif Block.is_block_class(field.type_):
-                    secrets.extend(
-                        f"{field.name}.{s}"
-                        for s in field.type_.schema()["secret_fields"]
-                    )
+                _collect_secret_fields(field.name, field.type_, secrets)
 
             # create block schema references
             refs = schema["block_schema_references"] = {}
@@ -715,7 +736,7 @@ class Block(BaseModel, ABC):
 
     @staticmethod
     def is_block_class(block) -> bool:
-        return inspect.isclass(block) and issubclass(block, Block)
+        return _is_subclass(block, Block)
 
     @classmethod
     @sync_compatible

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -171,6 +171,145 @@ class TestAPICompatibility:
             "type": "object",
         }
 
+    def test_create_api_block_with_nested_secret_fields_in_base_model_reflected_in_schema(
+        self,
+    ):
+        class Child(BaseModel):
+            a: SecretStr
+            b: str
+            c: SecretDict
+
+        class Parent(Block):
+            a: SecretStr
+            b: str
+            child: Child
+
+        assert Parent.schema()["secret_fields"] == ["a", "child.a", "child.c.*"]
+        schema = Parent._to_block_schema(block_type_id=uuid4())
+        assert schema.fields["secret_fields"] == ["a", "child.a", "child.c.*"]
+        assert schema.fields == {
+            "title": "Parent",
+            "type": "object",
+            "properties": {
+                "a": {
+                    "title": "A",
+                    "type": "string",
+                    "writeOnly": True,
+                    "format": "password",
+                },
+                "b": {"title": "B", "type": "string"},
+                "child": {"$ref": "#/definitions/Child"},
+            },
+            "required": ["a", "b", "child"],
+            "block_type_slug": "parent",
+            "secret_fields": ["a", "child.a", "child.c.*"],
+            "block_schema_references": {},
+            "definitions": {
+                "Child": {
+                    "title": "Child",
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "title": "A",
+                            "type": "string",
+                            "writeOnly": True,
+                            "format": "password",
+                        },
+                        "b": {"title": "B", "type": "string"},
+                        "c": {"title": "C", "type": "object"},
+                    },
+                    "required": ["a", "b", "c"],
+                }
+            },
+        }
+
+    def test_create_api_block_with_deeply_nested_secret_fields_in_base_model_reflected_in_schema(
+        self,
+    ):
+        class SubChild(BaseModel):
+            a: str
+            b: SecretDict
+            c: SecretBytes
+
+        class Child(BaseModel):
+            a: SecretStr
+            b: str
+            sub_child: SubChild
+
+        class Parent(Block):
+            a: SecretStr
+            b: str
+            child: Child
+
+        assert Parent.schema()["secret_fields"] == [
+            "a",
+            "child.a",
+            "child.sub_child.b.*",
+            "child.sub_child.c",
+        ]
+        schema = Parent._to_block_schema(block_type_id=uuid4())
+        assert schema.fields["secret_fields"] == [
+            "a",
+            "child.a",
+            "child.sub_child.b.*",
+            "child.sub_child.c",
+        ]
+        assert schema.fields == {
+            "title": "Parent",
+            "type": "object",
+            "properties": {
+                "a": {
+                    "title": "A",
+                    "type": "string",
+                    "writeOnly": True,
+                    "format": "password",
+                },
+                "b": {"title": "B", "type": "string"},
+                "child": {"$ref": "#/definitions/Child"},
+            },
+            "required": ["a", "b", "child"],
+            "block_type_slug": "parent",
+            "secret_fields": [
+                "a",
+                "child.a",
+                "child.sub_child.b.*",
+                "child.sub_child.c",
+            ],
+            "block_schema_references": {},
+            "definitions": {
+                "SubChild": {
+                    "title": "SubChild",
+                    "type": "object",
+                    "properties": {
+                        "a": {"title": "A", "type": "string"},
+                        "b": {"title": "B", "type": "object"},
+                        "c": {
+                            "title": "C",
+                            "type": "string",
+                            "writeOnly": True,
+                            "format": "password",
+                        },
+                    },
+                    "required": ["a", "b", "c"],
+                },
+                "Child": {
+                    "title": "Child",
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "title": "A",
+                            "type": "string",
+                            "writeOnly": True,
+                            "format": "password",
+                        },
+                        "b": {"title": "B", "type": "string"},
+                        "sub_child": {"$ref": "#/definitions/SubChild"},
+                    },
+                    "required": ["a", "b", "sub_child"],
+                },
+            },
+        }
+
     def test_create_api_block_with_secret_values_are_obfuscated_by_default(self):
         class SecretBlock(Block):
             w: SecretDict


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Previously, secret fields in `pydantic.BaseModel` did not have explicit support, i.e. they were not added to the secret_fields under the block schema, which resulted in the UI showing them in plain text.

This PR recursively adds secret typed fields to `secrets = schema["secret_fields"] = []`

First step in fixing https://github.com/PrefectHQ/prefect-sqlalchemy/issues/42

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
