### PR TITLE
Update web app name in UI

### DIFF
--- a/orion-ui/index.html
+++ b/orion-ui/index.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prefect Orion</title>
+    <title>Prefect Server</title>
   </head>
   <body>
     <div id="app"></div>

--- a/orion-ui/src/compositions/usePageTitle.ts
+++ b/orion-ui/src/compositions/usePageTitle.ts
@@ -2,7 +2,7 @@ import { computed, Ref, unref, watchEffect } from 'vue'
 
 export function usePageTitle(...pages: (string | Ref<string | null>)[]): void {
 
-  const pagesWithProject = [...pages, 'Prefect Orion']
+  const pagesWithProject = [...pages, 'Prefect Server']
 
   const title = computed<string>(() => {
     return pagesWithProject

--- a/orion-ui/src/pages/Settings.vue
+++ b/orion-ui/src/pages/Settings.vue
@@ -16,7 +16,7 @@
       <ColorModeSelect v-model:selected="activeColorMode" />
     </p-label>
 
-    <p-label label="Orion Settings">
+    <p-label label="Server Settings">
       <SettingsCodeBlock class="settings__code-block" :engine-settings="engineSettings" />
     </p-label>
   </p-layout-default>

--- a/orion-ui/src/router/index.ts
+++ b/orion-ui/src/router/index.ts
@@ -69,7 +69,7 @@ router.beforeEach(async (to, from) => {
 
 router.afterEach((to, from) => {
   if (to.fullPath !== from.fullPath) {
-    document.title = 'Prefect Orion'
+    document.title = 'Prefect Server'
   }
 
   return RouteGuardExecutioner.after(to, from)

--- a/orion-ui/src/utilities/api.ts
+++ b/orion-ui/src/utilities/api.ts
@@ -7,7 +7,7 @@ export async function healthCheck(): Promise<void> {
     await healthApi.getHealth()
   } catch (error) {
     const apiUrl = await UiSettings.get('apiUrl').then(res => res)
-    showToast(`Can't connect to Orion API at ${apiUrl}. Check that it's accessible from your machine.`, 'error', { timeout: false })
+    showToast(`Can't connect to Server API at ${apiUrl}. Check that it's accessible from your machine.`, 'error', { timeout: false })
     console.warn(error)
   }
 }


### PR DESCRIPTION
This PR switches to using Prefect Server in the following places in UI:

- Rename web app tabs
- Rename the default web app title
- Rename setting label
- Rename the failsafe title in the router
- Rename the web app name in the "Can't connect" message

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
