### PR TITLE
Consolidate `WorkItem` and `Call` classes

### DIFF
--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -20,7 +20,7 @@ Future = Union[concurrent.futures.Future, asyncio.Future]
 
 
 def create_call(__fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Call[T]:
-    return Call(fn=__fn, args=args, kwargs=kwargs)
+    return Call.new(__fn, *args, **kwargs)
 
 
 class _base(abc.ABC):

--- a/tests/_internal/concurrency/test_supervisors.py
+++ b/tests/_internal/concurrency/test_supervisors.py
@@ -28,6 +28,14 @@ async def aidentity(x):
     return x
 
 
+def raises(exc):
+    raise exc
+
+
+async def araises(exc):
+    raise exc
+
+
 def sleep_repeatedly(seconds: int):
     # Synchronous sleeps cannot be interrupted unless a signal is used, so we check
     # for cancellation between sleep calls
@@ -157,3 +165,23 @@ async def test_async_call_sync_function():
 async def test_async_call_async_function():
     call = Call.new(aidentity, 1)
     assert await call() == 1
+
+
+@pytest.mark.parametrize("fn", [raises, araises])
+def test_sync_call_with_exception(fn):
+    call = Call.new(fn, ValueError("test"))
+    with pytest.raises(ValueError, match="test"):
+        call()
+
+
+async def test_async_call_sync_function():
+    call = Call.new(raises, ValueError("test"))
+    with pytest.raises(ValueError, match="test"):
+        call()
+
+
+async def test_async_call_async_function():
+    call = Call.new(araises, ValueError("test"))
+    coro = call()  # should not raise
+    with pytest.raises(ValueError):
+        await coro

--- a/tests/_internal/concurrency/test_supervisors.py
+++ b/tests/_internal/concurrency/test_supervisors.py
@@ -20,6 +20,14 @@ def fake_fn(*args, **kwargs):
     pass
 
 
+def identity(x):
+    return x
+
+
+async def aidentity(x):
+    return x
+
+
 def sleep_repeatedly(seconds: int):
     # Synchronous sleeps cannot be interrupted unless a signal is used, so we check
     # for cancellation between sleep calls
@@ -133,3 +141,19 @@ async def test_async_supervisor_timeout_in_main_thread():
         # to the main thread should have a timeout error
         with pytest.raises(asyncio.CancelledError):
             future.result()
+
+
+@pytest.mark.parametrize("fn", [identity, aidentity])
+def test_sync_call(fn):
+    call = Call.new(fn, 1)
+    assert call() == 1
+
+
+async def test_async_call_sync_function():
+    call = Call.new(identity, 1)
+    assert call() == 1
+
+
+async def test_async_call_async_function():
+    call = Call.new(aidentity, 1)
+    assert await call() == 1


### PR DESCRIPTION
All changes are internal to the `supervisors` module.

- Combine `WorkItem` and `Call` classes
- Update `Call.__call__` to use `Call.run` behind the scenes
- Improve `Call.run` handling of async

