### PR TITLE
Add callouts directing users to Prefect 2 as latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
 </p>
 
-Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.
+Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while users migrate to Prefect 2.
 
 If you're ready to start migrating your workflows to Prefect 2, see our [migration guide](https://docs.prefect.io/migration-guide/).
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,6 @@
 </p>
 
 <p align="center">
-<a href=https://circleci.com/gh/PrefectHQ/prefect/tree/master>
-    <img src="https://circleci.com/gh/PrefectHQ/prefect/tree/master.svg?style=shield&circle-token=28689a55edc3c373486aaa5f11a1af3e5fc53344">
-</a>
-
-<a href=https://github.com/ambv/black>
-    <img src="https://img.shields.io/badge/code%20style-black-000000.svg">
-</a>
-
 <a href="https://pypi.org/project/prefect/">
     <img src="https://static.pepy.tech/badge/prefect/month">
 </a>
@@ -23,21 +15,19 @@
     <img src="https://img.shields.io/static/v1.svg?label=chat&message=on%20slack&color=27b1ff&style=flat">
 </a>
 
-
 <a href="https://discourse.prefect.io/">
     <img src="https://img.shields.io/static/v1.svg?label=chat&message=on%20discourse&color=27b1ff&style=flat">
 </a>
-
-
 </p>
 
-<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
-Looking for the latest <a href="https://docs.prefect.io/">Prefect 2.0</a> release? Prefect 2.0 and <a href="https://app.prefect.cloud">Prefect Cloud 2.0</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
-</div>
 
-Prefect 1.0 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.0.
+<p style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</p>
 
-If you're ready to start migrating your workflows to Prefect 2.0, see our [migration guide](https://docs.prefect.io/migration-guide/).
+Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.
+
+If you're ready to start migrating your workflows to Prefect 2, see our [migration guide](https://docs.prefect.io/migration-guide/).
 
 If you are unsure which Prefect version to choose for your specific use case, [this Prefect Discourse page](https://discourse.prefect.io/t/should-i-start-with-prefect-2-0-orion-skipping-prefect-1-0/544) may help you decide.
 

--- a/docs/core/PINs/README.md
+++ b/docs/core/PINs/README.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Contents
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 **Prefect Improvement Notices** are used to propose, discuss, accept, and memorialize any major architectural decisions for Prefect Core.
 
 ## [PIN-1: Introduce Prefect Improvement Notices](PIN-01-Introduce-PINs.md)

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -3,6 +3,10 @@ title: Welcome
 sidebarDepth: 0
 ---
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 <div align="center" style="margin-top:50px; margin-bottom:40px">
     <img src="/illustrations/core-illustration.svg"  width=500>
 </div>

--- a/docs/core/about_prefect/next-steps.md
+++ b/docs/core/about_prefect/next-steps.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Next Steps
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 In the [introduction](thinking-prefectly.md), we took a look at creating tasks and combining them into flows. Prefect's functional and imperative APIs make that easy, but the result was a fairly vanilla data pipeline. In this section, we're going to explore how Prefect enables advanced mechanisms for overlaying complex business logic on your workflow.
 
 

--- a/docs/core/about_prefect/thinking-prefectly.md
+++ b/docs/core/about_prefect/thinking-prefectly.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Thinking Prefectly
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This page will give you a gentle introduction to Prefect's core concepts. If you are keen to get started we have a [Getting Started guide](/core/getting_started/quick-start.html) and [ETL tutorial](/core/tutorial/01-etl-before-prefect.html) on building real-world data applications with Prefect.
 
 Prefect is a tool for building **data workflows**. A workflow is a series of steps that are performed in a certain order.

--- a/docs/core/about_prefect/why-not-airflow.md
+++ b/docs/core/about_prefect/why-not-airflow.md
@@ -4,9 +4,11 @@ sidebarDepth: 1
 
 # Why Not Airflow?
 
-:::tip Read the original post
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 You can view the original version of this post [on our blog](https://medium.com/the-prefect-blog/why-not-airflow-4cfa423299c4).
-:::
 
 > Why should I choose Prefect over Airflow?
 

--- a/docs/core/about_prefect/why-prefect.md
+++ b/docs/core/about_prefect/why-prefect.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Why Prefect?
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Details matter
 
 Prefect is a workflow engine, which means that users need absolute confidence that 1) it works and 2) it works well. For that reason, Prefect's design is backed by a strong philosophy of data engineering and we hold its code to a high standard.

--- a/docs/core/advanced_tutorials/README.md
+++ b/docs/core/advanced_tutorials/README.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Contents
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 These tutorials are intended to help the reader get acquainted with the many features of Prefect and its vocabulary. All code examples
 are locally executable in any Python version supported by Prefect (3.7+). Note that all features presented here are run without
 the Prefect server.

--- a/docs/core/advanced_tutorials/advanced-mapping.md
+++ b/docs/core/advanced_tutorials/advanced-mapping.md
@@ -1,5 +1,9 @@
 # Advanced Features <Badge text="advanced" type="warn"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > Topics covered: _mapping tasks_, _parallelization_, _parameters_, _flow.run() keyword arguments_
 
 Here we will dig into some of the more advanced features that Prefect offers; in the process, we will construct a real world workflow that highlights how Prefect can be a powerful tool for local development, allowing us to expressively and efficiently create, inspect and extend custom data workflows.

--- a/docs/core/advanced_tutorials/calculator.md
+++ b/docs/core/advanced_tutorials/calculator.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Using Prefect as a Calculator
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > Can your data engineering framework do this?
 
 Prefect is a heavy-duty data workflow system, but it handles lightweight applications just as well.

--- a/docs/core/advanced_tutorials/custom-logs.md
+++ b/docs/core/advanced_tutorials/custom-logs.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Deployment: Logging
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > How can you customize your Prefect logs?
 
 ## Logging

--- a/docs/core/advanced_tutorials/dask-cluster.md
+++ b/docs/core/advanced_tutorials/dask-cluster.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Deployment: Dask
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > How can you run a Prefect flow in a [distributed Dask cluster](https://distributed.readthedocs.io/en/latest/)?
 
 ## The Dask Executor

--- a/docs/core/advanced_tutorials/etl.md
+++ b/docs/core/advanced_tutorials/etl.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # ETL
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > The "hello, world!" of the data engineering world
 
 ETL ("extract, transform, load") is a basic data workflow, but can be surprisingly complicated to set up in most data engineering frameworks.

--- a/docs/core/advanced_tutorials/local-debugging.md
+++ b/docs/core/advanced_tutorials/local-debugging.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 ## Local Debugging
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Whether you're running Prefect locally with `Flow.run()` or experimenting with your ideas before putting them into production with Prefect Cloud, Prefect provides you with a wealth of tools for debugging your flows and diagnosing issues.
 
 ### Use a FlowRunner for stateless execution

--- a/docs/core/advanced_tutorials/slack-notifications.md
+++ b/docs/core/advanced_tutorials/slack-notifications.md
@@ -4,6 +4,10 @@ sidebarDepth: 1
 
 # Slack Notifications
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ![slack-banner](https://uploads-ssl.webflow.com/5ba446b0e783e26d5a2f2382/5bc4f20bd534b99be66f24aa_slack.png){.viz-md}
 
 ::: warning Deprecation warning

--- a/docs/core/advanced_tutorials/task-guide.md
+++ b/docs/core/advanced_tutorials/task-guide.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # The Anatomy of a Prefect Task
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 > Everything you wanted to know about Prefect Tasks and more.
 
 **Contents**

--- a/docs/core/advanced_tutorials/task-looping.md
+++ b/docs/core/advanced_tutorials/task-looping.md
@@ -3,6 +3,10 @@ sidebarDepth: 0
 ---
 # Dynamic DAGs: Task Looping
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect's rich state system allows for unique forms of workflow dynamicism that alter the underlying DAG structure at runtime, while still providing all of the underlying workflow guarantees: individual tasks can have custom retry settings, exchange data, activate notifications, etc.
 
 Previously, [task mapping](/core/concepts/mapping.html) allowed users to elevate parallelizable for-loops into first class parallel pipelines at runtime. Task looping offers much the same benefit, but for situations that require a while-loop pattern.

--- a/docs/core/advanced_tutorials/using-results.md
+++ b/docs/core/advanced_tutorials/using-results.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Using Results
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Let's take a look at using results to persist and track task output. As introduced in the concept documentation for ["Results"](../concepts/results.md), Prefect tasks associate their return value with a `Result` object attached to a task's `State`. If you configure the `Result` object for a task and enable checkpointing, the pipeline will also persist results to storage as a pickle into one of the supported storage backends.
 
 Why would you persist the output of your tasks? The most common situation is to enable retrying from failure of a task for users that use a state database, such as Prefect Core's server or Prefect Cloud. By persisting the output of a task somewhere besides in-memory, a state database that knows the persisted location of a task's output can restart from where it left off. In the same vein, using a persistent cache to prevent reruns of expensive or slow tasks outside of a single Python interpreter is only possible when the return value of tasks are persisted somewhere outside of memory. Another common situation is to allow for inspection of intermediary data when debugging flows (including—maybe especially—production ones). By checkpointing data during different data transformation Tasks, runtime data bugs can be tracked down by analyzing the checkpoints sequentially.

--- a/docs/core/advanced_tutorials/visualization.md
+++ b/docs/core/advanced_tutorials/visualization.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 ## Flow Visualization
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 It is a common mantra that the first thing data professionals should do when trying to understand a dataset is to _visualize_ it; similarly, when designing workflows it is always a good idea to visually inspect what you've created.
 
 Prefect provides multiple tools for building, inspecting and testing your flows locally. In this tutorial we will cover some ways you can _visualize_ your flow and its execution. Everything we discuss will require Prefect to be installed with either the `"viz"` or `"dev"` extras:

--- a/docs/core/code_of_conduct.md
+++ b/docs/core/code_of_conduct.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 ---
 # Prefect Code of Conduct
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as

--- a/docs/core/community.md
+++ b/docs/core/community.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Community
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 We welcome issues, contributions and discussion from all users, regardless of background or experience level. In order to create a positive and welcoming environment, all interactions are governed by Prefect's [Code of Conduct](code_of_conduct.md).
 
 Please consider [Chris White](https://github.com/cicdw) the main point of contact for the Prefect repo.

--- a/docs/core/concepts/README.md
+++ b/docs/core/concepts/README.md
@@ -4,6 +4,10 @@ sidebarDepth: 0
 
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Core Concepts
 
 [Tasks](tasks.md), [Flows](flows.md), and [Parameters](parameters.md), oh my!

--- a/docs/core/concepts/best-practices.md
+++ b/docs/core/concepts/best-practices.md
@@ -1,5 +1,9 @@
 # Best Practices
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Writing Prefect code
 
 To maximize the clarity of your Prefect code, we recommend organizing your scripts in a few sections:

--- a/docs/core/concepts/common-pitfalls.md
+++ b/docs/core/concepts/common-pitfalls.md
@@ -1,5 +1,9 @@
 # Common Pitfalls
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Stateful tasks
 
 ### Persisting information in a Task's run method

--- a/docs/core/concepts/configuration.md
+++ b/docs/core/concepts/configuration.md
@@ -1,5 +1,9 @@
 # Configuration
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect's settings are stored in a configuration file called `config.toml`. In general, you should not edit this file directly to modify Prefect's settings. Instead, you should use [environment variables](#environment-variables) for temporary settings, or create a [user configuration file](#user-configuration) for permanent settings.
 
 The configuration file is parsed when Prefect is first imported and is available as a live object in `prefect.config`. To access any value, use dot-notation (for example, `prefect.config.tasks.defaults.checkpoint`).

--- a/docs/core/concepts/engine.md
+++ b/docs/core/concepts/engine.md
@@ -1,5 +1,9 @@
 # Engine
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 Prefect's execution model is built around two classes, `FlowRunner` and `TaskRunner`, which produce and operate on [State](states.html) objects. The actual execution is handled by `Executor` classes, which can interface with external environments.

--- a/docs/core/concepts/execution.md
+++ b/docs/core/concepts/execution.md
@@ -1,5 +1,9 @@
 # Execution
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Within the Prefect engine, there are many ways for users to affect execution.
 
 [[toc]]

--- a/docs/core/concepts/flows.md
+++ b/docs/core/concepts/flows.md
@@ -1,5 +1,9 @@
 # Flows
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 A `Flow` is a container for `Tasks`. It represents an entire workflow or application by describing the dependencies between tasks.

--- a/docs/core/concepts/logging.md
+++ b/docs/core/concepts/logging.md
@@ -1,5 +1,9 @@
 # Logging
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect has a variety of ways to generate logs from tasks.
 
 ## Logging Configuration

--- a/docs/core/concepts/mapping.md
+++ b/docs/core/concepts/mapping.md
@@ -1,5 +1,9 @@
 # Mapping
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect introduces a flexible map/reduce model for dynamically executing tasks across an iterable input. This, in turn, gives you the ability to execute mapped tasks in a distributed or parallel manner using an executor like the DaskExecutor.
 
 Classic "map/reduce" is a powerful two-stage programming model that can be used to distribute and parallelize work (the "map" phase) before collecting and processing all the results (the "reduce" phase).

--- a/docs/core/concepts/notifications.md
+++ b/docs/core/concepts/notifications.md
@@ -1,5 +1,9 @@
 # Notifications and State Handlers
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Alerts, notifications, and dynamically responding to task state are important features of any workflow tool. Using Prefect primitives, users can create Tasks that send notifications after certain tasks run or fail using Prefect's trigger logic. This will work, but does not cover more subtle uses of notification logic (e.g., receiving a notification if a task _retries_). For this reason, Prefect introduces a flexible concept called "state handlers", which can be attached to individual tasks or flows. At a high level, a state handler is a function that is called on every change of state for the underlying object; these can be used for sending alerts upon failure, emails upon success, or more nuanced handling based on the information contained in both the old and new states.
 
 In addition to working with the `state_handler` API directly, Prefect provides higher level wrappers for implementing common use cases

--- a/docs/core/concepts/parameters.md
+++ b/docs/core/concepts/parameters.md
@@ -1,5 +1,9 @@
 # Parameters
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Parameters are special tasks that can receive user inputs whenever a flow is run. Setting a default is optional. 
 
 ```python

--- a/docs/core/concepts/persistence.md
+++ b/docs/core/concepts/persistence.md
@@ -1,5 +1,9 @@
 # Caching and Persisting Data
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect provides a few ways to work with cached data between tasks or flows. In-memory caching of task **inputs** is automatically applied by the Prefect pipeline to optimize retries or other times when Prefect can anticipate rerunning the same task in the future. Users can also configure to cache the **output** of a prior run of a task and use it as the output of a future run of that task or even as the output of a run of a different task.
 
 Out of the box, Prefect Core does not persist cached data in a permanent fashion. All data, results, _and_ cached states are only stored in memory within the

--- a/docs/core/concepts/results.md
+++ b/docs/core/concepts/results.md
@@ -1,5 +1,9 @@
 # Results
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect allows data to be represented by a first-class Prefect object called a `Result`. The Prefect pipeline uses result objects to pass data between Tasks as a first class operation. Users may also use Prefect's result objects to write or read any arbitrary data in their task with a single abstraction.
 
 At a high level, all `State` objects produced by the Prefect pipeline have a `Result` object associated with them. That `Result` object may be a subclass specifying a storage backend, such as `S3Result` or `GCSResult`, which specifies how the outputs of that Task should be handled if they need to be persisted for any reason.

--- a/docs/core/concepts/schedules.md
+++ b/docs/core/concepts/schedules.md
@@ -1,5 +1,9 @@
 # Schedules
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 Prefect assumes that flows can be run at any time, for any reason. However, it is often useful to automate flow runs at certain times. Simple schedules can be attached to Flows via the `schedule` keyword argument. For more detailed or complex schedules, Prefect provides a versatile `Schedule` object which allows for subtle date time adjustments and filtering, along with updating `Parameter` values based on the scheduled time.

--- a/docs/core/concepts/secrets.md
+++ b/docs/core/concepts/secrets.md
@@ -1,5 +1,9 @@
 # Secrets
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 Very often, workflows require sensitive information to run: API keys, passwords, tokens, credentials, etc. As a matter of best practice, such information should never be hardcoded into a workflow's source code, as the code itself will need to be guarded. Furthermore, sensitive information should not be provided via a Prefect `Parameter`, because Parameters, like many tasks, can have their results stored.

--- a/docs/core/concepts/states.md
+++ b/docs/core/concepts/states.md
@@ -1,5 +1,9 @@
 # States
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 States are the "currency" of Prefect. All information about tasks and flows is transmitted via rich `State` objects. While you don't need to know the details of the state system to use Prefect, you can give your workflows superpowers by taking advantage of it.

--- a/docs/core/concepts/tasks.md
+++ b/docs/core/concepts/tasks.md
@@ -1,5 +1,9 @@
 # Tasks
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 A `Task` represents a discrete action in a Prefect workflow.

--- a/docs/core/concepts/templating.md
+++ b/docs/core/concepts/templating.md
@@ -1,5 +1,9 @@
 # Templating names
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 There are several places within Prefect where names can be templated at runtime to create a value relevant to that specific run.
 These names can be passed as literal strings, e.g. `"my_foo_task"`, but to get dynamic values based on the current state, we'll need to use _template_ strings.
 Here, we take advantage of Python's [format string](https://www.python.org/dev/peps/pep-3101/#format-strings) and provide various arguments.

--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Documentation
 
 Contributing to Prefect's docs is just as important as adding new code! We welcome your help, whether fixing a simple typo or writing a new tutorial. For new users, this can be an excellent way to get involved.

--- a/docs/core/development/documentation.md
+++ b/docs/core/development/documentation.md
@@ -1,5 +1,9 @@
 # Documentation
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Documentation is incredibly important to Prefect, both for explaining its concepts to general audiences and describing its API to developers.
 
 ## Docstrings

--- a/docs/core/development/overview.md
+++ b/docs/core/development/overview.md
@@ -5,6 +5,10 @@ title: Overview
 
 # Development Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Thanks for contributing to Prefect! This section of the docs is designed to help you become familiar with how we work, the standards we apply, and how to ensure your contribution is successful.
 
 If you're stuck, don't be shy about asking for help [on GitHub](https://github.com/PrefectHQ/prefect/issues/new/choose) or in the `#prefect-contributors` channel of our [Slack community](https://www.prefect.io/slack). You can also ask us any question in our [Discourse](https://discourse.prefect.io) forum.

--- a/docs/core/development/release-checklist.md
+++ b/docs/core/development/release-checklist.md
@@ -1,5 +1,9 @@
 # Release Checklist
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 There are a few steps we need to take when cutting a new Prefect release; this document serves as a checklist for what needs to happen for a successful release:
 
 - [ ] Update the [CHANGELOG.md](https://github.com/PrefectHQ/prefect/blob/master/CHANGELOG.md) section headers

--- a/docs/core/development/sprints.md
+++ b/docs/core/development/sprints.md
@@ -5,6 +5,10 @@ title: Sprints
 
 # Join Prefect at Sprints
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Join Prefect at one of our upcoming digital events where core contributors will support new and veteran contributors during development sprints.
 
 ::: tip Already sprinting?

--- a/docs/core/development/style.md
+++ b/docs/core/development/style.md
@@ -1,5 +1,9 @@
 # Code Style
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Black formatting
 
 Prefect's code is formatted using the [black](https://github.com/ambv/black) style. This style is checked in a CI step, and merges to master are prevented if code does not conform.

--- a/docs/core/development/tests.md
+++ b/docs/core/development/tests.md
@@ -1,5 +1,9 @@
 # Testing
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect loves tests! There are a few important reasons to write tests:
 
 - **Make sure your code works**

--- a/docs/core/examples/overview.md
+++ b/docs/core/examples/overview.md
@@ -1,5 +1,9 @@
 # Prefect Tutorial Examples
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect includes a number of examples covering different features. Some are 
 covered in the tutorials, and all can be accessed from the GitHub repo
 [here](https://github.com/PrefectHQ/prefect/tree/master/examples).

--- a/docs/core/faq.md
+++ b/docs/core/faq.md
@@ -1,5 +1,9 @@
 # FAQ
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 [[toc]]
 
 ### Does Prefect have a UI, and if so, how can I use it?

--- a/docs/core/getting_started/basic-core-flow.md
+++ b/docs/core/getting_started/basic-core-flow.md
@@ -1,5 +1,9 @@
 # Run a flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Now that you have Prefect installed,  you're ready to run a flow.
 
 A [flow](/core/concepts/flows.html) is a container for [tasks](/core/concepts/tasks.html) and shows the direction of work and the dependencies between tasks.

--- a/docs/core/getting_started/install.md
+++ b/docs/core/getting_started/install.md
@@ -1,5 +1,9 @@
 # Installation
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Basic installation
 
 Prefect requires Python 3.7+. If you're new to Python, we recommend installing the [Anaconda distribution](https://www.anaconda.com/distribution/).

--- a/docs/core/getting_started/more-resources.md
+++ b/docs/core/getting_started/more-resources.md
@@ -1,7 +1,12 @@
 
 # More Resources
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Core Quick Start guide has covered: 
+
 - Installing prefect
 - Running a flow
 

--- a/docs/core/getting_started/quick-start.md
+++ b/docs/core/getting_started/quick-start.md
@@ -1,6 +1,10 @@
 
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This is a Quick Start guide to help you get a basic Prefect 1 flow up and running on your local machine.  If you want to run a simple flow and have no need (yet) for an API or UI, then Prefect Core is for you.  If you know that you want a UI or API, then check out our [orchestration layer](/orchestration/getting-started/quick-start.md) docs.  
 
 Once you've gone through the tutorial, we encourage you to find out more about Prefect core concepts by reading [Thinking Prefectly](/core/about_prefect/thinking-prefectly.md) or to check out our list of [more resources](/core/getting_started/more-resources.md).

--- a/docs/core/idioms/conditional.md
+++ b/docs/core/idioms/conditional.md
@@ -1,5 +1,9 @@
 # Using conditional logic in a Flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Sometimes you have parts of a flow that you only want to run under certain
 conditions. To support this, Prefect provides several built-in [tasks for
 control-flow](/api/latest/tasks/control_flow.html) that you can use to add

--- a/docs/core/idioms/flow-to-flow.md
+++ b/docs/core/idioms/flow-to-flow.md
@@ -1,5 +1,9 @@
 # Running dependent flows
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 There are many situations where users want to configure dependencies at the flow level; for example,
 if you have a data preprocessing flow that you maintain separately from a model training flow, and you
 always want to ensure that the preprocessing flow runs before the training flow.

--- a/docs/core/idioms/idioms.md
+++ b/docs/core/idioms/idioms.md
@@ -1,5 +1,9 @@
 # Prefect Idioms
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 - [Running dependent flows](flow-to-flow.html)
 - [Using conditional logic in a flow](conditional.html)
 - [Use task mapping to map over a specific set of arguments](mapping.html)

--- a/docs/core/idioms/logging.md
+++ b/docs/core/idioms/logging.md
@@ -1,6 +1,10 @@
 
 # Logging configuration and usage
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect natively ships with a default logger configured to handle the management of logs. More information on logging in Prefect can be found in the [logging concept document](/core/concepts/logging.html).
 
 ### Configure the logger

--- a/docs/core/idioms/mapping.md
+++ b/docs/core/idioms/mapping.md
@@ -1,5 +1,9 @@
 # Use task mapping to map over a specific set of arguments
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 [Mapping](/core/concepts/mapping.html) in Prefect is a great way for dynamic task creation and parallel execution. Sometimes you may want to pass extra arguments to functions that you're using to map over inputs but you don't want to map over those extra arguments. This is where Prefect's [`unmapped`](/api/latest/utilities/tasks.html#unmapped) operator can come into play.
 
 In this example let's take a flow where we want to pass in a [Parameter](/core/concepts/parameters.html) `multiple` to be multiplied against a random list of numbers also specified with a `total` Parameter. This random list of numbers will be generated at runtime. If your tasks map over iterables that are generated at runtime then Prefect will dynamically build the DAG based on those values.

--- a/docs/core/idioms/notifications.md
+++ b/docs/core/idioms/notifications.md
@@ -1,5 +1,9 @@
 # Configuring notifications
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Sending notifications based on events in Prefect is a common pattern. Types of notifications generally include functionality such as posting state of runs to Slack, sending a text message on failure, etc. There are many places in Prefect to hook in notification systems and this idiom will go over three possibilities.
 
 ### Downstream tasks

--- a/docs/core/idioms/parallel.md
+++ b/docs/core/idioms/parallel.md
@@ -1,5 +1,9 @@
 # Parallelism within a Prefect flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect supports fully asynchronous / parallel running of a flow's tasks and the preferred method for doing this is using [Dask](https://dask.org/). By connecting to a Dask scheduler, a flow can begin executing its tasks on either local or remote Dask workers. Parallel execution is incredibly useful when executing many mapped tasks simultaneously but for this example you will see a flow that has three pre-defined tasks at the same level that we want to execute asynchronously in order to better visualize it.
 
 ![Parallel Tasks](/faq/parallel.png)

--- a/docs/core/idioms/pause-for-approval.md
+++ b/docs/core/idioms/pause-for-approval.md
@@ -1,5 +1,9 @@
 # Pause for Approval
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 There are many situations when a workflow contains tasks that require some form of manual approval to continue. Prefect has two built-in mechanisms for achieving this pattern:
 
 - a manual-only trigger that can be configured on a per task basis, and unconditionally prevents the task from running unless a user approves it

--- a/docs/core/idioms/piping.md
+++ b/docs/core/idioms/piping.md
@@ -1,5 +1,9 @@
 # Using the functional pipe operator
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Background and Motivation
 
 Functional pipes are a common idiom in several languages. For example, you may

--- a/docs/core/idioms/resource-manager.md
+++ b/docs/core/idioms/resource-manager.md
@@ -1,5 +1,9 @@
 # Managing temporary resources
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Sometimes you have workloads that depend on resources that need to be setup,
 used, then cleaned up. Examples might include:
 

--- a/docs/core/idioms/script-based.md
+++ b/docs/core/idioms/script-based.md
@@ -1,5 +1,9 @@
 # Using script based flow storage
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 As of Prefect version `0.12.5` all storage options support storing flows as
 source files instead of pickled objects. This means that flow code can change
 in between (or even during) runs without needing to be re-registered. As long as

--- a/docs/core/idioms/secrets.md
+++ b/docs/core/idioms/secrets.md
@@ -1,5 +1,9 @@
 # Authentication and Secrets in Prefect
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The management of sensitive information (private keys, api access strings, passwords, etc.) is an integral aspect of production workflows. Prefect has a few ways to securely manage and use this sensitive information. This document will cover the use of local secrets _only_ however they easily translate to using [Prefect Cloud's secret management](/orchestration/concepts/secrets.html) option. For more information on Prefect Secrets visit the relevant [concept document](/core/concepts/secrets.html).
 
 ::: warning use_local_secrets

--- a/docs/core/idioms/targets.md
+++ b/docs/core/idioms/targets.md
@@ -1,5 +1,9 @@
 # Using Result targets for efficient caching <Badge text="0.11.0+"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Targets in Prefect are [templatable]((/core/concepts/templating.html)) location strings that are used to check for the existence of a task [Result](/core/concepts/results.html). This is useful in cases where you might want a task to only write data to a location once or merely not rerun if some piece of data is present. If a result exists at that location then the task run will enter a cached state. This behavior is commonly referred to as caching in Prefect and it is generally used when you do not want to recompute the result of a task if it already exists and can be retrieved easily.
 
 The flow below will write the result of the first task to a target specified with a filepath of `{task_name}-{today}`. These values are not hardcoded and instead will be interpolated using [templating](/core/concepts/templating.html). This is a powerful construct because it means that only the first run of this task on any given day will run and write the result. Any other runs up until the next calendar day will use the cached result found at `{task_name}-{today}`.

--- a/docs/core/idioms/task-results.md
+++ b/docs/core/idioms/task-results.md
@@ -1,5 +1,9 @@
 # Accessing task results locally
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 When working on your flows locally Prefect makes it easy to retrieve the [results](/core/concepts/results.html) from your individual tasks in the flow. This is done by grabbing the `.result` attribute from [states](/core/concepts/states.html). Calling `flow.run` returns the flow's final state which can be used to retrieve results from all of the tasks in the flow.
 
 ::: warning Local Only

--- a/docs/core/idioms/task-run-names.md
+++ b/docs/core/idioms/task-run-names.md
@@ -1,5 +1,9 @@
 # Naming task runs based on inputs
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Tasks in Prefect provide a way for dynamically naming task runs based on the inputs provided to them from upstream tasks. Creating a dynamic task run name is a great way to help identify errors that may occur in a flow, for example, easily showing which mapped task failed based on the input it received. See [the page on templating](/core/concepts/templating.html) for details on how dynamically templated names work.
 
 ::: warning Backend Only

--- a/docs/core/idioms/testing-flows.md
+++ b/docs/core/idioms/testing-flows.md
@@ -1,5 +1,9 @@
 # Testing Prefect flows and tasks
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Since Prefect flows are Python objects they can be tested in any way you would normally test your Python code! This means that it is common for users to test their flows in unit tests with libraries like [pytest](https://docs.pytest.org/en/latest/). Below runs through a few ways to test your flows and if you want further examples Prefect's [tests directory](https://github.com/PrefectHQ/prefect/tree/master/tests) has thousands of tests that could serve as inspiration for testing your [flows](https://github.com/PrefectHQ/prefect/blob/master/tests/core/test_flow.py) and [tasks](https://github.com/PrefectHQ/prefect/blob/master/tests/core/test_task.py).
 
 Use the following flow as an example:

--- a/docs/core/task_library/contributing.md
+++ b/docs/core/task_library/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Contributing to Prefect's task library is a great way to assist in open source development! Generally
 users have contributed tasks to the task library that accomplish a specific goal or action.
 

--- a/docs/core/task_library/overview.md
+++ b/docs/core/task_library/overview.md
@@ -1,5 +1,9 @@
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Prefect task library is a constantly growing list of pre-defined tasks that provide off-the-shelf
 functionality for working with a wide range of tools anywhere from shell script execution to kubernetes
 job management to sending tweets. A majority of the task library is community supported and thus opens

--- a/docs/core/tutorial/01-etl-before-prefect.md
+++ b/docs/core/tutorial/01-etl-before-prefect.md
@@ -4,11 +4,9 @@ sidebarDepth: 0
 
 # Introduction to ETL
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-
-If you are unsure which Prefect version to choose for your specific use case, [this Prefect Discourse page](https://discourse.prefect.io/t/should-i-start-with-prefect-2-0-orion-skipping-prefect-1-0/544) may help you decide.
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 Before we even `import prefect`, let's begin by reviewing a typical real-life ETL workflow.
 

--- a/docs/core/tutorial/02-etl-flow.md
+++ b/docs/core/tutorial/02-etl-flow.md
@@ -4,9 +4,9 @@ sidebarDepth: 0
 
 # ETL with Prefect
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 In this tutorial, we'll use Prefect to improve the overall structure of the ETL workflow from the [previous tutorial](/core/tutorial/01-etl-before-prefect.html).
 

--- a/docs/core/tutorial/03-parameterized-flow.md
+++ b/docs/core/tutorial/03-parameterized-flow.md
@@ -4,9 +4,9 @@ sidebarDepth: 0
 
 # Adding Parameters
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 ::: tip Follow along in the Terminal
 

--- a/docs/core/tutorial/04-handling-failure.md
+++ b/docs/core/tutorial/04-handling-failure.md
@@ -4,9 +4,9 @@ sidebarDepth: 0
 
 # Handling Failure
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 ::: tip Follow along in the Terminal
 

--- a/docs/core/tutorial/05-running-on-a-schedule.md
+++ b/docs/core/tutorial/05-running-on-a-schedule.md
@@ -3,9 +3,9 @@ sidebarDepth: 0
 ---
 # Running on Schedule
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 ::: tip Follow along in the Terminal
 

--- a/docs/core/tutorial/06-parallel-execution.md
+++ b/docs/core/tutorial/06-parallel-execution.md
@@ -3,9 +3,9 @@ sidebarDepth: 0
 ---
 # Scaling Out
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 ::: tip Follow along in the Terminal
 

--- a/docs/core/tutorial/07-next-steps.md
+++ b/docs/core/tutorial/07-next-steps.md
@@ -1,8 +1,8 @@
 # Next Steps
 
-::: tip Prefect 2
-With general availability of Prefect 2, we recommend new users start with [Prefect 2](https://docs.prefect.io/#getting-started-with-prefect).
-:::
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 In this tutorial we showed how Prefect can be used to improve the behavior of your workflow. However, there is a lot more to Prefect that we didn't cover!
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -577,6 +577,13 @@ if __name__ == "__main__":
                 This API reference is automatically generated from Prefect's source code
                 and unit-tested to ensure it's up to date.
 
+                <div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+                Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? 
+                Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been 
+                released for General Availability. 
+                See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+                </div>
+
                 """
             )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,12 +23,12 @@ footer: Copyright © 2018-present Prefect Technologies, Inc.
 </div>
 
 <div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
-Looking for the latest <a href="https://docs.prefect.io/">Prefect 2.0</a> release? Prefect 2.0 and <a href="https://app.prefect.cloud">Prefect Cloud 2.0</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
 </div>
 
-Prefect 1.0 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.0.
+Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.
 
-If you're ready to start migrating your workflows to Prefect 2.0, see our [migration guide](https://docs.prefect.io/migration-guide/).
+If you're ready to start migrating your workflows to Prefect 2, see our [migration guide](https://docs.prefect.io/migration-guide/).
 
 We recommend starting new projects with [Prefect 2](https://docs.prefect.io/). If you have questions about specific use cases, see our [Prefect Discourse](https://discourse.prefect.io/) discussions for more information.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ footer: Copyright © 2018-present Prefect Technologies, Inc.
 Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
 </div>
 
-Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while migrating users to Prefect 2.
+Prefect 1 Core, Server, and Cloud are our first-generation workflow and orchestration tools. You can continue to use them and we'll continue to support them while users migrate to Prefect 2.
 
 If you're ready to start migrating your workflows to Prefect 2, see our [migration guide](https://docs.prefect.io/migration-guide/).
 

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -3,6 +3,10 @@ title: Welcome
 sidebarDepth: 0
 ---
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 <div align="center" style="margin-top:50px; margin-bottom:40px;">
     <img src="/illustrations/cloud-illustration.svg"  width=300 >
 </div>

--- a/docs/orchestration/agents/docker.md
+++ b/docs/orchestration/agents/docker.md
@@ -1,5 +1,9 @@
 # Docker Agent
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Docker agent executes flow runs in individual Docker containers. This
 provides more isolation and control than the [Local Agent](./local.md), while
 still working well on a single machine.

--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -1,5 +1,9 @@
 # ECS Agent
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The ECS Agent deploys flow runs as [AWS ECS Tasks](https://aws.amazon.com/ecs/)
 on either EC2 or Fargate.
 

--- a/docs/orchestration/agents/kubernetes.md
+++ b/docs/orchestration/agents/kubernetes.md
@@ -1,5 +1,9 @@
 # Kubernetes Agent
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Kubernetes Agent deploys flow runs as [Kubernetes
 Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/). It can
 be run both in-cluster (recommended for production deployments) as well as

--- a/docs/orchestration/agents/local.md
+++ b/docs/orchestration/agents/local.md
@@ -1,5 +1,9 @@
 # Local Agent
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The local agent starts flow runs as processes local to the same machine it is
 running on. It's useful for running lightweight workflows on standalone
 machines, testing flows locally, or quickly getting acclimated with the Prefect

--- a/docs/orchestration/agents/overview.md
+++ b/docs/orchestration/agents/overview.md
@@ -1,5 +1,9 @@
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Agents are lightweight processes for orchestrating flow runs. Agents
 run inside a user's architecture, and are responsible for starting and
 monitoring flow runs. During operation the agent process queries the Prefect

--- a/docs/orchestration/agents/vertex.md
+++ b/docs/orchestration/agents/vertex.md
@@ -1,5 +1,9 @@
 # Vertex Agent
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Vertex Agent executes flow runs as [Vertex Custom Jobs](https://cloud.google.com/vertex-ai/docs/training/create-custom-job).
 Vertex describes these as "training" jobs, but they can be used to run any kind of flow.
 

--- a/docs/orchestration/concepts/api.md
+++ b/docs/orchestration/concepts/api.md
@@ -4,6 +4,10 @@ sidebarDepth: 2
 
 # API
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect exposes a powerful GraphQL API for interacting with the platform and is accessed through `https://api.prefect.io` when using Prefect Cloud or `http://localhost:4200` when using the default Prefect Core setup. There are a variety of ways you can access the API.
 
 ## Authentication <Badge text="Cloud"/>

--- a/docs/orchestration/concepts/api_keys.md
+++ b/docs/orchestration/concepts/api_keys.md
@@ -1,5 +1,9 @@
 # API Keys <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 API keys are how clients authenticate with the Prefect Cloud API.  They encapsulate the identity of a User or a service account.  Ultimately, all clients that interact with the Prefect Cloud API must provide an API key as a Bearer Token included in the request header.
 
 See our [API documentation](api.html) more information on how to use these keys to interact with the GraphQL API.

--- a/docs/orchestration/concepts/artifacts.md
+++ b/docs/orchestration/concepts/artifacts.md
@@ -1,5 +1,9 @@
 # Artifacts
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The [Artifacts API](/api/latest/backend/artifacts.html) enables you to publish data from task runs that is rendered natively in the Prefect UI, both Prefect Cloud and Prefect Server. 
 
 Using the Artifacts API, you can easily publish information directly to the Prefect UI. These published artifacts are linked to specific task runs and flow runs, and artifacts can render more sophisticated information than you'd typically log, such as reports, tables, charts, images, and links to external data.

--- a/docs/orchestration/concepts/automations.md
+++ b/docs/orchestration/concepts/automations.md
@@ -1,5 +1,9 @@
 # Automations <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Automations allow you to configure actions &mdash; such as cancelling a flow run or sending a notification to certain endpoints &mdash; when an event occurs in the Prefect ecosystem.
 
 Automations are a feature of [Prefect Cloud](https://cloud.prefect.io) and are included with all Prefect Cloud plans. Some automation features are available only in Standard plan and above.

--- a/docs/orchestration/concepts/cli.md
+++ b/docs/orchestration/concepts/cli.md
@@ -4,6 +4,10 @@ sidebarDepth: 2
 
 # CLI
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 In conjunction with both the GraphQL API and the UI, Prefect offers a fully-integrated CLI for working with the Prefect API. Using Prefect's GraphQL API as the backbone for communicating with the back end, we have designed the CLI to operate as a wrapper for GraphQL queries and mutations.
 
 For CLI information visit the relevant [API documentation](/api/latest/cli/agent.html)

--- a/docs/orchestration/concepts/cloud_hooks.md
+++ b/docs/orchestration/concepts/cloud_hooks.md
@@ -1,6 +1,10 @@
 
 # Cloud Hooks
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 *Psst! We have recently added [Automations](/orchestration/concepts/automations.html) which offer more functionality than Cloud Hooks and will eventually replace them.*
 
 Cloud Hooks allow you to send notifications to certain endpoints when your flow enters a given state. For example, you can send a Slack message to your team when a production-critical flow has failed, along with the reason for the failure, so you can respond immediately. The Prefect backend API currently supports hooks for Slack, Twilio, Pager Duty, email, and a more general Webhook.

--- a/docs/orchestration/concepts/flows.md
+++ b/docs/orchestration/concepts/flows.md
@@ -1,5 +1,9 @@
 # Flows
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Flows can be registered with the Prefect API for scheduling and execution, as well as management of run histories, logs, and other important metrics.
 
 ## Registration

--- a/docs/orchestration/concepts/kv_store.md
+++ b/docs/orchestration/concepts/kv_store.md
@@ -1,5 +1,9 @@
 # KV Store <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Key Value Store is a managed metadata database for Prefect Cloud.
 
 **Keys** are strings. **Values** are JSON blobs.

--- a/docs/orchestration/concepts/projects.md
+++ b/docs/orchestration/concepts/projects.md
@@ -1,5 +1,9 @@
 # Projects
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Projects are used to organize flows that have been registered with the Prefect API. Each flow is contained within a single project.
 
 ## Creating a project

--- a/docs/orchestration/concepts/secrets.md
+++ b/docs/orchestration/concepts/secrets.md
@@ -1,5 +1,9 @@
 # Secrets
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Secrets provide a common way to store any sensitive values (access
 tokens, passwords, credentials, ...) used by your flows. Storing these values
 external to your flow's source is good practice, and helps keep your

--- a/docs/orchestration/concepts/services.md
+++ b/docs/orchestration/concepts/services.md
@@ -1,5 +1,9 @@
 # Services
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Prefect platform runs a variety of automatic services to ensure workflow semantics are respected robustly.
 
 ## Scheduler

--- a/docs/orchestration/execution/custom_environment.md
+++ b/docs/orchestration/execution/custom_environment.md
@@ -1,5 +1,9 @@
 # Custom Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/dask_cloud_provider_environment.md
+++ b/docs/orchestration/execution/dask_cloud_provider_environment.md
@@ -1,5 +1,9 @@
 # Dask Cloud Provider Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/dask_k8s_environment.md
+++ b/docs/orchestration/execution/dask_k8s_environment.md
@@ -1,5 +1,9 @@
 # Dask Kubernetes Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/fargate_task_environment.md
+++ b/docs/orchestration/execution/fargate_task_environment.md
@@ -1,5 +1,9 @@
 # Fargate Task Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/k8s_job_environment.md
+++ b/docs/orchestration/execution/k8s_job_environment.md
@@ -1,5 +1,9 @@
 # Kubernetes Job Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/local_environment.md
+++ b/docs/orchestration/execution/local_environment.md
@@ -1,5 +1,9 @@
 # Local Environment
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 :::

--- a/docs/orchestration/execution/overview.md
+++ b/docs/orchestration/execution/overview.md
@@ -1,5 +1,9 @@
 # Environments Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 

--- a/docs/orchestration/execution/storage_options.md
+++ b/docs/orchestration/execution/storage_options.md
@@ -1,5 +1,9 @@
 # Storage Options
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: warning
 Flows configured with environments are no longer supported. We recommend users transition to using [RunConfig](/orchestration/flow_config/run_configs.html) instead. See the [Flow Configuration](/orchestration/flow_config/overview.md) and [Upgrading Environments to RunConfig](/orchestration/faq/upgrade_environments.md) documentation for more information.
 

--- a/docs/orchestration/faq/config.md
+++ b/docs/orchestration/faq/config.md
@@ -1,5 +1,9 @@
 # Configuration Options
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 A full list of configuration options can be seen in the Prefect [config.toml](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/config.toml). To update configuration settings you can update them in `./prefect/config.toml` or by setting [environment variables](/core/concepts/configuration.html#environment-variables).
 
 For more on configuration, you can also see the [Prefect Core configuration docs](/core/concepts/configuration.html).

--- a/docs/orchestration/faq/dataflow.md
+++ b/docs/orchestration/faq/dataflow.md
@@ -1,5 +1,9 @@
 # Data Handling in the Hybrid Model
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Cloud's innovative hybrid execution model was designed to satisfy the majority of on-prem needs while still offering a managed platform. In order to achieve this, Prefect was designed to allow users the ability to ensure both their _code_ and their _data_ never leaves their internal ecosystem. This guide will focus on how _data_ moves between tasks and flows in the Prefect Cloud execution model, as well as call out any caveats that might result in data being exposed to Prefect Cloud.
 
 All data being referenced here are the inputs and outputs of Prefect tasks. Note that _all task execution_ occurs in user-controlled infrastructure; consequently, when a task passes data to a downstream task, this data passage occurs _entirely in the user's infrastructure_ as well. The only time data might leave the user's execution infrastructure is when task data is persisted.

--- a/docs/orchestration/faq/debug.md
+++ b/docs/orchestration/faq/debug.md
@@ -3,6 +3,10 @@ sidebarDepth: 2
 ---
 # Debugging Flows running with a Prefect API
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
  [[toc]]
 
 ## My flow is stuck in a `Scheduled` state!

--- a/docs/orchestration/faq/faq.md
+++ b/docs/orchestration/faq/faq.md
@@ -1,5 +1,9 @@
 # Frequently Asked Questions
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The questions listed here are specific to using Prefect to orchestrate flows. The [FAQ in the Core section](/core/faq.html) is for people looking to learn more about Prefect in general.
 
 [[toc]]

--- a/docs/orchestration/faq/upgrade_environments.md
+++ b/docs/orchestration/faq/upgrade_environments.md
@@ -1,5 +1,9 @@
 # Upgrading Environments to RunConfig
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect 0.14.0 included a new Flow configuration system based on
 [RunConfig](../flow_config/run_configs.md) objects. This replaces the previous system based
 on [Environment](/orchestration/execution/overview.md) objects, with

--- a/docs/orchestration/faq/upgrading_1.0.md
+++ b/docs/orchestration/faq/upgrading_1.0.md
@@ -1,5 +1,9 @@
 # Upgrading to Prefect 1.0
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect 1.0 includes some important changes that may require updates to your flow and task definitions. 
 
 Importantly, many features previously marked as deprecated have been removed. This means flows using deprecated features will encounter errors rather than warnings.

--- a/docs/orchestration/flow-runs/concurrency-limits.md
+++ b/docs/orchestration/flow-runs/concurrency-limits.md
@@ -1,5 +1,9 @@
 # Concurrency limits <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ::: tip Standard Tier Feature
 Setting global concurrency limits is a feature of Prefect Cloud's Standard Tier.
 :::

--- a/docs/orchestration/flow-runs/creation.md
+++ b/docs/orchestration/flow-runs/creation.md
@@ -1,5 +1,9 @@
 # Creating flow runs
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Creating a flow run indicates to the backend that you'd like your flow to be executed. The backend will then place your flow run into a queue that agents poll. When your flow run is ready to execute, the agent will deploy the flow run to its infrastructure and the flow run will report its status to the backend.
 
 If you're looking for documentation on how to set up a _schedule_ that creates a flow run repeatedly, see the [scheduling documentation](./scheduling.md)

--- a/docs/orchestration/flow-runs/inspection.md
+++ b/docs/orchestration/flow-runs/inspection.md
@@ -1,5 +1,9 @@
 # Inspecting flow runs
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 For monitoring flow runs from the UI, see the [UI documentation on flow runs](../ui/flow-run.md).
 
 ## Python

--- a/docs/orchestration/flow-runs/overview.md
+++ b/docs/orchestration/flow-runs/overview.md
@@ -5,6 +5,10 @@ editLink: false
 
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 When a flow is run with Prefect Core, it executes locally and its state is not persisted. When a flow is run with a Prefect backend i.e. Prefect Cloud, information about the flow's execution is streamed to the backend for live inspection of your flow's status. This information is persisted for later access. In the Prefect backend, a flow run represents the full picture of your flow's execution from scheduling to completion.
 
 ## Creating flow runs

--- a/docs/orchestration/flow-runs/scheduling.md
+++ b/docs/orchestration/flow-runs/scheduling.md
@@ -1,5 +1,9 @@
 # Scheduling flow runs
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 If a flow has a schedule attached, then the Prefect backend can [automatically create new flow runs](#scheduled-flow-run-creation) according to that schedule.
 
 ::: tip

--- a/docs/orchestration/flow-runs/setting-states.md
+++ b/docs/orchestration/flow-runs/setting-states.md
@@ -1,5 +1,9 @@
 # Setting flow run states
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Sometimes, it's useful to update a flow run state manually.
 
 ### UI

--- a/docs/orchestration/flow-runs/task-runs.md
+++ b/docs/orchestration/flow-runs/task-runs.md
@@ -1,5 +1,9 @@
 # Task runs
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 A task run is created for each task in your flow during a flow run. Like flow runs, task runs have a backend generated unique `id` and their `state` is updated as they are executed.
 
 ::: tip Results

--- a/docs/orchestration/flow_config/docker.md
+++ b/docs/orchestration/flow_config/docker.md
@@ -1,5 +1,9 @@
 # Managing Docker Images
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Several Prefect Agents rely on [Docker images](https://docs.docker.com) for
 distributing dependencies. These include the
 [Docker](/orchestration/agents/docker.md),

--- a/docs/orchestration/flow_config/executors.md
+++ b/docs/orchestration/flow_config/executors.md
@@ -1,5 +1,9 @@
 # Executors
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 A flow's `Executor` is responsible for running tasks in a flow. During
 execution of a flow run, a flow's executor will be initialized, used to execute
 all tasks in the flow, then shutdown.

--- a/docs/orchestration/flow_config/overview.md
+++ b/docs/orchestration/flow_config/overview.md
@@ -1,5 +1,9 @@
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 When deploying flows using Prefect Cloud or Server, flows need some additional
 configuration not used when deploying flows locally:
 

--- a/docs/orchestration/flow_config/run_configs.md
+++ b/docs/orchestration/flow_config/run_configs.md
@@ -1,5 +1,9 @@
 # Run Configuration
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 `RunConfig` objects define where and how a flow run should be executed. Each
 `RunConfig` type has a corresponding Prefect Agent (i.e. `LocalRun` pairs with
 a Local Agent, `DockerRun` pairs with a Docker Agent, ...). The options

--- a/docs/orchestration/flow_config/storage.md
+++ b/docs/orchestration/flow_config/storage.md
@@ -1,5 +1,9 @@
 # Storage
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 `Storage` objects define where a Flow's definition is stored. Examples include
 things like `Local` storage (which uses the local filesystem) or `S3` (which
 stores flows remotely on AWS S3). Flows themselves are never stored directly in

--- a/docs/orchestration/getting-started/basic-core-flow.md
+++ b/docs/orchestration/getting-started/basic-core-flow.md
@@ -1,5 +1,9 @@
 # Run a flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Now that you have Prefect installed, you're ready to run a flow.
 
 A [flow](/core/concepts/flows.html) is a container for [tasks](/core/concepts/tasks.html) and shows the direction of work and the dependencies between tasks.

--- a/docs/orchestration/getting-started/flow-configs.md
+++ b/docs/orchestration/getting-started/flow-configs.md
@@ -1,5 +1,9 @@
 # Flow Configuration
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 So far we've been using the default [flow
 configuration](/orchestration/flow_config/overview.md). When using a Prefect Backend,
 each flow is configured with:

--- a/docs/orchestration/getting-started/install.md
+++ b/docs/orchestration/getting-started/install.md
@@ -1,5 +1,9 @@
 # Installation
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Basic installation
 
 Prefect requires Python 3.7+. If you're new to Python, we recommend installing the [Anaconda distribution](https://www.anaconda.com/distribution/).

--- a/docs/orchestration/getting-started/more-resources.md
+++ b/docs/orchestration/getting-started/more-resources.md
@@ -1,6 +1,10 @@
 
 # More Resources
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Quick Start guide has covered: 
 - Installing Prefect Core
 - Writing a flow

--- a/docs/orchestration/getting-started/next-steps.md
+++ b/docs/orchestration/getting-started/next-steps.md
@@ -1,5 +1,9 @@
 # Parameters & Mapped Tasks
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Writing a flow to greet one person is all good, but if the requirements change, prefect can still help you. Let's say:
 
 - You now need to greet multiple people

--- a/docs/orchestration/getting-started/quick-start.md
+++ b/docs/orchestration/getting-started/quick-start.md
@@ -1,5 +1,9 @@
 # Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This is a Quick Start guide to help you get a basic Prefect flow registered and running on one of our Prefect Cloud or Prefect Core server orchestration layers.  
 
 Because it is a foundational part of running a flow, this guide includes an overview of what is needed to get started with Prefect Core.  If you already have a solid understanding of Prefect Core and want to move on to orchestration, go straight to [using Prefect Cloud or Prefect Core server](/orchestration/getting-started/set-up.md).  

--- a/docs/orchestration/getting-started/registering-and-running-a-flow.md
+++ b/docs/orchestration/getting-started/registering-and-running-a-flow.md
@@ -1,5 +1,9 @@
 # Deploy a Flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Now that your environment is set up, it's time to deploy your flow.
 
 ## Creating a Project

--- a/docs/orchestration/getting-started/set-up.md
+++ b/docs/orchestration/getting-started/set-up.md
@@ -1,5 +1,9 @@
 # Orchestration Layer
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 The Prefect orchestration layer lets you move from running single flows as scripts to running, monitoring, and scheduling many flows through a single web UI. 
 
 Prefect Cloud and the Prefect Server provide ready-to-use backend for maintaining task and flow state and inspecting their progress regardless of where your task and flow code runs.

--- a/docs/orchestration/integrations/pagerduty.md
+++ b/docs/orchestration/integrations/pagerduty.md
@@ -1,5 +1,9 @@
 # PagerDuty + Prefect
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Using the PagerDuty integration with Prefect, you can receive PagerDuty alerts based on events raised by your flow runs and agents.
 
 ## Integration benefits

--- a/docs/orchestration/rbac/overview.md
+++ b/docs/orchestration/rbac/overview.md
@@ -1,5 +1,9 @@
 # Role Based Access Controls <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Cloud has a rich feature set of role based access controls.
 
 **Roles** are used to denote the permissions a user has as part of a team.

--- a/docs/orchestration/recipes/configuring_storage.md
+++ b/docs/orchestration/recipes/configuring_storage.md
@@ -1,5 +1,9 @@
 # Configuring Docker Storage
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This recipe is for configuring your Flow's [Docker storage object](/api/latest/storage.html#docker) to handle potentially complicated non-Python dependencies. This is useful to understand for Flows which rely on complex environments to run successfully; for example if your Flow uses:
 - database drivers
 - reliance on C bindings for file-types such as HDF files

--- a/docs/orchestration/recipes/k8s_dask.md
+++ b/docs/orchestration/recipes/k8s_dask.md
@@ -1,5 +1,9 @@
 # Static Dask Cluster on Kubernetes
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This recipe is for a flow deployed to Kubernetes using a shared static
 [Dask](https://dask.org) cluster. This Dask cluster runs on the same Kubernetes
 cluster that the flow runs on.

--- a/docs/orchestration/recipes/k8s_docker_sidecar.md
+++ b/docs/orchestration/recipes/k8s_docker_sidecar.md
@@ -1,5 +1,9 @@
 # Docker Sidecar on Kubernetes
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This recipe is for a Flow deployed to Kubernetes, making use of a Docker
 sidecar container to pull an image and run a container. This is an adaptation
 of the [Docker Pipeline](../../core/examples/imperative_docker.md) example

--- a/docs/orchestration/recipes/multi_flow_storage.md
+++ b/docs/orchestration/recipes/multi_flow_storage.md
@@ -1,6 +1,10 @@
 
 # Multi Flow Storage
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This recipe is for storing multiple flows inside a single [Docker storage object](/api/latest/storage.html#docker). This is useful when you have a suite of flows that registers off of a CI/CD process or if you want to reduce the number of images stored in a container registry. For this recipe we are going to put two example flows — [ETL](/core/advanced_tutorials/etl.html) and [Map Reduce](/core/concepts/mapping.html#reduce) — inside of the same Docker storage object.
 
 [[toc]]

--- a/docs/orchestration/recipes/third_party_auth.md
+++ b/docs/orchestration/recipes/third_party_auth.md
@@ -1,5 +1,9 @@
 # Third Party Authentication
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 This recipe describes various ways to securely authenticate your flow runs with third party services.
 
 [[toc]]

--- a/docs/orchestration/server/architecture.md
+++ b/docs/orchestration/server/architecture.md
@@ -1,5 +1,9 @@
 # Architecture
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ![Server Architecture](/orchestration/server/server-diagram.svg)
 
 Prefect Server is composed of a few different services:

--- a/docs/orchestration/server/deploy-local.md
+++ b/docs/orchestration/server/deploy-local.md
@@ -1,5 +1,9 @@
 # Deploying to a single node
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Server can be deployed on a single node using [docker-compose](https://docs.docker.com/compose/). 
 
 The easiest way accomplish this is to use the built-in command in the Prefect CLI.

--- a/docs/orchestration/server/overview.md
+++ b/docs/orchestration/server/overview.md
@@ -4,6 +4,10 @@ sidebarDepth: 1
 
 # Server Overview
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 
 [[toc]]
 

--- a/docs/orchestration/server/telemetry.md
+++ b/docs/orchestration/server/telemetry.md
@@ -1,5 +1,9 @@
 # Telemetry
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Prefect Server sends usage telemetry and statistics to Prefect Technologies, Inc. All information collected is anonymous. We use this information to better understand how Prefect Server is used and to ensure that we're supporting active versions.
 
 To opt-out of telemetry, add the following to a prefect server configuration file on the same machine as your Prefect Server instance (wherever you're calling `prefect server start`).

--- a/docs/orchestration/server/troubleshooting.md
+++ b/docs/orchestration/server/troubleshooting.md
@@ -1,5 +1,9 @@
 # Troubleshooting
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Having trouble with Prefect Server? This page contains solutions to common problems.
 
 ## How to know if there's a problem

--- a/docs/orchestration/ui/automations.md
+++ b/docs/orchestration/ui/automations.md
@@ -1,5 +1,9 @@
 # Automations <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Automations allow you to configure actions when an event occurs in the Prefect ecosystem.
 
 ## Overview

--- a/docs/orchestration/ui/dashboard.md
+++ b/docs/orchestration/ui/dashboard.md
@@ -1,5 +1,9 @@
 # Dashboard
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 The UI's dashboard provides an overview of all of your flows. It was designed around a simple question:

--- a/docs/orchestration/ui/flow-run.md
+++ b/docs/orchestration/ui/flow-run.md
@@ -1,5 +1,9 @@
 # Flow Run
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 ![](/orchestration/ui/flowrun-overview.png)

--- a/docs/orchestration/ui/flow.md
+++ b/docs/orchestration/ui/flow.md
@@ -1,5 +1,9 @@
 # Flow
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 The flow overview summarizes each flow's recent behavior. It is a dashboard for a single workflow.

--- a/docs/orchestration/ui/interactive-api.md
+++ b/docs/orchestration/ui/interactive-api.md
@@ -1,5 +1,8 @@
 # Interactive API
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
 
 The Interactive API is an embedded GraphQL client that allows you to access all of your data with complete flexibility. Thanks to features like schema introspection and automatic authentication, the interactive API makes it simple to access all metadata. You can also see the GraphQL API documentation directly inline.
 

--- a/docs/orchestration/ui/task-run.md
+++ b/docs/orchestration/ui/task-run.md
@@ -1,5 +1,9 @@
 # Task Run
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 ## Overview
 
 The task run schematic is an interactive, live-updating look at the progress of this task run and its immediate neighbors. As tasks go through different states, their colors and state messages update accordingly.

--- a/docs/orchestration/ui/team-settings.md
+++ b/docs/orchestration/ui/team-settings.md
@@ -1,5 +1,9 @@
 # Team Settings <Badge text="Cloud"/>
 
+<div style="border: 2px solid #27b1ff; border-radius: 10px; padding: 1em;">
+Looking for the latest <a href="https://docs.prefect.io/">Prefect 2</a> release? Prefect 2 and <a href="https://app.prefect.cloud">Prefect Cloud 2</a> have been released for General Availability. See <a href="https://docs.prefect.io/">https://docs.prefect.io/</a> for details.
+</div>
+
 Teams in Cloud allow you to share your work among users and to assign [roles](/orchestration/rbac/overview.html). Each team member will also have their own (free) Cloud Developer account.
 
 ## Switching Teams


### PR DESCRIPTION
Adds a note at the top of each page _except for generated API docs pages_ directing users to Prefect 2 docs as the most up to date source of information.

Addresses an SEO issue where search results for common Prefect nomenclature may rank an older Prefect 1 doc page over Prefect 2 docs.

Note: I did not attempt to add the note to pages generated from source code. If that is desired, we can handle in a separate PR.

### Example

[Preview](https://deploy-preview-8335--prefect-docs.netlify.app/core/)

![v1banner](https://user-images.githubusercontent.com/370316/215892990-bfe93f7f-672a-4bf7-8d97-e4d82e2799e0.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
