### PR TITLE
Disable Postgres JIT

### DIFF
--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -105,6 +105,7 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
                 connect_args["timeout"] = self.connection_timeout
 
             if connect_args:
+                connect_args["server_settings"] = {"jit": "off"}
                 kwargs["connect_args"] = connect_args
 
             engine = create_async_engine(self.connection_url, echo=self.echo, **kwargs)


### PR DESCRIPTION
Duplicate of https://github.com/PrefectHQ/prefect/pull/8803 authored by @jakekaplan — based on `main` instead of #8702 

We've seen timeouts in tests running against Postgres servers and massive slowdowns when running Postgres 14 vs 13. 

A possible cause is https://lightrun.com/answers/magicstack-asyncpg-slow-introspection-when-using-multiple-custom-types-in-a-query

We've confirmed that JIT is enabled in 13 by default as well as 14 so it would probably need to be a specific change to JIT behavior in 14.