### PR TITLE
Fix flaky `test_controls_client_and_thread_lifecycle` test

### DIFF
--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -41,7 +41,6 @@ def test_controls_client_and_thread_lifecycle(worker: EventsWorker):
     assert not worker._thread.is_alive()
     assert not hasattr(worker, "_client")
     worker.start()
-    worker.emit(None)
 
     assert worker._thread.is_alive()
     assert isinstance(worker._client, AssertingEventsClient)


### PR DESCRIPTION
This fixes the `test_controls_client_and_thread_lifecycle` test. I think the test had an artifact from an older version of the code and was emitting `None` which now means that the worker should shut down, but then we're asserting that it's alive which is, unsurprisingly, failing. I ran this version in a loop 25 times and didn't see it fail, but was able to reproduce the failure every ~5th iteration before the fix.

Closes #8764 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
