### PR TITLE
Add background to FlowRun count on flowRun dashboard

### DIFF
--- a/ui/src/pages/FlowRuns.vue
+++ b/ui/src/pages/FlowRuns.vue
@@ -106,9 +106,10 @@
   sticky
   top-0
   bg-opacity-90
-  py-2
+  py-3
   z-10
   bg-background
+  dark:bg-background-400
   rounded-b
   px-2
 }

--- a/ui/src/pages/FlowRuns.vue
+++ b/ui/src/pages/FlowRuns.vue
@@ -108,6 +108,9 @@
   bg-opacity-90
   py-2
   z-10
+  bg-background
+  rounded-b
+  px-2
 }
 
 .flow-runs__list-controls--right { @apply


### PR DESCRIPTION
### Description
FlowRun count on flowRun dashboard doesn't have background in prefect server

Was:
<img width="700" alt="Screenshot 2023-02-15 at 10 28 05 AM" src="https://user-images.githubusercontent.com/40467112/219090126-fae7c25a-7392-41d5-b7a4-e32c0732bc03.png">

Now:
<img width="700" alt="Screenshot 2023-02-15 at 11 27 03 AM" src="https://user-images.githubusercontent.com/40467112/219090195-763816a5-6bef-41db-b562-203d43d58eba.png">

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1155

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
