### PR TITLE
Add role permissions regarding block secrets

### DIFF
--- a/docs/ui/roles.md
+++ b/docs/ui/roles.md
@@ -46,8 +46,8 @@ The following built-in roles have permissions within a given workspace in Prefec
 
 | Role | Abilities |
 | --- | --- |
-| Owner | &bull; Run flows. <br> &bull; View and delete flow runs within a workspace. <br> &bull; Create, view, edit, and delete deployments within a workspace. <br> &bull; Create, view, edit, and delete work queues within a workspace. <br> &bull; Create, view, edit, and delete blocks within a workspace. <br> &bull; Create, view, edit, and delete automations within a workspace. <br> &bull; Add and remove organization members, and set their role within a workspace. <br> &bull; Set the workspace’s default workspace role for all users in the organization. <br> &bull; Set, view, edit workspace settings. |
-| Developer | &bull; Run flows within a workspace. <br> &bull; View and delete flow runs within a workspace. <br> &bull; Create, view, edit, and delete deployments within a workspace. <br> &bull; Create, view, edit, and delete work queues within a workspace. <br> &bull; Create, view, edit, and delete all blocks within a workspace. <br> &bull; Create, view, edit, and delete automations within a workspace. <br> &bull; View workspace setting within a workspace. |
+| Owner | &bull; Run flows. <br> &bull; View and delete flow runs within a workspace. <br> &bull; Create, view, edit, and delete deployments within a workspace. <br> &bull; Create, view, edit, and delete work queues within a workspace. <br> &bull; Create, view, edit, and delete blocks and their secrets within a workspace. <br> &bull; Create, view, edit, and delete automations within a workspace. <br> &bull; Add and remove organization members, and set their role within a workspace. <br> &bull; Set the workspace’s default workspace role for all users in the organization. <br> &bull; Set, view, edit workspace settings. |
+| Developer | &bull; Run flows within a workspace. <br> &bull; View and delete flow runs within a workspace. <br> &bull; Create, view, edit, and delete deployments within a workspace. <br> &bull; Create, view, edit, and delete work queues within a workspace. <br> &bull; Create, view, edit, and delete all blocks and their secrets within a workspace. <br> &bull; Create, view, edit, and delete automations within a workspace. <br> &bull; View workspace setting within a workspace. |
 | Runner | &bull; View flow runs within a workspace. <br> &bull; View and run deployments within a workspace. <br> &bull; View all work queues within a workspace. <br> &bull; View all blocks within a workspace. <br> &bull; View all automations within a workspace. <br> &bull; View workspace settings (handle and description currently). |
 | Viewer | &bull; View flow runs within a workspace. <br> &bull; View deployments within a workspace. <br> &bull; View all work queues within a workspace. <br> &bull; View all blocks within a workspace. <br> &bull; View all automations within a workspace. <br> &bull; View workspace settings (handle and description currently). |
 
@@ -89,7 +89,8 @@ The following permissions are available for custom roles.
 | Permission | Description |
 | --- | --- |
 | View blocks | User can see configured blocks within a workspace. |
-| Create, edit, and delete blocks | User can create, edit, and delete blocks within a workspace. Includes permissions of **View blocks**. |
+| View secret block data | User can see configured blocks and their secrets within a workspace. Includes permissions of **View blocks**. |
+| Create, edit, and delete blocks | User can create, edit, and delete blocks within a workspace. Includes permissions of **View blocks** and **View secret block data**. |
 
 ### Deployments
 


### PR DESCRIPTION
Adds permissions details regarding blocks secrets to Roles documentation.

### Example

[Preview](https://deploy-preview-8309--prefect-orion.netlify.app/ui/roles/)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
