### PR TITLE
Enhancement: Increase polling interval on flow runs to match logs

### DIFF
--- a/orion-ui/src/pages/FlowRun.vue
+++ b/orion-ui/src/pages/FlowRun.vue
@@ -77,7 +77,7 @@
   })
 
   const api = useWorkspaceApi()
-  const flowRunDetailsSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 30000 })
+  const flowRunDetailsSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 5000 })
   const flowRun = computed(() => flowRunDetailsSubscription.response)
   const deploymentId = computed(() => flowRun.value?.deploymentId)
   const deployment = useDeployment(deploymentId)


### PR DESCRIPTION
^`FlowRunLogs` component coming from the component library has a much more aggressive poll interval than this component; this was leading to a mismatch in page state 
