### PR TITLE
Remove type requirement when creating a work pool via CLI

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -29,9 +29,6 @@ app.add_typer(work_pool_app, aliases=["work-pool"])
 )
 async def create(
     name: str = typer.Argument(..., help="The name of the work pool."),
-    pool_type: str = typer.Option(
-        None, "-t", "--type", help="The infrastructure type of the work pool."
-    ),
     paused: Optional[bool] = typer.Option(
         False,
         "--paused",
@@ -43,27 +40,20 @@ async def create(
 
     \b
     Examples:
-        $ prefect work-pool create "my-pool" --type "process" --paused
+        $ prefect work-pool create "my-pool" --paused
     """
-    if not pool_type:
-        exit_with_error(
-            "Please provide a pool type. "
-            "See `prefect work-pool create --help` for more information."
-        )
     # will always be an empty dict until workers added
     base_job_template = dict()
     async with get_client() as client:
         try:
             wp = WorkPoolCreate(
                 name=name,
-                type=pool_type,
+                type="prefect-agent",
                 base_job_template=base_job_template,
                 is_paused=paused,
             )
             work_pool = await client.create_work_pool(work_pool=wp)
-            exit_with_success(
-                f"Created work pool {work_pool.name!r} with infrastructure type {work_pool.type!r}."
-            )
+            exit_with_success(f"Created work pool {work_pool.name!r}.")
         except ObjectAlreadyExists:
             exit_with_error(
                 f"Work pool {name} already exists. Please choose a different name."

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -21,16 +21,12 @@ def auto_enable_work_pools(enable_work_pools):
 class TestCreate:
     async def test_create_work_pool(self, orion_client):
         pool_name = "my-pool"
-        infra_type = "process"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t {infra_type}",
+            f"work-pool create {pool_name}",
         )
         assert res.exit_code == 0
-        assert (
-            f"Created work pool {pool_name!r} with infrastructure type {infra_type!r}"
-            in res.output
-        )
+        assert f"Created work pool {pool_name!r}" in res.output
         client_res = await orion_client.read_work_pool(pool_name)
         assert client_res.name == pool_name
         assert isinstance(client_res, WorkPool)
@@ -39,7 +35,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t process",
+            f"work-pool create {pool_name}",
         )
         assert res.exit_code == 0
         client_res = await orion_client.read_work_pool(pool_name)
@@ -49,7 +45,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t process",
+            f"work-pool create {pool_name}",
         )
         assert res.exit_code == 0
         client_res = await orion_client.read_work_pool(pool_name)
@@ -59,7 +55,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} --paused -t process",
+            f"work-pool create {pool_name} --paused",
         )
         assert res.exit_code == 0
         client_res = await orion_client.read_work_pool(pool_name)


### PR DESCRIPTION
Users can't meaningfully interact with work pool types at this time; therefore, we should remove references of `type` especially from all creation logic to avoid confusing users or misleading them into thinking there are options for the value here.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
