### PR TITLE
Removes experimental guards around work pools

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -39,7 +39,7 @@ from prefect.orion.schemas.schedules import (
     IntervalSchedule,
     RRuleSchedule,
 )
-from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS, PREFECT_UI_URL
+from prefect.settings import PREFECT_UI_URL
 from prefect.states import Scheduled
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.collections import listrepr
@@ -95,10 +95,6 @@ async def get_deployment(client: OrionClient, name, deployment_id):
 async def create_work_queue_and_set_concurrency_limit(
     work_queue_name, work_pool_name, work_queue_concurrency
 ):
-    if not PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS.value():
-        # Set work_pool_name to `None` to use default agent pool
-        # via the 'legacy' work queue API
-        work_pool_name = None
     async with get_client() as client:
         if work_queue_concurrency is not None and work_queue_name:
             try:
@@ -146,7 +142,7 @@ async def create_work_queue_and_set_concurrency_limit(
 
 
 async def check_work_pool_exists(work_pool_name: Optional[str]):
-    if work_pool_name is not None and PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS.value():
+    if work_pool_name is not None:
         async with get_client() as client:
             try:
                 await client.read_work_pool(work_pool_name=work_pool_name)

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -744,7 +744,7 @@ class OrionClient:
         try:
             if work_pool_name is not None:
                 response = await self._client.post(
-                    f"experimental/work_pools/{work_pool_name}/queues", json=data
+                    f"/work_pools/{work_pool_name}/queues", json=data
                 )
             else:
                 response = await self._client.post("/work_queues/", json=data)

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -2076,7 +2076,7 @@ class OrionClient:
                 else None
             ),
         }
-        response = await self._client.post("/experimental/work_pools/filter", json=body)
+        response = await self._client.post("/work_pools/filter", json=body)
         return pydantic.parse_obj_as(List[WorkPool], response.json())
 
     async def create_work_pool(
@@ -2121,7 +2121,7 @@ class OrionClient:
             work_pool_name: Name of the work pool to delete.
         """
         try:
-            await self._client.delete(f"/experimental/work_pools/{work_pool_name}")
+            await self._client.delete(f"/work_pools/{work_pool_name}")
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:
                 raise prefect.exceptions.ObjectNotFound(http_exc=e) from e

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -780,7 +780,7 @@ class OrionClient:
         try:
             if work_pool_name is not None:
                 response = await self._client.get(
-                    f"/experimental/work_pools/{work_pool_name}/queues/{name}"
+                    f"/work_pools/{work_pool_name}/queues/{name}"
                 )
             else:
                 response = await self._client.get(f"/work_queues/name/{name}")
@@ -1993,7 +1993,7 @@ class OrionClient:
             worker_name: The name of the worker sending the heartbeat.
         """
         await self._client.post(
-            f"/experimental/work_pools/{work_pool_name}/workers/heartbeat",
+            f"/work_pools/{work_pool_name}/workers/heartbeat",
             json={"name": worker_name},
         )
 
@@ -2015,7 +2015,7 @@ class OrionClient:
             offset: Limit for the worker query.
         """
         response = await self._client.post(
-            f"/experimental/work_pools/{work_pool_name}/workers/filter",
+            f"/work_pools/{work_pool_name}/workers/filter",
             json={
                 "worker_filter": (
                     worker_filter.dict(json_compatible=True, exclude_unset=True)
@@ -2041,9 +2041,7 @@ class OrionClient:
             Information about the requested work pool.
         """
         try:
-            response = await self._client.get(
-                f"/experimental/work_pools/{work_pool_name}"
-            )
+            response = await self._client.get(f"/work_pools/{work_pool_name}")
             return pydantic.parse_obj_as(WorkPool, response.json())
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:
@@ -2095,7 +2093,7 @@ class OrionClient:
             Information about the newly created work pool.
         """
         response = await self._client.post(
-            "/experimental/work_pools/",
+            "/work_pools/",
             json=work_pool.dict(json_compatible=True, exclude_unset=True),
         )
 
@@ -2108,7 +2106,7 @@ class OrionClient:
     ):
 
         await self._client.patch(
-            f"/experimental/work_pools/{work_pool_name}",
+            f"/work_pools/{work_pool_name}",
             json=work_pool.dict(json_compatible=True, exclude_unset=True),
         )
 
@@ -2162,7 +2160,7 @@ class OrionClient:
         if work_pool_name:
             try:
                 response = await self._client.post(
-                    f"/experimental/work_pools/{work_pool_name}/queues/filter",
+                    f"/work_pools/{work_pool_name}/queues/filter",
                     json=json,
                 )
             except httpx.HTTPStatusError as e:
@@ -2203,7 +2201,7 @@ class OrionClient:
             body["scheduled_before"] = str(scheduled_before)
 
         response = await self._client.post(
-            f"/experimental/work_pools/{work_pool_name}/get_scheduled_flow_runs",
+            f"/work_pools/{work_pool_name}/get_scheduled_flow_runs",
             json=body,
         )
 

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -20,7 +20,6 @@ from prefect.orion.utilities.server import OrionRouter
 router = OrionRouter(
     prefix="/work_pools",
     tags=["Work Pools"],
-    dependencies=[Depends(error_404_if_workers_not_enabled)],
 )
 
 

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -16,16 +16,9 @@ from prefect.orion.database.dependencies import provide_database_interface
 from prefect.orion.database.interface import OrionDBInterface
 from prefect.orion.utilities.schemas import DateTimeTZ
 from prefect.orion.utilities.server import OrionRouter
-from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
-
-
-def error_404_if_workers_not_enabled():
-    if not PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS:
-        raise HTTPException(status_code=404, detail="Work pools are not enabled")
-
 
 router = OrionRouter(
-    prefix="/experimental/work_pools",
+    prefix="/work_pools",
     tags=["Work Pools"],
     dependencies=[Depends(error_404_if_workers_not_enabled)],
 )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -936,11 +936,11 @@ The maximum number of characters allowed for a task run cache key.
 This setting cannot be changed client-side, it must be set on the server.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.
 """
-PREFECT_EXPERIMENTAL_WARN_WORK_POOLS = Setting(bool, default=True)
+PREFECT_EXPERIMENTAL_WARN_WORK_POOLS = Setting(bool, default=False)
 """
 Whether or not to warn when experimental Prefect work pools are used.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -463,4 +463,4 @@ def test_enabled_experiments_with_opt_in():
 
 
 def test_enabled_experiments_without_opt_in():
-    assert enabled_experiments() == set("work_pools")
+    assert enabled_experiments() == set(["work_pools"])

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -459,8 +459,8 @@ def test_experimental_marker_cannot_be_used_without_opt_in_setting_if_required()
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
 def test_enabled_experiments_with_opt_in():
-    assert enabled_experiments() == {"test"}
+    assert enabled_experiments() == {"test", "work_pools"}
 
 
 def test_enabled_experiments_without_opt_in():
-    assert enabled_experiments() == set()
+    assert enabled_experiments() == set("work_pools")

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -258,7 +258,9 @@ async def test_agent_creates_work_queue_if_doesnt_exist(session, prefect_caplog)
 
 
 async def test_agent_creates_work_queue_if_doesnt_exist(
-    session, work_pool, prefect_caplog, enable_work_pools
+    session,
+    work_pool,
+    prefect_caplog,
 ):
     name = "hello-there"
     assert not await models.workers.read_work_queue_by_name(
@@ -292,7 +294,10 @@ async def test_agent_does_not_create_work_queues_if_matching_with_prefix(
 
 
 async def test_agent_gracefully_handles_error_when_creating_work_queue(
-    session, monkeypatch, prefect_caplog, work_pool, enable_work_pools
+    session,
+    monkeypatch,
+    prefect_caplog,
+    work_pool,
 ):
     """
     Mimics a race condition in which multiple agents were started against the
@@ -912,7 +917,6 @@ async def test_agent_with_work_queue_and_work_pool(
     deployment_in_non_default_work_pool: schemas.core.Deployment,
     work_pool: schemas.core.WorkPool,
     work_queue_1: schemas.core.WorkQueue,
-    enable_work_pools,
 ):
     @flow
     def foo():
@@ -975,7 +979,6 @@ async def test_agent_with_work_pool(
     deployment_in_non_default_work_pool: schemas.core.Deployment,
     work_pool: schemas.core.WorkPool,
     work_queue_1: schemas.core.WorkQueue,
-    enable_work_pools,
 ):
     @flow
     def foo():
@@ -1041,7 +1044,6 @@ async def test_agent_with_work_pool_and_work_queue_prefix(
     deployment_in_non_default_work_pool: schemas.core.Deployment,
     work_pool: schemas.core.WorkPool,
     work_queue_1: schemas.core.WorkQueue,
-    enable_work_pools,
 ):
     @flow
     def foo():

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -257,7 +257,7 @@ async def test_agent_creates_work_queue_if_doesnt_exist(session, prefect_caplog)
     assert f"Created work queue '{name}'." in prefect_caplog.text
 
 
-async def test_agent_creates_work_queue_if_doesnt_exist(
+async def test_agent_creates_work_queue_if_doesnt_exist_in_work_pool(
     session,
     work_pool,
     prefect_caplog,

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -656,31 +656,12 @@ class TestWorkQueue:
 
 
 class TestWorkPool:
-    def test_warns_when_work_pool_name_provided(self, patch_import, tmp_path):
-        with pytest.warns(
-            ExperimentalFeature, match="The field 'work_pool_name' is experimental."
-        ):
-            invoke_and_assert(
-                [
-                    "deployment",
-                    "build",
-                    "fake-path.py:fn",
-                    "-n",
-                    "TEST",
-                    "-p",
-                    "test-pool",
-                    "-o",
-                    str(tmp_path / "test.yaml"),
-                ],
-                expected_code=0,
-                temp_dir=tmp_path,
-            )
-
-            deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
-            assert deployment.work_pool_name == "test-pool"
-
     async def test_creates_work_queue_in_work_pool(
-        self, patch_import, tmp_path, work_pool, session, enable_work_pools
+        self,
+        patch_import,
+        tmp_path,
+        work_pool,
+        session,
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -739,7 +720,9 @@ class TestAutoApply:
         )
 
     def test_auto_apply_work_pool_does_not_exist(
-        self, patch_import, tmp_path, enable_work_pools
+        self,
+        patch_import,
+        tmp_path,
     ):
         invoke_and_assert(
             [

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -10,7 +10,6 @@ import pytest
 import prefect.orion.models as models
 import prefect.orion.schemas as schemas
 from prefect import flow
-from prefect._internal.compatibility.experimental import ExperimentalFeature
 from prefect.deployments import Deployment
 from prefect.filesystems import LocalFileSystem
 from prefect.infrastructure import Process

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -122,7 +122,9 @@ class TestOutputMessages:
         )
 
     def test_message_with_missing_nonexistent_work_pool(
-        self, patch_import, tmp_path, enable_work_pools
+        self,
+        patch_import,
+        tmp_path,
     ):
         Deployment.build_from_flow(
             flow=my_flow,

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -3,19 +3,8 @@ import pytest
 from prefect.exceptions import ObjectNotFound
 from prefect.orion.schemas.actions import WorkPoolUpdate
 from prefect.orion.schemas.core import WorkPool
-from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
-
-
-@pytest.fixture(autouse=True)
-def auto_enable_work_pools(enable_work_pools):
-    """
-    Enable workers for testing
-    """
-    assert PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
-    # Import to register worker CLI
-    import prefect.experimental.cli.worker  # noqa
 
 
 class TestCreate:

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -43,7 +43,9 @@ class TestCreateWorkQueue:
         )
 
     def test_create_work_queue_with_pool(
-        self, orion_client, work_pool, enable_work_pools
+        self,
+        orion_client,
+        work_pool,
     ):
         queue_name = "q-name"
         res = invoke_and_assert(
@@ -59,7 +61,10 @@ class TestCreateWorkQueue:
         assert queue.work_pool_id == work_pool.id
         assert queue.name == queue_name
 
-    def test_work_queue_with_pool_and_tag_errors(self, work_pool, enable_work_pools):
+    def test_work_queue_with_pool_and_tag_errors(
+        self,
+        work_pool,
+    ):
         res = invoke_and_assert(
             command=f"work-queue create q-name -p {work_pool.name} -t dog",
             expected_code=1,
@@ -84,7 +89,8 @@ class TestCreateWorkQueue:
         assert queue.work_pool_id is not None
 
     def test_create_work_queue_with_bad_pool_name(
-        self, orion_client, enable_work_pools
+        self,
+        orion_client,
     ):
         queue_name = "q-name"
         res = invoke_and_assert(
@@ -114,7 +120,9 @@ class TestSetConcurrencyLimit:
         assert q.concurrency_limit == 5
 
     def test_set_concurrency_limit_with_pool_with_name(
-        self, orion_client, work_queue_1, enable_work_pools
+        self,
+        orion_client,
+        work_queue_1,
     ):
         assert work_queue_1.concurrency_limit is None
         cmd = (
@@ -143,7 +151,10 @@ class TestSetConcurrencyLimit:
             expected_code=1,
         )
 
-    def test_set_concurrency_limit_bad_pool_name(self, work_queue, enable_work_pools):
+    def test_set_concurrency_limit_bad_pool_name(
+        self,
+        work_queue,
+    ):
         invoke_and_assert(
             command=f"work-queue set-concurrency-limit {work_queue.name} 5 -p bad-pool",
             expected_code=1,
@@ -175,7 +186,9 @@ class TestClearConcurrencyLimit:
         assert q.concurrency_limit is None
 
     async def test_clear_concurrency_limit_with_pool(
-        self, orion_client, work_queue_1, enable_work_pools
+        self,
+        orion_client,
+        work_queue_1,
     ):
         pool_name = work_queue_1.work_pool.name
 
@@ -213,7 +226,10 @@ class TestClearConcurrencyLimit:
             expected_code=1,
         )
 
-    def test_clear_concurrency_limit_bad_pool_name(self, work_queue, enable_work_pools):
+    def test_clear_concurrency_limit_bad_pool_name(
+        self,
+        work_queue,
+    ):
         invoke_and_assert(
             command=f"work-queue clear-concurrency-limit {work_queue.name} -p bad-pool",
             expected_code=1,
@@ -239,7 +255,11 @@ class TestPauseWorkQueue:
         q = read_queue(orion_client, work_queue.name)
         assert q.is_paused
 
-    def test_pause_with_pool(self, orion_client, work_queue_1, enable_work_pools):
+    def test_pause_with_pool(
+        self,
+        orion_client,
+        work_queue_1,
+    ):
         assert not work_queue_1.is_paused
         cmd = (
             f"work-queue pause {work_queue_1.name} " f"-p {work_queue_1.work_pool.name}"
@@ -268,7 +288,10 @@ class TestPauseWorkQueue:
             expected_code=1,
         )
 
-    def test_pause_bad_pool_name(self, work_queue, enable_work_pools):
+    def test_pause_bad_pool_name(
+        self,
+        work_queue,
+    ):
         invoke_and_assert(
             command=f"work-queue pause {work_queue.name} -p bad-pool",
             expected_code=1,
@@ -295,7 +318,9 @@ class TestResumeWorkQueue:
         assert not q.is_paused
 
     async def test_resume_with_pool(
-        self, orion_client, work_queue_1, enable_work_pools
+        self,
+        orion_client,
+        work_queue_1,
     ):
         pool_name = work_queue_1.work_pool.name
         await orion_client.update_work_queue(
@@ -332,7 +357,10 @@ class TestResumeWorkQueue:
             expected_code=1,
         )
 
-    def test_resume_bad_pool_name(self, work_queue, enable_work_pools):
+    def test_resume_bad_pool_name(
+        self,
+        work_queue,
+    ):
         invoke_and_assert(
             command=f"work-queue resume {work_queue.name} -p bad-pool",
             expected_code=1,
@@ -360,7 +388,10 @@ class TestInspectWorkQueue:
             expected_code=0,
         )
 
-    def test_inspect_with_pool(self, work_queue_1, enable_work_pools):
+    def test_inspect_with_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = (
             f"work-queue inspect {work_queue_1.name} "
             f"-p {work_queue_1.work_pool.name}"
@@ -387,7 +418,10 @@ class TestInspectWorkQueue:
             expected_code=1,
         )
 
-    def test_inspect_bad_input_work_pool(self, work_queue_1, enable_work_pools):
+    def test_inspect_bad_input_work_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = (
             f"work-queue inspect {work_queue_1.name} "
             f"-p {work_queue_1.work_pool.name}-bad"
@@ -415,7 +449,11 @@ class TestDelete:
         with pytest.raises(prefect.exceptions.ObjectNotFound):
             read_queue(orion_client, work_queue.name)
 
-    def test_delete_with_pool(self, orion_client, work_queue_1, enable_work_pools):
+    def test_delete_with_pool(
+        self,
+        orion_client,
+        work_queue_1,
+    ):
         pool_name = work_queue_1.work_pool.name
         cmd = f"work-queue delete {work_queue_1.name} " f"-p {pool_name}"
         invoke_and_assert(
@@ -426,7 +464,11 @@ class TestDelete:
             read_queue(orion_client, work_queue_1.name, pool=pool_name)
 
     # Tests all of the above, but with bad input
-    def test_delete_with_bad_pool(self, orion_client, work_queue_1, enable_work_pools):
+    def test_delete_with_bad_pool(
+        self,
+        orion_client,
+        work_queue_1,
+    ):
         pool_name = work_queue_1.work_pool.name
         cmd = f"work-queue delete {work_queue_1.name} " f"-p {pool_name}bad"
         invoke_and_assert(
@@ -456,7 +498,10 @@ class TestPreview:
             expected_code=0,
         )
 
-    def test_preview_with_pool(self, work_queue_1, enable_work_pools):
+    def test_preview_with_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = (
             f"work-queue preview {work_queue_1.name} "
             f"-p {work_queue_1.work_pool.name}"
@@ -479,7 +524,10 @@ class TestPreview:
             expected_code=1,
         )
 
-    def test_preview_bad_pool(self, work_queue_1, enable_work_pools):
+    def test_preview_bad_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = (
             f"work-queue preview {work_queue_1.name} "
             f"-p {work_queue_1.work_pool.name}-bad"
@@ -497,14 +545,20 @@ class TestLS:
             expected_code=0,
         )
 
-    def test_ls_with_pool(self, work_queue_1, enable_work_pools):
+    def test_ls_with_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = f"work-queue ls -p {work_queue_1.work_pool.name}"
         invoke_and_assert(
             command=cmd,
             expected_code=0,
         )
 
-    def test_ls_with_bad_pool(self, work_queue_1, enable_work_pools):
+    def test_ls_with_bad_pool(
+        self,
+        work_queue_1,
+    ):
         cmd = f"work-queue ls -p {work_queue_1.work_pool.name}-bad"
         res = invoke_and_assert(
             command=cmd,

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -1,7 +1,6 @@
 import pytest
 
 import prefect.exceptions
-from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 
@@ -9,16 +8,6 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compati
 @sync_compatible
 async def read_queue(orion_client, name, pool=None):
     return await orion_client.read_work_queue_by_name(name=name, work_pool_name=pool)
-
-
-@pytest.fixture(autouse=False)
-def enable_work_pools(enable_work_pools):
-    """
-    Enable workers for testing
-    """
-    assert PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
-    # Import to register worker CLI
-    import prefect.experimental.cli.worker  # noqa
 
 
 class TestCreateWorkQueue:

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1532,7 +1532,7 @@ async def test_update_deployment_schedule_active_overwrites_when_provided(
 
 
 class TestWorkPools:
-    async def test_read_work_pools(self, enable_work_pools, orion_client):
+    async def test_read_work_pools(self, orion_client):
         # default pool shows up when running the test class or individuals, but not when running
         # test as a module
         pools = await orion_client.read_work_pools()
@@ -1557,7 +1557,7 @@ class TestWorkPools:
             work_pool_2.id,
         }
 
-    async def test_delete_work_pool(self, enable_work_pools, orion_client, work_pool):
+    async def test_delete_work_pool(self, orion_client, work_pool):
         await orion_client.delete_work_pool(work_pool.name)
         with pytest.raises(prefect.exceptions.ObjectNotFound):
             await orion_client.read_work_pool(work_pool.id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,9 +41,7 @@ from prefect.settings import (
     PREFECT_ASYNC_FETCH_STATE_RESULT,
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
-    PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS,
     PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
-    PREFECT_EXPERIMENTAL_WARN_WORK_POOLS,
     PREFECT_EXPERIMENTAL_WARN_WORKERS,
     PREFECT_HOME,
     PREFECT_LOCAL_STORAGE_PATH,
@@ -483,17 +481,6 @@ def caplog(caplog):
                 logger.handlers.append(caplog.handler)
 
     yield caplog
-
-
-@pytest.fixture
-def enable_work_pools():
-    with temporary_settings(
-        {
-            PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS: 1,
-            PREFECT_EXPERIMENTAL_WARN_WORK_POOLS: 0,
-        }
-    ):
-        yield
 
 
 @pytest.fixture

--- a/tests/experimental/cli/test_worker.py
+++ b/tests/experimental/cli/test_worker.py
@@ -3,7 +3,6 @@ import pytest
 import prefect
 from prefect.client.orion import OrionClient
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS,
     PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     temporary_settings,
@@ -21,14 +20,6 @@ def auto_enable_workers(enable_workers):
     assert PREFECT_EXPERIMENTAL_ENABLE_WORKERS
     # Import to register worker CLI
     import prefect.experimental.cli.worker  # noqa
-
-
-@pytest.fixture(autouse=True)
-def auto_enable_work_pools(enable_work_pools):
-    """
-    Enable work pools for testing
-    """
-    assert PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 
 
 def test_start_worker_run_once_with_name():

--- a/tests/experimental/workers/test_base_worker.py
+++ b/tests/experimental/workers/test_base_worker.py
@@ -18,7 +18,6 @@ from prefect.experimental.workers.base import (
 from prefect.flows import flow
 from prefect.orion import models
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS,
     PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     PREFECT_WORKER_WORKFLOW_STORAGE_PATH,
@@ -44,14 +43,6 @@ def auto_enable_workers(enable_workers):
     Enable workers for testing
     """
     assert PREFECT_EXPERIMENTAL_ENABLE_WORKERS
-
-
-@pytest.fixture(autouse=True)
-def auto_enable_work_pools(enable_work_pools):
-    """
-    Enable workers for testing
-    """
-    assert PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 
 
 @pytest.fixture(autouse=True)
@@ -437,7 +428,7 @@ async def test_base_worker_gets_job_configuration_when_syncing_with_backend_with
 
     # Create a new worker pool
     response = await client.post(
-        "/experimental/work_pools/", json=dict(name=pool_name, type="test-type")
+        "/work_pools/", json=dict(name=pool_name, type="test-type")
     )
     result = pydantic.parse_obj_as(schemas.core.WorkPool, response.json())
     model = await models.workers.read_work_pool(session=session, work_pool_id=result.id)
@@ -491,7 +482,7 @@ async def test_base_worker_gets_job_configuration_when_syncing_with_backend_with
 
     # Create a new worker pool
     response = await client.post(
-        "/experimental/work_pools/", json=dict(name=pool_name, type="test-type")
+        "/work_pools/", json=dict(name=pool_name, type="test-type")
     )
     result = pydantic.parse_obj_as(schemas.core.WorkPool, response.json())
     model = await models.workers.read_work_pool(session=session, work_pool_id=result.id)

--- a/tests/experimental/workers/test_process_worker.py
+++ b/tests/experimental/workers/test_process_worker.py
@@ -13,10 +13,7 @@ from prefect.client.schemas import State
 from prefect.experimental.workers.process import ProcessWorker, ProcessWorkerResult
 from prefect.orion.schemas.core import WorkPool
 from prefect.orion.schemas.states import StateDetails, StateType
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS,
-    PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
-)
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORKERS
 from prefect.testing.utilities import AsyncMock, MagicMock
 
 
@@ -26,14 +23,6 @@ def auto_enable_workers(enable_workers):
     Enable workers for testing
     """
     assert PREFECT_EXPERIMENTAL_ENABLE_WORKERS
-
-
-@pytest.fixture(autouse=True)
-def auto_enable_work_pools(enable_work_pools):
-    """
-    Enable workers for testing
-    """
-    assert PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 
 
 @flow

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -363,7 +363,6 @@ class TestCreateDeployment:
         infrastructure_document_id,
         work_pool,
         work_queue_1,
-        enable_work_pools,
     ):
         data = DeploymentCreate(
             name="My Deployment",
@@ -410,7 +409,6 @@ class TestCreateDeployment:
         session,
         infrastructure_document_id,
         work_pool,
-        enable_work_pools,
     ):
         default_queue = await models.workers.read_work_queue(
             session=session, work_queue_id=work_pool.default_queue_id
@@ -537,7 +535,6 @@ class TestCreateDeployment:
         infrastructure_document_id,
         template,
         overrides,
-        enable_work_pools,
     ):
         work_pool = await models.workers.create_work_pool(
             session=session,
@@ -628,7 +625,6 @@ class TestCreateDeployment:
         infrastructure_document_id,
         template,
         overrides,
-        enable_work_pools,
     ):
         work_pool = await models.workers.create_work_pool(
             session=session,
@@ -665,7 +661,6 @@ class TestCreateDeployment:
         session,
         infrastructure_document_id,
         work_pool,
-        enable_work_pools,
     ):
         data = DeploymentCreate(
             name="My Deployment",
@@ -705,7 +700,6 @@ class TestCreateDeployment:
         session,
         infrastructure_document_id,
         work_pool,
-        enable_work_pools,
     ):
         data = DeploymentCreate(
             name="My Deployment",

--- a/tests/orion/api/test_deployments.py
+++ b/tests/orion/api/test_deployments.py
@@ -457,7 +457,6 @@ class TestCreateDeployment:
         session,
         infrastructure_document_id,
         work_pool,
-        enable_work_pools,
     ):
         data = DeploymentCreate(
             name="My Deployment",

--- a/tests/orion/api/test_flow_runs.py
+++ b/tests/orion/api/test_flow_runs.py
@@ -317,7 +317,11 @@ class TestReadFlowRuns:
         )
 
     async def test_read_flow_runs_work_pool_fields(
-        self, flow_runs, client, work_pool, work_queue_1, enable_work_pools
+        self,
+        flow_runs,
+        client,
+        work_pool,
+        work_queue_1,
     ):
         response = await client.post("/flow_runs/filter")
         assert response.status_code == status.HTTP_200_OK

--- a/tests/orion/models/test_deployments.py
+++ b/tests/orion/models/test_deployments.py
@@ -954,7 +954,9 @@ class TestScheduledRuns:
 
 class TestUpdateDeployment:
     async def test_updating_deployment_creates_associated_work_queue(
-        self, session, deployment, enable_work_pools
+        self,
+        session,
+        deployment,
     ):
         wq = await models.work_queues.read_work_queue_by_name(
             session=session, name="new-work-queue-name"
@@ -976,7 +978,11 @@ class TestUpdateDeployment:
         assert wq is not None
 
     async def test_update_work_pool_deployment(
-        self, session, deployment, work_pool, work_queue_1, enable_work_pools
+        self,
+        session,
+        deployment,
+        work_pool,
+        work_queue_1,
     ):
         await models.deployments.update_deployment(
             session=session,
@@ -993,7 +999,11 @@ class TestUpdateDeployment:
         assert updated_deployment.work_queue_id == work_queue_1.id
 
     async def test_update_work_pool_deployment_with_only_pool(
-        self, session, deployment, work_pool, work_queue, enable_work_pools
+        self,
+        session,
+        deployment,
+        work_pool,
+        work_queue,
     ):
         default_queue = await models.workers.read_work_queue(
             session=session, work_queue_id=work_pool.default_queue_id
@@ -1012,7 +1022,10 @@ class TestUpdateDeployment:
         assert updated_deployment.work_queue_id == default_queue.id
 
     async def test_update_work_pool_can_create_work_queue(
-        self, session, deployment, work_pool, enable_work_pools
+        self,
+        session,
+        deployment,
+        work_pool,
     ):
         await models.deployments.update_deployment(
             session=session,

--- a/tests/orion/test_app.py
+++ b/tests/orion/test_app.py
@@ -40,7 +40,6 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
     client = TestClient(app)
     response = client.get("/ui-settings")
     response.raise_for_status()
-    assert response.json() == {
-        "api_url": PREFECT_ORION_UI_API_URL.value(),
-        "flags": ["test", "work_pools"],
-    }
+    json = response.json()
+    assert json["api_url"] == PREFECT_ORION_UI_API_URL.value()
+    assert set(json["flags"]) == {"test", "work_pools"}

--- a/tests/orion/test_app.py
+++ b/tests/orion/test_app.py
@@ -28,7 +28,10 @@ def test_app_exposes_ui_settings():
     client = TestClient(app)
     response = client.get("/ui-settings")
     response.raise_for_status()
-    assert response.json() == {"api_url": PREFECT_ORION_UI_API_URL.value(), "flags": []}
+    assert response.json() == {
+        "api_url": PREFECT_ORION_UI_API_URL.value(),
+        "flags": ["work_pools"],
+    }
 
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
@@ -39,5 +42,5 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
     response.raise_for_status()
     assert response.json() == {
         "api_url": PREFECT_ORION_UI_API_URL.value(),
-        "flags": ["test"],
+        "flags": ["test", "work_pools"],
     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Removes `/experimental` prefix from `work_pools` routes. Also enables `PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS` and turns off warnings.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
