### PR TITLE
Fix race condition in worker thread start

### DIFF
--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -41,6 +41,7 @@ class WorkerThread(Portal):
         """
         with self._lock:
             if not self._started:
+                self._started = True
                 self.thread.start()
 
     def submit(self, call: Call) -> Call:
@@ -87,7 +88,6 @@ class WorkerThread(Portal):
             raise
 
     def _run_until_shutdown(self):
-        self._started = True
         while True:
             call = self._queue.get()
             if call is None:


### PR DESCRIPTION
Fixes race condition where thread.start() would return but not set the thread as started until a bit later. See 'https://github.com/PrefectHQ/prefect/actions/runs/4494685885/jobs/7907472976?pr=8882'
