### PR TITLE
Use the len of the JSON representation when determining log size

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -7,7 +7,7 @@ import threading
 import time
 import traceback
 import warnings
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import anyio
 import pendulum
@@ -39,7 +39,7 @@ class OrionLogWorker:
     def __init__(self, profile_context: prefect.context.SettingsContext) -> None:
         self.profile_context = profile_context.copy()
 
-        self._queue: queue.Queue[tuple[dict[str, Any], int]] = queue.Queue()
+        self._queue: queue.Queue[Tuple[Dict[str, Any], int]] = queue.Queue()
 
         self._send_thread = threading.Thread(
             target=self._send_logs_loop,
@@ -194,7 +194,7 @@ class OrionLogWorker:
             f"    Pending log batch size: {self._pending_size}\n"
         )
 
-    def enqueue(self, log: dict[str, Any], log_size: int):
+    def enqueue(self, log: Dict[str, Any], log_size: int):
         if self._stopped:
             raise RuntimeError(
                 "Logs cannot be enqueued after the Orion log worker is stopped."
@@ -304,7 +304,7 @@ class OrionHandler(logging.Handler):
 
     def prepare(
         self, record: logging.LogRecord, settings: prefect.settings.Settings
-    ) -> tuple[dict[str, Any], int]:
+    ) -> Tuple[Dict[str, Any], int]:
         """
         Convert a `logging.LogRecord` to the Orion `LogCreate` schema and serialize.
 
@@ -372,7 +372,7 @@ class OrionHandler(logging.Handler):
 
         return super().close()
 
-    def get_log_size(self, log: dict[str, Any]) -> int:
+    def get_log_size(self, log: Dict[str, Any]) -> int:
         return len(json.dumps(log))
 
 

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import logging
 import queue
 import sys
@@ -6,7 +7,7 @@ import threading
 import time
 import traceback
 import warnings
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import anyio
 import pendulum
@@ -38,7 +39,7 @@ class OrionLogWorker:
     def __init__(self, profile_context: prefect.context.SettingsContext) -> None:
         self.profile_context = profile_context.copy()
 
-        self._queue: queue.Queue[dict] = queue.Queue()
+        self._queue: queue.Queue[tuple[dict[str, Any], int]] = queue.Queue()
 
         self._send_thread = threading.Thread(
             target=self._send_logs_loop,
@@ -135,9 +136,9 @@ class OrionLogWorker:
             # Pull logs from the queue until it is empty or we reach the batch size
             try:
                 while self._pending_size < max_batch_size:
-                    log = self._queue.get_nowait()
+                    log, log_size = self._queue.get_nowait()
                     self._pending_logs.append(log)
-                    self._pending_size += sys.getsizeof(log)
+                    self._pending_size += log_size
 
             except queue.Empty:
                 done = True
@@ -193,12 +194,12 @@ class OrionLogWorker:
             f"    Pending log batch size: {self._pending_size}\n"
         )
 
-    def enqueue(self, log: LogCreate):
+    def enqueue(self, log: dict[str, Any], log_size: int):
         if self._stopped:
             raise RuntimeError(
                 "Logs cannot be enqueued after the Orion log worker is stopped."
             )
-        self._queue.put(log)
+        self._queue.put((log, log_size))
 
     def flush(self, block: bool = False) -> None:
         with self._lock:
@@ -276,7 +277,8 @@ class OrionHandler(logging.Handler):
             if not getattr(record, "send_to_orion", True):
                 return  # Do not send records that have opted out
 
-            self.get_worker(profile).enqueue(self.prepare(record, profile.settings))
+            log, log_size = self.prepare(record, profile.settings)
+            self.get_worker(profile).enqueue(log, log_size)
         except Exception:
             self.handleError(record)
 
@@ -302,7 +304,7 @@ class OrionHandler(logging.Handler):
 
     def prepare(
         self, record: logging.LogRecord, settings: prefect.settings.Settings
-    ) -> LogCreate:
+    ) -> tuple[dict[str, Any], int]:
         """
         Convert a `logging.LogRecord` to the Orion `LogCreate` schema and serialize.
 
@@ -351,14 +353,14 @@ class OrionHandler(logging.Handler):
             message=self.format(record),
         ).dict(json_compatible=True)
 
-        log_size = sys.getsizeof(log)
+        log_size = self.get_log_size(log)
         if log_size > PREFECT_LOGGING_ORION_MAX_LOG_SIZE.value():
             raise ValueError(
                 f"Log of size {log_size} is greater than the max size of "
                 f"{PREFECT_LOGGING_ORION_MAX_LOG_SIZE.value()}"
             )
 
-        return log
+        return (log, log_size)
 
     def close(self) -> None:
         """
@@ -369,6 +371,9 @@ class OrionHandler(logging.Handler):
             worker.flush()
 
         return super().close()
+
+    def get_log_size(self, log: dict[str, Any]) -> int:
+        return len(json.dumps(log))
 
 
 class PrefectConsoleHandler(logging.StreamHandler):

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -373,7 +373,7 @@ class OrionHandler(logging.Handler):
         return super().close()
 
     def get_log_size(self, log: Dict[str, Any]) -> int:
-        return len(json.dumps(log))
+        return len(json.dumps(log).encode())
 
 
 class PrefectConsoleHandler(logging.StreamHandler):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Issue #8397 reported that they had trouble sending large logs. The `OrionHandler` has some logic for ensuring that it only sends logs below certain size. _However_ it was using `getsizeof` which doesn't return the full size of a dict and was always returning `360` bytes no matter how much data was contained in the log. This updates the logic to use `len(json.dumps(log).encode())` which should more accurately represent the size of the log with respect to how the API will receive it.

Closes #8397  


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
