### PR TITLE
Document Prefect Cloud API rate limits

### DIFF
--- a/docs/api-ref/overview.md
+++ b/docs/api-ref/overview.md
@@ -25,4 +25,4 @@ Prefect 2 provides a number of programmatic workflow interfaces. Each API is doc
     The Prefect REST API documentation for locally run open-source Prefect servers is also available in the [Prefect REST API Reference](/api-ref/rest-api-reference/).
 
 !!! info "Prefect Cloud API rate limits"
-    The Prefect Cloud API enforces rate limits enable us to control the number of requests any given app can make on the platform. It ensures that, when you make an API call, you get a response. See [Prefect Cloud API Rate Limits](/ui/rate-limits/) for details.
+    The Prefect Cloud API enforces rate limits, restricting the number of requests that a single client can make in a given time period. It ensures that, when you make an API call, you get a response. See [Prefect Cloud API Rate Limits](/ui/rate-limits/) for details.

--- a/docs/api-ref/overview.md
+++ b/docs/api-ref/overview.md
@@ -23,3 +23,6 @@ Prefect 2 provides a number of programmatic workflow interfaces. Each API is doc
     The Prefect REST API documentation for a local instance run with with `prefect server start` is available at <a href="http://localhost:4200/docs" target="_blank">http://localhost:4200/docs</a> or the `/docs` endpoint of the [`PREFECT_API_URL`](/concepts/settings/#prefect_api_url) you have configured to access the server.
 
     The Prefect REST API documentation for locally run open-source Prefect servers is also available in the [Prefect REST API Reference](/api-ref/rest-api-reference/).
+
+!!! info "Prefect Cloud API rate limits"
+    The Prefect Cloud API enforces rate limits enable us to control the number of requests any given app can make on the platform. It ensures that, when you make an API call, you get a response. See [Prefect Cloud API Rate Limits](/ui/rate-limits/) for details.

--- a/docs/ui/rate-limits.md
+++ b/docs/ui/rate-limits.md
@@ -1,0 +1,46 @@
+---
+description: Prefect Cloud API rate limits.
+tags:
+    - API
+    - Prefect Cloud
+    - rate limits
+---
+
+# Prefect Cloud API Rate Limits
+
+An API rate limit is a way for Prefect to ensure the stability of the Prefect Cloud platform. API rate limits enable us to control the number of requests any given app can make on the platform. It ensures that, when you make an API call, you get a response.
+
+!!! info "Prefect Cloud rate limits are subject to change"
+    The following rate limits are in effect currently, but are subject to change. Contact Prefect support at [help@prefect.io](mailto:help@prefect.io) if you have questions about current rate limits.
+
+Prefect Cloud enforces the following rate limits: 
+
+- Flow and task creation rate limits
+- Log service rate limits
+- Service-wide rate limits (applies to all requests)
+
+## Flow and task creation rate limits
+
+We limit creation of flow and task runs to: 
+
+- 2,000 per minute per account
+
+The Prefect Cloud API will return a `429` response with an appropriate `Retry-After` header if these limits are triggered.
+
+## Log service rate limits
+
+The `logs` service enforces limits on the number of logs sent. 
+
+- 700 logs per minute for personal accounts
+- 10,000 logs per minute for organization accounts
+
+## Service-wide rate limits
+
+Prefect also enforces service-wide rate limiting for all Prefect Cloud API routes. This is intended to protect against high request volumes that may degrade service for all users. Service-wide rate limits apply to all routes.
+
+Service-wide rate limits include: 
+
+- 5,000 requests per minute per API key 
+- 10,000 requests per minute per client IP
+
+The Prefect Cloud API will return a `429` response if these limits are triggered.

--- a/docs/ui/rate-limits.md
+++ b/docs/ui/rate-limits.md
@@ -8,7 +8,7 @@ tags:
 
 # Prefect Cloud API Rate Limits
 
-An API rate limit is a way for Prefect to ensure the stability of the Prefect Cloud platform. API rate limits enable us to control the number of requests any given app can make on the platform. It ensures that, when you make an API call, you get a response.
+API rate limits restrict the number of requests that a single client can make in a given time period. They ensure Prefect Cloud's stability, so that when you make an API call, you always get a response.
 
 !!! info "Prefect Cloud rate limits are subject to change"
     The following rate limits are in effect currently, but are subject to change. Contact Prefect support at [help@prefect.io](mailto:help@prefect.io) if you have questions about current rate limits.
@@ -17,11 +17,11 @@ Prefect Cloud enforces the following rate limits:
 
 - Flow and task creation rate limits
 - Log service rate limits
-- Service-wide rate limits (applies to all requests)
+- Service-wide rate limits (applicable to all requests)
 
 ## Flow and task creation rate limits
 
-We limit creation of flow and task runs to: 
+Prefect Cloud limits creation of flow and task runs to: 
 
 - 2,000 per minute per account
 
@@ -29,14 +29,14 @@ The Prefect Cloud API will return a `429` response with an appropriate `Retry-Af
 
 ## Log service rate limits
 
-The `logs` service enforces limits on the number of logs sent. 
+Prefect Cloud limits the number of logs accepted:
 
 - 700 logs per minute for personal accounts
 - 10,000 logs per minute for organization accounts
 
 ## Service-wide rate limits
 
-Prefect also enforces service-wide rate limiting for all Prefect Cloud API routes. This is intended to protect against high request volumes that may degrade service for all users. Service-wide rate limits apply to all routes.
+Prefect Cloud also enforces service-wide rate limiting for all API routes. This is intended to protect against high request volumes that may degrade service for all users.
 
 Service-wide rate limits include: 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
         - Single Sign-on (SSO): ui/sso.md
         - Audit Log: ui/audit-log.md
         - Troubleshooting: ui/troubleshooting.md
+        - Prefect Cloud API Rate Limits: ui/rate-limits.md
     - Integrations:
         - Collections Catalog: collections/catalog.md
         - Using Collections: collections/usage.md


### PR DESCRIPTION
Add a new Prefect Cloud API Rate Limits page documenting API route rate limits.

Also adds a note to the API reference overview page linking to rate limit docs.

### Example

[Prefect Cloud API Rate Limits](https://deploy-preview-8529--prefect-docs.netlify.app/ui/rate-limits/)

[API Reference](https://deploy-preview-8529--prefect-docs.netlify.app/api-ref/overview/)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
