### PR TITLE
Add a hint to the Kubernetes block description for imageref

### DIFF
--- a/src/prefect/infrastructure/kubernetes.py
+++ b/src/prefect/infrastructure/kubernetes.py
@@ -55,7 +55,9 @@ class KubernetesJob(Infrastructure):
             start the flow run. In most cases you should not override this.
         customizations: A list of JSON 6902 patches to apply to the base Job manifest.
         env: Environment variables to set for the container.
-        image: An optional string specifying the tag of a Docker image to use for the job.
+        image: An optional string specifying the image reference of a container image
+            to use for the job, for example, docker.io/prefecthq/prefect:2-latest. The
+            behavior is as described in https://kubernetes.io/docs/concepts/containers/images/#image-names.
             Defaults to the Prefect image.
         image_pull_policy: The Kubernetes image pull policy to use for job containers.
         job: The base manifest for the Kubernetes Job.
@@ -82,8 +84,8 @@ class KubernetesJob(Infrastructure):
     image: Optional[str] = Field(
         default=None,
         description=(
-            "The tag of a Docker image to use for the job. Defaults to the Prefect "
-            "image unless an image is already present in a provided job manifest."
+            "The image reference of a container image to use for the job, for example, `docker.io/prefecthq/prefect:2-latest`."
+            "The behavior is as described in the Kubernetes documentation and uses the latest version of Prefect by default, unless an image is already present in a provided job manifest."
         ),
     )
     namespace: Optional[str] = Field(


### PR DESCRIPTION
The OCI spec calls refers to the fully-qualified image path (optional registry, tags, digest, etc) as an "image reference", so we can do the same here.

---

References:

* https://kubernetes.io/docs/concepts/containers/images/#image-names
* https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

In doing research for this, it seems that the name "image reference" isn't very well-defined. I think the example should help illustrate what users should put here, and in particular that they may need to include a tag, if they're not using `latest`

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
