### PR TITLE
Fixes server compatibility for deployments API

### DIFF
--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -11,6 +11,7 @@ import jsonschema
 from pydantic import Field, root_validator, validator
 
 import prefect.orion.schemas as schemas
+from prefect._internal.compatibility.experimental import experimental_field
 from prefect.orion.utilities.schemas import (
     DateTimeTZ,
     FieldFrom,
@@ -76,6 +77,11 @@ class FlowUpdate(ActionBaseModel):
     tags: List[str] = FieldFrom(schemas.core.Flow)
 
 
+@experimental_field(
+    "work_pool_name",
+    group="work_pools",
+    when=lambda x: x is not None,
+)
 @copy_model_fields
 class DeploymentCreate(ActionBaseModel):
     """Data used by the Orion API to create a deployment."""
@@ -90,6 +96,7 @@ class DeploymentCreate(ActionBaseModel):
         worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
         worker_pool_name = values_copy.pop("worker_pool_name", None)
         worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
+        work_pool_queue_name = values_copy.pop("work_pool_queue_name", None)
         if worker_pool_queue_id:
             warnings.warn(
                 "`worker_pool_queue_id` is no longer supported for creating "
@@ -97,9 +104,10 @@ class DeploymentCreate(ActionBaseModel):
                 "`work_queue_name` instead.",
                 UserWarning,
             )
-        if worker_pool_name or worker_pool_queue_name:
+        if worker_pool_name or worker_pool_queue_name or work_pool_queue_name:
             warnings.warn(
-                "`worker_pool_name` and `worker_pool_queue_name` are "
+                "`worker_pool_name`, `worker_pool_queue_name`, and "
+                "`work_pool_name` are"
                 "no longer supported for creating "
                 "deployments. Please use `work_pool_name` and "
                 "`work_queue_name` instead.",
@@ -148,6 +156,11 @@ class DeploymentCreate(ActionBaseModel):
             jsonschema.validate(self.infra_overrides, schema)
 
 
+@experimental_field(
+    "work_pool_name",
+    group="work_pools",
+    when=lambda x: x is not None,
+)
 @copy_model_fields
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Orion API to update a deployment."""
@@ -162,6 +175,7 @@ class DeploymentUpdate(ActionBaseModel):
         worker_pool_queue_id = values_copy.pop("worker_pool_queue_id", None)
         worker_pool_name = values_copy.pop("worker_pool_name", None)
         worker_pool_queue_name = values_copy.pop("worker_pool_queue_name", None)
+        work_pool_queue_name = values_copy.pop("work_pool_queue_name", None)
         if worker_pool_queue_id:
             warnings.warn(
                 "`worker_pool_queue_id` is no longer supported for updating "
@@ -169,10 +183,11 @@ class DeploymentUpdate(ActionBaseModel):
                 "`work_queue_name` instead.",
                 UserWarning,
             )
-        if worker_pool_name or worker_pool_queue_name:
+        if worker_pool_name or worker_pool_queue_name or work_pool_queue_name:
             warnings.warn(
-                "`worker_pool_name` and `worker_pool_queue_name` are "
-                "no longer supported for updating "
+                "`worker_pool_name`, `worker_pool_queue_name`, and "
+                "`work_pool_name` are"
+                "no longer supported for creating "
                 "deployments. Please use `work_pool_name` and "
                 "`work_queue_name` instead.",
                 UserWarning,

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -498,6 +498,7 @@ class TestCreateDeployment:
         infrastructure_document_id,
         template,
         overrides,
+        enable_work_pools,
     ):
         work_pool = await models.workers.create_work_pool(
             session=session,
@@ -588,6 +589,7 @@ class TestCreateDeployment:
         infrastructure_document_id,
         template,
         overrides,
+        enable_work_pools,
     ):
         work_pool = await models.workers.create_work_pool(
             session=session,
@@ -664,6 +666,7 @@ class TestCreateDeployment:
         session,
         infrastructure_document_id,
         work_pool,
+        enable_work_pools,
     ):
         data = DeploymentCreate(
             name="My Deployment",

--- a/tests/orion/models/test_deployments.py
+++ b/tests/orion/models/test_deployments.py
@@ -976,7 +976,7 @@ class TestUpdateDeployment:
         assert wq is not None
 
     async def test_update_work_pool_deployment(
-        self, session, deployment, work_pool, work_pool_queue
+        self, session, deployment, work_pool, work_pool_queue, enable_work_pools
     ):
         await models.deployments.update_deployment(
             session=session,

--- a/tests/orion/schemas/test_actions.py
+++ b/tests/orion/schemas/test_actions.py
@@ -49,21 +49,29 @@ class TestDeploymentCreate:
 
         assert getattr(deployment_create, "worker_pool_queue_id", 0) == 0
 
-    def test_create_with_worker_pool_name_warns(self):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            ({"worker_pool_queue_name": "test-worker-pool-queue"}),
+            ({"work_pool_queue_name": "test-work-pool-queue"}),
+            ({"worker_pool_name": "test-worker-pool"}),
+        ],
+    )
+    def test_create_with_worker_pool_name_warns(self, kwargs):
         with pytest.warns(
             UserWarning,
-            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            match="`worker_pool_name`, `worker_pool_queue_name`, and "
+            "`work_pool_name` are"
             "no longer supported for creating "
             "deployments. Please use `work_pool_name` and "
             "`work_queue_name` instead.",
         ):
             deployment_create = DeploymentCreate(
-                **dict(
-                    name="test-deployment", worker_pool_queue_name="test-worker-pool"
-                )
+                **dict(name="test-deployment", **kwargs)
             )
 
-        assert getattr(deployment_create, "worker_pool_name", 0) == 0
+        for key in kwargs.keys():
+            assert getattr(deployment_create, key, 0) == 0
 
 
 class TestDeploymentUpdate:
@@ -78,16 +86,24 @@ class TestDeploymentUpdate:
 
         assert getattr(deployment_update, "worker_pool_queue_id", 0) == 0
 
-    def test_update_with_worker_pool_name_warns(self):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            ({"worker_pool_queue_name": "test-worker-pool-queue"}),
+            ({"work_pool_queue_name": "test-work-pool-queue"}),
+            ({"worker_pool_name": "test-worker-pool"}),
+        ],
+    )
+    def test_update_with_worker_pool_name_warns(self, kwargs):
         with pytest.warns(
             UserWarning,
-            match="`worker_pool_name` and `worker_pool_queue_name` are "
+            match="`worker_pool_name`, `worker_pool_queue_name`, and "
+            "`work_pool_name` are"
             "no longer supported for creating "
             "deployments. Please use `work_pool_name` and "
             "`work_queue_name` instead.",
         ):
-            deployment_update = DeploymentCreate(
-                **dict(worker_pool_queue_name="test-worker-pool")
-            )
+            deployment_update = DeploymentCreate(**kwargs)
 
-        assert getattr(deployment_update, "worker_pool_name", 0) == 0
+        for key in kwargs.keys():
+            assert getattr(deployment_update, key, 0) == 0


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
`work_pool_queue_name` name was removed in lieu of `work_queue_name` which caused issues with 2.7.8 clients that don't have logic to filter out unset fields. This PR add compatibility with 2.7.8 client by filtering out `work_pool_queue_name` if it is included in a deployments API request.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
