### PR TITLE
Add support for custom static task storage keys

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -399,6 +399,30 @@ You can configure this to use a specific storage using one of the following:
 - A storage instance, e.g. `LocalFileSystem(basepath=".my-results")`
 - A storage slug, e.g. `'s3/dev-s3-block'`
 
+#### Result storage key
+
+The path of the result file in the result storage can be configured with the `result_storage_key`. The `result_storage_key` option defaults to a null value, which generates a unique identifier for each result.
+
+
+```python
+from prefect import flow, task
+from prefect.filesystems import LocalFileSystem, S3
+
+@flow()
+def my_flow(result_storage=S3(bucket_path="my-bucket")):
+    my_task()
+
+@task(persist_result=True, result_storage_key="my_task.json")
+def my_task():
+    ...
+
+my_flow()  # The task's result will be persisted to 's3://my-bucket/my_task.json'
+```
+
+If a result exists at a given storage key in the storage location, it will be overwritten.
+
+Result storage keys can only be configured on tasks at this time. Result storage keys are not templated with any runtime information at this time.
+
 #### Result serializer
 
 [The result serializer](#result-serializer-types) can be configured with the `result_serializer` option. The `result_serializer` option defaults to a null value, which infers the serializer from the context.

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -148,6 +148,8 @@ class Task(Generic[P, R]):
             the features being used.
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
+        result_storage_key: An optional key to store the result in storage at when persisted.
+            Defaults to a unique identifier.
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
             called in.
@@ -188,6 +190,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
+        result_storage_key: Optional[str] = None,
         cache_result_in_memory: bool = True,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = False,
@@ -251,6 +254,7 @@ class Task(Generic[P, R]):
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer
+        self.result_storage_key = result_storage_key
         self.cache_result_in_memory = cache_result_in_memory
         self.timeout_seconds = float(timeout_seconds) if timeout_seconds else None
         # Warn if this task's `name` conflicts with another task while having a
@@ -303,6 +307,7 @@ class Task(Generic[P, R]):
         persist_result: Optional[bool] = NotSet,
         result_storage: Optional[ResultStorage] = NotSet,
         result_serializer: Optional[ResultSerializer] = NotSet,
+        result_storage_key: Optional[str] = NotSet,
         cache_result_in_memory: Optional[bool] = None,
         timeout_seconds: Union[int, float] = None,
         log_prints: Optional[bool] = NotSet,
@@ -336,6 +341,7 @@ class Task(Generic[P, R]):
             persist_result: A new option for enabling or disabling result persistence.
             result_storage: A new storage type to use for results.
             result_serializer: A new serializer to use for results.
+            result_storage_key: A new key for the persisted result to be stored at.
             timeout_seconds: A new maximum time for the task to complete in seconds.
             log_prints: A new option for enabling or disabling redirection of `print` statements.
             refresh_cache: A new option for enabling or disabling cache refresh.
@@ -403,6 +409,11 @@ class Task(Generic[P, R]):
             ),
             result_storage=(
                 result_storage if result_storage is not NotSet else self.result_storage
+            ),
+            result_storage_key=(
+                result_storage_key
+                if result_storage_key is not NotSet
+                else self.result_storage_key
             ),
             result_serializer=(
                 result_serializer
@@ -873,6 +884,7 @@ def task(
     retry_jitter_factor: Optional[float] = None,
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
+    result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
@@ -904,6 +916,7 @@ def task(
     retry_jitter_factor: Optional[float] = None,
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
+    result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
     cache_result_in_memory: bool = True,
     timeout_seconds: Union[int, float] = None,
@@ -950,6 +963,8 @@ def task(
             the features being used.
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
+        result_storage_key: An optional key to store the result in storage at when persisted.
+            Defaults to a unique identifier.
         result_serializer: An optional serializer to use to serialize the result of this
             task for persistence. Defaults to the value set in the flow the task is
             called in.
@@ -1029,6 +1044,7 @@ def task(
                 retry_jitter_factor=retry_jitter_factor,
                 persist_result=persist_result,
                 result_storage=result_storage,
+                result_storage_key=result_storage_key,
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,
@@ -1055,6 +1071,7 @@ def task(
                 retry_jitter_factor=retry_jitter_factor,
                 persist_result=persist_result,
                 result_storage=result_storage,
+                result_storage_key=result_storage_key,
                 result_serializer=result_serializer,
                 cache_result_in_memory=cache_result_in_memory,
                 timeout_seconds=timeout_seconds,

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from prefect.filesystems import LocalFileSystem
-from prefect.results import PersistedResult, PersistedResultBlob
+from prefect.results import DEFAULT_STORAGE_KEY_FN, PersistedResult, PersistedResultBlob
 from prefect.serializers import JSONSerializer, PickleSerializer
 
 
@@ -20,6 +20,7 @@ async def test_result_reference_create_and_get(cache_object, storage_block):
         "test",
         storage_block_id=storage_block._block_document_id,
         storage_block=storage_block,
+        storage_key_fn=DEFAULT_STORAGE_KEY_FN,
         serializer=JSONSerializer(),
         cache_object=cache_object,
     )
@@ -40,6 +41,7 @@ async def test_result_literal_populates_default_artifact_metadata(
         "test",
         storage_block_id=storage_block._block_document_id,
         storage_block=storage_block,
+        storage_key_fn=DEFAULT_STORAGE_KEY_FN,
         serializer=JSONSerializer(),
         cache_object=cache_object,
     )
@@ -54,6 +56,7 @@ async def test_result_reference_create_uses_storage(storage_block):
         "test",
         storage_block_id=storage_block._block_document_id,
         storage_block=storage_block,
+        storage_key_fn=DEFAULT_STORAGE_KEY_FN,
         serializer=JSONSerializer(),
     )
 
@@ -69,6 +72,7 @@ async def test_result_reference_create_uses_serializer(storage_block):
         "test",
         storage_block_id=storage_block._block_document_id,
         storage_block=storage_block,
+        storage_key_fn=DEFAULT_STORAGE_KEY_FN,
         serializer=serializer,
     )
 
@@ -88,6 +92,7 @@ async def test_result_reference_file_blob_is_json(storage_block):
         "test",
         storage_block_id=storage_block._block_document_id,
         storage_block=storage_block,
+        storage_key_fn=DEFAULT_STORAGE_KEY_FN,
         serializer=serializer,
     )
 
@@ -101,3 +106,17 @@ async def test_result_reference_file_blob_is_json(storage_block):
 
     assert blob.serializer
     assert blob.data
+
+
+async def test_result_reference_create_uses_storage_key_fn(storage_block):
+    result = await PersistedResult.create(
+        "test",
+        storage_block_id=storage_block._block_document_id,
+        storage_block=storage_block,
+        storage_key_fn=lambda: "test",
+        serializer=JSONSerializer(),
+    )
+
+    assert result.storage_key == "test"
+    contents = await storage_block.read_path("test")
+    assert contents

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -248,6 +248,29 @@ async def test_task_result_storage(orion_client, source):
     await assert_uses_result_storage(api_state, storage)
 
 
+async def test_task_result_storage_key(orion_client):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow
+    def foo():
+        return bar(return_state=True)
+
+    @task(result_storage=storage, persist_result=True, result_storage_key="test")
+    def bar():
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+    assert task_state.data.storage_key == "test"
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+    assert task_state.data.storage_key == "test"
+
+
 async def test_task_result_missing_with_null_return(orion_client):
     @flow
     def foo():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2399,6 +2399,7 @@ class TestTaskWithOptions:
             cache_result_in_memory=False,
             timeout_seconds=None,
             refresh_cache=False,
+            result_storage_key="foo",
         )
         def initial_task():
             pass
@@ -2417,6 +2418,7 @@ class TestTaskWithOptions:
             cache_result_in_memory=True,
             timeout_seconds=42,
             refresh_cache=True,
+            result_storage_key="bar",
         )
 
         assert task_with_options.name == "Copied task"
@@ -2432,6 +2434,7 @@ class TestTaskWithOptions:
         assert task_with_options.cache_result_in_memory is True
         assert task_with_options.timeout_seconds == 42
         assert task_with_options.refresh_cache == True
+        assert task_with_options.result_storage_key == "bar"
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         def cache_key_fn(*_):
@@ -2451,6 +2454,7 @@ class TestTaskWithOptions:
             cache_result_in_memory=False,
             timeout_seconds=42,
             refresh_cache=True,
+            result_storage_key="test",
         )
         def initial_task():
             pass
@@ -2474,6 +2478,7 @@ class TestTaskWithOptions:
         assert task_with_options.cache_result_in_memory is False
         assert task_with_options.timeout_seconds == 42
         assert task_with_options.refresh_cache == True
+        assert task_with_options.result_storage_key == "test"
 
     def test_with_options_can_unset_result_options_with_none(self):
         @task(
@@ -2481,6 +2486,7 @@ class TestTaskWithOptions:
             result_serializer="json",
             result_storage=LocalFileSystem(),
             refresh_cache=True,
+            result_storage_key="test",
         )
         def initial_task():
             pass
@@ -2490,11 +2496,13 @@ class TestTaskWithOptions:
             result_serializer=None,
             result_storage=None,
             refresh_cache=None,
+            result_storage_key=None,
         )
         assert task_with_options.persist_result is None
         assert task_with_options.result_serializer is None
         assert task_with_options.result_storage is None
         assert task_with_options.refresh_cache is None
+        assert task_with_options.result_storage_key is None
 
     def test_tags_are_copied_from_original_task(self):
         "Ensure changes to the tags on the original task don't affect the new task"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect/issues/8894

New documentation at https://deploy-preview-8924--prefect-docs.netlify.app/concepts/results/#result-storage-key

Only allows static keys at this time. A follow-up can add support for templating keys with task run parameters by default. An additional follow-up can add support for providing a callable directly instead of a string.

Could also be accomplished by #8580 but I think that's a bit too low level to do first.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect import flow, task
from prefect.serializers import JSONSerializer

@task(persist_result=True, result_storage_key="foo.json")
def hello_world():
    return "hello world"


@flow(result_serializer=JSONSerializer())
def my_flow():
    hello_world()


my_flow()
```

```
❯ cat ~/.prefect/storage/foo.json | jq
{
  "serializer": {
    "type": "json",
    "jsonlib": "json",
    "object_encoder": "prefect.serializers.prefect_json_object_encoder",
    "object_decoder": "prefect.serializers.prefect_json_object_decoder",
    "dumps_kwargs": {},
    "loads_kwargs": {}
  },
  "data": "\"hello world\"",
  "prefect_version": "2.8.7+11.gfb8822153"
}
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
