### PR TITLE
Fix `prefect dev start`

### DIFF
--- a/src/prefect/cli/dev.py
+++ b/src/prefect/cli/dev.py
@@ -182,9 +182,7 @@ async def ui():
     with tmpchdir(prefect.__root_path__):
         with tmpchdir(prefect.__root_path__ / "ui"):
             app.console.print("Installing npm packages...")
-            await run_process(
-                ["npm", "install"], shell=sys.platform == "win32", stream_output=True
-            )
+            await run_process(["npm", "install"], stream_output=True)
 
             app.console.print("Starting UI development server...")
             await run_process(command=["npm", "run", "serve"], stream_output=True)


### PR DESCRIPTION
### Overview
Running `prefect dev start` on `main` leads to the following error: 

```bash
❯ prefect dev start
Running: uvicorn --factory prefect.server.api.server:create_app --host 127.0.0.1 --port 4200 --log-level debug
Installing npm packages...
Creating hot-reloading agent process...
Traceback (most recent call last):
  File "/Users/bean/code-oss/prefect/src/prefect/cli/_utilities.py", line 41, in wrapper
    return fn(*args, **kwargs)
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/asyncutils.py", line 260, in coroutine_wrapper
    return call()
  File "/Users/bean/code-oss/prefect/src/prefect/_internal/concurrency/calls.py", line 245, in __call__
    return self.result()
  File "/Users/bean/code-oss/prefect/src/prefect/_internal/concurrency/calls.py", line 173, in result
    return self.future.result(timeout=timeout)
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/Users/bean/code-oss/prefect/src/prefect/_internal/concurrency/calls.py", line 218, in _run_async
    result = await coro
  File "/Users/bean/code-oss/prefect/src/prefect/cli/dev.py", line 324, in start
    tg.start_soon(agent, host, work_queues)
  File "/Users/bean/code-oss/prefect/venv-demo2/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "/Users/bean/code-oss/prefect/src/prefect/cli/dev.py", line 185, in ui
    await run_process(
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/processutils.py", line 258, in run_process
    async with open_process(
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/contextlib.py", line 181, in __aenter__
    return await self.gen.__anext__()
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/processutils.py", line 202, in open_process
    process = await anyio.open_process(command, **kwargs)
TypeError: open_process() got an unexpected keyword argument 'shell'
```
It appears that `run_process()` from `prefect.utilities.processutils` doesn't use the `shell` param like `subprocess.check_output()` did, and so the `shell` argument keeps getting passed as a kwarg until it reaches [anyio.open_process()](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/processutils.py#L202), which won't accept that param.
With the fix, running the `prefect dev start` command will result in the following output being displayed for both Darwin and win32 operating systems:

```
Starting v2.8.6+11.gb1364e97b agent connected to http://127.0.0.1:4200/api...

  ___ ___ ___ ___ ___ ___ _____     _   ___ ___ _  _ _____
 | _ \ _ \ __| __| __/ __|_   _|   /_\ / __| __| \| |_   _|
 |  _/   / _|| _|| _| (__  | |    / _ \ (_ | _|| .` | | |
 |_| |_|_\___|_| |___\___| |_|   /_/ \_\___|___|_|\_| |_|


Agent started! Looking for work from queue(s): default...
```

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
