### PR TITLE
Adds ability to exclude experimental fields in API calls

### DIFF
--- a/src/prefect/_internal/compatibility/experimental.py
+++ b/src/prefect/_internal/compatibility/experimental.py
@@ -229,6 +229,9 @@ def experimental_field(
             # Perform warning check
             if name in data.keys() and when(data[name]):
                 experimental_check()
+            field = __pydantic_self__.__fields__.get(name)
+            if field is not None and not _opt_in_setting_for_group(group):
+                field.field_info.extra["experimental"] = True
 
         # Patch the model's init method
         model_cls.__init__ = __init__

--- a/src/prefect/_internal/compatibility/experimental.py
+++ b/src/prefect/_internal/compatibility/experimental.py
@@ -230,8 +230,9 @@ def experimental_field(
             if name in data.keys() and when(data[name]):
                 experimental_check()
             field = __pydantic_self__.__fields__.get(name)
-            if field is not None and not _opt_in_setting_for_group(group):
+            if field is not None:
                 field.field_info.extra["experimental"] = True
+                field.field_info.extra["experimental-group"] = group
 
         # Patch the model's init method
         model_cls.__init__ = __init__

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -266,6 +266,14 @@ class PrefectBaseModel(BaseModel):
             dict
         """
 
+        experimental_fields = [
+            name
+            for name, field in self.__fields__.items()
+            if field.field_info.extra.get("experimental")
+        ]
+
+        kwargs["exclude"] = kwargs.get("exclude", set()).union(experimental_fields)
+
         if json_compatible and shallow:
             raise ValueError(
                 "`json_compatible` can only be applied to the entire object."

--- a/src/prefect/orion/utilities/schemas.py
+++ b/src/prefect/orion/utilities/schemas.py
@@ -279,9 +279,10 @@ class PrefectBaseModel(BaseModel):
             if not experiment_enabled(field.field_info.extra["experimental-group"])
         ]
 
-        kwargs["exclude"] = kwargs.get("exclude", set()).union(
-            experimental_fields_to_exclude
-        )
+        if experimental_fields_to_exclude:
+            kwargs["exclude"] = (kwargs.get("exclude") or set()).union(
+                experimental_fields_to_exclude
+            )
 
         if json_compatible and shallow:
             raise ValueError(

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -12,6 +12,7 @@ from prefect._internal.compatibility.experimental import (
     experimental_field,
     experimental_parameter,
 )
+from prefect.orion.utilities.schemas import PrefectBaseModel
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_WARN,
     SETTING_VARIABLES,
@@ -245,6 +246,32 @@ def test_experimental_field_warning_no_warning_when_not_provided():
         value: int = 1
 
     assert Foo().value == 1
+
+
+def test_experimental_fields_excluded_from_dict_by_default():
+    @experimental_field(
+        "value",
+        group="test",
+        help="This is just a test, don't worry.",
+    )
+    class Foo(PrefectBaseModel):
+        value: int = 1
+
+    assert Foo().dict() == {}
+
+
+def test_experimental_fields_included_in_dict_when_opted_in(
+    enable_prefect_experimental_test_opt_in_setting,
+):
+    @experimental_field(
+        "value",
+        group="test",
+        help="This is just a test, don't worry.",
+    )
+    class Foo(PrefectBaseModel):
+        value: int = 1
+
+    assert Foo().dict() == {"value": 1}
 
 
 def test_experimental_field_warning_when():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Marks fields as experimental if `experimental_field` decorator is used and also adds the corresponding `group_name`. Those fields are then excluded from dictionaries generated from a `PrefectBaseModel` to avoid sending experimental fields to the API unless specifically enabled.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
