### PR TITLE
Chore: Don't use a path for mkdocs package CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -171,7 +171,7 @@ Content-Security-Policy = """\
         https://cdn.segment.com/ \
         https://cdn.segment.prefect.io \
         https://www.googletagmanager.com \
-        https://unpkg.com/mermaid \
+        https://unpkg.com \
         ; \
       style-src \
         'self' \


### PR DESCRIPTION
Follow up from #8700 