### PR TITLE
Fix sleep time assertion

### DIFF
--- a/tests/public/tasks/test_task_timeouts.py
+++ b/tests/public/tasks/test_task_timeouts.py
@@ -81,7 +81,7 @@ async def test_async_task_timeout_in_async_flow():
         return t1 - t0, state
 
     runtime, task_state = await parent_flow()
-    assert runtime < 1, f"Task should exit early; ran for {runtime}s"
+    assert runtime < SLEEP_TIME, f"Task should exit early; ran for {runtime}s"
     assert task_state.is_failed()
     with pytest.raises(TimeoutError):
         await task_state.result()


### PR DESCRIPTION
This assertion was still < 1s instead of the variable sleep time constant which caused it to flake in CI