### PR TITLE
Enable events client experimental flag by default

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1088,7 +1088,7 @@ application. If disabled, task runs and subflow runs belonging to cancelled flow
 remain in non-terminal states.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -459,8 +459,8 @@ def test_experimental_marker_cannot_be_used_without_opt_in_setting_if_required()
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
 def test_enabled_experiments_with_opt_in():
-    assert enabled_experiments() == {"test", "work_pools"}
+    assert enabled_experiments() == {"test", "work_pools", "events_client"}
 
 
 def test_enabled_experiments_without_opt_in():
-    assert enabled_experiments() == set(["work_pools"])
+    assert enabled_experiments() == set(["work_pools", "events_client"])

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -89,7 +89,7 @@ def test_worker_from_settings_null_client_non_cloud_api_url():
     with temporary_settings(
         updates={
             PREFECT_API_URL: "http://localhost:8080/api",
-            PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
+            PREFECT_CLOUD_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
         }
     ):
         worker = get_worker_from_settings()

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -28,10 +28,11 @@ def test_app_exposes_ui_settings():
     client = TestClient(app)
     response = client.get("/ui-settings")
     response.raise_for_status()
-    assert response.json() == {
-        "api_url": PREFECT_UI_API_URL.value(),
-        "flags": ["work_pools"],
-    }
+
+    json = response.json()
+    assert json.keys() == {"api_url", "flags"}
+    assert json["api_url"] == PREFECT_UI_API_URL.value()
+    assert set(json["flags"]) == {"work_pools", "events_client"}
 
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
@@ -41,5 +42,6 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
     response = client.get("/ui-settings")
     response.raise_for_status()
     json = response.json()
+    assert json.keys() == {"api_url", "flags"}
     assert json["api_url"] == PREFECT_UI_API_URL.value()
-    assert set(json["flags"]) == {"test", "work_pools"}
+    assert set(json["flags"]) == {"test", "work_pools", "events_client"}


### PR DESCRIPTION
This turns the events client experimental flag on by default.

Closes #8869 