### PR TITLE
Add flow name support to `prefect.runtime.flow_run`

### DIFF
--- a/tests/runtime/test_flow_run.py
+++ b/tests/runtime/test_flow_run.py
@@ -6,6 +6,7 @@ import pytest
 from prefect import flow, states, tags
 from prefect.client.schemas import FlowRun
 from prefect.context import FlowRunContext
+from prefect.flows import Flow
 from prefect.runtime import flow_run
 
 
@@ -133,3 +134,33 @@ class TestName:
         monkeypatch.setenv(name="PREFECT__FLOW_RUN_ID", value=str(run.id))
 
         assert flow_run.name == "foo"
+
+
+class TestFlowName:
+    async def test_flow_name_is_attribute(self):
+        assert "flow_name" in dir(flow_run)
+
+    async def test_flow_name_is_empty_when_not_set(self):
+        assert flow_run.flow_name is None
+
+    async def test_flow_name_returns_flow_name_when_present_dynamically(self):
+        assert flow_run.flow_name is None
+
+        with FlowRunContext.construct(
+            flow_run=FlowRun.construct(), flow=Flow(fn=lambda: None, name="foo")
+        ):
+            assert flow_run.flow_name == "foo"
+
+        assert flow_run.flow_name is None
+
+    async def test_flow_name_pulls_from_api_when_needed(
+        self, monkeypatch, orion_client
+    ):
+        run = await orion_client.create_flow_run(
+            flow=flow(lambda: None, name="foo"), name="bar"
+        )
+        assert flow_run.flow_name is None
+
+        monkeypatch.setenv(name="PREFECT__FLOW_RUN_ID", value=str(run.id))
+
+        assert flow_run.flow_name == "foo"


### PR DESCRIPTION
Extends #8947 
Closes https://github.com/PrefectHQ/prefect/issues/8941

```python
from prefect import flow
import prefect.runtime


@flow(name="test")
def my_flow():
    print(prefect.runtime.flow_run.flow_name)
    

my_flow()
```

```
11:48:33.097 | INFO    | prefect.engine - Created flow run 'shrewd-chihuahua' for flow 'test'
test
11:48:33.202 | INFO    | Flow run 'shrewd-chihuahua' - Finished in state Completed()
```