### PR TITLE
Updated "deployment build options" in Deployment Concepts to include --param and --params

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -193,8 +193,8 @@ You may specify additional options to further customize your deployment.
 | `--apply` | When provided, automatically registers the resulting deployment with the API. |
 | `--skip-upload` | When provided, skips uploading this deployment's files to remote storage. |
 | `--path` | An optional path to specify a subdirectory of remote storage to upload to, or to point to a subdirectory of a locally stored flow. |
-| `--param` | An optional parameter override, values are parsed as JSON strings. For example, `--param question=ultimate --param answer=42` |
-| `--params` | An optional parameter override in a JSON string format. For example, `--params=\'{"question": "ultimate", "answer": 42}\'` |
+| `--param` | An optional parameter override, values are parsed as JSON strings. For example, `--param question=ultimate --param answer=42`. |
+| `--params` | An optional parameter override in a JSON string format. For example, `--params=\'{"question": "ultimate", "answer": 42}\'`. |
 
 ### Block identifiers
 

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -193,6 +193,8 @@ You may specify additional options to further customize your deployment.
 | `--apply` | When provided, automatically registers the resulting deployment with the API. |
 | `--skip-upload` | When provided, skips uploading this deployment's files to remote storage. |
 | `--path` | An optional path to specify a subdirectory of remote storage to upload to, or to point to a subdirectory of a locally stored flow. |
+| `--param` | An optional parameter override, values are parsed as JSON strings. For example, `--param question=ultimate --param answer=42` |
+| `--params` | An optional parameter override in a JSON string format. For example, `--params=\'{"question": "ultimate", "answer": 42}\'` |
 
 ### Block identifiers
 


### PR DESCRIPTION
<!-- Include an overview here -->
The [Deployment page](https://docs.prefect.io/concepts/deployments/?h=deploy#deployment-build-options) of the Concepts docs do not describe the options for including parameter overrides in the `prefect deployment build` command. I've added `--param` and `--params` to the table, with the descriptions copied from the `prefect.cli.deployment` docs, with minor changes for formatting.

Screenshot of the rendered markdown in the proposed change:
![image](https://user-images.githubusercontent.com/8505845/216836597-5aa09a34-3773-4558-af93-97c126be1f9f.png)


This closes #7510

### Checklist
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`

