### PR TITLE
Clearer output CLI message when switching profiles

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -124,7 +124,7 @@ async def use(name: str):
         ),
         ConnectionStatus.EPHEMERAL: (
             exit_with_success,
-            f"No Prefect Orion instance specified using profile {name!r}. Flow run metadata will be stored at the locally configured database: {prefect.settings.PREFECT_ORION_DATABASE_CONNECTION_URL.value()}",
+            f"No Prefect Orion instance specified using profile {name!r} - the API will run in ephemeral mode.",
         ),
         ConnectionStatus.INVALID_API: (
             exit_with_error,

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -198,7 +198,7 @@ class TestChangingProfileAndCheckingOrionConnection:
         save_profiles(profiles)
         invoke_and_assert(
             ["profile", "use", "ephemeral-orion"],
-            expected_output_contains="No Prefect Orion instance specified using profile 'ephemeral-orion'.",
+            expected_output_contains="No Prefect Orion instance specified using profile 'ephemeral-orion'",
             expected_code=0,
         )
 


### PR DESCRIPTION
If you store the following two profiles in `~/.prefect/profiles.toml`:

```yaml
active = "one"

[profiles.one]
PREFECT_ORION_DATABASE_CONNECTION_URL = "one"

[profiles.two]
PREFECT_ORION_DATABASE_CONNECTION_URL = "two"
```
and then run the following CLI:
```
prefect profile use two
```
you will find the following misleading output:
```
No Prefect Orion instance specified using profile 'two'. 
Flow run metadata will be stored at the locally configured database: one
```
This is because the output messages were created prior to the profile switch.  In addition, I believe we should disambiguate between the API and the persistent DB layer where possible, as this separation is key for certain use cases.  

This PR updates the CLI message as can be seen in the example below.

### Example
With the same profile setup as above, we now get:
```
prefect profile use two
No Prefect Orion instance specified using profile 'two' - the API will run in ephemeral mode.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
