### PR TITLE
Update block event resource IDs to use block-document id instead of name.

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -611,11 +611,16 @@ class Block(BaseModel, ABC):
     def _event_kind(self) -> str:
         return f"prefect.block.{self.get_block_type_slug()}"
 
-    def _event_method_called_resources(self) -> ResourceTuple:
-        name = self._block_document_name if self._block_document_name else "anonymous"
+    def _event_method_called_resources(self) -> Optional[ResourceTuple]:
+        if not self._block_document_id:
+            return None
+
         return (
             {
-                "prefect.resource.id": f"prefect.block-document.{name}",
+                "prefect.resource.id": (
+                    f"prefect.block-document.{self._block_document_id}"
+                ),
+                "prefect.block-document.name": self._block_document_name,
             },
             [
                 {

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -612,7 +612,7 @@ class Block(BaseModel, ABC):
         return f"prefect.block.{self.get_block_type_slug()}"
 
     def _event_method_called_resources(self) -> Optional[ResourceTuple]:
-        if not self._block_document_id:
+        if not (self._block_document_id and self._block_document_name):
             return None
 
         return (
@@ -620,7 +620,7 @@ class Block(BaseModel, ABC):
                 "prefect.resource.id": (
                     f"prefect.block-document.{self._block_document_id}"
                 ),
-                "prefect.block-document.name": self._block_document_name,
+                "prefect.name": self._block_document_name,
             },
             [
                 {

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -1,6 +1,17 @@
 import functools
 import inspect
-from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 from prefect.events import Event
 from prefect.events.worker import get_events_worker
@@ -14,7 +25,11 @@ def emit_instance_method_called_event(
     successful: bool,
 ):
     kind = instance._event_kind()
-    resources: ResourceTuple = instance._event_method_called_resources()
+    resources: Optional[ResourceTuple] = instance._event_method_called_resources()
+
+    if not resources:
+        return
+
     resource, related = resources
     result = "called" if successful else "failed"
 

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -26,21 +26,21 @@ async def test_async_blocks_instrumented(
     save_event = asserting_events_worker._client.events[0]
     assert save_event.event == "prefect.block.secret.save.called"
     assert save_event.resource.id == f"prefect.block-document.{document_id}"
-    assert save_event.resource["prefect.block-document.name"] == "top-secret"
+    assert save_event.resource["prefect.name"] == "top-secret"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 
     load_event = asserting_events_worker._client.events[1]
     assert load_event.event == "prefect.block.secret.load.called"
     assert load_event.resource.id == f"prefect.block-document.{document_id}"
-    assert load_event.resource["prefect.block-document.name"] == "top-secret"
+    assert load_event.resource["prefect.name"] == "top-secret"
     assert load_event.related[0].id == "prefect.block-type.secret"
     assert load_event.related[0].role == "block-type"
 
     get_event = asserting_events_worker._client.events[2]
     assert get_event.event == "prefect.block.secret.get.called"
     assert get_event.resource.id == f"prefect.block-document.{document_id}"
-    assert get_event.resource["prefect.block-document.name"] == "top-secret"
+    assert get_event.resource["prefect.name"] == "top-secret"
     assert get_event.related[0].id == "prefect.block-type.secret"
     assert get_event.related[0].role == "block-type"
 
@@ -61,21 +61,21 @@ def test_sync_blocks_instrumented(
     save_event = asserting_events_worker._client.events[0]
     assert save_event.event == "prefect.block.secret.save.called"
     assert save_event.resource.id == f"prefect.block-document.{document_id}"
-    assert save_event.resource["prefect.block-document.name"] == "top-secret"
+    assert save_event.resource["prefect.name"] == "top-secret"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 
     load_event = asserting_events_worker._client.events[1]
     assert load_event.event == "prefect.block.secret.load.called"
     assert load_event.resource.id == f"prefect.block-document.{document_id}"
-    assert load_event.resource["prefect.block-document.name"] == "top-secret"
+    assert load_event.resource["prefect.name"] == "top-secret"
     assert load_event.related[0].id == "prefect.block-type.secret"
     assert load_event.related[0].role == "block-type"
 
     get_event = asserting_events_worker._client.events[2]
     assert get_event.event == "prefect.block.secret.get.called"
     assert get_event.resource.id == f"prefect.block-document.{document_id}"
-    assert get_event.resource["prefect.block-document.name"] == "top-secret"
+    assert get_event.resource["prefect.name"] == "top-secret"
     assert get_event.related[0].id == "prefect.block-type.secret"
     assert get_event.related[0].role == "block-type"
 
@@ -103,23 +103,21 @@ def test_notifications_notify_instrumented_sync(
         save_event = asserting_events_worker._client.events[0]
         assert save_event.event == "prefect.block.pager-duty-webhook.save.called"
         assert save_event.resource.id == f"prefect.block-document.{document_id}"
-        assert save_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        assert save_event.resource["prefect.name"] == "pager-duty-events"
         assert save_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert save_event.related[0].role == "block-type"
 
         load_event = asserting_events_worker._client.events[1]
         assert load_event.event == "prefect.block.pager-duty-webhook.load.called"
         assert load_event.resource.id == f"prefect.block-document.{document_id}"
-        assert load_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        assert load_event.resource["prefect.name"] == "pager-duty-events"
         assert load_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert load_event.related[0].role == "block-type"
 
         notify_event = asserting_events_worker._client.events[2]
         assert notify_event.event == "prefect.block.pager-duty-webhook.notify.called"
         assert notify_event.resource.id == f"prefect.block-document.{document_id}"
-        assert (
-            notify_event.resource["prefect.block-document.name"] == "pager-duty-events"
-        )
+        assert notify_event.resource["prefect.name"] == "pager-duty-events"
         assert notify_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert notify_event.related[0].role == "block-type"
 
@@ -147,22 +145,20 @@ async def test_notifications_notify_instrumented_async(
         save_event = asserting_events_worker._client.events[0]
         assert save_event.event == "prefect.block.pager-duty-webhook.save.called"
         assert save_event.resource.id == f"prefect.block-document.{document_id}"
-        assert save_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        assert save_event.resource["prefect.name"] == "pager-duty-events"
         assert save_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert save_event.related[0].role == "block-type"
 
         load_event = asserting_events_worker._client.events[1]
         assert load_event.event == "prefect.block.pager-duty-webhook.load.called"
         assert load_event.resource.id == f"prefect.block-document.{document_id}"
-        assert load_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        assert load_event.resource["prefect.name"] == "pager-duty-events"
         assert load_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert load_event.related[0].role == "block-type"
 
         notify_event = asserting_events_worker._client.events[2]
         assert notify_event.event == "prefect.block.pager-duty-webhook.notify.called"
         assert notify_event.resource.id == f"prefect.block-document.{document_id}"
-        assert (
-            notify_event.resource["prefect.block-document.name"] == "pager-duty-events"
-        )
+        assert notify_event.resource["prefect.name"] == "pager-duty-events"
         assert notify_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert notify_event.related[0].role == "block-type"

--- a/tests/events/test_block_events_instrumentation.py
+++ b/tests/events/test_block_events_instrumentation.py
@@ -14,7 +14,7 @@ async def test_async_blocks_instrumented(
     asserting_events_worker: EventsWorker, reset_worker_events
 ):
     secret = Secret(value=SecretStr("I'm hidden!"))
-    await secret.save("top-secret", overwrite=True)
+    document_id = await secret.save("top-secret", overwrite=True)
     secret = await Secret.load("top-secret")
     secret.get()
 
@@ -25,19 +25,22 @@ async def test_async_blocks_instrumented(
 
     save_event = asserting_events_worker._client.events[0]
     assert save_event.event == "prefect.block.secret.save.called"
-    assert save_event.resource.id == "prefect.block-document.top-secret"
+    assert save_event.resource.id == f"prefect.block-document.{document_id}"
+    assert save_event.resource["prefect.block-document.name"] == "top-secret"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 
     load_event = asserting_events_worker._client.events[1]
     assert load_event.event == "prefect.block.secret.load.called"
-    assert load_event.resource.id == "prefect.block-document.top-secret"
+    assert load_event.resource.id == f"prefect.block-document.{document_id}"
+    assert load_event.resource["prefect.block-document.name"] == "top-secret"
     assert load_event.related[0].id == "prefect.block-type.secret"
     assert load_event.related[0].role == "block-type"
 
     get_event = asserting_events_worker._client.events[2]
     assert get_event.event == "prefect.block.secret.get.called"
-    assert get_event.resource.id == "prefect.block-document.top-secret"
+    assert get_event.resource.id == f"prefect.block-document.{document_id}"
+    assert get_event.resource["prefect.block-document.name"] == "top-secret"
     assert get_event.related[0].id == "prefect.block-type.secret"
     assert get_event.related[0].role == "block-type"
 
@@ -46,7 +49,7 @@ def test_sync_blocks_instrumented(
     asserting_events_worker: EventsWorker, reset_worker_events
 ):
     secret = Secret(value=SecretStr("I'm hidden!"))
-    secret.save("top-secret", overwrite=True)
+    document_id = secret.save("top-secret", overwrite=True)
     secret = Secret.load("top-secret")
     secret.get()
 
@@ -57,19 +60,22 @@ def test_sync_blocks_instrumented(
 
     save_event = asserting_events_worker._client.events[0]
     assert save_event.event == "prefect.block.secret.save.called"
-    assert save_event.resource.id == "prefect.block-document.top-secret"
+    assert save_event.resource.id == f"prefect.block-document.{document_id}"
+    assert save_event.resource["prefect.block-document.name"] == "top-secret"
     assert save_event.related[0].id == "prefect.block-type.secret"
     assert save_event.related[0].role == "block-type"
 
     load_event = asserting_events_worker._client.events[1]
     assert load_event.event == "prefect.block.secret.load.called"
-    assert load_event.resource.id == "prefect.block-document.top-secret"
+    assert load_event.resource.id == f"prefect.block-document.{document_id}"
+    assert load_event.resource["prefect.block-document.name"] == "top-secret"
     assert load_event.related[0].id == "prefect.block-type.secret"
     assert load_event.related[0].role == "block-type"
 
     get_event = asserting_events_worker._client.events[2]
     assert get_event.event == "prefect.block.secret.get.called"
-    assert get_event.resource.id == "prefect.block-document.top-secret"
+    assert get_event.resource.id == f"prefect.block-document.{document_id}"
+    assert get_event.resource["prefect.block-document.name"] == "top-secret"
     assert get_event.related[0].id == "prefect.block-type.secret"
     assert get_event.related[0].role == "block-type"
 
@@ -84,7 +90,7 @@ def test_notifications_notify_instrumented_sync(
         block = PagerDutyWebHook(
             integration_key=SecretStr("integration_key"), api_key=SecretStr("api_key")
         )
-        block.save("pager-duty-events", overwrite=True)
+        document_id = block.save("pager-duty-events", overwrite=True)
 
         pgduty = PagerDutyWebHook.load("pager-duty-events")
         pgduty.notify("Oh, we're you sleeping?")
@@ -96,19 +102,24 @@ def test_notifications_notify_instrumented_sync(
 
         save_event = asserting_events_worker._client.events[0]
         assert save_event.event == "prefect.block.pager-duty-webhook.save.called"
-        assert save_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert save_event.resource.id == f"prefect.block-document.{document_id}"
+        assert save_event.resource["prefect.block-document.name"] == "pager-duty-events"
         assert save_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert save_event.related[0].role == "block-type"
 
         load_event = asserting_events_worker._client.events[1]
         assert load_event.event == "prefect.block.pager-duty-webhook.load.called"
-        assert load_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert load_event.resource.id == f"prefect.block-document.{document_id}"
+        assert load_event.resource["prefect.block-document.name"] == "pager-duty-events"
         assert load_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert load_event.related[0].role == "block-type"
 
         notify_event = asserting_events_worker._client.events[2]
         assert notify_event.event == "prefect.block.pager-duty-webhook.notify.called"
-        assert notify_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert notify_event.resource.id == f"prefect.block-document.{document_id}"
+        assert (
+            notify_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        )
         assert notify_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert notify_event.related[0].role == "block-type"
 
@@ -123,7 +134,7 @@ async def test_notifications_notify_instrumented_async(
         block = PagerDutyWebHook(
             integration_key=SecretStr("integration_key"), api_key=SecretStr("api_key")
         )
-        await block.save("pager-duty-events", overwrite=True)
+        document_id = await block.save("pager-duty-events", overwrite=True)
 
         pgduty = await PagerDutyWebHook.load("pager-duty-events")
         await pgduty.notify("Oh, we're you sleeping?")
@@ -135,18 +146,23 @@ async def test_notifications_notify_instrumented_async(
 
         save_event = asserting_events_worker._client.events[0]
         assert save_event.event == "prefect.block.pager-duty-webhook.save.called"
-        assert save_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert save_event.resource.id == f"prefect.block-document.{document_id}"
+        assert save_event.resource["prefect.block-document.name"] == "pager-duty-events"
         assert save_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert save_event.related[0].role == "block-type"
 
         load_event = asserting_events_worker._client.events[1]
         assert load_event.event == "prefect.block.pager-duty-webhook.load.called"
-        assert load_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert load_event.resource.id == f"prefect.block-document.{document_id}"
+        assert load_event.resource["prefect.block-document.name"] == "pager-duty-events"
         assert load_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert load_event.related[0].role == "block-type"
 
         notify_event = asserting_events_worker._client.events[2]
         assert notify_event.event == "prefect.block.pager-duty-webhook.notify.called"
-        assert notify_event.resource.id == "prefect.block-document.pager-duty-events"
+        assert notify_event.resource.id == f"prefect.block-document.{document_id}"
+        assert (
+            notify_event.resource["prefect.block-document.name"] == "pager-duty-events"
+        )
         assert notify_event.related[0].id == "prefect.block-type.pager-duty-webhook"
         assert notify_event.related[0].role == "block-type"


### PR DESCRIPTION
While testing out the block events we found that while the `name` of the block document was nicely human-readable it didn't provide an easy way to hook back into the API to get the block document itself. This updates the block events to emit the document id as the resource id and include the name as a label.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
