### PR TITLE
fixup: kubernetes package version to conform to v66 of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ orchestration_extras = {
     "git": ["dulwich >= 0.19.7"],
     "github": ["PyGithub >= 1.51"],
     "gitlab": ["python-gitlab >= 2.5.0"],
-    "kubernetes": ["kubernetes >= 9.0.0a1.0"],
+    "kubernetes": ["kubernetes >= 9.0.0a1"],
 }
 
 extras = {


### PR DESCRIPTION
i have an application pinned to this branch, and started seeing some build failures:

```
'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
```

`v66.0.0` of setuptools was released earlier in the month, with a breaking change on dropping support for non-conforming version expressions for PEP 440

https://setuptools.pypa.io/en/latest/history.html#id9

checking the setuptools version loaded into the subprocess during pip install, im seeing v67

```
#10 17.31   Installing build dependencies: started
#10 17.31   Running command pip subprocess to install build dependencies
#10 18.53   Collecting setuptools>=40.8.0
#10 18.82     Downloading setuptools-67.0.0-py3-none-any.whl (1.1 MB)
#10 19.17        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 3.2 MB/s eta 0:00:00
```

running through the generated values in `extras_required`, i saw this strange kubernetes-python package value:

```
kubernetes >= 9.0.0a1.0
```

on their releases, i see that there's a `v9.0.0a1` (w/o the trailing `.0`)

https://github.com/kubernetes-client/python/releases?q=9.0.0a1

this "fix" doesn't look like it needs to go into the default branch