### PR TITLE
Remove `PreventRedundantTransitions` rule from core task orchestration policy

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -61,7 +61,6 @@ class CoreTaskPolicy(BaseOrchestrationPolicy):
             CacheRetrieval,
             HandleTaskTerminalStateTransitions,
             PreventRunningTasksFromStoppedFlows,
-            PreventRedundantTransitions,
             SecureTaskConcurrencySlots,  # retrieve cached states even if slots are full
             CopyScheduledTime,
             WaitForScheduledTime,

--- a/tests/server/api/test_task_runs.py
+++ b/tests/server/api/test_task_runs.py
@@ -346,12 +346,12 @@ class TestSetTaskRunState:
         assert run.run_count == 1
 
     @pytest.mark.parametrize("proposed_state", ["PENDING", "RUNNING"])
-    async def test_setting_task_run_state_twice_aborts(
+    async def test_setting_task_run_state_twice_works(
         self, task_run, client, session, proposed_state
     ):
-        # A multi-agent environment may attempt to orchestrate a run more than once,
-        # this test ensures that a 2nd agent cannot re-propose a state that's already
-        # been set
+        # Task runners may choose to kill and restart tasks with no way for Prefect
+        # to know it has happened. This test checks that a task can re-transition
+        # to its current state to ensure restarts occur without error.
 
         # first ensure the parent flow run is in a running state
         await client.post(
@@ -372,10 +372,10 @@ class TestSetTaskRunState:
             f"/task_runs/{task_run.id}/set_state",
             json=dict(state=dict(type=proposed_state, name="Test State")),
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
 
         api_response = OrchestrationResult.parse_obj(response.json())
-        assert api_response.status == responses.SetStateStatus.ABORT
+        assert api_response.status == responses.SetStateStatus.ACCEPT
 
     async def test_set_task_run_ignores_client_provided_timestamp(
         self, flow_run, client

--- a/tests/server/api/test_task_runs.py
+++ b/tests/server/api/test_task_runs.py
@@ -349,11 +349,11 @@ class TestSetTaskRunState:
     async def test_setting_task_run_state_twice_works(
         self, task_run, client, session, proposed_state
     ):
-        # Task runners may choose to kill and restart tasks with no way for Prefect
-        # to know it has happened. This test checks that a task can re-transition
-        # to its current state to ensure restarts occur without error.
+        # Task runner infrastructure may kill and restart tasks without informing
+        # Prefect. This test checks that a task can re-transition  its current state
+        # to ensure restarts occur without error.
 
-        # first ensure the parent flow run is in a running state
+        # first, ensure the parent flow run is in a running state
         await client.post(
             f"/flow_runs/{task_run.flow_run_id}/set_state",
             json=dict(state=dict(type="RUNNING")),


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Some users choose to run Dask workers on ephemeral infrastructure like EC2 spot instances, as reported in https://github.com/PrefectHQ/prefect/issues/8602. Sometimes, this infrastructure disappears without giving Prefect the opportunity to gracefully handle the shutdown - instead, Dask itself will [retry the task](https://github.com/dask/distributed/blob/main/distributed/distributed.yaml#L12).

The abrupt shutdown, combined with Dask retrying the task without giving Prefect an opportunity to gracefully terminate the task, leave the task in a RUNNING state, causing an error when retrying: `This run cannot transition to the RUNNING state from the RUNNING state. Task run is in RUNNING state`.

The issue also appears to happen when running Ray on spot instances: https://github.com/PrefectHQ/prefect-ray/issues/71

After discussing the issue, we decided Prefect should not try to orchestrate things happening outside its control, so this PR removes the `PreventRedundantTransitions` rule from `CoreTaskPolicy.`

Closes #8602

A related issue also solved by this PR is #8597, where API timeouts occasionally result in task run trying to re-set the running state when it was already saved server-side.

Closes #8597 

### Example
Before applying the changes in this PR, run task in a Dask worker, and either kill the worker manually or call `os.abort()` inside the worker. Dask should restart the worker and begin re-running the task. 

Below is a simple test that will cause random crashes, but succeed eventually. We want the task to crash the Dask runner on the first run, but succeed eventually:
```python
import os
import random

from prefect import flow, task
from prefect_dask import DaskTaskRunner


@task()
def sometimes_crashes():
    num = random.randint(1, 10)
    if num > 3:
        os.abort()


@flow(
    task_runner=DaskTaskRunner(
        cluster_kwargs={"processes": True, "scheduler_kwargs": {"allowed_failures": 10}}
    )
)
def task_crash_test():
    res = sometimes_crashes.submit()
    res.result()



if __name__ == "__main__":
    task_crash_test()

```

Before applying this PR, when the worker crashes and tries to re-run the task, Prefect aborts the state transition and fails the flow run:
```
10:22:50.689 | INFO    | Flow run 'jolly-chicken' - Created task run 'sometimes_crashes-0' for task 'sometimes_crashes'
10:22:51.084 | INFO    | Flow run 'jolly-chicken' - Submitted task run 'sometimes_crashes-0' for execution.
10:22:51.378 | INFO    | distributed.nanny - Worker process 94265 was killed by signal 6
10:22:51.381 | WARNING | distributed.nanny - Restarting worker
10:22:51.463 | WARNING | Task run 'sometimes_crashes-0' - Task run 'a05d0e42-64ea-4b5b-819a-d06a25a32ab3' received abort during orchestration: This run cannot transition to the RUNNING state from the RUNNING state. Task run is in RUNNING state.
10:22:52.841 | ERROR   | Flow run 'jolly-chicken' - Finished in state Failed()
```

After applying the PR's changes, Prefect allows the task to restart, so Dask restarts it and when it completes, the flow finishes successfully:
```
10:24:45.489 | INFO    | Flow run 'encouraging-chicken' - Created task run 'sometimes_crashes-0' for task 'sometimes_crashes'
10:24:45.824 | INFO    | Flow run 'encouraging-chicken' - Submitted task run 'sometimes_crashes-0' for execution.
10:24:45.965 | INFO    | distributed.nanny - Worker process 94592 was killed by signal 6
10:24:45.968 | WARNING | distributed.nanny - Restarting worker
10:24:46.048 | INFO    | Task run 'sometimes_crashes-0' - Finished in state Completed()
10:24:47.434 | INFO    | Flow run 'encouraging-chicken' - Finished in state Completed('All states completed.')
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
