### PR TITLE
Remove beta notes regarding agents and deployments

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -20,9 +20,6 @@ Each deployment references a single "entrypoint" flow (though that flow may, in 
 
 At a high level, you can think of a deployment as configuration for managing flows, whether you run them via the CLI, the UI, or the API.
 
-!!! warning "Deployments have changed since beta"
-    Deployments based on `DeploymentSpec` are no longer supported. Instead, you can define deployments by using either the [`prefect deployment` CLI command](#create-a-deployment-on-the-cli) or [the `Deployment` Python object](/api-ref/prefect/deployments/).
-
 ## Deployments overview
 
 All Prefect flow runs are tracked by the API. The API does not require prior registration of flows. With Prefect, you can call a flow locally or on a remote environment and it will be tracked.
@@ -87,6 +84,8 @@ To define how your flow execution environment should be configured, you may eith
 
     Note that **backward compatibility is maintained** and work queues that use tag-based matching can still be created and will continue to work. However, those work queues are now considered legacy and we encourage you to use the new behavior by specifying work queues explicitly on agents and deployments.
 
+    See [Agents & Work Pools](/concepts/work-pools/) for details.
+
 ## Deployments and flows
 
 Each deployment is associated with a single flow, but any given flow can be referenced by multiple deployments.
@@ -150,7 +149,7 @@ For example:
 
 <div class="terminal">
 ```bash
-$ prefect deployment build flows/marvin.py:say_hi -n marvin -q test
+$ prefect deployment build -n marvin -p default-agent-pool -q test flows/marvin.py:say_hi
 ```
 </div>
 
@@ -174,26 +173,30 @@ When you run this command, Prefect:
 
 You may specify additional options to further customize your deployment.
 
+<span class="no-wrap">
+
 | Options | Description |
 | ------- | ----------- |
 | PATH | Path, filename, and flow name of the flow definition. (Required) |
-|  `-v`, `--version TEXT`            | An optional version for the deployment. This could be a git commit hash if you use this command from a CI/CD pipeline. |
-|  `-n`, `--name TEXT`               | The name of the deployment. |
-|  `-t`, `--tag TEXT`                | One or more optional tags to apply to the deployment. |
-|  `-q`. `--work-queue TEXT`        |  The work queue that will handle this deployment's runs. It will be created if it doesn't already exist. Defaults to `None`. Note that if a work queue is not set, work will not be scheduled.
-|  `-o`, `--output TEXT`            | Optional location for the YAML manifest generated as a result of the `build` step. You can version-control that file, but it's not required since the CLI can generate everything you need to define a deployment. |
-|  `-i`, `--infra`                   | The [infrastructure type](/concepts/infrastructure/) to use. (Default is `Process`) |
-|  `-ib`, `--infra-block TEXT`       | The [infrastructure block](#block-identifiers) to use, in `block-type/block-name` format. |
-|  `--override TEXT`       | One or more optional infrastructure overrides provided as a dot delimited path. For example, specify an environment variable: `env.env_key=env_value`. For Kubernetes, specify customizations: `customizations='[{"op": "add","path": "/spec/template/spec/containers/0/resources/limits", "value": {"memory": "8Gi","cpu": "4000m"}}]'` (note the string format).|
-|  <span class="no-wrap">`-sb`, `--storage-block TEXT`</span>    | The [storage block](#block-identifiers) to use, in `block-type/block-name` or `block-type/block-name/path` format. Note that the appropriate library supporting the storage filesystem must be installed. |
-|  `--cron TEXT`    | A cron string that will be used to set a [`CronSchedule`](/concepts/schedules/) on the deployment. For example, `--cron "*/1 * * * *"` to create flow runs from that deployment every minute. |
-|  `--interval INTEGER`     | An integer specifying an interval (in seconds) that will be used to set an [`IntervalSchedule`](/concepts/schedules/) on the deployment. For example, `--interval 60` to create flow runs from that deployment every minute. |
-|  `--rrule TEXT`     | An `RRule` that will be used to set an [`RRuleSchedule`](/concepts/schedules/) on the deployment. For example, `--rrule 'FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9,10,11,12,13,14,15,16,17'` to create flow runs from that deployment every hour but only during business hours. |
-| `--apply` | When provided, automatically registers the resulting deployment with the API. |
-| `--skip-upload` | When provided, skips uploading this deployment's files to remote storage. |
-| `--path` | An optional path to specify a subdirectory of remote storage to upload to, or to point to a subdirectory of a locally stored flow. |
+| `--apply`, `-a` | When provided, automatically registers the resulting deployment with the API. |
+| `--cron TEXT` | A cron string that will be used to set a [`CronSchedule`](/concepts/schedules/) on the deployment. For example, `--cron "*/1 * * * *"` to create flow runs from that deployment every minute. |
+| `--help` | Display help for available commands and options. |
+| `--infra-block TEXT`, `-ib` | The [infrastructure block](#block-identifiers) to use, in `block-type/block-name` format. |
+| `--infra`, `-i` | The [infrastructure type](/concepts/infrastructure/) to use. (Default is `Process`) |
+| `--interval INTEGER` | An integer specifying an interval (in seconds) that will be used to set an [`IntervalSchedule`](/concepts/schedules/) on the deployment. For example, `--interval 60` to create flow runs from that deployment every minute. |
+| `--name TEXT`, `-n` | The name of the deployment. |
+| `--output TEXT`, `-o` | Optional location for the YAML manifest generated as a result of the `build` step. You can version-control that file, but it's not required since the CLI can generate everything you need to define a deployment. |
+| `--override TEXT` | One or more optional infrastructure overrides provided as a dot delimited path. For example, specify an environment variable: `env.env_key=env_value`. For Kubernetes, specify customizations: `customizations='[{"op": "add","path": "/spec/template/spec/containers/0/resources/limits", "value": {"memory": "8Gi","cpu": "4000m"}}]'` (note the string format).|
 | `--param` | An optional parameter override, values are parsed as JSON strings. For example, `--param question=ultimate --param answer=42`. |
 | `--params` | An optional parameter override in a JSON string format. For example, `--params=\'{"question": "ultimate", "answer": 42}\'`. |
+| `--path` | An optional path to specify a subdirectory of remote storage to upload to, or to point to a subdirectory of a locally stored flow. |
+| `--pool TEXT`, `-p` | The [work pool](/concepts/work-pools/) that will handle this deployment's runs. │
+| `--rrule TEXT` | An `RRule` that will be used to set an [`RRuleSchedule`](/concepts/schedules/) on the deployment. For example, `--rrule 'FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9,10,11,12,13,14,15,16,17'` to create flow runs from that deployment every hour but only during business hours. |
+| `--skip-upload` | When provided, skips uploading this deployment's files to remote storage. |
+| <span class="no-wrap">`--storage-block TEXT`, `-sb`</span> | The [storage block](#block-identifiers) to use, in `block-type/block-name` or `block-type/block-name/path` format. Note that the appropriate library supporting the storage filesystem must be installed. |
+| `--tag TEXT`, `-t` | One or more optional tags to apply to the deployment. |
+| `--version TEXT`, `-v` | An optional version for the deployment. This could be a git commit hash if you use this command from a CI/CD pipeline. |
+| `--work-queue TEXT`, `-q` |  The [work queue](/concepts/work-pools/) that will handle this deployment's runs. It will be created if it doesn't already exist. Defaults to `None`. Note that if a work queue is not set, work will not be scheduled. |
 
 ### Block identifiers
 

--- a/docs/concepts/work-pools.md
+++ b/docs/concepts/work-pools.md
@@ -21,14 +21,6 @@ To run deployments, you must configure at least one agent (and its associated wo
 1. [Start an agent](#starting-an-agent)
 2. [Configure a work pool](#work-pool-configuration) (optional)
 
-!!! tip "Agent role has changed from Prefect 1"
-    Work pools are a new concept. The role of agents has changed from their implementation in Prefect 1. If you're familiar with that model, please take some time to understand the new work pool/agent model. It requires a little more setup, but offers much greater control and flexibility with how deployments are executed.
-
-    Key changes: 
-    
-    - Work pools contain all the logic about what flows run and how. Agents just pick up work from pools and execute the flows.
-    - There is no global agent that picks up deployed work by default. You must configure an agent with a specific work pool.
-
 ## Agent overview
 
 Agent processes are lightweight polling services that get scheduled work from a [work pool](#work-pool-overview) and deploy the corresponding flow runs. 
@@ -41,16 +33,16 @@ Agents are configured to pull work from one or more work pool queues. If the age
 
 Configuration parameters you can specify when starting an agent include:
 
-| Option               | Description |
-|---|---|
-| -p, --pool     | A work pool name for the agent to pull from. [default: None]                                                                                 |
-| -q, --work-queue     | One or more work queue names for the agent to pull from. [default: None]                                                                                 |
-| -m, --match | Dynamically matches work queue names with the specified prefix for the agent to pull from,for example `dev-` will match all work queues with a name that starts with `dev-`[default: None]                 |   
-| --limit         | Maximum number of flow runs to start simultaneously. [default: None]                 |   
-| --api           | The API URL for the Prefect server. Default is the value of `PREFECT_API_URL`.                                                       |
-| --run-once           | Only run agent polling once. By default, the agent runs forever. [default: no-run-once]                                                                          |
-| <span class="no-wrap">--prefetch-seconds</span>   | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
-| --hide-welcome       | Do not display the startup ASCII art for the agent process.                                                                                |               
+| Option | Description |
+| --- | --- |
+| `--api` | The API URL for the Prefect server. Default is the value of `PREFECT_API_URL`. |
+| `--hide-welcome` | Do not display the startup ASCII art for the agent process. |               
+| `--limit` | Maximum number of flow runs to start simultaneously. [default: None] |   
+| `--match`, `-m` | Dynamically matches work queue names with the specified prefix for the agent to pull from,for example `dev-` will match all work queues with a name that starts with `dev-`. [default: None] |   
+| `--pool`, `-p` | A work pool name for the agent to pull from. [default: None] |
+| <span class="no-wrap">`--prefetch-seconds`</span> | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_AGENT_PREFETCH_SECONDS`. |
+| `--run-once` | Only run agent polling once. By default, the agent runs forever. [default: no-run-once] |
+| `--work-queue`, `-q` | One or more work queue names for the agent to pull from. [default: None] |
 
 You must start an agent within an environment that can access or create the infrastructure needed to execute flow runs. Your agent will deploy flow runs to the infrastructure specified by the deployment.
 
@@ -67,17 +59,14 @@ You must start an agent within an environment that can access or create the infr
 Use the `prefect agent start` CLI command to start an agent. You must pass at least one work pool name or match string that the agent will poll for work. If the work pool does not exist, it will be created.
 
 <div class="terminal">
-
 ```bash
 $ prefect agent start -p [work pool name]
 ```
-
 </div>
 
 For example:
 
 <div class="terminal">
-
 ```bash
 $ prefect agent start -p "my-pool"
 Starting agent with ephemeral API...
@@ -88,7 +77,6 @@ Starting agent with ephemeral API...
 
 Agent started! Looking for work from work pool 'my-pool'...
 ```
-
 </div>
 
 In this case, Prefect automatically created a new `my-queue` work queue.
@@ -98,12 +86,11 @@ By default, the agent polls the API specified by the `PREFECT_API_URL` environme
 In addition, agents can match multiple queues in a work pool by providing a `--match` string instead of specifying all of the queues. The agent will poll every queue with a name that starts with the given string. New queues matching this prefix will be found by the agent without needing to restart it.
 
 For example:
-<div class="terminal">
 
+<div class="terminal">
 ```bash
 $ prefect agent start --match "foo-"
 ```
-
 </div>
 
 This example will poll every work queue that starts with "foo-".
@@ -141,13 +128,14 @@ prefect work-pool create [OPTIONS] NAME
 
 Optional configuration parameters you can specify to filter work on the pool include:
 
-| Option      | Description                                                         |
-| ----------- | ------------------------------------------------------------------- |
-| --paused    | If provided, the work pool will be created in a paused state.       |
+| Option | Description |
+| ---- | --- |
+| `--paused` | If provided, the work pool will be created in a paused state. |
 
 For example, to create a work pool called `test-pool`, you would run this command: 
 
 <div class="terminal">
+
 ```bash
 $ prefect work-pool create test-pool
 


### PR DESCRIPTION
Removes outdated notes about changes to agents and deployments from beta releases. 

Also adds `--pool` to deployment example and fixes errors, missing items in deployments and agents options tables.

### Example

Previews:
- [Deployments](https://deploy-preview-8630--prefect-docs.netlify.app/concepts/deployments/)
- [Agents & Work Pools](https://deploy-preview-8630--prefect-docs.netlify.app/concepts/work-pools/)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
