### PR TITLE
Add ability to pass in RRule string to `--rrule` option in `prefect set-schedule` command

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -301,8 +301,8 @@ async def set_schedule(
         )
 
     if rrule_string is not None:
-        # a provided timezone gets ignored by the RRuleSchedule constructor
-        if not timezone and "TZID" in rrule_string:
+        # a timezone in the `rrule_string` gets ignored by the RRuleSchedule constructor
+        if "TZID" in rrule_string and not timezone:
             exit_with_error(
                 "You can provide a timezone by providing a dict with a `timezone` key to the --rrule option. E.g. {'rrule': 'FREQ=MINUTELY;INTERVAL=5', 'timezone': 'America/New_York'}."
                 "\nAlternatively, you can provide a timezone by passing in a --timezone argument."

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -241,12 +241,12 @@ async def set_schedule(
         None,
         "--interval",
         help="An interval to schedule on, specified in seconds",
+        min=0.0001,
     ),
     interval_anchor: Optional[str] = typer.Option(
         None,
         "--anchor-date",
         help="The anchor date for an interval schedule",
-        min=0.0001,
     ),
     rrule_string: Optional[str] = typer.Option(
         None, "--rrule", help="Deployment schedule rrule string"

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -267,36 +267,53 @@ async def set_schedule(
     """
     assert_deployment_name_format(name)
 
-    interval_schedule = {
-        "interval": interval,
-        "interval_anchor": interval_anchor,
-        "timezone": timezone,
-    }
-    cron_schedule = {"cron": cron_string, "day_or": cron_day_or, "timezone": timezone}
-    if rrule_string is not None:
-        rrule_schedule = json.loads(rrule_string)
-        if timezone:
-            # override timezone if specified via CLI argument
-            rrule_schedule.update({"timezone": timezone})
-    else:
-        # fall back to empty schedule dictionary
-        rrule_schedule = {"rrule": None}
-
-    def updated_schedule_check(schedule):
-        return any(v is not None for k, v in schedule.items() if k != "timezone")
-
-    updated_schedules = list(
-        filter(
-            updated_schedule_check, (interval_schedule, cron_schedule, rrule_schedule)
+    if sum(option is not None for option in [interval, rrule_string, cron_string]) != 1:
+        exit_with_error(
+            "Exactly one of `--interval`, `--rrule`, or `--cron` must be provided."
         )
-    )
 
-    if len(updated_schedules) == 0:
-        exit_with_error("No deployment schedule updates provided")
-    if len(updated_schedules) > 1:
-        exit_with_error("Incompatible schedule parameters")
+    if interval_anchor and not interval:
+        exit_with_error("An anchor date can only be provided with an interval schedule")
 
-    updated_schedule = {k: v for k, v in updated_schedules[0].items() if v is not None}
+    if interval is not None:
+        if interval_anchor:
+            try:
+                pendulum.parse(interval_anchor)
+            except ValueError:
+                exit_with_error("The anchor date must be a valid date string.")
+        interval_schedule = {
+            "interval": interval,
+            "anchor_date": interval_anchor,
+            "timezone": timezone,
+        }
+        updated_schedule = IntervalSchedule(
+            **{k: v for k, v in interval_schedule.items() if v is not None}
+        )
+
+    if cron_string is not None:
+        cron_schedule = {
+            "cron": cron_string,
+            "day_or": cron_day_or,
+            "timezone": timezone,
+        }
+        updated_schedule = CronSchedule(
+            **{k: v for k, v in cron_schedule.items() if v is not None}
+        )
+
+    if rrule_string is not None:
+        # a provided timezone gets ignored by the RRuleSchedule constructor
+        if not timezone and "TZID" in rrule_string:
+            exit_with_error(
+                "You can provide a timezone by providing a dict with a `timezone` key to the --rrule option. E.g. {'rrule': 'FREQ=MINUTELY;INTERVAL=5', 'timezone': 'America/New_York'}."
+                "\nAlternatively, you can provide a timezone by passing in a --timezone argument."
+            )
+        try:
+            updated_schedule = RRuleSchedule(**json.loads(rrule_string))
+            if timezone:
+                # override timezone if specified via CLI argument
+                updated_schedule.timezone = timezone
+        except json.JSONDecodeError:
+            updated_schedule = RRuleSchedule(rrule=rrule_string, timezone=timezone)
 
     async with get_client() as client:
         try:

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -478,20 +478,7 @@ class TestUpdatingDeployments:
                 "2040-01-01T00:00:00",
             ],
             expected_code=1,
-            expected_output_contains="An anchor date can only be provided with an interval schedule",
-        )
-
-    def test_set_schedule_updating_invalid_interval_raises(self, flojo):
-        invoke_and_assert(
-            [
-                "deployment",
-                "set-schedule",
-                "rence-griffith/test-deployment",
-                "--interval",
-                "0",
-            ],
-            expected_code=1,
-            expected_output_contains="interval must be greater than zero seconds",
+            expected_output_contains="Exactly one of `--interval`, `--rrule`, or `--cron` must be provided",
         )
 
 

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -204,42 +204,6 @@ class TestUpdatingDeployments:
             expected_code=0,
         )
 
-    def test_set_schedule_interval_with_anchor_date(self, flojo):
-        invoke_and_assert(
-            [
-                "deployment",
-                "inspect",
-                "rence-griffith/test-deployment",
-            ],
-            expected_output_contains=["10.76"],  # 100 m record
-            expected_code=0,
-        )
-
-        invoke_and_assert(
-            [
-                "deployment",
-                "set-schedule",
-                "rence-griffith/test-deployment",
-                "--interval",
-                "10.49",  # July 16, 1988
-                "--anchor-date",
-                "2040-07-16T00:00:00",
-            ],
-            expected_code=0,
-        )
-
-        invoke_and_assert(
-            [
-                "deployment",
-                "inspect",
-                "rence-griffith/test-deployment",
-            ],
-            expected_output_contains=[
-                "2040-07-16T00:00:00"
-            ],  # flo-jo breaks the world record
-            expected_code=0,
-        )
-
     def test_set_schedule_with_too_many_schedule_options_raises(self, flojo):
         invoke_and_assert(
             [

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -172,7 +172,7 @@ class TestUpdatingDeployments:
         )
         return deployment_id
 
-    def test_updating_schedules(self, flojo):
+    def test_set_schedule_interval_without_anchor_date(self, flojo):
         invoke_and_assert(
             [
                 "deployment",
@@ -204,7 +204,43 @@ class TestUpdatingDeployments:
             expected_code=0,
         )
 
-    def test_incompatible_schedule_parameters(self, flojo):
+    def test_set_schedule_interval_with_anchor_date(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["10.76"],  # 100 m record
+            expected_code=0,
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--interval",
+                "10.49",  # July 16, 1988
+                "--anchor-date",
+                "2040-07-16T00:00:00",
+            ],
+            expected_code=0,
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=[
+                "2040-07-16T00:00:00"
+            ],  # flo-jo breaks the world record
+            expected_code=0,
+        )
+
+    def test_set_schedule_with_too_many_schedule_options_raises(self, flojo):
         invoke_and_assert(
             [
                 "deployment",
@@ -216,10 +252,44 @@ class TestUpdatingDeployments:
                 "i dont know cron syntax dont judge",
             ],
             expected_code=1,
-            expected_output_contains="Incompatible schedule parameters",
+            expected_output_contains="Exactly one of `--interval`, `--rrule`, or `--cron` must be provided",
         )
 
-    def test_rrule_schedules_are_parsed_properly(self, flojo):
+    def test_set_schedule_with_no_schedule_options_raises(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+            ],
+            expected_code=1,
+            expected_output_contains="Exactly one of `--interval`, `--rrule`, or `--cron` must be provided",
+        )
+
+    def test_set_schedule_json_rrule(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                '{"rrule": "DTSTART:20300910T110000\\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"}',
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["UTC"],
+            expected_code=0,
+        )
+
+    def test_set_schedule_json_rrule_has_timezone(self, flojo):
         invoke_and_assert(
             [
                 "deployment",
@@ -242,7 +312,34 @@ class TestUpdatingDeployments:
             expected_code=0,
         )
 
-    def test_rrule_schedule_timezone_overrides_if_passed_explicitly(self, flojo):
+    def test_set_schedule_json_rrule_with_timezone_arg(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                '{"rrule": "DTSTART:20220910T110000\\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"}',
+                "--timezone",
+                "Asia/Seoul",
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["Asia/Seoul"],
+            expected_code=0,
+        )
+
+    def test_set_schedule_json_rrule_with_timezone_arg_overrides_if_passed_explicitly(
+        self, flojo
+    ):
         invoke_and_assert(
             [
                 "deployment",
@@ -250,6 +347,84 @@ class TestUpdatingDeployments:
                 "rence-griffith/test-deployment",
                 "--rrule",
                 '{"rrule": "DTSTART:20220910T110000\\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17", "timezone": "America/New_York"}',
+                "--timezone",
+                "Asia/Seoul",
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["Asia/Seoul"],
+            expected_code=0,
+        )
+
+    def test_set_schedule_str_literal_rrule(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17",
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["UTC"],
+            expected_code=0,
+        )
+
+    def test_set_schedule_str_literal_rrule_has_timezone(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                "DTSTART;TZID=US-Eastern:19970902T090000\nRRULE:FREQ=DAILY;COUNT=10",
+            ],
+            expected_code=1,
+            expected_output_contains="You can provide a timezone by providing a dict with a `timezone` key to the --rrule option",
+        )
+
+    def test_set_schedule_str_literal_rrule_with_timezone_arg(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17",
+                "--timezone",
+                "Asia/Seoul",
+            ],
+            expected_code=0,
+            expected_output_contains="Updated deployment schedule!",
+        )
+
+    def test_set_schedule_str_literal_rrule_with_timezone_arg_overrides_if_passed_explicitly(
+        self, flojo
+    ):
+        invoke_and_assert(
+            [
+                "deployment",
+                "set-schedule",
+                "rence-griffith/test-deployment",
+                "--rrule",
+                "DTSTART;TZID=US-Eastern:19970902T090000\nRRULE:FREQ=DAILY;COUNT=10",
                 "--timezone",
                 "Asia/Seoul",
             ],


### PR DESCRIPTION
### Overview
This enhancement:
1. Allows support for either a valid RRule string or dictionary (we currently only support the latter).
2. Handles each type of schedule more explicitly and checks for and returns clearer error messages sooner to the user, which builds slightly off of interval handling adjustments here: https://github.com/PrefectHQ/prefect/pull/8524. 

### Example
Currently, when using `prefect deployment set-schedule` to add or update a schedule on a deployment, you must pass in a JSON string to the `--rrule` option, like so: 

```python
prefect deployment set-schedule 'flow-name/deployment-name' \
--rrule '{"rrule": "DTSTART;TZID=America/Chicago:20221027T124000\nRRULE:FREQ=DAILY", \
"timezone": "America/Chicago"}'
```
One user describes their pain point around this here: https://github.com/PrefectHQ/prefect/issues/7406
It can be intuitive for users to desire to pass in a valid RRule to the `--rrule` option, like so:
```python
prefect deployment set-schedule 'flow-name/deployment-name' \
--rrule 'DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA' \
--timezone "America/Chicago"
```
```python
prefect deployment set-schedule 'flow-name/deployment-name' \
--rrule 'FREQ=HOURLY'
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
