### PR TITLE
Bugfix: Only create hyperlinks to non-local persisted results

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -497,7 +497,7 @@ class PersistedResult(BaseResult):
         uri = cls._infer_path(storage_block, key)
         if uri:
             if isinstance(storage_block, LocalFileSystem):
-                description += f" persisted to `{uri}`."
+                description += f" persisted to: `{uri}`"
             else:
                 description += f" persisted to [{uri}]({uri})."
         else:

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -496,7 +496,10 @@ class PersistedResult(BaseResult):
         description = f"Result of type `{type(obj).__name__}`"
         uri = cls._infer_path(storage_block, key)
         if uri:
-            description += f" persisted to [{uri}]({uri})."
+            if isinstance(storage_block, LocalFileSystem):
+                description += f" persisted to `{uri}`."
+            else:
+                description += f" persisted to [{uri}]({uri})."
         else:
             description += f" persisted with storage block `{storage_block_id}`."
 


### PR DESCRIPTION
This PR addresses an issue where locally-persisted results had a markdown link embedded in the description. For any non-local deployments (including Cloud), these links aren't usable due to browser security limitations. This replaces links with code blocks instead. 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Before:

![Screenshot 2023-03-23 at 12 27 14 PM](https://user-images.githubusercontent.com/27291717/227270563-1538399f-763a-4a6d-b714-3839ef6741c8.png)


After:

![Screenshot 2023-03-23 at 12 27 19 PM](https://user-images.githubusercontent.com/27291717/227270592-e6d358f6-327d-4544-b86e-172045482701.png)



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
