### PR TITLE
Fix loading of existing deployment descriptions from the server

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -787,8 +787,8 @@ async def build(
         "--description",
         "-d",
         help=(
-            "The description to give the deployment. "
-            "If not provided, the description will be populated from the flow's description."
+            "The description to give the deployment. If not provided, the description"
+            " will be populated from the flow's description."
         ),
     ),
     version: str = typer.Option(
@@ -1077,6 +1077,9 @@ async def build(
     if parameters:
         init_kwargs["parameters"] = parameters
 
+    if description:
+        init_kwargs["description"] = description
+
     # if a schedule, tags, work_queue_name, or infrastructure are not provided via CLI,
     # we let `build_from_flow` load them from the server
     if schedule:
@@ -1094,7 +1097,6 @@ async def build(
     deployment = await Deployment.build_from_flow(
         flow=flow,
         name=name,
-        description=description,
         output=deployment_loc,
         skip_upload=skip_upload,
         apply=False,

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -687,7 +687,6 @@ class Deployment(BaseModel):
         cls,
         flow: Flow,
         name: str,
-        description: str = None,
         output: str = None,
         skip_upload: bool = False,
         ignore_file: str = ".prefectignore",
@@ -701,7 +700,6 @@ class Deployment(BaseModel):
         Args:
             flow: A flow function to deploy
             name: A name for the deployment
-            description (optional): A description for the deployment; defaults to the flow's description
             output (optional): if provided, the full deployment specification will be written as a YAML
                 file in the location specified by `output`
             skip_upload: if True, deployment files are not automatically uploaded to remote storage
@@ -718,7 +716,7 @@ class Deployment(BaseModel):
 
         # note that `deployment.load` only updates settings that were *not*
         # provided at initialization
-        deployment = cls(name=name, description=description, **kwargs)
+        deployment = cls(name=name, **kwargs)
         deployment.flow_name = flow.name
         if not deployment.entrypoint:
             ## first see if an entrypoint can be determined


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/pull/8603 accidentally broke loading of an existing description from the server by always providing the description kwarg.