### PR TITLE
Add setting to exclude traversal of Pydantic models in parameters

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -594,6 +594,16 @@ The default setting for persisting results when not otherwise specified. If enab
 flow and task results will be persisted unless they opt out.
 """
 
+PREFECT_PARAMETERS_TRAVERSE_PYDANTIC_MODELS = Setting(
+    bool,
+    default=True,
+)
+"""
+Determines if Pydantic models should be traversed in order to resolve Prefect futures
+and states into results.
+"""
+
+
 PREFECT_TASKS_REFRESH_CACHE = Setting(
     bool,
     default=False,

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -29,6 +29,8 @@ from unittest.mock import Mock
 
 import pydantic
 
+from prefect.settings import PREFECT_PARAMETERS_TRAVERSE_PYDANTIC_MODELS
+
 # Quote moved to `prefect.utilities.annotations` but preserved here for compatibility
 from prefect.utilities.annotations import BaseAnnotation, Quote, quote  # noqa
 
@@ -336,7 +338,10 @@ def visit_collection(
         items = {field.name: value for field, value in zip(fields(expr), values)}
         result = typ(**items) if return_data else None
 
-    elif isinstance(expr, pydantic.BaseModel):
+    elif (
+        isinstance(expr, pydantic.BaseModel)
+        and PREFECT_PARAMETERS_TRAVERSE_PYDANTIC_MODELS
+    ):
         # NOTE: This implementation *does not* traverse private attributes
         # Pydantic does not expose extras in `__fields__` so we use `__fields_set__`
         # as well to get all of the relevant attributes


### PR DESCRIPTION
Addresses concerns raised in #8542 by allowing Pydantic model traversal to be disabled so they are not copied during visits. We could introduce a setting like this for dataclasses as well.