### PR TITLE
Retry on sqlite operational errors

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -527,8 +527,8 @@ def create_app(
         == "sqlite"
     ):
         app.add_middleware(RequestLimitMiddleware, limit=100)
-        app.add_exception_handler(
-            sqlalchemy.exc.OperationalError, db_operational_exception_handler
+        api_app.add_exception_handler(
+            sqlalchemy.exc.OperationalError, retry_exception_handler
         )
 
     api_app.mount(

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -157,9 +157,7 @@ async def integrity_exception_handler(request: Request, exc: Exception):
     )
 
 
-async def db_operational_exception_handler(
-    request: Request, exc: sqlalchemy.exc.OperationalError
-):
+async def retry_exception_handler(request: Request, exc: Exception):
     """Return a 503 so the client can try again."""
     return JSONResponse(
         content={"exception_message": "Service Unavailable"},

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -5,7 +5,6 @@ Defines the Prefect REST API FastAPI app.
 import asyncio
 import mimetypes
 import os
-import random
 from contextlib import asynccontextmanager
 from functools import partial, wraps
 from hashlib import sha256
@@ -57,17 +56,6 @@ enforce_minimum_version = EnforceMinimumAPIVersion(
     minimum_api_version="0.8.0",
     logger=logger,
 )
-
-SERVICE_UNAVAILABLE_RETRY_AFTER = (
-    2  # The number of seconds after which the client should retry on 503s
-)
-SERVICE_UNAVAILABLE_RETRY_AFTER_JITTER = 1  # Retry jitter for 503s
-
-
-def get_retry_after_value() -> float:
-    return SERVICE_UNAVAILABLE_RETRY_AFTER + (
-        random.random() * SERVICE_UNAVAILABLE_RETRY_AFTER_JITTER
-    )
 
 
 API_ROUTERS = (
@@ -162,7 +150,6 @@ async def retry_exception_handler(request: Request, exc: Exception):
     return JSONResponse(
         content={"exception_message": "Service Unavailable"},
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        headers={"Retry-After": str(get_retry_after_value())},
     )
 
 


### PR DESCRIPTION
Return a 503 error if the sqlite db is locked due to other connections accessing it. This will let the client retry with exponential backoff so the connections will all eventually resolve instead of erroring and returning 500s