### PR TITLE
Feature: Gzip middleware API and UI responses

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -186,6 +187,7 @@ def create_orion_api(
     """
     fast_api_app_kwargs = fast_api_app_kwargs or {}
     api_app = FastAPI(title=API_TITLE, **fast_api_app_kwargs)
+    api_app.add_middleware(GZipMiddleware)
 
     @api_app.get(health_check_path, tags=["Root"])
     async def health_check():
@@ -245,6 +247,7 @@ def create_orion_api(
 
 def create_ui_app(ephemeral: bool) -> FastAPI:
     ui_app = FastAPI(title=UI_TITLE)
+    ui_app.add_middleware(GZipMiddleware)
 
     if os.name == "nt":
         # Windows defaults to text/plain for .js files


### PR DESCRIPTION
This PR adds Gzip middleware to the UI and API FastAPI apps for compressing responses.

### Example
This script runs a flow that accepts a string input and passes a string of ~20mb:

```py
from prefect import flow

def create_string_of_size_x_bytes(size_in_bytes):
    return "*" * size_in_bytes

@flow
def massive_input(input_str: str):
    pass

if __name__ == "__main__":
    input_str = create_string_of_size_x_bytes(20000000)
    massive_input(input_str=input_str)
```

Testing these changes with and without an `Accept-Encoding: gzip` header:
![Screenshot 2023-03-24 at 6 42 27 PM](https://user-images.githubusercontent.com/27291717/227656580-634b8396-2d1b-40a0-b167-d7af03f63972.png)

The gzipped response has a compressed size of ~20kb, compared to the uncompressed ~19mb.
