### PR TITLE
Allow opt-out of server dependencies during installation

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,0 +1,7 @@
+aiosqlite >= 0.17.0
+alembic >= 1.7.5
+asgi-lifespan >= 1.0
+asyncpg >= 0.23
+fastapi >= 0.70
+sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0
+uvicorn >= 0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-aiosqlite >= 0.17.0
-alembic >= 1.7.5
 anyio >= 3.4.0
 apprise >= 1.1.0
-asgi-lifespan >= 1.0
-asyncpg >= 0.23
 click >= 8.0, < 8.2
 cloudpickle >= 2.0
 coolname >= 1.0.4
@@ -11,7 +7,6 @@ croniter >= 1.0.12
 cryptography >= 36.0.1
 dateparser >= 1.1.1
 docker >= 4.0
-fastapi >= 0.70
 fsspec >= 2022.5.0, != 2023.3.0
 griffe >= 0.20.0
 httpx[http2] >= 0.23, != 0.23.2
@@ -30,9 +25,7 @@ pytz >= 2021.1
 pyyaml >= 5.4.1
 readchar >= 4.0.0
 rich >= 11.0
-sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0
 toml >= 0.10.0
 typer >= 0.4.2
 typing_extensions >= 4.1.0
-uvicorn >= 0.14.0
 websockets >= 10.4

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
+import os
+
 from setuptools import find_packages, setup
 
 import versioneer
 
 install_requires = open("requirements.txt").read().strip().split("\n")
+server_requires = open("requirements-server.txt").read().strip().split("\n")
 dev_requires = open("requirements-dev.txt").read().strip().split("\n")
 
 setup(
@@ -36,7 +39,11 @@ setup(
     },
     # Requirements
     python_requires=">=3.7",
-    install_requires=install_requires,
+    install_requires=(
+        install_requires
+        # Allow opt-out of server requirements
+        + ([] if os.getenv("PREFECT_INSTALL_NO_SERVER") else server_requires)
+    ),
     extras_require={"dev": dev_requires},
     classifiers=[
         "Natural Language :: English",


### PR DESCRIPTION
Will require substantial updates to prevent importing required libraries when the server dependencies are not installed.

I'd prefer to use "extras" instead of an environment variable, but there's not support for this case upstream https://discuss.python.org/t/adding-a-default-extra-require-environment/4898