### PR TITLE
Enables updates to work queue `last_polled` time when polling work pools

### DIFF
--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -4,6 +4,7 @@ Routes for interacting with work queue objects.
 from typing import List
 from uuid import UUID
 
+import pendulum
 import sqlalchemy as sa
 from fastapi import BackgroundTasks, Body, Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -304,7 +305,7 @@ async def get_scheduled_flow_runs(
         background_tasks.add_task(
             _record_work_queue_polls,
             db=db,
-            work_pool_name=work_pool_name,
+            work_pool_id=work_pool_id,
             work_queue_names=work_queue_names,
         )
 
@@ -313,7 +314,7 @@ async def get_scheduled_flow_runs(
 
 async def _record_work_queue_polls(
     db: OrionDBInterface,
-    work_pool_id: str,
+    work_pool_id: UUID,
     work_queue_names: List[str],
 ):
     """

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -5,7 +5,7 @@ from typing import List
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import Body, Depends, HTTPException, Path, status
+from fastapi import BackgroundTasks, Body, Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.orion.api.dependencies as dependencies
@@ -255,6 +255,7 @@ async def delete_work_pool(
 
 @router.post("/{name}/get_scheduled_flow_runs")
 async def get_scheduled_flow_runs(
+    background_tasks: BackgroundTasks,
     work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     work_queue_names: List[str] = Body(
         None, description="The names of work pool queues"
@@ -300,7 +301,49 @@ async def get_scheduled_flow_runs(
             limit=limit,
         )
 
+        background_tasks.add_task(
+            _record_work_queue_polls,
+            db=db,
+            work_pool_name=work_pool_name,
+            work_queue_names=work_queue_names,
+        )
+
         return queue_response
+
+
+async def _record_work_queue_polls(
+    db: OrionDBInterface,
+    work_pool_id: str,
+    work_queue_names: List[str],
+):
+    """
+    Records that a set of work queues have been polled.
+
+    If no work queue names are provided, all work queues in the work pool are recorded as polled.
+    """
+    async with db.session_context(begin_transaction=True) as session:
+
+        work_queue_filter = (
+            schemas.filters.WorkQueueFilter(
+                name=schemas.filters.WorkQueueFilterName(any_=work_queue_names)
+            )
+            if work_queue_names
+            else None
+        )
+        work_queues = await models.workers.read_work_queues(
+            session=session,
+            work_pool_id=work_pool_id,
+            work_queue_filter=work_queue_filter,
+        )
+
+        for work_queue in work_queues:
+            await models.workers.update_work_queue(
+                session=session,
+                work_queue_id=work_queue.id,
+                work_queue=schemas.actions.WorkQueueUpdate(
+                    last_polled=pendulum.now("UTC")
+                ),
+            )
 
 
 # -----------------------------------------------------

--- a/tests/orion/api/test_workers.py
+++ b/tests/orion/api/test_workers.py
@@ -757,3 +757,88 @@ class TestGetScheduledRuns:
             List[schemas.responses.WorkerFlowRunResponse], response.json()
         )
         assert len(data) == 0
+
+    async def test_updates_last_polled_on_a_single_work_queue(
+        self, client, work_queues, work_pools
+    ):
+        now = pendulum.now()
+        poll_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/get_scheduled_flow_runs",
+            json=dict(work_queue_names=[work_queues["wq_aa"].name]),
+        )
+        assert poll_response.status_code == status.HTTP_200_OK
+
+        work_queue_response = await client.get(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/queues/{work_queues['wq_aa'].name}"
+        )
+        assert work_queue_response.status_code == status.HTTP_200_OK
+
+        work_queue = pydantic.parse_obj_as(WorkQueue, work_queue_response.json())
+        work_queues_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/queues/filter"
+        )
+        assert work_queues_response.status_code == status.HTTP_200_OK
+
+        work_queues = pydantic.parse_obj_as(
+            List[WorkQueue], work_queues_response.json()
+        )
+
+        for work_queue in work_queues:
+            if work_queue.name == "AA":
+                assert work_queue.last_polled is not None
+                assert work_queue.last_polled > now
+            else:
+                assert work_queue.last_polled is None
+
+    async def test_updates_last_polled_on_a_multiple_work_queues(
+        self, client, work_queues, work_pools
+    ):
+        now = pendulum.now()
+        poll_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/get_scheduled_flow_runs",
+            json=dict(
+                work_queue_names=[
+                    work_queues["wq_aa"].name,
+                    work_queues["wq_ab"].name,
+                ]
+            ),
+        )
+        assert poll_response.status_code == status.HTTP_200_OK
+
+        work_queues_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/queues/filter"
+        )
+        assert work_queues_response.status_code == status.HTTP_200_OK
+
+        work_queues = pydantic.parse_obj_as(
+            List[WorkQueue], work_queues_response.json()
+        )
+
+        for work_queue in work_queues:
+            if work_queue.name == "AA" or work_queue.name == "AB":
+                assert work_queue.last_polled is not None
+                assert work_queue.last_polled > now
+            else:
+                assert work_queue.last_polled is None
+
+    async def test_updates_last_polled_on_a_full_work_pool(
+        self, client, work_queues, work_pools
+    ):
+        now = pendulum.now()
+        poll_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/get_scheduled_flow_runs",
+        )
+        assert poll_response.status_code == status.HTTP_200_OK
+
+        work_queues_response = await client.post(
+            f"/experimental/work_pools/{work_pools['wp_a'].name}/queues/filter"
+        )
+        assert work_queues_response.status_code == status.HTTP_200_OK
+
+        work_queues = pydantic.parse_obj_as(
+            List[WorkQueue], work_queues_response.json()
+        )
+
+        for work_queue in work_queues:
+            assert work_queue.last_polled is not None
+            assert work_queue.last_polled > now


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds logic to the get scheduled flow runs endpoint so that work queues that are polled for work from that endpoint have their `last_polled` timestamp updated. If any work queues are specified when polling this endpoint, only the `last_polled` timestamp of those work queues will updated. If an entire work pool is being polled, all the work queues in the work pool will have their `last_polled` timestamp updated.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
