### PR TITLE
Adds `WorkQueueResponse` 

### DIFF
--- a/src/prefect/orion/api/work_queues.py
+++ b/src/prefect/orion/api/work_queues.py
@@ -23,7 +23,7 @@ router = OrionRouter(prefix="/work_queues", tags=["Work Queues"])
 async def create_work_queue(
     work_queue: schemas.actions.WorkQueueCreate,
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkQueue:
+) -> schemas.responses.WorkQueueResponse:
     """
     Creates a new work queue.
 
@@ -68,7 +68,7 @@ async def update_work_queue(
 async def read_work_queue_by_name(
     name: str = Path(..., description="The work queue name"),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkQueue:
+) -> schemas.responses.WorkQueueResponse:
     """
     Get a work queue by id.
     """
@@ -87,7 +87,7 @@ async def read_work_queue_by_name(
 async def read_work_queue(
     work_queue_id: UUID = Path(..., description="The work queue id", alias="id"),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkQueue:
+) -> schemas.responses.WorkQueueResponse:
     """
     Get a work queue by id.
     """
@@ -175,7 +175,7 @@ async def read_work_queues(
     offset: int = Body(0, ge=0),
     work_queues: schemas.filters.WorkQueueFilter = None,
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> List[schemas.core.WorkQueue]:
+) -> List[schemas.responses.WorkQueueResponse]:
     """
     Query for work queues.
     """

--- a/src/prefect/orion/api/workers.py
+++ b/src/prefect/orion/api/workers.py
@@ -362,7 +362,7 @@ async def create_work_queue(
     work_pool_name: str = Path(..., description="The work pool name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkQueue:
+) -> schemas.responses.WorkQueueResponse:
     """
     Creates a new work pool queue. If a work pool queue with the same
     name already exists, an error will be raised.
@@ -398,7 +398,7 @@ async def read_work_queue(
     ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> schemas.core.WorkQueue:
+) -> schemas.responses.WorkQueueResponse:
     """
     Read a work pool queue
     """
@@ -423,7 +423,7 @@ async def read_work_queues(
     offset: int = Body(0, ge=0),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: OrionDBInterface = Depends(provide_database_interface),
-) -> List[schemas.core.WorkQueue]:
+) -> List[schemas.responses.WorkQueueResponse]:
     """
     Read all work pool queues
     """

--- a/src/prefect/orion/schemas/core.py
+++ b/src/prefect/orion/schemas/core.py
@@ -839,8 +839,7 @@ class WorkQueue(ORMBaseModel):
         default=1,
         description="The queue's priority. Lower values are higher priority (1 is the highest).",
     )
-    # Will be required after a future migration
-    work_pool_id: Optional[UUID] = Field(
+    work_pool_id: UUID = Field(
         description="The work pool with which the queue is associated."
     )
     filter: Optional[QueueFilter] = Field(

--- a/src/prefect/orion/schemas/responses.py
+++ b/src/prefect/orion/schemas/responses.py
@@ -242,3 +242,26 @@ class DeploymentResponse(ORMBaseModel):
                 response.work_pool_name = orm_deployment.work_queue.work_pool.name
 
         return response
+
+
+@copy_model_fields
+class WorkQueueResponse(ORMBaseModel):
+    name: str = FieldFrom(schemas.core.WorkQueue)
+    description: Optional[str] = FieldFrom(schemas.core.WorkQueue)
+    is_paused: bool = FieldFrom(schemas.core.WorkQueue)
+    concurrency_limit: Optional[int] = FieldFrom(schemas.core.WorkQueue)
+    priority: int = FieldFrom(schemas.core.WorkQueue)
+    work_pool_id: UUID = FieldFrom(schemas.core.WorkQueue)
+    work_pool_name: str = Field(
+        default=...,
+        description="The name of the work queue's work pool.",
+    )
+    filter: Optional[schemas.core.QueueFilter] = FieldFrom(schemas.core.WorkQueue)
+    last_polled: Optional[DateTimeTZ] = FieldFrom(schemas.core.WorkQueue)
+
+    @classmethod
+    def from_orm(cls, orm_work_queue: "prefect.orion.database.orm_models.ORMWorkQueue"):
+        orm_work_queue.work_pool_name = orm_work_queue.work_pool.name
+
+        response = super().from_orm(orm_work_queue)
+        return response


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Creates WorkQueueResponse to return the work_pool_name for the work pool associated with a queue. Needed to be able to get a work pool for a work queue since the work pool endpoints only accept name.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
