### PR TITLE
Update task input resolution to avoid spawning worker threads

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1797,11 +1797,16 @@ async def resolve_inputs(
 
     # Only retrieve the result if requested as it may be expensive
     if return_data:
+        finished_states = [state for state in states if state.is_final()]
+
         state_results = await asyncio.gather(
-            *[state.result(raise_on_failure=False, fetch=True) for state in states]
+            *[
+                state.result(raise_on_failure=False, fetch=True)
+                for state in finished_states
+            ]
         )
 
-        for state, result in zip(states, state_results):
+        for state, result in zip(finished_states, state_results):
             result_by_state[state] = result
 
     def resolve_input(expr, context):

--- a/tests/engine/reliability/test_deadlocks.py
+++ b/tests/engine/reliability/test_deadlocks.py
@@ -10,7 +10,8 @@ from tests.generic_tasks import (
 )
 
 
-@pytest.mark.skip(reason="Causes a deadlock.")
+@pytest.mark.service("slow")
+@pytest.mark.timeout(120)
 def test_map_wait_for_many_tasks():
     @flow
     def run(n):
@@ -22,7 +23,8 @@ def test_map_wait_for_many_tasks():
     run(500)
 
 
-@pytest.mark.skip(reason="Causes a deadlock.")
+@pytest.mark.service("slow")
+@pytest.mark.timeout(120)
 def test_loop_wait_for_many_tasks():
     @flow
     def run(n):

--- a/tests/engine/reliability/test_deadlocks.py
+++ b/tests/engine/reliability/test_deadlocks.py
@@ -11,7 +11,7 @@ from tests.generic_tasks import (
 
 
 @pytest.mark.service("slow")
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(200)
 def test_map_wait_for_many_tasks():
     @flow
     def run(n):
@@ -24,7 +24,7 @@ def test_map_wait_for_many_tasks():
 
 
 @pytest.mark.service("slow")
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(200)
 def test_loop_wait_for_many_tasks():
     @flow
     def run(n):

--- a/tests/engine/reliability/test_deadlocks.py
+++ b/tests/engine/reliability/test_deadlocks.py
@@ -10,8 +10,7 @@ from tests.generic_tasks import (
 )
 
 
-@pytest.mark.service("slow")
-@pytest.mark.timeout(200)
+@pytest.mark.skip(reason="This test takes multiple minutes")
 def test_map_wait_for_many_tasks():
     @flow
     def run(n):
@@ -23,8 +22,7 @@ def test_map_wait_for_many_tasks():
     run(500)
 
 
-@pytest.mark.service("slow")
-@pytest.mark.timeout(200)
+@pytest.mark.skip(reason="This test takes multiple minutes")
 def test_loop_wait_for_many_tasks():
     @flow
     def run(n):


### PR DESCRIPTION
Updates the two major engine methods `collect_task_run_inputs`  and `resolve_inputs` to avoid creating worker threads. Instead, we run `visit_collection` without performing blocking calls! In `collect_task_run_inputs`, we now just collect futures then wait for them to be submitted after the collection has been traversed. For `resolve_inputs`, we're actually mutating the collections so this requires two traversals of the inputs so we can first collect all states and futures then resolve them asynchronously before updating the value in the collection.

Task run scaling which was previously bounded by the AnyIO worker thread limit (~250 https://github.com/PrefectHQ/prefect/pull/7961) which caused the engine to easily deadlock when we were doing too much synchronous work. In #8702, we moved task run execution into worker threads without a limiter. Here, we avoid spawning worker threads while traversing task inputs and waiting for upstreams which should resolve all problems with task run scaling.

Closes https://github.com/PrefectHQ/prefect/issues/8770
Closes https://github.com/PrefectHQ/prefect/issues/7934
May help https://github.com/PrefectHQ/prefect/issues/8579
May help https://github.com/PrefectHQ/prefect/issues/6492