### PR TITLE
Fix runtime bug where async context vars were not propagated

### DIFF
--- a/src/prefect/_internal/concurrency/runtime.py
+++ b/src/prefect/_internal/concurrency/runtime.py
@@ -73,8 +73,17 @@ class _WorkItem:
             self.future.set_result(result)
 
     async def _run_async(self):
+        loop = asyncio.get_running_loop()
         try:
-            result = await self.context.run(self.fn, *self.args, **self.kwargs)
+            # Call the function in the context; this is not necessary if the function
+            # is a standard cortouine function but if it's a synchronous function that
+            # returns a coroutine we want to ensure the correct context is available
+            coro = self.context.run(self.fn, *self.args, **self.kwargs)
+
+            # Run the coroutine in a new task to run with the correct async context
+            task = self.context.run(loop.create_task, coro)
+            result = await task
+
         except BaseException as exc:
             self.future.set_exception(exc)
             # Prevent reference cycle in `exc`

--- a/tests/_internal/concurrency/test_runtime.py
+++ b/tests/_internal/concurrency/test_runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 
 import anyio
 import pytest
@@ -13,6 +14,9 @@ def identity(x):
 async def aidentity(x):
     await asyncio.sleep(0)
     return x
+
+
+TEST_CONTEXTVAR = contextvars.ContextVar("TEST_CONTEXTVAR")
 
 
 def test_runtime_context_manager():
@@ -108,3 +112,60 @@ def test_async_runtime_submit_from_worker_thread():
 
     with Runtime() as runtime:
         assert runtime.run_in_thread(work) == 1
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_runtime_run_in_thread_captures_context_variables(sync):
+    def _get_value():
+        return TEST_CONTEXTVAR.get()
+
+    if sync:
+
+        def get_value():
+            return _get_value()
+
+    else:
+
+        async def get_value():
+            return _get_value()
+
+    with Runtime() as runtime:
+        try:
+            token = TEST_CONTEXTVAR.set("test")
+            assert await runtime.run_in_thread(get_value) == "test"
+        finally:
+            TEST_CONTEXTVAR.reset(token)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_runtime_run_in_loop_captures_context_variables(sync):
+    async def get_value():
+        return TEST_CONTEXTVAR.get()
+
+    with Runtime() as runtime:
+        try:
+            token = TEST_CONTEXTVAR.set("test")
+            result = await runtime.run_in_loop(get_value)
+            assert result == "test"
+        finally:
+            TEST_CONTEXTVAR.reset(token)
+
+
+async def test_async_runtime_submit_from_thread_captures_context_variables():
+    def _get_value():
+        return TEST_CONTEXTVAR.get()
+
+    async def get_value():
+        return _get_value()
+
+    async def work():
+        token = TEST_CONTEXTVAR.set("test")
+        try:
+            future = runtime.submit_from_thread(get_value)
+        finally:
+            TEST_CONTEXTVAR.reset(token)
+        return await asyncio.wrap_future(future)
+
+    with Runtime() as runtime:
+        result = await runtime.run_in_loop(work)
+        assert result == "test"


### PR DESCRIPTION
When we called `await self.context.run(self.fn, *self.args, **self.kwargs)` the coroutine would be _created_ within the context but not _run_ within the context. Instead, we must create a new _async task_ with the desired context. This is a little slower, but we need context variables to propagate.