### PR TITLE
Allow multiple artifacts to have the same key

### DIFF
--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,14 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Remove Artifact unique constraint
+SQLite: `1d7441c031d0`
+Postgres: `aa84ac237ce8`
+
+# Add Artifact description column
+SQLite: `cf1159bd0d3c`
+Postgres: `4a1a0e4f89de`
+
 # Remove Flow Run foreign keys
 SQLite: `f3df94dca3cc`
 Postgres: `7d918a392297`

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_03_20_175243_aa84ac237ce8_remove_artifact_uq.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_03_20_175243_aa84ac237ce8_remove_artifact_uq.py
@@ -1,0 +1,32 @@
+"""Removes unique constraint from artifact table key column
+Revision ID: aa84ac237ce8
+Revises: 4a1a0e4f89de
+Create Date: 2023-03-20 17:52:43.438841
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aa84ac237ce8"
+down_revision = "4a1a0e4f89de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("artifact", schema=None) as batch_op:
+        batch_op.drop_index("ix_artifact__key")
+        batch_op.create_index(
+            "ix_artifact__key",
+            ["key"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("artifact", schema=None) as batch_op:
+        batch_op.drop_index("ix_artifact__key")
+        batch_op.create_index(
+            "ix_artifact__key",
+            ["key"],
+            unique=True,
+        )

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_03_20_153925_1d7441c031d0_remove_uq_from_artifact_table.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_03_20_153925_1d7441c031d0_remove_uq_from_artifact_table.py
@@ -1,0 +1,34 @@
+"""Removes unique constraint from artifact table key column
+
+Revision ID: 1d7441c031d0
+Revises: cf1159bd0d3c
+Create Date: 2023-03-20 15:39:25.077241
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1d7441c031d0"
+down_revision = "cf1159bd0d3c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index(op.f("ix_artifact__key"), table_name="artifact")
+    op.create_index(
+        op.f("ix_artifact__key"),
+        "artifact",
+        ["key"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_artifact__key"), table_name="artifact")
+    op.create_index(
+        op.f("ix_artifact__key"),
+        "artifact",
+        ["key"],
+        unique=True,
+    )

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_03_20_153925_1d7441c031d0_remove_uq_from_artifact_table.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_03_20_153925_1d7441c031d0_remove_uq_from_artifact_table.py
@@ -15,6 +15,7 @@ depends_on = None
 
 
 def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
     op.drop_index(op.f("ix_artifact__key"), table_name="artifact")
     op.create_index(
         op.f("ix_artifact__key"),
@@ -22,9 +23,11 @@ def upgrade():
         ["key"],
         unique=False,
     )
+    op.execute("PRAGMA foreign_keys=ON")
 
 
 def downgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
     op.drop_index(op.f("ix_artifact__key"), table_name="artifact")
     op.create_index(
         op.f("ix_artifact__key"),
@@ -32,3 +35,4 @@ def downgrade():
         ["key"],
         unique=True,
     )
+    op.execute("PRAGMA foreign_keys=ON")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -311,7 +311,12 @@ class ORMArtifact:
 
     @declared_attr
     def __table_args__(cls):
-        return (sa.UniqueConstraint("key"),)
+        return (
+            sa.Index(
+                "ix_artifact__key",
+                "key",
+            ),
+        )
 
 
 class ORMTaskRunStateCache:

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -114,7 +114,7 @@ class TestCreateArtifact:
         assert response.json()["flow_run_id"] == str(flow_run.id)
         assert response.json()["task_run_id"] == str(task_run.id)
 
-    async def test_create_artifact_raises_error_on_existing_key(
+    async def test_create_artifact_with_existing_key_in_same_workspace_succeeds(
         self,
         artifact,
         client,
@@ -129,7 +129,7 @@ class TestCreateArtifact:
             json=data,
         )
 
-        assert response.status_code == 409
+        assert response.status_code == 201
 
 
 class TestReadArtifact:


### PR DESCRIPTION
OSS implementation of: https://github.com/PrefectHQ/nebula/pull/3971

Since we want to be able to have multiple artifacts with a single key, we need to remove the unique constraint from the artifact table.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
