### PR TITLE
Configure result metadata

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -691,6 +691,7 @@ async def orchestrate_flow_run(
             terminal_state = await return_value_to_state(
                 await resolve_futures_to_states(result),
                 result_factory=flow_run_context.result_factory,
+                result_description_fn=flow.result_description_fn,
             )
 
         if not waited_for_task_runs:
@@ -1536,6 +1537,7 @@ async def orchestrate_task_run(
             terminal_state = await return_value_to_state(
                 result,
                 result_factory=task_run_context.result_factory,
+                result_description_fn=task.result_description_fn,
             )
 
             # for COMPLETED tasks, add the cache key and expiration

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -115,8 +115,9 @@ class Flow(Generic[P, R]):
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
         result_description_fn: An optional callable that, when passed the return value
-            of the flow, returns a markdown string that will be used to describe the
-            result of this flow.
+            of the flow, the WritableFilesystemBlock used to persist the result, and
+            key used to retrieve the persisted result; returns a markdown string that
+            will be used to describe the result of this flow.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -258,9 +259,10 @@ class Flow(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
-            result_description_fn: An optional callable that, when passed the return value
-                of the flow, returns a markdown string that will be used to describe the
-                result of this flow.
+            result_description_fn: An optional callable that, when passed the return
+                value of the flow, the WritableFilesystemBlock used to persist the
+                result, and key used to retrieve the persisted result; returns a
+                markdown string that will be used to describe the result of this flow.
             cache_result_in_memory: A new value indicating if the flow's result should
                 be cached in memory.
 
@@ -611,8 +613,9 @@ def flow(
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
         result_description_fn: An optional callable that, when passed the return value
-            of the flow, returns a markdown string that will be used to describe the
-            result of this flow.
+            of the flow, the WritableFilesystemBlock used to persist the result, and
+            key used to retrieve the persisted result; returns a markdown string that
+            will be used to describe the result of this flow.
         log_prints: If set, `print` statements in the flow will be redirected to the
             Prefect logger for the flow run. Defaults to `None`, which indicates that
             the value from the parent flow should be used. If this is a parent flow,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -115,9 +115,8 @@ class Flow(Generic[P, R]):
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
         result_description_fn: An optional callable that, when passed the return value
-            of the flow, the WritableFilesystemBlock used to persist the result, and
-            key used to retrieve the persisted result; returns a markdown string that
-            will be used to describe the result of this flow.
+            of the flow and result object; returns a markdown string that will be used
+            to describe the result of this flow.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -260,9 +259,8 @@ class Flow(Generic[P, R]):
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
             result_description_fn: An optional callable that, when passed the return
-                value of the flow, the WritableFilesystemBlock used to persist the
-                result, and key used to retrieve the persisted result; returns a
-                markdown string that will be used to describe the result of this flow.
+                value of the flow and result object; returns a markdown string that will
+                be used to describe the result of this flow.
             cache_result_in_memory: A new value indicating if the flow's result should
                 be cached in memory.
 
@@ -613,9 +611,8 @@ def flow(
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
         result_description_fn: An optional callable that, when passed the return value
-            of the flow, the WritableFilesystemBlock used to persist the result, and
-            key used to retrieve the persisted result; returns a markdown string that
-            will be used to describe the result of this flow.
+            of the flow and result object; returns a markdown string that will be used
+            to describe the result of this flow.
         log_prints: If set, `print` statements in the flow will be redirected to the
             Prefect logger for the flow run. Defaults to `None`, which indicates that
             the value from the parent flow should be used. If this is a parent flow,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -114,6 +114,9 @@ class Flow(Generic[P, R]):
             in this flow. If not provided, the value of `PREFECT_RESULTS_DEFAULT_SERIALIZER`
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
+        result_description_fn: An optional callable that, when passed the return value
+            of the flow, returns a markdown string that will be used to describe the
+            result of this flow.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -133,6 +136,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        result_description_fn: Optional[Callable[R]] = None,
         cache_result_in_memory: bool = True,
         log_prints: Optional[bool] = None,
     ):
@@ -195,6 +199,7 @@ class Flow(Generic[P, R]):
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer
+        self.result_description_fn = result_description_fn
         self.cache_result_in_memory = cache_result_in_memory
 
         # Check for collision in the registry
@@ -229,6 +234,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        result_description_fn: Optional[Callable[R]] = NotSet,
         cache_result_in_memory: bool = None,
         log_prints: Optional[bool] = NotSet,
     ):
@@ -252,6 +258,9 @@ class Flow(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
+            result_description_fn: An optional callable that, when passed the return value
+                of the flow, returns a markdown string that will be used to describe the
+                result of this flow.
             cache_result_in_memory: A new value indicating if the flow's result should
                 be cached in memory.
 
@@ -308,6 +317,11 @@ class Flow(Generic[P, R]):
                 result_serializer
                 if result_serializer is not NotSet
                 else self.result_serializer
+            ),
+            result_description_fn=(
+                result_description_fn
+                if result_description_fn is not NotSet
+                else self.result_description_fn
             ),
             cache_result_in_memory=(
                 cache_result_in_memory
@@ -526,6 +540,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_description_fn: Optional[Callable[R]] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
@@ -547,6 +562,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_description_fn: Optional[Callable[R]] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ):
@@ -594,6 +610,9 @@ def flow(
             in this flow. If not provided, the value of `PREFECT_RESULTS_DEFAULT_SERIALIZER`
             will be used unless called as a subflow, at which point the default will be
             loaded from the parent flow.
+        result_description_fn: An optional callable that, when passed the return value
+            of the flow, returns a markdown string that will be used to describe the
+            result of this flow.
         log_prints: If set, `print` statements in the flow will be redirected to the
             Prefect logger for the flow run. Defaults to `None`, which indicates that
             the value from the parent flow should be used. If this is a parent flow,
@@ -654,6 +673,7 @@ def flow(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_description_fn=result_description_fn,
                 cache_result_in_memory=cache_result_in_memory,
                 log_prints=log_prints,
             ),
@@ -675,6 +695,7 @@ def flow(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_description_fn=result_description_fn,
                 cache_result_in_memory=cache_result_in_memory,
                 log_prints=log_prints,
             ),

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -136,7 +136,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
-        result_description_fn: Optional[Callable[R]] = None,
+        result_description_fn: Optional[Callable[R, str]] = None,
         cache_result_in_memory: bool = True,
         log_prints: Optional[bool] = None,
     ):
@@ -234,7 +234,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
-        result_description_fn: Optional[Callable[R]] = NotSet,
+        result_description_fn: Optional[Callable[R, str]] = NotSet,
         cache_result_in_memory: bool = None,
         log_prints: Optional[bool] = NotSet,
     ):
@@ -540,7 +540,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R]] = None,
+    result_description_fn: Optional[Callable[R, str]] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
@@ -562,7 +562,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R]] = None,
+    result_description_fn: Optional[Callable[R, str]] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ):

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -41,7 +41,7 @@ from prefect.exceptions import (
 )
 from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
-from prefect.results import ResultSerializer, ResultStorage
+from prefect.results import ResultDescriptionFnType, ResultSerializer, ResultStorage
 from prefect.server.schemas.core import raise_on_invalid_name
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner, ConcurrentTaskRunner
@@ -136,7 +136,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
-        result_description_fn: Optional[Callable[R, str]] = None,
+        result_description_fn: Optional[ResultDescriptionFnType] = None,
         cache_result_in_memory: bool = True,
         log_prints: Optional[bool] = None,
     ):
@@ -234,7 +234,7 @@ class Flow(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
-        result_description_fn: Optional[Callable[R, str]] = NotSet,
+        result_description_fn: Optional[ResultDescriptionFnType] = NotSet,
         cache_result_in_memory: bool = None,
         log_prints: Optional[bool] = NotSet,
     ):
@@ -540,7 +540,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R, str]] = None,
+    result_description_fn: Optional[ResultDescriptionFnType] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
@@ -562,7 +562,7 @@ def flow(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R, str]] = None,
+    result_description_fn: Optional[ResultDescriptionFnType] = None,
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
 ):

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -35,16 +35,17 @@ if TYPE_CHECKING:
     from prefect import Flow, Task
     from prefect.client.orchestration import PrefectClient
 
-
-ResultStorage = Union[WritableFileSystem, str]
-ResultSerializer = Union[Serializer, str]
-LITERAL_TYPES = {type(None), bool}
-
 logger = get_logger("results")
 
 # from prefect.server.schemas.states import State
 R = TypeVar("R")
-ResultDescriptionFnType = Callable[R, str]
+
+ResultStorage = Union[WritableFileSystem, str]
+ResultSerializer = Union[Serializer, str]
+ResultDescriptionFnType = Callable[
+    [R, Optional[WritableFileSystem], Optional[str]], str
+]
+LITERAL_TYPES = {type(None), bool}
 
 
 def get_default_result_storage() -> ResultStorage:
@@ -406,7 +407,7 @@ class LiteralResult(BaseResult):
             )
 
         if result_description_fn:
-            description = result_description_fn(obj)
+            description = result_description_fn(obj, None, None)
         else:
             description = f"Literal: `{obj}`"
 
@@ -505,7 +506,7 @@ class PersistedResult(BaseResult):
         await storage_block.write_path(key, content=blob.to_bytes())
 
         if result_description_fn:
-            description = result_description_fn(obj)
+            description = result_description_fn(obj, storage_block, key)
         else:
             description = cls._infer_description(obj, storage_block, key)
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -44,6 +44,7 @@ logger = get_logger("results")
 
 # from prefect.server.schemas.states import State
 R = TypeVar("R")
+ResultDescriptionFnType = Callable[R, str]
 
 
 def get_default_result_storage() -> ResultStorage:
@@ -298,7 +299,7 @@ class ResultFactory(pydantic.BaseModel):
 
     @sync_compatible
     async def create_result(
-        self, obj: R, result_description_fn: Optional[Callable[R, str]] = None
+        self, obj: R, result_description_fn: Optional[ResultDescriptionFnType] = None
     ) -> Union[R, "BaseResult[R]"]:
         """
         Create a result type for the given object.
@@ -396,7 +397,7 @@ class LiteralResult(BaseResult):
     async def create(
         cls: "Type[LiteralResult]",
         obj: R,
-        result_description_fn: Optional[Callable[R, str]] = None,
+        result_description_fn: Optional[ResultDescriptionFnType] = None,
     ) -> "LiteralResult[R]":
         if type(obj) not in LITERAL_TYPES:
             raise TypeError(
@@ -489,7 +490,7 @@ class PersistedResult(BaseResult):
         storage_block_id: uuid.UUID,
         serializer: Serializer,
         cache_object: bool = True,
-        result_description_fn: Optional[Callable[R, str]] = None,
+        result_description_fn: Optional[ResultDescriptionFnType] = None,
     ) -> "PersistedResult[R]":
         """
         Create a new result reference from a user's object.

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -411,7 +411,7 @@ class LiteralResult(BaseResult):
         else:
             description = f"Literal: `{obj}`"
 
-        result.description = description
+        result.artifact_description = description
         return result
 
 
@@ -511,7 +511,6 @@ class PersistedResult(BaseResult):
             storage_block_id=storage_block_id,
             storage_key=key,
             artifact_type="result",
-            artifact_description=description,
         )
 
         if result_description_fn:
@@ -519,7 +518,7 @@ class PersistedResult(BaseResult):
         else:
             description = cls._infer_description(obj, storage_block, key)
 
-        result.description = description
+        result.artifact_description = description
 
         if cache_object:
             # Attach the object to the result so it's available without deserialization

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -23,7 +23,7 @@ from prefect.exceptions import (
     MissingResult,
     PausedRun,
 )
-from prefect.results import BaseResult, R, ResultFactory
+from prefect.results import BaseResult, R, ResultDescriptionFnType, ResultFactory
 from prefect.server import schemas
 from prefect.server.schemas.states import StateDetails, StateType
 from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
@@ -204,7 +204,7 @@ async def exception_to_failed_state(
 async def return_value_to_state(
     retval: R,
     result_factory: ResultFactory,
-    result_description_fn: Optional[Callable[R, str]] = None,
+    result_description_fn: Optional[ResultDescriptionFnType] = None,
 ) -> State[R]:
     """
     Given a return value from a user's function, create a `State` the run should

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -204,7 +204,7 @@ async def exception_to_failed_state(
 async def return_value_to_state(
     retval: R,
     result_factory: ResultFactory,
-    result_description_fn: Optional[Callable[R, str]],
+    result_description_fn: Optional[Callable[R, str]] = None,
 ) -> State[R]:
     """
     Given a return value from a user's function, create a `State` the run should

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -4,7 +4,7 @@ import traceback
 import warnings
 from collections import Counter
 from types import GeneratorType, TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Type, TypeVar
 
 import anyio
 import httpx

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -151,9 +151,8 @@ class Task(Generic[P, R]):
             task for persistence. Defaults to the value set in the flow the task is
             called in.
         result_description_fn: An optional callable that, when passed the return value
-            of the task, the WritableFilesystemBlock used to persist the result, and
-            key used to retrieve the persisted result; returns a markdown string that
-            will be used to describe the result of this task.
+            of the task and result object; returns a markdown string that will be used
+            to describe the result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the
@@ -330,9 +329,8 @@ class Task(Generic[P, R]):
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
             result_description_fn: An optional callable that, when passed the return
-                value of the task, the WritableFilesystemBlock used to persist the
-                result, and key used to retrieve the persisted result; returns a
-                markdown string that will be used to describe the result of this task.
+                value of the task and result object; returns a markdown string that will
+                be used to describe the result of this task.
             timeout_seconds: A new maximum time for the task to complete in seconds.
             log_prints: A new option for enabling or disabling redirection of `print` statements.
             refresh_cache: A new option for enabling or disabling cache refresh.
@@ -950,9 +948,8 @@ def task(
             task for persistence. Defaults to the value set in the flow the task is
             called in.
         result_description_fn: An optional callable that, when passed the return value
-            of the task, the WritableFilesystemBlock used to persist the result, and
-            key used to retrieve the persisted result; returns a markdown string that
-            will be used to describe the result of this task.
+            of the task and result object; returns a markdown string that will be used
+            to describe the result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -151,8 +151,9 @@ class Task(Generic[P, R]):
             task for persistence. Defaults to the value set in the flow the task is
             called in.
         result_description_fn: An optional callable that, when passed the return value
-            of the task, returns a markdown string that will be used to describe the
-            result of this task.
+            of the task, the WritableFilesystemBlock used to persist the result, and
+            key used to retrieve the persisted result; returns a markdown string that
+            will be used to describe the result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the
@@ -329,8 +330,9 @@ class Task(Generic[P, R]):
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
             result_description_fn: An optional callable that, when passed the return
-                value of the task, returns a markdown string that will be used to
-                describe the result of this task.
+                value of the task, the WritableFilesystemBlock used to persist the
+                result, and key used to retrieve the persisted result; returns a
+                markdown string that will be used to describe the result of this task.
             timeout_seconds: A new maximum time for the task to complete in seconds.
             log_prints: A new option for enabling or disabling redirection of `print` statements.
             refresh_cache: A new option for enabling or disabling cache refresh.
@@ -948,8 +950,9 @@ def task(
             task for persistence. Defaults to the value set in the flow the task is
             called in.
         result_description_fn: An optional callable that, when passed the return value
-            of the task, returns a markdown string that will be used to describe the
-            result of this task.
+            of the task, the WritableFilesystemBlock used to persist the result, and
+            key used to retrieve the persisted result; returns a markdown string that
+            will be used to describe the result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -31,7 +31,7 @@ from typing_extensions import Literal, ParamSpec
 
 from prefect.context import PrefectObjectRegistry
 from prefect.futures import PrefectFuture
-from prefect.results import ResultSerializer, ResultStorage
+from prefect.results import ResultDescriptionFnType, ResultSerializer, ResultStorage
 from prefect.states import State
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import Async, Sync
@@ -188,7 +188,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
-        result_description_fn: Optional[Callable[R, str]] = None,
+        result_description_fn: Optional[ResultDescriptionFnType] = None,
         cache_result_in_memory: bool = True,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = False,
@@ -296,7 +296,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
-        result_description_fn: Optional[Callable[R, str]] = NotSet,
+        result_description_fn: Optional[ResultDescriptionFnType] = NotSet,
         cache_result_in_memory: Optional[bool] = None,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = NotSet,
@@ -870,7 +870,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R, str]] = None,
+    result_description_fn: Optional[ResultDescriptionFnType] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,
@@ -900,7 +900,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
-    result_description_fn: Optional[Callable[R, str]] = None,
+    result_description_fn: Optional[ResultDescriptionFnType] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -150,6 +150,9 @@ class Task(Generic[P, R]):
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
             called in.
+        result_description_fn: An optional callable that, when passed the return value
+            of the task, returns a markdown string that will be used to describe the
+            result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the
@@ -185,6 +188,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        result_description_fn: Optional[Callable[R, str]] = None,
         cache_result_in_memory: bool = True,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = False,
@@ -246,6 +250,7 @@ class Task(Generic[P, R]):
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer
+        self.result_description_fn = result_description_fn
         self.cache_result_in_memory = cache_result_in_memory
         self.timeout_seconds = float(timeout_seconds) if timeout_seconds else None
         # Warn if this task's `name` conflicts with another task while having a
@@ -291,6 +296,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        result_description_fn: Optional[Callable[R, str]] = NotSet,
         cache_result_in_memory: Optional[bool] = None,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = NotSet,
@@ -322,6 +328,9 @@ class Task(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
+            result_description_fn: An optional callable that, when passed the return
+                value of the task, returns a markdown string that will be used to
+                describe the result of this task.
             timeout_seconds: A new maximum time for the task to complete in seconds.
             log_prints: A new option for enabling or disabling redirection of `print` statements.
             refresh_cache: A new option for enabling or disabling cache refresh.
@@ -392,6 +401,11 @@ class Task(Generic[P, R]):
                 result_serializer
                 if result_serializer is not NotSet
                 else self.result_serializer
+            ),
+            result_description_fn=(
+                result_description_fn
+                if result_description_fn is not NotSet
+                else self.result_description_fn
             ),
             cache_result_in_memory=(
                 cache_result_in_memory
@@ -856,6 +870,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_description_fn: Optional[Callable[R, str]] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,
@@ -885,6 +900,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_description_fn: Optional[Callable[R, str]] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,
@@ -931,6 +947,9 @@ def task(
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
             called in.
+        result_description_fn: An optional callable that, when passed the return value
+            of the task, returns a markdown string that will be used to describe the
+            result of this task.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for
             the task. If the task exceeds this runtime, it will be marked as failed.
         log_prints: If set, `print` statements in the task will be redirected to the
@@ -1006,6 +1025,7 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_description_fn=result_description_fn,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
                 log_prints=log_prints,
@@ -1030,6 +1050,7 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_description_fn=result_description_fn,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
                 log_prints=log_prints,

--- a/tests/results/test_literal_result.py
+++ b/tests/results/test_literal_result.py
@@ -46,6 +46,7 @@ async def test_result_literal_populates_default_artifact_metadata(value):
 async def test_result_literal_uses_result_description_fn(value):
     def description_fn(obj, block, key):
         return f"Custom: `{value}`"
+
     result = await LiteralResult.create(value, result_description_fn=description_fn)
     assert result.artifact_type == "result"
     assert result.artifact_description == f"Custom: `{value}`"

--- a/tests/results/test_literal_result.py
+++ b/tests/results/test_literal_result.py
@@ -44,8 +44,8 @@ async def test_result_literal_populates_default_artifact_metadata(value):
 
 @pytest.mark.parametrize("value", LITERAL_VALUES)
 async def test_result_literal_uses_result_description_fn(value):
-    def description_fn(obj, block, key):
-        return f"Custom: `{value}`"
+    def description_fn(obj, res):
+        return f"Custom: `{obj}`"
 
     result = await LiteralResult.create(value, result_description_fn=description_fn)
     assert result.artifact_type == "result"

--- a/tests/results/test_literal_result.py
+++ b/tests/results/test_literal_result.py
@@ -42,6 +42,15 @@ async def test_result_literal_populates_default_artifact_metadata(value):
     assert result.artifact_description == f"Literal: `{value}`"
 
 
+@pytest.mark.parametrize("value", LITERAL_VALUES)
+async def test_result_literal_uses_result_description_fn(value):
+    def description_fn(obj, block, key):
+        return f"Custom: `{value}`"
+    result = await LiteralResult.create(value, result_description_fn=description_fn)
+    assert result.artifact_type == "result"
+    assert result.artifact_description == f"Custom: `{value}`"
+
+
 async def test_result_literal_does_not_allow_unsupported_types():
     with pytest.raises(TypeError, match="Unsupported type 'dict' for result literal"):
         await LiteralResult.create({"foo": "bar"})

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -50,9 +50,7 @@ async def test_result_literal_populates_default_artifact_metadata(
 
 
 @pytest.mark.parametrize("cache_object", [True, False])
-async def test_result_literal_result_description_fn(
-    cache_object, storage_block
-):
+async def test_result_literal_result_description_fn(cache_object, storage_block):
     def description_fn(obj, block, key):
         return f"custom description {obj}"
 

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -54,7 +54,7 @@ async def test_result_literal_result_description_fn(
     cache_object, storage_block
 ):
     def description_fn(obj, block, key):
-        return "custom description {obj}"
+        return f"custom description {obj}"
 
     result = await PersistedResult.create(
         "test",
@@ -62,6 +62,7 @@ async def test_result_literal_result_description_fn(
         storage_block=storage_block,
         serializer=JSONSerializer(),
         cache_object=cache_object,
+        result_description_fn=description_fn,
     )
     assert result.artifact_type == "result"
     assert result.artifact_description == "custom description test"

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -49,6 +49,24 @@ async def test_result_literal_populates_default_artifact_metadata(
     ), "the artifact description should be populated, the form is block-specific"
 
 
+@pytest.mark.parametrize("cache_object", [True, False])
+async def test_result_literal_result_description_fn(
+    cache_object, storage_block
+):
+    def description_fn(obj, block, key):
+        return "custom description {obj}"
+
+    result = await PersistedResult.create(
+        "test",
+        storage_block_id=storage_block._block_document_id,
+        storage_block=storage_block,
+        serializer=JSONSerializer(),
+        cache_object=cache_object,
+    )
+    assert result.artifact_type == "result"
+    assert result.artifact_description == "custom description test"
+
+
 async def test_result_reference_create_uses_storage(storage_block):
     result = await PersistedResult.create(
         "test",

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -51,7 +51,7 @@ async def test_result_literal_populates_default_artifact_metadata(
 
 @pytest.mark.parametrize("cache_object", [True, False])
 async def test_result_literal_result_description_fn(cache_object, storage_block):
-    def description_fn(obj, block, key):
+    def description_fn(obj, res):
         return f"custom description {obj}"
 
     result = await PersistedResult.create(


### PR DESCRIPTION
Extends https://github.com/PrefectHQ/prefect/pull/8501

Allows users to pass a custom `result_description_fn` to a `Task` or `Flow` to modify a result's metadata that will be displayed in the UI.

The interface for the result formatter currently accepts the result object, but I've also considered `obj, storage_block, storage_key` as the callback signature—the latter is not generic to all `Result` types, but has all the information needed to format a result, where the block etc will need to be looked up again if all we have is the result object. Any thoughts about this @madkinsz?


### Example

```python
def result_formatter(obj, result):
    if isinstance(result, LiteralResult):
        return str(obj)
    if isinstance(result, PersistedResult):
        return f"{obj} persisted with {PersistedResult.storage_block_id}

@flow(persist_results=True, result_description_fn=result_formatter)
def the_answer():
    return 42
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
