### PR TITLE
Add timeout support to supervisors

### DIFF
--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -265,8 +265,11 @@ class SyncSupervisor(Supervisor[T]):
             cancel_sync_after(timeout)
             if timeout is not None
             else contextlib.nullcontext()
-        ):
+        ) as ctx:
             self._watch_for_work_items()
+
+        if timeout is not None and ctx.cancelled:
+            raise TimeoutError()
 
         logger.debug("Retrieving result for %r", self)
         return self._future.result(
@@ -320,8 +323,11 @@ class AsyncSupervisor(Supervisor[T]):
             cancel_async_after(timeout)
             if timeout is not None
             else contextlib.nullcontext()
-        ):
+        ) as ctx:
             await self._watch_for_work_items()
+
+        if timeout is not None and ctx.cancelled:
+            raise TimeoutError()
 
         logger.debug("Retrieving result for %r", self)
         return await self._future

--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -261,14 +261,10 @@ class SyncSupervisor(Supervisor[T]):
         # deadline and enforce the timeout when retrieving the result as well
         deadline = (time.time() + timeout) if timeout is not None else None
 
-        with (
-            cancel_sync_after(timeout)
-            if timeout is not None
-            else contextlib.nullcontext()
-        ) as ctx:
+        with cancel_sync_after(timeout) as ctx:
             self._watch_for_work_items()
 
-        if timeout is not None and ctx.cancelled:
+        if ctx.cancelled:
             raise TimeoutError()
 
         logger.debug("Retrieving result for %r", self)
@@ -319,14 +315,10 @@ class AsyncSupervisor(Supervisor[T]):
         if not self._future:
             raise ValueError("No future being supervised.")
 
-        with (
-            cancel_async_after(timeout)
-            if timeout is not None
-            else contextlib.nullcontext()
-        ) as ctx:
+        with cancel_async_after(timeout) as ctx:
             await self._watch_for_work_items()
 
-        if timeout is not None and ctx.cancelled:
+        if ctx.cancelled:
             raise TimeoutError()
 
         logger.debug("Retrieving result for %r", self)

--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -13,7 +13,6 @@ import functools
 import inspect
 import queue
 import threading
-import time
 from typing import (
     Any,
     Awaitable,
@@ -27,10 +26,17 @@ from typing import (
 )
 
 from prefect._internal.concurrency.event_loop import call_soon_in_loop, get_running_loop
-from prefect._internal.concurrency.timeouts import cancel_async_after, cancel_sync_after
+from prefect._internal.concurrency.timeouts import (
+    cancel_async_after,
+    cancel_async_at,
+    cancel_sync_after,
+    cancel_sync_at,
+    get_deadline,
+)
 from prefect.logging import get_logger
 
 T = TypeVar("T")
+Fn = TypeVar("Fn", bound=Callable)
 
 # Python uses duck typing for futures; asyncio/threaded futures do not share a base
 AnyFuture = Any
@@ -111,12 +117,12 @@ class WorkItem:
             result = self.context.run(self.fn, *self.args, **self.kwargs)
         except BaseException as exc:
             self.future.set_exception(exc)
+            logger.debug("Encountered exception in work item %r", self)
             # Prevent reference cycle in `exc`
-            self = None
+            del self
         else:
             self.future.set_result(result)
-
-        logger.debug("Finished work item %r", self)
+            logger.debug("Finished work item %r", self)
 
     async def _run_async(self):
         loop = asyncio.get_running_loop()
@@ -133,11 +139,11 @@ class WorkItem:
         except BaseException as exc:
             self.future.set_exception(exc)
             # Prevent reference cycle in `exc`
-            self = None
+            logger.debug("Encountered exception %s in work item %r", exc, self)
+            del self
         else:
             self.future.set_result(result)
-
-        logger.debug("Finished work item %r", self)
+            logger.debug("Finished work item %r", self)
 
 
 class Supervisor(abc.ABC, Generic[T]):
@@ -147,12 +153,21 @@ class Supervisor(abc.ABC, Generic[T]):
     Work sent to the supervisor will be executed when the owner waits for the result.
     """
 
-    def __init__(self, submit_fn: Callable[..., concurrent.futures.Future]) -> None:
+    def __init__(
+        self,
+        submit_fn: Callable[..., concurrent.futures.Future],
+        timeout: Optional[float] = None,
+    ) -> None:
         self._submit_fn = submit_fn
         self._owner_thread = threading.current_thread()
-        self._future: AnyFuture = None
-        self._future_thread = concurrent.futures.Future()
+        self._future: Optional[concurrent.futures.Future] = None
         self._future_call: Tuple[Callable, Tuple, Dict] = None
+        self._timeout: Optional[float] = timeout
+
+        # Delayed computation
+        self._worker_thread_future = concurrent.futures.Future()
+        self._deadline_future = concurrent.futures.Future()
+
         logger.debug("Created supervisor %r", self)
 
     def submit(self, __fn, *args, **kwargs) -> concurrent.futures.Future:
@@ -167,17 +182,16 @@ class Supervisor(abc.ABC, Generic[T]):
         if self._future:
             raise RuntimeError("A supervisor can only monitor a single future")
 
-        @functools.wraps(__fn)
-        def _call_in_supervised_thread():
-            # Capture the worker thread before running the function
-            thread = threading.current_thread()
-            self._future_thread.set_result(thread)
-            return __fn(*args, **kwargs)
-
         with set_supervisor(self):
-            future = self._submit_fn(_call_in_supervised_thread)
+            future = self._submit_fn(self._add_supervision(__fn), *args, **kwargs)
 
-        self._set_future(future)
+        logger.debug(
+            "Call to %r submitted to supervisor %r tracked by future %r",
+            __fn.__name__,
+            self,
+            future,
+        )
+        self._future = future
         self._future_call = (__fn, args, kwargs)
 
         return future
@@ -188,24 +202,50 @@ class Supervisor(abc.ABC, Generic[T]):
         """
         work_item = WorkItem.from_call(__fn, *args, **kwargs)
         self._put_work_item(work_item)
-        logger.debug("Sent work item to %r", self)
+        logger.debug("Sent work item to supervisor %r", self)
         return work_item.future
 
     @property
     def owner_thread(self):
         return self._owner_thread
 
+    def _add_supervision(self, fn: Fn) -> Fn:
+        """
+        Attach supervision to a callable.
+        """
+
+        @functools.wraps(fn)
+        def _call_in_supervised_thread(*args, **kwargs):
+            # Capture the worker thread before running the function
+            thread = threading.current_thread()
+            self._worker_thread_future.set_result(thread)
+
+            # Set the execution deadline
+            self._deadline_future.set_result(get_deadline(self._timeout))
+
+            # Enforce timeouts on synchronous execution
+            with cancel_sync_after(self._timeout):
+                retval = fn(*args, **kwargs)
+
+            # Enforce timeouts on asynchronous execution
+            if inspect.isawaitable(retval):
+
+                async def _call_in_supervised_coro():
+                    # TODO: Technnically, this should use the deadline but it is not
+                    #       clear how to mix sync/async deadlines yet
+                    with cancel_async_after(self._timeout):
+                        return await retval
+
+                return _call_in_supervised_coro()
+
+            return retval
+
+        return _call_in_supervised_thread
+
     @abc.abstractmethod
     def _put_work_item(self, work_item: WorkItem) -> None:
         """
         Add a work item to the supervisor. Used by `send_call`.
-        """
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _set_future(self, future: AnyFuture) -> None:
-        """
-        Assign a future to the supervisor.
         """
         raise NotImplementedError()
 
@@ -231,21 +271,20 @@ class Supervisor(abc.ABC, Generic[T]):
 
 
 class SyncSupervisor(Supervisor[T]):
-    def __init__(self, submit_fn: Callable[..., concurrent.futures.Future]) -> None:
-        super().__init__(submit_fn=submit_fn)
+    def __init__(
+        self,
+        submit_fn: Callable[..., concurrent.futures.Future],
+        timeout: Optional[float] = None,
+    ) -> None:
+        super().__init__(submit_fn=submit_fn, timeout=timeout)
         self._queue: queue.Queue = queue.Queue()
-        self._future: Optional[concurrent.futures.Future] = None
 
     def _put_work_item(self, work_item: WorkItem):
         self._queue.put_nowait(work_item)
 
-    def _set_future(self, future: concurrent.futures.Future):
-        future.add_done_callback(lambda _: self._queue.put_nowait(None))
-        self._future = future
-
     def _watch_for_work_items(self):
+        logger.debug("Watching for work sent to supervisor %r", self)
         while True:
-            logger.debug("Watching for work sent to %r", self)
             work_item: WorkItem = self._queue.get()
             if work_item is None:
                 break
@@ -253,52 +292,45 @@ class SyncSupervisor(Supervisor[T]):
             work_item.run()
             del work_item
 
-    def result(self, timeout: Optional[float] = None) -> T:
+    def result(self) -> T:
         if not self._future:
             raise ValueError("No future being supervised.")
 
-        # Sometimes, `cancel_sync_after` cannot be enforced so we will track the
-        # deadline and enforce the timeout when retrieving the result as well
-        deadline = (time.time() + timeout) if timeout is not None else None
+        # Stop watching for work once the future is done
+        self._future.add_done_callback(lambda _: self._queue.put_nowait(None))
 
-        with cancel_sync_after(timeout) as ctx:
-            self._watch_for_work_items()
+        # Cancel work sent to the supervisor if the future exceeds its timeout
+        deadline = self._deadline_future.result()
+        try:
+            with cancel_sync_at(deadline) as ctx:
+                self._watch_for_work_items()
+        except TimeoutError:
+            # Timeouts will be generally be raised on future result retrieval but
+            # if its not our timeout it should be reraised
+            if not ctx.cancelled:
+                raise
 
-        if ctx.cancelled:
-            raise TimeoutError()
-
-        logger.debug("Retrieving result for %r", self)
-        return self._future.result(
-            timeout=max(deadline - time.time(), 0) if deadline else None
-        )
+        logger.debug("Supervisor %r retrieving result of future %r", self, self._future)
+        return self._future.result()
 
 
 class AsyncSupervisor(Supervisor[T]):
-    def __init__(self, submit_fn: Callable[..., concurrent.futures.Future]) -> None:
-        super().__init__(submit_fn=submit_fn)
+    def __init__(
+        self,
+        submit_fn: Callable[..., concurrent.futures.Future],
+        timeout: Optional[float] = None,
+    ) -> None:
+        super().__init__(submit_fn=submit_fn, timeout=timeout)
         self._queue: asyncio.Queue = asyncio.Queue()
         self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
-        self._future: Optional[asyncio.Future] = None
-
-    def _set_future(
-        self, future: Union[asyncio.Future, concurrent.futures.Future]
-    ) -> None:
-        # Ensure we're working with an asyncio future internally
-        if isinstance(future, concurrent.futures.Future):
-            future = asyncio.wrap_future(future)
-
-        future.add_done_callback(
-            lambda _: call_soon_in_loop(self._loop, self._queue.put_nowait, None)
-        )
-        self._future = future
 
     def _put_work_item(self, work_item: WorkItem):
         # We must put items in the queue from the event loop that owns it
         call_soon_in_loop(self._loop, self._queue.put_nowait, work_item)
 
     async def _watch_for_work_items(self):
+        logger.debug("Watching for work sent to %r", self)
         while True:
-            logger.debug("Watching for work sent to %r", self)
             work_item: WorkItem = await self._queue.get()
             if work_item is None:
                 break
@@ -312,19 +344,31 @@ class AsyncSupervisor(Supervisor[T]):
 
             del work_item
 
-    async def result(self, timeout: Optional[float] = None) -> T:
+    async def result(self) -> T:
         if not self._future:
             raise ValueError("No future being supervised.")
 
-        with cancel_async_after(timeout) as ctx:
-            await self._watch_for_work_items()
+        future = (
+            # Convert to an asyncio future if necessary for non-blocking wait
+            asyncio.wrap_future(self._future)
+            if isinstance(self._future, concurrent.futures.Future)
+            else self._future
+        )
 
-        if ctx.cancelled:
-            try:
-                await self._future
-            except:
-                pass
-            raise TimeoutError()
+        # Stop watching for work once the future is done
+        future.add_done_callback(
+            lambda _: call_soon_in_loop(self._loop, self._queue.put_nowait, None)
+        )
 
-        logger.debug("Retrieving result for %r", self)
-        return
+        # Cancel work sent to the supervisor if the future exceeds its timeout
+        deadline = await asyncio.wrap_future(self._deadline_future)
+        try:
+            with cancel_async_at(deadline) as ctx:
+                await self._watch_for_work_items()
+        except TimeoutError:
+            # Timeouts will be re-raised on future result retrieval
+            if not ctx.cancelled:
+                raise
+
+        logger.debug("Supervisor %r retrieving result of future %r", self, future)
+        return await future

--- a/src/prefect/_internal/concurrency/supervisors.py
+++ b/src/prefect/_internal/concurrency/supervisors.py
@@ -305,9 +305,10 @@ class AsyncSupervisor(Supervisor[T]):
 
             # TODO: We could use `cancel_sync_after` to guard this call as a sync call
             #       could block a timeout here
-            result = work_item.run()
-            if inspect.isawaitable(result):
-                await result
+            retval = work_item.run()
+
+            if inspect.isawaitable(retval):
+                await retval
 
             del work_item
 
@@ -319,7 +320,11 @@ class AsyncSupervisor(Supervisor[T]):
             await self._watch_for_work_items()
 
         if ctx.cancelled:
+            try:
+                await self._future
+            except:
+                pass
             raise TimeoutError()
 
         logger.debug("Retrieving result for %r", self)
-        return await self._future
+        return

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -148,6 +148,10 @@ def cancel_sync_after(timeout: Optional[float]):
 
     if sys.platform.startswith("win"):
         # Timeouts cannot be enforced on Windows
+        logger.warning(
+            f"Entered cancel context on Windows; {timeout:.2}s timeout will not be"
+            " enforced."
+        )
         yield ctx
         return
 

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -5,7 +5,7 @@ import signal
 import sys
 import threading
 import time
-from typing import Type
+from typing import Optional, Type
 
 import anyio
 
@@ -33,7 +33,7 @@ class CancelContext:
 
 
 @contextlib.contextmanager
-def cancel_async_after(timeout: float):
+def cancel_async_after(timeout: Optional[float]):
     """
     Cancel any async calls within the context if it does not exit after the given
     timeout.
@@ -43,6 +43,10 @@ def cancel_async_after(timeout: float):
     Yields a `CancelContext`.
     """
     ctx = CancelContext()
+    if timeout is None:
+        yield ctx
+        return
+
     try:
         with anyio.fail_after(timeout) as cancel_scope:
             yield ctx
@@ -51,7 +55,7 @@ def cancel_async_after(timeout: float):
 
 
 @contextlib.contextmanager
-def cancel_sync_after(timeout: float):
+def cancel_sync_after(timeout: Optional[float]):
     """
     Cancel any sync calls within the context if it does not exit after the given
     timeout.
@@ -62,6 +66,9 @@ def cancel_sync_after(timeout: float):
     Yields a `CancelContext`.
     """
     ctx = CancelContext()
+    if timeout is None:
+        yield ctx
+        return
 
     if sys.platform.startswith("win"):
         # Timeouts cannot be enforced on Windows

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -221,7 +221,7 @@ def _watcher_thread_based_timeout(timeout: float):
         time.sleep(timeout)
         if not event.is_set():
             logger.debug(
-                "Cancel fired for watched based timeout of thread %r",
+                "Cancel fired for watcher based timeout of thread %r",
                 supervised_thread.name,
             )
             ctx.cancelled = True

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -60,7 +60,7 @@ def cancel_async_after(timeout: Optional[float]):
     try:
         with anyio.fail_after(timeout) as cancel_scope:
             logger.debug(
-                f"Entered asynchronous cancel context with {timeout:.2}s timeout"
+                f"Entered asynchronous cancel context with %.2f timeout", timeout
             )
             yield ctx
     finally:
@@ -149,8 +149,8 @@ def cancel_sync_after(timeout: Optional[float]):
     if sys.platform.startswith("win"):
         # Timeouts cannot be enforced on Windows
         logger.warning(
-            f"Entered cancel context on Windows; {timeout:.2}s timeout will not be"
-            " enforced."
+            f"Entered cancel context on Windows; %.2f timeout will not be enforced.",
+            timeout,
         )
         yield ctx
         return
@@ -165,8 +165,9 @@ def cancel_sync_after(timeout: Optional[float]):
     try:
         with method(timeout) as inner_ctx:
             logger.debug(
-                f"Entered synchronous cancel context with {timeout:.2}s"
-                f" {method_name} based timeout"
+                f"Entered synchronous cancel context with %.2f %s based timeout",
+                timeout,
+                method_name,
             )
             yield ctx
     finally:

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -1,0 +1,97 @@
+import contextlib
+import ctypes
+import math
+import signal
+import sys
+import threading
+import time
+from typing import Type
+
+import anyio
+
+
+@contextlib.contextmanager
+def cancel_async_after(timeout: float):
+    with anyio.fail_after(timeout):
+        yield
+
+
+@contextlib.contextmanager
+def cancel_sync_after(timeout: float):
+    if sys.platform.startswith("win"):
+        # Timeouts cannot be enforced on Windows
+        yield
+        return
+
+    if threading.current_thread() is threading.main_thread():
+        method = _alarm_based_timeout
+    else:
+        method = _watcher_thread_based_timeout
+
+    with method(timeout):
+        yield
+
+
+@contextlib.contextmanager
+def _alarm_based_timeout(timeout: float):
+    """
+    Enforce a timeout using an alarm.
+
+    Sets an alarm for `timeout` seconds, then raises a timeout error if the context is
+    not exited before the deadline.
+
+    Alarms have the benefit of interrupt sys calls like `sleep`, but signals are always
+    raised in the main thread and this cannot be used elsewhere.
+    """
+    if not threading.current_thread() is threading.main_thread():
+        raise ValueError("Alarm based timeouts can only be used in the main thread.")
+
+    def raise_alarm_as_timeout(signum, frame):
+        raise TimeoutError()
+
+    try:
+        signal.signal(signal.SIGALRM, raise_alarm_as_timeout)
+        signal.alarm(math.ceil(timeout))  # alarms do not support floats
+        yield
+    finally:
+        signal.alarm(0)  # Clear the alarm when the context exits
+
+
+@contextlib.contextmanager
+def _watcher_thread_based_timeout(timeout: float):
+    """
+    Enforce a timeout using a watcher thread.
+
+    Creates a thread that sleeps for `timeout` seconds, then sends a timeout error to
+    the supervised (current) thread if the context is not exited before the deadline.
+
+    Note this will not interrupt sys calls like `sleep`.
+    """
+    event = threading.Event()
+    supervised_thread = threading.current_thread()
+
+    def timeout_enforcer():
+        time.sleep(timeout)
+        if not event.is_set():
+            _send_exception_to_thread(supervised_thread, TimeoutError)
+
+    enforcer = threading.Thread(target=timeout_enforcer, daemon=True)
+    enforcer.start()
+
+    try:
+        yield
+    finally:
+        event.set()
+
+
+def _send_exception_to_thread(thread: threading.Thread, exc_type: Type[BaseException]):
+    """
+    Raise an exception in a thread.
+
+    This will not interrupt long-running system calls like `sleep` or `wait`.
+    """
+    ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_long(thread.ident), ctypes.py_object(exc_type)
+    )
+    if ret == 0:
+        raise ValueError("Thread not found.")

--- a/tests/_internal/concurrency/test_supervisors.py
+++ b/tests/_internal/concurrency/test_supervisors.py
@@ -72,9 +72,7 @@ async def test_async_supervisor_timeout_in_worker_thread():
         supervisor = AsyncSupervisor(submit_fn=executor.submit)
         future = supervisor.submit(sleep_repeatedly, 1)
         with pytest.raises(TimeoutError):
-            supervisor.result(timeout=0.1)
-
-        future.result()
+            await supervisor.result(timeout=0.1)
 
 
 async def test_async_supervisor_timeout_in_main_thread():
@@ -88,6 +86,4 @@ async def test_async_supervisor_timeout_in_main_thread():
 
         future = supervisor.submit(on_worker_thread)
         with pytest.raises(TimeoutError):
-            supervisor.result(timeout=0.1)
-
-        future.result()
+            await supervisor.result(timeout=0.1)

--- a/tests/_internal/concurrency/test_timeouts.py
+++ b/tests/_internal/concurrency/test_timeouts.py
@@ -4,28 +4,36 @@ import time
 
 import pytest
 
-from prefect._internal.concurrency.timeouts import cancel_async_after, cancel_sync_after
+from prefect._internal.concurrency.timeouts import (
+    cancel_async_after,
+    cancel_async_at,
+    cancel_sync_after,
+    cancel_sync_at,
+    get_deadline,
+)
 
 
 async def test_cancel_async_after():
     t0 = time.perf_counter()
     with pytest.raises(TimeoutError):
-        with cancel_async_after(0.1):
+        with cancel_async_after(0.1) as ctx:
             await asyncio.sleep(1)
     t1 = time.perf_counter()
 
+    assert ctx.cancelled
     assert t1 - t0 < 1
 
 
 def test_cancel_sync_after_in_main_thread():
     t0 = time.perf_counter()
     with pytest.raises(TimeoutError):
-        with cancel_sync_after(0.1):
+        with cancel_sync_after(0.1) as ctx:
             # floats are not suppported by alarm timeouts so this will actually timeout
             # after 1s
             time.sleep(2)
     t1 = time.perf_counter()
 
+    assert ctx.cancelled
     assert t1 - t0 < 2
 
 
@@ -33,14 +41,41 @@ def test_cancel_sync_after_in_worker_thread():
     def on_worker_thread():
         t0 = time.perf_counter()
         with pytest.raises(TimeoutError):
-            with cancel_sync_after(0.1):
+            with cancel_sync_after(0.1) as ctx:
                 # this timeout method does not interrupt sleep calls, the timeout is
                 # raised on the next instruction
                 for _ in range(10):
                     time.sleep(0.1)
         t1 = time.perf_counter()
-        return t1 - t0
+        return t1 - t0, ctx
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future = executor.submit(on_worker_thread)
-        assert future.result() < 1
+        elapsed_time, ctx = future.result()
+
+    assert elapsed_time < 1
+    assert ctx.cancelled
+
+
+async def test_cancel_async_at():
+    t0 = time.perf_counter()
+    with pytest.raises(TimeoutError):
+        with cancel_async_at(get_deadline(timeout=0.1)) as ctx:
+            await asyncio.sleep(1)
+    t1 = time.perf_counter()
+
+    assert ctx.cancelled
+    assert t1 - t0 < 1
+
+
+def test_cancel_sync_at():
+    t0 = time.perf_counter()
+    with pytest.raises(TimeoutError):
+        with cancel_sync_at(get_deadline(timeout=0.1)) as ctx:
+            # floats are not suppported by alarm timeouts so this will actually timeout
+            # after 1s
+            time.sleep(2)
+    t1 = time.perf_counter()
+
+    assert ctx.cancelled
+    assert t1 - t0 < 2

--- a/tests/_internal/concurrency/test_timeouts.py
+++ b/tests/_internal/concurrency/test_timeouts.py
@@ -1,0 +1,46 @@
+import asyncio
+import concurrent.futures
+import time
+
+import pytest
+
+from prefect._internal.concurrency.timeouts import cancel_async_after, cancel_sync_after
+
+
+async def test_cancel_async_after():
+    t0 = time.perf_counter()
+    with pytest.raises(TimeoutError):
+        with cancel_async_after(0.1):
+            await asyncio.sleep(1)
+    t1 = time.perf_counter()
+
+    assert t1 - t0 < 1
+
+
+def test_cancel_sync_after_in_main_thread():
+    t0 = time.perf_counter()
+    with pytest.raises(TimeoutError):
+        with cancel_sync_after(0.1):
+            # floats are not suppported by alarm timeouts so this will actually timeout
+            # after 1s
+            time.sleep(2)
+    t1 = time.perf_counter()
+
+    assert t1 - t0 < 2
+
+
+def test_cancel_sync_after_in_worker_thread():
+    def on_worker_thread():
+        t0 = time.perf_counter()
+        with pytest.raises(TimeoutError):
+            with cancel_sync_after(0.1):
+                # this timeout method does not interrupt sleep calls, the timeout is
+                # raised on the next instruction
+                for _ in range(10):
+                    time.sleep(0.1)
+        t1 = time.perf_counter()
+        return t1 - t0
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(on_worker_thread)
+        assert future.result() < 1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds timeout handling to supervisors.

Supervisors can be created with a `timeout`. The timeout will start when the future submitted to the supervisor begins running. The timeout will be enforced for both synchronous and asynchronous work that the future represents. The timeout will also be enforced on work sent _back_ to the supervising thread by the supervised call, ensuring that the supervising thread never waits for a result longer than the timeout.

Timeouts are implemented in three ways:
- Asynchronous cancel scopes (async only)
- Alarm signal (main thread only — can notably interrupt sys calls)
- Watcher threads

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
import concurrent.futures
import time

from prefect._internal.concurrency.supervisors import SyncSupervisor


def slow_worker():
    for _ in range(100):
        time.sleep(0.1)


executor = concurrent.futures.ThreadPoolExecutor()

supervisor = SyncSupervisor(submit_fn=executor.submit, timeout=0.1)
supervisor.submit(slow_worker)
supervisor.result()
```

In this example, you'll see two cancel contexts get created. One, alarm based is for the main thread which is watching for work returned by the future. This prevents the future from blocking the main thread by sending work back. The other, watcher based, is for the future executing in the worker thread.

```
13:52:42.257 | DEBUG   | prefect._internal.concurrency.supervisors - Created supervisor <SyncSupervisor submit_fn='submit', owner='MainThread'>
13:52:42.259 | DEBUG   | prefect._internal.concurrency.supervisors - Call to 'slow_worker' submitted to supervisor <SyncSupervisor submit_fn='submit', owner='MainThread'> tracked by future <Future at 0x7f8281e5d5b0 state=running>
13:52:42.259 | DEBUG   | prefect._internal.concurrency.timeouts - Entered synchronous cancel context with 0.1s alarm based timeout
13:52:42.260 | DEBUG   | prefect._internal.concurrency.supervisors - Watching for work sent to supervisor <SyncSupervisor submit_fn='submit', submitted='slow_worker', owner='MainThread'>
13:52:42.260 | DEBUG   | prefect._internal.concurrency.timeouts - Entered synchronous cancel context with 0.1s watcher based timeout
13:52:42.364 | DEBUG   | prefect._internal.concurrency.timeouts - Cancel fired for watched based timeout of thread 'ThreadPoolExecutor-0_0'
13:52:42.471 | DEBUG   | prefect._internal.concurrency.supervisors - Supervisor <SyncSupervisor submit_fn='submit', submitted='slow_worker', owner='MainThread'> retrieving result of future <Future at 0x7f8281e5d5b0 state=finished raised TimeoutError>
Traceback (most recent call last):
  File "example.py", line 15, in <module>
    supervisor.result()
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/supervisors.py", line 314, in result
    return self._future.result()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/opt/homebrew/Caskroom/miniconda/base/envs/orion-dev-38/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/supervisors.py", line 228, in _call_in_supervised_thread
    retval = fn(*args, **kwargs)
  File "example.py", line 8, in slow_worker
    time.sleep(0.1)
TimeoutError
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
