### PR TITLE
Add chaining to cancel contexts

### DIFF
--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -157,7 +157,7 @@ def cancel_sync_after(timeout: Optional[float]):
             f"Entered cancel context on Windows; %.2f timeout will not be enforced.",
             timeout,
         )
-        yield ctx
+        yield CancelContext(timeout=None)
         return
 
     if threading.current_thread() is threading.main_thread():

--- a/tests/_internal/concurrency/test_timeouts.py
+++ b/tests/_internal/concurrency/test_timeouts.py
@@ -5,12 +5,39 @@ import time
 import pytest
 
 from prefect._internal.concurrency.timeouts import (
+    CancelContext,
     cancel_async_after,
     cancel_async_at,
     cancel_sync_after,
     cancel_sync_at,
     get_deadline,
 )
+
+
+async def test_cancel_context():
+    ctx = CancelContext(timeout=1)
+    assert not ctx.cancelled
+    ctx.mark_cancelled()
+    assert ctx.cancelled
+
+
+async def test_cancel_context_chain():
+    ctx1 = CancelContext(timeout=1)
+    ctx2 = CancelContext(timeout=None)
+    ctx1.chain(ctx2)
+    assert not ctx2.cancelled
+    ctx1.mark_cancelled()
+    assert ctx1.cancelled
+    assert ctx2.cancelled
+
+
+async def test_cancel_context_chain_cancelled_first():
+    ctx1 = CancelContext(timeout=1)
+    ctx2 = CancelContext(timeout=None)
+    ctx1.mark_cancelled()
+    ctx1.chain(ctx2)
+    assert ctx1.cancelled
+    assert ctx2.cancelled
 
 
 async def test_cancel_async_after():


### PR DESCRIPTION
Adds a `chain` method to `CancelContexts` allowing cancelled marks to be propagated upstream. This will be required for adding a `cancelled` attribute to `Call` objects in supervisors since they can be cancelled by multiple implementations (sync / async); this is, in turn, required for only reporting cancellations caused by us as flow run timeouts in #8702.