### PR TITLE
Fix sequential execution with mapped tasks using the SequentialTaskRunner

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1059,6 +1059,11 @@ async def begin_task_map(
             )
         )
 
+    # Maintain the order of the task runs when using the sequential task runner
+    runner = task_runner if task_runner else flow_run_context.task_runner
+    if runner.concurrency_type == TaskConcurrencyType.SEQUENTIAL:
+        return [await task_run() for task_run in task_runs]
+
     return await gather(*task_runs)
 
 
@@ -1145,7 +1150,7 @@ async def create_task_run_future(
     # Default to the flow run's task runner
     task_runner = task_runner or flow_run_context.task_runner
 
-    # Generate a name for the future
+    # Generate a name for th future
     dynamic_key = _dynamic_key_for_task_run(flow_run_context, task)
     task_run_name = f"{task.name}-{dynamic_key}"
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1150,7 +1150,7 @@ async def create_task_run_future(
     # Default to the flow run's task runner
     task_runner = task_runner or flow_run_context.task_runner
 
-    # Generate a name for th future
+    # Generate a name for the future
     dynamic_key = _dynamic_key_for_task_run(flow_run_context, task)
     task_run_name = f"{task.name}-{dynamic_key}"
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3027,6 +3027,7 @@ class TestTaskMap:
         task_states = my_flow()
         assert [state.result() for state in task_states] == [2, 3, 4]
 
+    @pytest.mark.skip
     def test_map_with_sequential_runner_is_sequential_sync_flow_sync_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks
@@ -3058,6 +3059,7 @@ class TestTaskMap:
 
         assert sync_mock_item.call_args_list == [call(n) for n in nums]
 
+    @pytest.mark.skip
     async def test_map_with_sequential_runner_is_sequential_async_flow_sync_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks
@@ -3089,6 +3091,7 @@ class TestTaskMap:
 
         assert sync_mock_item.call_args_list == [call(n) for n in nums]
 
+    @pytest.mark.skip
     async def test_map_with_sequential_runner_is_sequential_async_flow_async_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3027,33 +3027,98 @@ class TestTaskMap:
         task_states = my_flow()
         assert [state.result() for state in task_states] == [2, 3, 4]
 
-    def test_map_with_sequential_runner_is_sequential(self):
-        """Tests that the sequential runner executes mapped tasks sequentially. The first tasks
-        sleeps for 3 seconds before appending and the second for 0, so if the tasks do not execute
-        sequentially, we expect the second task to append before the first.
+    def test_map_with_sequential_runner_is_sequential_sync_flow_sync_map(self):
+        """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
+        1/100th the value of their input, starting with the longest sleep first. If the tasks
+        do not execute sequentially, we expect the later tasks to append before the earlier.
         """
 
         @task
         def sleepy_task(n, mock_item):
-            time.sleep(n)
+            time.sleep(n / 100)
             mock_item(n)
             return n
 
         @flow
-        def my_flow(mock_item):
-            sleepy_task.map([3, 0], unmapped(mock_item))
+        def my_flow(mock_item, nums):
+            sleepy_task.map(nums, unmapped(mock_item))
+
+        nums = [i for i in range(10, 0, -1)]
 
         mock_item = MagicMock()
-        my_flow(mock_item)
-        assert mock_item.call_args_list == [call(0), call(3)]
+        my_flow(mock_item, nums)
+        assert mock_item.call_args_list != [call(n) for n in nums]
 
         @flow(task_runner=SequentialTaskRunner())
-        def seq_flow(mock_item):
-            sleepy_task.map([3, 0], unmapped(mock_item))
+        def seq_flow(mock_item, nums):
+            sleepy_task.map(nums, unmapped(mock_item))
 
         sync_mock_item = MagicMock()
-        seq_flow(sync_mock_item)
-        assert sync_mock_item.call_args_list == [call(3), call(0)]
+        seq_flow(sync_mock_item, nums)
+
+        assert sync_mock_item.call_args_list == [call(n) for n in nums]
+
+    async def test_map_with_sequential_runner_is_sequential_async_flow_sync_map(self):
+        """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
+        1/100th the value of their input, starting with the longest sleep first. If the tasks
+        do not execute sequentially, we expect the later tasks to append before the earlier.
+        """
+
+        @task
+        def sleepy_task(n, mock_item):
+            time.sleep(n / 100)
+            mock_item(n)
+            return n
+
+        @flow
+        async def my_flow(mock_item, nums):
+            sleepy_task.map(nums, unmapped(mock_item))
+
+        nums = [i for i in range(10, 0, -1)]
+
+        mock_item = MagicMock()
+        await my_flow(mock_item, nums)
+        assert mock_item.call_args_list != [call(n) for n in nums]
+
+        @flow(task_runner=SequentialTaskRunner())
+        async def seq_flow(mock_item, nums):
+            sleepy_task.map(nums, unmapped(mock_item))
+
+        sync_mock_item = MagicMock()
+        await seq_flow(sync_mock_item, nums)
+
+        assert sync_mock_item.call_args_list == [call(n) for n in nums]
+
+    async def test_map_with_sequential_runner_is_sequential_async_flow_async_map(self):
+        """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
+        1/100th the value of their input, starting with the longest sleep first. If the tasks
+        do not execute sequentially, we expect the later tasks to append before the earlier.
+        """
+
+        @task
+        async def sleepy_task(n, mock_item):
+            time.sleep(n / 100)
+            mock_item(n)
+            return n
+
+        @flow
+        async def my_flow(mock_item, nums):
+            await sleepy_task.map(nums, unmapped(mock_item))
+
+        nums = [i for i in range(10, 0, -1)]
+
+        mock_item = MagicMock()
+        await my_flow(mock_item, nums)
+        assert mock_item.call_args_list != [call(n) for n in nums]
+
+        @flow(task_runner=SequentialTaskRunner())
+        async def seq_flow(mock_item, nums):
+            await sleepy_task.map(nums, unmapped(mock_item))
+
+        sync_mock_item = MagicMock()
+        await seq_flow(sync_mock_item, nums)
+
+        assert sync_mock_item.call_args_list == [call(n) for n in nums]
 
 
 class TestTaskConstructorValidation:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3027,7 +3027,6 @@ class TestTaskMap:
         task_states = my_flow()
         assert [state.result() for state in task_states] == [2, 3, 4]
 
-    @pytest.mark.skip
     def test_map_with_sequential_runner_is_sequential_sync_flow_sync_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks
@@ -3059,7 +3058,6 @@ class TestTaskMap:
 
         assert sync_mock_item.call_args_list == [call(n) for n in nums]
 
-    @pytest.mark.skip
     async def test_map_with_sequential_runner_is_sequential_async_flow_sync_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks
@@ -3091,7 +3089,6 @@ class TestTaskMap:
 
         assert sync_mock_item.call_args_list == [call(n) for n in nums]
 
-    @pytest.mark.skip
     async def test_map_with_sequential_runner_is_sequential_async_flow_async_map(self):
         """Tests that the sequential runner executes mapped tasks sequentially. Tasks sleep for
         1/100th the value of their input, starting with the longest sleep first. If the tasks


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Closes https://github.com/PrefectHQ/prefect/issues/7763

Mapped tasks were being executed asynchronously even when using the SequentialTaskRunner. This was because inside of the `begin_task_map` function we get a list of partial `get_task_call_return_value` functions, which are async, and then we call ` return await gather(*task_runs)`.

My solution sidesteps this by doing a check right before we call gather to see if the runner is sequential, and if so, executes the coroutines without the gather. 

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
