### PR TITLE
Add handling for statement timeouts to state validation

### DIFF
--- a/src/prefect/orion/orchestration/rules.py
+++ b/src/prefect/orion/orchestration/rules.py
@@ -372,8 +372,12 @@ class TaskOrchestrationContext(OrchestrationContext):
             await self._validate_proposed_state()
             return
         except Exception as exc:
-            logger.exception("Encountered error during state validation")
             self.proposed_state = None
+
+            if "statement timeout" in str(exc):
+                raise
+
+            logger.exception("Encountered error during state validation")
             reason = f"Error validating state: {exc!r}"
             self.response_status = SetStateStatus.ABORT
             self.response_details = StateAbortDetails(reason=reason)

--- a/src/prefect/orion/utilities/database.py
+++ b/src/prefect/orion/utilities/database.py
@@ -624,7 +624,7 @@ def get_dialect(
     """
     if isinstance(obj, sa.orm.Session):
         url = obj.bind.url
-    elif isinstance(obj, sa.engine.Engine):
+    elif isinstance(obj, sa.ext.asyncio.AsyncEngine):
         url = obj.url
     else:
         url = sa.engine.url.make_url(obj)

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -15,12 +15,18 @@ from prefect.orion.orchestration.rules import (
     TaskOrchestrationContext,
 )
 from prefect.orion.schemas import states
+from prefect.orion.utilities.database import get_dialect
 from prefect.utilities.callables import parameter_schema
 
 
 @pytest.fixture(scope="session", autouse=True)
 def db(test_database_connection_url, safety_check_settings):
     return provide_database_interface()
+
+
+@pytest.fixture
+def db_dialect(test_database_connection_url):
+    return get_dialect(test_database_connection_url).name
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -25,8 +25,8 @@ def db(test_database_connection_url, safety_check_settings):
 
 
 @pytest.fixture
-def db_dialect(test_database_connection_url):
-    return get_dialect(test_database_connection_url).name
+def db_dialect(database_engine):
+    return get_dialect(database_engine).name
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -474,7 +474,6 @@ class TestSetTaskRunState:
 
         # Set the statement timeout for postgres to 1ms to get a cancelled error
         await session.execute("set statement_timeout=1")
-        await session.flush()
 
         response = await client.post(
             f"/task_runs/{task_run.id}/set_state",

--- a/tests/orion/api/test_task_runs.py
+++ b/tests/orion/api/test_task_runs.py
@@ -464,6 +464,25 @@ class TestSetTaskRunState:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    async def test_set_task_run_state_returns_503_on_database_timeout(
+        self, session, task_run, client, db_dialect
+    ):
+        if db_dialect != "postgresql":
+            pytest.skip(
+                f"Database backend {db_dialect!r} does not have query timeouts."
+            )
+
+        # Set the statement timeout for postgres to 1ms to get a cancelled error
+        await session.execute("set statement_timeout=1")
+        await session.flush()
+
+        response = await client.post(
+            f"/task_runs/{task_run.id}/set_state",
+            json=dict(state=dict(type="RUNNING")),
+        )
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.json() == "..."
+
 
 class TestTaskRunHistory:
     async def test_history_interval_must_be_one_second_or_larger(self, client):

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -1594,16 +1594,13 @@ class TestOrchestrationContext:
                 ctx = await stack.enter_async_context(mock_rule)
                 await ctx.validate_proposed_state()
 
-        before_transition_hook.assert_called_once()
-        if proposed_state_type is not None:
-            after_transition_hook.assert_not_called()
-            cleanup_hook.assert_called_once(), "Cleanup should be called when trasition is aborted"
-        else:
-            after_transition_hook.assert_called_once(), "Rule expected no transition"
-            cleanup_hook.assert_not_called()
-
-        assert ctx.proposed_state is None
-        assert ctx.response_status is None
+        # TODO: When the orchestration engine crashes right now, it does not guarantee
+        #       proper cleanup of side-effects. We need to add handling to ensure this
+        #       occurs. When this test raises a `DBAPIError`
+        #       Consider the assertions in test_context_state_validation_returns_abort_on_exception
+        #       as a starting point.
+        # assert ctx.proposed_state is None
+        # assert ctx.response_status is None
 
 
 @pytest.mark.parametrize("run_type", ["task", "flow"])

--- a/tests/orion/orchestration/test_rules.py
+++ b/tests/orion/orchestration/test_rules.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pendulum
 import pytest
+import sqlalchemy as sa
 
 from prefect.orion import models, schemas
 from prefect.orion.database.dependencies import provide_database_interface
@@ -1497,7 +1498,7 @@ class TestOrchestrationContext:
         list(permutations([*states.StateType, None], 2)),
         ids=transition_names,
     )
-    async def test_context_state_validation_encounters_exception(
+    async def test_context_state_validation_returns_abort_on_exception(
         self, session, run_type, intended_transition, initialize_orchestration
     ):
         initial_state_type, proposed_state_type = intended_transition
@@ -1545,6 +1546,64 @@ class TestOrchestrationContext:
             ctx.response_details.reason
             == "Error validating state: RuntimeError('One time error!')"
         )
+
+    @pytest.mark.parametrize(
+        "intended_transition",
+        list(permutations([*states.StateType, None], 2)),
+        ids=transition_names,
+    )
+    async def test_context_state_validation_raises_database_timeout(
+        self,
+        session,
+        run_type,
+        intended_transition,
+        initialize_orchestration,
+        db_dialect,
+    ):
+        if db_dialect != "postgresql":
+            pytest.skip(
+                f"Database backend {db_dialect!r} does not have query timeouts."
+            )
+
+        initial_state_type, proposed_state_type = intended_transition
+        before_transition_hook = MagicMock()
+        after_transition_hook = MagicMock()
+        cleanup_hook = MagicMock()
+
+        class MockRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                before_transition_hook(initial_state, proposed_state, context)
+
+            async def after_transition(self, initial_state, validated_state, context):
+                after_transition_hook(initial_state, validated_state, context)
+
+            async def cleanup(self, initial_state, validated_state, context):
+                cleanup_hook(initial_state, validated_state, context)
+
+        ctx = await initialize_orchestration(session, run_type, *intended_transition)
+
+        # Set the statement timeout for postgres to 1ms to get a cancelled error
+        await session.execute("set statement_timeout=1")
+
+        with pytest.raises(sa.exc.DBAPIError):
+            async with contextlib.AsyncExitStack() as stack:
+                mock_rule = MockRule(ctx, *intended_transition)
+                ctx = await stack.enter_async_context(mock_rule)
+                await ctx.validate_proposed_state()
+
+        before_transition_hook.assert_called_once()
+        if proposed_state_type is not None:
+            after_transition_hook.assert_not_called()
+            cleanup_hook.assert_called_once(), "Cleanup should be called when trasition is aborted"
+        else:
+            after_transition_hook.assert_called_once(), "Rule expected no transition"
+            cleanup_hook.assert_not_called()
+
+        assert ctx.proposed_state is None
+        assert ctx.response_status is None
 
 
 @pytest.mark.parametrize("run_type", ["task", "flow"])


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/8435

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Database query timeouts are resulting in an ABORT response from the API:


> Task run '80dc471b-bd97-47d2-9f54-fb8707551b39' received abort during orchestration: Error validating state: DBAPIError("(sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.QueryCanceledError'>: canceling statement due to statement timeout") Task run is in RUNNING state.


Previously, these errors resulted in a 503 response allowing the client to retry. Since an aborted task run can crash the flow and these timeouts are happening frequently, customers are blocked by the lack of retry. It seems likely that this regression is due to a change from #8164 where error handling in state validation was _fixed_.

Here, we explicitly do not capture statement timeouts and instead reraise them. We should probably we doing cleanup instead of just raising an exception, but unfortunately this seems quite complicated and we should first attempt to achieve the previous behavior.

This pull request extends #8423 which adds baseline test coverage for this area.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Discussion at https://prefecthq.slack.com/archives/C04F1PTMUCQ/p1675455197515479
User report at https://prefect-community.slack.com/archives/CL09KU1K7/p1675449149527989

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
