### PR TITLE
Add support for float timeouts using alarms

### DIFF
--- a/tests/_internal/concurrency/test_timeouts.py
+++ b/tests/_internal/concurrency/test_timeouts.py
@@ -65,13 +65,11 @@ def test_cancel_sync_after_in_main_thread():
     t0 = time.perf_counter()
     with pytest.raises(TimeoutError):
         with cancel_sync_after(0.1) as ctx:
-            # floats are not suppported by alarm timeouts so this will actually timeout
-            # after 1s
-            time.sleep(2)
+            time.sleep(1)
     t1 = time.perf_counter()
 
     assert ctx.cancelled()
-    assert t1 - t0 < 2
+    assert t1 - t0 < 1
 
 
 def test_cancel_sync_after_in_worker_thread():
@@ -109,10 +107,8 @@ def test_cancel_sync_at():
     t0 = time.perf_counter()
     with pytest.raises(TimeoutError):
         with cancel_sync_at(get_deadline(timeout=0.1)) as ctx:
-            # floats are not suppported by alarm timeouts so this will actually timeout
-            # after 1s
-            time.sleep(2)
+            time.sleep(1)
     t1 = time.perf_counter()
 
     assert ctx.cancelled()
-    assert t1 - t0 < 2
+    assert t1 - t0 < 1

--- a/tests/_internal/concurrency/test_waiters.py
+++ b/tests/_internal/concurrency/test_waiters.py
@@ -74,7 +74,7 @@ def test_sync_waiter_timeout_in_main_thread():
     with WorkerThread(run_once=True) as portal:
 
         def on_worker_thread():
-            callback = Call.new(time.sleep, 2)
+            callback = Call.new(time.sleep, 1)
             call.add_callback(callback)
             return callback
 
@@ -93,8 +93,7 @@ def test_sync_waiter_timeout_in_main_thread():
     with pytest.raises(TimeoutError):
         callback.result()
 
-    # main thread timeouts round up to the nearest second
-    assert t1 - t0 < 2
+    assert t1 - t0 < 1
 
     assert callback.cancelled()
     assert not call.cancelled()


### PR DESCRIPTION
After much annoyance adjusting tests that used subsecond timeouts, I figured out how to make float values work with alarm based timeouts.

See https://docs.python.org/3/library/signal.html#signal.ITIMER_REAL and https://docs.python.org/3/library/signal.html#signal.setitimer