### PR TITLE
Name your runs

### DIFF
--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -104,6 +104,7 @@ Flows allow a great deal of configuration by passing arguments to the decorator.
 | `name` | An optional name for the flow. If not provided, the name will be inferred from the function. |
 | `retries` | An optional number of times to retry on flow run failure. |
 | <span class="no-wrap">`retry_delay_seconds`</span> | An optional number of seconds to wait before retrying the flow after failure. This is only applicable if `retries` is nonzero. |
+| `flow_run_name` | An optional name to distinguish runs of this flow; this name can be provided as a string template with the flow's parameters as variables. |
 | `task_runner` | An optional [task runner](/concepts/task-runners/) to use for task execution within the flow when you `.submit()` tasks. If not provided and you `.submit()` tasks, the `ConcurrentTaskRunner` will be used. |
 | `timeout_seconds` | An optional number of seconds indicating a maximum runtime for the flow. If the flow exceeds this runtime, it will be marked as failed. Flow execution may continue until the next task is called. |
 | `validate_parameters` | Boolean indicating whether parameters passed to flows are validated by Pydantic. Default is `True`.  |
@@ -130,6 +131,20 @@ You can also provide the description as the docstring on the flow function.
 def my_flow():
     """My flow using SequentialTaskRunner"""
     return
+```
+
+You can distinguish runs of this flow by providing a `flow_run_name`; this setting accepts a string that can optionally contain templated references to the parameters of your flow. The name will be formatted using Python's standard string formatting syntax as can be seen here:
+
+```python
+import datetime
+from prefect import flow
+
+@flow(flow_run_name="{name}-on-{date:%A}")
+def my_flow(name: str, date: datetime.datetime):
+    pass
+
+# creates a flow run called 'marvin-on-Thursday'
+my_flow(name="marvin", date=datetime.datetime.utcnow())
 ```
 
 Note that `validate_parameters` will check that input values conform to the annotated types on the function. Where possible, values will be coerced into the correct type. For example, if a parameter is defined as `x: int` and "5" is passed, it will be resolved to `5`. If set to `False`, no validation will be performed on flow parameters.

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -84,14 +84,15 @@ Tasks allow a great deal of customization via arguments. Examples include retry 
 
 | Argument | Description |
 | --- | --- |
-| name | An optional name for the task. If not provided, the name will be inferred from the function name. |
-| description | An optional string description for the task. If not provided, the description will be pulled from the docstring for the decorated function. |
-| tags | An optional set of tags to be associated with runs of this task. These tags are combined with any tags defined by a `prefect.tags` context at task runtime. |
-| cache_key_fn | An optional callable that, given the task run context and call parameters, generates a string key. If the key matches a previous completed state, that state result will be restored instead of running the task again. |
-| cache_expiration | An optional amount of time indicating how long cached states for this task should be restorable; if not provided, cached states will never expire. |
-| retries | An optional number of times to retry on task run failure. |
-| retry_delay_seconds | An optional number of seconds to wait before retrying the task after failure. This is only applicable if `retries` is nonzero. |
-| version | An optional string specifying the version of this task definition. |
+| `name` | An optional name for the task. If not provided, the name will be inferred from the function name. |
+| `description` | An optional string description for the task. If not provided, the description will be pulled from the docstring for the decorated function. |
+| `tags` | An optional set of tags to be associated with runs of this task. These tags are combined with any tags defined by a `prefect.tags` context at task runtime. |
+| `cache_key_fn` | An optional callable that, given the task run context and call parameters, generates a string key. If the key matches a previous completed state, that state result will be restored instead of running the task again. |
+| `cache_expiration` | An optional amount of time indicating how long cached states for this task should be restorable; if not provided, cached states will never expire. |
+| `task_run_name` | An optional name to distinguish runs of this task; this name can be provided as a string template with the task's keyword arguments as variables. |
+| `retries` | An optional number of times to retry on task run failure. |
+| `retry_delay_seconds` | An optional number of seconds to wait before retrying the task after failure. This is only applicable if `retries` is nonzero. |
+| `version` | An optional string specifying the version of this task definition. |
 
 For example, you can provide a `name` value for the task. Here we've used the optional `description` argument as well.
 
@@ -100,6 +101,24 @@ For example, you can provide a `name` value for the task. Here we've used the op
       description="This task says hello.")
 def my_task():
     print("Hello, I'm a task")
+```
+
+You can distinguish runs of this task by providing a `task_run_name`; this setting accepts a string that can optionally contain templated references to the keyword arguments of your task. The name will be formatted using Python's standard string formatting syntax as can be seen here:
+
+```python
+import datetime
+from prefect import flow, task
+
+@task(name="My Example Task", 
+      description="An example task for a tutorial.",
+      task_run_name="hello-{name}-on-{date:%A}")
+def my_task(name, date):
+    pass
+
+@flow
+def my_flow():
+    # creates a run with a name like "hello-marvin-on-Thursday"
+    my_task(name="marvin", date=datetime.datetime.utcnow())
 ```
 
 ## Tags

--- a/docs/tutorials/flow-task-config.md
+++ b/docs/tutorials/flow-task-config.md
@@ -80,6 +80,20 @@ def my_flow():
 
 You don't have to supply a version for your flow. By default, Prefect makes a best effort to compute a stable hash of the `.py` file in which the flow is defined to automatically detect when your code changes.  However, this computation is not always possible and so, depending on your setup, you may see that your flow has a version of `None`.
 
+You can also distinguish runs of this flow by providing a `flow_run_name`; this setting accepts a string that can optionally contain templated references to the parameters of your flow. The name will be formatted using Python's standard string formatting syntax as can be seen here:
+
+```python
+import datetime
+from prefect import flow
+
+@flow(flow_run_name="{name}-on-{date:%A}")
+def my_flow(name: str, date: datetime.datetime):
+    pass
+
+# creates a flow run called 'marvin-on-Thursday'
+my_flow(name="marvin", date=datetime.datetime.utcnow())
+```
+
 ## Basic task configuration
 
 By design, tasks follow a very similar model to flows: you can independently assign tasks their own name and description.

--- a/docs/tutorials/flow-task-config.md
+++ b/docs/tutorials/flow-task-config.md
@@ -115,6 +115,24 @@ def my_flow():
     my_task()
 ```
 
+You can also distinguish runs of this task by providing a `task_run_name`; this setting accepts a string that can optionally contain templated references to the keyword arguments of your task. The name will be formatted using Python's standard string formatting syntax as can be seen here:
+
+```python
+import datetime
+from prefect import flow, task
+
+@task(name="My Example Task", 
+      description="An example task for a tutorial.",
+      task_run_name="hello-{name}-on-{date:%A}")
+def my_task(name, date):
+    pass
+
+@flow
+def my_flow():
+    # creates a run with a name like "hello-marvin-on-Thursday"
+    my_task(name="marvin", date=datetime.datetime.utcnow())
+```
+
 ## Flow and task retries
 
 Prefect includes built-in support for both flow and [task retries](/concepts/tasks/#retries), which you configure on the flow or task. This enables flows and tasks to automatically retry on failure. You can specify how many retries you want to attempt and, optionally, a delay between retry attempts:

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -1675,6 +1675,13 @@ class OrionClient:
         )
         return pydantic.parse_obj_as(List[prefect.states.State], response.json())
 
+    async def set_task_run_name(self, task_run_id: UUID, name: str):
+        task_run_data = schemas.actions.TaskRunUpdate(name=name)
+        return await self._client.patch(
+            f"/task_runs/{task_run_id}",
+            json=task_run_data.dict(json_compatible=True, exclude_unset=True),
+        )
+
     async def create_task_run(
         self,
         task: "Task",

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -604,8 +604,6 @@ async def orchestrate_flow_run(
         logger.extra["flow_run_name"] = flow_run_name
         logger.debug(f"Renamed flow run {flow_run.name!r} to {flow_run_name!r}")
         flow_run.name = flow_run_name
-    else:
-        flow_run_name = None
 
     state = await propose_state(client, Running(), flow_run_id=flow_run.id)
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1475,6 +1475,11 @@ async def orchestrate_task_run(
                     await client.set_task_run_name(
                         task_run_id=task_run.id, name=task_run_name
                     )
+                    logger.extra["task_run_name"] = task_run_name
+                    logger.debug(
+                        f"Renamed task run {task_run.name!r} to {task_run_name!r}"
+                    )
+                    task_run.name = task_run_name
                     run_name_set = True
 
                 if PREFECT_DEBUG_MODE.value():

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -83,6 +83,8 @@ class Flow(Generic[P, R]):
         version: An optional version string for the flow; if not provided, we will
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
+        flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
+            as a string template with the flow's parameters as variables
         task_runner: An optional task runner to use for task execution within the flow;
             if not provided, a `ConcurrentTaskRunner` will be used.
         description: An optional string description for the flow; if not provided, the
@@ -121,6 +123,7 @@ class Flow(Generic[P, R]):
         fn: Callable[P, R],
         name: Optional[str] = None,
         version: Optional[str] = None,
+        flow_run_name: Optional[str] = None,
         retries: int = 0,
         retry_delay_seconds: Union[int, float] = 0,
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = ConcurrentTaskRunner,
@@ -141,6 +144,7 @@ class Flow(Generic[P, R]):
             raise_on_invalid_name(name)
 
         self.name = name or fn.__name__.replace("_", "-")
+        self.flow_run_name = flow_run_name
         task_runner = task_runner or ConcurrentTaskRunner()
         self.task_runner = (
             task_runner() if isinstance(task_runner, type) else task_runner
@@ -218,6 +222,7 @@ class Flow(Generic[P, R]):
         retries: int = 0,
         retry_delay_seconds: Union[int, float] = 0,
         description: str = None,
+        flow_run_name: str = None,
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = None,
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = None,
@@ -234,6 +239,8 @@ class Flow(Generic[P, R]):
             name: A new name for the flow.
             version: A new version for the flow.
             description: A new description for the flow.
+            flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
+                as a string template with the flow's parameters as variables
             task_runner: A new task runner for the flow.
             timeout_seconds: A new number of seconds to fail the flow after if still
                 running.
@@ -278,6 +285,7 @@ class Flow(Generic[P, R]):
             fn=self.fn,
             name=name or self.name,
             description=description or self.description,
+            flow_run_name=flow_run_name,
             version=version or self.version,
             task_runner=task_runner or self.task_runner,
             retries=retries or self.retries,
@@ -508,6 +516,7 @@ def flow(
     *,
     name: Optional[str] = None,
     version: Optional[str] = None,
+    flow_run_name: Optional[str] = None,
     retries: int = 0,
     retry_delay_seconds: Union[int, float] = 0,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
@@ -528,6 +537,7 @@ def flow(
     *,
     name: Optional[str] = None,
     version: Optional[str] = None,
+    flow_run_name: Optional[str] = None,
     retries: int = 0,
     retry_delay_seconds: Union[int, float] = 0,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
@@ -553,6 +563,8 @@ def flow(
         version: An optional version string for the flow; if not provided, we will
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
+        flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
+            as a string template with the flow's parameters as variables
         task_runner: An optional task runner to use for task execution within the flow; if
             not provided, a `ConcurrentTaskRunner` will be instantiated.
         description: An optional string description for the flow; if not provided, the
@@ -632,6 +644,7 @@ def flow(
                 fn=__fn,
                 name=name,
                 version=version,
+                flow_run_name=flow_run_name,
                 task_runner=task_runner,
                 description=description,
                 timeout_seconds=timeout_seconds,
@@ -652,6 +665,7 @@ def flow(
                 flow,
                 name=name,
                 version=version,
+                flow_run_name=flow_run_name,
                 task_runner=task_runner,
                 description=description,
                 timeout_seconds=timeout_seconds,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -84,7 +84,7 @@ class Flow(Generic[P, R]):
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
         flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-            as a string template with the flow's parameters as variables
+            as a string template with the flow's parameters as variables.
         task_runner: An optional task runner to use for task execution within the flow;
             if not provided, a `ConcurrentTaskRunner` will be used.
         description: An optional string description for the flow; if not provided, the
@@ -240,7 +240,7 @@ class Flow(Generic[P, R]):
             version: A new version for the flow.
             description: A new description for the flow.
             flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-                as a string template with the flow's parameters as variables
+                as a string template with the flow's parameters as variables.
             task_runner: A new task runner for the flow.
             timeout_seconds: A new number of seconds to fail the flow after if still
                 running.
@@ -564,7 +564,7 @@ def flow(
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
         flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-            as a string template with the flow's parameters as variables
+            as a string template with the flow's parameters as variables.
         task_runner: An optional task runner to use for task execution within the flow; if
             not provided, a `ConcurrentTaskRunner` will be instantiated.
         description: An optional string description for the flow; if not provided, the

--- a/src/prefect/orion/api/task_runs.py
+++ b/src/prefect/orion/api/task_runs.py
@@ -60,6 +60,23 @@ async def create_task_run(
     return model
 
 
+@router.patch("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def update_task_run(
+    task_run: schemas.actions.TaskRunUpdate,
+    task_run_id: UUID = Path(..., description="The task run id", alias="id"),
+    db: OrionDBInterface = Depends(provide_database_interface),
+):
+    """
+    Updates a task run.
+    """
+    async with db.session_context(begin_transaction=True) as session:
+        result = await models.task_runs.update_task_run(
+            session=session, task_run=task_run, task_run_id=task_run_id
+        )
+    if not result:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Task run not found")
+
+
 @router.post("/count")
 async def count_task_runs(
     db: OrionDBInterface = Depends(provide_database_interface),

--- a/src/prefect/orion/models/task_runs.py
+++ b/src/prefect/orion/models/task_runs.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import pendulum
 import sqlalchemy as sa
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.orion.models as models
 import prefect.orion.schemas as schemas
@@ -85,6 +86,34 @@ async def create_task_run(
             orchestration_parameters=orchestration_parameters,
         )
     return model
+
+
+@inject_db
+async def update_task_run(
+    session: AsyncSession,
+    task_run_id: UUID,
+    task_run: schemas.actions.TaskRunUpdate,
+    db: OrionDBInterface,
+) -> bool:
+    """
+    Updates a task run.
+
+    Args:
+        session: a database session
+        task_run_id: the task run id to update
+        task_run: a task run model
+
+    Returns:
+        bool: whether or not matching rows were found to update
+    """
+    update_stmt = (
+        sa.update(db.TaskRun).where(db.TaskRun.id == task_run_id)
+        # exclude_unset=True allows us to only update values provided by
+        # the user, ignoring any defaults on the model
+        .values(**task_run.dict(shallow=True, exclude_unset=True))
+    )
+    result = await session.execute(update_stmt)
+    return result.rowcount > 0
 
 
 @inject_db

--- a/src/prefect/orion/schemas/actions.py
+++ b/src/prefect/orion/schemas/actions.py
@@ -294,6 +294,13 @@ class TaskRunCreate(ActionBaseModel):
 
 
 @copy_model_fields
+class TaskRunUpdate(ActionBaseModel):
+    """Data used by the Orion API to update a task run"""
+
+    name: str = FieldFrom(schemas.core.TaskRun)
+
+
+@copy_model_fields
 class FlowRunCreate(ActionBaseModel):
     """Data used by the Orion API to create a flow run."""
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -128,6 +128,7 @@ class Task(Generic[P, R]):
         cache_expiration: An optional amount of time indicating how long cached states
             for this task should be restorable; if not provided, cached states will
             never expire.
+        task_run_name: An optional name to distinguish runs of this task
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This
@@ -171,6 +172,7 @@ class Task(Generic[P, R]):
             ["TaskRunContext", Dict[str, Any]], Optional[str]
         ] = None,
         cache_expiration: datetime.timedelta = None,
+        task_run_name: str = None,
         retries: int = 0,
         retry_delay_seconds: Union[
             float,
@@ -203,6 +205,7 @@ class Task(Generic[P, R]):
         else:
             self.name = name
 
+        self.task_run_name = task_run_name
         self.version = version
         self.log_prints = log_prints
 
@@ -274,6 +277,7 @@ class Task(Generic[P, R]):
         cache_key_fn: Callable[
             ["TaskRunContext", Dict[str, Any]], Optional[str]
         ] = None,
+        task_run_name: str = None,
         cache_expiration: datetime.timedelta = None,
         retries: Optional[int] = NotSet,
         retry_delay_seconds: Union[
@@ -301,6 +305,7 @@ class Task(Generic[P, R]):
                 not merged.
             cache_key_fn: A new cache key function for the task.
             cache_expiration: A new cache expiration time for the task.
+            task_run_name: A name to distinguish runs of this task
             retries: A new number of times to retry on task run failure.
             retry_delay_seconds: Optionally configures how long to wait before retrying
                 the task after failure. This is only applicable if `retries` is nonzero.
@@ -363,6 +368,7 @@ class Task(Generic[P, R]):
             tags=tags or copy(self.tags),
             cache_key_fn=cache_key_fn or self.cache_key_fn,
             cache_expiration=cache_expiration or self.cache_expiration,
+            task_run_name=task_run_name,
             retries=retries if retries is not NotSet else self.retries,
             retry_delay_seconds=(
                 retry_delay_seconds
@@ -836,6 +842,7 @@ def task(
     version: str = None,
     cache_key_fn: Callable[["TaskRunContext", Dict[str, Any]], Optional[str]] = None,
     cache_expiration: datetime.timedelta = None,
+    task_run_name: str = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -864,6 +871,7 @@ def task(
     version: str = None,
     cache_key_fn: Callable[["TaskRunContext", Dict[str, Any]], Optional[str]] = None,
     cache_expiration: datetime.timedelta = None,
+    task_run_name: str = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -899,6 +907,7 @@ def task(
         cache_expiration: An optional amount of time indicating how long cached states
             for this task should be restorable; if not provided, cached states will
             never expire.
+        task_run_name: A name to distinguish runs of this task
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This
@@ -987,6 +996,7 @@ def task(
                 version=version,
                 cache_key_fn=cache_key_fn,
                 cache_expiration=cache_expiration,
+                task_run_name=task_run_name,
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
                 retry_jitter_factor=retry_jitter_factor,
@@ -1010,6 +1020,7 @@ def task(
                 version=version,
                 cache_key_fn=cache_key_fn,
                 cache_expiration=cache_expiration,
+                task_run_name=task_run_name,
                 retries=retries,
                 retry_delay_seconds=retry_delay_seconds,
                 retry_jitter_factor=retry_jitter_factor,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -129,7 +129,7 @@ class Task(Generic[P, R]):
             for this task should be restorable; if not provided, cached states will
             never expire.
         task_run_name: An optional name to distinguish runs of this task; this name can be provided
-            as a string template with the task's keyword arguments as variables
+            as a string template with the task's keyword arguments as variables.
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This
@@ -307,7 +307,7 @@ class Task(Generic[P, R]):
             cache_key_fn: A new cache key function for the task.
             cache_expiration: A new cache expiration time for the task.
             task_run_name: An optional name to distinguish runs of this task; this name can be provided
-                as a string template with the task's keyword arguments as variables
+                as a string template with the task's keyword arguments as variables.
             retries: A new number of times to retry on task run failure.
             retry_delay_seconds: Optionally configures how long to wait before retrying
                 the task after failure. This is only applicable if `retries` is nonzero.
@@ -910,7 +910,7 @@ def task(
             for this task should be restorable; if not provided, cached states will
             never expire.
         task_run_name: An optional name to distinguish runs of this task; this name can be provided
-            as a string template with the task's keyword arguments as variables
+            as a string template with the task's keyword arguments as variables.
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -128,7 +128,8 @@ class Task(Generic[P, R]):
         cache_expiration: An optional amount of time indicating how long cached states
             for this task should be restorable; if not provided, cached states will
             never expire.
-        task_run_name: An optional name to distinguish runs of this task
+        task_run_name: An optional name to distinguish runs of this task; this name can be provided
+            as a string template with the task's keyword arguments as variables
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This
@@ -305,7 +306,8 @@ class Task(Generic[P, R]):
                 not merged.
             cache_key_fn: A new cache key function for the task.
             cache_expiration: A new cache expiration time for the task.
-            task_run_name: A name to distinguish runs of this task
+            task_run_name: An optional name to distinguish runs of this task; this name can be provided
+                as a string template with the task's keyword arguments as variables
             retries: A new number of times to retry on task run failure.
             retry_delay_seconds: Optionally configures how long to wait before retrying
                 the task after failure. This is only applicable if `retries` is nonzero.
@@ -907,7 +909,8 @@ def task(
         cache_expiration: An optional amount of time indicating how long cached states
             for this task should be restorable; if not provided, cached states will
             never expire.
-        task_run_name: A name to distinguish runs of this task
+        task_run_name: An optional name to distinguish runs of this task; this name can be provided
+            as a string template with the task's keyword arguments as variables
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -950,7 +950,7 @@ class TestOrchestrateTaskRun:
         task_run = await orion_client.read_task_run(task_run.id)
         assert task_run.name == "fixed-name"
 
-    async def test_task_run_name_is_set_with_kwargs(
+    async def test_task_run_name_is_set_with_kwargs_including_defaults(
         self, orion_client, flow_run, result_factory, local_filesystem
     ):
         # the flow run must be running prior to running tasks
@@ -962,8 +962,8 @@ class TestOrchestrateTaskRun:
         # Define a mock to ensure the task was not run
         mock = MagicMock()
 
-        @task(task_run_name="{name}-wuz-here")
-        def my_task(name):
+        @task(task_run_name="{name}-wuz-{where}")
+        def my_task(name, where="here"):
             return name
 
         # Create a task run to test
@@ -1906,6 +1906,38 @@ class TestCreateThenBeginFlowRun:
         )
         assert state.type == StateType.COMPLETED
         assert await state.result() == ("bar", 1)
+
+    async def test_sets_run_name_when_provided(self, orion_client):
+        @flow(flow_run_name="hi")
+        def flow_with_name(foo: str = "bar", bar: int = 1):
+            pass
+
+        state = await create_then_begin_flow_run(
+            flow=flow_with_name,
+            parameters={},
+            wait_for=None,
+            return_type="state",
+            client=orion_client,
+        )
+        assert state.type == StateType.COMPLETED
+        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+        assert flow_run.name == "hi"
+
+    async def test_sets_run_name_with_params_including_defaults(self, orion_client):
+        @flow(flow_run_name="hi-{foo}-{bar}")
+        def flow_with_name(foo: str = "one", bar: str = "1"):
+            pass
+
+        state = await create_then_begin_flow_run(
+            flow=flow_with_name,
+            parameters={"bar": "two"},
+            wait_for=None,
+            return_type="state",
+            client=orion_client,
+        )
+        assert state.type == StateType.COMPLETED
+        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+        assert flow_run.name == "hi-one-two"
 
     async def test_handles_other_errors(
         self, orion_client, parameterized_flow, monkeypatch

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2013,3 +2013,27 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert res == "woof!"
     flow_runs = await orion_client.read_flows()
     assert len(flow_runs) == 1
+
+
+async def test_sets_run_name_when_provided(orion_client):
+    @flow(flow_run_name="hi")
+    def flow_with_name(foo: str = "bar", bar: int = 1):
+        pass
+
+    state = flow_with_name(return_state=True)
+
+    assert state.type == StateType.COMPLETED
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+    assert flow_run.name == "hi"
+
+
+async def test_sets_run_name_with_params_including_defaults(orion_client):
+    @flow(flow_run_name="hi-{foo}-{bar}")
+    def flow_with_name(foo: str = "one", bar: str = "1"):
+        pass
+
+    state = flow_with_name(bar="two", return_state=True)
+
+    assert state.type == StateType.COMPLETED
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+    assert flow_run.name == "hi-one-two"

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -44,11 +44,18 @@ from prefect.utilities.hashing import file_hash
 
 class TestFlow:
     def test_initializes(self):
-        f = Flow(name="test", fn=lambda **kwargs: 42, version="A", description="B")
+        f = Flow(
+            name="test",
+            fn=lambda **kwargs: 42,
+            version="A",
+            description="B",
+            flow_run_name="hi",
+        )
         assert f.name == "test"
         assert f.fn() == 42
         assert f.version == "A"
         assert f.description == "B"
+        assert f.flow_run_name == "hi"
 
     def test_initializes_with_default_version(self):
         f = Flow(name="test", fn=lambda **kwargs: 42)
@@ -144,7 +151,7 @@ class TestFlow:
 class TestDecorator:
     def test_flow_decorator_initializes(self):
         # TODO: We should cover initialization with a task runner once introduced
-        @flow(name="foo", version="B")
+        @flow(name="foo", version="B", flow_run_name="hi")
         def my_flow():
             return "bar"
 
@@ -152,6 +159,7 @@ class TestDecorator:
         assert my_flow.name == "foo"
         assert my_flow.version == "B"
         assert my_flow.fn() == "bar"
+        assert my_flow.flow_run_name == "hi"
 
     def test_flow_decorator_sets_default_version(self):
         my_flow = flow(flatdict_to_dict)
@@ -164,6 +172,7 @@ class TestFlowWithOptions:
         @flow(
             name="Initial flow",
             description="Flow before with options",
+            flow_run_name="OG",
             task_runner=ConcurrentTaskRunner,
             timeout_seconds=10,
             validate_parameters=True,
@@ -178,6 +187,7 @@ class TestFlowWithOptions:
         flow_with_options = initial_flow.with_options(
             name="Copied flow",
             description="A copied flow",
+            flow_run_name="new-name",
             task_runner=SequentialTaskRunner,
             retries=3,
             retry_delay_seconds=20,
@@ -191,6 +201,7 @@ class TestFlowWithOptions:
 
         assert flow_with_options.name == "Copied flow"
         assert flow_with_options.description == "A copied flow"
+        assert flow_with_options.flow_run_name == "new-name"
         assert isinstance(flow_with_options.task_runner, SequentialTaskRunner)
         assert flow_with_options.timeout_seconds == 5
         assert flow_with_options.retries == 3

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -78,6 +78,32 @@ class TestTaskName:
         assert my_task.name == "another_name"
 
 
+class TestTaskRunName:
+    def test_run_name_default(self):
+        @task
+        def my_task():
+            pass
+
+        assert my_task.task_run_name is None
+
+    def test_run_name_from_kwarg(self):
+        @task(task_run_name="another_name")
+        def my_task():
+            pass
+
+        assert my_task.task_run_name == "another_name"
+
+    def test_run_name_from_options(self):
+        @task(task_run_name="first_name")
+        def my_task():
+            pass
+
+        assert my_task.task_run_name == "first_name"
+
+        new_task = my_task.with_options(task_run_name="second_name")
+        assert new_task.task_run_name == "second_name"
+
+
 class TestTaskCall:
     def test_task_called_outside_flow_raises(self):
         @task


### PR DESCRIPTION
This PR introduces the ability to name your flow and task runs using a dynamic template; names are provided as strings to the respective decorator.  These strings can optionally include references to keyword arguments of the task / flow as the example below demonstrates.  Run names do not need to be unique.

Note that Cloud will need to be updated for this to be compatible, as I had to introduce a new API route and action model.

Closes https://github.com/PrefectHQ/prefect/issues/7463
Closes https://github.com/PrefectHQ/prefect/issues/7579

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
import pendulum
from prefect import task, flow

@task(task_run_name="{greeting}-{name}")
def my_task(name, greeting="hi"):
    print(f"{greeting} {name}!")

@flow(flow_run_name="{date:%A}-run")
def my_flow(date):
    return my_task(name="chris")

my_flow(date=pendulum.now())
```
produces the following logs (and corresponding backend changes):
```
11:42:38.058 | INFO    | prefect.engine - Created flow run 'Thursday-run' for flow 'my-flow'
11:42:38.167 | INFO    | Flow run 'Thursday-run' - Created task run 'my_task-0' for task 'my_task'
11:42:38.168 | INFO    | Flow run 'Thursday-run' - Executing 'my_task-0' immediately...
## there's a DEBUG log in here that calls out the name change
11:42:38.201 | INFO    | Task run 'hi-chris' - Finished in state Completed()
11:42:38.212 | INFO    | Flow run 'Thursday-run' - Finished in state Completed('All states completed.')
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
