### PR TITLE
Accept functions to flow_run_name and task_run_name settings

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -89,7 +89,7 @@ Tasks allow a great deal of customization via arguments. Examples include retry 
 | `tags` | An optional set of tags to be associated with runs of this task. These tags are combined with any tags defined by a `prefect.tags` context at task runtime. |
 | `cache_key_fn` | An optional callable that, given the task run context and call parameters, generates a string key. If the key matches a previous completed state, that state result will be restored instead of running the task again. |
 | `cache_expiration` | An optional amount of time indicating how long cached states for this task should be restorable; if not provided, cached states will never expire. |
-| `task_run_name` | An optional name to distinguish runs of this task; this name can be provided as a string template with the task's keyword arguments as variables. |
+| `task_run_name` | An optional name to distinguish runs of this task; this name can be provided as a string template with the task's keyword arguments as variables; this name can also be provided via a function that returns a string. |
 | `retries` | An optional number of times to retry on task run failure. |
 | `retry_delay_seconds` | An optional number of seconds to wait before retrying the task after failure. This is only applicable if `retries` is nonzero. |
 | `version` | An optional string specifying the version of this task definition. |
@@ -119,6 +119,56 @@ def my_task(name, date):
 def my_flow():
     # creates a run with a name like "hello-marvin-on-Thursday"
     my_task(name="marvin", date=datetime.datetime.utcnow())
+```
+
+Additionally this setting also accepts a function that returns a string to be used for the task run name:
+
+```python
+import datetime
+from prefect import flow, task
+
+def generate_task_name():
+    date = datetime.datetime.utcnow()
+    return f"{date:%A}-is-a-lovely-day"
+
+@task(name="My Example Task",
+      description="An example task for a tutorial.",
+      task_run_name=generate_task_name)
+def my_task(name):
+    pass
+
+@flow
+def my_flow():
+    # creates a run with a name like "Thursday-is-a-lovely-day"
+    my_task(name="marvin")
+```
+
+If you need access to information about the task, use the `prefect.runtime` module. For example:
+
+```python
+from prefect import flow
+from prefect.runtime import flow_run, task_run
+
+def generate_task_name():
+    flow_name = flow_run.flow_name
+    task_name = task_run.task_name
+
+    parameters = task_run.parameters
+    name = parameters["name"]
+    limit = parameters["limit"]
+
+    return f"{flow_name}-{task_name}-with-{name}-and-{limit}"
+
+@task(name="my-example-task",
+      description="An example task for a tutorial.",
+      task_run_name=generate_task_name)
+def my_task(name: str, limit: int = 100):
+    pass
+
+@flow
+def my_flow(name: str):
+    # creates a run with a name like "my-flow-my-example-task-with-marvin-and-100"
+    my_task(name="marvin")
 ```
 
 ## Tags

--- a/docs/tutorials/flow-task-config.md
+++ b/docs/tutorials/flow-task-config.md
@@ -190,6 +190,57 @@ def my_flow():
     my_task(name="marvin", date=datetime.datetime.utcnow())
 ```
 
+Additionally this setting also accepts a function that returns a string to be used for the task run name:
+
+```python
+import datetime
+from prefect import flow, task
+
+def generate_task_name():
+    date = datetime.datetime.utcnow()
+    return f"{date:%A}-is-a-lovely-day"
+
+@task(name="My Example Task",
+      description="An example task for a tutorial.",
+      task_run_name=generate_task_name)
+def my_task(name):
+    pass
+
+@flow
+def my_flow():
+    # creates a run with a name like "Thursday-is-a-lovely-day"
+    my_task(name="marvin")
+```
+
+If you need access to information about the task, use the `prefect.runtime` module. For example:
+
+```python
+from prefect import flow
+from prefect.runtime import flow_run, task_run
+
+def generate_task_name():
+    flow_name = flow_run.flow_name
+    task_name = task_run.task_name
+
+    parameters = task_run.parameters
+    name = parameters["name"]
+    limit = parameters["limit"]
+
+    return f"{flow_name}-{task_name}-with-{name}-and-{limit}"
+
+@task(name="my-example-task",
+      description="An example task for a tutorial.",
+      task_run_name=generate_task_name)
+def my_task(name: str, limit: int = 100):
+    pass
+
+@flow
+def my_flow(name: str):
+    # creates a run with a name like "my-flow-my-example-task-with-marvin-and-100"
+    my_task(name="marvin")
+```
+
+
 ## Flow and task retries
 
 Prefect includes built-in support for both flow and [task retries](/concepts/tasks/#retries), which you configure on the flow or task. This enables flows and tasks to automatically retry on failure. You can specify how many retries you want to attempt and, optionally, a delay between retry attempts:

--- a/docs/tutorials/flow-task-config.md
+++ b/docs/tutorials/flow-task-config.md
@@ -94,6 +94,49 @@ def my_flow(name: str, date: datetime.datetime):
 my_flow(name="marvin", date=datetime.datetime.utcnow())
 ```
 
+Additionally this setting also accepts a function that returns a string for the flow run name:
+
+```python
+import datetime
+from prefect import flow
+
+def generate_flow_run_name():
+    date = datetime.datetime.utcnow()
+
+    return f"{date:%A}-is-a-nice-day"
+
+@flow(flow_run_name=generate_flow_run_name)
+def my_flow(name: str):
+    pass
+
+# creates a flow run called 'Thursday-is-a-nice-day'
+my_flow(name="marvin")
+```
+
+If you need access to information about the flow, use the `prefect.runtime` module. For example:
+
+```python
+from prefect import flow
+from prefect.runtime import flow_run
+
+def generate_flow_run_name():
+    flow_name = flow_run.flow_name
+
+    parameters = flow_run.parameters
+    name = parameters["name"]
+    limit = parameters["limit"]
+
+    return f"{flow_name}-with-{name}-and-{limit}"
+
+@flow(flow_run_name=generate_flow_run_name)
+def my_flow(name: str, limit: int = 100):
+    pass
+
+# creates a flow run called 'my-flow-with-marvin-and-100'
+my_flow(name="marvin")
+```
+
+
 ## Basic task configuration
 
 By design, tasks follow a very similar model to flows: you can independently assign tasks their own name and description.

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -614,6 +614,9 @@ async def orchestrate_flow_run(
 
     state = await propose_state(client, Running(), flow_run_id=flow_run.id)
 
+    # flag to ensure we only update the flow run name once
+    run_name_set = False
+
     while state.is_running():
         waited_for_task_runs = False
 
@@ -627,7 +630,7 @@ async def orchestrate_flow_run(
                 parameters=parameters,
             ) as flow_run_context:
                 # update flow run name
-                if flow.flow_run_name:
+                if not run_name_set and flow.flow_run_name:
                     flow_run_name = _resolve_custom_flow_run_name(
                         flow=flow, parameters=parameters
                     )
@@ -640,6 +643,7 @@ async def orchestrate_flow_run(
                         f"Renamed flow run {flow_run.name!r} to {flow_run_name!r}"
                     )
                     flow_run.name = flow_run_name
+                    run_name_set = True
 
                 args, kwargs = parameters_to_args_kwargs(flow.fn, parameters)
                 logger.debug(

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -613,6 +613,9 @@ async def orchestrate_flow_run(
         )
 
     if flow.flow_run_name:
+        if not isinstance(flow.flow_run_name, str):
+            raise RuntimeError("'flow_run_name' is not a string")
+
         flow_run_name = flow.flow_run_name.format(**parameters)
         await client.update_flow_run(flow_run_id=flow_run.id, name=flow_run_name)
         logger.extra["flow_run_name"] = flow_run_name

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1531,6 +1531,9 @@ async def orchestrate_task_run(
 
                     # update task run name
                     if not run_name_set and task.task_run_name:
+                        if not isinstance(task.task_run_name, str):
+                            raise RuntimeError("'task_run_name' is not a string")
+
                         task_run_name = task.task_run_name.format(**resolved_parameters)
                         await client.set_task_run_name(
                             task_run_id=task_run.id, name=task_run_name

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -83,8 +83,9 @@ class Flow(Generic[P, R]):
         version: An optional version string for the flow; if not provided, we will
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
-        flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-            as a string template with the flow's parameters as variables.
+        flow_run_name: An optional name to distinguish runs of this flow; this name can
+            be provided as a string template with the flow's parameters as variables,
+            or a function that returns a string.
         task_runner: An optional task runner to use for task execution within the flow;
             if not provided, a `ConcurrentTaskRunner` will be used.
         description: An optional string description for the flow; if not provided, the
@@ -125,7 +126,7 @@ class Flow(Generic[P, R]):
         fn: Callable[P, R],
         name: Optional[str] = None,
         version: Optional[str] = None,
-        flow_run_name: Optional[str] = None,
+        flow_run_name: Optional[Union[Callable[[], str], str]] = None,
         retries: int = 0,
         retry_delay_seconds: Union[int, float] = 0,
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = ConcurrentTaskRunner,
@@ -149,8 +150,12 @@ class Flow(Generic[P, R]):
 
         self.name = name or fn.__name__.replace("_", "-")
 
-        if flow_run_name is not None and not isinstance(flow_run_name, str):
-            raise TypeError("'flow_run_name' is not a string")
+        if flow_run_name is not None:
+            if not isinstance(flow_run_name, str) and not callable(flow_run_name):
+                raise TypeError(
+                    "Expected string or callable for 'flow_run_name'; got"
+                    f" {type(flow_run_name).__name__} instead."
+                )
         self.flow_run_name = flow_run_name
 
         task_runner = task_runner or ConcurrentTaskRunner()
@@ -232,7 +237,7 @@ class Flow(Generic[P, R]):
         retries: int = 0,
         retry_delay_seconds: Union[int, float] = 0,
         description: str = None,
-        flow_run_name: str = None,
+        flow_run_name: Optional[Union[Callable[[], str], str]] = None,
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = None,
         timeout_seconds: Union[int, float] = None,
         validate_parameters: bool = None,
@@ -251,8 +256,9 @@ class Flow(Generic[P, R]):
             name: A new name for the flow.
             version: A new version for the flow.
             description: A new description for the flow.
-            flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-                as a string template with the flow's parameters as variables.
+            flow_run_name: An optional name to distinguish runs of this flow; this name
+                can be provided as a string template with the flow's parameters as variables,
+                or a function that returns a string.
             task_runner: A new task runner for the flow.
             timeout_seconds: A new number of seconds to fail the flow after if still
                 running.
@@ -532,7 +538,7 @@ def flow(
     *,
     name: Optional[str] = None,
     version: Optional[str] = None,
-    flow_run_name: Optional[str] = None,
+    flow_run_name: Optional[Union[Callable[[], str], str]] = None,
     retries: int = 0,
     retry_delay_seconds: Union[int, float] = 0,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
@@ -555,7 +561,7 @@ def flow(
     *,
     name: Optional[str] = None,
     version: Optional[str] = None,
-    flow_run_name: Optional[str] = None,
+    flow_run_name: Optional[Union[Callable[[], str], str]] = None,
     retries: int = 0,
     retry_delay_seconds: Union[int, float] = 0,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
@@ -583,8 +589,9 @@ def flow(
         version: An optional version string for the flow; if not provided, we will
             attempt to create a version string as a hash of the file containing the
             wrapped function; if the file cannot be located, the version will be null.
-        flow_run_name: An optional name to distinguish runs of this flow; this name can be provided
-            as a string template with the flow's parameters as variables.
+        flow_run_name: An optional name to distinguish runs of this flow; this name can
+            be provided as a string template with the flow's parameters as variables,
+            or a function that returns a string.
         task_runner: An optional task runner to use for task execution within the flow; if
             not provided, a `ConcurrentTaskRunner` will be instantiated.
         description: An optional string description for the flow; if not provided, the

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -148,7 +148,11 @@ class Flow(Generic[P, R]):
             raise_on_invalid_name(name)
 
         self.name = name or fn.__name__.replace("_", "-")
+
+        if flow_run_name is not None and not isinstance(flow_run_name, str):
+            raise TypeError("'flow_run_name' is not a string")
         self.flow_run_name = flow_run_name
+
         task_runner = task_runner or ConcurrentTaskRunner()
         self.task_runner = (
             task_runner() if isinstance(task_runner, type) else task_runner

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -130,7 +130,8 @@ class Task(Generic[P, R]):
             for this task should be restorable; if not provided, cached states will
             never expire.
         task_run_name: An optional name to distinguish runs of this task; this name can be provided
-            as a string template with the task's keyword arguments as variables.
+            as a string template with the task's keyword arguments as variables,
+            or a function that returns a string.
         retries: An optional number of times to retry on task run failure.
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This
@@ -178,7 +179,7 @@ class Task(Generic[P, R]):
             ["TaskRunContext", Dict[str, Any]], Optional[str]
         ] = None,
         cache_expiration: datetime.timedelta = None,
-        task_run_name: str = None,
+        task_run_name: Optional[Union[Callable[[], str], str]] = None,
         retries: int = 0,
         retry_delay_seconds: Union[
             float,
@@ -214,8 +215,12 @@ class Task(Generic[P, R]):
         else:
             self.name = name
 
-        if task_run_name is not None and not isinstance(task_run_name, str):
-            raise TypeError("'task_run_name' is not a string")
+        if task_run_name is not None:
+            if not isinstance(task_run_name, str) and not callable(task_run_name):
+                raise TypeError(
+                    "Expected string or callable for 'task_run_name'; got"
+                    f" {type(task_run_name).__name__} instead."
+                )
         self.task_run_name = task_run_name
 
         self.version = version
@@ -297,7 +302,7 @@ class Task(Generic[P, R]):
         cache_key_fn: Callable[
             ["TaskRunContext", Dict[str, Any]], Optional[str]
         ] = None,
-        task_run_name: str = None,
+        task_run_name: Optional[Union[Callable[[], str], str]] = None,
         cache_expiration: datetime.timedelta = None,
         retries: Optional[int] = NotSet,
         retry_delay_seconds: Union[
@@ -329,7 +334,8 @@ class Task(Generic[P, R]):
             cache_key_fn: A new cache key function for the task.
             cache_expiration: A new cache expiration time for the task.
             task_run_name: An optional name to distinguish runs of this task; this name can be provided
-                as a string template with the task's keyword arguments as variables.
+                as a string template with the task's keyword arguments as variables,
+                or a function that returns a string.
             retries: A new number of times to retry on task run failure.
             retry_delay_seconds: Optionally configures how long to wait before retrying
                 the task after failure. This is only applicable if `retries` is nonzero.
@@ -877,7 +883,7 @@ def task(
     version: str = None,
     cache_key_fn: Callable[["TaskRunContext", Dict[str, Any]], Optional[str]] = None,
     cache_expiration: datetime.timedelta = None,
-    task_run_name: str = None,
+    task_run_name: Optional[Union[Callable[[], str], str]] = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -909,7 +915,7 @@ def task(
     version: str = None,
     cache_key_fn: Callable[["TaskRunContext", Dict[str, Any]], Optional[str]] = None,
     cache_expiration: datetime.timedelta = None,
-    task_run_name: str = None,
+    task_run_name: Optional[Union[Callable[[], str], str]] = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -949,7 +955,8 @@ def task(
             for this task should be restorable; if not provided, cached states will
             never expire.
         task_run_name: An optional name to distinguish runs of this task; this name can be provided
-            as a string template with the task's keyword arguments as variables.
+            as a string template with the task's keyword arguments as variables,
+            or a function that returns a string.
         retries: An optional number of times to retry on task run failure
         retry_delay_seconds: Optionally configures how long to wait before retrying the
             task after failure. This is only applicable if `retries` is nonzero. This

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -214,7 +214,10 @@ class Task(Generic[P, R]):
         else:
             self.name = name
 
+        if task_run_name is not None and not isinstance(task_run_name, str):
+            raise TypeError("'task_run_name' is not a string")
         self.task_run_name = task_run_name
+
         self.version = version
         self.log_prints = log_prints
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -52,6 +52,12 @@ class TestFlow:
         assert f.description == "B"
         assert f.flow_run_name == "hi"
 
+    def test_initializes_with_callable_flow_run_name(self):
+        f = Flow(name="test", fn=lambda **kwargs: 42, flow_run_name=lambda: "hi")
+        assert f.name == "test"
+        assert f.fn() == 42
+        assert f.flow_run_name() == "hi"
+
     def test_initializes_with_default_version(self):
         f = Flow(name="test", fn=lambda **kwargs: 42)
         assert isinstance(f.version, str)
@@ -127,7 +133,13 @@ class TestFlow:
             def format(*args, **kwargs):
                 pass
 
-        with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
+        with pytest.raises(
+            TypeError,
+            match=(
+                "Expected string or callable for 'flow_run_name'; got"
+                " InvalidFlowRunNameArg instead."
+            ),
+        ):
             Flow(fn=lambda: 1, name="hello", flow_run_name=InvalidFlowRunNameArg())
 
     def test_using_return_state_in_flow_definition_raises_reserved(self):
@@ -164,6 +176,15 @@ class TestDecorator:
         assert my_flow.fn() == "bar"
         assert my_flow.flow_run_name == "hi"
 
+    def test_flow_decorator_initializes_with_callable_flow_run_name(self):
+        @flow(flow_run_name=lambda: "hi")
+        def my_flow():
+            return "bar"
+
+        assert isinstance(my_flow, Flow)
+        assert my_flow.fn() == "bar"
+        assert my_flow.flow_run_name() == "hi"
+
     def test_flow_decorator_sets_default_version(self):
         my_flow = flow(flatdict_to_dict)
 
@@ -174,7 +195,13 @@ class TestDecorator:
             def format(*args, **kwargs):
                 pass
 
-        with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
+        with pytest.raises(
+            TypeError,
+            match=(
+                "Expected string or callable for 'flow_run_name'; got"
+                " InvalidFlowRunNameArg instead."
+            ),
+        ):
 
             @flow(flow_run_name=InvalidFlowRunNameArg())
             def flow_with_illegal_run_name():
@@ -206,7 +233,7 @@ class TestFlowWithOptions:
         flow_with_options = initial_flow.with_options(
             name="Copied flow",
             description="A copied flow",
-            flow_run_name="new-name",
+            flow_run_name=lambda: "new-name",
             task_runner=SequentialTaskRunner,
             retries=3,
             retry_delay_seconds=20,
@@ -222,7 +249,7 @@ class TestFlowWithOptions:
 
         assert flow_with_options.name == "Copied flow"
         assert flow_with_options.description == "A copied flow"
-        assert flow_with_options.flow_run_name == "new-name"
+        assert flow_with_options.flow_run_name() == "new-name"
         assert isinstance(flow_with_options.task_runner, SequentialTaskRunner)
         assert flow_with_options.timeout_seconds == 5
         assert flow_with_options.retries == 3
@@ -1971,7 +1998,13 @@ class TestFlowRunName:
 
         my_flow.flow_run_name = InvalidFlowRunNameArg()
 
-        with pytest.raises(RuntimeError, match="'flow_run_name' is not a string"):
+        with pytest.raises(
+            TypeError,
+            match=(
+                "Expected string or callable for 'flow_run_name'; got"
+                " InvalidFlowRunNameArg instead."
+            ),
+        ):
             my_flow()
 
     async def test_sets_run_name_when_provided(self, orion_client):
@@ -1995,6 +2028,39 @@ class TestFlowRunName:
         assert state.type == StateType.COMPLETED
         flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
         assert flow_run.name == "hi-one-two"
+
+    async def test_sets_run_name_with_function(self, orion_client):
+        def generate_flow_run_name():
+            return "hi"
+
+        @flow(flow_run_name=generate_flow_run_name)
+        def flow_with_name(foo: str = "one", bar: str = "1"):
+            pass
+
+        state = flow_with_name(bar="two", return_state=True)
+
+        assert state.type == StateType.COMPLETED
+        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+        assert flow_run.name == "hi"
+
+    async def test_sets_run_name_with_function_not_returning_string(self, orion_client):
+        def generate_flow_run_name():
+            pass
+
+        @flow(flow_run_name=generate_flow_run_name)
+        def flow_with_name(foo: str = "one", bar: str = "1"):
+            pass
+
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"Callable <function"
+                r" TestFlowRunName.test_sets_run_name_with_function_not_returning_string.<locals>.generate_flow_run_name"
+                r" at .*> for 'flow_run_name' returned type NoneType but a string is"
+                r" required."
+            ),
+        ):
+            flow_with_name(bar="two")
 
 
 def create_hook(mock_obj):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1940,28 +1940,28 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
     assert len(flow_runs) == 1
 
 
-async def test_sets_run_name_when_provided(orion_client):
-    @flow(flow_run_name="hi")
-    def flow_with_name(foo: str = "bar", bar: int = 1):
-        pass
+class TestFlowRunName:
+    async def test_sets_run_name_when_provided(self, orion_client):
+        @flow(flow_run_name="hi")
+        def flow_with_name(foo: str = "bar", bar: int = 1):
+            pass
 
-    state = flow_with_name(return_state=True)
+        state = flow_with_name(return_state=True)
 
-    assert state.type == StateType.COMPLETED
-    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-    assert flow_run.name == "hi"
+        assert state.type == StateType.COMPLETED
+        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+        assert flow_run.name == "hi"
 
+    async def test_sets_run_name_with_params_including_defaults(self, orion_client):
+        @flow(flow_run_name="hi-{foo}-{bar}")
+        def flow_with_name(foo: str = "one", bar: str = "1"):
+            pass
 
-async def test_sets_run_name_with_params_including_defaults(orion_client):
-    @flow(flow_run_name="hi-{foo}-{bar}")
-    def flow_with_name(foo: str = "one", bar: str = "1"):
-        pass
+        state = flow_with_name(bar="two", return_state=True)
 
-    state = flow_with_name(bar="two", return_state=True)
-
-    assert state.type == StateType.COMPLETED
-    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
-    assert flow_run.name == "hi-one-two"
+        assert state.type == StateType.COMPLETED
+        flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+        assert flow_run.name == "hi-one-two"
 
 
 def create_hook(mock_obj):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -122,6 +122,14 @@ class TestFlow:
         with pytest.raises(InvalidNameError, match="contains an invalid character"):
             Flow(fn=lambda: 1, name=name)
 
+    def test_invalid_run_name(self):
+        class InvalidFlowRunNameArg:
+            def format(*args, **kwargs):
+                pass
+
+        with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
+            Flow(fn=lambda: 1, name='hello', flow_run_name=InvalidFlowRunNameArg())
+
     def test_using_return_state_in_flow_definition_raises_reserved(self):
         with pytest.raises(
             ReservedArgumentError, match="'return_state' is a reserved argument name"
@@ -160,6 +168,17 @@ class TestDecorator:
         my_flow = flow(flatdict_to_dict)
 
         assert my_flow.version == file_hash(flatdict_to_dict.__globals__["__file__"])
+
+    def test_invalid_run_name(self):
+        class InvalidFlowRunNameArg:
+            def format(*args, **kwargs):
+                pass
+
+        with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
+            @flow(flow_run_name=InvalidFlowRunNameArg())
+            def flow_with_illegal_run_name():
+                pass
+
 
 
 class TestFlowWithOptions:
@@ -1941,6 +1960,20 @@ async def test_handling_script_with_unprotected_call_in_flow_script(
 
 
 class TestFlowRunName:
+    async def test_invalid_runtime_run_name(self):
+        class InvalidFlowRunNameArg:
+            def format(*args, **kwargs):
+                pass
+
+        @flow
+        def my_flow():
+            pass
+
+        my_flow.flow_run_name = InvalidFlowRunNameArg()
+
+        with pytest.raises(RuntimeError, match="'flow_run_name' is not a string"):
+            my_flow()
+
     async def test_sets_run_name_when_provided(self, orion_client):
         @flow(flow_run_name="hi")
         def flow_with_name(foo: str = "bar", bar: int = 1):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -128,7 +128,7 @@ class TestFlow:
                 pass
 
         with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
-            Flow(fn=lambda: 1, name='hello', flow_run_name=InvalidFlowRunNameArg())
+            Flow(fn=lambda: 1, name="hello", flow_run_name=InvalidFlowRunNameArg())
 
     def test_using_return_state_in_flow_definition_raises_reserved(self):
         with pytest.raises(
@@ -175,10 +175,10 @@ class TestDecorator:
                 pass
 
         with pytest.raises(TypeError, match="'flow_run_name' is not a string"):
+
             @flow(flow_run_name=InvalidFlowRunNameArg())
             def flow_with_illegal_run_name():
                 pass
-
 
 
 class TestFlowWithOptions:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -86,6 +86,35 @@ class TestTaskRunName:
 
         assert my_task.task_run_name is None
 
+    def test_invalid_run_name(self):
+        class InvalidTaskRunNameArg:
+            def format(*args, **kwargs):
+                pass
+
+        with pytest.raises(TypeError, match="'task_run_name' is not a string"):
+
+            @task(task_run_name=InvalidTaskRunNameArg())
+            def my_task():
+                pass
+
+    def test_invalid_runtime_run_name(self):
+        class InvalidTaskRunNameArg:
+            def format(*args, **kwargs):
+                pass
+
+        @task
+        def my_task():
+            pass
+
+        @flow
+        def my_flow():
+            my_task()
+
+        my_task.task_run_name = InvalidTaskRunNameArg()
+
+        with pytest.raises(RuntimeError, match="'task_run_name' is not a string"):
+            my_flow()
+
     def test_run_name_from_kwarg(self):
         @task(task_run_name="another_name")
         def my_task():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->
Currently flow_run_name and task_run_name settings only accept template strings to generate new name. This PR enhances this feature by accept a function that expects input parameters dict and returns a string. This should ideally allow injecting flow run context and task run context too.
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
 
#### Flow run name setting
 ```python
import datetime
from prefect import flow

def generate_flow_run_name(params):
    date = datetime.datetime.utcnow()
    name = "anon" if "name" not in params else str(params["name"])

    return f"{name}-on-{date:%A}"

@flow(flow_run_name=generate_flow_run_name)
def my_flow(name: str):
    pass

# creates a flow run called 'marvin-on-Thursday'
my_flow(name="marvin")
```

#### Task run name setting
```python
import datetime
from prefect import flow, task

def generate_task_name(params):
    name = "anon" if "name" not in params else params["name"]
    date = datetime.datetime.utcnow()

    return f"hello-{name}-on-{date:%A}")

@task(name="My Example Task", 
      description="An example task for a tutorial.",
      task_run_name=generate_task_name)
def my_task(name):
    pass

@flow
def my_flow():
    # creates a run with a name like "hello-marvin-on-Thursday"
    my_task(name="marvin")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

closes https://github.com/PrefectHQ/prefect/issues/8895