### PR TITLE
add display_name field to graphs endpoint

### DIFF
--- a/src/prefect/orion/models/flow_runs.py
+++ b/src/prefect/orion/models/flow_runs.py
@@ -305,6 +305,7 @@ async def read_flow_runs(
 class DependencyResult(PrefectBaseModel):
     id: UUID
     name: str
+    display_name: str
     upstream_dependencies: List[TaskRunResult]
     state: State
     expected_start_time: Optional[datetime.datetime]
@@ -351,6 +352,7 @@ async def read_task_run_dependencies(
                 "state": task_run.state,
                 "expected_start_time": task_run.expected_start_time,
                 "name": task_run.name,
+                "display_name": task_run.task_key.rpartition(".")[-1],
                 "start_time": task_run.start_time,
                 "end_time": task_run.end_time,
                 "total_run_time": task_run.total_run_time,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Resolves PrefectHQ/graphs/issues/55

This PR adds a `display_name` field to the graphs endpoint, so that on the Flow Run Timeline, we can show the task name in a more human readable way, without the unique id's that make the name super long:

<img width="747" alt="image" src="https://user-images.githubusercontent.com/6776415/215131415-36551395-143b-4361-b076-ab4038888be4.png">
See `display_name` compared to `name`.

This was achieved by grabbing the end of the `task_key`, which consistently uses the original task name (either the default, or user specified one) at the end, according to a scanning of the latest 1000 records in staging.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
