### PR TITLE
Resolving #6676 missing slash in block command

### DIFF
--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -219,6 +219,8 @@ async def block_delete(
             except ObjectNotFound:
                 exit_with_error(f"Deployment {block_id!r} not found!")
         elif slug is not None:
+            if "/" not in slug:
+                exit_with_error(f"Slug must contain '/' -- {slug} is not valid")
             block_type_slug, block_document_name = slug.split("/")
             try:
                 block_document = await client.read_block_document_by_name(
@@ -286,6 +288,8 @@ async def block_inspect(
             except ObjectNotFound:
                 exit_with_error(f"Deployment {block_id!r} not found!")
         elif slug is not None:
+            if "/" not in slug:
+                exit_with_error(f"Slug must contain '/' -- {slug} is not valid")
             block_type_slug, block_document_name = slug.split("/")
             try:
                 block_document = await client.read_block_document_by_name(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Resolves issue #[6676](https://github.com/PrefectHQ/prefect/issues/6676) where an exception is raised instead of an error being raised with the `prefect block` command is run with a slug missing a `/`.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

An example of the new behavior is:

```
(.venv) (base) ➜  prefect git:(main) prefect block delete foobar
slug must contain '/' -- foobar is not valid
```

and 

```
(.venv) (base) ➜  prefect git:(main) ✗ prefect block inspect footbar
Slug must contain '/' -- footbar is not valid
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes https://github.com/PrefectHQ/prefect/issues/6676"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
