### PR TITLE
Refactor supervisors to manage submission

### DIFF
--- a/src/prefect/_internal/concurrency/from_async.py
+++ b/src/prefect/_internal/concurrency/from_async.py
@@ -4,11 +4,7 @@ from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 
 from prefect._internal.concurrency.runtime import get_runtime_thread
-from prefect._internal.concurrency.supervisors import (
-    AsyncSupervisor,
-    get_supervisor,
-    set_supervisor,
-)
+from prefect._internal.concurrency.supervisors import AsyncSupervisor, get_supervisor
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -22,17 +18,19 @@ def call_soon_in_runtime_thread(
 
     Returns a supervisor.
     """
-    current_future = get_supervisor()
+    current_supervisor = get_supervisor()
     runtime = get_runtime_thread()
-    supervisor = AsyncSupervisor()
 
-    with set_supervisor(supervisor):
-        if current_future is None or current_future.owner_thread_ident != runtime.ident:
-            future = runtime.submit_to_loop(__fn, *args, **kwargs)
-        else:
-            future = current_future.send_call(__fn, *args, **kwargs)
+    if (
+        current_supervisor is None
+        or current_supervisor.owner_thread_ident != runtime.ident
+    ):
+        submit_fn = runtime.submit_to_loop
+    else:
+        submit_fn = current_supervisor.send_call
 
-    supervisor.set_future(future)
+    supervisor = AsyncSupervisor(submit_fn=submit_fn)
+    supervisor.submit(__fn, *args, **kwargs)
     return supervisor
 
 
@@ -45,10 +43,8 @@ def call_soon_in_worker_thread(
     Returns a supervisor.
     """
     runtime = get_runtime_thread()
-    supervisor = AsyncSupervisor()
-    with set_supervisor(supervisor):
-        future = runtime.submit_to_worker_thread(__fn, *args, **kwargs)
-    supervisor.set_future(future)
+    supervisor = AsyncSupervisor(runtime.submit_to_worker_thread)
+    supervisor.submit(__fn, *args, **kwargs)
     return supervisor
 
 

--- a/src/prefect/_internal/concurrency/from_sync.py
+++ b/src/prefect/_internal/concurrency/from_sync.py
@@ -4,11 +4,7 @@ from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 
 from prefect._internal.concurrency.runtime import get_runtime_thread
-from prefect._internal.concurrency.supervisors import (
-    SyncSupervisor,
-    get_supervisor,
-    set_supervisor,
-)
+from prefect._internal.concurrency.supervisors import SyncSupervisor, get_supervisor
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -25,18 +21,16 @@ def call_soon_in_runtime_thread(
     current_supervisor = get_supervisor()
     runtime = get_runtime_thread()
 
-    supervisor = SyncSupervisor()
+    if (
+        current_supervisor is None
+        or current_supervisor.owner_thread_ident != runtime.ident
+    ):
+        submit_fn = runtime.submit_to_loop
+    else:
+        submit_fn = current_supervisor.send_call
 
-    with set_supervisor(supervisor):
-        if (
-            current_supervisor is None
-            or current_supervisor.owner_thread_ident != runtime.ident
-        ):
-            future = runtime.submit_to_loop(__fn, *args, **kwargs)
-        else:
-            future = current_supervisor.send_call(__fn, *args, **kwargs)
-
-    supervisor.set_future(future)
+    supervisor = SyncSupervisor(submit_fn=submit_fn)
+    supervisor.submit(__fn, *args, **kwargs)
     return supervisor
 
 
@@ -49,10 +43,8 @@ def call_soon_in_worker_thread(
     Returns a supervisor.
     """
     runtime = get_runtime_thread()
-    supervisor = SyncSupervisor()
-    with set_supervisor(supervisor):
-        future = runtime.submit_to_worker_thread(__fn, *args, **kwargs)
-    supervisor.set_future(future)
+    supervisor = SyncSupervisor(runtime.submit_to_worker_thread)
+    supervisor.submit(__fn, *args, **kwargs)
     return supervisor
 
 


### PR DESCRIPTION
This allows the supervisor to track the thread the supervised future is executing on, which is essential for cancellation handling. This also has the benefit of clarifying the supervisor interface and reducing the responsibilities of users of the supervisor.
