### PR TITLE
Introduces the Prefect Cloud Events schema and clients.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,5 @@ sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0
 toml >= 0.10.0
 typer >= 0.4.2
 typing_extensions >= 4.1.0
-uvicorn  >= 0.14.0
+uvicorn >= 0.14.0
+websockets >= 10.4

--- a/src/prefect/events/__init__.py
+++ b/src/prefect/events/__init__.py
@@ -1,0 +1,1 @@
+from .schemas import Event, Resource, RelatedResource

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -1,0 +1,191 @@
+import abc
+import asyncio
+from types import TracebackType
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type
+
+from websockets.client import WebSocketClientProtocol, connect
+from websockets.exceptions import ConnectionClosed
+
+from prefect.events import Event
+
+
+class EventsClient(abc.ABC):
+    """The abstract interface for all Prefect Events clients"""
+
+    @abc.abstractmethod
+    async def emit(self, event: Event) -> None:  # pragma: no cover
+        """Emit a single event"""
+
+    def _require_context(self) -> None:
+        if not hasattr(self, "_in_context"):
+            raise TypeError(
+                "Events may only be emitted while this client is being used as a "
+                "context manager"
+            )
+
+    async def __aenter__(self) -> "EventsClient":
+        self._in_context = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        del self._in_context
+        return None
+
+
+class NullEventsClient(EventsClient):
+    """A Prefect Events client implementation that does nothing"""
+
+    async def emit(self, event: Event) -> None:
+        """Emit a single event"""
+        self._require_context()
+
+
+class AssertingEventsClient(EventsClient):
+    """A Prefect Events client that records all events sent to it for inspection during
+    tests."""
+
+    last: ClassVar["AssertingEventsClient | None"] = None
+    all: ClassVar[List["AssertingEventsClient"]] = []
+
+    args: Tuple
+    kwargs: Dict[str, Any]
+    events: List[Event]
+
+    def __init__(self, *args, **kwargs):
+        AssertingEventsClient.last = self
+        AssertingEventsClient.all.append(self)
+        self.args = args
+        self.kwargs = kwargs
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset all captured instances and their events.  For use this between tests"""
+        cls.last = None
+        cls.all = []
+
+    async def emit(self, event: Event) -> None:
+        """Emit a single event"""
+        self._require_context()
+        self.events.append(event)
+
+    async def __aenter__(self) -> "AssertingEventsClient":
+        await super().__aenter__()
+        self.events = []
+        return self
+
+
+class PrefectCloudEventsClient(EventsClient):
+    """A Prefect Events client that streams Events to a Prefect Cloud Workspace"""
+
+    _websocket: Optional[WebSocketClientProtocol]
+    _unconfirmed_events: List[Event]
+
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        reconnection_attempts: int = 10,
+        checkpoint_every: int = 20,
+    ):
+        """
+        Args:
+            api_url: The base URL for a Prefect Cloud workspace
+            api_key: The API of an actor with the manage_events scope
+            reconnection_attempts: When the client is disconnected, how many times
+                the client should attempt to reconnect
+            checkpoint_every: How often the client should sync with the server to
+                confirm receipt of all previously sent events
+        """
+        socket_url = api_url.replace("https://", "wss://").replace("http://", "ws://")
+        self._connect = connect(
+            socket_url + "/events/in",
+            extra_headers={"Authorization": f"bearer {api_key}"},
+        )
+        self._websocket = None
+        self._reconnection_attempts = reconnection_attempts
+        self._unconfirmed_events = []
+        self._checkpoint_every = checkpoint_every
+
+    async def __aenter__(self) -> "PrefectCloudEventsClient":
+        # Don't handle any errors in the initial connection, because these are most
+        # likely a permission or configuration issue that should propagate
+        await super().__aenter__()
+        await self._reconnect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self._websocket = None
+        await self._connect.__aexit__(exc_type, exc_val, exc_tb)
+        return await super().__aexit__(exc_type, exc_val, exc_tb)
+
+    async def _reconnect(self) -> None:
+        if self._websocket:
+            self._websocket = None
+            await self._connect.__aexit__(None, None, None)
+
+        self._websocket = await self._connect.__aenter__()
+
+        # make sure we have actually connected
+        pong = await self._websocket.ping()
+        await pong
+
+        events_to_resend = self._unconfirmed_events
+        # Clear the unconfirmed events here, because they are going back through emit
+        # and will be added again through the normal checkpointing process
+        self._unconfirmed_events = []
+        for event in events_to_resend:
+            await self.emit(event)
+
+    async def _checkpoint(self, event: Event) -> None:
+        assert self._websocket
+
+        self._unconfirmed_events.append(event)
+
+        unconfirmed_count = len(self._unconfirmed_events)
+        if unconfirmed_count < self._checkpoint_every:
+            return
+
+        pong = await self._websocket.ping()
+        await pong
+
+        # once the pong returns, we know for sure that we've sent all the messages
+        # we had enqueued prior to that.  There could be more that came in after, so
+        # don't clear the list, just the ones that we are sure of.
+        self._unconfirmed_events = self._unconfirmed_events[unconfirmed_count:]
+
+    async def emit(self, event: Event) -> None:
+        self._require_context()
+        assert self._websocket
+
+        for i in range(self._reconnection_attempts + 1):
+            try:
+                # after the first time through this loop, we're recovering from a
+                # ConnectionClosed, so reconnect now, resending any unconfirmed
+                # events before we send this one.
+                if i > 0:
+                    await self._reconnect()
+
+                await self._websocket.send(event.json())
+                await self._checkpoint(event)
+
+                return
+            except ConnectionClosed:
+                if i == self._reconnection_attempts:
+                    # this was our final chance, raise the most recent error
+                    raise
+
+                if i > 2:
+                    # let the first two attempts happen quickly in case this is just
+                    # a standard load balancer timeout, but after that, just take a
+                    # beat to let things come back around.
+                    await asyncio.sleep(1)

--- a/src/prefect/events/schemas.py
+++ b/src/prefect/events/schemas.py
@@ -1,0 +1,125 @@
+from typing import Any, Dict, Iterable, List, Tuple, cast
+from uuid import UUID, uuid4
+
+import pendulum
+from pydantic import Field, root_validator, validator
+
+from prefect.orion.utilities.schemas import DateTimeTZ, PrefectBaseModel
+
+# These are defined by Prefect Cloud
+MAXIMUM_LABELS_PER_RESOURCE = 500
+MAXIMUM_RELATED_RESOURCES = 500
+
+
+class Labelled(PrefectBaseModel):
+    """An object defined by string labels and values"""
+
+    __root__: Dict[str, str]
+
+    def keys(self) -> Iterable[str]:
+        return self.__root__.keys()
+
+    def items(self) -> Iterable[Tuple[str, str]]:
+        return self.__root__.items()
+
+    def __getitem__(self, label: str) -> str:
+        return self.__root__[label]
+
+
+class Resource(Labelled):
+    """An observable business object of interest to the user"""
+
+    @root_validator(pre=True)
+    def enforce_maximum_labels(cls, values: Dict[str, Any]):
+        labels = values.get("__root__")
+        if not isinstance(labels, dict):
+            return values
+
+        if len(labels) > MAXIMUM_LABELS_PER_RESOURCE:
+            raise ValueError(
+                "The maximum number of labels per resource "
+                f"is {MAXIMUM_LABELS_PER_RESOURCE}"
+            )
+
+        return values
+
+    @root_validator(pre=True)
+    def requires_resource_id(cls, values: Dict[str, Any]):
+        labels = values.get("__root__")
+        if not isinstance(labels, dict):
+            return values
+
+        labels = cast(Dict[str, str], labels)
+
+        if "prefect.resource.id" not in labels:
+            raise ValueError("Resources must include the prefect.resource.id label")
+        if not labels["prefect.resource.id"]:
+            raise ValueError("The prefect.resource.id label must be non-empty")
+
+        return values
+
+    @property
+    def id(self) -> str:
+        return self["prefect.resource.id"]
+
+
+class RelatedResource(Resource):
+    """A Resource with a specific role in an Event"""
+
+    @root_validator(pre=True)
+    def requires_resource_role(cls, values: Dict[str, Any]):
+        labels = values.get("__root__")
+        if not isinstance(labels, dict):
+            return values
+
+        labels = cast(Dict[str, str], labels)
+
+        if "prefect.resource.role" not in labels:
+            raise ValueError(
+                "Related Resources must include the prefect.resource.role label"
+            )
+        if not labels["prefect.resource.role"]:
+            raise ValueError("The prefect.resource.role label must be non-empty")
+
+        return values
+
+    @property
+    def role(self) -> str:
+        return self["prefect.resource.role"]
+
+
+class Event(PrefectBaseModel):
+    """The client-side view of an event that has happened to a Resource"""
+
+    occurred: DateTimeTZ = Field(
+        default_factory=pendulum.now,
+        description="When the event happened from the sender's perspective",
+    )
+    event: str = Field(
+        description="The name of the event that happened",
+    )
+    resource: Resource = Field(
+        description="The primary Resource this event concerns",
+    )
+    related: List[RelatedResource] = Field(
+        default_factory=list,
+        description="A list of additional Resources involved in this event",
+    )
+    payload: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="An open-ended set of data describing what happened",
+    )
+    id: UUID = Field(
+        default_factory=uuid4,
+        description="The client-provided identifier of this event",
+    )
+
+    @validator("related")
+    def enforce_maximum_related_resources(cls, value: List[RelatedResource]):
+        if len(value) > MAXIMUM_RELATED_RESOURCES:
+            raise ValueError(
+                "The maximum number of related resources "
+                f"is {MAXIMUM_RELATED_RESOURCES}"
+            )
+
+        return value

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -1,0 +1,55 @@
+import pendulum
+import pytest
+
+from prefect.events import Event
+from prefect.events.clients import AssertingEventsClient
+
+
+@pytest.fixture(autouse=True)
+def reset_asserting_events_client():
+    AssertingEventsClient.reset()
+
+
+@pytest.fixture
+def start_of_test() -> pendulum.DateTime:
+    return pendulum.now("UTC")
+
+
+@pytest.fixture
+def example_event_1() -> Event:
+    return Event(
+        event="marvelous.things.happened",
+        resource={"prefect.resource.id": "something-valuable"},
+    )
+
+
+@pytest.fixture
+def example_event_2() -> Event:
+    return Event(
+        event="wonderous.things.happened",
+        resource={"prefect.resource.id": "something-valuable"},
+    )
+
+
+@pytest.fixture
+def example_event_3() -> Event:
+    return Event(
+        event="delightful.things.happened",
+        resource={"prefect.resource.id": "something-valuable"},
+    )
+
+
+@pytest.fixture
+def example_event_4() -> Event:
+    return Event(
+        event="ingenious.things.happened",
+        resource={"prefect.resource.id": "something-valuable"},
+    )
+
+
+@pytest.fixture
+def example_event_5() -> Event:
+    return Event(
+        event="delectable.things.happened",
+        resource={"prefect.resource.id": "something-valuable"},
+    )

--- a/tests/events/test_cloud_events_client.py
+++ b/tests/events/test_cloud_events_client.py
@@ -1,0 +1,178 @@
+from typing import AsyncGenerator, List, Optional
+from uuid import UUID
+
+import pytest
+from websockets.exceptions import ConnectionClosed
+from websockets.legacy.server import WebSocketServer, WebSocketServerProtocol, serve
+
+from prefect.events import Event
+from prefect.events.clients import PrefectCloudEventsClient
+
+
+class Recorder:
+    connections: int
+    path: Optional[str]
+    events: List[Event]
+
+    def __init__(self):
+        self.connections = 0
+        self.path = None
+        self.events = []
+
+
+class Puppeteer:
+    refuse_any_further_connections: bool
+    hard_disconnect_after: Optional[UUID]
+
+    def __init__(self):
+        self.refuse_any_further_connections = False
+        self.hard_disconnect_after = None
+
+
+@pytest.fixture
+def recorder() -> Recorder:
+    return Recorder()
+
+
+@pytest.fixture
+def puppeteer() -> Puppeteer:
+    return Puppeteer()
+
+
+@pytest.fixture
+async def events_server(
+    unused_tcp_port: int, recorder: Recorder, puppeteer: Puppeteer
+) -> AsyncGenerator[WebSocketServer, None]:
+    server: WebSocketServer
+
+    async def handler(socket: WebSocketServerProtocol, path: str) -> None:
+        recorder.connections += 1
+        if puppeteer.refuse_any_further_connections:
+            raise ValueError("nope")
+
+        recorder.path = path
+
+        while True:
+            try:
+                message = await socket.recv()
+            except ConnectionClosed:
+                return
+
+            event = Event.parse_raw(message)
+            recorder.events.append(event)
+
+            if puppeteer.hard_disconnect_after == event.id:
+                raise ValueError("zonk")
+
+    async with serve(handler, host="localhost", port=unused_tcp_port) as server:
+        yield server
+
+
+@pytest.fixture
+def api_url(events_server: WebSocketServer, unused_tcp_port: int) -> str:
+    return f"http://localhost:{unused_tcp_port}/accounts/A/workspaces/W"
+
+
+async def test_cloud_client_can_connect_and_emit(
+    api_url: str, example_event_1: Event, recorder: Recorder
+):
+    async with PrefectCloudEventsClient(api_url, "my-token") as client:
+        await client.emit(example_event_1)
+
+    assert recorder.connections == 1
+    assert recorder.path == "/accounts/A/workspaces/W/events/in"
+    assert recorder.events == [example_event_1]
+
+
+async def test_reconnects_and_resends_after_hard_disconnect(
+    api_url: str,
+    example_event_1: Event,
+    example_event_2: Event,
+    example_event_3: Event,
+    example_event_4: Event,
+    example_event_5: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+):
+    client = PrefectCloudEventsClient(api_url, "my-token", checkpoint_every=1)
+    async with client:
+        assert recorder.connections == 1
+
+        await client.emit(example_event_1)
+
+        puppeteer.hard_disconnect_after = example_event_2.id
+        await client.emit(example_event_2)
+
+        await client.emit(example_event_3)
+        await client.emit(example_event_4)
+        await client.emit(example_event_5)
+
+    assert recorder.connections == 2
+    assert recorder.events == [
+        example_event_1,
+        example_event_2,
+        example_event_3,
+        example_event_3,  # resent due to the hard disconnect after event 2
+        example_event_4,
+        example_event_5,
+    ]
+
+
+@pytest.mark.parametrize("attempts", [4, 1, 0])
+async def test_gives_up_after_a_certain_amount_of_tries(
+    api_url: str,
+    example_event_1: Event,
+    example_event_2: Event,
+    example_event_3: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+    attempts: int,
+):
+    client = PrefectCloudEventsClient(
+        api_url, "my-token", checkpoint_every=1, reconnection_attempts=attempts
+    )
+    async with client:
+        assert recorder.connections == 1
+
+        await client.emit(example_event_1)
+
+        puppeteer.hard_disconnect_after = example_event_2.id
+        puppeteer.refuse_any_further_connections = True
+        await client.emit(example_event_2)
+
+        with pytest.raises(ConnectionClosed):
+            await client.emit(example_event_3)
+
+    assert recorder.connections == 1 + attempts
+    assert recorder.events == [
+        example_event_1,
+        example_event_2,
+    ]
+
+
+async def test_giving_up_after_negative_one_tries_is_a_noop(
+    api_url: str,
+    example_event_1: Event,
+    example_event_2: Event,
+    example_event_3: Event,
+    recorder: Recorder,
+    puppeteer: Puppeteer,
+):
+    """This is a nonsensical configuration, but covers a branch of client.emit where
+    the primary reconnection loop does nothing (not even sending events)"""
+    client = PrefectCloudEventsClient(
+        api_url, "my-token", checkpoint_every=1, reconnection_attempts=-1
+    )
+    async with client:
+        assert recorder.connections == 1
+
+        await client.emit(example_event_1)
+
+        puppeteer.hard_disconnect_after = example_event_2.id
+        puppeteer.refuse_any_further_connections = True
+        await client.emit(example_event_2)
+
+        await client.emit(example_event_3)
+
+    assert recorder.connections == 1
+    assert recorder.events == []

--- a/tests/events/test_event_schemas.py
+++ b/tests/events/test_event_schemas.py
@@ -1,0 +1,124 @@
+import json
+from uuid import UUID, uuid4
+
+import pendulum
+import pytest
+from pendulum.datetime import DateTime
+from pydantic import ValidationError
+
+from prefect.events import Event, RelatedResource, Resource
+
+
+def test_client_events_generate_an_id_by_default():
+    event1 = Event(event="hello", resource={"prefect.resource.id": "hello"})
+    event2 = Event(event="hello", resource={"prefect.resource.id": "hello"})
+    assert isinstance(event1.id, UUID)
+    assert isinstance(event2.id, UUID)
+    assert event1.id != event2.id
+
+
+def test_client_events_generate_occurred_by_default(start_of_test: DateTime):
+    event = Event(event="hello", resource={"prefect.resource.id": "hello"})
+    assert start_of_test <= event.occurred <= pendulum.now()
+
+
+def test_client_events_may_have_empty_related_resources():
+    event = Event(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "hello"},
+        id=uuid4(),
+    )
+    assert event.related == []
+
+
+def test_client_event_resources_have_correct_types():
+    event = Event(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "hello"},
+        related=[
+            {"prefect.resource.id": "related-1", "prefect.resource.role": "role-1"},
+        ],
+        id=uuid4(),
+    )
+    assert isinstance(event.resource, Resource)
+    assert isinstance(event.related[0], Resource)
+    assert isinstance(event.related[0], RelatedResource)
+
+
+def test_client_events_may_have_multiple_related_resources():
+    event = Event(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "hello"},
+        related=[
+            {"prefect.resource.id": "related-1", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-2", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-3", "prefect.resource.role": "role-2"},
+        ],
+        id=uuid4(),
+    )
+    assert event.related[0].id == "related-1"
+    assert event.related[0].role == "role-1"
+    assert event.related[1].id == "related-2"
+    assert event.related[1].role == "role-1"
+    assert event.related[2].id == "related-3"
+    assert event.related[2].role == "role-2"
+
+
+def test_json_representation():
+    event = Event(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "hello"},
+        related=[
+            {"prefect.resource.id": "related-1", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-2", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-3", "prefect.resource.role": "role-2"},
+        ],
+        payload={"hello": "world"},
+        id=uuid4(),
+    )
+
+    jsonified = json.loads(event.json().encode())
+
+    assert jsonified == {
+        "occurred": event.occurred.isoformat(),
+        "event": "hello",
+        "resource": {"prefect.resource.id": "hello"},
+        "related": [
+            {"prefect.resource.id": "related-1", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-2", "prefect.resource.role": "role-1"},
+            {"prefect.resource.id": "related-3", "prefect.resource.role": "role-2"},
+        ],
+        "payload": {"hello": "world"},
+        "id": str(event.id),
+    }
+
+
+def test_limit_on_labels(monkeypatch: pytest.MonkeyPatch):
+    labels = {"prefect.resource.id": "the.thing"}
+    labels.update({str(i): str(i) for i in range(10)})
+
+    monkeypatch.setattr("prefect.events.schemas.MAXIMUM_LABELS_PER_RESOURCE", 10)
+    with pytest.raises(ValidationError, match="maximum number of labels"):
+        Resource(__root__=labels)
+
+
+def test_limit_on_related_resources(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("prefect.events.schemas.MAXIMUM_RELATED_RESOURCES", 10)
+    with pytest.raises(ValidationError, match="maximum number of related"):
+        Event(
+            occurred=pendulum.now("UTC"),
+            event="anything",
+            resource={"prefect.resource.id": "the.thing"},
+            related=[
+                {
+                    "prefect.resource.id": f"another.thing.{i}",
+                    "prefect.resource.role": "related",
+                }
+                for i in range(11)
+            ],
+            id=uuid4(),
+        )

--- a/tests/events/test_resource_schemas.py
+++ b/tests/events/test_resource_schemas.py
@@ -1,0 +1,230 @@
+import json
+from typing import Type
+
+import pytest
+from pydantic import ValidationError
+
+from prefect.events import RelatedResource, Resource
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_root_is_required(resource_class: Type[Resource]) -> None:
+    with pytest.raises(ValidationError) as error:
+        resource_class(__root__=None)
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "none is not an allowed value",
+            "type": "type_error.none.not_allowed",
+        }
+    ]
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_root_is_a_dictionary(resource_class: Type[Resource]) -> None:
+    with pytest.raises(ValidationError) as error:
+        resource_class(__root__=11)
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "value is not a valid dict",
+            "type": "type_error.dict",
+        }
+    ]
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_requires_resource_id(resource_class: Type[Resource]) -> None:
+    with pytest.raises(ValidationError) as error:
+        resource_class(
+            __root__={
+                "prefect.resource.role": "any-role",
+            }
+        )
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "Resources must include the prefect.resource.id label",
+            "type": "value_error",
+        }
+    ]
+
+
+def test_related_resources_require_role() -> None:
+    with pytest.raises(ValidationError) as error:
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": "my.unique.resource",
+            }
+        )
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "Related Resources must include the prefect.resource.role label",
+            "type": "value_error",
+        },
+    ]
+
+
+def test_related_resources_require_non_empty_role() -> None:
+    with pytest.raises(ValidationError) as error:
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": "my.unique.resource",
+                "prefect.resource.role": None,
+            }
+        )
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "The prefect.resource.role label must be non-empty",
+            "type": "value_error",
+        },
+    ]
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_requires_non_empty_resource_id(
+    resource_class: Type[Resource],
+) -> None:
+    with pytest.raises(ValidationError) as error:
+        resource_class(
+            __root__={
+                "prefect.resource.id": None,
+                "prefect.resource.role": "any-role",
+            }
+        )
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__",),
+            "msg": "The prefect.resource.id label must be non-empty",
+            "type": "value_error",
+        }
+    ]
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_disallows_none_values(resource_class: Type[Resource]) -> None:
+    with pytest.raises(ValidationError) as error:
+        resource_class(
+            __root__={
+                "prefect.resource.id": "my.unique.resource",
+                "prefect.resource.role": "any-role",
+                "another.thing": None,
+            }
+        )
+
+    assert error.value.errors() == [
+        {
+            "loc": ("__root__", "another.thing"),
+            "msg": "none is not an allowed value",
+            "type": "type_error.none.not_allowed",
+        },
+    ]
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_coerces_other_values(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+            "another.thing": 5,
+        }
+    )
+    assert resource["another.thing"] == "5"
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resources_support_indexing(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+            "this.thing": "hello",
+            "that.thing": "world",
+        }
+    )
+    assert resource["this.thing"] == "hello"
+    assert resource["that.thing"] == "world"
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_id_shortcut(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+        }
+    )
+    assert resource.id == "my.unique.resource"
+
+
+def test_resource_role_shortcut() -> None:
+    resource = RelatedResource(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+        }
+    )
+    assert resource.role == "any-role"
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_labels_are_iterable(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+            "hello": "world",
+            "goodbye": "moon",
+        }
+    )
+    assert set(resource.keys()) == {
+        "prefect.resource.id",
+        "prefect.resource.role",
+        "hello",
+        "goodbye",
+    }
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resource_label_pairs_are_iterable(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+            "hello": "world",
+            "goodbye": "moon",
+        }
+    )
+    assert set(resource.items()) == {
+        ("prefect.resource.id", "my.unique.resource"),
+        ("prefect.resource.role", "any-role"),
+        ("hello", "world"),
+        ("goodbye", "moon"),
+    }
+
+
+@pytest.mark.parametrize("resource_class", [Resource, RelatedResource])
+def test_resources_export_to_simple_dicts(resource_class: Type[Resource]) -> None:
+    resource = resource_class(
+        __root__={
+            "prefect.resource.id": "my.unique.resource",
+            "prefect.resource.role": "any-role",
+            "hello": "world",
+            "goodbye": "moon",
+        }
+    )
+    assert json.loads(resource.json()) == {
+        "prefect.resource.id": "my.unique.resource",
+        "prefect.resource.role": "any-role",
+        "hello": "world",
+        "goodbye": "moon",
+    }

--- a/tests/events/test_utility_events_clients.py
+++ b/tests/events/test_utility_events_clients.py
@@ -1,0 +1,53 @@
+from typing import Type
+
+import pytest
+
+from prefect.events import Event
+from prefect.events.clients import AssertingEventsClient, EventsClient, NullEventsClient
+
+
+async def test_null_events_client_does_nothing(example_event_1: Event):
+    async with NullEventsClient() as client:
+        await client.emit(example_event_1)
+
+
+async def test_asserting_events_client_records_instances():
+    client1 = AssertingEventsClient()
+    assert AssertingEventsClient.last is client1
+
+    client2 = AssertingEventsClient()
+    assert AssertingEventsClient.last is client2
+
+    assert AssertingEventsClient.all == [client1, client2]
+
+
+def test_asserting_events_client_captures_arguments():
+    client = AssertingEventsClient("hello", "world", got_this_kwarg=True)
+    assert client.args == ("hello", "world")
+    assert client.kwargs == {"got_this_kwarg": True}
+
+
+async def test_asserting_events_client_captures_events(example_event_1: Event):
+    client = AssertingEventsClient("hello", "world", got_this_kwarg=True)
+
+    assert not hasattr(client, "events")
+
+    async with client:
+        assert client.events == []
+
+        await client.emit(example_event_1)
+
+        assert client.events == [example_event_1]
+
+    # In order to be maximally useful in test contexts, AssertingEventsClient should
+    # preserve the list of captured events even after the context has exited
+    assert client.events == [example_event_1]
+
+
+@pytest.mark.parametrize("client_class", [NullEventsClient, AssertingEventsClient])
+async def test_asserting_events_client_must_be_used_as_a_context_manager(
+    client_class: Type[EventsClient], example_event_1: Event
+):
+    client = client_class()
+    with pytest.raises(TypeError, match="context manager"):
+        await client.emit(example_event_1)


### PR DESCRIPTION
This includes the client-side schema for Prefect Cloud events, as well as the
initial set of client implementations.  The primary client streams events over
WebSockets to Prefect Cloud, including reliable delivery through unreliable
network connections.  Prefect Cloud limits connections to ~30 seconds, so we
need to have highly reliable handling of disconnects.  This implementation has
been tested emperically at high rates (several hundreds of events per second)
and tested with Prefect Cloud for accuracy in their delivery.

Also included are the `NullEventsClient` which will be the default for non-Cloud
users and an `AssertingEventsClient` that will assist in future unit testing of
event emission from various Prefect components.

### Example

```
async with PrefectCloudEventsClient(API_URL, API_KEY) as client:
    await client.emit(
       Event(
           event="marvelous.things.happened",
           resource={
               "prefect.resource.id": "amazement"
           }
       )
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
