### PR TITLE
Update default database to be `prefect.db` instead of `orion.db`

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -177,7 +177,7 @@ jobs:
           --tmpfs /var/lib/postgresql/data
           --env POSTGRES_USER="prefect"
           --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="orion"
+          --env POSTGRES_DB="prefect"
           --env LANG="C.UTF-8"
           --env LANGUAGE="C.UTF-8"
           --env LC_ALL="C.UTF-8"
@@ -187,7 +187,7 @@ jobs:
 
           ./scripts/wait-for-healthy-container.sh postgres 30
 
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/orion" >> $GITHUB_ENV
+          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_USER: prefect
       POSTGRES_PASSWORD: prefect
-      POSTGRES_DB: orion
+      POSTGRES_DB: prefect
       LANG: 'C.UTF-8'
       LANGUAGE: 'C.UTF-8'
       LC_ALL: 'C.UTF-8'

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -29,7 +29,7 @@ Currently Prefect supports the following databases:
 
 A local SQLite database is the default for Prefect. A local SQLite database is configured on installation.
 
-When you first install Prefect, your database will be located at `~/.prefect/orion.db`.
+When you first install Prefect, your database will be located at `~/.prefect/prefect.db`.
 
 If at any point in your testing you'd like to reset your database, run the CLI command:  
 
@@ -47,7 +47,7 @@ To configure the database location, you can specify a connection URL with the `P
 
 <div class="terminal">
 ```bash
-prefect config set PREFECT_API_DATABASE_CONNECTION_URL="sqlite+aiosqlite:////full/path/to/a/location/orion.db"
+prefect config set PREFECT_API_DATABASE_CONNECTION_URL="sqlite+aiosqlite:////full/path/to/a/location/prefect.db"
 ```
 </div>
 

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -57,7 +57,7 @@ To connect Prefect to a PostgreSQL database, you can set the following environme
 
 <div class="terminal">
 ```bash
-prefect config set PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://postgres:yourTopSecretPassword@localhost:5432/orion"
+prefect config set PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://postgres:yourTopSecretPassword@localhost:5432/prefect"
 ```
 </div>
 
@@ -67,22 +67,22 @@ The above environment variable assumes that:
 - Your password is set to `yourTopSecretPassword`
 - Your database runs on the same host as the Prefect server instance, `localhost`
 - You use the default PostgreSQL port `5432`
-- Your PostgreSQL instance has a database called `orion`
+- Your PostgreSQL instance has a database called `prefect`
 
 If you want to quickly start a PostgreSQL instance that can be used as your Prefect database, you can use the following command that will start a Docker container running PostgreSQL:
 
 <div class="terminal">
 ```bash
-docker run -d --name orion_postgres -v oriondb:/var/lib/postgresql/data -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=yourTopSecretPassword -e POSTGRES_DB=orion postgres:latest
+docker run -d --name prefect-postgres -v prefectdb:/var/lib/postgresql/data -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=yourTopSecretPassword -e POSTGRES_DB=prefect postgres:latest
 ```
 </div>
 
 The above command:
 
 - Pulls the [latest](https://hub.docker.com/_/postgres?tab=tags) version of the official `postgres` Docker image, which is compatible with Prefect 2.
-- Starts a container with the name `orion_postgres`.
-- Creates a database `orion` with a user `postgres` and `yourTopSecretPassword` password.
-- Mounts the PostgreSQL data to a Docker volume called `oriondb` to provide persistence if you ever have to restart or rebuild that container.
+- Starts a container with the name `prefect-postgres`.
+- Creates a database `prefect` with a user `postgres` and `yourTopSecretPassword` password.
+- Mounts the PostgreSQL data to a Docker volume called `prefectdb` to provide persistence if you ever have to restart or rebuild that container.
 
 You can inspect your profile to be sure that the environment variable has been set properly:
 

--- a/docs/concepts/settings.md
+++ b/docs/concepts/settings.md
@@ -74,7 +74,7 @@ PREFECT_LOCAL_STORAGE_PATH='${PREFECT_HOME}/storage'
 Prefect provides several settings for configuring the [Prefect database](/concepts/database/).
 
 ```bash
-PREFECT_API_DATABASE_CONNECTION_URL='sqlite+aiosqlite:///${PREFECT_HOME}/orion.db'
+PREFECT_API_DATABASE_CONNECTION_URL='sqlite+aiosqlite:///${PREFECT_HOME}/prefect.db'
 PREFECT_API_DATABASE_ECHO='False'
 PREFECT_API_DATABASE_MIGRATE_ON_START='True'
 PREFECT_API_DATABASE_PASSWORD='None'

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,7 +101,7 @@ Prefect Cloud users do not need to worry about the Prefect database. Prefect Clo
 
 ### What databases does Prefect support?
 
-A self-hosted Prefect server can work with SQLite and PostgreSQL. New Prefect installs default to a SQLite database hosted at `~/.prefect/orion.db` on Mac or Linux machines. SQLite and PostgreSQL are not installed by Prefect.
+A self-hosted Prefect server can work with SQLite and PostgreSQL. New Prefect installs default to a SQLite database hosted at `~/.prefect/prefect.db` on Mac or Linux machines. SQLite and PostgreSQL are not installed by Prefect.
 
 ### How do I choose between SQLite and Postgres?
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -283,7 +283,7 @@ Upgrading from Prefect version 2.0a9 or earlier requires resetting the Prefect d
 
 Prior to 2.0a10, Prefect did not have database migrations and required a hard reset of the database between versions. Now that migrations have been added, your database will be upgraded automatically with each version change. However, you must still perform a hard reset of the database if you are upgrading from 2.0a9 or earlier.
 
-Resetting the database with the CLI command `prefect server database reset` is not compatible a database from 2.0a9 or earlier. Instead, delete the database file `~/.prefect/orion.db`. Prefect automatically creates a new database on the next write.
+Resetting the database with the CLI command `prefect server database reset` is not compatible a database from 2.0a9 or earlier. Instead, delete the database file `~/.prefect/prefect.db`. Prefect automatically creates a new database on the next write.
 
 !!! warning "Resetting the database deletes data"
     Note that resetting the database causes the loss of any existing data.

--- a/docs/tutorials/orchestration.md
+++ b/docs/tutorials/orchestration.md
@@ -146,10 +146,10 @@ Prefect Cloud provides its own hosted database.
 
 Prefect creates a SQLite database, but you can configure your own database. 
 
-When you first install Prefect, your database will be located at `~/.prefect/orion.db`. To configure this location, you can specify a connection URL with the `PREFECT_API_DATABASE_CONNECTION_URL` environment variable:
+When you first install Prefect, your database will be located at `~/.prefect/prefect.db`. To configure this location, you can specify a connection URL with the `PREFECT_API_DATABASE_CONNECTION_URL` environment variable:
 
 ```bash
-$ export PREFECT_API_DATABASE_CONNECTION_URL="sqlite+aiosqlite:////full/path/to/a/location/orion.db"
+$ export PREFECT_API_DATABASE_CONNECTION_URL="sqlite+aiosqlite:////full/path/to/a/location/prefect.db"
 ```
 If at any point in your testing you'd like to reset your database, run the `prefect server database reset` CLI command:  
 

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -164,7 +164,7 @@ def prefect_test_harness():
             # temporarily override any database interface components
             stack.enter_context(temporary_database_interface())
 
-            DB_PATH = "sqlite+aiosqlite:///" + str(Path(temp_dir) / "orion.db")
+            DB_PATH = "sqlite+aiosqlite:///" + str(Path(temp_dir) / "prefect-test.db")
             stack.enter_context(
                 prefect.settings.temporary_settings(
                     # Clear the PREFECT_API_URL


### PR DESCRIPTION
If `PREFECT_API_DATABASE_CONNECTION_URL` is set, nothing changes here.

Otherwise, the default value is now a SQLite database called `prefect.db`. For backwards compatibility, if the `orion.db` file exists and `prefect.db` does not, we will use that as the default instead. 

No warnings are displayed here, users can keep using the old database name. I'm very hesitant to move the database for the user as it could be in-use.