### PR TITLE
Run uvicorn signal forwarding tests in service test suite

### DIFF
--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -89,6 +89,7 @@ async def server_process():
         out.close()
 
 
+@pytest.mark.service("process")
 class TestUvicornSignalForwarding:
     @pytest.mark.skipif(
         sys.platform == "win32",


### PR DESCRIPTION
Similar to #8745 these tests are slow and can be run on another job for an overall speed increase.