### PR TITLE
Add getting started tutorial video to Prefect Cloud Quickstart

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -60,6 +60,12 @@ img {
     margin-bottom: 0;
 }
 
+.video-wrapper {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    filter: drop-shadow(0.2rem 0.2rem 0.3rem rgba(0,0,0,0.2))
+}
+
 /* push "go to prefect cloud" */
 .cloud-link {
     margin-left: auto;

--- a/docs/ui/cloud-quickstart.md
+++ b/docs/ui/cloud-quickstart.md
@@ -21,6 +21,12 @@ Get signed in and using Prefect Cloud, including running a flow observed by Pref
 1. [Log into Prefect Cloud](#log-into-prefect-cloud-from-a-terminal) from a local terminal session.
 1. [Run a flow](#run-a-flow-with-prefect-cloud) locally and view flow run execution in Prefect Cloud.
 
+Prefer to follow this tutorial in a video? We've got exactly what you need. Happy engineering!
+
+<div class="video-wrapper">
+  <iframe width="100%" height="500" src="https://www.youtube.com/embed/vOpmE5w0XuU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
 ## Sign in or register
 
 To sign in with an existing account or register an account, go to [https://app.prefect.cloud/](https://app.prefect.cloud/).

--- a/docs/ui/cloud.md
+++ b/docs/ui/cloud.md
@@ -15,6 +15,9 @@ tags:
 
 Prefect Cloud is a workflow coordination-as-a-service platform. Prefect Cloud provides all the capabilities of the [Prefect Orion Server](https://docs.prefect.io/tutorials/orion/?h=server#running-the-prefect-server) and [UI](/ui/overview/) in a hosted environment, plus additional features such as automations, workspaces, and organizations.
 
+!!! success "Prefect Cloud Quickstart"
+    Ready to jump right in and start running flows that are monitored by Prefect Cloud? See the [Prefect Cloud Quickstart](/ui/cloud-quickstart/) to create a workspace, configure a local execution environment, and write your first Prefect Cloud-monitored flow run.
+
 ![Viewing a workspace dashboard in the Prefect Cloud UI.](../img/ui/cloud-workspace-dashboard.png)
 
 Prefect Cloud includes the same features as the open-source Prefect Orion server, including:
@@ -42,9 +45,6 @@ Prefect Cloud includes the same features as the open-source Prefect Orion server
     - [Single Sign-on (SSO)](/ui/sso/) &mdash; authentication using your identity provider.
     - [Audit Log](/ui/audit-log/) &mdash; a record of user activities to monitor security and compliance.
     - Collaborators &mdash; invite others to work in your [workspace](/ui/workspaces/#workspace-collaborators) or [organization](/ui/organizations/#organization-members).
-
-!!! success "Prefect Cloud Quickstart"
-    Ready to jump right in and start running flows that are monitored by Prefect Cloud? See the [Prefect Cloud Quickstart](/ui/cloud-quickstart/) to create a workspace, configure a local execution environment, and write your first Prefect Cloud-monitored flow run.
 
 ## User accounts
 


### PR DESCRIPTION
Adds a getting started video to the Prefect Cloud Quickstart page.

Moves around a few other bits to emphasize getting started content.

### Example

[Preview](https://deploy-preview-8336--prefect-orion.netlify.app/ui/cloud-quickstart/)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
