### PR TITLE
Fix cancellation bug

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -34,7 +34,13 @@ from prefect.orion.schemas.filters import (
     FlowRunFilterWorkQueueName,
 )
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
-from prefect.states import Cancelled, Crashed, Pending, StateType, exception_to_failed_state
+from prefect.states import (
+    Cancelled,
+    Crashed,
+    Pending,
+    StateType,
+    exception_to_failed_state,
+)
 
 
 class OrionAgent:

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -34,7 +34,7 @@ from prefect.orion.schemas.filters import (
     FlowRunFilterWorkQueueName,
 )
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
-from prefect.states import Crashed, Pending, StateType, exception_to_failed_state
+from prefect.states import Cancelled, Crashed, Pending, StateType, exception_to_failed_state
 
 
 class OrionAgent:
@@ -369,8 +369,7 @@ class OrionAgent:
         self, flow_run: FlowRun, state_updates: Optional[dict] = None
     ) -> None:
         state_updates = state_updates or {}
-        state_updates.setdefault("name", "Cancelled")
-        state = flow_run.state.copy(update=state_updates)
+        state = Cancelled(**state_updates)
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)
 

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -375,7 +375,9 @@ class OrionAgent:
         self, flow_run: FlowRun, state_updates: Optional[dict] = None
     ) -> None:
         state_updates = state_updates or {}
-        state = Cancelled(**state_updates)
+        state_updates.setdefault("name", "Cancelled")
+        state_updates.setdefault("type", StateType.CANCELLED)
+        state = flow_run.state.copy(update=state_updates)
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)
 

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -34,13 +34,7 @@ from prefect.orion.schemas.filters import (
     FlowRunFilterWorkQueueName,
 )
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
-from prefect.states import (
-    Cancelled,
-    Crashed,
-    Pending,
-    StateType,
-    exception_to_failed_state,
-)
+from prefect.states import Crashed, Pending, StateType, exception_to_failed_state
 
 
 class OrionAgent:


### PR DESCRIPTION
Agents were not properly updating `Cancelling` runs to a `Cancelled` state after cancellation logic has fired. This update fixes that.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
