### PR TITLE
Add release notes for 2.8.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@
 ### New names, same behavior
 We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” - the orchestration API, “Orion Server” - a hosted instance of that API, and components of that server. 
 
-With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backawards compatible**. These changes clarify the function of various components, commands, variables, and more:
+With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
 
 - Default SQLite database name changed from `orion.db` to `prefect.db`
 - Logger `prefect.orion` renamed to `prefect.server`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -62,6 +62,7 @@ With this release, **we've removed references to "Orion" and replaced them with 
 
 ### Enhancements
 - Add `MattermostWebhook` notification block — https://github.com/PrefectHQ/prefect/pull/8341
+- Add ability to pass in RRule string to `--rrule` option in `prefect set-schedule` command - https://github.com/PrefectHQ/prefect/pull/8543
 
 ### Fixes
 - Fix default deployment parameters not populating in the UI — https://github.com/PrefectHQ/prefect/pull/8518

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,7 @@
 ## Release 2.8.1
 
 ### New names, same behavior
-We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that its difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” - the orchestration API, “Orion Server” - a hosted instance of that API, and components of that server. 
+We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” - the orchestration API, “Orion Server” - a hosted instance of that API, and components of that server. 
 
 With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backawards compatible**. These changes clarify the function of various components, commands, variables, and more:
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,7 @@
 ## Release 2.8.1
 
 ### New names, same behavior
-We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” - the orchestration API, “Orion Server” - a hosted instance of that API, and components of that server. 
+We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second-generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” (the orchestration API), “Orion Server” (a hosted instance of that API), and individual components of that server. 
 
 With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,9 +4,9 @@
 
 ### New names, same behavior
 
-We knew we were onto something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second-generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of dynamism, developer experience, and observability have shaped the Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” (the orchestration API), an “Orion Server” (a hosted instance of that API), and individual components of that server. 
+We knew we were onto something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second-generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of dynamism, developer experience, and observability have shaped the Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. For example, it's been challenging to communicate clearly about the “Orion API” (the orchestration API), an “Orion Server” (a hosted instance of the API and UI), and individual components of that server. 
 
-With this release, **we've removed references to "Orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
+With this release, **we've removed references to "Orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible** and will follow our standard deprecation cycle of six months. These changes clarify the function of various components, commands, variables, and more:
 
 - Default SQLite database name changed from `orion.db` to `prefect.db`
 - Logger `prefect.orion` renamed to `prefect.server`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Release 2.8.1
 
 ### New names, same behavior
+
 We knew we were onto something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second-generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of dynamism, developer experience, and observability have shaped the Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” (the orchestration API), an “Orion Server” (a hosted instance of that API), and individual components of that server. 
 
 With this release, **we've removed references to "Orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
@@ -61,10 +62,10 @@ With this release, **we've removed references to "Orion" and replaced them with 
 
 ### Enhancements
 - Add `MattermostWebhook` notification block — https://github.com/PrefectHQ/prefect/pull/8341
-- Add default artifact metadata to `LiteralResults` and `PersistedResults` — https://github.com/PrefectHQ/prefect/pull/8501
 
 ### Fixes
 - Fix default deployment parameters not populating in the UI — https://github.com/PrefectHQ/prefect/pull/8518
+- Fix ability to use anchor date when setting an interval schedule with the `prefect set-schedule` command — https://github.com/PrefectHQ/prefect/pull/8524
 
 ### Documentation
 - Add table listing available blocks — https://github.com/PrefectHQ/prefect/pull/8443
@@ -75,6 +76,7 @@ With this release, **we've removed references to "Orion" and replaced them with 
 
 ### Experimental
 - Add metadata fields to `BaseWorker` — https://github.com/PrefectHQ/prefect/pull/8527
+- Add default artifact metadata to `LiteralResults` and `PersistedResults` — https://github.com/PrefectHQ/prefect/pull/8501
 
 ### Contributors
 - @qheuristics made their first contribution in https://github.com/PrefectHQ/prefect/pull/8478

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,65 @@
 # Prefect Release Notes
 
+## Release 2.8.1
+
+### New names, same behavior
+We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that its difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” - the orchestration API, “Orion Server” - a hosted instance of that API, and components of that server. 
+
+With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backawards compatible**. These changes clarify the function of various components, commands, variables, and more:
+
+- Default SQLite database name changed from `orion.db` to `prefect.db`
+- Logger `prefect.orion` renamed to `prefect.server`
+- Constant `ORION_API_VERSION` renamed to `SERVER_API_VERSION`
+- Kubernetes deployment template application name changed from `prefect-orion` to `prefect-server`
+- Command `prefect kubernetes manifest orion` renamed to `prefect kubernetes manifest server`
+- Log config  handler `orion` renamed to `api`
+- Class `OrionLogWorker` renamed to `APILogWorker`
+- Class `OrionHandler` renamed to `APILogHandler`
+- Directory `orion-ui` renamed to `ui`
+- Class `OrionRouter` renamed to `PrefectRouter`
+- Class `OrionAPIRoute` renamed to `PrefectAPIRoute`
+- Class `OrionDBInterface` renamed to `PrefectDBInterface`
+- Class `OrionClient` renamed to `PrefectClient`
+- Module `prefect.client.orion` renamed to `prefect.client.orchestration`
+- Command group `prefect orion` renamed to `prefect server`
+- Module `prefect.orion` renamed to `prefect.server`
+- The following settings have been renamed:
+    - `PREFECT_LOGGING_ORION_ENABLED` → `PREFECT_LOGGING_TO_API_ENABLED`
+    - `PREFECT_LOGGING_ORION_BATCH_INTERVAL` → `PREFECT_LOGGING_TO_API_BATCH_INTERVAL`
+    - `PREFECT_LOGGING_ORION_BATCH_SIZE` → `PREFECT_LOGGING_TO_API_BATCH_SIZE`
+    - `PREFECT_LOGGING_ORION_MAX_LOG_SIZE` → `PREFECT_LOGGING_TO_API_MAX_LOG_SIZE`
+    - `PREFECT_LOGGING_ORION_WHEN_MISSING_FLOW` → `PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW`
+    - `PREFECT_ORION_BLOCKS_REGISTER_ON_START` → `PREFECT_API_BLOCKS_REGISTER_ON_START`
+    - `PREFECT_ORION_DATABASE_CONNECTION_URL` → `PREFECT_API_DATABASE_CONNECTION_URL`
+    - `PREFECT_ORION_DATABASE_MIGRATE_ON_START` → `PREFECT_API_DATABASE_MIGRATE_ON_START`
+    - `PREFECT_ORION_DATABASE_TIMEOUT` → `PREFECT_API_DATABASE_TIMEOUT`
+    - `PREFECT_ORION_DATABASE_CONNECTION_TIMEOUT` → `PREFECT_API_DATABASE_CONNECTION_TIMEOUT`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_LOOP_SECONDS` → `PREFECT_API_SERVICES_SCHEDULER_LOOP_SECONDS`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_DEPLOYMENT_BATCH_SIZE` → `PREFECT_API_SERVICES_SCHEDULER_DEPLOYMENT_BATCH_SIZE`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_MAX_RUNS` → `PREFECT_API_SERVICES_SCHEDULER_MAX_RUNS`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_MIN_RUNS` → `PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME` → `PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME` → `PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_INSERT_BATCH_SIZE` → `PREFECT_API_SERVICES_SCHEDULER_INSERT_BATCH_SIZE`
+    - `PREFECT_ORION_SERVICES_LATE_RUNS_LOOP_SECONDS` → `PREFECT_API_SERVICES_LATE_RUNS_LOOP_SECONDS`
+    - `PREFECT_ORION_SERVICES_LATE_RUNS_AFTER_SECONDS` → `PREFECT_API_SERVICES_LATE_RUNS_AFTER_SECONDS`
+    - `PREFECT_ORION_SERVICES_PAUSE_EXPIRATIONS_LOOP_SECONDS` → `PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_LOOP_SECONDS`
+    - `PREFECT_ORION_SERVICES_CANCELLATION_CLEANUP_LOOP_SECONDS` → `PREFECT_API_SERVICES_CANCELLATION_CLEANUP_LOOP_SECONDS`
+    - `PREFECT_ORION_API_DEFAULT_LIMIT` → `PREFECT_API_DEFAULT_LIMIT`
+    - `PREFECT_ORION_API_HOST` → `PREFECT_SERVER_API_HOST`
+    - `PREFECT_ORION_API_PORT` → `PREFECT_SERVER_API_PORT`
+    - `PREFECT_ORION_API_KEEPALIVE_TIMEOUT` → `PREFECT_SERVER_API_KEEPALIVE_TIMEOUT`
+    - `PREFECT_ORION_UI_ENABLED` → `PREFECT_UI_ENABLED`
+    - `PREFECT_ORION_UI_API_URL` → `PREFECT_UI_API_URL`
+    - `PREFECT_ORION_ANALYTICS_ENABLED` → `PREFECT_SERVER_ANALYTICS_ENABLED`
+    - `PREFECT_ORION_SERVICES_SCHEDULER_ENABLED` → `PREFECT_API_SERVICES_SCHEDULER_ENABLED`
+    - `PREFECT_ORION_SERVICES_LATE_RUNS_ENABLED` → `PREFECT_API_SERVICES_LATE_RUNS_ENABLED`
+    - `PREFECT_ORION_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED` → `PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED`
+    - `PREFECT_ORION_SERVICES_PAUSE_EXPIRATIONS_ENABLED` → `PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED`
+    - `PREFECT_ORION_TASK_CACHE_KEY_MAX_LENGTH` → `PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH`
+    - `PREFECT_ORION_SERVICES_CANCELLATION_CLEANUP_ENABLED` → `PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED`
+
+
 ## Release 2.8.0
 
 ### Prioritize flow runs with work pools 🏊

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -76,9 +76,9 @@ With this release, **we've removed references to "Orion" and replaced them with 
 ### Experimental
 - Add metadata fields to `BaseWorker` — https://github.com/PrefectHQ/prefect/pull/8527
 
-## Contributors
-* @qheuristics made their first contribution in https://github.com/PrefectHQ/prefect/pull/8478
-* @KernelErr made their first contribution in https://github.com/PrefectHQ/prefect/pull/8485
+### Contributors
+- @qheuristics made their first contribution in https://github.com/PrefectHQ/prefect/pull/8478
+- @KernelErr made their first contribution in https://github.com/PrefectHQ/prefect/pull/8485
 
 ## Release 2.8.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -64,14 +64,14 @@ With this release, **we've removed references to "Orion" and replaced them with 
 - Add default artifact metadata to `LiteralResults` and `PersistedResults` — https://github.com/PrefectHQ/prefect/pull/8501
 
 ### Fixes
-- Fix default parameters not populating on the UI — https://github.com/PrefectHQ/prefect/pull/8518
+- Fix default deployment parameters not populating on the UI — https://github.com/PrefectHQ/prefect/pull/8518
 
 ### Documentation
+- Add table listing available blocks — https://github.com/PrefectHQ/prefect/pull/8443
 - Fix work pools documentation links — https://github.com/PrefectHQ/prefect/pull/8477
 - Add examples for custom automation triggers — https://github.com/PrefectHQ/prefect/pull/8476
 - Add webhooks to Automations  docs — https://github.com/PrefectHQ/prefect/pull/8514
 - Document Prefect Cloud API rate limits — https://github.com/PrefectHQ/prefect/pull/8529
-- Add table listing available blocks — https://github.com/PrefectHQ/prefect/pull/8443
 
 ### Experimental
 - Add metadata fields to `BaseWorker` — https://github.com/PrefectHQ/prefect/pull/8527

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -59,6 +59,26 @@ With today's release, **we've removed references to "Orion" and replaced them wi
     - `PREFECT_ORION_TASK_CACHE_KEY_MAX_LENGTH` → `PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH`
     - `PREFECT_ORION_SERVICES_CANCELLATION_CLEANUP_ENABLED` → `PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED`
 
+### Enhancements
+- Add `MattermostWebhook` notification block — https://github.com/PrefectHQ/prefect/pull/8341
+- Add default artifact metadata to `LiteralResults` and `PersistedResults` — https://github.com/PrefectHQ/prefect/pull/8501
+
+### Fixes
+- Fix default parameters not populating on the UI — https://github.com/PrefectHQ/prefect/pull/8518
+
+### Documentation
+- Fix work pools documentation links — https://github.com/PrefectHQ/prefect/pull/8477
+- Add examples for custom automation triggers — https://github.com/PrefectHQ/prefect/pull/8476
+- Add webhooks to Automations  docs — https://github.com/PrefectHQ/prefect/pull/8514
+- Document Prefect Cloud API rate limits — https://github.com/PrefectHQ/prefect/pull/8529
+- Add table listing available blocks — https://github.com/PrefectHQ/prefect/pull/8443
+
+### Experimental
+- Add metadata fields to `BaseWorker` — https://github.com/PrefectHQ/prefect/pull/8527
+
+## Contributors
+* @qheuristics made their first contribution in https://github.com/PrefectHQ/prefect/pull/8478
+* @KernelErr made their first contribution in https://github.com/PrefectHQ/prefect/pull/8485
 
 ## Release 2.8.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@
 ### New names, same behavior
 We knew that we were on to something big when we [first announced Prefect Orion](https://www.prefect.io/guide/blog/announcing-prefect-orion/), our second-generation orchestration engine, but we didn't know just how big. Orion's foundational design principles of "dynamism, developer experience, and observability" have influenced the entire Prefect 2 codebase to such an extent that it's difficult to tell where Orion ends and other components begin. In particular, it can be difficult to distinguish between the “Orion API” (the orchestration API), “Orion Server” (a hosted instance of that API), and individual components of that server. 
 
-With today's release, **we've removed references to "orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
+With today's release, **we've removed references to "Orion" and replaced them with more explicit, conventional nomenclature throughout the codebase**. All changes are **fully backwards compatible**. These changes clarify the function of various components, commands, variables, and more:
 
 - Default SQLite database name changed from `orion.db` to `prefect.db`
 - Logger `prefect.orion` renamed to `prefect.server`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -64,7 +64,7 @@ With this release, **we've removed references to "Orion" and replaced them with 
 - Add default artifact metadata to `LiteralResults` and `PersistedResults` — https://github.com/PrefectHQ/prefect/pull/8501
 
 ### Fixes
-- Fix default deployment parameters not populating on the UI — https://github.com/PrefectHQ/prefect/pull/8518
+- Fix default deployment parameters not populating in the UI — https://github.com/PrefectHQ/prefect/pull/8518
 
 ### Documentation
 - Add table listing available blocks — https://github.com/PrefectHQ/prefect/pull/8443


### PR DESCRIPTION
Adds 2.8.1 release notes section describing orion rename.
[Preview](https://github.com/PrefectHQ/prefect/blob/2.8.1-release-notes/RELEASE-NOTES.md)