### PR TITLE
POC: Expose custom persisted result types

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -21,6 +21,7 @@ from typing import (
     List,
     NoReturn,
     Optional,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -31,7 +32,7 @@ from typing_extensions import Literal, ParamSpec
 
 from prefect.context import PrefectObjectRegistry
 from prefect.futures import PrefectFuture
-from prefect.results import ResultSerializer, ResultStorage
+from prefect.results import PersistedResult, ResultSerializer, ResultStorage
 from prefect.states import State
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import Async, Sync
@@ -185,6 +186,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        result_cls: Optional[Type[PersistedResult]] = None,
         cache_result_in_memory: bool = True,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = False,
@@ -245,6 +247,7 @@ class Task(Generic[P, R]):
 
         self.persist_result = persist_result
         self.result_storage = result_storage
+        self.result_cls = result_cls
         self.result_serializer = result_serializer
         self.cache_result_in_memory = cache_result_in_memory
         self.timeout_seconds = float(timeout_seconds) if timeout_seconds else None
@@ -291,6 +294,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        result_cls: Optional[Type[PersistedResult]] = NotSet,
         cache_result_in_memory: Optional[bool] = None,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = NotSet,
@@ -388,6 +392,7 @@ class Task(Generic[P, R]):
             result_storage=(
                 result_storage if result_storage is not NotSet else self.result_storage
             ),
+            result_cls=(result_cls if result_cls is not NotSet else self.result_cls),
             result_serializer=(
                 result_serializer
                 if result_serializer is not NotSet
@@ -856,6 +861,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_cls: Optional[Type[PersistedResult]] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,
@@ -885,6 +891,7 @@ def task(
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_serializer: Optional[ResultSerializer] = None,
+    result_cls: Optional[Type[PersistedResult]] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
     log_prints: Optional[bool] = None,
@@ -1006,6 +1013,7 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_cls=result_cls,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
                 log_prints=log_prints,
@@ -1030,6 +1038,7 @@ def task(
                 persist_result=persist_result,
                 result_storage=result_storage,
                 result_serializer=result_serializer,
+                result_cls=result_cls,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
                 log_prints=log_prints,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Demonstrates the addition of a `result_cls` option to tasks, allowing users to use a custom subclass of `PersistedResult` to perform arbitrary persistence behavior.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect import flow, task
from prefect.results import (
    PersistedResult,
    WritableFileSystem,
    Serializer,
    R,
)
from typing import Type
import uuid
from prefect.serializers import JSONSerializer


class CustomResult(PersistedResult):
    """
    This differs from the default `PersistedResult` in that the data written does not
    have the serializer inlined; instead the serializer config is stored in the Prefect
    database.
    """

    serializer: Serializer
    type = "custom-result"

    @classmethod
    async def create(
        cls: "Type[CustomResult]",
        obj: R,
        storage_block: WritableFileSystem,
        storage_block_id: uuid.UUID,
        serializer: Serializer,
        cache_object: bool = True,
    ) -> "CustomResult[R]":
        """
        Create a new result reference from a user's object.
        """
        data = serializer.dumps(obj)

        key = uuid.uuid4().hex

        await storage_block.write_path(key, content=data)
        print(f"Wrote to {storage_block.basepath}/{key}")

        description = cls._infer_description(obj, storage_block, key)

        result = cls(
            serializer=serializer,
            serializer_type=serializer.type,
            storage_block_id=storage_block_id,
            storage_key=key,
            artifact_type="result",
            artifact_description=description,
        )

        if cache_object:
            # Attach the object to the result so it's available without deserialization
            result._cache_object(obj)

        object.__setattr__(result, "_should_cache_object", cache_object)

        return result


@flow
def example():
    my_task()


@task(persist_result=True, result_cls=CustomResult, result_serializer=JSONSerializer())
def my_task():
    return 1


example()
```
```
11:52:26.002 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/prefect.db
11:52:26.066 | INFO    | prefect.engine - Created flow run 'lean-cassowary' for flow 'example'
11:52:26.067 | DEBUG   | Flow run 'lean-cassowary' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
11:52:26.067 | DEBUG   | prefect.task_runner.concurrent - Starting task runner...
11:52:26.203 | DEBUG   | Flow run 'lean-cassowary' - Executing flow 'example' for flow run 'lean-cassowary'...
11:52:26.203 | DEBUG   | Flow run 'lean-cassowary' - Beginning execution...
11:52:26.225 | INFO    | Flow run 'lean-cassowary' - Created task run 'my_task-0' for task 'my_task'
11:52:26.225 | INFO    | Flow run 'lean-cassowary' - Executing 'my_task-0' immediately...
11:52:26.250 | DEBUG   | Task run 'my_task-0' - Beginning execution...
Wrote to /Users/mz/.prefect/storage/5049278029664ec3aa86e3f2a28773d2
11:52:26.266 | INFO    | Task run 'my_task-0' - Finished in state Completed()
11:52:26.280 | DEBUG   | prefect.task_runner.concurrent - Shutting down task runner...
11:52:26.280 | INFO    | Flow run 'lean-cassowary' - Finished in state Completed('All states completed.')
11:52:26.281 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/prefect.db
```
```
❯ cat /Users/mz/.prefect/storage/5049278029664ec3aa86e3f2a28773d2
1%           
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
