### PR TITLE
Fix ability to use anchor date when setting an interval schedule with the `prefect set-schedule` command

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -243,7 +243,10 @@ async def set_schedule(
         help="An interval to schedule on, specified in seconds",
     ),
     interval_anchor: Optional[str] = typer.Option(
-        None, "--anchor-date", help="The anchor date for an interval schedule"
+        None,
+        "--anchor-date",
+        help="The anchor date for an interval schedule",
+        min=0.0001,
     ),
     rrule_string: Optional[str] = typer.Option(
         None, "--rrule", help="Deployment schedule rrule string"
@@ -268,7 +271,9 @@ async def set_schedule(
     assert_deployment_name_format(name)
 
     if interval_anchor and not interval:
-        exit_with_error("An anchor date can only be provided with an interval schedule")
+        exit_with_error(
+            "An anchor date can only be provided with an interval schedule."
+        )
     if interval_anchor:
         try:
             pendulum.parse(interval_anchor)

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -267,16 +267,17 @@ async def set_schedule(
     """
     assert_deployment_name_format(name)
 
-    if interval_anchor and not interval:
-        exit_with_error(
-            "Cannot specify an anchor date without an interval. Please specify an interval."
-        )
-
     if interval_anchor:
         try:
             pendulum.parse(interval_anchor)
         except ValueError:
             exit_with_error("The anchor date must be a valid date string.")
+        if not interval:
+            exit_with_error(
+                "Cannot specify an anchor date without an interval. Please specify an interval."
+            )
+        if interval <= 0:
+            exit_with_error("The interval must be greater than zero seconds.")
 
     interval_schedule = {
         "interval": interval,

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -267,6 +267,17 @@ async def set_schedule(
     """
     assert_deployment_name_format(name)
 
+    if interval_anchor and not interval:
+        exit_with_error(
+            "Cannot specify an anchor date without an interval. Please specify an interval."
+        )
+
+    if interval_anchor:
+        try:
+            pendulum.parse(interval_anchor)
+        except ValueError:
+            exit_with_error("The anchor date must be a valid date string.")
+
     interval_schedule = {
         "interval": interval,
         "anchor_date": interval_anchor,

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -269,7 +269,7 @@ async def set_schedule(
 
     interval_schedule = {
         "interval": interval,
-        "interval_anchor": interval_anchor,
+        "anchor_date": interval_anchor,
         "timezone": timezone,
     }
     cron_schedule = {"cron": cron_string, "day_or": cron_day_or, "timezone": timezone}

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -267,17 +267,15 @@ async def set_schedule(
     """
     assert_deployment_name_format(name)
 
+    if interval_anchor and not interval:
+        exit_with_error("An anchor date can only be provided with an interval schedule")
     if interval_anchor:
         try:
             pendulum.parse(interval_anchor)
         except ValueError:
             exit_with_error("The anchor date must be a valid date string.")
-        if not interval:
-            exit_with_error(
-                "Cannot specify an anchor date without an interval. Please specify an interval."
-            )
-        if interval <= 0:
-            exit_with_error("The interval must be greater than zero seconds.")
+    if interval is not None and interval <= 0:
+        exit_with_error("The interval must be greater than zero seconds.")
 
     interval_schedule = {
         "interval": interval,

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -190,7 +190,7 @@ class TestSchedules:
                 "--interval",
                 "42",
                 "--anchor-date",
-                "2018-02-02",
+                "2040-02-02",
                 "--timezone",
                 "America/New_York",
             ],
@@ -200,7 +200,7 @@ class TestSchedules:
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
         assert deployment.schedule.interval == timedelta(seconds=42)
-        assert deployment.schedule.anchor_date == pendulum.parse("2018-02-02")
+        assert deployment.schedule.anchor_date == pendulum.parse("2040-02-02")
         assert deployment.schedule.timezone == "America/New_York"
 
     def test_passing_anchor_without_interval_exits(self, patch_import, tmp_path):

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -304,6 +304,31 @@ class TestUpdatingDeployments:
             expected_output_contains=["'is_schedule_active': True"],
         )
 
+    def test_set_schedule_updating_anchor_date_respected(self, flojo):
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--interval",
+                "1800",
+                "--anchor-date",
+                "2040-01-01T00:00:00",
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'anchor_date': '2040-01-01T00:00:00+00:00'"],
+        )
+
 
 class TestDeploymentRun:
     @pytest.fixture

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -329,6 +329,32 @@ class TestUpdatingDeployments:
             expected_output_contains=["'anchor_date': '2040-01-01T00:00:00+00:00'"],
         )
 
+    def test_set_schedule_updating_anchor_date_without_interval_raises(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--anchor-date",
+                "2040-01-01T00:00:00",
+            ],
+            expected_code=1,
+            expected_output_contains="An anchor date can only be provided with an interval schedule",
+        )
+
+    def test_set_schedule_updating_invalid_interval_raises(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--interval",
+                "0",
+            ],
+            expected_code=1,
+            expected_output_contains="interval must be greater than zero seconds",
+        )
+
 
 class TestDeploymentRun:
     @pytest.fixture


### PR DESCRIPTION
## Overview
Setting the `anchor_date` when setting a schedule via the CLI was not working. This fix enables the `anchor_date` to be correctly parsed when passed in alongside the `--interval` arg.

## Example
### Current behavior on main
```bash
prefect deployment set-schedule flows/my_flow --interval "1800" --anchor-date "2040-01-01"
```

Results in error:
```
Traceback (most recent call last):
  File "/Users/bean/code/prefect/src/prefect/cli/_utilities.py", line 41, in wrapper
    return fn(*args, **kwargs)
  File "/Users/bean/code/prefect/src/prefect/utilities/asyncutils.py", line 230, in coroutine_wrapper
    return run_async_in_new_loop(async_fn, *args, **kwargs)
  File "/Users/bean/code/prefect/src/prefect/utilities/asyncutils.py", line 181, in run_async_in_new_loop
    return anyio.run(partial(__fn, *args, **kwargs))
  File "/Users/bean/code/prefect/venv-healthcheck/lib/python3.9/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/Users/bean/code/prefect/venv-healthcheck/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/Users/bean/code/prefect/venv-healthcheck/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "/Users/bean/code/prefect/src/prefect/cli/deployment.py", line 307, in set_schedule
    await client.update_deployment(deployment, schedule=updated_schedule)
  File "/Users/bean/code/prefect/src/prefect/client/orion.py", line 1397, in update_deployment
    deployment_create = schemas.actions.DeploymentUpdate(
  File "/Users/bean/code/prefect/src/prefect/_internal/compatibility/experimental.py", line 228, in __init__
    cls_init(__pydantic_self__, **data)
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 7 validation errors for DeploymentUpdate
schedule -> interval_anchor
  extra fields not permitted (type=value_error.extra)
schedule -> cron
  field required (type=value_error.missing)
schedule -> interval
  extra fields not permitted (type=value_error.extra)
schedule -> interval_anchor
  extra fields not permitted (type=value_error.extra)
schedule -> rrule
  field required (type=value_error.missing)
schedule -> interval
  extra fields not permitted (type=value_error.extra)
schedule -> interval_anchor
  extra fields not permitted (type=value_error.extra)
```
### Fixed behavior results
```bash
Updated deployment schedule!
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
