### PR TITLE
Properly limit artifact migration to states that have non-null data

### DIFF
--- a/src/prefect/orion/database/migrations/versions/postgresql/2023_01_26_045501_2882cd2df464_create_migration_index.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2023_01_26_045501_2882cd2df464_create_migration_index.py
@@ -35,14 +35,14 @@ def upgrade():
     def populate_flow_has_data_in_batches(batch_size):
         return f"""
             UPDATE flow_run_state
-            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
+            SET has_data = (data IS NOT NULL AND data != 'null')
             WHERE flow_run_state.id in (SELECT id FROM flow_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 
     def populate_task_has_data_in_batches(batch_size):
         return f"""
             UPDATE task_run_state
-            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
+            SET has_data = (data IS NOT NULL AND data != 'null')
             WHERE task_run_state.id in (SELECT id FROM task_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 

--- a/src/prefect/orion/database/migrations/versions/postgresql/2023_01_26_045501_2882cd2df464_create_migration_index.py
+++ b/src/prefect/orion/database/migrations/versions/postgresql/2023_01_26_045501_2882cd2df464_create_migration_index.py
@@ -35,14 +35,14 @@ def upgrade():
     def populate_flow_has_data_in_batches(batch_size):
         return f"""
             UPDATE flow_run_state
-            SET has_data = (data IS NOT NULL or data != 'null')
+            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
             WHERE flow_run_state.id in (SELECT id FROM flow_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 
     def populate_task_has_data_in_batches(batch_size):
         return f"""
             UPDATE task_run_state
-            SET has_data = (data IS NOT NULL or data != 'null')
+            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
             WHERE task_run_state.id in (SELECT id FROM task_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 

--- a/src/prefect/orion/database/migrations/versions/sqlite/2023_01_12_000043_f92143d30c25_create_migration_index.py
+++ b/src/prefect/orion/database/migrations/versions/sqlite/2023_01_12_000043_f92143d30c25_create_migration_index.py
@@ -37,14 +37,14 @@ def upgrade():
     def populate_flow_has_data_in_batches(batch_size):
         return f"""
             UPDATE flow_run_state
-            SET has_data = (data IS NOT NULL or data != 'null')
+            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
             WHERE flow_run_state.id in (SELECT id FROM flow_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 
     def populate_task_has_data_in_batches(batch_size):
         return f"""
             UPDATE task_run_state
-            SET has_data = (data IS NOT NULL or data != 'null')
+            SET has_data = (data IS NOT NULL AND data IS NOT 'null')
             WHERE task_run_state.id in (SELECT id FROM task_run_state WHERE (has_data IS NULL) LIMIT {batch_size});
         """
 


### PR DESCRIPTION
Thanks to @hateyouinfinity for the excellent bug report.

Addresses the bug raised in https://github.com/PrefectHQ/prefect/issues/8417.

Our artifact migration improperly marked too many states to copy over to the artifact table, causing table bloat and, at times, migrations that might not end. We've implemented the changes suggested in #8417.

Users that have already made it past this migration should don't need to change anything, this change makes it so that users who have not yet upgraded are less likely to need to run a too-large migration.
