### PR TITLE
Updates agent logic to respect work queue priority

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -219,7 +219,7 @@ class OrionAgent:
                     except Exception as exc:
                         self.logger.exception(exc)
 
-        submittable_runs.sort(key=lambda run: run.next_scheduled_start_time)
+            submittable_runs.sort(key=lambda run: run.next_scheduled_start_time)
 
         for flow_run in submittable_runs:
 

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -1149,6 +1149,15 @@ async def test_agent_runs_high_priority_flow_runs_first(
     work_pool: schemas.core.WorkPool,
     work_queue_1: schemas.core.WorkQueue,
 ):
+    """
+    This test creates two queues in the same work pool and a deployment
+    for each queue. Many flow runs are created for the deployment on the
+    lower priority queue and one flow run is created for the deployment
+    on the higher priority queue. The agent is started with a limit
+    of 1 to ensure only one flow run is submitted. The flow run for the
+    deployment on the higher priority queue should be run first even though
+    there are late flow runs for the deployment on the lower priority queue.
+    """
     @flow
     def foo():
         pass

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -1158,6 +1158,7 @@ async def test_agent_runs_high_priority_flow_runs_first(
     deployment on the higher priority queue should be run first even though
     there are late flow runs for the deployment on the lower priority queue.
     """
+
     @flow
     def foo():
         pass

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 from typing import Generator
 from unittest.mock import MagicMock
@@ -14,6 +15,7 @@ from prefect.infrastructure.base import Infrastructure
 from prefect.orion import models, schemas
 from prefect.states import Completed, Pending, Running, Scheduled, State, StateType
 from prefect.testing.utilities import AsyncMock
+from prefect.utilities.callables import parameter_schema
 from prefect.utilities.dispatch import get_registry_for_type
 
 
@@ -1103,3 +1105,91 @@ async def test_agent_with_work_pool_and_work_queue_prefix(
 
     submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
     assert submitted_flow_run_ids == work_queue_flow_run_ids
+
+
+@pytest.fixture
+async def deployment_on_default_queue(
+    session,
+    flow,
+    flow_function,
+    infrastructure_document_id,
+    storage_document_id,
+    work_pool,
+):
+    def hello(name: str):
+        pass
+
+    deployment = await models.deployments.create_deployment(
+        session=session,
+        deployment=schemas.core.Deployment(
+            name="My High Priority Deployment",
+            tags=["test"],
+            flow_id=flow.id,
+            schedule=schemas.schedules.IntervalSchedule(
+                interval=datetime.timedelta(days=1),
+                anchor_date=pendulum.datetime(2020, 1, 1),
+            ),
+            storage_document_id=storage_document_id,
+            path="./subdir",
+            entrypoint="/file.py:flow",
+            infrastructure_document_id=infrastructure_document_id,
+            work_queue_name="wq",
+            parameter_openapi_schema=parameter_schema(hello),
+            work_queue_id=work_pool.default_queue_id,
+        ),
+    )
+    await session.commit()
+    return deployment
+
+
+async def test_agent_runs_high_priority_flow_runs_first(
+    orion_client: OrionClient,
+    deployment_in_non_default_work_pool: schemas.core.Deployment,
+    deployment_on_default_queue: schemas.core.Deployment,
+    work_pool: schemas.core.WorkPool,
+    work_queue_1: schemas.core.WorkQueue,
+):
+    @flow
+    def foo():
+        pass
+
+    create_high_priority_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment_on_default_queue.id, state=state
+        )
+    )
+
+    create_low_priority_run_with_deployment = (
+        lambda state: orion_client.create_flow_run_from_deployment(
+            deployment_in_non_default_work_pool.id, state=state
+        )
+    )
+
+    flow_runs = [
+        await create_low_priority_run_with_deployment(Pending()),
+        await create_low_priority_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+        ),
+        await create_low_priority_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_high_priority_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
+        ),
+        await create_low_priority_run_with_deployment(
+            Scheduled(scheduled_time=pendulum.now("utc").add(seconds=20))
+        ),
+        await create_low_priority_run_with_deployment(Running()),
+        await create_low_priority_run_with_deployment(Completed()),
+        await orion_client.create_flow_run(foo, state=Scheduled()),
+    ]
+    flow_run_ids = [run.id for run in flow_runs]
+
+    agent = OrionAgent(work_pool_name=work_pool.name, prefetch_seconds=10, limit=1)
+
+    async with agent:
+        agent.submit_run = AsyncMock()  # do not actually run anything
+        submitted_flow_runs = await agent.get_and_submit_flow_runs()
+
+    submitted_flow_run_ids = {flow_run.id for flow_run in submitted_flow_runs}
+    assert submitted_flow_run_ids == {flow_run_ids[3]}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Agents were not respecting work queue priority when pulling from multiple queues because the runs were being sorted by `scheduled_start_time`. This PR makes a change to only sort flow runs in the case when no work pool is provided. Otherwise, the order sent by the API is used, which is pre-sorted by priority.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
