### PR TITLE
docs: fix missing ``` in work-pools.md

### DIFF
--- a/docs/concepts/work-pools.md
+++ b/docs/concepts/work-pools.md
@@ -181,6 +181,7 @@ prefect work-pool ls
 │ test-pool  │  prefect-agent │ a51adf8c-58bb-4949-abe6-1b87af46eabd │ None              │
 └────────────┴────────────────┴──────────────────────────────────────┴───────────────────┘
                        (**) denotes a paused pool
+```
 </div>
 
 `prefect work-pool inspect` provides all configuration metadata for a specific work pool by ID.


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

fix for missing ``` in work-pools.md, that was messing up the display.

This was before:
![before](https://user-images.githubusercontent.com/5349963/227880374-08292c6b-bd3e-4e09-a8a8-00dd5e577314.png)
  

This is after (screenshot taken from VSCode preview):
![after](https://user-images.githubusercontent.com/5349963/227881992-7187c258-0e30-4fde-93ab-ef3658396e40.png)



### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
