### PR TITLE
Update deployment block foreign keys to set null on delete instead of cascade

### DIFF
--- a/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/orion/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# SET NULL deployment block relationship on delete instead of CASCADE
+SQLite: `55d6a0b2f12f`
+Postgres: `12caf319f245`
+
 # Add infrastructure_pid to flow runs
 SQLite: `7201de756d85`
 Postgres: `5d526270ddb4`

--- a/src/prefect/orion/database/migrations/versions/postgresql/2023_01_25_142939_12caf319f245_set_null_deployment_block_relationship_.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2023_01_25_142939_12caf319f245_set_null_deployment_block_relationship_.py
@@ -1,0 +1,72 @@
+"""SET NULL deployment block relationship on delete instead of CASCADE
+
+Revision ID: 12caf319f245
+Revises: d481d5058a19
+Create Date: 2023-01-25 14:29:39.128803
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "12caf319f245"
+down_revision = "d481d5058a19"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk_deployment__storage_document_id__block_document",
+        "deployment",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_deployment__infrastructure_document_id__block_document",
+        "deployment",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk_deployment__infrastructure_document_id__block_document"),
+        "deployment",
+        "block_document",
+        ["infrastructure_document_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        op.f("fk_deployment__storage_document_id__block_document"),
+        "deployment",
+        "block_document",
+        ["storage_document_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_deployment__storage_document_id__block_document"),
+        "deployment",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_deployment__infrastructure_document_id__block_document"),
+        "deployment",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_deployment__infrastructure_document_id__block_document",
+        "deployment",
+        "block_document",
+        ["infrastructure_document_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_deployment__storage_document_id__block_document",
+        "deployment",
+        "block_document",
+        ["storage_document_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/src/prefect/orion/database/migrations/versions/sqlite/2023_01_25_142649_55d6a0b2f12f_set_null_deployment_block_relationship_.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2023_01_25_142649_55d6a0b2f12f_set_null_deployment_block_relationship_.py
@@ -1,0 +1,74 @@
+"""SET NULL deployment block relationship on delete instead of CASCADE
+
+Revision ID: 55d6a0b2f12f
+Revises: bb38729c471a
+Create Date: 2023-01-25 14:26:49.264075
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "55d6a0b2f12f"
+down_revision = "bb38729c471a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_deployment__storage_document_id__block_document", type_="foreignkey"
+        )
+        batch_op.drop_constraint(
+            "fk_deployment__infrastructure_document_id__block_document",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__infrastructure_document_id__block_document"),
+            "block_document",
+            ["infrastructure_document_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_deployment__storage_document_id__block_document"),
+            "block_document",
+            ["storage_document_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")
+
+
+def downgrade():
+
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_deployment__storage_document_id__block_document"),
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            batch_op.f("fk_deployment__infrastructure_document_id__block_document"),
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_deployment__infrastructure_document_id__block_document",
+            "block_document",
+            ["infrastructure_document_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "fk_deployment__storage_document_id__block_document",
+            "block_document",
+            ["storage_document_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")

--- a/src/prefect/orion/database/orm_models.py
+++ b/src/prefect/orion/database/orm_models.py
@@ -747,7 +747,7 @@ class ORMDeployment:
     def infrastructure_document_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("block_document.id", ondelete="CASCADE"),
+            sa.ForeignKey("block_document.id", ondelete="SET NULL"),
             nullable=True,
             index=False,
         )
@@ -756,7 +756,7 @@ class ORMDeployment:
     def storage_document_id(cls):
         return sa.Column(
             UUID,
-            sa.ForeignKey("block_document.id", ondelete="CASCADE"),
+            sa.ForeignKey("block_document.id", ondelete="SET NULL"),
             nullable=True,
             index=False,
         )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

First step to address https://github.com/PrefectHQ/nebula/issues/3145

Deletion of a storage or infrastructure block cascades to the deployment which can be a costly delete. The deployment may not be usable without the storage or infrastructure block, but both fields are nullable and we should probably just set it to null when the block is deleted. The user can replace the block with another to repair the deployment. UX improvements may be needed to guard against common deployment behaviors when the blocks are not attached (i.e. scheduled runs without a storage block will all fail).