### PR TITLE
Add basic event instrumentation to blocks

### DIFF
--- a/src/prefect/blocks/abstract.py
+++ b/src/prefect/blocks/abstract.py
@@ -54,6 +54,7 @@ class NotificationBlock(Block, ABC):
     """
 
     _block_schema_capabilities = ["notify"]
+    _events_excluded_methods = Block._events_excluded_methods + ["notify"]
 
     @property
     def logger(self) -> Logger:

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -11,6 +11,7 @@ from pydantic import AnyHttpUrl, Field, SecretStr
 from typing_extensions import Literal
 
 from prefect.blocks.abstract import NotificationBlock
+from prefect.events.instrument import instrument_instance_method_call
 from prefect.utilities.asyncutils import sync_compatible
 
 
@@ -59,6 +60,7 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         self._start_apprise_client(self.url)
 
     @sync_compatible
+    @instrument_instance_method_call()
     async def notify(self, body: str, subject: Optional[str] = None):
         await self._apprise_client.async_notify(
             body=body, title=subject, notify_type=self.notify_type

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -65,7 +65,8 @@ class AssertingEventsClient(EventsClient):
 
     @classmethod
     def reset(cls) -> None:
-        """Reset all captured instances and their events.  For use this between tests"""
+        """Reset all captured instances and their events. For use between
+        tests"""
         cls.last = None
         cls.all = []
 

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -1,11 +1,11 @@
 import functools
 import inspect
-from typing import Any, Callable, Dict, Generator, List, Tuple, Type, TypeAlias, Union
+from typing import Any, Callable, Dict, Generator, List, Tuple, Type, Union
 
 from prefect.events import Event
 from prefect.events.worker import get_events_worker
 
-ResourceTuple: TypeAlias = Tuple[Dict[str, Any], List[Dict[str, Any]]]
+ResourceTuple = Tuple[Dict[str, Any], List[Dict[str, Any]]]
 
 
 def emit_instance_method_called_event(

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -1,0 +1,129 @@
+import functools
+import inspect
+from typing import Any, Callable, Dict, Generator, List, Tuple, Type, TypeAlias, Union
+
+from prefect.events import Event
+from prefect.events.worker import get_events_worker
+
+ResourceTuple: TypeAlias = Tuple[Dict[str, Any], List[Dict[str, Any]]]
+
+
+def emit_instance_method_called_event(
+    instance: Any,
+    method_name: str,
+    successful: bool,
+):
+    kind = instance._event_kind()
+    resources: ResourceTuple = instance._event_method_called_resources(method_name)
+    resource, related = resources
+    resource["prefect.result"] = "successful" if successful else "failure"
+
+    event = Event(event=f"{kind}-method.called", resource=resource, related=related)
+
+    with get_events_worker() as events:
+        events.emit(event)
+
+
+def instrument_instance_method_call():
+    def instrument(function):
+        if is_instrumented(function):
+            return function
+
+        if inspect.iscoroutinefunction(function):
+
+            @functools.wraps(function)
+            async def inner(self, *args, **kwargs):
+                success = True
+                try:
+                    return await function(self, *args, **kwargs)
+                except Exception as exc:
+                    success = False
+                    raise exc
+                finally:
+                    emit_instance_method_called_event(
+                        instance=self, method_name=function.__name__, successful=success
+                    )
+
+        else:
+
+            @functools.wraps(function)
+            def inner(self, *args, **kwargs):
+                success = True
+                try:
+                    return function(self, *args, **kwargs)
+                except Exception as exc:
+                    success = False
+                    raise exc
+                finally:
+                    emit_instance_method_called_event(
+                        instance=self, method_name=function.__name__, successful=success
+                    )
+
+        setattr(inner, "__events_instrumented__", True)
+        return inner
+
+    return instrument
+
+
+def is_instrumented(function: Callable) -> bool:
+    """Indicates whether the given function is already instrumented"""
+
+    return getattr(function, "__events_instrumented__", False)
+
+
+def instrumentable_methods(
+    cls: Type,
+    exclude_methods: Union[list[str], set[str], None] = None,
+) -> Generator[Tuple[str, Callable], None, None]:
+    """Returns all of the public methods on a class."""
+
+    for name, kind, definer, method in inspect.classify_class_attrs(cls):
+        if kind == "method":
+            if exclude_methods and name in exclude_methods:
+                continue
+            if name.startswith("_"):
+                continue
+            if definer != cls:
+                continue
+            if not callable(method):
+                continue
+            yield name, method
+
+
+def instrument_method_calls_on_class_instances(
+    exclude_methods: Union[list[str], set[str], None] = None,
+) -> Type:
+    def instrument(cls: Type):
+        """Given a Python class, instruments all "public" and "private" methods that are
+        defined directly on the class (excluding base class methods).
+
+        Examples:
+
+            @instrument_class
+            class MyClass(MyBase):
+                def my_method(self):
+                    ... this method will be instrumented ...
+
+                def _my_method(self):
+                    ... as will this ...
+
+        The tracer used to instrument the class will be the one defined for the class's
+        module.
+        """
+
+        required_events_methods = ["_event_kind", "_event_method_called_resources"]
+        for method in required_events_methods:
+            if not hasattr(cls, method):
+                raise RuntimeError(
+                    f"Unable to instrument class {cls}. Class must define {method!r}."
+                )
+
+        decorator = instrument_instance_method_call()
+        for name, method in instrumentable_methods(
+            cls,
+            exclude_methods=exclude_methods,
+        ):
+            setattr(cls, name, decorator(method))
+        return cls
+
+    return instrument

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -94,8 +94,8 @@ def instrument_method_calls_on_class_instances(
     exclude_methods: Union[List[str], Set[str], None] = None,
 ) -> Type:
     def instrument(cls: Type):
-        """Given a Python class, instruments all "public" and "private" methods that are
-        defined directly on the class (excluding base class methods).
+        """Given a Python class, instruments all "public" methods that are
+        defined directly on the class to emit events when called.
 
         Examples:
 
@@ -105,10 +105,7 @@ def instrument_method_calls_on_class_instances(
                     ... this method will be instrumented ...
 
                 def _my_method(self):
-                    ... as will this ...
-
-        The tracer used to instrument the class will be the one defined for the class's
-        module.
+                    ... this method will not ...
         """
 
         required_events_methods = ["_event_kind", "_event_method_called_resources"]

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -1,6 +1,6 @@
 import functools
 import inspect
-from typing import Any, Callable, Dict, Generator, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Type, Union
 
 from prefect.events import Event
 from prefect.events.worker import get_events_worker
@@ -73,7 +73,7 @@ def is_instrumented(function: Callable) -> bool:
 
 def instrumentable_methods(
     cls: Type,
-    exclude_methods: Union[list[str], set[str], None] = None,
+    exclude_methods: Union[List[str], Set[str], None] = None,
 ) -> Generator[Tuple[str, Callable], None, None]:
     """Returns all of the public methods on a class."""
 
@@ -91,7 +91,7 @@ def instrumentable_methods(
 
 
 def instrument_method_calls_on_class_instances(
-    exclude_methods: Union[list[str], set[str], None] = None,
+    exclude_methods: Union[List[str], Set[str], None] = None,
 ) -> Type:
     def instrument(cls: Type):
         """Given a Python class, instruments all "public" and "private" methods that are

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -3,7 +3,7 @@ import atexit
 import concurrent.futures
 import threading
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect._internal.concurrency.event_loop import call_soon_in_loop
@@ -56,7 +56,7 @@ class EventsWorker:
 
                 await self._client.emit(event)
 
-    def _enqueue(self, value: Optional[Event]):
+    def _enqueue(self, value: Union[Event, None]):
         call_soon_in_loop(self._loop, self._queue.put_nowait, value)
 
     def start(self):

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -1,8 +1,12 @@
+from typing import Generator
+from unittest import mock
+
 import pendulum
 import pytest
 
 from prefect.events import Event
 from prefect.events.clients import AssertingEventsClient
+from prefect.events.worker import EventsWorker
 
 
 @pytest.fixture(autouse=True)
@@ -53,3 +57,25 @@ def example_event_5() -> Event:
         event="delectable.things.happened",
         resource={"prefect.resource.id": "something-valuable"},
     )
+
+
+@pytest.fixture(scope="session")
+def events_worker() -> Generator[EventsWorker, None, None]:
+    worker = EventsWorker(AssertingEventsClient)
+
+    # Mock `get_worker_from_run_context` so that `get_events_worker` context
+    # manager doesn't attempt to manage the lifecycle of this worker.
+    with mock.patch(
+        "prefect.events.worker.get_worker_from_run_context"
+    ) as worker_from_context:
+        worker_from_context.return_value = worker
+
+        worker.start()
+        yield worker
+        worker.stop()
+
+
+@pytest.fixture(autouse=True)
+def reset_worker_events(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+    events_worker._client.events = []

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -59,8 +59,8 @@ def example_event_5() -> Event:
     )
 
 
-@pytest.fixture(scope="session")
-def events_worker() -> Generator[EventsWorker, None, None]:
+@pytest.fixture(scope="module")
+def asserting_events_worker() -> Generator[EventsWorker, None, None]:
     worker = EventsWorker(AssertingEventsClient)
 
     # Mock `get_worker_from_run_context` so that `get_events_worker` context
@@ -75,7 +75,7 @@ def events_worker() -> Generator[EventsWorker, None, None]:
         worker.stop()
 
 
-@pytest.fixture(autouse=True)
-def reset_worker_events(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
-    events_worker._client.events = []
+@pytest.fixture()
+def reset_worker_events(asserting_events_worker: EventsWorker):
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+    asserting_events_worker._client.events = []

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -1,0 +1,34 @@
+import time
+
+from pydantic import SecretStr
+
+from prefect.blocks.system import Secret
+from prefect.events.clients import AssertingEventsClient
+from prefect.events.worker import EventsWorker
+
+
+async def test_blocks_instrumented(events_worker: EventsWorker):
+    secret = Secret(value=SecretStr("I'm hidden!"))
+    await secret.save("top-secret", overwrite=True)
+    secret = await Secret.load("top-secret")
+    secret.get()
+
+    time.sleep(0.1)
+
+    assert isinstance(events_worker._client, AssertingEventsClient)
+    assert len(events_worker._client.events) == 3
+
+    save_event = events_worker._client.events[0]
+    assert save_event.resource.id == "prefect.block-document.anonymous.save"
+    assert save_event.related[0].id == "prefect.block-type.secret"
+    assert save_event.related[0].role == "block-type"
+
+    load_event = events_worker._client.events[1]
+    assert load_event.resource.id == "prefect.block-document.top-secret.load"
+    assert load_event.related[0].id == "prefect.block-type.secret"
+    assert load_event.related[0].role == "block-type"
+
+    get_event = events_worker._client.events[2]
+    assert get_event.resource.id == "prefect.block-document.top-secret.get"
+    assert get_event.related[0].id == "prefect.block-type.secret"
+    assert get_event.related[0].role == "block-type"

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -7,7 +7,7 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 
 
-async def test_blocks_instrumented(
+async def test_async_blocks_instrumented(
     asserting_events_worker: EventsWorker, reset_worker_events
 ):
     secret = Secret(value=SecretStr("I'm hidden!"))
@@ -21,7 +21,36 @@ async def test_blocks_instrumented(
     assert len(asserting_events_worker._client.events) == 3
 
     save_event = asserting_events_worker._client.events[0]
-    assert save_event.resource.id == "prefect.block-document.anonymous.save"
+    assert save_event.resource.id == "prefect.block-document.top-secret.save"
+    assert save_event.related[0].id == "prefect.block-type.secret"
+    assert save_event.related[0].role == "block-type"
+
+    load_event = asserting_events_worker._client.events[1]
+    assert load_event.resource.id == "prefect.block-document.top-secret.load"
+    assert load_event.related[0].id == "prefect.block-type.secret"
+    assert load_event.related[0].role == "block-type"
+
+    get_event = asserting_events_worker._client.events[2]
+    assert get_event.resource.id == "prefect.block-document.top-secret.get"
+    assert get_event.related[0].id == "prefect.block-type.secret"
+    assert get_event.related[0].role == "block-type"
+
+
+def test_sync_blocks_instrumented(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
+    secret = Secret(value=SecretStr("I'm hidden!"))
+    secret.save("top-secret", overwrite=True)
+    secret = Secret.load("top-secret")
+    secret.get()
+
+    time.sleep(0.1)
+
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+    assert len(asserting_events_worker._client.events) == 3
+
+    save_event = asserting_events_worker._client.events[0]
+    assert save_event.resource.id == "prefect.block-document.top-secret.save"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -7,7 +7,9 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 
 
-async def test_blocks_instrumented(events_worker: EventsWorker):
+async def test_blocks_instrumented(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
     secret = Secret(value=SecretStr("I'm hidden!"))
     await secret.save("top-secret", overwrite=True)
     secret = await Secret.load("top-secret")
@@ -15,20 +17,20 @@ async def test_blocks_instrumented(events_worker: EventsWorker):
 
     time.sleep(0.1)
 
-    assert isinstance(events_worker._client, AssertingEventsClient)
-    assert len(events_worker._client.events) == 3
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+    assert len(asserting_events_worker._client.events) == 3
 
-    save_event = events_worker._client.events[0]
+    save_event = asserting_events_worker._client.events[0]
     assert save_event.resource.id == "prefect.block-document.anonymous.save"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 
-    load_event = events_worker._client.events[1]
+    load_event = asserting_events_worker._client.events[1]
     assert load_event.resource.id == "prefect.block-document.top-secret.load"
     assert load_event.related[0].id == "prefect.block-type.secret"
     assert load_event.related[0].role == "block-type"
 
-    get_event = events_worker._client.events[2]
+    get_event = asserting_events_worker._client.events[2]
     assert get_event.resource.id == "prefect.block-document.top-secret.get"
     assert get_event.related[0].id == "prefect.block-type.secret"
     assert get_event.related[0].role == "block-type"

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -7,6 +7,7 @@ from prefect.blocks.notifications import PagerDutyWebHook
 from prefect.blocks.system import Secret
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
+from prefect.testing.utilities import AsyncMock
 
 
 async def test_async_blocks_instrumented(
@@ -78,7 +79,7 @@ def test_notifications_notify_instrumented_sync(
 ):
     with mock.patch("apprise.Apprise", autospec=True) as AppriseMock:
         apprise_instance_mock = AppriseMock.return_value
-        apprise_instance_mock.async_notify = mock.AsyncMock()
+        apprise_instance_mock.async_notify = AsyncMock()
 
         block = PagerDutyWebHook(
             integration_key=SecretStr("integration_key"), api_key=SecretStr("api_key")
@@ -117,7 +118,7 @@ async def test_notifications_notify_instrumented_async(
 ):
     with mock.patch("apprise.Apprise", autospec=True) as AppriseMock:
         apprise_instance_mock = AppriseMock.return_value
-        apprise_instance_mock.async_notify = mock.AsyncMock()
+        apprise_instance_mock.async_notify = AsyncMock()
 
         block = PagerDutyWebHook(
             integration_key=SecretStr("integration_key"), api_key=SecretStr("api_key")

--- a/tests/events/test_events_instrument.py
+++ b/tests/events/test_events_instrument.py
@@ -1,0 +1,179 @@
+import time
+from typing import Generator
+from unittest import mock
+
+import pytest
+
+from prefect.events.clients import AssertingEventsClient
+from prefect.events.instrument import (
+    ResourceTuple,
+    instrument_method_calls_on_class_instances,
+)
+from prefect.events.worker import EventsWorker
+
+
+@pytest.fixture(scope="module")
+def events_worker() -> Generator[EventsWorker, None, None]:
+    worker = EventsWorker(AssertingEventsClient)
+
+    # Mock `get_worker_from_run_context` so that `get_events_worker` context
+    # manager doesn't attempt to manage the lifecycle of this worker.
+    with mock.patch(
+        "prefect.events.worker.get_worker_from_run_context"
+    ) as worker_from_context:
+        worker_from_context.return_value = worker
+
+        worker.start()
+        yield worker
+        worker.stop()
+
+
+@pytest.fixture(autouse=True)
+def reset_worker_events(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+    events_worker._client.events = []
+
+
+def test_requires_events_methods_to_be_defined():
+    with pytest.raises(RuntimeError, match="Class must define '_event_kind'."):
+
+        @instrument_method_calls_on_class_instances()
+        class Nope:
+            pass
+
+
+@instrument_method_calls_on_class_instances(exclude_methods=["excluded_method"])
+class InstrumentedClass:
+    not_callable = "some value"
+
+    def _event_kind(self):
+        return "prefect.instrumented"
+
+    def _event_method_called_resources(self, method_name: str) -> ResourceTuple:
+        return (
+            {
+                "prefect.resource.id": f"prefect.some-class.{method_name}",
+            },
+            [
+                {
+                    "prefect.resource.id": f"prefect.class.InstrumentedClass",
+                    "prefect.resource.role": "class",
+                }
+            ],
+        )
+
+    def excluded_method(self):
+        pass
+
+    def sync_method(self):
+        pass
+
+    async def async_method(self):
+        pass
+
+    def sync_fail(self):
+        raise Exception("Sync method failed.")
+
+    async def async_fail(self):
+        raise Exception("Async method failed.")
+
+    def _private_method(self):
+        pass
+
+    @staticmethod
+    def static_method():
+        pass
+
+
+async def test_instruments_methods(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+
+    instance = InstrumentedClass()
+    instance.sync_method()
+    await instance.async_method()
+
+    time.sleep(0.1)
+
+    assert len(events_worker._client.events) == 2
+
+    sync_event = events_worker._client.events[0]
+    assert sync_event.resource.id == "prefect.some-class.sync_method"
+    assert sync_event.resource["prefect.result"] == "successful"
+    assert sync_event.related[0].id == "prefect.class.InstrumentedClass"
+    assert sync_event.related[0].role == "class"
+
+    async_event = events_worker._client.events[1]
+    assert async_event.resource.id == "prefect.some-class.async_method"
+    assert async_event.resource["prefect.result"] == "successful"
+    assert async_event.related[0].id == "prefect.class.InstrumentedClass"
+    assert async_event.related[0].role == "class"
+
+
+async def test_handles_method_failure(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+
+    instance = InstrumentedClass()
+
+    try:
+        instance.sync_fail()
+    except:
+        pass
+
+    try:
+        await instance.async_fail()
+    except:
+        pass
+
+    time.sleep(0.1)
+
+    assert len(events_worker._client.events) == 2
+
+    sync_event = events_worker._client.events[0]
+    assert sync_event.resource.id == "prefect.some-class.sync_fail"
+    assert sync_event.resource["prefect.result"] == "failure"
+    assert sync_event.related[0].id == "prefect.class.InstrumentedClass"
+    assert sync_event.related[0].role == "class"
+
+    async_event = events_worker._client.events[1]
+    assert async_event.resource.id == "prefect.some-class.async_fail"
+    assert async_event.resource["prefect.result"] == "failure"
+    assert async_event.related[0].id == "prefect.class.InstrumentedClass"
+    assert async_event.related[0].role == "class"
+
+
+async def test_ignores_excluded_and_private_methods(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+
+    instance = InstrumentedClass()
+
+    instance.excluded_method()
+    instance._private_method()
+    InstrumentedClass.static_method()
+
+    time.sleep(0.1)
+
+    assert len(events_worker._client.events) == 0
+
+
+async def test_instrument_idempotent(events_worker: EventsWorker):
+    assert isinstance(events_worker._client, AssertingEventsClient)
+
+    class AClass:
+        def _event_kind(self):
+            return "prefect.a-class"
+
+        def _event_method_called_resources(self, method_name: str) -> ResourceTuple:
+            return ({"prefect.resource.id": "some-id"}, [])
+
+        def some_method(self):
+            pass
+
+    Instrumented = instrument_method_calls_on_class_instances()(AClass)
+    InstrumentedTwice = instrument_method_calls_on_class_instances()(Instrumented)
+
+    instance = InstrumentedTwice()
+    instance.some_method()
+
+    time.sleep(0.1)
+
+    assert len(events_worker._client.events) == 1

--- a/tests/events/test_events_instrument.py
+++ b/tests/events/test_events_instrument.py
@@ -1,6 +1,4 @@
 import time
-from typing import Generator
-from unittest import mock
 
 import pytest
 
@@ -10,28 +8,6 @@ from prefect.events.instrument import (
     instrument_method_calls_on_class_instances,
 )
 from prefect.events.worker import EventsWorker
-
-
-@pytest.fixture(scope="module")
-def events_worker() -> Generator[EventsWorker, None, None]:
-    worker = EventsWorker(AssertingEventsClient)
-
-    # Mock `get_worker_from_run_context` so that `get_events_worker` context
-    # manager doesn't attempt to manage the lifecycle of this worker.
-    with mock.patch(
-        "prefect.events.worker.get_worker_from_run_context"
-    ) as worker_from_context:
-        worker_from_context.return_value = worker
-
-        worker.start()
-        yield worker
-        worker.stop()
-
-
-@pytest.fixture(autouse=True)
-def reset_worker_events(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
-    events_worker._client.events = []
 
 
 def test_requires_events_methods_to_be_defined():

--- a/tests/events/test_events_instrument.py
+++ b/tests/events/test_events_instrument.py
@@ -61,8 +61,10 @@ class InstrumentedClass:
         pass
 
 
-async def test_instruments_methods(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
+async def test_instruments_methods(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
     instance = InstrumentedClass()
     instance.sync_method()
@@ -70,23 +72,25 @@ async def test_instruments_methods(events_worker: EventsWorker):
 
     time.sleep(0.1)
 
-    assert len(events_worker._client.events) == 2
+    assert len(asserting_events_worker._client.events) == 2
 
-    sync_event = events_worker._client.events[0]
+    sync_event = asserting_events_worker._client.events[0]
     assert sync_event.resource.id == "prefect.some-class.sync_method"
     assert sync_event.resource["prefect.result"] == "successful"
     assert sync_event.related[0].id == "prefect.class.InstrumentedClass"
     assert sync_event.related[0].role == "class"
 
-    async_event = events_worker._client.events[1]
+    async_event = asserting_events_worker._client.events[1]
     assert async_event.resource.id == "prefect.some-class.async_method"
     assert async_event.resource["prefect.result"] == "successful"
     assert async_event.related[0].id == "prefect.class.InstrumentedClass"
     assert async_event.related[0].role == "class"
 
 
-async def test_handles_method_failure(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
+async def test_handles_method_failure(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
     instance = InstrumentedClass()
 
@@ -102,23 +106,25 @@ async def test_handles_method_failure(events_worker: EventsWorker):
 
     time.sleep(0.1)
 
-    assert len(events_worker._client.events) == 2
+    assert len(asserting_events_worker._client.events) == 2
 
-    sync_event = events_worker._client.events[0]
+    sync_event = asserting_events_worker._client.events[0]
     assert sync_event.resource.id == "prefect.some-class.sync_fail"
     assert sync_event.resource["prefect.result"] == "failure"
     assert sync_event.related[0].id == "prefect.class.InstrumentedClass"
     assert sync_event.related[0].role == "class"
 
-    async_event = events_worker._client.events[1]
+    async_event = asserting_events_worker._client.events[1]
     assert async_event.resource.id == "prefect.some-class.async_fail"
     assert async_event.resource["prefect.result"] == "failure"
     assert async_event.related[0].id == "prefect.class.InstrumentedClass"
     assert async_event.related[0].role == "class"
 
 
-async def test_ignores_excluded_and_private_methods(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
+async def test_ignores_excluded_and_private_methods(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
     instance = InstrumentedClass()
 
@@ -128,11 +134,13 @@ async def test_ignores_excluded_and_private_methods(events_worker: EventsWorker)
 
     time.sleep(0.1)
 
-    assert len(events_worker._client.events) == 0
+    assert len(asserting_events_worker._client.events) == 0
 
 
-async def test_instrument_idempotent(events_worker: EventsWorker):
-    assert isinstance(events_worker._client, AssertingEventsClient)
+async def test_instrument_idempotent(
+    asserting_events_worker: EventsWorker, reset_worker_events
+):
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
     class AClass:
         def _event_kind(self):
@@ -152,4 +160,4 @@ async def test_instrument_idempotent(events_worker: EventsWorker):
 
     time.sleep(0.1)
 
-    assert len(events_worker._client.events) == 1
+    assert len(asserting_events_worker._client.events) == 1

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+from unittest import mock
 
 import pytest
 
@@ -61,6 +62,13 @@ def test_stop_is_idempontent(worker: EventsWorker):
     worker.start()
     worker.stop()
     worker.stop()
+
+
+def test_worker_failure(worker: EventsWorker):
+    with mock.patch.object(worker, "_main_loop") as main_loop:
+        main_loop.side_effect = Exception("Boom!")
+        with pytest.raises(Exception, match="Boom!"):
+            worker.start()
 
 
 def test_emits_event_via_client(worker: EventsWorker, event: Event):


### PR DESCRIPTION
This adds basic support for sending events when a methods on a block are called. It's supported via decorators that decorate each method of a class and use the `EventsWorker` to emit events when one of those methods are called. The class itself supplies the main `kind` as well as the bulk of the resource and related resources.

Related to #8672 

### Example
```python
from pydantic import SecretStr
from prefect.blocks.system import Secret


secret = Secret(value=SecretStr("I'm hidden!"))
await secret.save("top-secret", overwrite=True)
secret = await Secret.load("top-secret")
secret.get()
```

Would result in three events being emitted, one for each method call to the
Secret block:

```
Event(
    occurred=...,
    event='prefect.block.secret.save.called',
    resource=Resource(__root__={'prefect.resource.id': 'prefect.block-document.top-secret'}),
    related=[RelatedResource(__root__={'prefect.resource.id': 'prefect.block-type.secret', 'prefect.resource.role': 'block-type'})],
    payload={},
    id=UUID(...)
)

Event(
    occurred=...,
    event='prefect.block.secret.load.called',
    resource=Resource(__root__={'prefect.resource.id': 'prefect.block-document.top-secret'}),
    related=[RelatedResource(__root__={'prefect.resource.id': 'prefect.block-type.secret', 'prefect.resource.role': 'block-type'})],
    payload={},
    id=UUID(...)
)

Event(
    occurred=...,
    event='prefect.block.secret.get.called',
    resource=Resource(__root__={'prefect.resource.id': 'prefect.block-document.top-secret', 'prefect.result': 'successful'}),
    related=[RelatedResource(__root__={'prefect.resource.id': 'prefect.block-type.secret', 'prefect.resource.role': 'block-type'})],
    payload={},
    id=UUID(...)
)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
