### PR TITLE
Enable plugin loading in `prefect` module init

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -62,8 +62,8 @@ prefect.client.schemas.State.update_forward_refs(
 # Ensure collections are imported and have the opportunity to register types
 import prefect.plugins
 
-# prefect.plugins.load_prefect_collections()
-# prefect.plugins.load_extra_entrypoints()
+prefect.plugins.load_prefect_collections()
+prefect.plugins.load_extra_entrypoints()
 
 # Configure logging
 import prefect.logging.configuration

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,8 +3,9 @@ import pathlib
 import textwrap
 from unittest.mock import Mock
 
-import prefect
 import pytest
+
+import prefect
 from prefect.plugins import load_extra_entrypoints
 from prefect.settings import PREFECT_EXTRA_ENTRYPOINTS, temporary_settings
 from prefect.testing.utilities import exceptions_equal

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,10 @@
 import importlib
 import pathlib
 import textwrap
+from unittest.mock import Mock
 
+import prefect
 import pytest
-
 from prefect.plugins import load_extra_entrypoints
 from prefect.settings import PREFECT_EXTRA_ENTRYPOINTS, temporary_settings
 from prefect.testing.utilities import exceptions_equal
@@ -236,3 +237,20 @@ def test_load_extra_entrypoints_missing_attribute(capsys):
         "Warning! Failed to load extra entrypoint 'test_module_name:missing_attr': "
         "AttributeError"
     ) in stderr
+
+
+def test_plugins_load_on_prefect_package_init(monkeypatch):
+    mock_load_prefect_collections = Mock()
+    mock_load_extra_entrypoints = Mock()
+
+    monkeypatch.setattr(
+        prefect.plugins, "load_prefect_collections", mock_load_prefect_collections
+    )
+    monkeypatch.setattr(
+        prefect.plugins, "load_extra_entrypoints", mock_load_extra_entrypoints
+    )
+
+    importlib.reload(prefect)
+
+    mock_load_prefect_collections.assert_called_once()
+    mock_load_extra_entrypoints.assert_called_once()


### PR DESCRIPTION
This PR re-enables plugin loading in `__init__.py__`.


### Example
With prefect 2.8.1, trying to run a flow using an `AzureContainerInstanceJob` block (or any other infrastructure block from a collection) results in an error message like `Submission failed. KeyError: “No class found for dispatch key ‘azure-container-instance-job’ in registry for type ‘Block’`. 

### Steps to QA
1. Install Prefect 2.8.1.
2. Try to run a deployed flow using ACI, ECS, or a Cloud Run Job.
3. Verify that you see a `KeyError` like the one shown above.
4. Install the `re-enable-plugin-loading` branch. 
5. Try to run the flow from step 2 again. 
6. Verify that it now runs as expected and does raise a `KeyError`. 

### QA Done
* Tested a flow deployed to Azure blob storage using `AzureContainerInstanceJob` 
  * It failed with a `KeyError` on 2.8.1. 
  * It worked after applying the changes in this PR. 


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
	- *The fix is small so I did not open an issue*
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
