### PR TITLE
Disable 500 task submit benchmark

### DIFF
--- a/benches/bench_tasks.py
+++ b/benches/bench_tasks.py
@@ -22,7 +22,7 @@ def bench_task_call(benchmark: BenchmarkFixture):
     benchmark_flow()
 
 
-@pytest.mark.parametrize("num_task_runs", [100, 250, 500])
+@pytest.mark.parametrize("num_task_runs", [100, 250])
 def bench_task_submit(benchmark: BenchmarkFixture, num_task_runs: int):
     noop_task = task(noop_function)
 


### PR DESCRIPTION
It is failing too often, e.g. https://github.com/PrefectHQ/prefect/actions/runs/4473244495/jobs/7860400718

```python
 Traceback (most recent call last):
  File "/home/runner/work/prefect/prefect/src/prefect/engine.py", line 671, in orchestrate_flow_run
    waited_for_task_runs = await wait_for_task_runs_and_report_crashes(
  File "/home/runner/work/prefect/prefect/src/prefect/engine.py", line 1608, in wait_for_task_runs_and_report_crashes
    states = await gather(*(future._wait for future in task_run_futures))
  File "/home/runner/work/prefect/prefect/src/prefect/utilities/asyncutils.py", line 418, in gather
    return [tg.get_result(key) for key in keys]
  File "/home/runner/work/prefect/prefect/src/prefect/utilities/asyncutils.py", line 418, in <listcomp>
    return [tg.get_result(key) for key in keys]
  File "/home/runner/work/prefect/prefect/src/prefect/utilities/asyncutils.py", line 381, in get_result
    raise GatherIncomplete(
prefect.utilities.asyncutils.GatherIncomplete: Task is not complete. Results should not be retrieved until the task group exits.
```