### PR TITLE
Update return type for get_run_logger

### DIFF
--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -3,7 +3,7 @@ import logging
 from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import prefect
 from prefect.exceptions import MissingContextError
@@ -55,7 +55,9 @@ def get_logger(name: str = None) -> logging.Logger:
     return logger
 
 
-def get_run_logger(context: "RunContext" = None, **kwargs: str) -> logging.Logger:
+def get_run_logger(
+    context: "RunContext" = None, **kwargs: str
+) -> Union[logging.Logger, logging.LoggerAdapter]:
     """
     Get a Prefect logger for the current task run or flow run.
 


### PR DESCRIPTION
### Description
Some of the code paths return `PrefectLogAdapter`, so updated the main `get_run_logger()` return type to include `logging.LoggerAdapter`.

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
