### PR TITLE
Update to use lifespan context manager as parameter in FastApi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ croniter >= 1.0.12
 cryptography >= 36.0.1
 dateparser >= 1.1.1
 docker >= 4.0
-fastapi >= 0.70
+fastapi >= 0.93
 fsspec >= 2022.5.0, != 2023.3.0
 griffe >= 0.20.0
 httpx[http2] >= 0.23, != 0.23.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ filterwarnings =
     ignore:Skipped unsupported reflection of expression-based index:sqlalchemy.exc.SAWarning
     # SQLAlchemy 2.0 warnings
     ignore::sqlalchemy.exc.RemovedIn20Warning
-    # See https://www.starlette.io/lifespan/
-    ignore::DeprecationWarning:starlette.routing
 
 [isort]
 skip = __init__.py

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -5,6 +5,7 @@ import signal
 import traceback
 import urllib.parse
 import webbrowser
+from contextlib import asynccontextmanager
 from typing import Hashable, Iterable, List, Optional, Tuple, Union
 
 import anyio
@@ -55,7 +56,16 @@ def set_login_api_ready_event():
     login_api.extra["ready-event"].set()
 
 
-login_api = FastAPI(on_startup=[set_login_api_ready_event])
+@asynccontextmanager
+async def lifespan():
+    try:
+        set_login_api_ready_event()
+        yield
+    finally:
+        pass
+
+
+login_api = FastAPI(lifespan=lifespan)
 """
 This small API server is used for data transmission for browser-based log in.
 """

--- a/src/prefect/cli/cloud.py
+++ b/src/prefect/cli/cloud.py
@@ -57,7 +57,7 @@ def set_login_api_ready_event():
 
 
 @asynccontextmanager
-async def lifespan():
+async def lifespan(app):
     try:
         set_login_api_ready_event()
         yield


### PR DESCRIPTION
### Overview
Replace the usage of deprecated arguments `on_startup` and `on_shutdown` with `lifespan` in the FastAPI constructor 

Closes #8786 

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
