### PR TITLE
Add cancellation reporting to calls and waiters

### DIFF
--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -15,6 +15,7 @@ from typing_extensions import ParamSpec
 
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.timeouts import (
+    CancelContext,
     cancel_async_at,
     cancel_sync_at,
     get_deadline,
@@ -56,6 +57,7 @@ class Call(Generic[T]):
     args: Tuple
     kwargs: Dict[str, Any]
     context: contextvars.Context
+    cancel_context: CancelContext
     deadline: Optional[float] = None
     portal: Optional["Portal"] = None
     callback_portal: Optional["Portal"] = None
@@ -68,6 +70,7 @@ class Call(Generic[T]):
             args=args,
             kwargs=kwargs,
             context=contextvars.copy_context(),
+            cancel_context=CancelContext(),
         )
 
     def set_timeout(self, timeout: Optional[float] = None) -> None:
@@ -139,13 +142,17 @@ class Call(Generic[T]):
 
         return None
 
-    def result(self):
+    def result(self) -> T:
         return self.future.result()
+
+    def cancelled(self) -> bool:
+        return self.cancel_context.cancelled or self.future.cancelled()
 
     def _run_sync(self):
         try:
             with set_current_call(self):
-                with cancel_sync_at(self.deadline):
+                with cancel_sync_at(self.deadline) as ctx:
+                    ctx.chain(self.cancel_context)
                     result = self.fn(*self.args, **self.kwargs)
 
             # Return the coroutine for async execution
@@ -164,7 +171,8 @@ class Call(Generic[T]):
     async def _run_async(self, coro):
         try:
             with set_current_call(self):
-                with cancel_async_at(self.deadline):
+                with cancel_async_at(self.deadline) as ctx:
+                    ctx.chain(self.cancel_context)
                     result = await coro
         except BaseException as exc:
             logger.debug("Encountered exception %s in async call %r", exc, self)

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -18,7 +18,6 @@ from prefect._internal.concurrency.timeouts import (
     CancelContext,
     cancel_async_at,
     cancel_sync_at,
-    get_deadline,
 )
 from prefect.logging import get_logger
 
@@ -57,8 +56,9 @@ class Call(Generic[T]):
     args: Tuple
     kwargs: Dict[str, Any]
     context: contextvars.Context
-    cancel_context: CancelContext
-    deadline: Optional[float] = None
+    cancel_context: CancelContext = dataclasses.field(
+        default_factory=lambda: CancelContext(timeout=None)
+    )
     portal: Optional["Portal"] = None
     callback_portal: Optional["Portal"] = None
 
@@ -70,7 +70,6 @@ class Call(Generic[T]):
             args=args,
             kwargs=kwargs,
             context=contextvars.copy_context(),
-            cancel_context=CancelContext(),
         )
 
     def set_timeout(self, timeout: Optional[float] = None) -> None:
@@ -82,7 +81,8 @@ class Call(Generic[T]):
         if self.future.done() or self.future.running():
             raise RuntimeError("Timeouts cannot be added when the call has started.")
 
-        self.deadline = get_deadline(timeout)
+        self.cancel_context = CancelContext(timeout=timeout)
+        logger.debug("Set cancel context %r for call %r", self.cancel_context, self)
 
     def set_portal(self, portal: "Portal") -> None:
         """
@@ -146,13 +146,15 @@ class Call(Generic[T]):
         return self.future.result()
 
     def cancelled(self) -> bool:
-        return self.cancel_context.cancelled or self.future.cancelled()
+        return self.cancel_context.cancelled() or self.future.cancelled()
 
     def _run_sync(self):
+        cancel_context = self.cancel_context
+
         try:
             with set_current_call(self):
-                with cancel_sync_at(self.deadline) as ctx:
-                    ctx.chain(self.cancel_context)
+                with cancel_sync_at(cancel_context.deadline) as ctx:
+                    ctx.chain(cancel_context)
                     result = self.fn(*self.args, **self.kwargs)
 
             # Return the coroutine for async execution
@@ -160,26 +162,34 @@ class Call(Generic[T]):
                 return result
 
         except BaseException as exc:
+            if not isinstance(exc, TimeoutError):
+                cancel_context.mark_completed()
             self.future.set_exception(exc)
             logger.debug("Encountered exception in call %r", self)
             # Prevent reference cycle in `exc`
             del self
         else:
+            cancel_context.mark_completed()
             self.future.set_result(result)
             logger.debug("Finished call %r", self)
 
     async def _run_async(self, coro):
+        cancel_context = self.cancel_context
+
         try:
             with set_current_call(self):
-                with cancel_async_at(self.deadline) as ctx:
-                    ctx.chain(self.cancel_context)
+                with cancel_async_at(cancel_context.deadline) as ctx:
+                    ctx.chain(cancel_context)
                     result = await coro
         except BaseException as exc:
+            if not isinstance(exc, asyncio.CancelledError):
+                cancel_context.mark_completed()
             logger.debug("Encountered exception %s in async call %r", exc, self)
             self.future.set_exception(exc)
             # Prevent reference cycle in `exc`
             del self
         else:
+            cancel_context.mark_completed()
             self.future.set_result(result)
             logger.debug("Finished async call %r", self)
 

--- a/src/prefect/_internal/concurrency/timeouts.py
+++ b/src/prefect/_internal/concurrency/timeouts.py
@@ -80,7 +80,8 @@ class CancelContext:
                 self._chained.append(ctx)
 
     def __repr__(self) -> str:
-        return f"<CancelContext at {hex(id(self))} timeout={self._timeout}>"
+        timeout = f"{self._timeout:.2f}" if self._timeout else "None"
+        return f"<CancelContext at {hex(id(self))} timeout={timeout}>"
 
 
 @contextlib.contextmanager
@@ -100,9 +101,7 @@ def cancel_async_after(timeout: Optional[float]):
 
     try:
         with anyio.fail_after(timeout) as cancel_scope:
-            logger.debug(
-                f"Entered asynchronous cancel context with %.2f timeout", timeout
-            )
+            logger.debug(f"Entered asynchronous cancel context %r", ctx)
             yield ctx
     finally:
         if cancel_scope.cancel_called:
@@ -196,9 +195,9 @@ def cancel_sync_after(timeout: Optional[float]):
 
     with method(timeout) as ctx:
         logger.debug(
-            f"Entered synchronous cancel context with %.2f %s based timeout",
-            timeout,
+            f"Entered synchronous %s based cancel context %r",
             method_name,
+            ctx,
         )
         yield ctx
 


### PR DESCRIPTION
Uses chaining introduced in #8719 to add cancellation reporting to calls

- Adds `CancelContext.mark_completed()` to avoid reporting completed items as cancelled in chains
- Adds lock to `CancelContext` to avoid completed/cancelled race conditions
- Updates `CancelContext.cancelled` to be a method instead of a property since it takes a lock
- Adds `Call.cancelled()` and `Call.cancel_context` to track cancellation of calls
- Adds reporting of cancelled callbacks to `Waiter`

All this is to allow us to determine if a call was cancelled due to exceeding its timeout, which will allow us to report flows as `TimedOut` correctly in #8702 

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
import time

from prefect._internal.concurrency.calls import Call

call = Call.new(time.sleep, 5)
call.set_timeout(1)
call.run()

print(call.cancelled())
```

```
10:43:03.661 | DEBUG   | prefect._internal.concurrency.calls - Set cancel context <CancelContext at 0x109cc9030 timeout=1.00> for call sleep(5)
10:43:03.662 | DEBUG   | prefect._internal.concurrency.calls - Running call sleep(5)
10:43:03.663 | DEBUG   | prefect._internal.concurrency.timeouts - Entered synchronous alarm based cancel context <CancelContext at 0x109cc8f10 timeout=1.00>
10:43:04.663 | DEBUG   | prefect._internal.concurrency.timeouts - Marked <CancelContext at 0x109cc8f10 timeout=1.00> as cancelled
10:43:04.665 | DEBUG   | prefect._internal.concurrency.timeouts - Marked <CancelContext at 0x109cc9030 timeout=1.00> as cancelled
10:43:04.666 | DEBUG   | prefect._internal.concurrency.timeouts - Cancel fired for alarm based timeout of thread 'MainThread'
10:43:04.666 | DEBUG   | prefect._internal.concurrency.calls - Encountered exception in call sleep(5)
True
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
