### PR TITLE
Improve CI time for migration tests

### DIFF
--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -70,6 +70,7 @@ async def test_backfill_state_name(db, flow):
     if dialect.name == "postgresql":
         revisions = ("605ebb4e9155", "14dc68cc5853")
     else:
+        pytest.skip(reason="Test is excessively slow on SQLite")
         revisions = ("7f5f335cace3", "db6bde582447")
 
     flow_run_id = uuid4()

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -32,6 +32,7 @@ async def sample_db_data(
     """Adds sample data to the database for testing migrations"""
 
 
+@pytest.mark.service("database")
 @pytest.mark.flaky(max_runs=3)
 async def test_orion_full_migration_works_with_data_in_db(sample_db_data):
     """


### PR DESCRIPTION
- Skip backfill test on SQLite (takes ~60s vs ~6s on Postgres)
- Add service test mark to database migration test to run in separate job (takes ~60s)
