### PR TITLE
fix `test_orion_full_migration_works_with_data_in_db`

### DIFF
--- a/src/prefect/server/database/alembic.ini
+++ b/src/prefect/server/database/alembic.ini
@@ -5,3 +5,38 @@ prepend_sys_path = .
 revision_environment = true
 
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(rev)s_%%(slug)s
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = DEBUG
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = DEBUG
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = DEBUG
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/src/prefect/server/database/alembic.ini
+++ b/src/prefect/server/database/alembic.ini
@@ -5,38 +5,3 @@ prepend_sys_path = .
 revision_environment = true
 
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(rev)s_%%(slug)s
-
-
-# Logging configuration
-[loggers]
-keys = root,sqlalchemy,alembic
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = DEBUG
-handlers = console
-qualname =
-
-[logger_sqlalchemy]
-level = DEBUG
-handlers =
-qualname = sqlalchemy.engine
-
-[logger_alembic]
-level = DEBUG
-handlers =
-qualname = alembic
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-formatter = generic
-
-[formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S

--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,6 +1,5 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
-from logging.config import fileConfig
 
 import sqlalchemy
 from alembic import context
@@ -12,7 +11,6 @@ from prefect.utilities.asyncutils import sync_compatible
 
 db_interface = provide_database_interface()
 config = context.config
-fileConfig(config.config_file_name, disable_existing_loggers=False)
 target_metadata = db_interface.Base.metadata
 dialect = get_dialect(db_interface.database_config.connection_url)
 

--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,5 +1,6 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
+from logging.config import fileConfig
 
 import sqlalchemy
 from alembic import context
@@ -11,6 +12,7 @@ from prefect.utilities.asyncutils import sync_compatible
 
 db_interface = provide_database_interface()
 config = context.config
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 target_metadata = db_interface.Base.metadata
 dialect = get_dialect(db_interface.database_config.connection_url)
 

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -34,14 +34,14 @@ async def sample_db_data(
 
 @pytest.mark.service("database")
 @pytest.mark.flaky(max_runs=3)
-async def test_orion_full_migration_works_with_data_in_db(sample_db_data):
+def test_orion_full_migration_works_with_data_in_db(sample_db_data):
     """
     Tests that downgrade migrations work when the database has data in it.
     """
     try:
-        await run_sync_in_worker_thread(alembic_downgrade)
+        alembic_downgrade()
     finally:
-        await run_sync_in_worker_thread(alembic_upgrade)
+        alembic_upgrade()
 
 
 @pytest.mark.parametrize(

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -33,15 +33,15 @@ async def sample_db_data(
 
 
 @pytest.mark.service("database")
-@pytest.mark.flaky(max_runs=3)
-def test_orion_full_migration_works_with_data_in_db(sample_db_data):
+@pytest.mark.timeout(120)
+async def test_orion_full_migration_works_with_data_in_db(sample_db_data):
     """
     Tests that downgrade migrations work when the database has data in it.
     """
     try:
-        alembic_downgrade()
+        await run_sync_in_worker_thread(alembic_downgrade)
     finally:
-        alembic_upgrade()
+        await run_sync_in_worker_thread(alembic_upgrade)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### TLDR:
Test was timing out but the error is obscured  because of bad interaction between what this test is doing, it failing and flaky

---
`test_orion_full_migration_works_with_data_in_db` was failing in CI more often then not with an error similar to:
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) table flow_run has no column named work_queue_id
[SQL: INSERT INTO flow_run (id, created, updated, name, state_type, state_name, state_timestamp, run_count, 
expected_start_time, next_scheduled_start_time, start_time, end_time, total_run_time, deployment_id, work_queue_name,
flow_version, parameters, idempotency_key, context, empirical_policy, tags, created_by, infrastructure_pid, auto_scheduled,
flow_id, infrastructure_document_id, parent_task_run_id, state_id, work_queue_id) VALUES (:id, :created, :updated, :name,
:state_type, :state_name, :state_timestamp, :run_count, :expected_start_time, :next_scheduled_start_time, :start_time,
:end_time, :total_run_time, :deployment_id, :work_queue_name, :flow_version, :parameters, :idempotency_key, :context, 
:empirical_policy, :tags, :created_by, :infrastructure_pid, :auto_scheduled, :flow_id, :infrastructure_document_id, :parent_task_run_id, :state_id, :work_queue_id)]
```

Some examples:
- https://github.com/PrefectHQ/prefect/actions/runs/4414949522/jobs/7737303380 (has SQLITE debug logs)
- https://github.com/PrefectHQ/prefect/actions/runs/4369228293/jobs/7642782870

the test originally looks like this:
```
@pytest.mark.service("database")
@pytest.mark.flaky(max_runs=3)
async def test_orion_full_migration_works_with_data_in_db(sample_db_data):
    """
    Tests that downgrade migrations work when the database has data in it.
    """
    try:
        await run_sync_in_worker_thread(alembic_downgrade)
    finally:
        await run_sync_in_worker_thread(alembic_upgrade)
```

- In setup.cfg the pytest timeout is set to 60. 
- The primary error that happening here is that the test will often timeout because it takes longer than 60s to run 
- due to the nature of the test (actually running upgrades that modify the tables), it will timeout in the middle of the migrations leaving the database in an unexpected state
- then flaky will kick in and try to rerun the test including re-running the fixture and inserting data into the tables that no longer have their expected state (fully upgraded)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
