### PR TITLE
Rename `prefect orion` CLI to `prefect server`

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Start server
         run: |
-          prefect orion start&
+          prefect server start&
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py
 
           # TODO: Replace `wait-for-server` with dedicated command

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,13 +15,12 @@ on:
 
 jobs:
   playwright-tests:
-    # disabling these tests for now since they are broken because of pixi-viewport 
-    if: ${{ false }}
     name: "Test UI"
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -41,13 +40,13 @@ jobs:
 
       - name: Run Orion in background
         run: |
-          prefect orion start&
+          prefect server start&
 
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
-          cache-dependency-path: "**/package-lock.json"
+          node-version-file: '.nvmrc'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Retrieve Playwright version
         id: playwright-cache-key
@@ -92,7 +91,6 @@ jobs:
           - "2.4"
           - "2.5"
           - "2.6"
-          - "2.7"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
@@ -117,10 +115,6 @@ jobs:
             server-incompatible: true
           - prefect-version: "2.5"
             server-incompatible: true
-
-          # 2.6 containers have a bad version of httpcore installed
-          - prefect-version: "2.6"
-            extra_docker_run_options: '--env EXTRA_PIP_PACKAGES="httpcore>=0.16.2"'
 
       fail-fast: false
 
@@ -150,9 +144,8 @@ jobs:
           --name "orion-server-${{ matrix.prefect-version }}"
           --detach
           --publish 4200:4200
-          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
-          prefect orion start --host 0.0.0.0
+          prefect server start --host 0.0.0.0
 
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           ./scripts/wait-for-server.py
@@ -163,9 +156,7 @@ jobs:
       - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
-          TEST_SERVER_VERSION=${{ matrix.prefect-version }}
           PREFECT_API_URL="http://127.0.0.1:4200/api"
-          TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py
 
       - name: Start server@dev
@@ -176,18 +167,15 @@ jobs:
           #       https://github.com/PrefectHQ/prefect/issues/6989
           docker stop "orion-server-${{ matrix.prefect-version }}" || echo "That's okay!"
 
-          prefect orion start&
+          prefect server start&
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py
 
       - name: Run integration flows with client@${{ matrix.prefect-version }}, server@dev
         run: >
           docker run
           --env PREFECT_API_URL="http://127.0.0.1:4200/api"
-          --env TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
-          --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts
           --network host
-          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -98,10 +98,6 @@ jobs:
           # but the value is not particularly clear and we can just append the
           # last minor version at each release time
           # - "2"
-        
-        server_command:
-          - "prefect server start"
-
 
         include:
           # While old clients should always be supported by new servers, a new
@@ -161,7 +157,7 @@ jobs:
           --publish 4200:4200
           ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
-          ${{ matrix.server_command }} --host 0.0.0.0
+          ${{ matrix.server_command || 'prefect server start' }} --host 0.0.0.0
 
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           ./scripts/wait-for-server.py

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,12 +15,13 @@ on:
 
 jobs:
   playwright-tests:
+    # disabling these tests for now since they are broken because of pixi-viewport 
+    if: ${{ false }}
     name: "Test UI"
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -40,13 +41,13 @@ jobs:
 
       - name: Run Orion in background
         run: |
-          prefect server start&
+          prefect orion start&
 
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache-dependency-path: '**/package-lock.json'
+          node-version-file: ".nvmrc"
+          cache-dependency-path: "**/package-lock.json"
 
       - name: Retrieve Playwright version
         id: playwright-cache-key
@@ -76,7 +77,7 @@ jobs:
           retention-days: 30
 
   compatibility-tests:
-    name: "Check compatibility"
+    name: "Check compatibility with Prefect ${{ matrix.prefect-version }}"
     timeout-minutes: 10
 
     strategy:
@@ -91,11 +92,16 @@ jobs:
           - "2.4"
           - "2.5"
           - "2.6"
+          - "2.7"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
           # last minor version at each release time
           # - "2"
+        
+        server_command:
+          - "prefect server start"
+
 
         include:
           # While old clients should always be supported by new servers, a new
@@ -115,6 +121,15 @@ jobs:
             server-incompatible: true
           - prefect-version: "2.5"
             server-incompatible: true
+
+          # 2.6 containers have a bad version of httpcore installed
+          - prefect-version: "2.6"
+            extra_docker_run_options: '--env EXTRA_PIP_PACKAGES="httpcore>=0.16.2"'
+            server_command: "prefect orion start"
+          
+          # 2.6/2.7 require `prefect orion start` instead of prefect server start
+          - prefect-version: "2.7"
+            server_command: "prefect orion start"
 
       fail-fast: false
 
@@ -141,11 +156,12 @@ jobs:
         if: ${{ ! matrix.server-incompatible }}
         run: >
           docker run
-          --name "orion-server-${{ matrix.prefect-version }}"
+          --name "prefect-server-${{ matrix.prefect-version }}"
           --detach
           --publish 4200:4200
+          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
-          prefect server start --host 0.0.0.0
+          ${{ matrix.server_command }} --host 0.0.0.0
 
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           ./scripts/wait-for-server.py
@@ -156,16 +172,18 @@ jobs:
       - name: Run integration flows with client@dev, server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         run: >
+          TEST_SERVER_VERSION=${{ matrix.prefect-version }}
           PREFECT_API_URL="http://127.0.0.1:4200/api"
+          TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py
 
       - name: Start server@dev
         run: |
           # First, we must stop the server container if it exists
-          # TODO: Once we have `prefect orion stop` we can run these tests first and the
+          # TODO: Once we have `prefect server stop` we can run these tests first and the
           #       optional tests above second
           #       https://github.com/PrefectHQ/prefect/issues/6989
-          docker stop "orion-server-${{ matrix.prefect-version }}" || echo "That's okay!"
+          docker stop "prefect-server-${{ matrix.prefect-version }}" || echo "That's okay!"
 
           prefect server start&
           PREFECT_API_URL="http://127.0.0.1:4200/api" ./scripts/wait-for-server.py
@@ -174,8 +192,11 @@ jobs:
         run: >
           docker run
           --env PREFECT_API_URL="http://127.0.0.1:4200/api"
+          --env TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
+          --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts
           --network host
+          ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ github_stars(["PrefectHQ/Prefect"])
 After running some flows, fire up the Prefect UI to gain insight into their execution:
 
 ```bash
-prefect orion start
+prefect server start
 ```
 
 ![](/docs/img/ui/prefect-dashboard.png)

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -35,7 +35,7 @@ If at any point in your testing you'd like to reset your database, run the CLI c
 
 <div class="terminal">
 ```bash
-prefect orion database reset -y
+prefect server database reset -y
 ```
 </div>
 
@@ -96,7 +96,7 @@ Start the Prefect server and it should from now on use your PostgreSQL database 
 
 <div class="terminal">
 ```bash
-prefect orion start
+prefect server start
 ```
 </div>
 

--- a/docs/concepts/logs.md
+++ b/docs/concepts/logs.md
@@ -16,7 +16,7 @@ tags:
 
 Prefect enables you to log a variety of useful information about your flow and task runs, capturing information about your workflows for purposes such as monitoring, troubleshooting, and auditing.
 
-Prefect captures logs for your flow and task runs by default, even if you have not started a Prefect server with `prefect orion start`.
+Prefect captures logs for your flow and task runs by default, even if you have not started a Prefect server with `prefect server start`.
 
 You can view and filter logs in the [Prefect UI](/ui/flow-runs/#inspect-a-flow-run) or Prefect Cloud, or access log records via the API.
 

--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -191,7 +191,7 @@ See the Python [RRuleSchedule class docs](/api-ref/server/schemas/schedules/#pre
 
 ## The `Scheduler` service
 
-The `Scheduler` service is started automatically when `prefect orion start` is run and it is a built-in service of Prefect Cloud. 
+The `Scheduler` service is started automatically when `prefect server start` is run and it is a built-in service of Prefect Cloud. 
 
 By default, the `Scheduler` service visits deployments on a 60-second loop, though recently-modified deployments will be visited more frequently. The `Scheduler` evaluates each deployment's schedule and creates new runs appropriately. For typical deployments, it will create the next three runs, though more runs will be scheduled if the next 3 would all start in the next hour. 
 

--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -186,7 +186,7 @@ prefect dev ui
 ```
 </div>
 
-Build the static UI (the UI served by `prefect orion start`):
+Build the static UI (the UI served by `prefect server start`):
 
 <div class="terminal">
 ```bash

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -95,7 +95,7 @@ See the [Installation](/getting-started/installation/) documentation and [Window
 
 ### What external requirements does Prefect have?
 
-Prefect does not have any additional requirements besides those installed by `pip install --pre prefect`. The entire system, including the UI and services, can be run in a single process via `prefect orion start` and does not require Docker.
+Prefect does not have any additional requirements besides those installed by `pip install --pre prefect`. The entire system, including the UI and services, can be run in a single process via `prefect server start` and does not require Docker.
 
 Prefect Cloud users do not need to worry about the Prefect database. Prefect Cloud uses PostgreSQL on GCP behind the scenes. To use PostgreSQL with a self-hosted Prefect server, users must provide the [connection string][prefect.settings.PREFECT_ORION_DATABASE_CONNECTION_URL] for a running database via the `PREFECT_ORION_DATABASE_CONNECTION_URL` environment variable.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -283,7 +283,7 @@ Upgrading from Prefect version 2.0a9 or earlier requires resetting the Prefect d
 
 Prior to 2.0a10, Prefect did not have database migrations and required a hard reset of the database between versions. Now that migrations have been added, your database will be upgraded automatically with each version change. However, you must still perform a hard reset of the database if you are upgrading from 2.0a9 or earlier.
 
-Resetting the database with the CLI command `prefect orion database reset` is not compatible a database from 2.0a9 or earlier. Instead, delete the database file `~/.prefect/orion.db`. Prefect automatically creates a new database on the next write.
+Resetting the database with the CLI command `prefect server database reset` is not compatible a database from 2.0a9 or earlier. Instead, delete the database file `~/.prefect/orion.db`. Prefect automatically creates a new database on the next write.
 
 !!! warning "Resetting the database deletes data"
     Note that resetting the database causes the loss of any existing data.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -28,7 +28,7 @@ That's it! You're ready to [start writing local flows](/tutorials/first-steps/).
 
 If you want to start running flows on a schedule, via the API, from the Prefect UI, or on distributed infrastructure, you'll need to understand a few additional concepts and perform some configuration.
 
-- Start a local [Prefect server](/ui/overview/) with `prefect orion start` or create a [free Prefect Cloud account](/ui/cloud-quickstart/).
+- Start a local [Prefect server](/ui/overview/) with `prefect server start` or create a [free Prefect Cloud account](/ui/cloud-quickstart/).
 - [Set `PREFECT_API_URL`](/tutorials/orchestration/#running-the-prefect-server) to enable communication between your execution environment and the Prefect server or Prefect Cloud API.
 - Configure [storage](/tutorials/storage/) to persist flow and task data.
 - Create a [deployment](/tutorials/deployments/) for a flow, giving the API metadata about where your flow's code is stored and how your flow should be run.

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,7 +199,7 @@ Fire up the Prefect UI locally by entering this command in your terminal:
 
 <div class="terminal">
 ```bash
-prefect orion start
+prefect server start
 ```
 </div>
 

--- a/docs/tutorials/deployments.md
+++ b/docs/tutorials/deployments.md
@@ -29,7 +29,7 @@ You need just a few ingredients to turn a flow definition into a deployment:
 
 That's it. To create flow runs based on the deployment, you need a few more pieces:
 
-- Prefect orchestration engine, either [Prefect Cloud](/ui/cloud/) or a local Prefect server started with `prefect orion start`.
+- Prefect orchestration engine, either [Prefect Cloud](/ui/cloud/) or a local Prefect server started with `prefect server start`.
 - An [agent and work queue](/concepts/work-queues/).
 
 These all come with Prefect. You just have to configure them and set them to work. You'll see how to configure each component during this tutorial.
@@ -388,11 +388,11 @@ All of the same configuration options apply here as well: you can skip automatic
 
 ## Run a Prefect server
 
-For the remainder of this tutorial, you'll use a local Prefect server. Open another terminal session and start the Prefect server with the `prefect orion start` CLI command:
+For the remainder of this tutorial, you'll use a local Prefect server. Open another terminal session and start the Prefect server with the `prefect server start` CLI command:
 
 <div class='terminal'>
 ```bash
-$ prefect orion start
+$ prefect server start
 
  ___ ___ ___ ___ ___ ___ _____    ___  ___ ___ ___  _  _
 | _ \ _ \ __| __| __/ __|_   _|  / _ \| _ \_ _/ _ \| \| |

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -27,15 +27,15 @@ To run a deployed flow in a Docker container, you'll need the following:
 
 - We'll use the flow script and deployment from the [Deployments](/tutorials/deployments/) tutorial. 
 - We'll also use the remote storage block created in the [Storage and Infrastructure](/tutorials/storage/) tutorial.
-- You must run a standalone Prefect server (`prefect orion start`) or use Prefect Cloud.
+- You must run a standalone Prefect server (`prefect server start`) or use Prefect Cloud.
 - You'll need [Docker Engine](https://docs.docker.com/engine/) installed and running on the same machine as your agent.
 
 [Docker Desktop](https://www.docker.com/products/docker-desktop) works fine for local testing if you don't already have Docker Engine configured in your environment.
 
 !!! note "Run a Prefect server"
-    This tutorial assumes you're already running a Prefect server with `prefect orion start`, as described in the [Deployments](/tutorials/deployments/) tutorial. 
+    This tutorial assumes you're already running a Prefect server with `prefect server start`, as described in the [Deployments](/tutorials/deployments/) tutorial. 
     
-    If you shut down the server from a previous tutorial, you can start it again by opening another terminal session and starting the Prefect server with the `prefect orion start` CLI command.
+    If you shut down the server from a previous tutorial, you can start it again by opening another terminal session and starting the Prefect server with the `prefect server start` CLI command.
 
 ## Create an infrastructure block
 

--- a/docs/tutorials/first-steps.md
+++ b/docs/tutorials/first-steps.md
@@ -220,11 +220,11 @@ main_flow()
 
 Whenever we run `main_flow` as above, a new run will be generated for `common_flow` as well.  Not only is this run tracked as a subflow run of `main_flow`, but you can also inspect it independently in the UI!
 
-Spin up a local Prefect server UI using the `prefect orion start` CLI command from your terminal:
+Spin up a local Prefect server UI using the `prefect server start` CLI command from your terminal:
 
 <div class="terminal">
 ```bash
-$ prefect orion start
+$ prefect server start
 ```
 </div>
 

--- a/docs/tutorials/orchestration.md
+++ b/docs/tutorials/orchestration.md
@@ -48,7 +48,7 @@ The Prefect server and orchestration engine is the central component of your Pre
 
 Without you having to configure or run anything other than your flow code, the ephemeral Prefect API keeps track of the state of your Prefect flow and task runs. 
 
-When you run a Prefect server with `prefect orion start`, the Prefect orchestration engine keeps track of the state of your Prefect flow and task runs, and also lets you:
+When you run a Prefect server with `prefect server start`, the Prefect orchestration engine keeps track of the state of your Prefect flow and task runs, and also lets you:
 
 - Create and manage deployments
 - Create and manage configuration for storage and services used by your flows
@@ -64,11 +64,11 @@ If your execution environment is logged into [Prefect Cloud](/ui/cloud/), Prefec
 
 ### Running the Prefect server
 
-To take full advantage of the Prefect orchestration engine and API server, you can spin up an instance at any time with the `prefect orion start` CLI command:
+To take full advantage of the Prefect orchestration engine and API server, you can spin up an instance at any time with the `prefect server start` CLI command:
 
 <div class='terminal'>
 ```bash
-$ prefect orion start
+$ prefect server start
 Starting...
 
  ___ ___ ___ ___ ___ ___ _____    ___  ___ ___ ___  _  _
@@ -106,7 +106,7 @@ When the Prefect API server is running (either in a local environment or using P
 - Configuring [agents and work queues](/concepts/work-queues/)
 - Executing [ad hoc flow runs from deployments](/tutorials/deployments/)
 
-During normal operation, we don't expect that most users will need to interact with the Prefect API directly, as this is handled for you automatically by the Prefect Python client and the [Prefect UI](#prefect-ui-and-prefect-cloud). Most users will spin up everything all at once with `prefect orion start`.
+During normal operation, we don't expect that most users will need to interact with the Prefect API directly, as this is handled for you automatically by the Prefect Python client and the [Prefect UI](#prefect-ui-and-prefect-cloud). Most users will spin up everything all at once with `prefect server start`.
 
 There are numerous ways to begin exploring the API:
 
@@ -151,10 +151,10 @@ When you first install Prefect, your database will be located at `~/.prefect/ori
 ```bash
 $ export PREFECT_ORION_DATABASE_CONNECTION_URL="sqlite+aiosqlite:////full/path/to/a/location/orion.db"
 ```
-If at any point in your testing you'd like to reset your database, run the `prefect orion database reset` CLI command:  
+If at any point in your testing you'd like to reset your database, run the `prefect server database reset` CLI command:  
 
 ```bash
-$ prefect orion database reset
+$ prefect server database reset
 ```
 
 This will completely clear all data and reapply the schema.

--- a/docs/ui/cloud-local-environment.md
+++ b/docs/ui/cloud-local-environment.md
@@ -99,7 +99,7 @@ $ prefect config set PREFECT_API_KEY="[API-KEY]"
 
 When you're in a Prefect Cloud workspace, you can copy the `PREFECT_API_URL` value directly from the page URL.
 
-In this example, we configured `PREFECT_API_URL` and `PREFECT_API_KEY` in the default profile. You can use `prefect profile` CLI commands to create settings profiles for different configurations. For example, you could have a "cloud" profile configured to use the Prefect Cloud API URL and API key, and another "local" profile for local development using a local Prefect API server started with `prefect orion start`. See [Settings](/concepts/settings/) for details.
+In this example, we configured `PREFECT_API_URL` and `PREFECT_API_KEY` in the default profile. You can use `prefect profile` CLI commands to create settings profiles for different configurations. For example, you could have a "cloud" profile configured to use the Prefect Cloud API URL and API key, and another "local" profile for local development using a local Prefect API server started with `prefect server start`. See [Settings](/concepts/settings/) for details.
 
 !!! note "Environment variables"
     You can also set `PREFECT_API_URL` and `PREFECT_API_KEY` as you would any other environment variable. See [Overriding defaults with environment variables](/concepts/settings/#overriding-defaults-with-environment-variables) for more information.

--- a/docs/ui/overview.md
+++ b/docs/ui/overview.md
@@ -37,11 +37,11 @@ You can filter the information displayed in the UI by time, flow state, and tags
 
 The Prefect UI is available via [Prefect Cloud](/ui/cloud/) by logging into your account at [https://app.prefect.cloud/](https://app.prefect.cloud/).
 
-The Prefect UI is also available in any environment where a Prefect server is running with `prefect orion start`.
+The Prefect UI is also available in any environment where a Prefect server is running with `prefect server start`.
 
 <div class="terminal">
 ```bash
-$ prefect orion start
+$ prefect server start
 Starting...
 
  ___ ___ ___ ___ ___ ___ _____    ___  ___ ___ ___  _  _
@@ -105,6 +105,6 @@ The [Prefect REST API](/api-ref/rest-api/) is used for communicating data from P
 !!! note "Prefect REST API interactive documentation"
     Prefect Cloud REST API documentation is available at <a href="https://app.prefect.cloud/api/docs" target="_blank">https://app.prefect.cloud/api/docs</a>.
 
-    The Prefect REST API documentation for a local instance run with with `prefect orion start` is available at <a href="http://localhost:4200/docs" target="_blank">http://localhost:4200/docs</a> or the `/docs` endpoint of the [`PREFECT_API_URL`](/concepts/settings/#prefect_api_url) you have configured to access the server.
+    The Prefect REST API documentation for a local instance run with with `prefect server start` is available at <a href="http://localhost:4200/docs" target="_blank">http://localhost:4200/docs</a> or the `/docs` endpoint of the [`PREFECT_API_URL`](/concepts/settings/#prefect_api_url) you have configured to access the server.
 
     The Prefect REST API documentation for locally run open-source Prefect servers is also available in the [Prefect REST API Reference](/api-ref/rest-api-reference/).

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -14,7 +14,7 @@ import prefect.cli.dev
 import prefect.cli.flow
 import prefect.cli.flow_run
 import prefect.cli.kubernetes
-import prefect.cli.orion
+import prefect.cli.server
 import prefect.cli.profile
 import prefect.cli.work_queue
 import prefect.cli.work_pool

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1019,7 +1019,7 @@ Refer to https://www.uvicorn.org/settings/#timeouts for details.
 When the API is hosted behind a load balancer, you may want to set this to a value
 greater than the load balancer's idle timeout.
 
-Note this setting only applies when calling `prefect orion start`; if hosting the
+Note this setting only applies when calling `prefect server start`; if hosting the
 API with another tool you will need to configure this there instead.
 """
 


### PR DESCRIPTION
Part of #8454 

Adds a duplicate command group `prefect server` that does everything `prefect orion` does and adds deprecation notices to all of the `prefect orion` commands. The deprecation notices are implemented in the `PrefectTyper` class to deprecate command groups in the future. The `orion` command is hidden from the `prefect --help` menu. The Typer builtin `deprecated` functionality isn't good enough for me, I tried doing that first and it was harder and less coherent with the rest of our interface.

```
❯ prefect orion start       
WARNING: The 'prefect orion' command group has been deprecated. It will not be available after Aug 2023. Use 'prefect server' instead.

 ___ ___ ___ ___ ___ ___ _____ 
| _ \ _ \ __| __| __/ __|_   _| 
|  _/   / _|| _|| _| (__  | |  
|_| |_|_\___|_| |___\___| |_|  
```