### PR TITLE
Resolves conflict when default work pool doesn't exist

### DIFF
--- a/src/prefect/orion/models/work_queues.py
+++ b/src/prefect/orion/models/work_queues.py
@@ -55,6 +55,13 @@ async def create_work_queue(
                     name=DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent"
                 ),
             )
+            if work_queue.name == "default":
+                # If the desired work queue name is default, it was created when the
+                # work pool was created. We can just return it.
+                return await models.workers.read_work_queue(
+                    session=session,
+                    work_queue_id=default_agent_work_pool.default_queue_id,
+                )
             data["work_pool_id"] = default_agent_work_pool.id
 
     # Set the priority to be the max priority + 1

--- a/tests/orion/models/test_work_queues.py
+++ b/tests/orion/models/test_work_queues.py
@@ -49,8 +49,9 @@ class TestCreateWorkQueue:
         pool = await models.workers.read_work_pool_by_name(
             session=session, work_pool_name=DEFAULT_AGENT_WORK_POOL_NAME
         )
-        await models.workers.delete_work_pool(session=session, work_pool_id=pool.id)
-        await session.commit()
+        if pool is not None:
+            await models.workers.delete_work_pool(session=session, work_pool_id=pool.id)
+            await session.commit()
 
         work_queue = await models.work_queues.create_work_queue(
             session=session,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
If the default work pool doesn't exist, then it's possible to get a conflict when creating a work queue named default. The default work pool is created, which creates a queue name default at the same time. This PR adds handling for that case.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
