### PR TITLE
Enforce lowercase artifact `key` field

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -43,7 +43,9 @@ def validate_block_document_name(value):
 
 def validate_artifact_key(value):
     if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
-        raise ValueError("Artifact name must only contain lowercase letters, numbers, and dashes")
+        raise ValueError(
+            "Artifact name must only contain lowercase letters, numbers, and dashes"
+        )
     return value
 
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -44,7 +44,7 @@ def validate_block_document_name(value):
 def validate_artifact_key(value):
     if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
         raise ValueError(
-            "Artifact name must only contain lowercase letters, numbers, and dashes"
+            "Artifact key must only contain lowercase letters, numbers, and dashes"
         )
     return value
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -43,7 +43,7 @@ def validate_block_document_name(value):
 
 def validate_artifact_key(value):
     if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
-        raise ValueError("key must only contain lowercase letters, numbers, and dashes")
+        raise ValueError("Artifact name must only contain lowercase letters, numbers, and dashes")
     return value
 
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -41,6 +41,12 @@ def validate_block_document_name(value):
     return value
 
 
+def validate_artifact_key(value):
+    if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
+        raise ValueError("key must only contain lowercase letters, numbers, and dashes")
+    return value
+
+
 class ActionBaseModel(PrefectBaseModel):
     class Config:
         extra = "forbid"
@@ -555,6 +561,10 @@ class ArtifactCreate(ActionBaseModel):
     metadata_: Optional[Dict[str, str]] = FieldFrom(schemas.core.Artifact)
     flow_run_id: Optional[UUID] = FieldFrom(schemas.core.Artifact)
     task_run_id: Optional[UUID] = FieldFrom(schemas.core.Artifact)
+
+    _validate_artifact_format = validator("key", allow_reuse=True)(
+        validate_artifact_key
+    )
 
 
 @copy_model_fields

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -131,6 +131,18 @@ class TestCreateArtifact:
 
         assert response.status_code == 409
 
+    async def test_create_camel_case_artifact_key_raises(
+        self,
+    ):
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="key must only contain lowercase letters, numbers, and dashes",
+        ):
+            schemas.actions.ArtifactCreate(
+                key="camelCase_Key",
+                data=1,
+            ).dict(json_compatible=True)
+
 
 class TestReadArtifact:
     async def test_read_artifact(self, artifact, client):

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -136,7 +136,7 @@ class TestCreateArtifact:
     ):
         with pytest.raises(
             pydantic.ValidationError,
-            match="name must only contain lowercase letters, numbers, and dashes",
+            match="key must only contain lowercase letters, numbers, and dashes",
         ):
             schemas.actions.ArtifactCreate(
                 key="camelCase_Key",

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -136,7 +136,7 @@ class TestCreateArtifact:
     ):
         with pytest.raises(
             pydantic.ValidationError,
-            match="key must only contain lowercase letters, numbers, and dashes",
+            match="name must only contain lowercase letters, numbers, and dashes",
         ):
             schemas.actions.ArtifactCreate(
                 key="camelCase_Key",


### PR DESCRIPTION
OSS implementation of: https://github.com/PrefectHQ/nebula/pull/4002

Users specify the key field when creating an artifact but we only want to allow lowercase key values.

Also see: https://github.com/PrefectHQ/nebula/pull/3971#issuecomment-1458876332

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
