### PR TITLE
Adds worker command output when applying deployments with a work pool

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -17,11 +17,13 @@ import yaml
 from rich.pretty import Pretty
 from rich.table import Table
 
+from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.blocks.core import Block
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.utilities import inject_client
 from prefect.context import PrefectObjectRegistry, registry_from_script
 from prefect.deployments import Deployment, load_deployments_from_yaml
 from prefect.exceptions import (
@@ -159,24 +161,60 @@ async def create_work_queue_and_set_concurrency_limit(
             )
 
 
-async def check_work_pool_exists(work_pool_name: Optional[str]):
+@inject_client
+async def check_work_pool_exists(
+    work_pool_name: Optional[str], client: PrefectClient = None
+):
     if work_pool_name is not None:
-        async with get_client() as client:
-            try:
-                await client.read_work_pool(work_pool_name=work_pool_name)
-            except ObjectNotFound:
-                app.console.print(
-                    (
-                        "\nThis deployment specifies a work pool name of"
-                        f" {work_pool_name!r}, but no such work pool exists.\n"
-                    ),
-                    style="red ",
-                )
-                app.console.print("To create a work pool via the CLI:\n")
-                app.console.print(
-                    f"$ prefect work-pool create {work_pool_name!r}\n", style="blue"
-                )
-                exit_with_error("Work pool not found!")
+        try:
+            await client.read_work_pool(work_pool_name=work_pool_name)
+        except ObjectNotFound:
+            app.console.print(
+                (
+                    "\nThis deployment specifies a work pool name of"
+                    f" {work_pool_name!r}, but no such work pool exists.\n"
+                ),
+                style="red ",
+            )
+            app.console.print("To create a work pool via the CLI:\n")
+            app.console.print(
+                f"$ prefect work-pool create {work_pool_name!r}\n", style="blue"
+            )
+            exit_with_error("Work pool not found!")
+
+
+@inject_client
+async def _print_deployment_work_pool_instructions(
+    work_pool_name: str, client: PrefectClient = None
+):
+    work_pool = await client.read_work_pool(work_pool_name)
+    blurb = (
+        "\nTo execute flow runs from this deployment, start an agent "
+        f"that pulls work from the {work_pool_name!r} work pool:"
+    )
+    command = f"$ prefect agent start -p {work_pool_name!r}"
+    if work_pool.type != "prefect-agent":
+        if experiment_enabled("workers"):
+            blurb = (
+                "\nTo execute flow runs from this deployment, start a"
+                " worker that pulls work from the"
+                f" {work_pool_name!r} work pool:"
+            )
+            command = f"$ prefect worker start -p {work_pool_name!r}"
+        else:
+            blurb = (
+                "\nTo execute flow runs from this deployment, please"
+                " enable the workers CLI and start a worker that pulls"
+                f" work from the {work_pool_name!r} work pool:"
+            )
+            command = (
+                "$ prefect config set"
+                " PREFECT_EXPERIMENTAL_ENABLE_WORKERS=True\n$ prefect"
+                f" worker start -p {work_pool_name!r}"
+            )
+
+    app.console.print(blurb)
+    app.console.print(command, style="blue")
 
 
 class RichTextIO:
@@ -644,84 +682,87 @@ async def apply(
     """
     Create or update a deployment from a YAML file.
     """
-    for path in paths:
-        try:
-            deployment = await Deployment.load_from_yaml(path)
-            app.console.print(f"Successfully loaded {deployment.name!r}", style="green")
-        except Exception as exc:
-            exit_with_error(f"'{path!s}' did not conform to deployment spec: {exc!r}")
+    async with get_client() as client:
+        for path in paths:
+            try:
+                deployment = await Deployment.load_from_yaml(path)
+                app.console.print(
+                    f"Successfully loaded {deployment.name!r}", style="green"
+                )
+            except Exception as exc:
+                exit_with_error(
+                    f"'{path!s}' did not conform to deployment spec: {exc!r}"
+                )
 
-        await create_work_queue_and_set_concurrency_limit(
-            deployment.work_queue_name,
-            deployment.work_pool_name,
-            work_queue_concurrency,
-        )
+            await create_work_queue_and_set_concurrency_limit(
+                deployment.work_queue_name,
+                deployment.work_pool_name,
+                work_queue_concurrency,
+            )
 
-        if upload:
-            if (
-                deployment.storage
-                and "put-directory" in deployment.storage.get_block_capabilities()
-            ):
-                file_count = await deployment.upload_to_storage()
-                if file_count:
+            if upload:
+                if (
+                    deployment.storage
+                    and "put-directory" in deployment.storage.get_block_capabilities()
+                ):
+                    file_count = await deployment.upload_to_storage()
+                    if file_count:
+                        app.console.print(
+                            (
+                                f"Successfully uploaded {file_count} files to"
+                                f" {deployment.location}"
+                            ),
+                            style="green",
+                        )
+                else:
                     app.console.print(
                         (
-                            f"Successfully uploaded {file_count} files to"
-                            f" {deployment.location}"
+                            f"Deployment storage {deployment.storage} does not have"
+                            " upload capabilities; no files uploaded."
                         ),
-                        style="green",
+                        style="red",
                     )
+            await check_work_pool_exists(
+                work_pool_name=deployment.work_pool_name, client=client
+            )
+            deployment_id = await deployment.apply()
+            app.console.print(
+                (
+                    f"Deployment '{deployment.flow_name}/{deployment.name}'"
+                    f" successfully created with id '{deployment_id}'."
+                ),
+                style="green",
+            )
+
+            if PREFECT_UI_URL:
+                app.console.print(
+                    "View Deployment in UI:"
+                    f" {PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
+                )
+
+            if deployment.work_pool_name is not None:
+                await _print_deployment_work_pool_instructions(
+                    work_pool_name=deployment.work_pool_name, client=client
+                )
+            elif deployment.work_queue_name is not None:
+                app.console.print(
+                    "\nTo execute flow runs from this deployment, start an agent that"
+                    f" pulls work from the {deployment.work_queue_name!r} work queue:"
+                )
+                app.console.print(
+                    f"$ prefect agent start -q {deployment.work_queue_name!r}",
+                    style="blue",
+                )
             else:
                 app.console.print(
                     (
-                        f"Deployment storage {deployment.storage} does not have upload"
-                        " capabilities; no files uploaded."
+                        "\nThis deployment does not specify a work queue name, which"
+                        " means agents will not be able to pick up its runs. To add a"
+                        " work queue, edit the deployment spec and re-run this command,"
+                        " or visit the deployment in the UI."
                     ),
                     style="red",
                 )
-        await check_work_pool_exists(deployment.work_pool_name)
-        deployment_id = await deployment.apply()
-        app.console.print(
-            (
-                f"Deployment '{deployment.flow_name}/{deployment.name}' successfully"
-                f" created with id '{deployment_id}'."
-            ),
-            style="green",
-        )
-
-        if PREFECT_UI_URL:
-            app.console.print(
-                "View Deployment in UI:"
-                f" {PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
-            )
-
-        if deployment.work_pool_name is not None:
-            app.console.print(
-                "\nTo execute flow runs from this deployment, start an agent "
-                f"that pulls work from the {deployment.work_pool_name!r} work pool:"
-            )
-            app.console.print(
-                f"$ prefect agent start -p {deployment.work_pool_name!r}",
-                style="blue",
-            )
-        elif deployment.work_queue_name is not None:
-            app.console.print(
-                "\nTo execute flow runs from this deployment, start an agent "
-                f"that pulls work from the {deployment.work_queue_name!r} work queue:"
-            )
-            app.console.print(
-                f"$ prefect agent start -q {deployment.work_queue_name!r}", style="blue"
-            )
-        else:
-            app.console.print(
-                (
-                    "\nThis deployment does not specify a work queue name, which means"
-                    " agents will not be able to pick up its runs. To add a work queue,"
-                    " edit the deployment spec and re-run this command, or visit the"
-                    " deployment in the UI."
-                ),
-                style="red",
-            )
 
 
 @deployment_app.command()
@@ -1137,43 +1178,42 @@ async def build(
             )
 
     if _apply:
-        await check_work_pool_exists(deployment.work_pool_name)
-        deployment_id = await deployment.apply()
-        app.console.print(
-            (
-                f"Deployment '{deployment.flow_name}/{deployment.name}' successfully"
-                f" created with id '{deployment_id}'."
-            ),
-            style="green",
-        )
-        if deployment.work_pool_name is not None:
-            app.console.print(
-                "\nTo execute flow runs from this deployment, start an agent "
-                f"that pulls work from the {deployment.work_pool_name!r} work pool:"
+        async with get_client() as client:
+            await check_work_pool_exists(
+                work_pool_name=deployment.work_pool_name, client=client
             )
-            app.console.print(
-                f"$ prefect agent start -p {deployment.work_pool_name!r}",
-                style="blue",
-            )
-
-        elif deployment.work_queue_name is not None:
-            app.console.print(
-                "\nTo execute flow runs from this deployment, start an agent "
-                f"that pulls work from the {deployment.work_queue_name!r} work queue:"
-            )
-            app.console.print(
-                f"$ prefect agent start -q {deployment.work_queue_name!r}", style="blue"
-            )
-        else:
+            deployment_id = await deployment.apply()
             app.console.print(
                 (
-                    "\nThis deployment does not specify a work queue name, which means"
-                    " agents will not be able to pick up its runs. To add a work queue,"
-                    " edit the deployment spec and re-run this command, or visit the"
-                    " deployment in the UI."
+                    f"Deployment '{deployment.flow_name}/{deployment.name}'"
+                    f" successfully created with id '{deployment_id}'."
                 ),
-                style="red",
+                style="green",
             )
+            if deployment.work_pool_name is not None:
+                await _print_deployment_work_pool_instructions(
+                    work_pool_name=deployment.work_pool_name, client=client
+                )
+
+            elif deployment.work_queue_name is not None:
+                app.console.print(
+                    "\nTo execute flow runs from this deployment, start an agent that"
+                    f" pulls work from the {deployment.work_queue_name!r} work queue:"
+                )
+                app.console.print(
+                    f"$ prefect agent start -q {deployment.work_queue_name!r}",
+                    style="blue",
+                )
+            else:
+                app.console.print(
+                    (
+                        "\nThis deployment does not specify a work queue name, which"
+                        " means agents will not be able to pick up its runs. To add a"
+                        " work queue, edit the deployment spec and re-run this command,"
+                        " or visit the deployment in the UI."
+                    ),
+                    style="red",
+                )
 
 
 def _load_json_key_values(

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -54,6 +54,85 @@ class TestOutputMessages:
             ],
         )
 
+    def test_message_with_prefect_agent_work_pool(
+        self, patch_import, tmp_path, prefect_agent_work_pool
+    ):
+        Deployment.build_from_flow(
+            flow=my_flow,
+            name="TEST",
+            flow_name="my_flow",
+            output=str(tmp_path / "test.yaml"),
+            work_pool_name=prefect_agent_work_pool.name,
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=[
+                (
+                    "To execute flow runs from this deployment, start an agent that"
+                    f" pulls work from the {prefect_agent_work_pool.name!r} work pool:"
+                ),
+                f"$ prefect agent start -p {prefect_agent_work_pool.name!r}",
+            ],
+        )
+
+    def test_message_with_process_work_pool(
+        self, patch_import, tmp_path, process_work_pool, enable_workers
+    ):
+        Deployment.build_from_flow(
+            flow=my_flow,
+            name="TEST",
+            flow_name="my_flow",
+            output=str(tmp_path / "test.yaml"),
+            work_pool_name=process_work_pool.name,
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=[
+                (
+                    "To execute flow runs from this deployment, start a worker "
+                    f"that pulls work from the {process_work_pool.name!r} work pool:"
+                ),
+                f"$ prefect worker start -p {process_work_pool.name!r}",
+            ],
+        )
+
+    def test_message_with_process_work_pool_without_workers_enabled(
+        self, patch_import, tmp_path, process_work_pool
+    ):
+        Deployment.build_from_flow(
+            flow=my_flow,
+            name="TEST",
+            flow_name="my_flow",
+            output=str(tmp_path / "test.yaml"),
+            work_pool_name=process_work_pool.name,
+        )
+        invoke_and_assert(
+            [
+                "deployment",
+                "apply",
+                str(tmp_path / "test.yaml"),
+            ],
+            expected_output_contains=[
+                (
+                    "\nTo execute flow runs from this deployment, please enable "
+                    "the workers CLI and start a worker that pulls work from the "
+                    f"{process_work_pool.name!r} work pool:"
+                ),
+                (
+                    "$ prefect config set PREFECT_EXPERIMENTAL_ENABLE_WORKERS=True\n"
+                    f"$ prefect worker start -p {process_work_pool.name!r}"
+                ),
+            ],
+        )
+
     def test_linking_to_deployment_in_ui(
         self,
         patch_import,

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -448,6 +448,19 @@ async def process_work_pool(session):
 
 
 @pytest.fixture
+async def prefect_agent_work_pool(session):
+    model = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate(
+            name="process-work-pool",
+            type="prefect-agent",
+        ),
+    )
+    await session.commit()
+    return model
+
+
+@pytest.fixture
 async def work_queue_1(session, work_pool):
     model = await models.workers.create_work_queue(
         session=session,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Updates suggested command output when applying a deployment to prompt the user to start a worker. If a deployment is assigned to a work pool whose type is not `prefect-agent`, then the `prefect worker start -p {deployment_work_pool_name}` command is displayed with an extra suggestion to the user to enable the experimental setting for the workers group to make sure that the worker CLI is accessible.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Applying a deployment associated with a `prefect-agent` work pool
```bash
> prefect deployment apply print_my_env-deployment.yaml
Successfully loaded 'test-env-flow'
Deployment 'print-my-env/test-env-flow' successfully created with id 'ef341f28-2d41-4084-8666-75e1c43ffe32'.
...

To execute flow runs from this deployment, start an agent that pulls work from the 'default-agent-pool' work pool:
$ prefect agent start -p 'default-agent-pool'
```

Applying a deployment associated with a `process` work pool
```bash
> prefect deployment apply print_my_env-deployment.yaml                                          
Successfully loaded 'test-env-flow'
Deployment 'print-my-env/test-env-flow' successfully created with id 'ef341f28-2d41-4084-8666-75e1c43ffe32'.
...

To execute flow runs from this deployment, start a worker that pulls work from the 'test-process-pool' work pool:
$ prefect worker start -p 'test-process-pool'
```

Applying a deployment associated with a `process` work pool without the workers feature enabled:
```bash
> prefect deployment apply print_my_env-deployment.yaml       
Successfully loaded 'test-env-flow'
Deployment 'print-my-env/test-env-flow' successfully created with id 'ef341f28-2d41-4084-8666-75e1c43ffe32'.
...

To execute flow runs from this deployment, please enable the workers CLI and start a worker that pulls work from the 'test-process-pool' work pool:
$ prefect config set PREFECT_EXPERIMENTAL_ENABLE_WORKERS=True
$ prefect worker start -p 'test-process-pool'
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
