### PR TITLE
Dezombify concurrency limits

### DIFF
--- a/src/prefect/cli/concurrency_limit.py
+++ b/src/prefect/cli/concurrency_limit.py
@@ -130,6 +130,21 @@ async def ls(limit: int = 15, offset: int = 0):
 
 
 @concurrency_limit_app.command()
+async def reset(tag: str):
+    """
+    Resets the concurrency limit slots set on the specified tag.
+    """
+
+    async with get_client() as client:
+        try:
+            await client.reset_concurrency_limit_by_tag(tag=tag)
+        except ObjectNotFound:
+            exit_with_error(f"No concurrency limit found for the tag: {tag}")
+
+    exit_with_success(f"Reset concurrency limit set on the tag: {tag}")
+
+
+@concurrency_limit_app.command()
 async def delete(tag: str):
     """
     Delete the concurrency limit set on the specified tag.

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -671,6 +671,7 @@ class OrionClient:
     async def reset_concurrency_limit_by_tag(
         self,
         tag: str,
+        slot_override: Optional[List[Union[UUID, str]]] = None,
     ):
         """
         Resets the concurrency limit slots set on a specific tag.
@@ -683,9 +684,13 @@ class OrionClient:
             httpx.RequestError: If request fails
 
         """
+        if slot_override is not None:
+            slot_override = [str(slot) for slot in slot_override]
+
         try:
             await self._client.post(
                 f"/concurrency_limits/reset/tag/{tag}",
+                json=dict(slot_override=slot_override),
             )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -668,6 +668,31 @@ class OrionClient:
             List[schemas.core.ConcurrencyLimit], response.json()
         )
 
+    async def reset_concurrency_limit_by_tag(
+        self,
+        tag: str,
+    ):
+        """
+        Resets the concurrency limit slots set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        """
+        try:
+            await self._client.post(
+                f"/concurrency_limits/reset/tag/{tag}",
+            )
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
     async def delete_concurrency_limit_by_tag(
         self,
         tag: str,

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -689,7 +689,7 @@ class OrionClient:
 
         try:
             await self._client.post(
-                f"/concurrency_limits/reset/tag/{tag}",
+                f"/concurrency_limits/tag/{tag}/reset",
                 json=dict(slot_override=slot_override),
             )
         except httpx.HTTPStatusError as e:

--- a/src/prefect/client/orion.py
+++ b/src/prefect/client/orion.py
@@ -678,6 +678,10 @@ class OrionClient:
 
         Args:
             tag: a tag the concurrency limit is applied to
+            slot_override: a list of task run IDs that are currently using a
+                concurrency slot, please check that any task run IDs included in
+                `slot_override` are currently running, otherwise those concurrency
+                slots will never be released.
 
         Raises:
             prefect.exceptions.ObjectNotFound: If request returns 404

--- a/src/prefect/orion/api/concurrency_limits.py
+++ b/src/prefect/orion/api/concurrency_limits.py
@@ -1,7 +1,7 @@
 """
 Routes for interacting with concurrency limit objects.
 """
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 import pendulum
@@ -110,11 +110,16 @@ async def read_concurrency_limits(
 @router.post("/reset/tag/{tag}")
 async def reset_concurrency_limit_by_tag(
     tag: str = Path(..., description="The tag name"),
+    slot_override: Optional[List[str]] = Body(
+        None,
+        embed=True,
+        description=("Manual override for active concurrency limit slots.",),
+    ),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):
     async with db.session_context(begin_transaction=True) as session:
         model = await models.concurrency_limits.reset_concurrency_limit_by_tag(
-            session=session, tag=tag
+            session=session, tag=tag, slot_override=slot_override
         )
     if not model:
         raise HTTPException(

--- a/src/prefect/orion/api/concurrency_limits.py
+++ b/src/prefect/orion/api/concurrency_limits.py
@@ -110,7 +110,7 @@ async def read_concurrency_limits(
 @router.post("/reset/tag/{tag}")
 async def reset_concurrency_limit_by_tag(
     tag: str = Path(..., description="The tag name"),
-    slot_override: Optional[List[str]] = Body(
+    slot_override: Optional[List[UUID]] = Body(
         None,
         embed=True,
         description=("Manual override for active concurrency limit slots."),

--- a/src/prefect/orion/api/concurrency_limits.py
+++ b/src/prefect/orion/api/concurrency_limits.py
@@ -107,7 +107,7 @@ async def read_concurrency_limits(
         )
 
 
-@router.post("/reset/tag/{tag}")
+@router.post("/tag/{tag}/reset")
 async def reset_concurrency_limit_by_tag(
     tag: str = Path(..., description="The tag name"),
     slot_override: Optional[List[UUID]] = Body(

--- a/src/prefect/orion/api/concurrency_limits.py
+++ b/src/prefect/orion/api/concurrency_limits.py
@@ -107,6 +107,21 @@ async def read_concurrency_limits(
         )
 
 
+@router.post("/reset/tag/{tag}")
+async def reset_concurrency_limit_by_tag(
+    tag: str = Path(..., description="The tag name"),
+    db: OrionDBInterface = Depends(provide_database_interface),
+):
+    async with db.session_context(begin_transaction=True) as session:
+        model = await models.concurrency_limits.reset_concurrency_limit_by_tag(
+            session=session, tag=tag
+        )
+    if not model:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Concurrency limit not found"
+        )
+
+
 @router.delete("/{id}")
 async def delete_concurrency_limit(
     concurrency_limit_id: UUID = Path(

--- a/src/prefect/orion/api/concurrency_limits.py
+++ b/src/prefect/orion/api/concurrency_limits.py
@@ -113,7 +113,7 @@ async def reset_concurrency_limit_by_tag(
     slot_override: Optional[List[str]] = Body(
         None,
         embed=True,
-        description=("Manual override for active concurrency limit slots.",),
+        description=("Manual override for active concurrency limit slots."),
     ),
     db: OrionDBInterface = Depends(provide_database_interface),
 ):

--- a/src/prefect/orion/models/concurrency_limits.py
+++ b/src/prefect/orion/models/concurrency_limits.py
@@ -94,7 +94,7 @@ async def reset_concurrency_limit_by_tag(
     session: sa.orm.Session,
     tag: str,
     db: OrionDBInterface,
-    slot_override: Optional[List[str]] = None,
+    slot_override: Optional[List[UUID]] = None,
 ):
     """
     Resets a concurrency limit by tag.
@@ -104,7 +104,7 @@ async def reset_concurrency_limit_by_tag(
     concurrency_limit = result.scalar()
     if concurrency_limit:
         if slot_override is not None:
-            concurrency_limit.active_slots = slot_override
+            concurrency_limit.active_slots = [str(slot) for slot in slot_override]
         else:
             concurrency_limit.active_slots = []
     return concurrency_limit

--- a/src/prefect/orion/models/concurrency_limits.py
+++ b/src/prefect/orion/models/concurrency_limits.py
@@ -90,6 +90,23 @@ async def read_concurrency_limit_by_tag(
 
 
 @inject_db
+async def reset_concurrency_limit_by_tag(
+    session: sa.orm.Session,
+    tag: str,
+    db: OrionDBInterface,
+):
+    """
+    Resets a concurrency limit by tag.
+    """
+    query = sa.select(db.ConcurrencyLimit).where(db.ConcurrencyLimit.tag == tag)
+    result = await session.execute(query)
+    concurrency_limit = result.scalar()
+    if concurrency_limit:
+        concurrency_limit.active_slots = []
+    return concurrency_limit
+
+
+@inject_db
 async def filter_concurrency_limits_for_orchestration(
     session: sa.orm.Session,
     tags: List[str],

--- a/src/prefect/orion/models/concurrency_limits.py
+++ b/src/prefect/orion/models/concurrency_limits.py
@@ -94,6 +94,7 @@ async def reset_concurrency_limit_by_tag(
     session: sa.orm.Session,
     tag: str,
     db: OrionDBInterface,
+    slot_override: Optional[List[str]] = None,
 ):
     """
     Resets a concurrency limit by tag.
@@ -102,7 +103,10 @@ async def reset_concurrency_limit_by_tag(
     result = await session.execute(query)
     concurrency_limit = result.scalar()
     if concurrency_limit:
-        concurrency_limit.active_slots = []
+        if slot_override is not None:
+            concurrency_limit.active_slots = slot_override
+        else:
+            concurrency_limit.active_slots = []
     return concurrency_limit
 
 

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -732,6 +732,26 @@ async def test_read_nonexistent_concurrency_limit_by_tag(orion_client):
         await orion_client.read_concurrency_limit_by_tag("not-a-real-tag")
 
 
+async def test_resetting_concurrency_limits(orion_client):
+    cl = await orion_client.create_concurrency_limit(
+        tag="an-unimportant-limit", concurrency_limit=100
+    )
+
+    await orion_client.reset_concurrency_limit_by_tag(
+        "an-unimportant-limit", slot_override=[uuid4(), uuid4(), uuid4()]
+    )
+    first_lookup = await orion_client.read_concurrency_limit_by_tag(
+        "an-unimportant-limit"
+    )
+    assert len(first_lookup.active_slots) == 3
+
+    await orion_client.reset_concurrency_limit_by_tag("an-unimportant-limit")
+    reset_lookup = await orion_client.read_concurrency_limit_by_tag(
+        "an-unimportant-limit"
+    )
+    assert len(reset_lookup.active_slots) == 0
+
+
 async def test_deleting_concurrency_limits(orion_client):
     cl = await orion_client.create_concurrency_limit(
         tag="dead-limit-walking", concurrency_limit=10

--- a/tests/orion/api/test_concurrency_limits.py
+++ b/tests/orion/api/test_concurrency_limits.py
@@ -86,7 +86,7 @@ class TestConcurrencyLimits:
         cl_id = create_response.json()["id"]
 
         override_response = await client.post(
-            f"/concurrency_limits/reset/tag/{tag}",
+            f"/concurrency_limits/tag/{tag}/reset",
             json=dict(slot_override=[str(uuid4()) for _ in range(50)]),
         )
         assert override_response.status_code == status.HTTP_200_OK

--- a/tests/orion/api/test_concurrency_limits.py
+++ b/tests/orion/api/test_concurrency_limits.py
@@ -94,7 +94,7 @@ class TestConcurrencyLimits:
         pre_reset = await client.get(f"/concurrency_limits/{cl_id}")
         assert len(pre_reset.json()["active_slots"]) == 50
 
-        reset_response = await client.post(f"/concurrency_limits/reset/tag/{tag}")
+        reset_response = await client.post(f"/concurrency_limits/tag/{tag}/reset")
         assert reset_response.status_code == status.HTTP_200_OK
 
         post_reset = await client.get(f"/concurrency_limits/{cl_id}")

--- a/tests/orion/api/test_concurrency_limits.py
+++ b/tests/orion/api/test_concurrency_limits.py
@@ -1,10 +1,8 @@
 from uuid import uuid4
 
-import pytest
 from fastapi import status
 
 from prefect.orion import schemas
-from prefect.orion.models import concurrency_limits
 from prefect.orion.schemas.actions import ConcurrencyLimitCreate
 
 

--- a/tests/orion/api/test_concurrency_limits.py
+++ b/tests/orion/api/test_concurrency_limits.py
@@ -1,6 +1,7 @@
+from uuid import uuid4
+
 import pytest
 from fastapi import status
-from uuid import uuid4
 
 from prefect.orion import schemas
 from prefect.orion.models import concurrency_limits
@@ -96,10 +97,10 @@ class TestConcurrencyLimits:
         cl_id = concurrency_limit_with_active_slots.id
 
         pre_reset = await client.get(f"/concurrency_limits/{cl_id}")
-        assert len(pre_reset.json()['active_slots']) == 50
+        assert len(pre_reset.json()["active_slots"]) == 50
 
         reset_response = await client.post(f"/concurrency_limits/reset/tag/{tag}")
         assert reset_response.status_code == status.HTTP_200_OK
 
         post_reset = await client.get(f"/concurrency_limits/{cl_id}")
-        assert len(post_reset.json()['active_slots']) == 0
+        assert len(post_reset.json()["active_slots"]) == 0

--- a/tests/orion/models/test_concurrency_limits.py
+++ b/tests/orion/models/test_concurrency_limits.py
@@ -41,6 +41,52 @@ class TestCreatingConcurrencyLimits:
         assert updated_limit.updated > creation_time
 
 
+class TestResettingConcurrencyLimits:
+    async def test_resetting_concurrency_limit(self, session):
+        concurrency_limit = await models.concurrency_limits.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimit(
+                tag="this bad boy", concurrency_limit=100
+            ),
+        )
+        concurrency_limit.active_slots = [str(uuid4()) for _ in range(50)]
+        limit_before_reset = (
+            await models.concurrency_limits.read_concurrency_limit_by_tag(
+                session, "this bad boy"
+            )
+        )
+        assert len(limit_before_reset.active_slots) == 50
+
+        await models.concurrency_limits.reset_concurrency_limit_by_tag(
+            session, "this bad boy"
+        )
+        limit_after_reset = (
+            await models.concurrency_limits.read_concurrency_limit_by_tag(
+                session, "this bad boy"
+            )
+        )
+        assert len(limit_before_reset.active_slots) == 0
+
+    async def test_resetting_limit_returns_limit(self, session):
+        concurrency_limit = await models.concurrency_limits.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimit(
+                tag="this bad boy", concurrency_limit=100
+            ),
+        )
+
+        result = await models.concurrency_limits.reset_concurrency_limit_by_tag(
+            session, "this bad boy"
+        )
+        assert len(result.active_slots) == 0
+
+    async def test_resetting_limit_returns_none_when_missing_limit(self, session):
+        result = await models.concurrency_limits.reset_concurrency_limit_by_tag(
+            session, "this missing_limit"
+        )
+        assert result is None
+
+
 class TestReadingSingleConcurrencyLimits:
     async def test_reading_concurrency_limits_by_id(self, session):
         concurrency_limit = await models.concurrency_limits.create_concurrency_limit(

--- a/tests/orion/models/test_concurrency_limits.py
+++ b/tests/orion/models/test_concurrency_limits.py
@@ -83,7 +83,7 @@ class TestResettingConcurrencyLimits:
         assert len(limit_before_reset.active_slots) == 50
 
         await models.concurrency_limits.reset_concurrency_limit_by_tag(
-            session, "this bad boy", slot_override=[str(uuid4()) for _ in range(42)]
+            session, "this bad boy", slot_override=[uuid4() for _ in range(42)]
         )
         limit_after_reset = (
             await models.concurrency_limits.read_concurrency_limit_by_tag(


### PR DESCRIPTION
Partially addresses zombie concurrency limit slot issues documented in #5995

Here we add a simple CLI utility to reset the active slots on a concurrency limit. Sometimes, task runs might never reach a terminal state due to infrastructure crashes. In these cases the runs may never release concurrency limit slots they have acquired. By resetting a concurrency limit a user can purge all existing runs from holding a concurrency limit slot.

WIP: Still need to add client/CLI tests, but it might be nice to get some QA to see if this feels right @EmilRex 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
