### PR TITLE
Switch deployment tabs

### DIFF
--- a/orion-ui/src/pages/Deployment.vue
+++ b/orion-ui/src/pages/Deployment.vue
@@ -71,10 +71,10 @@
 
   const computedTabs = computed(() => [
     { label: 'Details', hidden: media.xl },
-    { label: 'Description' },
     { label: 'Runs' },
     { label: 'Parameters', hidden: deployment.value?.deprecated },
     { label: 'Infra Overrides', hidden: deployment.value?.deprecated },
+    { label: 'Description' },
   ])
   const tabs = useTabs(computedTabs)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Currently the first tab a user sees (if they are on a larger screen) on the deployments page is the description. However, not everyone uses a description. This PR tries out showing the runs tab first instead. Complement to https://github.com/PrefectHQ/nebula-ui/pull/2282



### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
