### PR TITLE
Fix work pools documentation links

### DIFF
--- a/docs/concepts/work-pools.md
+++ b/docs/concepts/work-pools.md
@@ -14,7 +14,7 @@ tags:
 
 Agents and work pools bridge the Prefect _orchestration environment_ with your _execution environment_. When a [deployment](/concepts/deployments/) creates a flow run, it is submitted to a specific work pool for scheduling. Agents running in the execution environment poll their respective work pools for new runs to execute.
 
-Each work pool has a default queue that all work will be sent to. Work queues are automatically created whenever they are referenced by either a deployment or an agent. For most applications, this automatic behavior will be sufficient to run flows as expected. For advanced needs, additional queues can be created to enable a greater degree of control over work delivery. See [work pool configuration](#work-queue-configuration) for more information. 
+Each work pool has a default queue that all work will be sent to. Work queues are automatically created whenever they are referenced by either a deployment or an agent. For most applications, this automatic behavior will be sufficient to run flows as expected. For advanced needs, additional queues can be created to enable a greater degree of control over work delivery. See [work pool configuration](#work-pool-configuration) for more information.
 
 To run deployments, you must configure at least one agent (and its associated work pool):
 

--- a/docs/ui/work-pools.md
+++ b/docs/ui/work-pools.md
@@ -12,7 +12,7 @@ tags:
 
 # Work Pools
 
-[Work Polls](/concepts/work-queues/) and agents work together to bridge your orchestration environment &mdash; a local Prefect server or Prefect Cloud &mdash; and your execution environments. Work pools gather flow runs for scheduled deployments, and agents pick up work from their configured work pool queues.
+[Work Pools](/concepts/work-pools/) and agents work together to bridge your orchestration environment &mdash; a local Prefect server or Prefect Cloud &mdash; and your execution environments. Work pools gather flow runs for scheduled deployments, and agents pick up work from their configured work pool queues.
 
 Work pool configuration lets you specify which queues handle which flow runs. You can filter runs based on tags and specific deployments.
 


### PR DESCRIPTION
There are a few broken links in the new work pools documentation.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
