### PR TITLE
Enhancement: Call `str` instead of `repr` on UnpersistedResult descriptions

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -369,7 +369,7 @@ class UnpersistedResult(BaseResult):
         obj: R,
         cache_object: bool = True,
     ) -> "UnpersistedResult[R]":
-        description = f"Unpersisted result of type `{type(obj).__name__!s}`"
+        description = f"Unpersisted result of type `{type(obj).__name__}`"
         result = cls(
             artifact_type="result",
             artifact_description=description,
@@ -493,12 +493,12 @@ class PersistedResult(BaseResult):
         key = uuid.uuid4().hex
         await storage_block.write_path(key, content=blob.to_bytes())
 
-        description = f"Result of type {type(obj).__name__!r}"
+        description = f"Result of type `{type(obj).__name__}`"
         uri = cls._infer_path(storage_block, key)
         if uri:
-            description += f" persisted to {uri}."
+            description += f" persisted to [{uri}]({uri})."
         else:
-            description += f" persisted with storage block '{storage_block_id}'."
+            description += f" persisted with storage block `{storage_block_id}`."
 
         result = cls(
             serializer_type=serializer.type,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -369,9 +369,10 @@ class UnpersistedResult(BaseResult):
         obj: R,
         cache_object: bool = True,
     ) -> "UnpersistedResult[R]":
+        description = f"Unpersisted result of type `{type(obj).__name__!s}`"
         result = cls(
             artifact_type="result",
-            artifact_description=f"Unpersisted result of type {type(obj).__name__!r}",
+            artifact_description=description,
         )
         # Only store the object in local memory, it will not be sent to the API
         if cache_object:

--- a/tests/results/test_unpersisted_result.py
+++ b/tests/results/test_unpersisted_result.py
@@ -47,5 +47,5 @@ async def test_unpersisted_result_populates_default_artifact_metadata(value):
     assert result.artifact_type == "result"
     assert (
         result.artifact_description
-        == f"Unpersisted result of type {type(value).__name__!r}"
+        == f"Unpersisted result of type `{type(value).__name__}`"
     )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
This PR changes how we stringify unpersisted result types by calling `str` instead of `repr` in the description and adding backticks (`). This creates a markdown-enabled string and removes the single quotes that python automatically wraps the type with otherwise.

**Before:**
 
![Screen Shot 2023-03-15 at 10 08 13 PM](https://user-images.githubusercontent.com/27291717/225491810-5eac9520-1b01-4bab-9dab-31b3db259cc5.png)

**After:**

![Screen Shot 2023-03-15 at 10 08 08 PM](https://user-images.githubusercontent.com/27291717/225491813-62bfa198-d198-4b7a-a231-5d3771e7c16b.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
