### PR TITLE
Fixes saving block document secrets that have not been modified

### DIFF
--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -449,7 +449,7 @@ async def update_block_document(
             current_secret = flat_current_data.get(secret_key)
             if current_secret is not None:
                 if flat_update_data.get(secret_key) == obfuscate_string(current_secret):
-                    del flat_update_data[secret_key]
+                    flat_update_data[secret_key] = current_secret
             # Looks for obfuscated values nested under a secret field with a wildcard.
             # If any obfuscated values are found, we assume that it shouldn't be update,
             # and they are replaced with the current value for that key to avoid losing

--- a/tests/server/models/test_block_documents.py
+++ b/tests/server/models/test_block_documents.py
@@ -1565,8 +1565,12 @@ class TestSecretBlockDocuments:
         assert blocks[0].data["y"] == Y
         assert blocks[0].data["z"] == Z
 
+    @pytest.mark.parametrize(
+        "merge_existing_data",
+        [True, False],
+    )
     async def test_updating_secret_block_document_with_obfuscated_result_is_ignored(
-        self, session, secret_block_document
+        self, session, secret_block_document, merge_existing_data
     ):
         block = await models.block_documents.read_block_document_by_id(
             session=session,
@@ -1581,7 +1585,8 @@ class TestSecretBlockDocuments:
             session=session,
             block_document_id=secret_block_document.id,
             block_document=schemas.actions.BlockDocumentUpdate(
-                data=dict(x=obfuscate_string(X))
+                data=dict(x=obfuscate_string(X)),
+                merge_existing_data=merge_existing_data,
             ),
         )
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Fixes a bug where a block document's secret values would be lost if the block document's data was updated with `merege_existing_data=False`. This behavior was seen in the UI since the UI sends back an obfuscated value for a secret if its value has not changed.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
