### PR TITLE
Update to worker base job template logic for nested placeholders

### DIFF
--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -1,6 +1,6 @@
 import abc
 import re
-from typing import Any, Dict, List, Optional, Set, Type, Union
+from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
 from uuid import uuid4
 
 import anyio
@@ -20,6 +20,17 @@ from prefect.server.schemas.responses import WorkerFlowRunResponse
 from prefect.settings import PREFECT_WORKER_PREFETCH_SECONDS, get_current_settings
 from prefect.states import Crashed, Pending, exception_to_failed_state
 from prefect.utilities.dispatch import register_base_type
+
+
+class Unset:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET: Unset = Unset()
+
+
+T = TypeVar("T")
 
 
 class BaseJobConfiguration(BaseModel):
@@ -63,11 +74,9 @@ class BaseJobConfiguration(BaseModel):
         Important: this method expects that the base_job_template was already
         validated server-side.
         """
-        job_config = base_job_template["job_configuration"]
+        job_config: Dict[str, Any] = base_job_template["job_configuration"]
         variables_schema = base_job_template["variables"]
-        variables = cls._base_variables_from_variable_properties(
-            variables_schema["properties"]
-        )
+        variables = cls._get_base_config_defaults(variables_schema["properties"])
         variables.update(deployment_overrides)
 
         populated_configuration = cls._apply_variables(job_config, variables)
@@ -96,57 +105,68 @@ class BaseJobConfiguration(BaseModel):
 
         return configuration
 
-    @staticmethod
-    def _apply_variables(job_config: Dict[str, str], variables: Dict[str, Any]):
+    @classmethod
+    def _apply_variables(cls, object: T, variables: Dict[str, Any]) -> Union[T, Unset]:
         """
-        Apply variables to a job configuration template by interpolating variables into the placeholders in the
-        template.
+        Apply variables to a job configuration template by recursively walking an object
+        and interpolating variables into any placeholders found.
 
-        If a value in the job configuration contains only a single placeholder, the value will be fully replaced
-        with the value.
+        If a value in the job configuration contains only a single placeholder, the
+        value will be fully replaced with the value.
 
-        If a value in the job configuration contains text before and after a placeholder or there are multiple
-        placeholders, the placeholders will be replaced with the corresponding variable values.
+        If a value in the job configuration contains text before and after a
+        placeholder or there are multiple placeholders, the placeholders will
+        be replaced with the corresponding variable values.
+
+        This method will return an UNSET value if the object contains a placeholder
+        that does not have a corresponding variable value.
 
         Args:
-            job_config: The job configuration portion of a base job template to apply variables to
+            object: Object to discover and replace variables in
             variables: The variables to apply to the job configuration
 
         Returns:
             The job configuration with variables applied
         """
         variable_capture_regex = re.compile(r"({{\s*(\w+)\s*}})")
-        applied_config = {}
-        for key, value in (job_config or {}).items():
-            used_variables = variable_capture_regex.findall(value)
+
+        if isinstance(object, str):
+            used_variables = variable_capture_regex.findall(object)
             if not used_variables:
                 # If there are no variables, we can just use the value
-                applied_config[key] = value
-            elif (
-                len(used_variables) == 1
-                and used_variables[0][0] == value
-                and variables[used_variables[0][1]] is not None
-            ):
-                # If there is only one variable with no surrounding text, we can just replace it
-                applied_config[key] = variables[key]
+                return object
+            elif len(used_variables) == 1 and used_variables[0][0] == object:
+                # If there is only one variable with no surrounding text,
+                # we can replace it. If there is no variable value, we
+                # return UNSET to indicate that the value should not be included.
+                return variables.get(used_variables[0][1], UNSET)
             else:
                 for full_match, variable_name in used_variables:
                     if (
                         variable_name in variables
                         and variables[variable_name] is not None
                     ):
-                        applied_config[key] = value.replace(
-                            full_match, variables[variable_name]
+                        object = object.replace(
+                            full_match, variables.get(variable_name, "")
                         )
-        return applied_config
+                return object
+        elif isinstance(object, dict):
+            updated_object = {}
+            for key, value in object.items():
+                updated_value = cls._apply_variables(value, variables)
+                if updated_value is not UNSET:
+                    updated_object[key] = updated_value
 
-    @classmethod
-    def _base_variables_from_variable_properties(cls, variable_properties):
-        """Get base template variables."""
-        default_variables = cls._get_base_config_defaults(variable_properties)
-        variables = {key: None for key in variable_properties.keys()}
-        variables.update(default_variables)
-        return variables
+            return updated_object
+        elif isinstance(object, list):
+            updated_list = []
+            for value in object:
+                updated_value = cls._apply_variables(value, variables)
+                if updated_value is not UNSET:
+                    updated_list.append(updated_value)
+            return updated_list
+        else:
+            raise ValueError(f"Unexpected type: {type(object)}")
 
 
 class BaseVariables(BaseModel):

--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Set, Type, Union
 from uuid import uuid4
 
 import anyio
@@ -20,17 +20,6 @@ from prefect.settings import PREFECT_WORKER_PREFETCH_SECONDS, get_current_settin
 from prefect.states import Crashed, Pending, exception_to_failed_state
 from prefect.utilities.dispatch import register_base_type
 from prefect.utilities.templating import apply_values, resolve_block_document_references
-
-
-class Unset:
-    def __bool__(self) -> bool:
-        return False
-
-
-UNSET: Unset = Unset()
-
-
-T = TypeVar("T")
 
 
 class BaseJobConfiguration(BaseModel):
@@ -520,7 +509,7 @@ class BaseWorker(abc.ABC):
         deployment = await self._client.read_deployment(flow_run.deployment_id)
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,
-            values=deployment.infra_overrides,
+            values=deployment.infra_overrides or {},
         )
         return configuration
 

--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -76,7 +76,9 @@ class BaseJobConfiguration(BaseModel):
         """
         job_config: Dict[str, Any] = base_job_template["job_configuration"]
         variables_schema = base_job_template["variables"]
-        variables = cls._get_base_config_defaults(variables_schema["properties"])
+        variables = cls._get_base_config_defaults(
+            variables_schema.get("properties", {})
+        )
         variables.update(deployment_overrides)
 
         populated_configuration = cls._apply_variables(job_config, variables)
@@ -130,6 +132,8 @@ class BaseJobConfiguration(BaseModel):
         """
         variable_capture_regex = re.compile(r"({{\s*(\w+)\s*}})")
 
+        if isinstance(object, (int, float, bool)):
+            return object
         if isinstance(object, str):
             used_variables = variable_capture_regex.findall(object)
             if not used_variables:

--- a/src/prefect/experimental/workers/base.py
+++ b/src/prefect/experimental/workers/base.py
@@ -66,9 +66,7 @@ class BaseJobConfiguration(BaseModel):
         return defaults
 
     @classmethod
-    async def from_template_and_overrides(
-        cls, base_job_template: dict, deployment_overrides: dict
-    ):
+    async def from_template_and_values(cls, base_job_template: dict, values: dict):
         """Creates a valid worker configuration object from the provided base
         configuration and overrides.
 
@@ -80,7 +78,7 @@ class BaseJobConfiguration(BaseModel):
         variables = cls._get_base_config_defaults(
             variables_schema.get("properties", {})
         )
-        variables.update(deployment_overrides)
+        variables.update(values)
         variables = await resolve_block_document_references(variables)
 
         populated_configuration = apply_values(job_config, variables)
@@ -586,9 +584,9 @@ class BaseWorker(abc.ABC):
 
     async def _get_configuration(self, flow_run: FlowRun) -> BaseJobConfiguration:
         deployment = await self._client.read_deployment(flow_run.deployment_id)
-        configuration = await self.job_configuration.from_template_and_overrides(
+        configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,
-            deployment_overrides=deployment.infra_overrides,
+            values=deployment.infra_overrides,
         )
         return configuration
 

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -2,6 +2,7 @@
 Full schemas of Prefect REST API objects.
 """
 import datetime
+import json
 import re
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
@@ -1107,16 +1108,18 @@ class WorkPool(ORMBaseModel):
         for template in job_config.values():
             # find any variables inside of double curly braces, minus any whitespace
             # e.g. "{{ var1 }}.{{var2}}" -> ["var1", "var2"]
-            found_variables = re.findall(r"{{\s*(.*?)\s*}}", template)
+            # convert to json string to handle nested objects and lists
+            found_variables = re.findall(r"{{\s*(.*?)\s*}}", json.dumps(template))
             template_variables.update(found_variables)
 
         provided_variables = set(variables["properties"].keys())
         if not template_variables.issubset(provided_variables):
+            missing_variables = template_variables - provided_variables
             raise ValueError(
                 "The variables specified in the job configuration template must be "
-                "present as attributes in the variables class. "
-                f"Your job expects the following variables: {template_variables!r}, "
-                f"but your template provides: {provided_variables!r}"
+                "present as properties in the variables schema. "
+                "Your job configuration uses the following undeclared "
+                f"variable(s): {' ,'.join(missing_variables)}."
             )
         return v
 

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -3,7 +3,6 @@ Full schemas of Prefect REST API objects.
 """
 import datetime
 import json
-import re
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
@@ -18,6 +17,7 @@ from prefect.server.utilities.schemas import DateTimeTZ, ORMBaseModel, PrefectBa
 from prefect.settings import PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
 from prefect.utilities.names import generate_slug, obfuscate, obfuscate_string
+from prefect.utilities.templating import find_placeholders
 
 INVALID_CHARACTERS = ["/", "%", "&", ">", "<"]
 
@@ -1109,8 +1109,8 @@ class WorkPool(ORMBaseModel):
             # find any variables inside of double curly braces, minus any whitespace
             # e.g. "{{ var1 }}.{{var2}}" -> ["var1", "var2"]
             # convert to json string to handle nested objects and lists
-            found_variables = re.findall(r"{{\s*(.*?)\s*}}", json.dumps(template))
-            template_variables.update(found_variables)
+            found_variables = find_placeholders(json.dumps(template))
+            template_variables = {placeholder.name for placeholder in found_variables}
 
         provided_variables = set(variables["properties"].keys())
         if not template_variables.issubset(provided_variables):

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -1,0 +1,126 @@
+import re
+from copy import copy
+from typing import Any, Dict, TypeVar, Union
+
+from prefect.client.orchestration import PrefectClient
+from prefect.client.utilities import inject_client
+
+
+class Unset:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET: Unset = Unset()
+
+
+T = TypeVar("T", str, int, float, bool, dict, list)
+
+
+def apply_values(template: T, values: Dict[str, Any]) -> Union[T, Unset]:
+    """
+    Replaces placeholders in a template with values from a supplied dictionary.
+
+    Will recursively replace placeholders in dictionaries and lists.
+
+    If a value has no placeholders, it will be returned unchanged.
+
+    If a template contains only a single placeholder, the placeholder will be
+    fully replaced with the value.
+
+    If a template contains text before or after a placeholder or there are
+    multiple placeholders, the placeholders will be replaced with the
+    corresponding variable values.
+
+    If a template contains a placeholder that is not in `values`, UNSET will
+    be returned to signify that no placeholder replacement occurred. If
+    `template` is a dictionary that contains a key with a value of UNSET,
+    the key will be removed in the return value.
+
+    Args:
+        template: template to discover and replace values in
+        values: The values to apply to placeholders in the template
+
+    Returns:
+        The template with the values applied
+    """
+    variable_capture_regex = re.compile(r"({{\s*(\w+)\s*}})")
+
+    if isinstance(template, (int, float, bool, Unset)):
+        return template
+    if isinstance(template, str):
+        used_values = variable_capture_regex.findall(template)
+        if not used_values:
+            # If there are no variables, we can just use the value
+            return template
+        elif len(used_values) == 1 and used_values[0][0] == template:
+            # If there is only one variable with no surrounding text,
+            # we can replace it. If there is no variable value, we
+            # return UNSET to indicate that the value should not be included.
+            return values.get(used_values[0][1], UNSET)
+        else:
+            for full_match, variable_name in used_values:
+                if variable_name in values and values[variable_name] is not None:
+                    template = template.replace(
+                        full_match, values.get(variable_name, "")
+                    )
+            return template
+    elif isinstance(template, dict):
+        updated_template = {}
+        for key, value in template.items():
+            updated_value = apply_values(value, values)
+            if updated_value is not UNSET:
+                updated_template[key] = updated_value
+
+        return updated_template
+    elif isinstance(template, list):
+        updated_list = []
+        for value in template:
+            updated_value = apply_values(value, values)
+            if updated_value is not UNSET:
+                updated_list.append(updated_value)
+        return updated_list
+    else:
+        raise ValueError(f"Unexpected type: {type(template)}")
+
+
+@inject_client
+async def resolve_block_document_references(
+    template: T, client: PrefectClient = None
+) -> T:
+    """
+    Resolve block document references in a template by replacing each reference with
+    the data of the block document.
+
+    Recursively searches for block document references in dictionaries and lists.
+
+    Args:
+        template: The template to resolve block documents in
+
+    Returns:
+        The template with block documents resolved
+    """
+    if isinstance(template, dict):
+        block_document_id = template.get("$ref", {}).get("block_document_id")
+        if block_document_id:
+            block_document = await client.read_block_document(block_document_id)
+            return block_document.data
+        template_copy = copy(template)
+        for key, value in template_copy.items():
+            if isinstance(value, dict):
+                block_document_id = value.get("$ref", {}).get("block_document_id")
+                if block_document_id:
+                    block_document = await client.read_block_document(block_document_id)
+                    template_copy[key] = block_document.data
+                else:
+                    template_copy[key] = await resolve_block_document_references(
+                        template=value, client=client
+                    )
+        return template_copy
+    elif isinstance(template, list):
+        return [
+            await resolve_block_document_references(item, client=client)
+            for item in template
+        ]
+
+    return template

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -124,6 +124,20 @@ async def resolve_block_document_references(
 
     Recursively searches for block document references in dictionaries and lists.
 
+    Identifies block document references by the as dictionary with the following
+    structure:
+    ```
+    {
+        "$ref": {
+            "block_document_id": <block_document_id>
+        }
+    }
+    ```
+    where `<block_document_id>` is the ID of the block document to resolve.
+
+    Once the block document is retrieved from the API, the data of the block document
+    is used to replace the reference.
+
     Args:
         template: The template to resolve block documents in
 

--- a/tests/experimental/workers/test_base_worker.py
+++ b/tests/experimental/workers/test_base_worker.py
@@ -813,6 +813,25 @@ def test_job_configuration_from_template_and_overrides_with_nested_variables():
     }
 
 
+def test_job_configuration_from_template_and_overrides_with_hard_coded_primitives():
+    template = {
+        "job_configuration": {"config": {"var1": 1, "var2": 1.1, "var3": True}},
+        "variables": {},
+    }
+
+    class ArbitraryJobConfiguration(BaseJobConfiguration):
+        config: dict = Field(template={"var1": 1, "var2": 1.1, "var3": True})
+
+    config = ArbitraryJobConfiguration.from_template_and_overrides(
+        base_job_template=template, deployment_overrides={}
+    )
+    assert config.dict() == {
+        "command": None,
+        "env": {},
+        "config": {"var1": 1, "var2": 1.1, "var3": True},
+    }
+
+
 def test_job_configuration_from_template_and_overrides_with_variables_in_a_list():
     template = {
         "job_configuration": {"config": ["{{ var1 }}", "{{ var2 }}"]},

--- a/tests/experimental/workers/test_base_worker.py
+++ b/tests/experimental/workers/test_base_worker.py
@@ -589,8 +589,8 @@ async def test_base_job_configuration_from_template_and_overrides(
     template, overrides, expected
 ):
     """Test that the job configuration is correctly built from the template and overrides"""
-    config = await BaseJobConfiguration.from_template_and_overrides(
-        base_job_template=template, deployment_overrides=overrides
+    config = await BaseJobConfiguration.from_template_and_values(
+        base_job_template=template, values=overrides
     )
     assert config.dict() == expected
 
@@ -770,8 +770,8 @@ async def test_job_configuration_from_template_and_overrides(
         var1: str = Field(template="{{ var1 }}")
         var2: int = Field(template="{{ var2 }}")
 
-    config = await ArbitraryJobConfiguration.from_template_and_overrides(
-        base_job_template=template, deployment_overrides=overrides
+    config = await ArbitraryJobConfiguration.from_template_and_values(
+        base_job_template=template, values=overrides
     )
     assert config.dict() == expected
 
@@ -803,8 +803,8 @@ async def test_job_configuration_from_template_and_overrides_with_nested_variabl
     class ArbitraryJobConfiguration(BaseJobConfiguration):
         config: dict = Field(template={"var1": "{{ var1 }}", "var2": "{{ var2 }}"})
 
-    config = await ArbitraryJobConfiguration.from_template_and_overrides(
-        base_job_template=template, deployment_overrides={"var1": "woof!"}
+    config = await ArbitraryJobConfiguration.from_template_and_values(
+        base_job_template=template, values={"var1": "woof!"}
     )
     assert config.dict() == {
         "command": None,
@@ -825,8 +825,8 @@ async def test_job_configuration_from_template_and_overrides_with_hard_coded_pri
     class ArbitraryJobConfiguration(BaseJobConfiguration):
         config: dict = Field(template={"var1": 1, "var2": 1.1, "var3": True})
 
-    config = await ArbitraryJobConfiguration.from_template_and_overrides(
-        base_job_template=template, deployment_overrides={}
+    config = await ArbitraryJobConfiguration.from_template_and_values(
+        base_job_template=template, values={}
     )
     assert config.dict() == {
         "command": None,
@@ -882,9 +882,9 @@ async def test_job_configuration_from_template_overrides_with_block():
 
     block_id = await ArbitraryBlock(a=1, b="hello").save(name="arbitrary-block")
 
-    config = await ArbitraryJobConfiguration.from_template_and_overrides(
+    config = await ArbitraryJobConfiguration.from_template_and_values(
         base_job_template=template,
-        deployment_overrides={
+        values={
             "var1": "woof!",
             "arbitrary_block": {"$ref": {"block_document_id": block_id}},
         },
@@ -921,8 +921,8 @@ async def test_job_configuration_from_template_and_overrides_with_variables_in_a
     class ArbitraryJobConfiguration(BaseJobConfiguration):
         config: list = Field(template=["{{ var1 }}", "{{ var2 }}"])
 
-    config = await ArbitraryJobConfiguration.from_template_and_overrides(
-        base_job_template=template, deployment_overrides={"var1": "woof!"}
+    config = await ArbitraryJobConfiguration.from_template_and_values(
+        base_job_template=template, values={"var1": "woof!"}
     )
     assert config.dict() == {
         "command": None,
@@ -940,7 +940,7 @@ async def test_job_configuration_from_template_and_overrides_with_variables_in_a
 )
 async def test_base_job_configuration_converts_falsey_values_to_none(falsey_value):
     """Test that valid falsey values are converted to None for `command`"""
-    template = await BaseJobConfiguration.from_template_and_overrides(
+    template = await BaseJobConfiguration.from_template_and_values(
         base_job_template={
             "job_configuration": {
                 "command": "{{ command }}",
@@ -955,7 +955,7 @@ async def test_base_job_configuration_converts_falsey_values_to_none(falsey_valu
                 "required": [],
             },
         },
-        deployment_overrides={"command": falsey_value},
+        values={"command": falsey_value},
     )
     assert template.command is None
 

--- a/tests/experimental/workers/test_process_worker.py
+++ b/tests/experimental/workers/test_process_worker.py
@@ -419,7 +419,7 @@ async def test_process_worker_command_override(
     flow_run, patch_run_process, work_pool, monkeypatch
 ):
     mock: AsyncMock = patch_run_process()
-    override_command = f"echo hello world"
+    override_command = "echo hello world"
     override = {"command": override_command}
     read_deployment_mock = patch_read_deployment(monkeypatch, overrides=override)
 

--- a/tests/server/schemas/test_core.py
+++ b/tests/server/schemas/test_core.py
@@ -340,8 +340,8 @@ class TestWorkPool:
         with pytest.raises(
             ValueError,
             match=(
-                ".*Your job expects the following variables: {'expected_variable'}, but"
-                " your template provides: {'wrong_variable'}"
+                r"Your job configuration uses the following undeclared variable\(s\):"
+                r" expected_variable"
             ),
         ):
             wp = schemas.core.WorkPool(

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -1,0 +1,128 @@
+import pytest
+
+from prefect.blocks.core import Block
+from prefect.utilities.templating import (
+    UNSET,
+    apply_values,
+    resolve_block_document_references,
+)
+
+
+class TestApplyValues:
+    def test_apply_values_simple_string_with_one_placeholder(self):
+        assert apply_values("Hello, {{name}}!", {"name": "Alice"}) == "Hello, Alice!"
+
+    def test_apply_values_simple_string_with_multiple_placeholders(self):
+        assert (
+            apply_values(
+                "Hello, {{first_name}} {{last_name}}!",
+                {"first_name": "Alice", "last_name": "Smith"},
+            )
+            == "Hello, Alice Smith!"
+        )
+
+    def test_apply_values_dictionary_with_placeholders(self):
+        template = {"name": "{{first_name}} {{last_name}}", "age": "{{age}}"}
+        values = {"first_name": "Alice", "last_name": "Smith", "age": 30}
+        assert apply_values(template, values) == {"name": "Alice Smith", "age": 30}
+
+    def test_apply_values_dictionary_with_unset_value(self):
+        template = {"last_name": "{{last_name}}", "age": "{{age}}"}
+        values = {"first_name": "Alice", "age": 30}
+        assert apply_values(template, values) == {"age": 30}
+
+    def test_apply_values_nested_dictionary_with_placeholders(self):
+        template = {
+            "name": {"first_name": "{{ first_name }}", "last_name": "{{ last_name }}"},
+            "age": "{{age}}",
+        }
+        values = {"first_name": "Alice", "last_name": "Smith", "age": 30}
+        assert apply_values(template, values) == {
+            "name": {"first_name": "Alice", "last_name": "Smith"},
+            "age": 30,
+        }
+
+    def test_apply_values_dictionary_with_UNSET_value_removed(self):
+        template = {"name": UNSET, "age": "{{age}}"}
+        values = {"age": 30}
+        assert apply_values(template, values) == {"age": 30}
+
+    def test_apply_values_list_with_placeholders(self):
+        template = [
+            "Hello, {{first_name}} {{last_name}}!",
+            {"name": "{{first_name}} {{last_name}}"},
+        ]
+        values = {"first_name": "Alice", "last_name": "Smith"}
+        assert apply_values(template, values) == [
+            "Hello, Alice Smith!",
+            {"name": "Alice Smith"},
+        ]
+
+    def test_apply_values_integer_input(self):
+        assert apply_values(123, {"name": "Alice"}) == 123
+
+    def test_apply_values_float_input(self):
+        assert apply_values(3.14, {"pi": 3.14}) == 3.14
+
+    def test_apply_values_boolean_input(self):
+        assert apply_values(True, {"flag": False}) is True
+
+
+class TestResolveBlockDocumentReferences:
+    @pytest.fixture
+    async def block_document_id(self):
+        class ArbitraryBlock(Block):
+            a: int
+            b: str
+
+        return await ArbitraryBlock(a=1, b="hello").save(name="arbitrary-block")
+
+    async def test_resolve_block_document_references_with_no_block_document_references(
+        self,
+    ):
+        assert await resolve_block_document_references({"key": "value"}) == {
+            "key": "value"
+        }
+
+    async def test_resolve_block_document_references_with_one_block_document_reference(
+        self, orion_client, block_document_id
+    ):
+        assert {
+            "key": {"a": 1, "b": "hello"}
+        } == await resolve_block_document_references(
+            {"key": {"$ref": {"block_document_id": block_document_id}}},
+            client=orion_client,
+        )
+
+    async def test_resolve_block_document_references_with_nested_block_document_references(
+        self, orion_client, block_document_id
+    ):
+        template = {
+            "key": {
+                "nested_key": {"$ref": {"block_document_id": block_document_id}},
+                "other_nested_key": {"$ref": {"block_document_id": block_document_id}},
+            }
+        }
+        block_document_data = {"a": 1, "b": "hello"}
+
+        result = await resolve_block_document_references(template, client=orion_client)
+
+        assert result == {
+            "key": {
+                "nested_key": block_document_data,
+                "other_nested_key": block_document_data,
+            }
+        }
+
+    async def test_resolve_block_document_references_with_list_of_block_document_references(
+        self, orion_client, block_document_id
+    ):
+        # given
+        template = [{"$ref": {"block_document_id": block_document_id}}]
+        block_document_data = {"a": 1, "b": "hello"}
+
+        # when
+        result = await resolve_block_document_references(template, client=orion_client)
+
+        # then
+        assert result == [block_document_data]


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Updates to the worker base job template templating logic to allow for placeholders to be placed into nested values within a JSON structure. Previously, attempts to create a work pool with a nested placeholder would fail validation. Once a work pool was created with a base job template that had a nested placeholder, the placeholders nested within dictionaries and lists would not be correctly replaced. This PR updates the placeholder replacement process to recursively walk a job configuration and replace all discovered placeholders.

Also adds functionality to resolve block document references within the variables supplied to populate a job configuration.

This PR supports the complexity of the default base job template for the kubernetes worker.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
For a worker job configuration class with a complex template:
```python
class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
    job_manifest: Dict[str, Any] = Field(template={
        "apiVersion": "batch/v1",
        "kind": "Job",
        "metadata": {
            "labels": "{{ labels }}",
            "namespace": "{{ namespace }}",
            "generateName": "{{ job_name_prefix }}",
        },
        "spec": {
            "template": {
                "spec": {
                    "parallelism": 1,
                    "completions": 1,
                    "restartPolicy": "Never",
                    "serviceAccountName": "{{ service_account_name }}",
                    "ttlSecondsAfterFinished": "{{ finished_job_ttl }}",
                    "containers": [
                        {
                            "name": "prefect-job",
                            "env": "{{ env }}",
                            "image": "{{ image }}",
                            "imagePullPolicy": "{{ image_pull_policy }}",
                            "args": "{{ command }}",
                        }
                    ],
                }
            }
        },
    })
    job_watch_timeout_seconds: Optional[int] = Field(default=None)
    pod_watch_timeout_seconds: int
    stream_output: bool
```

Populated configurations can be populated with overrides:
```python
> KubernetesWorkerJobConfiguration.from_template_and_values(
    base_job_template=KubernetesWorker.get_default_base_job_template(),
    values={"command": "echo hello"}
)

KubernetesWorkerJobConfiguration(
    command='echo hello',
    env={},
    job_manifest={
        'apiVersion': 'batch/v1',
        'kind': 'Job',
        'metadata': {
            'namespace': 'default', 
            'generateName': 'prefect-job-'
        }, 
        'spec': {
             'template': {
                 'spec': {
                    'parallelism': 1, 
                    'completions': 1,
                    'restartPolicy': 'Never',
                    'containers': [
                        {
                            'name': 'prefect-job', 
                            'image': 'prefecthq/prefect:2.8.5-python3.8',
                            'imagePullPolicy': 'IfNotPresent',
                            'args': 'echo hello'
                        }
                    ]
                }
            }
        }
    },
    job_watch_timeout_seconds=None,
    pod_watch_timeout_seconds=60,
    stream_output=True
)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
