### PR TITLE
Redirect from old Cloud Getting Started page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -70,3 +70,8 @@ publish = "site"
   from = "/concepts/work-queues/"
   to = "/concepts/work-pools/"
   status = 301
+
+[[redirects]]
+  from = "/ui/cloud-getting-started/"
+  to = "/ui/cloud-quickstart/"
+  status = 301


### PR DESCRIPTION
Redirect from old Cloud Getting Started URL to new Cloud Quickstart tutorial

### Example

[/ui/cloud-getting-started/](https://deploy-preview-8622--prefect-docs.netlify.app/ui/cloud-getting-started/) should now redirect to /ui/cloud-quickstart/

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
