### PR TITLE
BugFix: Use recentFlowRunFilter instead of flowRunFilter

### DIFF
--- a/orion-ui/src/pages/WorkPoolQueue.vue
+++ b/orion-ui/src/pages/WorkPoolQueue.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { useWorkspaceApi, PageHeadingWorkPoolQueue, CodeBanner, WorkPoolQueueDetails, WorkPoolQueueUpcomingFlowRunsList, useFlowRunFilter, FlowRunFilteredList } from '@prefecthq/orion-design'
+  import { useWorkspaceApi, PageHeadingWorkPoolQueue, CodeBanner, WorkPoolQueueDetails, WorkPoolQueueUpcomingFlowRunsList, useRecentFlowRunFilter, FlowRunFilteredList } from '@prefecthq/orion-design'
   import { media } from '@prefecthq/prefect-design'
   import { useRouteParam, useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
@@ -52,7 +52,7 @@
   const workPoolWorkerName = computed(() => workPoolWorkers.value[0]?.name ?? '<worker name>')
   const workPoolQueueCliCommand = computed(() => `prefect agent start --pool ${workPoolName.value} --queue ${workPoolQueueName.value}`)
 
-  const flowRunFilter = useFlowRunFilter({ workPoolQueueName: [workPoolQueueName.value], workPoolName: [workPoolName.value] })
+  const flowRunFilter = useRecentFlowRunFilter({ workPoolQueueName: [workPoolQueueName.value], workPoolName: [workPoolName.value] })
 
   const tabs = computed(() => {
     const values = ['Upcoming Runs', 'Runs']


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Uses the recentFlowRunFilter instead of runFilter to match the date filter that's applied on work pools and the empty state message. 


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
