### PR TITLE
Add `check_if_running` utility to exit runs that should not be running

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -30,7 +30,7 @@ from prefect.context import tags
 from prefect.manifests import Manifest
 from prefect.utilities.annotations import unmapped, allow_failure
 from prefect.results import BaseResult
-from prefect.engine import pause_flow_run, resume_flow_run, checkpoint
+from prefect.engine import pause_flow_run, resume_flow_run, check_if_running
 from prefect.client.orchestration import get_client, PrefectClient
 from prefect.client.cloud import get_cloud_client, CloudClient
 import prefect.variables
@@ -133,7 +133,7 @@ if not hasattr(sys, "frozen"):
 # Declare API for type-checkers
 __all__ = [
     "allow_failure",
-    "checkpoint",
+    "check_if_running",
     "flow",
     "Flow",
     "get_client",

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -30,7 +30,7 @@ from prefect.context import tags
 from prefect.manifests import Manifest
 from prefect.utilities.annotations import unmapped, allow_failure
 from prefect.results import BaseResult
-from prefect.engine import pause_flow_run, resume_flow_run
+from prefect.engine import pause_flow_run, resume_flow_run, checkpoint
 from prefect.client.orchestration import get_client, PrefectClient
 from prefect.client.cloud import get_cloud_client, CloudClient
 import prefect.variables
@@ -133,6 +133,7 @@ if not hasattr(sys, "frozen"):
 # Declare API for type-checkers
 __all__ = [
     "allow_failure",
+    "checkpoint",
     "flow",
     "Flow",
     "get_client",

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2191,7 +2191,7 @@ async def check_api_reachable(client: PrefectClient, fail_message: str):
 
 
 @sync_compatible
-async def checkpoint(raise_on_failure: bool = True) -> Optional[State]:
+async def check_if_running(raise_on_failure: bool = True) -> Optional[State]:
     """
     Check the state of the current flow or task run according to the API. If the state
     is not running, raise an exception. Otherwise, return the state.

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2227,7 +2227,9 @@ async def check_if_running(raise_on_failure: bool = True) -> Optional[State]:
             return None
 
     if flow_run_id:  # Check the state of the flow run first
-        flow_run = await flow_run_context.client.read_flow_run(flow_run_id)
+        flow_run = await from_async.call_soon_in_loop_thread(
+            create_call(flow_run_context.client.read_flow_run, flow_run_id)
+        ).aresult()
 
         if not flow_run.state.is_running():
             if raise_on_failure:
@@ -2239,7 +2241,9 @@ async def check_if_running(raise_on_failure: bool = True) -> Optional[State]:
                 )
 
     if task_run_id:
-        task_run = await task_run_context.client.read_task_run(task_run_id)
+        task_run = await from_async.call_soon_in_loop_thread(
+            create_call(task_run_context.client.read_task_run, task_run_id)
+        ).aresult()
 
         if not task_run.state.is_running():
             if raise_on_failure:

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2214,7 +2214,9 @@ async def check_if_running(raise_on_failure: bool = True) -> Optional[State]:
 
     if not flow_run_context and not task_run_context:
         if raise_on_failure:
-            raise RuntimeError("checkpoint must be called from within a flow or task.")
+            raise RuntimeError(
+                "`check_if_running` must be called from within a flow or task."
+            )
         else:
             return None
 

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -168,7 +168,7 @@ class State(StateBaseModel, Generic[R]):
         return self.type == StateType.CRASHED
 
     def is_cancelled(self) -> bool:
-        return self.type == StateType.CANCELLED
+        return self.type == StateType.CANCELLED or self.type == StateType.CANCELLING
 
     def is_final(self) -> bool:
         return self.type in TERMINAL_STATES

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -319,7 +319,7 @@ async def get_state_exception(state: State) -> BaseException:
     elif state.is_crashed():
         wrapper = CrashedRun
         default_message = "Run crashed."
-    elif state.is_cancelled() or state.is_cancelled():
+    elif state.is_cancelled():
         wrapper = CancelledRun
         default_message = "Run cancelled."
     else:
@@ -368,7 +368,7 @@ async def get_state_exception(state: State) -> BaseException:
 @sync_compatible
 async def raise_state_exception(state: State) -> None:
     """
-    Given a FAILED or CRASHED state, raise the contained exception.
+    Given a FAILED / CRASHED / CANCELLED state, raise the contained exception.
     """
     if not (state.is_failed() or state.is_crashed() or state.is_cancelled()):
         return None

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -310,7 +310,7 @@ async def get_state_exception(state: State) -> BaseException:
     When a wrapper exception is returned, the type will be:
         - `FailedRun` if the state type is FAILED.
         - `CrashedRun` if the state type is CRASHED.
-        - `CancelledRun` if the state type is CANCELLED.
+        - `CancelledRun` if the state type is CANCELLED or CANCELLING.
     """
 
     if state.is_failed():
@@ -319,7 +319,7 @@ async def get_state_exception(state: State) -> BaseException:
     elif state.is_crashed():
         wrapper = CrashedRun
         default_message = "Run crashed."
-    elif state.is_cancelled():
+    elif state.is_cancelled() or state.is_cancelled():
         wrapper = CancelledRun
         default_message = "Run cancelled."
     else:

--- a/tests/test_check_if_running.py
+++ b/tests/test_check_if_running.py
@@ -1,0 +1,193 @@
+import prefect
+import pytest
+
+from prefect.utilities.annotations import quote
+import prefect.states
+import prefect.context
+import prefect.runtime
+from prefect.exceptions import FailedRun, CancelledRun
+from prefect.states import StateType
+
+
+def test_check_if_running_does_not_raise_in_normal_operation_sync():
+    @prefect.task
+    def check_task():
+        prefect.check_if_running()
+
+    @prefect.flow
+    def check_flow():
+        check_task()
+        return quote(prefect.check_if_running())
+
+    result = check_flow().unwrap()
+
+    # A RUNNING state should be returned by `check_if_running`
+    assert isinstance(result, prefect.State)
+    assert result.is_running()
+
+
+async def test_check_if_running_does_not_raise_in_normal_operation_async():
+    @prefect.task
+    async def acheck_task():
+        await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+        return quote(await prefect.check_if_running())
+
+    result = (await acheck_flow()).unwrap()
+
+    # A RUNNING state should be returned by `check_if_running`
+    assert isinstance(result, prefect.State)
+    assert result.is_running()
+
+
+@pytest.mark.parametrize("state_type", [StateType.CANCELLED, StateType.CANCELLING])
+async def test_check_if_running_raises_on_cancelled_flow_state_from_task(state_type):
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.State(type=state_type)
+            )
+
+        with pytest.raises(FailedRun):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+@pytest.mark.parametrize("state_type", [StateType.CANCELLED, StateType.CANCELLING])
+async def test_check_if_running_raises_on_cancelled_task_state_from_task(state_type):
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_task_run_state(
+                prefect.runtime.task_run.id, prefect.states.State(type=state_type)
+            )
+        with pytest.raises(CancelledRun):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+@pytest.mark.parametrize("state_type", [StateType.CANCELLED, StateType.CANCELLING])
+async def test_check_if_running_raises_on_cancelled_flow_state_from_flow(state_type):
+    @prefect.flow
+    async def acheck_flow():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.State(type=state_type)
+            )
+
+        with pytest.raises(CancelledRun):
+            await prefect.check_if_running()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_failed_flow_state_from_task():
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.Failed()
+            )
+
+        with pytest.raises(FailedRun):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_failed_task_state_from_task():
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_task_run_state(
+                prefect.runtime.task_run.id, prefect.states.Failed()
+            )
+        with pytest.raises(FailedRun):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_failed_flow_state_from_flow():
+    @prefect.flow
+    async def acheck_flow():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.Failed()
+            )
+
+        with pytest.raises(FailedRun):
+            await prefect.check_if_running()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_pending_flow_state_from_task():
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.Pending(), force=True
+            )
+
+        with pytest.raises(RuntimeError, match="foo"):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_pending_task_state_from_task():
+    @prefect.task
+    async def acheck_task():
+        async with prefect.get_client() as client:
+            await client.set_task_run_state(
+                prefect.runtime.task_run.id, prefect.states.Pending(), force=True
+            )
+        with pytest.raises(RuntimeError, match="foo"):
+            await prefect.check_if_running()
+
+    @prefect.flow
+    async def acheck_flow():
+        await acheck_task()
+
+    await acheck_flow(return_state=True)
+
+
+async def test_check_if_running_raises_on_pending_flow_state_from_flow():
+    @prefect.flow
+    async def acheck_flow():
+        async with prefect.get_client() as client:
+            await client.set_flow_run_state(
+                prefect.runtime.flow_run.id, prefect.states.Pending(), force=True
+            )
+
+        with pytest.raises(RuntimeError, match="foo"):
+            await prefect.check_if_running()
+
+    await acheck_flow(return_state=True)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

A while back, we discussed adding a utility that users could call from within their task or flow that would check for cancellation. It can be challenging to interrupt runs externally, and this would allow users to opt-in to period checks. Their run would then exit if it was not in a running state according to the API.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
import asyncio
import time

from prefect import check_if_running, flow, get_client, task
from prefect.states import Cancelled


@task
def looper():
    for _ in range(10):
        time.sleep(1)
        check_if_running()
        print("Happy checkpoint :)")


@flow
async def test_flow():
    future = looper.submit()
    # Let the task be happy for a little :)
    await asyncio.sleep(3)

    async with get_client() as client:
        await client.set_task_run_state(
            future.task_run.id, state=Cancelled(message="Get cancelled!")
        )

    print("Task finished in state:", future.wait())
    return True


asyncio.run(test_flow())
```

```
15:36:17.252 | INFO    | prefect.engine - Created flow run 'amazing-adder' for flow 'test-flow'
15:36:17.418 | INFO    | Flow run 'amazing-adder' - Created task run 'looper-ba8747e8-0' for task 'looper'
15:36:17.419 | INFO    | Flow run 'amazing-adder' - Submitted task run 'looper-ba8747e8-0' for execution.
Happy checkpoint :)
Happy checkpoint :)
/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py:258: UserWarning: `sync` called from an asynchronous context; you should `await` the async function directly instead.
  warnings.warn(
15:36:20.559 | ERROR   | Task run 'looper-ba8747e8-0' - Encountered exception during execution:
Traceback (most recent call last):
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 1489, in orchestrate_task_run
    result = await run_sync(task.fn, *args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py", line 156, in run_sync_in_interruptible_worker_thread
    tg.start_soon(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py", line 135, in capture_worker_thread_and_result
    result = __fn(*args, **kwargs)
  File "example.py", line 12, in looper
    checkpoint()
  File "/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py", line 226, in coroutine_wrapper
    return run_async_from_worker_thread(async_fn, *args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py", line 177, in run_async_from_worker_thread
    return anyio.from_thread.run(call)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/from_thread.py", line 49, in run
    return asynclib.run_async_from_thread(func, *args)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 970, in run_async_from_thread
    return f.result()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 1981, in checkpoint
    await raise_state_exception(task_run.state)
  File "/Users/mz/dev/prefect/src/prefect/states.py", line 370, in raise_state_exception
    raise await get_state_exception(state)
prefect.exceptions.CancelledRun: Get cancelled!
15:36:20.581 | INFO    | Task run 'looper-ba8747e8-0' - Task run '6110e28c-e820-4d47-9dfe-8b247850546c' already finished.
Task finished in state: Cancelled('Get cancelled!')
15:36:20.594 | INFO    | Flow run 'amazing-adder' - Finished in state Completed()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
