### PR TITLE
Add publish of Kubernetes flavored Docker images with `prefect-kubernetes`

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -22,6 +22,7 @@ jobs:
         flavor:
           - ""
           - "-conda"
+          - "-kubernetes"
         python-version:
           - "3.7"
           - "3.8"
@@ -101,6 +102,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             ${{ ( endsWith(matrix.flavor, 'conda') && 'BASE_IMAGE=prefect-conda' ) || '' }}
+            ${{ ( endsWith(matrix.flavor, 'kubernetes') && 'EXTRA_PIP_PACKAGES=prefect-kubernetes' ) || '' }}
           tags: ${{ join(steps.metadata-dev.outputs.tags) }},${{ join(steps.metadata-prod.outputs.tags) }}
           labels: ${{ steps.metadata-dev.outputs.labels }}
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim
 ARG BUILD_PYTHON_VERSION=3.8
 # THe version used to build the UI distributable.
 ARG NODE_VERSION=16.15
-
+# Any extra Python requirements to install
+ARG EXTRA_PIP_PACKAGES=""
 
 # Build the UI distributable.
 FROM node:${NODE_VERSION}-bullseye-slim as ui-builder
@@ -113,6 +114,9 @@ COPY --from=python-builder /opt/prefect/dist ./dist
 # Extras to include during `pip install`. Must be wrapped in brackets, e.g. "[dev]"
 ARG PREFECT_EXTRAS=${PREFECT_EXTRAS:-""}
 RUN pip install --no-cache-dir "./dist/prefect.tar.gz${PREFECT_EXTRAS}"
+
+ARG EXTRA_PIP_PACKAGES=${EXTRA_PIP_PACKAGES:-""}
+RUN pip install --no-cache-dir ${EXTRA_PIP_PACKAGES}
 
 # Smoke test
 RUN prefect version

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ ARG PREFECT_EXTRAS=${PREFECT_EXTRAS:-""}
 RUN pip install --no-cache-dir "./dist/prefect.tar.gz${PREFECT_EXTRAS}"
 
 ARG EXTRA_PIP_PACKAGES=${EXTRA_PIP_PACKAGES:-""}
-RUN pip install --no-cache-dir ${EXTRA_PIP_PACKAGES}
+RUN [ -z "${EXTRA_PIP_PACKAGES}" ] && pip install --no-cache-dir "${EXTRA_PIP_PACKAGES}"
 
 # Smoke test
 RUN prefect version

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ ARG PREFECT_EXTRAS=${PREFECT_EXTRAS:-""}
 RUN pip install --no-cache-dir "./dist/prefect.tar.gz${PREFECT_EXTRAS}"
 
 ARG EXTRA_PIP_PACKAGES=${EXTRA_PIP_PACKAGES:-""}
-RUN [ -z "${EXTRA_PIP_PACKAGES}" ] && pip install --no-cache-dir "${EXTRA_PIP_PACKAGES}"
+RUN [ -z "${EXTRA_PIP_PACKAGES}" ] || pip install --no-cache-dir "${EXTRA_PIP_PACKAGES}"
 
 # Smoke test
 RUN prefect version


### PR DESCRIPTION
Explores adding additional image flavors for major deployment providers to our Docker image publishing step. Here, we add a `kubernetes` flavor image with `prefect-kubernetes` installed.