### PR TITLE
Add carriage return to `prompt_select_from_list`

### DIFF
--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -200,7 +200,7 @@ def prompt_select_from_list(
             elif key == readchar.key.CTRL_C:
                 # gracefully exit with no message
                 exit_with_error("")
-            elif key == readchar.key.ENTER:
+            elif key == readchar.key.ENTER or key == readchar.key.CR:
                 selected_option = options[current_idx]
                 if isinstance(selected_option, tuple):
                     selected_option = selected_option[0]


### PR DESCRIPTION
Otherwise, when I attempted to use the `prefect cloud login` CLI command it would not let me move forward.

`ENTER` on my machine actually sent `CR` then `CTRL_M`; no idea what's up with that maybe it's a readchar bug?

```
❯ pip show readchar          
Name: readchar
Version: 4.0.3
```