### PR TITLE
Idea: Add optional server-only requirements

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,0 +1,1 @@
+sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ pytz >= 2021.1
 pyyaml >= 5.4.1
 readchar >= 4.0.0
 rich >= 11.0
-sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 2.0
 toml >= 0.10.0
 typer >= 0.4.2
 typing_extensions >= 4.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages, setup
 import versioneer
 
 install_requires = open("requirements.txt").read().strip().split("\n")
+server_requires = open("requirements-server.txt").read().strip().split("\n")
 dev_requires = open("requirements-dev.txt").read().strip().split("\n")
 
 setup(
@@ -37,7 +38,7 @@ setup(
     # Requirements
     python_requires=">=3.7",
     install_requires=install_requires,
-    extras_require={"dev": dev_requires},
+    extras_require={"dev": dev_requires, "server": server_requires},
     classifiers=[
         "Natural Language :: English",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Prompted by: https://github.com/PrefectHQ/prefect/issues/8052

The very beginnings of a way to have more optional requirements.
Obviously this would require many changes to documentation, and probably more libs should be made optional, and likely another set of requirements (such as `-cli` would be needed).

Would be great for production flows to only need to bare minimum requirements, as this would make our Docker images lighter too.

### Example
```bash
pip install prefect[server]
```

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.