### PR TITLE
Use 8-core machines for GitHub Actions runs of test suite

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -47,7 +47,7 @@ jobs:
           - "postgres:14"
           - "sqlite"
         os:
-          - ubuntu-latest
+          - ubuntu-latest-8-cores
         python-version:
           - "3.7"
           - "3.8"


### PR DESCRIPTION
As seen in https://github.com/PrefectHQ/nebula/pull/3953/

Not sure if we have these available in this repository.