### PR TITLE
Swap order of runs and deployments on flow page

### DIFF
--- a/orion-ui/src/pages/Flow.vue
+++ b/orion-ui/src/pages/Flow.vue
@@ -37,7 +37,7 @@
   const flowId = useRouteParam('flowId')
   const router = useRouter()
   const tabs = computed(() => {
-    const values = ['Deployments', 'Runs']
+    const values = ['Runs', 'Deployments']
 
     if (!media.xl) {
       values.unshift('Details')


### PR DESCRIPTION
This PR makes a simple adjustment to display Runs before Deployments on an individual flow page.  This tab typically will have more interesting activity, and run creation is a simpler activity than deployment creation - displaying the tabs in this way implicitly emphasizes that more.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
