### PR TITLE
Add coverage for flow run with agent to integration test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
-          TEST_SERVER_VERSION=${{ matrix.client_version }}
+          TEST_SERVER_VERSION=${{ matrix.prefect-version }}
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -164,6 +164,8 @@ jobs:
         if: ${{ ! matrix.server-incompatible }}
         run: >
           PREFECT_API_URL="http://127.0.0.1:4200/api"
+          TEST_SERVER_VERSION=$(python -c "import prefect; print(prefect.__version__)")
+          TEST_CLIENT_VERSION=${{ matrix.client_version }}
           ./scripts/run-integration-flows.py
 
       - name: Start server@dev
@@ -181,6 +183,8 @@ jobs:
         run: >
           docker run
           --env PREFECT_API_URL="http://127.0.0.1:4200/api"
+          --env TEST_SERVER_VERSION=$(python -c "import prefect; print(prefect.__version__)")
+          --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts
           --network host

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -163,8 +163,9 @@ jobs:
       - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
+          TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
+
           PREFECT_API_URL="http://127.0.0.1:4200/api"
-          TEST_SERVER_VERSION=$(python -c "import prefect; print(prefect.__version__)")
           TEST_CLIENT_VERSION=${{ matrix.client_version }}
           ./scripts/run-integration-flows.py
 
@@ -183,7 +184,7 @@ jobs:
         run: >
           docker run
           --env PREFECT_API_URL="http://127.0.0.1:4200/api"
-          --env TEST_SERVER_VERSION=$(python -c "import prefect; print(prefect.__version__)")
+          --env TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -163,9 +163,9 @@ jobs:
       - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
-          TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
+          TEST_SERVER_VERSION=${{ matrix.client_version }}
           PREFECT_API_URL="http://127.0.0.1:4200/api"
-          TEST_CLIENT_VERSION=${{ matrix.client_version }}
+          TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py
 
       - name: Start server@dev

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -164,7 +164,6 @@ jobs:
         if: ${{ ! matrix.server-incompatible }}
         run: >
           TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
-
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           TEST_CLIENT_VERSION=${{ matrix.client_version }}
           ./scripts/run-integration-flows.py

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -38,7 +38,7 @@ async def read_flow_run(flow_run_id):
         return await client.read_flow_run(flow_run_id)
 
 
-if __name__ == "__main__":
+def main():
     # Create deployment
     if Version(prefect.__version__) < Version("2.1.0"):
         deployment = Deployment(
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             "is running 2.7+ and the server is running 2.6 checks for cancelled flows "
             "will fail. This is a known incompatibility."
         )
-        exit(0)
+        return
     elif Version(prefect.__version__) < Version("2.6"):
         # --run-once is not available so just run for a bit
         try:
@@ -92,3 +92,7 @@ if __name__ == "__main__":
 
     flow_run = anyio.run(read_flow_run, flow_run.id)
     assert flow_run.state.is_completed()
+
+
+if __name__ == "__main__":
+    main()

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -1,3 +1,4 @@
+import pathlib
 import subprocess
 
 import anyio
@@ -13,10 +14,15 @@ def hello(name: str = "world"):
     prefect.get_run_logger().info(f"Hello {name}!")
 
 
-async def apply_deployment(deployment):
+async def apply_deployment_20(deployment):
     async with prefect.get_client() as client:
         flow_id = await client.create_flow_from_name(deployment.flow_name)
-        return await client.create_deployment(flow_id=flow_id, name=deployment.name)
+        return await client.create_deployment(
+            flow_id=flow_id,
+            name=deployment.name,
+            path=deployment.path,
+            entrypoint=deployment.entrypoint,
+        )
 
 
 async def create_flow_run(deployment_id):
@@ -38,8 +44,10 @@ if __name__ == "__main__":
             name="test-deployment",
             flow_name=hello.name,
             parameter_openapi_schema=parameter_schema(hello),
+            path=str(pathlib.Path(__file__).parent),
+            entrypoint=f"{__file__}:hello",
         )
-        deployment_id = anyio.run(apply_deployment, deployment)
+        deployment_id = anyio.run(apply_deployment_20, deployment)
     else:
         deployment = Deployment.build_from_flow(flow=hello, name="test-deployment")
         deployment_id = deployment.apply()

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -60,9 +60,9 @@ def main():
 
     if Version(prefect.__version__) < Version("2.1"):
         # work queue is positional instead of a flag and requires creation
-        subprocess.run(["prefect", "work-queue", "create", "default"])
+        subprocess.run(["prefect", "work-queue", "create", "test"])
         try:
-            subprocess.run(["prefect", "agent", "start", "default"], timeout=30)
+            subprocess.run(["prefect", "agent", "start", "test"], timeout=30)
         except subprocess.TimeoutExpired:
             pass
     elif (

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     elif (
         Version(prefect.__version__) > Version("2.6")
         and TEST_SERVER_VERSION
-        and Version(TEST_SERVER_VERSION) < Version(2.6)
+        and Version(TEST_SERVER_VERSION) < Version("2.6")
         and Version(TEST_SERVER_VERSION) > Version("2.5")
     ):
         print(

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -1,0 +1,59 @@
+import subprocess
+
+import anyio
+from packaging.version import Version
+
+import prefect
+from prefect.deployments import Deployment
+from prefect.utilities.callables import parameter_schema
+
+
+@prefect.flow
+def hello(name: str = "world"):
+    prefect.get_run_logger().info(f"Hello {name}!")
+
+
+async def apply_deployment(deployment):
+    async with prefect.get_client() as client:
+        flow_id = await client.create_flow_from_name(deployment.flow_name)
+        return await client.create_deployment(flow_id=flow_id, name=deployment.name)
+
+
+async def create_flow_run(deployment_id):
+    async with prefect.get_client() as client:
+        return await client.create_flow_run_from_deployment(
+            deployment_id, parameters={"name": "integration tests"}
+        )
+
+
+async def read_flow_run(flow_run_id):
+    async with prefect.get_client() as client:
+        return await client.read_flow_run(flow_run_id)
+
+
+if __name__ == "__main__":
+    # Create deployment
+    if Version(prefect.__version__) < Version("2.1.0"):
+        deployment = Deployment(
+            name="test-deployment",
+            flow_name=hello.name,
+            parameter_openapi_schema=parameter_schema(hello),
+        )
+        deployment_id = anyio.run(apply_deployment, deployment)
+    else:
+        deployment = Deployment.build_from_flow(flow=hello, name="test-deployment")
+        deployment_id = deployment.apply()
+
+    # Update deployment
+    deployment.tags = ["test"]
+    if Version(prefect.__version__) >= Version("2.1.0"):
+        deployment_id = deployment.apply()
+
+    flow_run = anyio.run(create_flow_run, deployment_id)
+
+    subprocess.check_call(
+        ["prefect", "agent", "start", "--run-once", "--work-queue", "default"],
+    )
+
+    flow_run = anyio.run(read_flow_run, flow_run.id)
+    assert flow_run.state.is_completed()

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             "is running 2.7+ and the server is running 2.6 checks for cancelled flows "
             "will fail. This is a known incompatibility."
         )
-        return
+        exit(0)
     elif Version(prefect.__version__) < Version("2.6"):
         # --run-once is not available so just run for a bit
         try:

--- a/flows/agent.py
+++ b/flows/agent.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     elif (
         Version(prefect.__version__) > Version("2.6")
         and TEST_SERVER_VERSION
-        and Version(TEST_SERVER_VERSION) < Version("2.6")
+        and Version(TEST_SERVER_VERSION) < Version("2.7")
         and Version(TEST_SERVER_VERSION) > Version("2.5")
     ):
         print(

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -12,6 +12,7 @@ Example:
 
     PREFECT_API_URL="http://localhost:4200" ./scripts/run-integration-flows.py
 """
+import os
 import runpy
 import sys
 from pathlib import Path
@@ -25,6 +26,10 @@ DEFAULT_PATH = __root_path__ / "flows"
 def run_flows(search_path: Union[str, Path]):
     count = 0
     print(f"Running integration tests with client version: {__version__}")
+    server_version = os.environ.get("TEST_SERVER_VERSION")
+    if server_version:
+        print(f"and server version: {server_version}")
+
     for file in sorted(Path(search_path).glob("*.py")):
         print(f" {file.relative_to(search_path)} ".center(90, "-"), flush=True)
         runpy.run_path(file, run_name="__main__")


### PR DESCRIPTION
Adds an integration test that creates a deployment, creates a flow run, and starts an agent.

Intended to test cases like https://github.com/PrefectHQ/prefect/pull/8373

## Example

```
❯ python flows/agent.py
11:44:05.976 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:06.049 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:06.106 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:06.215 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
Starting v2.7.10+46.gb3dcf538f2 agent with ephemeral API...
11:44:09.056 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db

  ___ ___ ___ ___ ___ ___ _____     _   ___ ___ _  _ _____
 | _ \ _ \ __| __| __/ __|_   _|   /_\ / __| __| \| |_   _|
 |  _/   / _|| _|| _| (__  | |    / _ \ (_ | _|| .` | | |
 |_| |_|_\___|_| |___\___| |_|   /_/ \_\___|___|_|\_| |_|


Agent started! Looking for work from queue(s): default...
11:44:09.058 | DEBUG   | prefect.agent - Checking for scheduled flow runs...
11:44:09.059 | DEBUG   | prefect.agent - Checking for cancelled flow runs...
11:44:09.134 | INFO    | prefect.agent - Submitting flow run 'f47d98f6-11ff-4bb3-bc68-4929e5724f4f'
11:44:09.191 | INFO    | prefect.infrastructure.process - Opening process 'unbiased-yak'...
11:44:09.192 | DEBUG   | prefect.infrastructure.process - Process 'unbiased-yak' running command: /opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/bin/python -m prefect.engine in /var/folders/q9/1myqgwxn2r3fvkvf6jy3npcm0000gn/T/tmpavriuf30prefect
11:44:09.216 | INFO    | prefect.agent - Completed submission of flow run 'f47d98f6-11ff-4bb3-bc68-4929e5724f4f'
/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/runpy.py:127: RuntimeWarning: 'prefect.engine' found in sys.modules after import of package 'prefect', but prior to execution of 'prefect.engine'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
11:44:11.597 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:11.641 | INFO    | Flow run 'unbiased-yak' - Downloading flow code from storage at '/Users/mz/dev/prefect'
11:44:13.648 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:28.313 | DEBUG   | Flow run 'unbiased-yak' - Importing flow code from 'flows/agent.py:hello'
11:44:28.326 | DEBUG   | Flow run 'unbiased-yak' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
11:44:28.326 | DEBUG   | prefect.task_runner.concurrent - Starting task runner...
11:44:28.462 | DEBUG   | Flow run 'unbiased-yak' - Executing flow 'hello' for flow run 'unbiased-yak'...
11:44:28.462 | DEBUG   | Flow run 'unbiased-yak' - Beginning execution...
11:44:28.463 | INFO    | Flow run 'unbiased-yak' - Hello integration tests!
11:44:28.478 | DEBUG   | prefect.task_runner.concurrent - Shutting down task runner...
11:44:28.479 | INFO    | Flow run 'unbiased-yak' - Finished in state Completed()
11:44:28.480 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
11:44:30.781 | INFO    | prefect.infrastructure.process - Process 'unbiased-yak' exited cleanly.
Agent stopped!
11:44:31.154 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/orion.db
```