### PR TITLE
Restore Prefect wrapper that shows details on HTTP errors

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -246,10 +246,12 @@ class PrefectHttpxClient(httpx.AsyncClient):
             ),
         )
 
+        # Convert to a Prefect response to add nicer errors messages
+        response = PrefectResponse.from_httpx_response(response)
+
         # Always raise bad responses
         # NOTE: We may want to remove this and handle responses per route in the
         #       `OrionClient`
-
         response.raise_for_status()
 
         return response

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -274,11 +274,10 @@ class TestPrefectHttpxClient:
         )
         assert isinstance(response, PrefectResponse)
 
-    # test that PrefectResponse info is contained when error response is returned
-    async def test_prefect_httpx_client_returns_prefect_response_with_error(
+    #
+    async def test_prefect_httpx_client_raises_prefect_http_status_error(
         self, monkeypatch
     ):
-        """Test that the PrefectHttpxClient returns a PrefectResponse"""
 
         RESPONSE_400 = Response(
             status.HTTP_400_BAD_REQUEST,

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -6,6 +6,7 @@ from fastapi import status
 from httpx import AsyncClient, Request, Response
 
 from prefect.client.base import PrefectHttpxClient, PrefectResponse
+from prefect.exceptions import PrefectHTTPStatusError
 from prefect.testing.utilities import AsyncMock
 
 RESPONSE_429_RETRY_AFTER_0 = Response(
@@ -18,6 +19,7 @@ RESPONSE_429_RETRY_AFTER_MISSING = Response(
     status.HTTP_429_TOO_MANY_REQUESTS,
     request=Request("a test request", "fake.url/fake/route"),
 )
+
 
 RESPONSE_200 = Response(
     status.HTTP_200_OK,
@@ -271,3 +273,27 @@ class TestPrefectHttpxClient:
             url="fake.url/fake/route", data={"evenmorefake": "data"}
         )
         assert isinstance(response, PrefectResponse)
+
+    # test that PrefectResponse info is contained when error response is returned
+    async def test_prefect_httpx_client_returns_prefect_response_with_error(
+        self, monkeypatch
+    ):
+        """Test that the PrefectHttpxClient returns a PrefectResponse"""
+
+        RESPONSE_400 = Response(
+            status.HTTP_400_BAD_REQUEST,
+            json={"extra_info": [{"message": "a test error message"}]},
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        client = PrefectHttpxClient()
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        base_client_send.return_value = RESPONSE_400
+        with pytest.raises(PrefectHTTPStatusError) as exc:
+            await client.post(url="fake.url/fake/route", data={"evenmorefake": "data"})
+            assert (
+                "Response: {'extra_info': [{'message': 'a test error message'}]}"
+                in str(exc)
+            )

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import status
 from httpx import AsyncClient, Request, Response
 
-from prefect.client.base import PrefectHttpxClient
+from prefect.client.base import PrefectHttpxClient, PrefectResponse
 from prefect.testing.utilities import AsyncMock
 
 RESPONSE_429_RETRY_AFTER_0 = Response(
@@ -258,3 +258,16 @@ class TestPrefectHttpxClient:
             await client.post(url="fake.url/fake/route", data={"evenmorefake": "data"})
 
         mock_anyio_sleep.assert_not_called()
+
+    async def test_prefect_httpx_client_returns_prefect_response(self, monkeypatch):
+        """Test that the PrefectHttpxClient returns a PrefectResponse"""
+        client = PrefectHttpxClient()
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        base_client_send.return_value = RESPONSE_200
+
+        response = await client.post(
+            url="fake.url/fake/route", data={"evenmorefake": "data"}
+        )
+        assert isinstance(response, PrefectResponse)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Somehow, this was removed. I noticed this a while ago in a user report and was confused.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
  File "/Users/mz/dev/prefect/src/prefect/client/base.py", line 130, in raise_for_status
    raise PrefectHTTPStatusError.from_httpx_error(exc) from exc.__cause__
prefect.exceptions.PrefectHTTPStatusError: Client error '422 Unprocessable Entity' for url 'http://127.0.0.1:4200/api/flow_runs/filter'
Response: {'exception_message': 'Invalid request received.', 'exception_detail': [{'loc': ['body', 'flow_runs', 'state', 'type', 'any_', 0], 'msg': "value is not a valid enumeration member; permitted: 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED', 'CRASHED'", 'type': 'type_error.enum', 'ctx': {'enum_values': ['SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED', 'CRASHED']}}], 'request_body': {'flows': None, 'flow_runs': {'operator': 'and_', 'id': {'any_': None, 'not_any_': []}, 'name': None, 'tags': None, 'deployment_id': None, 'work_queue_name': {'operator': 'and_', 'any_': [], 'is_null_': None}, 'state': {'operator': 'and_', 'type': {'any_': ['CANCELLING']}, 'name': None}, 'flow_version': None, 'start_time': None, 'expected_start_time': None, 'next_scheduled_start_time': None, 'parent_task_run_id': None}, 'task_runs': None, 'deployments': None, 'work_pools': None, 'work_pool_queues': None, 'sort': None, 'limit': None, 'offset': 0}}
For more information check: https://httpstatuses.com/422
```

instead of

```
  File "/Users/mz/dev/prefect/src/prefect/client/base.py", line 253, in send
    response.raise_for_status()
  File "/Users/mz/dev/contrib/httpx/httpx/_models.py", line 749, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url 'http://127.0.0.1:4200/api/flow_runs/filter'
For more information check: https://httpstatuses.com/422
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
