### PR TITLE
Use `PREFECT_API_URL` when initializing events client

### DIFF
--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -127,7 +127,7 @@ def get_worker_from_settings() -> EventsWorker:
         return EventsWorker(
             PrefectCloudEventsClient,
             {
-                "api_url": PREFECT_CLOUD_API_URL.value(),
+                "api_url": PREFECT_API_URL.value(),
                 "api_key": PREFECT_API_KEY.value(),
             },
         )

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -90,7 +90,7 @@ def test_worker_from_settings_null_client_non_cloud_api_url():
     with temporary_settings(
         updates={
             PREFECT_API_URL: "http://localhost:8080/api",
-            PREFECT_CLOUD_API_URL: "https://api.prefect.cloud/api/",
+            PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
         }
     ):
         worker = get_worker_from_settings()
@@ -101,7 +101,7 @@ def test_worker_from_settings_null_client_cloud_api_url_experiment_disabled():
     with temporary_settings(
         updates={
             PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT: False,
-            PREFECT_API_URL: "https://api.prefect.cloud/api/",
+            PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
             PREFECT_CLOUD_API_URL: "https://api.prefect.cloud/api/",
         }
     ):
@@ -113,7 +113,7 @@ def test_worker_from_settings_null_client_cloud_api_url_experiment_enabled():
     with temporary_settings(
         updates={
             PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT: True,
-            PREFECT_API_URL: "https://api.prefect.cloud/api/",
+            PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
             PREFECT_CLOUD_API_URL: "https://api.prefect.cloud/api/",
         }
     ):


### PR DESCRIPTION
When connecting to Cloud's events API via the events worker the events client was getting a 400, this turned out to be because the worker was using the `PREFECT_CLOUD_API_URL` instead of the `PREFECT_API_URL`.