### PR TITLE
Add artifacts for unpersisted results

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -239,6 +239,10 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
     ):
         state = retval
 
+        # Do not modify states with data documents attached; backwards compatibility
+        if isinstance(state.data, DataDocument):
+            return state
+
         # Unless the user has already constructed a result explicitly, use the factory
         # to update the data to the correct type
         if not isinstance(state.data, BaseResult):

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -3,7 +3,7 @@ import pytest
 from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
-from prefect.results import LiteralResult
+from prefect.results import UnpersistedResult
 from prefect.serializers import (
     CompressedSerializer,
     JSONSerializer,
@@ -65,6 +65,22 @@ async def test_flow_with_uncached_and_unpersisted_result(orion_client):
         await api_state.result()
 
 
+async def test_flow_with_uncached_and_unpersisted_null_result(orion_client):
+    @flow(persist_result=False, cache_result_in_memory=False)
+    def foo():
+        return None
+
+    state = foo(return_state=True)
+    # Nulls do not consume memory and are still available
+    assert await state.result() is None
+
+    api_state = (
+        await orion_client.read_flow_run(state.state_details.flow_run_id)
+    ).state
+    with pytest.raises(MissingResult):
+        await api_state.result()
+
+
 async def test_flow_with_uncached_but_persisted_result(orion_client):
     @flow(persist_result=True, cache_result_in_memory=False)
     def foo():
@@ -96,7 +112,7 @@ async def test_flow_with_uncached_but_literal_result(orion_client):
     assert await api_state.result() is True
 
 
-async def test_flow_result_not_missing_with_null_return(orion_client):
+async def test_flow_result_missing_with_null_return(orion_client):
     @flow
     def foo():
         return None
@@ -107,7 +123,8 @@ async def test_flow_result_not_missing_with_null_return(orion_client):
     api_state = (
         await orion_client.read_flow_run(state.state_details.flow_run_id)
     ).state
-    assert await api_state.result() is None
+    with pytest.raises(MissingResult):
+        await api_state.result()
 
 
 @pytest.mark.parametrize("value", [True, False, None])
@@ -304,7 +321,7 @@ async def test_child_flow_result_storage(orion_client, source):
     await assert_uses_result_storage(api_state, storage)
 
 
-async def test_child_flow_result_not_missing_with_null_return(orion_client):
+async def test_child_flow_result_missing_with_null_return(orion_client):
     @flow
     def foo():
         return bar(return_state=True)
@@ -315,13 +332,14 @@ async def test_child_flow_result_not_missing_with_null_return(orion_client):
 
     parent_state = foo(return_state=True)
     child_state = await parent_state.result()
-    assert isinstance(child_state.data, LiteralResult)
+    assert isinstance(child_state.data, UnpersistedResult)
     assert await child_state.result() is None
 
     api_state = (
         await orion_client.read_flow_run(child_state.state_details.flow_run_id)
     ).state
-    assert await api_state.result() is None
+    with pytest.raises(MissingResult):
+        await api_state.result()
 
 
 @pytest.mark.parametrize("empty_type", [dict, list])
@@ -341,6 +359,8 @@ def test_flow_empty_result_is_retained(persist_result, empty_type):
         {"type": "foo"},
         {"type": "literal", "user-stuff": "bar"},
         {"type": "persisted"},
+        {"type": "persisted", "value": "test"},
+        {"type": "unpersisted"},
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -94,6 +94,27 @@ async def test_task_with_uncached_and_unpersisted_result(orion_client):
         await api_state.result()
 
 
+async def test_task_with_uncached_and_unpersisted_null_result(orion_client):
+    @flow
+    def foo():
+        return bar(return_state=True)
+
+    @task(persist_result=False, cache_result_in_memory=False)
+    def bar():
+        return None
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    # Nulls do not consume memory and are still available
+    assert await task_state.result() is None
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    with pytest.raises(MissingResult):
+        await api_state.result()
+
+
 async def test_task_with_uncached_but_persisted_result(orion_client):
     @flow
     def foo():
@@ -227,7 +248,7 @@ async def test_task_result_storage(orion_client, source):
     await assert_uses_result_storage(api_state, storage)
 
 
-async def test_task_result_not_missing_with_null_return(orion_client):
+async def test_task_result_missing_with_null_return(orion_client):
     @flow
     def foo():
         return bar(return_state=True)
@@ -243,7 +264,8 @@ async def test_task_result_not_missing_with_null_return(orion_client):
     api_state = (
         await orion_client.read_task_run(task_state.state_details.task_run_id)
     ).state
-    assert await api_state.result() is None
+    with pytest.raises(MissingResult):
+        await api_state.result()
 
 
 @pytest.mark.parametrize("value", [True, False, None])

--- a/tests/results/test_unpersisted_result.py
+++ b/tests/results/test_unpersisted_result.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+import pytest
+
+from prefect.results import MissingResult, UnpersistedResult
+
+
+@dataclass
+class MyDataClass:
+    x: int
+
+
+TEST_VALUES = [None, "test", MyDataClass(x=1)]
+
+
+@pytest.mark.parametrize("value", TEST_VALUES)
+async def test_unpersisted_result_create_and_get(value):
+    result = await UnpersistedResult.create(value)
+    assert await result.get() == value
+
+
+@pytest.mark.parametrize("value", TEST_VALUES)
+def test_unpersisted_result_create_and_get_sync(value):
+    result = UnpersistedResult.create(value)
+    assert result.get() == value
+
+
+@pytest.mark.parametrize("value", TEST_VALUES)
+async def test_unpersisted_result_create_and_get_no_cache(value):
+    result = await UnpersistedResult.create(value, cache_object=False)
+    with pytest.raises(MissingResult):
+        await result.get()
+
+
+@pytest.mark.parametrize("value", TEST_VALUES)
+async def test_unpersisted_result_missing_after_json_roundtrip(value):
+    result = await UnpersistedResult.create(value)
+    serialized = result.json()
+    deserialized = UnpersistedResult.parse_raw(serialized)
+    with pytest.raises(MissingResult):
+        await deserialized.get()
+
+
+@pytest.mark.parametrize("value", TEST_VALUES)
+async def test_unpersisted_result_populates_default_artifact_metadata(value):
+    result = await UnpersistedResult.create(value)
+    assert result.artifact_type == "result"
+    assert (
+        result.artifact_description
+        == f"Unpersisted result of type {type(value).__name__!r}"
+    )

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -11,24 +11,20 @@ import pydantic
 import pytest
 
 from prefect import flow, get_run_logger, tags, task
-from prefect.blocks.core import Block
 from prefect.client.orchestration import PrefectClient
 from prefect.context import PrefectObjectRegistry
 from prefect.deprecated.data_documents import DataDocument
 from prefect.exceptions import (
     CancelledRun,
     InvalidNameError,
-    MissingResult,
     ParameterTypeError,
     ReservedArgumentError,
 )
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import Flow, load_flow_from_entrypoint
-from prefect.results import PersistedResult
 from prefect.server.schemas.core import TaskRunResult
 from prefect.server.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.server.schemas.sorting import FlowRunSort
-from prefect.settings import PREFECT_LOCAL_STORAGE_PATH, temporary_settings
 from prefect.states import Cancelled, State, StateType, raise_state_exception
 from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
 from prefect.testing.utilities import (
@@ -1465,85 +1461,6 @@ class TestSubflowRunLogs:
             logs[log_messages.index("Hello smaller world!")].flow_run_id
             == subflow_run_id
         )
-
-
-class TestFlowResults:
-    """
-    See `tests/results/test_flow_results.py` instead please.
-
-    These tests were retained during the results rewrite but new tests should be added
-    in the dedicated file.
-    """
-
-    async def test_flow_results_are_not_stored_by_default(self, orion_client):
-        @flow
-        def foo():
-            return 6
-
-        state = foo(return_state=True)
-
-        # Available in local cache
-        assert await state.result() == 6
-
-        # Data is not a reference
-        assert state.data == 6
-
-        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-        assert flow_run.state.data is None
-
-        with pytest.raises(MissingResult, match="State data is missing"):
-            await flow_run.state.result()
-
-    async def test_flow_results_are_stored_locally_if_enabled(self, orion_client):
-        @flow(persist_result=True)
-        def foo():
-            return 6
-
-        state = foo(return_state=True)
-
-        # Available from memory cache
-        assert await state.result() == 6
-
-        # Check that the storage block uses local path
-        reference = state.result(fetch=False)
-        assert isinstance(reference, PersistedResult)
-        storage_block = Block._from_block_document(
-            await orion_client.read_block_document(reference.storage_block_id)
-        )
-        assert storage_block.basepath == str(PREFECT_LOCAL_STORAGE_PATH.value())
-
-        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-        # The result can be fetched using the API state
-        assert await flow_run.state.result() == 6
-
-    async def test_subflow_results_use_parent_flow_run_storage_block_by_default(
-        self, orion_client, tmp_path
-    ):
-        @flow(persist_result=True)
-        async def foo():
-            with temporary_settings({PREFECT_LOCAL_STORAGE_PATH: tmp_path / "foo"}):
-                return bar(return_state=True)
-
-        @flow(persist_result=True)
-        def bar():
-            return 6
-
-        parent_state = await foo(return_state=True)
-        child_state = await parent_state.result()
-
-        parent_flow_run = await orion_client.read_flow_run(
-            parent_state.state_details.flow_run_id
-        )
-        child_flow_run = await orion_client.read_flow_run(
-            child_state.state_details.flow_run_id
-        )
-
-        parent_result_ref = parent_flow_run.state.result(fetch=False)
-        child_result_ref = child_flow_run.state.result(fetch=False)
-        assert parent_result_ref.storage_block_id == child_result_ref.storage_block_id
-
-        # The result can be fetched using the API state
-        assert await child_flow_run.state.result() == 6
 
 
 class TestFlowRetries:

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -4,7 +4,12 @@ import pytest
 
 from prefect import flow
 from prefect.exceptions import CancelledRun, CrashedRun, FailedRun
-from prefect.results import LiteralResult, PersistedResult, ResultFactory
+from prefect.results import (
+    LiteralResult,
+    PersistedResult,
+    ResultFactory,
+    UnpersistedResult,
+)
 from prefect.states import (
     Cancelled,
     Completed,
@@ -151,8 +156,7 @@ class TestReturnValueToState:
         state = Completed(data=None)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
-        assert isinstance(result_state.data, LiteralResult)
-        assert result_state.data.value is None
+        assert isinstance(result_state.data, UnpersistedResult)
         assert await result_state.result() is None
 
     async def test_returns_single_state_with_data_to_persist(self, factory):
@@ -170,7 +174,11 @@ class TestReturnValueToState:
         state = Completed(data=result)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
-        assert result_state.data is result
+        # Pydantic makes a copy of the result type during state so we cannot assert that
+        # it is the original `result` object but we can assert there is not a copy in
+        # `return_value_to_state`
+        assert result_state.data is state.data
+        assert result_state.data == result
         assert await result_state.result() == "test"
 
     async def test_all_completed_states(self, factory):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Previously, when results were not persisted no artifact would be sent to the API unless the return value was `None`. This can cause confusing behavior i.e. the presence of a return value of the task or flow can affect restart behavior. It also leads to a less than ideal experience with the upcoming result and artifact display in the UI. In general, result persistence needed to be enabled to see any information about the results in the UI; unless your task or flow returned `None`, then we'd show a result in the UI. This behavior made it challenging to set expectations about what user action was required to see results in the UI.

Here, instead of leaning on `LiteralResult(None)` to distinguish between unpersisted results and null return values, we introduce an `UnpersistedResult` class. This type is used whenever result persistence is disabled. The result value itself is cached in memory, but never sent to the API. The result artifact _is_ sent to the API though which allows metadata for unpersisted results to be tracked and eventually displayed in the UI.

Note we include the _type_ of the result _value_ as the default artifact description for unpersisted results. We should expose ways to customize this description and allow opt-in of increased exposure of the value (e.g. a `repr` of the result value) or opt-out (e.g. no description or no artifact).

Now, `LiteralResult` is used to represent _persisted results_ whose data was deemed unworthy of persistence outside of the Prefect database. We store bools and nulls in the database directly to reduce the overhead of writing to external locations. We'll likely support additional types and data here in the future.

There should be no user-facing changes here yet. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
