### PR TITLE
Add generic webhook block

### DIFF
--- a/src/prefect/blocks/__init__.py
+++ b/src/prefect/blocks/__init__.py
@@ -4,4 +4,4 @@ import prefect.blocks.notifications
 import prefect.blocks.system
 import prefect.blocks.webhook
 
-__all__ = ["notifications", "storage", "system", "webhook"]
+__all__ = ["notifications", "system", "webhook"]

--- a/src/prefect/blocks/__init__.py
+++ b/src/prefect/blocks/__init__.py
@@ -2,5 +2,6 @@
 
 import prefect.blocks.notifications
 import prefect.blocks.system
+import prefect.blocks.webhook
 
-__all__ = ["notifications", "storage", "system"]
+__all__ = ["notifications", "storage", "system", "webhook"]

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -18,7 +18,7 @@ class Webhook(Block):
     """
 
     _block_type_name = "Webhook"
-    _logo_url = "http://todo.jpg"  # type: ignore
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6ciCsTFsvUAiiIvTllMfOU/627e9513376ca457785118fbba6a858d/webhook_icon_138018.png?h=250"  # type: ignore
     _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/webhook/#prefect.blocks.webhook.Webhook"
 
     method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -1,7 +1,8 @@
-from typing import Literal, Optional
+from typing import Optional
 
 from httpx import AsyncClient, AsyncHTTPTransport, Response
 from pydantic import Field, SecretStr
+from typing_extensions import Literal
 
 from prefect.blocks.core import Block
 from prefect.blocks.fields import SecretDict

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -18,8 +18,6 @@ class Webhook(Block):
 
     _block_type_name = "Webhook"
     _logo_url = "http://todo.jpg"  # type: ignore
-    # Overwrite default code example because this block cannot be used client side
-    _code_example = ""
 
     method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(
         default="POST", description="The webhook request method. Defaults to `POST`"

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -1,0 +1,56 @@
+from typing import Literal, Optional
+
+from httpx import AsyncClient, AsyncHTTPTransport, Response
+from pydantic import Field, SecretStr
+
+from prefect.blocks.core import Block
+from prefect.blocks.fields import SecretDict
+
+# Use a global HTTP transport to maintain a process-wide connection pool for
+# interservice requests
+_http_transport = AsyncHTTPTransport()
+
+
+class Webhook(Block):
+    """
+    Block that enables calling webhooks.
+    """
+
+    _block_type_name = "Webhook"
+    _logo_url = "http://todo.jpg"  # type: ignore
+    # Overwrite default code example because this block cannot be used client side
+    _code_example = ""
+
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(
+        default="POST", description="The webhook request method. Defaults to `POST`"
+    )
+
+    url: SecretStr = Field(
+        default=...,
+        title="Webhook URL",
+        description="The webhook URL",
+        example="https://hooks.slack.com/XXX",
+    )
+
+    headers: SecretDict = Field(
+        default_factory=lambda: SecretDict(dict()),
+        description="A dictionary of headers to send with the webhook request.",
+    )
+
+    def block_initialization(self):
+        self._client = AsyncClient(transport=_http_transport)
+
+    async def call(self, payload: Optional[dict] = None) -> Response:
+        """
+        Call the webhook.
+
+        Args:
+            payload: an optional payload to send when calling the webhook.
+        """
+        async with self._client:
+            return await self._client.request(
+                method=self.method,
+                url=self.url.get_secret_value(),
+                headers=self.headers.get_secret_value(),
+                json=payload,
+            )

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -19,20 +19,22 @@ class Webhook(Block):
 
     _block_type_name = "Webhook"
     _logo_url = "http://todo.jpg"  # type: ignore
+    _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/webhook/#prefect.blocks.webhook.Webhook"
 
     method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(
-        default="POST", description="The webhook request method. Defaults to `POST`"
+        default="POST", description="The webhook request method. Defaults to `POST`."
     )
 
     url: SecretStr = Field(
         default=...,
         title="Webhook URL",
-        description="The webhook URL",
+        description="The webhook URL.",
         example="https://hooks.slack.com/XXX",
     )
 
     headers: SecretDict = Field(
         default_factory=lambda: SecretDict(dict()),
+        title="Webhook Headers",
         description="A dictionary of headers to send with the webhook request.",
     )
 

--- a/src/prefect/orion/models/block_registration.py
+++ b/src/prefect/orion/models/block_registration.py
@@ -18,6 +18,7 @@ async def _install_protected_system_blocks(session):
     """Install block types that the system expects to be present"""
 
     for block in [
+        prefect.blocks.webhook.Webhook,
         prefect.blocks.system.JSON,
         prefect.blocks.system.DateTime,
         prefect.blocks.system.Secret,

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from prefect.blocks.webhook import Webhook
+
+
+class TestWebhook:
+    def test_webhook_raises_error_on_bad_request_method(self):
+        for method in ["GET", "PUT", "POST", "PATCH", "DELETE"]:
+            Webhook(method=method, url="http://google.com")
+
+        for bad_method in ["get", "BLAH", ""]:
+            with pytest.raises(ValueError):
+                Webhook(method=bad_method, url="http://google.com")
+
+    async def test_webhook_sends(self, monkeypatch):
+        send_mock = AsyncMock()
+        monkeypatch.setattr("httpx.AsyncClient.request", send_mock)
+
+        await Webhook(
+            method="POST", url="http://yahoo.com", headers={"authorization": "password"}
+        ).call(payload={"event_id": "123"})
+
+        send_mock.assert_called_with(
+            method="POST",
+            url="http://yahoo.com",
+            headers={"authorization": "password"},
+            json={"event_id": "123"},
+        )
+
+    async def test_webhook_sends_get_request_with_no_payload(self, monkeypatch):
+        send_mock = AsyncMock()
+        monkeypatch.setattr("httpx.AsyncClient.request", send_mock)
+        await Webhook(
+            method="GET", url="http://google.com", headers={"foo": "bar"}
+        ).call(payload=None)
+
+        send_mock.assert_called_with(
+            method="GET", url="http://google.com", headers={"foo": "bar"}, json=None
+        )

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -38,3 +38,13 @@ class TestWebhook:
         send_mock.assert_called_with(
             method="GET", url="http://google.com", headers={"foo": "bar"}, json=None
         )
+
+    async def test_save_and_load_webhook(self):
+        await Webhook(
+            method="GET", url="http://google.com", headers={"foo": "bar"}
+        ).save(name="webhook-test")
+
+        webhook = await Webhook.load(name="webhook-test")
+        assert webhook.url.get_secret_value() == "http://google.com"
+        assert webhook.method == "GET"
+        assert webhook.headers.get_secret_value() == {"foo": "bar"}

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -1,8 +1,7 @@
-from unittest.mock import AsyncMock
-
 import pytest
 
 from prefect.blocks.webhook import Webhook
+from prefect.testing.utilities import AsyncMock
 
 
 class TestWebhook:

--- a/tests/orion/models/test_block_registration.py
+++ b/tests/orion/models/test_block_registration.py
@@ -37,6 +37,7 @@ class TestRunAutoRegistration:
             "secret",
             "local-file-system",
             "process",
+            "webhook",
         }
 
         starting_block_types = await read_block_types(session)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

This PR adds a new `Webhook` block type. 

The block allows customizing webhook url, method, and headers. Any payload sent must be explicitly provided at the time of firing.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
my_webhook = Webhook(
    method="POST", url="http://yahoo.com", headers={"authorization": "password"}
)

await my_webhook.call(payload={"example": "json payload"})
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
