### PR TITLE
Fix error when using `prefect work-queue ls` without enabling work pools

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@ See [the docs](https://docs.prefect.io/tutorials/flow-task-config/#basic-flow-co
 
 ### Fixes
 - Fix artifact migration to only include states that have non-null data — https://github.com/PrefectHQ/prefect/pull/8420
+- Fix error when using `prefect work-queue ls` without enabling work pools — https://github.com/PrefectHQ/prefect/pull/8427
 
 ### Experimental
 - Add error when attempting to apply a deployment to a work pool that hasn't been created yet — https://github.com/PrefectHQ/prefect/pull/8413

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -11,14 +11,16 @@ from rich.pretty import Pretty
 from rich.table import Table
 
 from prefect import get_client
-from prefect._internal.compatibility.experimental import experimental_parameter
+from prefect._internal.compatibility.experimental import (
+    experiment_enabled,
+    experimental_parameter,
+)
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.orion.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
 from prefect.orion.schemas.filters import WorkPoolFilter, WorkPoolFilterId
-from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS
 
 work_app = PrefectTyper(
     name="work-queue", help="Commands for working with work queues."
@@ -366,7 +368,7 @@ async def ls(
     """
     View all work queues.
     """
-    if not pool and PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS.value() is False:
+    if not pool and not experiment_enabled("work_pools"):
         table = Table(
             title="Work Queues",
             caption="(**) denotes a paused queue",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Closes https://github.com/PrefectHQ/prefect/issues/8426

The `prefect work-queue ls` command was using a route to lookup work pools associated with with each of the work queues. This doesn't work without enabling a flag. This wasn't caught by my tests because I was using a fixture that auto-enabled the flag. This is no longer the case. 

Updated video of the changes:
https://www.loom.com/share/c697692aa93e4c2f90c185f23e160fed

Note, it shows two default queues because I have a default-agent-pool and a separate pool with a default queue. I could see this potentially causing confusion. 

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
