### PR TITLE
Improve supervisor repr for debugging

### DIFF
--- a/src/prefect/_internal/concurrency/from_async.py
+++ b/src/prefect/_internal/concurrency/from_async.py
@@ -23,7 +23,7 @@ def call_soon_in_runtime_thread(
 
     if (
         current_supervisor is None
-        or current_supervisor.owner_thread_ident != runtime.ident
+        or current_supervisor.owner_thread.ident != runtime.ident
     ):
         submit_fn = runtime.submit_to_loop
     else:

--- a/src/prefect/_internal/concurrency/from_sync.py
+++ b/src/prefect/_internal/concurrency/from_sync.py
@@ -23,7 +23,7 @@ def call_soon_in_runtime_thread(
 
     if (
         current_supervisor is None
-        or current_supervisor.owner_thread_ident != runtime.ident
+        or current_supervisor.owner_thread.ident != runtime.ident
     ):
         submit_fn = runtime.submit_to_loop
     else:

--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -147,9 +147,10 @@ class Supervisor(abc.ABC, Generic[T]):
 
     def __init__(self, submit_fn: Callable[..., concurrent.futures.Future]) -> None:
         self._submit_fn = submit_fn
-        self.owner_thread_ident = threading.get_ident()
+        self._owner_thread = threading.current_thread()
         self._future: AnyFuture = None
         self._future_thread = concurrent.futures.Future()
+        self._future_call: Tuple[Callable, Tuple, Dict] = None
         logger.debug("Created supervisor %r", self)
 
     def submit(self, __fn, *args, **kwargs) -> concurrent.futures.Future:
@@ -175,6 +176,7 @@ class Supervisor(abc.ABC, Generic[T]):
             future = self._submit_fn(_call_in_supervised_thread)
 
         self._set_future(future)
+        self._future_call = (__fn, args, kwargs)
 
         return future
 
@@ -186,6 +188,10 @@ class Supervisor(abc.ABC, Generic[T]):
         self._put_work_item(work_item)
         logger.debug("Sent work item to %r", self)
         return work_item.future
+
+    @property
+    def owner_thread(self):
+        return self._owner_thread
 
     @abc.abstractmethod
     def _put_work_item(self, work_item: WorkItem) -> None:
@@ -211,9 +217,14 @@ class Supervisor(abc.ABC, Generic[T]):
         raise NotImplementedError()
 
     def __repr__(self) -> str:
+        if self._future_call:
+            extra = f" submitted={self._future_call[0].__name__},"
+        else:
+            extra = ""
+
         return (
-            f"<{self.__class__.__name__}(id={id(self)},"
-            f" owner={self.owner_thread_ident})>"
+            f"<{self.__class__.__name__}({self._submit_fn.__name__},"
+            f"{extra} owner={self._owner_thread.name!r})>"
         )
 
 

--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -217,14 +217,14 @@ class Supervisor(abc.ABC, Generic[T]):
         raise NotImplementedError()
 
     def __repr__(self) -> str:
+        extra = ""
+
         if self._future_call:
-            extra = f" submitted={self._future_call[0].__name__},"
-        else:
-            extra = ""
+            extra += f" submitted={self._future_call[0].__name__!r},"
 
         return (
-            f"<{self.__class__.__name__}({self._submit_fn.__name__},"
-            f"{extra} owner={self._owner_thread.name!r})>"
+            f"<{self.__class__.__name__} submit_fn={self._submit_fn.__name__!r},"
+            f"{extra} owner={self._owner_thread.name!r}>"
         )
 
 

--- a/tests/_internal/concurrency/test_supervisors.py
+++ b/tests/_internal/concurrency/test_supervisors.py
@@ -1,0 +1,26 @@
+import concurrent.futures
+
+import pytest
+
+from prefect._internal.concurrency.supervisors import AsyncSupervisor, SyncSupervisor
+
+
+def fake_submit_fn(__fn, *args, **kwargs):
+    future = concurrent.futures.Future()
+    future.set_result(__fn(*args, **kwargs))
+    return future
+
+
+def fake_fn(*args, **kwargs):
+    pass
+
+
+@pytest.mark.parametrize("cls", [AsyncSupervisor, SyncSupervisor])
+async def test_supervisor_repr(cls):
+    supervisor = cls(submit_fn=fake_submit_fn)
+    assert repr(supervisor) == f"<{cls.__name__}(fake_submit_fn, owner='MainThread')>"
+    supervisor.submit(fake_fn, 1, 2)
+    assert (
+        repr(supervisor)
+        == f"<{cls.__name__}(fake_submit_fn, submitted=fake_fn, owner='MainThread')>"
+    )

--- a/tests/_internal/concurrency/test_supervisors.py
+++ b/tests/_internal/concurrency/test_supervisors.py
@@ -18,9 +18,13 @@ def fake_fn(*args, **kwargs):
 @pytest.mark.parametrize("cls", [AsyncSupervisor, SyncSupervisor])
 async def test_supervisor_repr(cls):
     supervisor = cls(submit_fn=fake_submit_fn)
-    assert repr(supervisor) == f"<{cls.__name__}(fake_submit_fn, owner='MainThread')>"
+    assert (
+        repr(supervisor)
+        == f"<{cls.__name__} submit_fn='fake_submit_fn', owner='MainThread'>"
+    )
     supervisor.submit(fake_fn, 1, 2)
     assert (
         repr(supervisor)
-        == f"<{cls.__name__}(fake_submit_fn, submitted=fake_fn, owner='MainThread')>"
+        == f"<{cls.__name__} submit_fn='fake_submit_fn', submitted='fake_fn',"
+        " owner='MainThread'>"
     )


### PR DESCRIPTION
```python
import concurrent.futures
import threading

import pytest

from prefect._internal.concurrency.supervisors import AsyncSupervisor, SyncSupervisor


def fake_submit_fn(__fn, *args, **kwargs):
    future = concurrent.futures.Future()
    future.set_result(__fn(*args, **kwargs))
    return future


def fake_fn(*args, **kwargs):
    pass


supervisor = SyncSupervisor(submit_fn=fake_submit_fn)
print(repr(supervisor))

supervisor.submit(fake_fn, 1, 2)
print(repr(supervisor))
```

```
<SyncSupervisor submit_fn='fake_submit_fn', owner='MainThread'>
<SyncSupervisor submit_fn='fake_submit_fn', submitted='fake_fn', owner='MainThread'>

vs previously

<SyncSupervisor(id=140242493845264, owner=8633447104)>
<SyncSupervisor(id=140242493845264, owner=8633447104)>
```