### PR TITLE
Bugfix: Deployment and ConcurrencyLimit pages tabs

### DIFF
--- a/ui/src/pages/ConcurrencyLimit.vue
+++ b/ui/src/pages/ConcurrencyLimit.vue
@@ -36,7 +36,7 @@
     { label: 'Details', hidden: media.xl },
     { label: 'Active Task Runs' },
   ])
-  const tabs = useTabs(computedTabs)
+  const { tabs } = useTabs(computedTabs)
 
   const subscriptionOptions = {
     interval: 300000,

--- a/ui/src/pages/Deployment.vue
+++ b/ui/src/pages/Deployment.vue
@@ -42,12 +42,7 @@
     </p-tabs>
 
     <template #well>
-      <DeploymentDetails
-        v-if="deployment"
-        :deployment="deployment"
-        alternate
-        @update="deploymentSubscription.refresh"
-      />
+      <DeploymentDetails v-if="deployment" :deployment="deployment" alternate @update="deploymentSubscription.refresh" />
     </template>
   </p-layout-well>
 </template>
@@ -72,6 +67,9 @@
     interval: 300000,
   }
 
+  const deploymentSubscription = useSubscription(api.deployments.getDeployment, [deploymentId.value], subscriptionOptions)
+  const deployment = computed(() => deploymentSubscription.response)
+
   const computedTabs = computed(() => [
     { label: 'Details', hidden: media.xl },
     { label: 'Runs' },
@@ -79,10 +77,7 @@
     { label: 'Infra Overrides', hidden: deployment.value?.deprecated },
     { label: 'Description' },
   ])
-  const tabs = useTabs(computedTabs)
-
-  const deploymentSubscription = useSubscription(api.deployments.getDeployment, [deploymentId.value], subscriptionOptions)
-  const deployment = computed(() => deploymentSubscription.response)
+  const { tabs } = useTabs(computedTabs)
 
   function routeToDeployments(): void {
     router.push(routes.deployments())
@@ -116,8 +111,7 @@
 </script>
 
 <style>
-.deployment__infra-overrides { @apply
-  px-4
-  py-3
+.deployment__infra-overrides {
+  @apply px-4 py-3
 }
 </style>

--- a/ui/src/pages/Deployment.vue
+++ b/ui/src/pages/Deployment.vue
@@ -111,7 +111,8 @@
 </script>
 
 <style>
-.deployment__infra-overrides {
-  @apply px-4 py-3
+.deployment__infra-overrides { @apply
+  px-4
+  py-3
 }
 </style>

--- a/ui/src/pages/TaskRun.vue
+++ b/ui/src/pages/TaskRun.vue
@@ -20,7 +20,7 @@
         </ExtraInfoModal>
       </template>
       <template #task-inputs>
-        <CopyableWrapper v-if="deployment" :text-to-copy="parameters">
+        <CopyableWrapper v-if="taskRun" :text-to-copy="parameters">
           <p-code-highlight lang="json" :text="parameters" class="task-run__inputs" />
         </CopyableWrapper>
       </template>


### PR DESCRIPTION
Updates the Deployment and ConcurrencyLimit pages to use the new `useTabs` composition return value properly instead of trying to map on an object. 

Resolves: #8712