### PR TITLE
Update `quote` handling in input resolution to skip descending into the quoted expression

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -100,7 +100,7 @@ from prefect.utilities.asyncutils import (
     sync_compatible,
 )
 from prefect.utilities.callables import parameters_to_args_kwargs
-from prefect.utilities.collections import isiterable, visit_collection
+from prefect.utilities.collections import StopVisiting, isiterable, visit_collection
 from prefect.utilities.pydantic import PartialModel
 
 R = TypeVar("R")
@@ -1729,7 +1729,7 @@ async def resolve_inputs(
 
         # Expressions inside quotes should not be modified
         if isinstance(context.get("annotation"), quote):
-            return expr
+            raise StopVisiting()
 
         if isinstance(expr, PrefectFuture):
             state = run_async_from_worker_thread(expr._wait)

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -208,6 +208,15 @@ def batched_iterable(iterable: Iterable[T], size: int) -> Iterator[Tuple[T, ...]
         yield batch
 
 
+class StopVisiting(BaseException):
+    """
+    A special exception used to stop recursive visits in `visit_collection`.
+
+    When raised, the expression is returned without modification and recursive visits
+    in that path will end.
+    """
+
+
 def visit_collection(
     expr,
     visit_fn: Callable[[Any], Any],
@@ -278,7 +287,11 @@ def visit_collection(
             return visit_fn(expr)
 
     # Visit every expression
-    result = visit_expression(expr)
+    try:
+        result = visit_expression(expr)
+    except StopVisiting:
+        max_depth = 0
+        result = expr
 
     if return_data:
         # Only mutate the expression while returning data, otherwise it could be null

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -10,6 +10,7 @@ import pytest
 from prefect.utilities.annotations import BaseAnnotation, quote
 from prefect.utilities.collections import (
     AutoEnum,
+    StopVisiting,
     dict_to_flatdict,
     flatdict_to_dict,
     isiterable,
@@ -452,6 +453,24 @@ class TestVisitCollection:
             foo, visit, context={}, return_data=True, remove_annotations=True
         )
         assert result == [2, 3, [4]]
+
+    def test_visit_collection_stop_visiting(self):
+        foo = [1, 2, quote([3, [4, 5, 6]])]
+
+        def visit(expr, context):
+            if isinstance(context.get("annotation"), quote):
+                raise StopVisiting()
+
+            if isinstance(expr, int):
+                return expr + 1
+            else:
+                return expr
+
+        result = visit_collection(
+            foo, visit, context={}, return_data=True, remove_annotations=True
+        )
+        # Only the first two items should be visited
+        assert result == [2, 3, [3, [4, 5, 6]]]
 
 
 class TestRemoveKeys:


### PR DESCRIPTION
Adds a `StopVisiting` signal that can be raised in a visit function to prevent further recursion then adds usage of it to input parameter resolution. Previously, we would recurse into objects and just not modify them if they were quoted. Quoting is much more useful if we avoid traversing the object though.