### PR TITLE
Fix test bug where `two` did not wait for creation of `event_one`

### DIFF
--- a/tests/_internal/concurrency/test_primitives.py
+++ b/tests/_internal/concurrency/test_primitives.py
@@ -1,5 +1,4 @@
 import anyio
-import pytest
 
 from prefect._internal.concurrency.primitives import Event
 
@@ -110,7 +109,6 @@ async def test_event_set_from_async_thread_before_wait():
         await event.wait()
 
 
-@pytest.mark.skip(reason="This test deadlocks sometimes")
 async def test_dependent_events_in_two_loops_do_not_deadlock():
     event_one = None
     event_two = None
@@ -126,7 +124,7 @@ async def test_dependent_events_in_two_loops_do_not_deadlock():
     async def two():
         nonlocal event_two
         event_two = Event()
-        while event_two is None:
+        while event_one is None:
             await anyio.sleep(0)
         event_one.set()
         await event_two.wait()


### PR DESCRIPTION
Enables the test that was flaking and solves the issue which was actually just a mistake in the test itself not the implementation.

Verified with flake-finder in https://github.com/PrefectHQ/prefect/pull/8515
