### PR TITLE
Add jitter to Prefect client request retries

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -206,7 +206,7 @@ class PrefectHttpxClient(httpx.AsyncClient):
 
             # Add jitter
             jitter_factor = PREFECT_CLIENT_RETRY_JITTER_FACTOR.value()
-            if jitter_factor > 0:
+            if retry_seconds > 0 and jitter_factor > 0:
                 if response is not None and "Retry-After" in response.headers:
                     # Always wait for _at least_ retry seconds if requested by the API
                     retry_seconds = bounded_poisson_interval(

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -15,6 +15,8 @@ from typing_extensions import Self
 
 from prefect.exceptions import PrefectHTTPStatusError
 from prefect.logging import get_logger
+from prefect.settings import PREFECT_CLIENT_RETRY_JITTER_FACTOR
+from prefect.utilities.math import bounded_poisson_interval, clamped_poisson_interval
 
 # Datastores for lifespan management, keys should be a tuple of thread and app identities.
 APP_LIFESPANS: Dict[Tuple[int, int], LifespanManager] = {}
@@ -201,6 +203,20 @@ class PrefectHttpxClient(httpx.AsyncClient):
             # Use an exponential back-off if not set in a header
             if retry_seconds is None:
                 retry_seconds = 2**try_count
+
+            # Add jitter
+            jitter_factor = PREFECT_CLIENT_RETRY_JITTER_FACTOR.value()
+            if jitter_factor > 0:
+                if "Retry-After" in response.headers:
+                    # Always wait for _at least_ retry seconds if requested by the API
+                    retry_seconds = bounded_poisson_interval(
+                        retry_seconds, retry_seconds * (1 + jitter_factor)
+                    )
+                else:
+                    # Otherwise, use a symmetrical jitter
+                    retry_seconds = clamped_poisson_interval(
+                        retry_seconds, jitter_factor
+                    )
 
             logger.debug(
                 (

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -207,7 +207,7 @@ class PrefectHttpxClient(httpx.AsyncClient):
             # Add jitter
             jitter_factor = PREFECT_CLIENT_RETRY_JITTER_FACTOR.value()
             if jitter_factor > 0:
-                if "Retry-After" in response.headers:
+                if response is not None and "Retry-After" in response.headers:
                     # Always wait for _at least_ retry seconds if requested by the API
                     retry_seconds = bounded_poisson_interval(
                         retry_seconds, retry_seconds * (1 + jitter_factor)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -516,6 +516,15 @@ If the API does not support HTTP/2, this will have no effect and connections wil
 made via HTTP/1.1.
 """
 
+PREFECT_CLIENT_RETRY_JITTER_FACTOR = Setting(float, default=0.2)
+"""
+A value greater than or equal to zero to control the amount of jitter added to retried
+client requests. Higher values introduce larger amounts of jitter.
+
+Set to 0 to disable jitter. See `clamped_poisson_interval` for details on the how jitter
+can affect retry lengths.
+"""
+
 PREFECT_CLOUD_API_URL = Setting(
     str,
     default="https://api.prefect.cloud/api",

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -55,3 +55,18 @@ def clamped_poisson_interval(average_interval, clamping_factor=0.3):
     upper_rv = exponential_cdf(upper_bound, average_interval)
     lower_rv = exponential_cdf(lower_bound, average_interval)
     return poisson_interval(average_interval, lower_rv, upper_rv)
+
+
+def bounded_poisson_interval(lower_bound, upper_bound):
+    """
+    Bounds Poisson "inter-arrival times" to a range.
+
+    Unlike `clamped_poisson_interval` this does not take a target average interval.
+    Instead, the interval is predetermined and the average is calculated as their
+    midpoint. This allows Poisson intervals to be used in cases where a lower bound
+    must be enforced.
+    """
+    average = (float(lower_bound) + float(upper_bound)) / 2
+    upper_rv = exponential_cdf(upper_bound, lower_bound)
+    lower_rv = exponential_cdf(lower_bound, upper_bound)
+    return poisson_interval(average, lower_rv, upper_rv)

--- a/src/prefect/utilities/math.py
+++ b/src/prefect/utilities/math.py
@@ -66,7 +66,7 @@ def bounded_poisson_interval(lower_bound, upper_bound):
     midpoint. This allows Poisson intervals to be used in cases where a lower bound
     must be enforced.
     """
-    average = (float(lower_bound) + float(upper_bound)) / 2
-    upper_rv = exponential_cdf(upper_bound, lower_bound)
-    lower_rv = exponential_cdf(lower_bound, upper_bound)
+    average = (float(lower_bound) + float(upper_bound)) / 2.0
+    upper_rv = exponential_cdf(upper_bound, average)
+    lower_rv = exponential_cdf(lower_bound, average)
     return poisson_interval(average, lower_rv, upper_rv)

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient, Request, Response
 
 from prefect.client.base import PrefectHttpxClient, PrefectResponse
 from prefect.exceptions import PrefectHTTPStatusError
+from prefect.settings import PREFECT_CLIENT_RETRY_JITTER_FACTOR, temporary_settings
 from prefect.testing.utilities import AsyncMock
 
 RESPONSE_429_RETRY_AFTER_0 = Response(
@@ -27,8 +28,14 @@ RESPONSE_200 = Response(
 )
 
 
+@pytest.fixture
+def disable_jitter():
+    with temporary_settings({PREFECT_CLIENT_RETRY_JITTER_FACTOR: 0}):
+        yield
+
+
 class TestPrefectHttpxClient:
-    @pytest.mark.usefixtures("mock_anyio_sleep")
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
     @pytest.mark.parametrize(
         "error_code",
         [status.HTTP_429_TOO_MANY_REQUESTS, status.HTTP_503_SERVICE_UNAVAILABLE],
@@ -67,7 +74,7 @@ class TestPrefectHttpxClient:
         assert "Another attempt will be made in 4s" in caplog.text
         assert "This is attempt 2/6" in caplog.text
 
-    @pytest.mark.usefixtures("mock_anyio_sleep")
+    @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
     @pytest.mark.parametrize(
         "exception_type",
         [
@@ -169,6 +176,7 @@ class TestPrefectHttpxClient:
         # 5 retries + 1 first attempt
         assert base_client_send.call_count == 6
 
+    @pytest.mark.usefixtures("disable_jitter")
     async def test_prefect_httpx_client_respects_retry_header(
         self, monkeypatch, mock_anyio_sleep
     ):
@@ -193,6 +201,7 @@ class TestPrefectHttpxClient:
             )
         assert response.status_code == status.HTTP_200_OK
 
+    @pytest.mark.usefixtures("disable_jitter")
     @pytest.mark.parametrize(
         "response_or_exc",
         [RESPONSE_429_RETRY_AFTER_MISSING, httpx.RemoteProtocolError("test")],
@@ -219,6 +228,7 @@ class TestPrefectHttpxClient:
         assert response.status_code == status.HTTP_200_OK
         mock_anyio_sleep.assert_has_awaits([call(2), call(4), call(8)])
 
+    @pytest.mark.usefixtures("disable_jitter")
     async def test_prefect_httpx_client_respects_retry_header_per_response(
         self, mock_anyio_sleep, monkeypatch
     ):
@@ -245,6 +255,60 @@ class TestPrefectHttpxClient:
             )
         assert response.status_code == status.HTTP_200_OK
         mock_anyio_sleep.assert_has_awaits([call(5), call(0), call(10), call(2.0)])
+
+    async def test_prefect_httpx_client_adds_jitter_with_retry_header(
+        self, monkeypatch, mock_anyio_sleep
+    ):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxClient()
+        retry_response = Response(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            headers={"Retry-After": "5"},
+            request=Request("a test request", "fake.url/fake/route"),
+        )
+
+        base_client_send.side_effect = [retry_response, RESPONSE_200]
+
+        response = await client.post(
+            url="fake.url/fake/route", data={"evenmorefake": "data"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        for call in mock_anyio_sleep.mock_calls:
+            sleep_time = call.args[0]
+            assert sleep_time > 5 and sleep_time < (5 * 1.2)
+
+    @pytest.mark.parametrize(
+        "response_or_exc",
+        [RESPONSE_429_RETRY_AFTER_MISSING, httpx.RemoteProtocolError("test")],
+    )
+    async def test_prefect_httpx_client_adds_jitter_with_exponential_backoff(
+        self, mock_anyio_sleep, response_or_exc, monkeypatch
+    ):
+        base_client_send = AsyncMock()
+        monkeypatch.setattr(AsyncClient, "send", base_client_send)
+
+        client = PrefectHttpxClient()
+
+        base_client_send.side_effect = [
+            response_or_exc,
+            response_or_exc,
+            response_or_exc,
+            RESPONSE_200,
+        ]
+
+        with mock_anyio_sleep.assert_sleeps_for(
+            2 + 4 + 8, extra_tolerance=0.2 * 14  # Add tolerance for jitter
+        ):
+            response = await client.post(
+                url="fake.url/fake/route", data={"evenmorefake": "data"}
+            )
+        assert response.status_code == status.HTTP_200_OK
+        mock_anyio_sleep.assert_has_awaits(
+            [call(pytest.approx(n, rel=0.2)) for n in [2, 4, 8]]
+        )
 
     async def test_prefect_httpx_client_does_not_retry_other_exceptions(
         self, mock_anyio_sleep, monkeypatch

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -269,7 +269,14 @@ class TestPrefectHttpxClient:
             request=Request("a test request", "fake.url/fake/route"),
         )
 
-        base_client_send.side_effect = [retry_response, RESPONSE_200]
+        base_client_send.side_effect = [
+            retry_response,
+            retry_response,
+            retry_response,
+            retry_response,
+            retry_response,
+            RESPONSE_200,
+        ]
 
         response = await client.post(
             url="fake.url/fake/route", data={"evenmorefake": "data"}


### PR DESCRIPTION
Adds jitter to the Prefect base client when retrying requests.

Uses a Poisson interval with a shifted average for responses with "Retry-After" headers to ensure we never retry sooner than requested. Otherwise, we use a Poisson interval with an average matching our previous exponential back-off. A setting is added to control the amount of jitter (can be disabled with a value of 0) which defaults to +/- 20%.