### PR TITLE
Hook events client into PrefectClient and ensure that its torn-down when needed.

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -269,15 +269,9 @@ class PrefectClient:
                 self._events_client = NullEventsClient()
 
             await self._events_client.__aenter__()
+            self._exit_stack.push_async_exit(self._events_client)
 
         return self._events_client
-
-    async def disconnect_events(self):
-        if self._events_client:
-            await self._events_client.__aexit__(
-                exc_tb=None, exc_type=None, exc_val=None
-            )
-            self._events_client = None
 
     # API methods ----------------------------------------------------------------------
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -17,8 +17,14 @@ import prefect.server.schemas as schemas
 import prefect.settings
 import prefect.states
 from prefect._internal.compatibility.deprecated import deprecated_callable
+from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
 from prefect.deprecated.data_documents import DataDocument
+from prefect.events.clients import (
+    EventsClient,
+    NullEventsClient,
+    PrefectCloudEventsClient,
+)
 from prefect.logging import get_logger
 from prefect.server.schemas.actions import (
     FlowRunNotificationPolicyCreate,
@@ -153,6 +159,8 @@ class PrefectClient:
         self._closed = False
         self._started = False
 
+        self._events_client: Optional[EventsClient] = None
+
         # Connect to an external application
         if isinstance(api, str):
             if httpx_settings.get("app"):
@@ -246,6 +254,30 @@ class PrefectClient:
         Get the base URL for the API.
         """
         return self._client.base_url
+
+    async def events(self) -> EventsClient:
+        if not self._events_client:
+            if (
+                experiment_enabled("events_client")
+                and self.server_type == ServerType.CLOUD
+            ):
+                self._events_client = PrefectCloudEventsClient(
+                    api_url=PREFECT_CLOUD_API_URL.value(),
+                    api_key=prefect.settings.PREFECT_API_KEY.value(),
+                )
+            else:
+                self._events_client = NullEventsClient()
+
+            await self._events_client.__aenter__()
+
+        return self._events_client
+
+    async def disconnect_events(self):
+        if self._events_client:
+            await self._events_client.__aexit__(
+                exc_tb=None, exc_type=None, exc_val=None
+            )
+            self._events_client = None
 
     # API methods ----------------------------------------------------------------------
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -393,7 +393,6 @@ async def begin_flow_run(
             msg=f"Currently paused and suspending execution. Resume before {timeout.to_rfc3339_string()} to finish execution.",
         )
         APILogHandler.flush(block=True)
-        await client.disconnect_events()
 
         return terminal_or_paused_state
     else:
@@ -410,7 +409,6 @@ async def begin_flow_run(
     # When a "root" flow run finishes, flush logs so we do not have to rely on handling
     # during interpreter shutdown
     APILogHandler.flush(block=True)
-    await client.disconnect_events()
 
     return terminal_state
 
@@ -1343,7 +1341,6 @@ async def begin_task_run(
                 # When a a task run finishes on a remote worker flush logs to prevent
                 # loss if the process exits
                 APILogHandler.flush(block=True)
-                await client.disconnect_events()
 
         except Abort as abort:
             # Task run probably already completed, fetch its state

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -393,6 +393,8 @@ async def begin_flow_run(
             msg=f"Currently paused and suspending execution. Resume before {timeout.to_rfc3339_string()} to finish execution.",
         )
         APILogHandler.flush(block=True)
+        await client.disconnect_events()
+
         return terminal_or_paused_state
     else:
         terminal_state = terminal_or_paused_state
@@ -408,6 +410,7 @@ async def begin_flow_run(
     # When a "root" flow run finishes, flush logs so we do not have to rely on handling
     # during interpreter shutdown
     APILogHandler.flush(block=True)
+    await client.disconnect_events()
 
     return terminal_state
 
@@ -1340,6 +1343,7 @@ async def begin_task_run(
                 # When a a task run finishes on a remote worker flush logs to prevent
                 # loss if the process exits
                 APILogHandler.flush(block=True)
+                await client.disconnect_events()
 
         except Abort as abort:
             # Task run probably already completed, fetch its state

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1061,6 +1061,16 @@ application. If disabled, task runs and subflow runs belonging to cancelled flow
 remain in non-terminal states.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=False)
+"""
+Whether or not to enable experimental Prefect work pools.
+"""
+
+PREFECT_EXPERIMENTAL_WARN_EVENTS_CLIENT = Setting(bool, default=False)
+"""
+Whether or not to warn when experimental Prefect work pools are used.
+"""
+
 PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -2,13 +2,17 @@ import os
 import socket
 import sys
 from contextlib import contextmanager
-from typing import Union
+from typing import AsyncGenerator, List, Optional, Union
+from uuid import UUID
 
 import anyio
 import httpx
 import pendulum
 import pytest
+from websockets.exceptions import ConnectionClosed
+from websockets.legacy.server import WebSocketServer, WebSocketServerProtocol, serve
 
+from prefect.events import Event
 from prefect.settings import PREFECT_API_URL, get_current_settings, temporary_settings
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.processutils import open_process
@@ -181,3 +185,67 @@ def mock_anyio_sleep(monkeypatch):
     sleep.assert_sleeps_for = assert_sleeps_for
 
     return sleep
+
+
+class Recorder:
+    connections: int
+    path: Optional[str]
+    events: List[Event]
+
+    def __init__(self):
+        self.connections = 0
+        self.path = None
+        self.events = []
+
+
+class Puppeteer:
+    refuse_any_further_connections: bool
+    hard_disconnect_after: Optional[UUID]
+
+    def __init__(self):
+        self.refuse_any_further_connections = False
+        self.hard_disconnect_after = None
+
+
+@pytest.fixture
+def recorder() -> Recorder:
+    return Recorder()
+
+
+@pytest.fixture
+def puppeteer() -> Puppeteer:
+    return Puppeteer()
+
+
+@pytest.fixture
+async def events_server(
+    unused_tcp_port: int, recorder: Recorder, puppeteer: Puppeteer
+) -> AsyncGenerator[WebSocketServer, None]:
+    server: WebSocketServer
+
+    async def handler(socket: WebSocketServerProtocol, path: str) -> None:
+        recorder.connections += 1
+        if puppeteer.refuse_any_further_connections:
+            raise ValueError("nope")
+
+        recorder.path = path
+
+        while True:
+            try:
+                message = await socket.recv()
+            except ConnectionClosed:
+                return
+
+            event = Event.parse_raw(message)
+            recorder.events.append(event)
+
+            if puppeteer.hard_disconnect_after == event.id:
+                raise ValueError("zonk")
+
+    async with serve(handler, host="localhost", port=unused_tcp_port) as server:
+        yield server
+
+
+@pytest.fixture
+def events_api_url(events_server: WebSocketServer, unused_tcp_port: int) -> str:
+    return f"http://localhost:{unused_tcp_port}/accounts/A/workspaces/W"

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -14,7 +14,7 @@ from prefect.testing.cli import invoke_and_assert
 
 def test_version_ephemeral_server_type():
     invoke_and_assert(
-        ["version"], expected_output_contains="Server type:         EPHEMERAL"
+        ["version"], expected_output_contains="Server type:         ephemeral"
     )
 
 
@@ -33,7 +33,7 @@ def test_version_cloud_server_type():
         }
     ):
         invoke_and_assert(
-            ["version"], expected_output_contains="Server type:         CLOUD"
+            ["version"], expected_output_contains="Server type:         cloud"
         )
 
 
@@ -62,7 +62,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         EPHEMERAL
+Server type:         ephemeral
 Server:
   Database:          sqlite
   SQLite version:    {sqlite3.sqlite_version}
@@ -88,7 +88,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         EPHEMERAL
+Server type:         ephemeral
 Server:
   Database:          postgres
 """,

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -14,7 +14,7 @@ from prefect.testing.cli import invoke_and_assert
 
 def test_version_ephemeral_server_type():
     invoke_and_assert(
-        ["version"], expected_output_contains="Server type:         ephemeral"
+        ["version"], expected_output_contains="Server type:         EPHEMERAL"
     )
 
 
@@ -33,7 +33,7 @@ def test_version_cloud_server_type():
         }
     ):
         invoke_and_assert(
-            ["version"], expected_output_contains="Server type:         cloud"
+            ["version"], expected_output_contains="Server type:         CLOUD"
         )
 
 
@@ -62,7 +62,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         ephemeral
+Server type:         EPHEMERAL
 Server:
   Database:          sqlite
   SQLite version:    {sqlite3.sqlite_version}
@@ -88,7 +88,7 @@ Git commit:          {version_info['full-revisionid'][:8]}
 Built:               {built.to_day_datetime_string()}
 OS/Arch:             {sys.platform}/{platform.machine()}
 Profile:             {profile.name}
-Server type:         ephemeral
+Server type:         EPHEMERAL
 Server:
   Database:          postgres
 """,

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -23,6 +23,7 @@ from prefect.client.orchestration import PrefectClient, ServerType, get_client
 from prefect.client.schemas import OrchestrationResult
 from prefect.client.utilities import inject_client
 from prefect.deprecated.data_documents import DataDocument
+from prefect.events.clients import NullEventsClient, PrefectCloudEventsClient
 from prefect.server import schemas
 from prefect.server.api.server import SERVER_API_VERSION, create_app
 from prefect.server.schemas.actions import LogCreate, WorkPoolCreate
@@ -40,6 +41,7 @@ from prefect.settings import (
     PREFECT_API_TLS_INSECURE_SKIP_VERIFY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT,
     temporary_settings,
 )
 from prefect.states import Completed, Pending, Running, Scheduled, State
@@ -1587,3 +1589,47 @@ class TestWorkPools:
         await orion_client.delete_work_pool(work_pool.name)
         with pytest.raises(prefect.exceptions.ObjectNotFound):
             await orion_client.read_work_pool(work_pool.id)
+
+
+class TestEvents:
+    async def test_initializes_null_events_client_ephemeral(self, orion_client):
+        events_client = await orion_client.events()
+        assert isinstance(events_client, NullEventsClient)
+        assert events_client._in_context
+
+    async def test_initializes_null_events_client_server(self, hosted_orion_api):
+        async with PrefectClient(hosted_orion_api) as prefect_client:
+            events_client = await prefect_client.events()
+            assert isinstance(events_client, NullEventsClient)
+            assert events_client._in_context
+
+    async def test_initializes_null_events_client_cloud_experiment_disabled(self):
+        with temporary_settings(
+            updates={PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT: False}
+        ):
+            async with PrefectClient(PREFECT_CLOUD_API_URL.value()) as prefect_client:
+                events_client = await prefect_client.events()
+                assert isinstance(events_client, NullEventsClient)
+                assert events_client._in_context
+
+    async def test_initializes_cloud_events_client_cloud_experiment_enabled(
+        self, events_api_url: str
+    ):
+        with temporary_settings(
+            updates={
+                PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT: True,
+                PREFECT_CLOUD_API_URL: events_api_url,
+            }
+        ):
+            async with PrefectClient(PREFECT_CLOUD_API_URL.value()) as prefect_client:
+                events_client = await prefect_client.events()
+                assert isinstance(events_client, PrefectCloudEventsClient)
+                assert events_client._in_context
+
+    async def test_disconnects(self, orion_client):
+        events_client = await orion_client.events()
+        assert events_client._in_context
+
+        await orion_client.disconnect_events()
+        assert orion_client._events_client is None
+        assert not hasattr(events_client, "_in_context")

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1625,11 +1625,3 @@ class TestEvents:
                 events_client = await prefect_client.events()
                 assert isinstance(events_client, PrefectCloudEventsClient)
                 assert events_client._in_context
-
-    async def test_disconnects(self, orion_client):
-        events_client = await orion_client.events()
-        assert events_client._in_context
-
-        await orion_client.disconnect_events()
-        assert orion_client._events_client is None
-        assert not hasattr(events_client, "_in_context")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This adds an `events` method to `PrefectClient` that will initialize and enter the context of an EventClient. The type of event client depends on the `server_type` being used by the PrefectClient. Only `cloud` will get a 'working' EventClient, all others will get a NullEventClient that is a no-op. Also added to `PrefectClient` is a `disconnect_events` method that will ensure that the events client context is exited and that the PrefectClient no longer maintains a reference to the EventsClient. The engine also calls `disconnect_events` whenever we're exiting orchestration of a task/flow so that we ensure that any open connections to Cloud's websocket endpoint are closed.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
