### PR TITLE
Ignore fsspec `2023.3.0` during requirements installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography >= 36.0.1
 dateparser >= 1.1.1
 docker >= 4.0
 fastapi >= 0.70
-fsspec >= 2022.5.0
+fsspec >= 2022.5.0, != 2023.3.0
 griffe >= 0.20.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'


### PR DESCRIPTION
This appears to have a breaking change and we can try to avoid releasing it to our users https://github.com/PrefectHQ/prefect/issues/8710
