### PR TITLE
Add Orion info route

### DIFF
--- a/src/prefect/orion/api/server.py
+++ b/src/prefect/orion/api/server.py
@@ -141,6 +141,7 @@ def create_orion_api(
     router_prefix: Optional[str] = "",
     dependencies: Optional[List[Depends]] = None,
     health_check_path: str = "/health",
+    version_check_path: str = "/version",
     fast_api_app_kwargs: dict = None,
     router_overrides: Mapping[str, Optional[APIRouter]] = None,
 ) -> FastAPI:
@@ -165,6 +166,10 @@ def create_orion_api(
     @api_app.get(health_check_path, tags=["Root"])
     async def health_check():
         return True
+
+    @api_app.get(version_check_path, tags=["Root"])
+    async def orion_info():
+        return ORION_API_VERSION
 
     # always include version checking
     if dependencies is None:

--- a/tests/orion/api/test_server.py
+++ b/tests/orion/api/test_server.py
@@ -7,10 +7,10 @@ from fastapi import APIRouter, status, testclient
 
 from prefect.orion.api.server import (
     API_ROUTERS,
+    ORION_API_VERSION,
     _memoize_block_auto_registration,
     create_orion_api,
     method_paths_from_routes,
-    ORION_API_VERSION,
 )
 from prefect.settings import (
     PREFECT_MEMO_STORE_PATH,

--- a/tests/orion/api/test_server.py
+++ b/tests/orion/api/test_server.py
@@ -10,6 +10,7 @@ from prefect.orion.api.server import (
     _memoize_block_auto_registration,
     create_orion_api,
     method_paths_from_routes,
+    ORION_API_VERSION,
 )
 from prefect.settings import (
     PREFECT_MEMO_STORE_PATH,
@@ -52,11 +53,18 @@ async def test_health_check_route(client):
     assert response.status_code == status.HTTP_200_OK
 
 
+async def test_version_route(client):
+    response = await client.get("/version")
+    assert response.json() == ORION_API_VERSION
+    assert response.status_code == status.HTTP_200_OK
+
+
 class TestCreateOrionAPI:
 
     BUILTIN_ROUTES = {
         "GET /redoc",
         "GET /health",
+        "GET /version",
         "HEAD /docs",
         "GET /openapi.json",
         "GET /docs/oauth2-redirect",


### PR DESCRIPTION
Adding an info route that returns the Orion version will be generally useful to maintain client compatibility in the future.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
