### PR TITLE
Update create & delete methods, add read_latest_artifact method

### DIFF
--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -244,6 +244,11 @@ class PrefectDBInterface(metaclass=DBSingleton):
         return self.orm.flow_run_unique_upsert_columns
 
     @property
+    def artifact_collection_unique_upsert_columns(self):
+        """Unique columns for upserting an ArtifactCollection"""
+        return self.orm.artifact_collection_unique_upsert_columns
+
+    @property
     def block_type_unique_upsert_columns(self):
         """Unique columns for upserting a BlockType"""
         return self.orm.block_type_unique_upsert_columns

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1561,6 +1561,11 @@ class BaseORMConfiguration(ABC):
         return [self.BlockType.slug]
 
     @property
+    def artifact_collection_unique_upsert_columns(self):
+        """Unique columns for upserting an ArtifactCollection"""
+        return [self.ArtifactCollection.key]
+
+    @property
     def block_schema_unique_upsert_columns(self):
         """Unique columns for upserting a BlockSchema"""
         return [self.BlockSchema.checksum, self.BlockSchema.version]

--- a/src/prefect/server/models/artifacts.py
+++ b/src/prefect/server/models/artifacts.py
@@ -11,15 +11,75 @@ from prefect.server.schemas.core import Artifact
 
 
 @inject_db
-async def create_artifact(
-    session: sa.orm.Session, artifact: Artifact, db: PrefectDBInterface, key: str = None
+async def _insert_into_artifact_collection(
+    session: sa.orm.Session,
+    key: str,
+    artifact_id: UUID,
+    db: PrefectDBInterface,
+    now: pendulum.DateTime = None,
 ):
-    now = pendulum.now("UTC")
+    """
+    Inserts a new artifact into the artifact_collection table or updates it.
+    """
+    upsert_new_latest_id = (
+        (await db.insert(db.ArtifactCollection))
+        .values(
+            key=key,
+            latest_id=artifact_id,
+            created=now,
+            updated=now,
+        )
+        .on_conflict_do_update(
+            index_elements=db.artifact_collection_unique_upsert_columns,
+            set_=dict(
+                latest_id=artifact_id,
+                updated=now,
+            ),
+        )
+    )
+
+    await session.execute(upsert_new_latest_id)
+
+    query = (
+        sa.select(db.ArtifactCollection)
+        .where(
+            sa.and_(
+                db.ArtifactCollection.key == key,
+                db.ArtifactCollection.latest_id == artifact_id,
+            )
+        )
+        .execution_options(populate_existing=True)
+    )
+
+    result = await session.execute(query)
+
+    model = result.scalar()
+
+    if model is not None:
+        if model.latest_id != artifact_id:
+            raise ValueError(
+                f"Artifact {artifact_id} was not inserted into the artifact collection"
+                " table."
+            )
+
+    return model
+
+
+@inject_db
+async def _insert_into_artifact(
+    session: sa.orm.Session,
+    artifact: Artifact,
+    db: PrefectDBInterface,
+    now: pendulum.DateTime = None,
+) -> Artifact:
+    """
+    Inserts a new artifact into the artifact table.
+    """
     artifact_id = artifact.id
     insert_stmt = (await db.insert(db.Artifact)).values(
         created=now,
         updated=now,
-        **artifact.dict(exclude={"created", "updated"}, shallow=True)
+        **artifact.dict(exclude={"created", "updated"}, shallow=True),
     )
     await session.execute(insert_stmt)
 
@@ -34,6 +94,56 @@ async def create_artifact(
     model = result.scalar()
 
     return model
+
+
+@inject_db
+async def create_artifact(
+    session: sa.orm.Session, artifact: Artifact, db: PrefectDBInterface, key: str = None
+):
+    now = pendulum.now("UTC")
+
+    if key is not None:
+        await _insert_into_artifact_collection(
+            session=session, key=key, now=now, db=db, artifact_id=artifact.id
+        )
+
+    result = await _insert_into_artifact(
+        session=session,
+        now=now,
+        db=db,
+        artifact=artifact,
+    )
+
+    return result
+
+
+@inject_db
+async def read_latest_artifact(
+    session: sa.orm.Session,
+    db: PrefectDBInterface,
+    key: str,
+):
+    """
+    Reads the latest artifact by key.
+    Args:
+        session: A database session
+        key: The artifact key
+    Returns:
+        Artifact: The latest artifact
+    """
+    query = (
+        sa.select(db.Artifact)
+        .where(
+            sa.and_(
+                db.Artifact.id == db.ArtifactCollection.latest_id,
+                db.ArtifactCollection.key == key,
+            )
+        )
+        .limit(1)
+    )
+
+    result = await session.execute(query)
+    return result.scalar()
 
 
 @inject_db
@@ -172,6 +282,44 @@ async def delete_artifact(
     Returns:
         bool: True if the delete was successful, False otherwise
     """
+    artifact = await session.get(db.Artifact, artifact_id)
+    if artifact is None:
+        return False
+
+    is_latest_version = (
+        await session.execute(
+            sa.select(db.ArtifactCollection)
+            .where(db.ArtifactCollection.key == artifact.key)
+            .where(db.ArtifactCollection.latest_id == artifact_id)
+        )
+    ).scalar_one_or_none() is not None
+
+    if is_latest_version:
+        next_latest_version = (
+            await session.execute(
+                sa.select(db.Artifact)
+                .where(db.Artifact.key == artifact.key)
+                .where(db.Artifact.id != artifact_id)
+                .order_by(db.Artifact.created.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        if next_latest_version is not None:
+            set_next_latest_version = (
+                sa.update(db.ArtifactCollection)
+                .where(db.ArtifactCollection.key == artifact.key)
+                .values(latest_id=next_latest_version.id)
+            )
+            await session.execute(set_next_latest_version)
+
+        else:
+            await session.execute(
+                sa.delete(db.ArtifactCollection)
+                .where(db.ArtifactCollection.key == artifact.key)
+                .where(db.ArtifactCollection.latest_id == artifact_id)
+            )
+
     delete_stmt = sa.delete(db.Artifact).where(db.Artifact.id == artifact_id)
 
     result = await session.execute(delete_stmt)

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -401,6 +401,7 @@ class TestUpdateArtifact:
 class TestDeleteArtifact:
     async def test_delete_artifact_succeeds(self, artifact, session, client):
         artifact_id = artifact["id"]
+        artifact_key = artifact["key"]
         response = await client.delete(f"/experimental/artifacts/{artifact_id}")
         assert response.status_code == 204
 
@@ -408,6 +409,11 @@ class TestDeleteArtifact:
             session=session, artifact_id=artifact_id
         )
         assert artifact is None
+
+        assert not await models.artifacts.read_latest_artifact(
+            session=session,
+            key=artifact_key,
+        )
 
         response = await client.get(f"/experimental/artifacts/{artifact_id}")
         assert response.status_code == 404

--- a/tests/server/models/test_artifacts.py
+++ b/tests/server/models/test_artifacts.py
@@ -6,16 +6,115 @@ from prefect.server import models, schemas
 from prefect.server.schemas import actions
 
 
-async def test_creating_artifacts(session):
+@pytest.fixture
+async def artifact(session):
     artifact_schema = schemas.core.Artifact(
         key="voltaic", data=1, metadata_={"description": "opens many doors"}
     )
     artifact = await models.artifacts.create_artifact(
-        session=session, artifact=artifact_schema
+        key=artifact_schema.key, session=session, artifact=artifact_schema
     )
-    assert artifact.key == "voltaic"
-    assert artifact.data == 1
-    assert artifact.metadata_ == {"description": "opens many doors"}
+    await session.commit()
+    return artifact
+
+
+class TestCreateArtifacts:
+    async def test_creating_artifacts(self, session):
+        artifact_schema = schemas.core.Artifact(
+            key="voltaic", data=1, metadata_={"description": "opens many doors"}
+        )
+        artifact = await models.artifacts.create_artifact(
+            session=session, artifact=artifact_schema
+        )
+        assert artifact.key == "voltaic"
+        assert artifact.data == 1
+        assert artifact.metadata_ == {"description": "opens many doors"}
+
+    async def test_creating_artifact_with_key_succeeds_and_upsert_to_artifact_collection(
+        self, artifact, session
+    ):
+        assert await models.artifacts.read_artifact(session, artifact.id)
+
+        artifact_collection_result = await models.artifacts.read_latest_artifact(
+            key=artifact.key, session=session
+        )
+        assert artifact_collection_result.id == artifact.id
+
+    async def test_creating_artifact_without_key_arg_does_not_upsert_to_artifact_collection(
+        self, session
+    ):
+        artifact_schema = schemas.core.Artifact(
+            key=None,
+            data=1,
+            description="Some info about my artifact",
+        )
+        artifact = await models.artifacts.create_artifact(
+            session=session, artifact=artifact_schema
+        )
+        assert artifact.id is not None
+        assert artifact.key == artifact_schema.key
+        assert artifact.data == artifact_schema.data
+        assert artifact.description == artifact_schema.description
+
+    async def test_creating_artifact_with_existing_key_appends_in_artifact_and_upserts_in_artifact_collection(
+        self, artifact, session
+    ):
+        artifact_result = await models.artifacts.read_latest_artifact(
+            session=session, key=artifact.key
+        )
+        assert artifact_result.id == artifact.id
+        assert artifact_result.key == artifact.key
+        assert artifact_result.updated == artifact_result.created
+
+        new_artifact_schema = schemas.core.Artifact(
+            key=artifact.key,
+            data=2,
+            description="Some info about my artifact",
+        )
+        new_artifact = await models.artifacts.create_artifact(
+            session=session,
+            artifact=new_artifact_schema,
+            key=new_artifact_schema.key,
+        )
+
+        assert await models.artifacts.read_artifact(
+            session=session,
+            artifact_id=artifact.id,
+        )
+        assert await models.artifacts.read_artifact(
+            session=session,
+            artifact_id=new_artifact.id,
+        )
+
+        new_artifact_version = await models.artifacts.read_latest_artifact(
+            session=session,
+            key=artifact.key,
+        )
+
+        assert new_artifact_version.id == new_artifact.id
+
+    async def test_creating_artifact_with_null_key_does_not_upsert_to_artifact_collection(
+        self, session
+    ):
+        artifact_schema = schemas.core.Artifact(
+            data=1,
+            description="Some info about my artifact",
+        )
+        artifact = await models.artifacts.create_artifact(
+            key=artifact_schema.key,
+            session=session,
+            artifact=artifact_schema,
+        )
+
+        assert await models.artifacts.read_artifact(
+            session=session,
+            artifact_id=artifact.id,
+        )
+
+        assert not await models.artifacts.read_latest_artifact(
+            session=session,
+            key=artifact_schema.key,
+        )
 
 
 class TestUpdateArtifacts:
@@ -214,6 +313,48 @@ class TestReadingMultipleArtifacts:
 
 
 class TestDeleteArtifacts:
+    @pytest.fixture
+    async def artifacts(
+        self,
+        session,
+    ):
+        # Create several artifacts with the same key
+        artifact1_schema = schemas.core.Artifact(
+            key="test-key-1",
+            data="my important data",
+            description="Info about the artifact",
+        )
+        artifact1 = await models.artifacts.create_artifact(
+            session=session,
+            artifact=artifact1_schema,
+            key=artifact1_schema.key,
+        )
+
+        artifact2_schema = schemas.core.Artifact(
+            key="test-key-1",
+            data="my important data",
+            description="Info about the artifact",
+        )
+        artifact2 = await models.artifacts.create_artifact(
+            session=session,
+            artifact=artifact2_schema,
+            key=artifact2_schema.key,
+        )
+
+        artifact3_schema = schemas.core.Artifact(
+            key="test-key-1",
+            data="my important data",
+            description="Info about the artifact",
+        )
+        artifact3 = await models.artifacts.create_artifact(
+            session=session,
+            artifact=artifact3_schema,
+            key=artifact3_schema.key,
+        )
+
+        await session.commit()
+        return [artifact1, artifact2, artifact3]
+
     async def test_delete_artifact_succeeds(self, session):
         artifact_schema = schemas.core.Artifact(
             key="voltaic", data=1, metadata_={"description": "opens many doors"}
@@ -234,3 +375,71 @@ class TestDeleteArtifacts:
         deleted_result = await models.artifacts.delete_artifact(session, str(uuid4()))
 
         assert not deleted_result
+
+    async def test_delete_only_artifact_version_deletes_row_in_artifact_and_artifact_collection(
+        self,
+        artifact,
+        session,
+    ):
+        assert await models.artifacts.delete_artifact(
+            session=session, artifact_id=artifact.id
+        )
+        assert not await models.artifacts.read_artifact(
+            session=session, artifact_id=artifact.id
+        )
+
+        assert not await models.artifacts.read_latest_artifact(
+            session=session, key=artifact.key
+        )
+
+    async def test_delete_earliest_artifact_deletes_row_in_artifact_and_ignores_artifact_collection(
+        self,
+        artifacts,
+        session,
+    ):
+        assert await models.artifacts.delete_artifact(
+            session=session, artifact_id=artifacts[0].id
+        )
+        assert not await models.artifacts.read_artifact(
+            session=session, artifact_id=artifacts[0].id
+        )
+
+        artifact_result = await models.artifacts.read_latest_artifact(
+            session=session, key=artifacts[1].key
+        )
+
+        assert artifact_result.id == artifacts[-1].id
+
+    async def test_delete_middle_artifact_deletes_row_in_artifact_and_ignores_artifact_collection(
+        self, artifacts, session
+    ):
+        assert await models.artifacts.delete_artifact(
+            session=session, artifact_id=artifacts[1].id
+        )
+
+        assert not await models.artifacts.read_artifact(
+            session=session, artifact_id=artifacts[1].id
+        )
+
+        artifact_result = await models.artifacts.read_latest_artifact(
+            session=session, key=artifacts[-1].key
+        )
+
+        assert artifact_result.id == artifacts[-1].id
+
+    async def test_delete_latest_artifact_deletes_row_in_artifact_and_updates_artifact_collection(
+        self, artifacts, session
+    ):
+        assert await models.artifacts.delete_artifact(
+            session=session, artifact_id=artifacts[2].id
+        )
+
+        assert not await models.artifacts.read_artifact(
+            session=session, artifact_id=artifacts[2].id
+        )
+
+        artifact_result = await models.artifacts.read_latest_artifact(
+            session=session, key=artifacts[1].key
+        )
+
+        assert artifact_result.id == artifacts[1].id

--- a/tests/server/models/test_artifacts.py
+++ b/tests/server/models/test_artifacts.py
@@ -163,6 +163,26 @@ class TestUpdateArtifacts:
         assert updated_artifact.data == 1
 
 
+class TestReadLatestArtifact:
+    async def test_reading_artifact_by_key(self, session):
+        artifact_schema = schemas.core.Artifact(
+            key="voltaic", data=1, description="opens many doors"
+        )
+        artifact = await models.artifacts.create_artifact(
+            session=session, artifact=artifact_schema, key=artifact_schema.key
+        )
+
+        assert artifact.key == "voltaic"
+
+        tutored_artifact = await models.artifacts.read_latest_artifact(
+            session=session, key=artifact.key
+        )
+
+        assert tutored_artifact.key == "voltaic"
+        assert tutored_artifact.data == 1
+        assert tutored_artifact.description == "opens many doors"
+
+
 class TestReadingSingleArtifacts:
     async def test_reading_artifacts_by_id(self, session):
         artifact_schema = schemas.core.Artifact(


### PR DESCRIPTION
OSS implementation of: https://github.com/PrefectHQ/nebula/pull/3975

Alongside the new `artifact_collection` table comes updated `create_artifact` and `delete_artifact` model methods to ensure upserting and deleting extends to this table (where the latest of each artifact is stored).

In `create_artifact`, we'll first upsert to the `artifact_collection` table, ensuring we keep track of the latest artifact version id. In `delete_artifact`, we now need to check if the artifact is the latest version. If it is, we'll need to update our reference to it in the `artifact_collection` table prior to deletion from the `artifact` table. If there are no prior versions of the artifact (there's just 1 version in the `artifact` table), then the row itself related to the artifact will be deleted from the `artifact_collection` table.

Also adding a `read_latest_artifact` method, so that we can add a new route for this to optimally retrieve the latest of each artifact on a given key!

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
