### PR TITLE
disambiguate reference to "Blocks"

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -13,7 +13,7 @@ Getting started building and running workflows with Prefect doesn't require much
 
 These guides are intended to provide the reader with a deeper understanding of how the system works and how it can be used to its full potential; in addition, these guides can be revisited as reference material as you learn more.
 
-## Building Blocks
+## The Core Concepts
 
 The fundamental building blocks of Prefect are [flows](/concepts/flows/) and [tasks](/concepts/tasks/).  We recommend all readers begin by understanding these concepts first. 
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -13,7 +13,7 @@ Getting started building and running workflows with Prefect doesn't require much
 
 These guides are intended to provide the reader with a deeper understanding of how the system works and how it can be used to its full potential; in addition, these guides can be revisited as reference material as you learn more.
 
-## The Core Concepts
+## Core Concepts
 
 The fundamental building blocks of Prefect are [flows](/concepts/flows/) and [tasks](/concepts/tasks/).  We recommend all readers begin by understanding these concepts first. 
 


### PR DESCRIPTION
Not upset to get shot down on this change, it's just been mildly annoying for a while so I figured I'd throw it out there.