### PR TITLE
Use standard warning handling for SQLAlchemy 2.0

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -190,9 +190,6 @@ jobs:
           echo "PREFECT_ORION_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/orion" >> $GITHUB_ENV
 
       - name: Run tests
-        # Turns off SQLAlchemy 2.0 deprecation warnings. We can remove this once we upgrade to 2.0 
-        env: 
-          SQLALCHEMY_SILENCE_UBER_WARNING: 1 
         run: |
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ markers =
 env =
     # NOTE: Additional Prefect setting values are set dynamically in conftest.py
     PREFECT_TEST_MODE = 1
-    SQLALCHEMY_SILENCE_UBER_WARNING = 1
 
 asyncio_mode = auto
 timeout = 60
@@ -55,6 +54,8 @@ filterwarnings =
     # apprise<=1.1.0 has not been updated to use the new locale functions in Python 3.11
     ignore:Use setlocale:DeprecationWarning
     ignore:Skipped unsupported reflection of expression-based index:sqlalchemy.exc.SAWarning
+    # SQLAlchemy 2.0 warnings
+    ignore::sqlalchemy.exc.RemovedIn20Warning
 
 [isort]
 skip = __init__.py


### PR DESCRIPTION
The environment variable in `setup.cfg` does not appear to work although it is present in pytest's environment — perhaps it needs to be set when SQLAlchemy is loaded. We can use typical warning ignore patterns instead of their variable.