### PR TITLE
Update docs CSS and config for versioning compatibility

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -400,7 +400,7 @@ to force column width */
 /* At 76.1875em, the hamburger menu disappears 
    and users see the full nav menu */
 @media screen and (min-width: 76.1875em) {
-    div[class="md-header__topic"]:not([data-md-component="header-topic"]) {
+    div[class="md-header__topic"]:not([data-md-component="header-topic"]) > span {
         display: none;
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ theme:
             name: Switch to light mode
 plugins:
     mike:
+      canonical_version: latest
+      version_selector: true
     autorefs: {}
     mkdocstrings:
         # custom_templates: docs/templates


### PR DESCRIPTION
This PR includes two minor changes to prepare for docs versioning:

- Makes a CSS selector more specific so we can hide the site title as intended without _also_ hiding the version selection box.
- Adds two `mike` configuration options to `mkdocs.yml`.

Neither of these changes impact the current non-versioned docs. They still build and display as expected. The changes only make a difference when `mike` is used to build versioned docs.

### Example
Before: 
<img width="370" alt="Screenshot 2023-03-27 at 5 05 29 PM" src="https://user-images.githubusercontent.com/228762/228066515-f3ba9de7-5219-40be-a126-1d0b108647d7.png">
Expected: Version selector. Actual: No version selector. 😢 

After:
<img width="228" alt="Screenshot 2023-03-27 at 4 59 59 PM" src="https://user-images.githubusercontent.com/228762/228065500-56206652-a97e-49c5-8bd9-cc9ab9838b87.png">
Expected: Version selector. Actual: Version selector! 😃 

Also after, as a result of the config changes:
<img width="539" alt="Screenshot 2023-03-27 at 5 01 20 PM" src="https://user-images.githubusercontent.com/228762/228065649-17abc2e2-e4ec-44dc-ae89-02a0b93d2d01.png">
Canonical links will point to the latest docs, avoiding penalties for duplicate content and keeping duplicate copies of docs pages out of search results. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
	- This is a very small issue
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
