### PR TITLE
Add formatting of task storage keys and `prefect.runtime.task_run` module

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -455,11 +455,18 @@ from prefect import flow, task
 def my_flow():
     hello_world()
 
-@task(persist_result=True, result_storage_key="{flow_run.flow_name}-{flow_run.name}-hello.json")
+@task(persist_result=True, result_storage_key="{flow_run.flow_name}_{flow_run.name}_hello.json")
 def hello_world(name: str = "world"):
     return f"hello {name}"
 
 my_flow()
+```
+
+After running this flow, we can see a result file templated with the name of the flow and the flow run:
+
+```
+❯ ls ~/.prefect/storage | grep "my-flow"    
+my-flow_industrious-trout_hello.json
 ```
 
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -419,13 +419,12 @@ def my_task():
 my_flow()  # The task's result will be persisted to 's3://my-bucket/my_task.json'
 ```
 
-Result storage keys are formatted with access to the `prefect` module and the run's `parameters`. In the following example, we will run a flow with three runs of the same task. Each task run will write its result to a unique file based on the `name` parameter.
+Result storage keys are formatted with access to all of the modules in `prefect.runtime` and the run's `parameters`. In the following example, we will run a flow with three runs of the same task. Each task run will write its result to a unique file based on the `name` parameter.
 
 ```python
 from prefect import flow, task
-from prefect.serializers import JSONSerializer
 
-@flow(result_serializer=JSONSerializer())
+@flow()
 def my_flow():
     hello_world()
     hello_world(name="foo")
@@ -446,6 +445,23 @@ hello-bar.json
 hello-foo.json
 hello-world.json
 ```
+
+In the next example, we include metadata about the flow run from the `prefect.runtime.flow_run` module:
+
+```
+from prefect import flow, task
+
+@flow
+def my_flow():
+    hello_world()
+
+@task(persist_result=True, result_storage_key="{flow_run.flow_name}-{flow_run.name}-hello.json")
+def hello_world(name: str = "world"):
+    return f"hello {name}"
+
+my_flow()
+```
+
 
 If a result exists at a given storage key in the storage location, it will be overwritten.
 

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -448,7 +448,7 @@ hello-world.json
 
 In the next example, we include metadata about the flow run from the `prefect.runtime.flow_run` module:
 
-```
+```python
 from prefect import flow, task
 
 @flow

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -33,6 +33,7 @@ from prefect.results import BaseResult
 from prefect.engine import pause_flow_run, resume_flow_run
 from prefect.client.orchestration import get_client, PrefectClient
 from prefect.client.cloud import get_cloud_client, CloudClient
+import prefect.runtime
 
 # Import modules that register types
 import prefect.serializers

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -262,13 +262,12 @@ class TaskRunContext(RunContext):
     Attributes:
         task: The task instance associated with the task run
         task_run: The API metadata for this task run
-        timeout_scope: The cancellation scope for task-level timeouts
     """
 
     task: "Task"
     task_run: TaskRun
-    timeout_scope: Optional[anyio.abc.CancelScope] = None
     log_prints: bool = False
+    parameters: Dict[str, Any]
 
     # Result handling
     result_factory: ResultFactory

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1471,7 +1471,10 @@ async def orchestrate_task_run(
     # Generate the cache key to attach to proposed states
     # The cache key uses a TaskRunContext that does not include a `timeout_context``
     cache_key = (
-        task.cache_key_fn(partial_task_run_context.finalize(), resolved_parameters)
+        task.cache_key_fn(
+            partial_task_run_context.finalize(parameters=resolved_parameters),
+            resolved_parameters,
+        )
         if task.cache_key_fn
         else None
     )

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1476,6 +1476,8 @@ async def orchestrate_task_run(
         else None
     )
 
+    task_run_context = partial_task_run_context.finalize(parameters=resolved_parameters)
+
     # Ignore the cached results for a cache key, default = false
     # Setting on task level overrules the Prefect setting (env var)
     refresh_cache = (
@@ -1509,105 +1511,107 @@ async def orchestrate_task_run(
         # Retrieve the latest metadata for the task run context
         task_run = await client.read_task_run(task_run.id)
 
-        try:
-            with timeout_context as timeout_scope:
-                task_run_context = partial_task_run_context.finalize(
-                    timeout_scope=timeout_scope
-                )
-                args, kwargs = parameters_to_args_kwargs(task.fn, resolved_parameters)
-
-                # update task run name
-                if not run_name_set and task.task_run_name:
-                    task_run_name = task.task_run_name.format(**resolved_parameters)
-                    await client.set_task_run_name(
-                        task_run_id=task_run.id, name=task_run_name
-                    )
-                    logger.extra["task_run_name"] = task_run_name
-                    logger.debug(
-                        f"Renamed task run {task_run.name!r} to {task_run_name!r}"
-                    )
-                    task_run.name = task_run_name
-                    run_name_set = True
-
-                if PREFECT_DEBUG_MODE.value():
-                    logger.debug(f"Executing {call_repr(task.fn, *args, **kwargs)}")
-                else:
-                    logger.debug(
-                        f"Beginning execution...", extra={"state_message": True}
+        with task_run_context.copy(
+            update={"task_run": task_run, "start_time": pendulum.now("UTC")}
+        ):
+            try:
+                with timeout_context as timeout_scope:
+                    args, kwargs = parameters_to_args_kwargs(
+                        task.fn, resolved_parameters
                     )
 
-                with task_run_context.copy(
-                    update={"task_run": task_run, "start_time": pendulum.now("UTC")}
+                    # update task run name
+                    if not run_name_set and task.task_run_name:
+                        task_run_name = task.task_run_name.format(**resolved_parameters)
+                        await client.set_task_run_name(
+                            task_run_id=task_run.id, name=task_run_name
+                        )
+                        logger.extra["task_run_name"] = task_run_name
+                        logger.debug(
+                            f"Renamed task run {task_run.name!r} to {task_run_name!r}"
+                        )
+                        task_run.name = task_run_name
+                        run_name_set = True
+
+                    if PREFECT_DEBUG_MODE.value():
+                        logger.debug(f"Executing {call_repr(task.fn, *args, **kwargs)}")
+                    else:
+                        logger.debug(
+                            f"Beginning execution...", extra={"state_message": True}
+                        )
+
+                        call = from_async.call_soon_in_new_thread(
+                            create_call(task.fn, *args, **kwargs)
+                        )
+                        result = await call.aresult()
+
+            except Exception as exc:
+                name = message = None
+                if (
+                    # Task run timeouts
+                    isinstance(exc, TimeoutError)
+                    and timeout_scope
+                    # Only update the message if the timeout was actually encountered since
+                    # this could be a timeout in the user's code
+                    and timeout_scope.cancel_called
                 ):
-                    call = from_async.call_soon_in_new_thread(
-                        create_call(task.fn, *args, **kwargs)
+                    name = "TimedOut"
+                    message = (
+                        f"Task run exceeded timeout of {task.timeout_seconds} seconds"
                     )
-                    result = await call.aresult()
+                    logger.exception(message)
+                else:
+                    message = "Task run encountered an exception:"
+                    logger.exception("Encountered exception during execution:")
 
-        except Exception as exc:
-            name = message = None
-            if (
-                # Task run timeouts
-                isinstance(exc, TimeoutError)
-                and timeout_scope
-                # Only update the message if the timeout was actually encountered since
-                # this could be a timeout in the user's code
-                and timeout_scope.cancel_called
-            ):
-                name = "TimedOut"
-                message = f"Task run exceeded timeout of {task.timeout_seconds} seconds"
-                logger.exception(message)
-            else:
-                message = "Task run encountered an exception:"
-                logger.exception("Encountered exception during execution:")
-
-            terminal_state = await exception_to_failed_state(
-                name=name,
-                message=message,
-                result_factory=task_run_context.result_factory,
-            )
-        else:
-            terminal_state = await return_value_to_state(
-                result,
-                result_factory=task_run_context.result_factory,
-            )
-
-            # for COMPLETED tasks, add the cache key and expiration
-            if terminal_state.is_completed():
-                terminal_state.state_details.cache_expiration = (
-                    (pendulum.now("utc") + task.cache_expiration)
-                    if task.cache_expiration
-                    else None
+                terminal_state = await exception_to_failed_state(
+                    name=name,
+                    message=message,
+                    result_factory=task_run_context.result_factory,
                 )
-                terminal_state.state_details.cache_key = cache_key
+            else:
+                terminal_state = await return_value_to_state(
+                    result,
+                    result_factory=task_run_context.result_factory,
+                )
 
-        state = await propose_state(client, terminal_state, task_run_id=task_run.id)
+                # for COMPLETED tasks, add the cache key and expiration
+                if terminal_state.is_completed():
+                    terminal_state.state_details.cache_expiration = (
+                        (pendulum.now("utc") + task.cache_expiration)
+                        if task.cache_expiration
+                        else None
+                    )
+                    terminal_state.state_details.cache_key = cache_key
 
-        await _run_task_hooks(
-            task=task,
-            task_run=task_run,
-            state=state,
-        )
+            state = await propose_state(client, terminal_state, task_run_id=task_run.id)
 
-        if state.type != terminal_state.type and PREFECT_DEBUG_MODE:
-            logger.debug(
-                (
-                    f"Received new state {state} when proposing final state"
-                    f" {terminal_state}"
-                ),
-                extra={"send_to_orion": False},
+            await _run_task_hooks(
+                task=task,
+                task_run=task_run,
+                state=state,
             )
 
-        if not state.is_final():
-            logger.info(
-                (
-                    f"Received non-final state {state.name!r} when proposing final"
-                    f" state {terminal_state.name!r} and will attempt to run again..."
-                ),
-                extra={"send_to_orion": False},
-            )
-            # Attempt to enter a running state again
-            state = await propose_state(client, Running(), task_run_id=task_run.id)
+            if state.type != terminal_state.type and PREFECT_DEBUG_MODE:
+                logger.debug(
+                    (
+                        f"Received new state {state} when proposing final state"
+                        f" {terminal_state}"
+                    ),
+                    extra={"send_to_orion": False},
+                )
+
+            if not state.is_final():
+                logger.info(
+                    (
+                        f"Received non-final state {state.name!r} when proposing final"
+                        f" state {terminal_state.name!r} and will attempt to run"
+                        " again..."
+                    ),
+                    extra={"send_to_orion": False},
+                )
+                # Attempt to enter a running state again
+                state = await propose_state(client, Running(), task_run_id=task_run.id)
 
     # If debugging, use the more complete `repr` than the usual `str` description
     display_state = repr(state) if PREFECT_DEBUG_MODE else str(state)

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -230,7 +230,7 @@ class ResultFactory(pydantic.BaseModel):
             cache_result_in_memory=cache_result_in_memory,
             client=client,
             storage_key_fn=(
-                (lambda: task.result_storage_key)
+                (lambda: task.result_storage_key.format(prefect=prefect))
                 if task.result_storage_key is not None
                 else DEFAULT_STORAGE_KEY_FN
             ),

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -101,8 +101,10 @@ def task_features_require_result_persistence(task: "Task") -> bool:
     return False
 
 
-def format_user_supplied_storage_key(key):
-    return key.format(prefect=prefect)
+def _format_user_supplied_storage_key(key):
+    # Note here we are pinning to task runs since flow runs do not support storage keys
+    # yet; we'll need to split logic in the future or have two separate functions
+    return key.format(prefect=prefect, parameters=prefect.runtime.task_run.parameters)
 
 
 class ResultFactory(pydantic.BaseModel):
@@ -235,7 +237,7 @@ class ResultFactory(pydantic.BaseModel):
             cache_result_in_memory=cache_result_in_memory,
             client=client,
             storage_key_fn=(
-                partial(format_user_supplied_storage_key, task.result_storage_key)
+                partial(_format_user_supplied_storage_key, task.result_storage_key)
                 if task.result_storage_key is not None
                 else DEFAULT_STORAGE_KEY_FN
             ),

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -104,7 +104,8 @@ def task_features_require_result_persistence(task: "Task") -> bool:
 def _format_user_supplied_storage_key(key):
     # Note here we are pinning to task runs since flow runs do not support storage keys
     # yet; we'll need to split logic in the future or have two separate functions
-    return key.format(prefect=prefect, parameters=prefect.runtime.task_run.parameters)
+    runtime_vars = {key: getattr(prefect.runtime, key) for key in dir(prefect.runtime)}
+    return key.format(**runtime_vars, parameters=prefect.runtime.task_run.parameters)
 
 
 class ResultFactory(pydantic.BaseModel):

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1,5 +1,6 @@
 import abc
 import uuid
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -98,6 +99,10 @@ def task_features_require_result_persistence(task: "Task") -> bool:
     if not task.cache_result_in_memory:
         return True
     return False
+
+
+def format_user_supplied_storage_key(key):
+    return key.format(prefect=prefect)
 
 
 class ResultFactory(pydantic.BaseModel):
@@ -230,7 +235,7 @@ class ResultFactory(pydantic.BaseModel):
             cache_result_in_memory=cache_result_in_memory,
             client=client,
             storage_key_fn=(
-                (lambda: task.result_storage_key.format(prefect=prefect))
+                partial(format_user_supplied_storage_key, task.result_storage_key)
                 if task.result_storage_key is not None
                 else DEFAULT_STORAGE_KEY_FN
             ),

--- a/src/prefect/runtime/__init__.py
+++ b/src/prefect/runtime/__init__.py
@@ -10,3 +10,4 @@ Example usage:
 """
 import prefect.runtime.flow_run
 import prefect.runtime.deployment
+import prefect.runtime.task_run

--- a/src/prefect/runtime/task_run.py
+++ b/src/prefect/runtime/task_run.py
@@ -11,8 +11,6 @@ Available attributes:
 """
 from typing import Any, Dict, List, Optional
 
-from prefect._internal.concurrency.api import create_call, from_sync
-from prefect.client.orchestration import get_client
 from prefect.context import TaskRunContext
 
 __all__ = ["id", "tags", "name", "parameters"]
@@ -35,11 +33,6 @@ def __dir__() -> List[str]:
     return sorted(__all__)
 
 
-async def _get_task_run(task_run_id):
-    async with get_client() as client:
-        return await client.read_task_run(task_run_id)
-
-
 def get_id() -> str:
     task_run_ctx = TaskRunContext.get()
     if task_run_ctx is not None:
@@ -48,28 +41,16 @@ def get_id() -> str:
 
 def get_tags() -> List[str]:
     task_run_ctx = TaskRunContext.get()
-    run_id = get_id()
-    if task_run_ctx is None and run_id is None:
+    if task_run_ctx is None:
         return []
-    elif task_run_ctx is None:
-        task_run = from_sync.call_soon_in_loop_thread(
-            create_call(_get_task_run, run_id)
-        ).result()
-
-        return task_run.tags
     else:
         return task_run_ctx.task_run.tags
 
 
 def get_name() -> Optional[str]:
     task_run_ctx = TaskRunContext.get()
-    run_id = get_id()
     if task_run_ctx is None:
-        task_run = from_sync.call_soon_in_loop_thread(
-            create_call(_get_task_run, run_id)
-        ).result()
-
-        return task_run.name
+        return None
     else:
         return task_run_ctx.task_run.name
 

--- a/src/prefect/runtime/task_run.py
+++ b/src/prefect/runtime/task_run.py
@@ -1,0 +1,90 @@
+"""
+Access attributes of the current task run dynamically.
+
+Note that if a task run cannot be discovered, all attributes will return empty values.
+
+Available attributes:
+    - `id`: the task run's unique ID
+    - `name`: the name of the task run
+    - `tags`: the task run's set of tags
+    - `parameters`: the parameters the task was called with
+"""
+from typing import Any, Dict, List, Optional
+
+from prefect._internal.concurrency.api import create_call, from_sync
+from prefect.client.orchestration import get_client
+from prefect.context import TaskRunContext
+
+__all__ = ["id", "tags", "name", "parameters"]
+
+
+def __getattr__(name: str) -> Any:
+    """
+    Attribute accessor for this submodule; note that imports also work with this:
+
+        from prefect.runtime.task_run import id
+    """
+    func = FIELDS.get(name)
+    if func is None:
+        raise AttributeError(f"{__name__} has no attribute {name!r}")
+    else:
+        return func()
+
+
+def __dir__() -> List[str]:
+    return sorted(__all__)
+
+
+async def _get_task_run(task_run_id):
+    async with get_client() as client:
+        return await client.read_task_run(task_run_id)
+
+
+def get_id() -> str:
+    task_run_ctx = TaskRunContext.get()
+    if task_run_ctx is not None:
+        return str(task_run_ctx.task_run.id)
+
+
+def get_tags() -> List[str]:
+    task_run_ctx = TaskRunContext.get()
+    run_id = get_id()
+    if task_run_ctx is None and run_id is None:
+        return []
+    elif task_run_ctx is None:
+        task_run = from_sync.call_soon_in_loop_thread(
+            create_call(_get_task_run, run_id)
+        ).result()
+
+        return task_run.tags
+    else:
+        return task_run_ctx.task_run.tags
+
+
+def get_name() -> Optional[str]:
+    task_run_ctx = TaskRunContext.get()
+    run_id = get_id()
+    if task_run_ctx is None:
+        task_run = from_sync.call_soon_in_loop_thread(
+            create_call(_get_task_run, run_id)
+        ).result()
+
+        return task_run.name
+    else:
+        return task_run_ctx.task_run.name
+
+
+def get_parameters() -> Dict[str, Any]:
+    task_run_ctx = TaskRunContext.get()
+    if task_run_ctx is not None:
+        return task_run_ctx.parameters
+    else:
+        return {}
+
+
+FIELDS = {
+    "id": get_id,
+    "tags": get_tags,
+    "name": get_name,
+    "parameters": get_parameters,
+}

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -298,6 +298,33 @@ async def test_task_result_parameter_formatted_storage_key(orion_client):
     assert task_state.data.storage_key == "1-foo-bar"
 
 
+async def test_task_result_flow_run_formatted_storage_key(orion_client):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow
+    def foo():
+        return bar(y="foo", return_state=True)
+
+    @task(
+        result_storage=storage,
+        persist_result=True,
+        result_storage_key="{flow_run.flow_name}__bar",
+    )
+    def bar(x: int = 1, y: str = "test"):
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+    assert task_state.data.storage_key == "foo__bar"
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+    assert task_state.data.storage_key == "foo__bar"
+
+
 async def test_task_result_missing_with_null_return(orion_client):
     @flow
     def foo():

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -248,7 +248,7 @@ async def test_task_result_storage(orion_client, source):
     await assert_uses_result_storage(api_state, storage)
 
 
-async def test_task_result_storage_key(orion_client):
+async def test_task_result_static_storage_key(orion_client):
     storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
 
     @flow
@@ -269,6 +269,33 @@ async def test_task_result_storage_key(orion_client):
     ).state
     assert await api_state.result() == 1
     assert task_state.data.storage_key == "test"
+
+
+async def test_task_result_parameter_formatted_storage_key(orion_client):
+    storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+
+    @flow
+    def foo():
+        return bar(y="foo", return_state=True)
+
+    @task(
+        result_storage=storage,
+        persist_result=True,
+        result_storage_key="{parameters[x]}-{parameters[y]}-bar",
+    )
+    def bar(x: int = 1, y: str = "test"):
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert await task_state.result() == 1
+    assert task_state.data.storage_key == "1-foo-bar"
+
+    api_state = (
+        await orion_client.read_task_run(task_state.state_details.task_run_id)
+    ).state
+    assert await api_state.result() == 1
+    assert task_state.data.storage_key == "1-foo-bar"
 
 
 async def test_task_result_missing_with_null_return(orion_client):

--- a/tests/runtime/test_task_run.py
+++ b/tests/runtime/test_task_run.py
@@ -1,0 +1,55 @@
+import pytest
+
+from prefect.client.schemas import TaskRun
+from prefect.context import TaskRunContext
+from prefect.runtime import task_run
+
+
+class TestAttributeAccessPatterns:
+    async def test_access_unknown_attribute_fails(self):
+        with pytest.raises(AttributeError, match="beep"):
+            task_run.beep
+
+    async def test_import_unknown_attribute_fails(self):
+        with pytest.raises(ImportError, match="boop"):
+            from prefect.runtime.task_run import boop  # noqa
+
+    async def test_known_attributes_autocomplete(self):
+        assert "id" in dir(task_run)
+        assert "foo" not in dir(task_run)
+
+
+class TestID:
+    async def test_id_is_attribute(self):
+        assert "id" in dir(task_run)
+
+    async def test_id_is_none_when_not_set(self):
+        assert task_run.id is None
+
+    async def test_id_from_context(self):
+        with TaskRunContext.construct(task_run=TaskRun.construct(id="foo")):
+            assert task_run.id == "foo"
+
+
+class TestTags:
+    async def test_tags_is_attribute(self):
+        assert "tags" in dir(task_run)
+
+    async def test_tags_is_empty_when_not_set(self):
+        assert task_run.tags == []
+
+    async def test_tags_returns_tags_when_present_dynamically(self):
+        with TaskRunContext.construct(task_run=TaskRun.construct(tags=["foo", "bar"])):
+            assert task_run.tags == ["foo", "bar"]
+
+
+class TestParameters:
+    async def test_parameters_is_attribute(self):
+        assert "parameters" in dir(task_run)
+
+    async def test_parameters_is_dict_when_not_set(self):
+        assert task_run.parameters == {}
+
+    async def test_parameters_from_context(self):
+        with TaskRunContext.construct(parameters={"x": "foo", "y": "bar"}):
+            assert task_run.parameters == {"x": "foo", "y": "bar"}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -123,12 +123,14 @@ async def test_task_run_context(orion_client, flow_run):
         task_run=task_run,
         client=orion_client,
         result_factory=result_factory,
+        parameters={"foo": "bar"},
     ):
         ctx = TaskRunContext.get()
         assert ctx.task is foo
         assert ctx.task_run == task_run
         assert ctx.result_factory == result_factory
         assert isinstance(ctx.start_time, DateTime)
+        assert ctx.parameters == {"foo": "bar"}
 
 
 @pytest.fixture
@@ -175,6 +177,7 @@ async def test_get_run_context(orion_client, local_filesystem):
                 task_run=task_run,
                 client=orion_client,
                 result_factory=await ResultFactory.from_task(bar, client=orion_client),
+                parameters={"foo": "bar"},
             ) as task_ctx:
                 assert get_run_context() is task_ctx, "Task context takes precendence"
 


### PR DESCRIPTION
Extends #8924 
Closes https://github.com/PrefectHQ/prefect/issues/8239

Adds dynamic task storage keys with formatting from parameters and the `prefect.runtime` modules. Instead of explicitly passing format variables through to the result factory, it adds a `prefect.runtime.task_run` module to pull from and adjusts the scope of the task run context so that it is available during result creation 

Read the docs https://deploy-preview-8949--prefect-docs.netlify.app/concepts/results/#result-storage-key or this example:

```python
from prefect import flow, task
from prefect.serializers import JSONSerializer


@task(
    persist_result=True,
    result_storage_key="{flow_run.flow_name}__hello-{parameters[name]}.json",
)
def hello_world(name: str = "world"):
    return f"hello {name}"


@flow(result_serializer=JSONSerializer())
def my_flow():
    hello_world()
    hello_world(name="foo")
    hello_world(name="bar")


my_flow()
```

```
❯ ls ~/.prefect/storage | grep "my-flow"
my-flow__hello-bar.json
my-flow__hello-foo.json
my-flow__hello-world.json
```