### PR TITLE
Add redirects for former work queue documentation pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,11 @@ publish = "site"
   status = 301
 
 [[redirects]]
+  from = "https://orion-docs.prefect.io/*"
+  to = "https://docs.prefect.io/:splat"
+  status = 301
+
+[[redirects]]
   from = "https://docs.prefect.io/migration_guide/"
   to = "https://docs.prefect.io/migration-guide/"
   status = 301
@@ -52,6 +57,11 @@ publish = "site"
   status = 301
 
 [[redirects]]
-  from = "https://orion-docs.prefect.io/*"
-  to = "https://docs.prefect.io/:splat"
+  from = "https://docs.prefect.io/ui/work-queues/"
+  to = "https://docs.prefect.io/ui/work-pools/"
+  status = 301
+
+[[redirects]]
+  from = "https://docs.prefect.io/concepts/work-queues/"
+  to = "https://docs.prefect.io/concepts/work-pools/"
   status = 301


### PR DESCRIPTION
Adds redirects for paths to work queue pages that are now work pools pages.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
