### PR TITLE
Move server type detection into PrefectClient

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -17,7 +17,7 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.cloud import CloudUnauthorizedError, get_cloud_client
 from prefect.cli.root import app
-from prefect.client import get_client
+from prefect.client.orchestration import ServerType, get_client
 from prefect.context import use_profile
 from prefect.utilities.collections import AutoEnum
 
@@ -276,7 +276,7 @@ async def check_orion_connection():
                 connect_error = await client.api_healthcheck()
                 if connect_error is not None:
                     return ConnectionStatus.ORION_ERROR
-                elif await client.using_ephemeral_app():
+                elif client.server_type == ServerType.EPHEMERAL:
                     # if the client is using an ephemeral Prefect app, inform the user
                     return ConnectionStatus.EPHEMERAL
                 else:
@@ -294,7 +294,7 @@ async def check_orion_connection():
             connect_error = await client.api_healthcheck()
             if connect_error is not None:
                 return ConnectionStatus.ORION_ERROR
-            elif await client.using_ephemeral_app():
+            elif client.server_type == ServerType.EPHEMERAL:
                 return ConnectionStatus.EPHEMERAL
             else:
                 return ConnectionStatus.ORION_CONNECTED

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -4,7 +4,6 @@ Base `prefect` command-line application
 import asyncio
 import platform
 import sys
-from typing import Optional
 
 import pendulum
 import rich.console
@@ -16,6 +15,7 @@ import prefect.context
 import prefect.settings
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import with_cli_exception_handling
+from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
     PREFECT_CLI_COLORS,
@@ -101,11 +101,7 @@ async def version():
 
     from prefect.server.api.server import SERVER_API_VERSION
     from prefect.server.utilities.database import get_dialect
-    from prefect.settings import (
-        PREFECT_API_DATABASE_CONNECTION_URL,
-        PREFECT_API_URL,
-        PREFECT_CLOUD_API_URL,
-    )
+    from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
 
     version_info = {
         "Version": prefect.__version__,
@@ -119,25 +115,14 @@ async def version():
         "Profile": prefect.context.get_settings_context().profile.name,
     }
 
-    is_ephemeral: Optional[bool] = None
     try:
         async with prefect.get_client() as client:
-            is_ephemeral = client._ephemeral_app is not None
-    except Exception as exc:
+            version_info["Server type"] = client.server_type
+    except Exception:
         version_info["Server type"] = "<client error>"
-    else:
-        version_info["Server type"] = (
-            "ephemeral"
-            if is_ephemeral
-            else (
-                "cloud"
-                if PREFECT_API_URL.value().startswith(PREFECT_CLOUD_API_URL.value())
-                else "hosted"
-            )
-        )
 
     # TODO: Consider adding an API route to retrieve this information?
-    if is_ephemeral:
+    if version_info["Server type"] == ServerType.EPHEMERAL:
         database = get_dialect(PREFECT_API_DATABASE_CONNECTION_URL.value()).name
         version_info["Server"] = {"Database": database}
         if database == "sqlite":

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -14,14 +14,14 @@ from prefect.testing.cli import invoke_and_assert
 
 def test_version_ephemeral_server_type():
     invoke_and_assert(
-        ["version"], expected_output_contains="Server type:         ephemeral"
+        ["version"], expected_output_contains="Server type:         EPHEMERAL"
     )
 
 
 @pytest.mark.usefixtures("use_hosted_orion")
 def test_version_hosted_server_type():
     invoke_and_assert(
-        ["version"], expected_output_contains="Server type:         hosted"
+        ["version"], expected_output_contains="Server type:         HOSTED"
     )
 
 
@@ -33,7 +33,7 @@ def test_version_cloud_server_type():
         }
     ):
         invoke_and_assert(
-            ["version"], expected_output_contains="Server type:         cloud"
+            ["version"], expected_output_contains="Server type:         CLOUD"
         )
 
 
@@ -62,7 +62,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         ephemeral
+Server type:         EPHEMERAL
 Server:
   Database:          sqlite
   SQLite version:    {sqlite3.sqlite_version}
@@ -88,7 +88,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         ephemeral
+Server type:         EPHEMERAL
 Server:
   Database:          postgres
 """,
@@ -110,6 +110,6 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         hosted
+Server type:         HOSTED
 """,
     )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This moves the server type detection from the version CLI to the PrefectClient itself and then updates the profile CLI to also use this new attribute. Having this attribute in the client itself will allow us to easily detect which events client to use.

Closes #8521 


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
