### PR TITLE
Add test coverage for logging outside flow run

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -508,6 +508,23 @@ class TestAPILogHandler:
         output = capsys.readouterr()
         assert output.err == ""
 
+    def test_does_not_raise_when_logger_outside_of_run_context_with_default_setting(
+        self,
+        logger,
+    ):
+        try:
+            logger.info("test")
+        except TypeError:
+            pytest.fail(
+                "Raised TypeError when logging outside of context with default 'warn' setting."
+            )
+        except UserWarning:
+            pass
+        except Exception:
+            pytest.fail(
+                "Raised unexpected exception when logging outside of context with default 'warn' setting."
+            )
+
     def test_does_not_send_logs_outside_of_run_context_with_error_setting(
         self, logger, mock_log_worker, capsys
     ):
@@ -526,6 +543,26 @@ class TestAPILogHandler:
         output = capsys.readouterr()
         assert output.err == ""
 
+    def test_does_not_warn_when_logger_outside_of_run_context_with_error_setting(
+        self,
+        logger,
+    ):
+        with temporary_settings(
+            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "error"},
+        ):
+            try:
+                logger.info("test")
+            except UserWarning:
+                pytest.fail(
+                    "Raised UserWarning when logging outside of context with 'error' setting."
+                )
+            except MissingContextError:
+                pass
+            except Exception:
+                pytest.fail(
+                    "Raised unexpected exception when logging outside of context with 'error' setting."
+                )
+
     def test_does_not_send_logs_outside_of_run_context_with_ignore_setting(
         self, logger, mock_log_worker, capsys
     ):
@@ -539,6 +576,28 @@ class TestAPILogHandler:
         # No stderr output
         output = capsys.readouterr()
         assert output.err == ""
+
+    def test_does_not_raise_or_warn_when_logger_outside_of_run_context_with_ignore_setting(
+        self,
+        logger,
+    ):
+        with temporary_settings(
+            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "ignore"},
+        ):
+            try:
+                logger.info("test")
+            except TypeError:
+                pytest.fail(
+                    "Raised TypeError when logging outside of context with 'ignore' setting."
+                )
+            except UserWarning:
+                pytest.fail(
+                    "Raised UserWarning when logging outside of context with 'ignore' setting."
+                )
+            except Exception:
+                pytest.fail(
+                    "Raised unexpected exception when logging outside of context with 'ignore' setting."
+                )
 
     def test_does_not_send_logs_outside_of_run_context_with_warn_setting(
         self, logger, mock_log_worker, capsys
@@ -557,6 +616,26 @@ class TestAPILogHandler:
         # No stderr output
         output = capsys.readouterr()
         assert output.err == ""
+
+    def test_does_not_raise_when_logger_outside_of_run_context_with_warn_setting(
+        self,
+        logger,
+    ):
+        with temporary_settings(
+            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "warn"},
+        ):
+            try:
+                logger.info("test")
+            except TypeError:
+                pytest.fail(
+                    "Raised TypeError when logging outside of context with 'warn' setting."
+                )
+            except UserWarning:
+                pass
+            except Exception:
+                pytest.fail(
+                    "Raised unexpected exception when logging outside of context with 'warn' setting."
+                )
 
     def test_missing_context_warning_refers_to_caller_lineno(
         self, logger, mock_log_worker

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -516,13 +516,13 @@ class TestAPILogHandler:
             logger.info("test")
         except TypeError:
             pytest.fail(
-                "Raised TypeError when logging outside of context with default 'warn' setting."
+                "Raised TypeError when logging outside of context with default `warn` setting."
             )
         except UserWarning:
             pass
         except Exception:
             pytest.fail(
-                "Raised unexpected exception when logging outside of context with default 'warn' setting."
+                "Raised unexpected exception when logging outside of context with default `warn` setting."
             )
 
     def test_does_not_send_logs_outside_of_run_context_with_error_setting(
@@ -554,13 +554,13 @@ class TestAPILogHandler:
                 logger.info("test")
             except UserWarning:
                 pytest.fail(
-                    "Raised UserWarning when logging outside of context with 'error' setting."
+                    "Raised UserWarning when logging outside of context with `error` setting."
                 )
             except MissingContextError:
                 pass
             except Exception:
                 pytest.fail(
-                    "Raised unexpected exception when logging outside of context with 'error' setting."
+                    "Raised unexpected exception when logging outside of context with `error` setting."
                 )
 
     def test_does_not_send_logs_outside_of_run_context_with_ignore_setting(
@@ -588,15 +588,15 @@ class TestAPILogHandler:
                 logger.info("test")
             except TypeError:
                 pytest.fail(
-                    "Raised TypeError when logging outside of context with 'ignore' setting."
+                    "Raised TypeError when logging outside of context with `ignore` setting."
                 )
             except UserWarning:
                 pytest.fail(
-                    "Raised UserWarning when logging outside of context with 'ignore' setting."
+                    "Raised UserWarning when logging outside of context with `ignore` setting."
                 )
             except Exception:
                 pytest.fail(
-                    "Raised unexpected exception when logging outside of context with 'ignore' setting."
+                    "Raised unexpected exception when logging outside of context with `ignore` setting."
                 )
 
     def test_does_not_send_logs_outside_of_run_context_with_warn_setting(
@@ -628,13 +628,13 @@ class TestAPILogHandler:
                 logger.info("test")
             except TypeError:
                 pytest.fail(
-                    "Raised TypeError when logging outside of context with 'warn' setting."
+                    "Raised TypeError when logging outside of context with `warn` setting."
                 )
             except UserWarning:
                 pass
             except Exception:
                 pytest.fail(
-                    "Raised unexpected exception when logging outside of context with 'warn' setting."
+                    "Raised unexpected exception when logging outside of context with `warn` setting."
                 )
 
     def test_missing_context_warning_refers_to_caller_lineno(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -512,18 +512,14 @@ class TestAPILogHandler:
         self,
         logger,
     ):
-        try:
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "Logger 'tests.test_logging' attempted to send logs to the API without"
+                " a flow run id."
+            ),
+        ):
             logger.info("test")
-        except TypeError:
-            pytest.fail(
-                "Raised TypeError when logging outside of context with default `warn` setting."
-            )
-        except UserWarning:
-            pass
-        except Exception:
-            pytest.fail(
-                "Raised unexpected exception when logging outside of context with default `warn` setting."
-            )
 
     def test_does_not_send_logs_outside_of_run_context_with_error_setting(
         self, logger, mock_log_worker, capsys
@@ -548,20 +544,16 @@ class TestAPILogHandler:
         logger,
     ):
         with temporary_settings(
-            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "error"},
+            updates={PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW: "error"},
         ):
-            try:
+            with pytest.raises(
+                MissingContextError,
+                match=(
+                    "Logger 'tests.test_logging' attempted to send logs to the API"
+                    " without a flow run id."
+                ),
+            ):
                 logger.info("test")
-            except UserWarning:
-                pytest.fail(
-                    "Raised UserWarning when logging outside of context with `error` setting."
-                )
-            except MissingContextError:
-                pass
-            except Exception:
-                pytest.fail(
-                    "Raised unexpected exception when logging outside of context with `error` setting."
-                )
 
     def test_does_not_send_logs_outside_of_run_context_with_ignore_setting(
         self, logger, mock_log_worker, capsys
@@ -582,22 +574,9 @@ class TestAPILogHandler:
         logger,
     ):
         with temporary_settings(
-            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "ignore"},
+            updates={PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW: "ignore"},
         ):
-            try:
-                logger.info("test")
-            except TypeError:
-                pytest.fail(
-                    "Raised TypeError when logging outside of context with `ignore` setting."
-                )
-            except UserWarning:
-                pytest.fail(
-                    "Raised UserWarning when logging outside of context with `ignore` setting."
-                )
-            except Exception:
-                pytest.fail(
-                    "Raised unexpected exception when logging outside of context with `ignore` setting."
-                )
+            logger.info("test")
 
     def test_does_not_send_logs_outside_of_run_context_with_warn_setting(
         self, logger, mock_log_worker, capsys
@@ -622,20 +601,16 @@ class TestAPILogHandler:
         logger,
     ):
         with temporary_settings(
-            updates={PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW: "warn"},
+            updates={PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW: "warn"},
         ):
-            try:
+            with pytest.raises(
+                UserWarning,
+                match=(
+                    "Logger 'tests.test_logging' attempted to send logs to the API"
+                    " without a flow run id."
+                ),
+            ):
                 logger.info("test")
-            except TypeError:
-                pytest.fail(
-                    "Raised TypeError when logging outside of context with `warn` setting."
-                )
-            except UserWarning:
-                pass
-            except Exception:
-                pytest.fail(
-                    "Raised unexpected exception when logging outside of context with `warn` setting."
-                )
 
     def test_missing_context_warning_refers_to_caller_lineno(
         self, logger, mock_log_worker

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -597,12 +597,14 @@ class TestAPILogHandler:
         assert output.err == ""
 
     def test_does_not_raise_when_logger_outside_of_run_context_with_warn_setting(
-        self,
-        logger,
+        self, logger
     ):
         with temporary_settings(
             updates={PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW: "warn"},
         ):
+            # NOTE: We use `raises` instead of `warns` because pytest will otherwise
+            #       capture the warning call and skip checing that we use it correctly
+            #       See https://github.com/pytest-dev/pytest/issues/9288
             with pytest.raises(
                 UserWarning,
                 match=(


### PR DESCRIPTION
### Overview

Adds 4 new tests around the `PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW` setting to ensure that:
1. a default setting of `warn` does not raise
2. a setting of `warn` does not raise
3. a setting of `ignore` does not raise or warn
4. a setting of `error` does not warn

### Example
Intended to test cases like:
```bash
❯ PREFECT_LOGGING_EXTRA_LOGGERS="my-logger" python example.py    
Traceback (most recent call last):
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 279, in emit
    self.get_worker(profile).enqueue(self.prepare(record, profile.settings))
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 323, in prepare
    raise MissingContextError(
prefect.exceptions.MissingContextError: Logger 'my-logger' attempted to send logs to Orion without a flow run id. The Orion log handler can only send logs within flow run contexts unless the flow run id is manually provided.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "example.py", line 6, in <module>
    my_logger.info("outside the flow")
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/logging/__init__.py", line 1434, in info
    self._log(INFO, msg, args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/logging/__init__.py", line 1577, in _log
    self.handle(record)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/logging/__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
    hdlr.handle(record)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/logging/__init__.py", line 950, in handle
    self.emit(record)
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 281, in emit
    self.handleError(record)
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 293, in handleError
    warnings.warn(exc, stacklevel=8)
TypeError: expected string or bytes-like object
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
