### PR TITLE
Adds experimental artifacts `prefect artifact ls` command

### DIFF
--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -1,3 +1,4 @@
+from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.cli.root import app
 import prefect.settings
 

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -24,5 +24,5 @@ if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_WORKERS.value():
     import prefect.experimental.cli.worker
 
 # Only load artifacts CLI if enabled via a setting
-if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS.value():
+if experiment_enabled("artifacts"):
     import prefect.experimental.cli.artifact

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -22,3 +22,7 @@ import prefect.cli.work_pool
 # Only load workers CLI if enabled via a setting
 if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_WORKERS.value():
     import prefect.experimental.cli.worker
+
+# Only load artifacts CLI if enabled via a setting
+if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS.value():
+    import prefect.experimental.cli.artifact

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2294,6 +2294,46 @@ class PrefectClient:
 
         return pydantic.parse_obj_as(Artifact, response.json())
 
+    async def read_artifacts(
+        self,
+        *,
+        artifact_filter: schemas.filters.ArtifactFilter = None,
+        flow_run_filter: schemas.filters.FlowRunFilter = None,
+        task_run_filter: schemas.filters.TaskRunFilter = None,
+        sort: schemas.sorting.ArtifactSort = None,
+        limit: int = None,
+        offset: int = 0,
+    ) -> List[Artifact]:
+        """
+        Query the Prefect API for artifacts. Only artifacts matching all criteria will
+        be returned.
+        Args:
+            artifact_filter: filter criteria for artifacts
+            flow_run_filter: filter criteria for flow runs
+            task_run_filter: filter criteria for task runs
+            sort: sort criteria for the artifacts
+            limit: limit for the artifact query
+            offset: offset for the artifact query
+        Returns:
+            a list of Artifact model representations of the artifacts
+        """
+        body = {
+            "artifacts": (
+                artifact_filter.dict(json_compatible=True) if artifact_filter else None
+            ),
+            "flow_runs": (
+                flow_run_filter.dict(json_compatible=True) if flow_run_filter else None
+            ),
+            "task_runs": (
+                task_run_filter.dict(json_compatible=True) if task_run_filter else None
+            ),
+            "sort": sort,
+            "limit": limit,
+            "offset": offset,
+        }
+        response = await self._client.post("/experimental/artifacts/filter", json=body)
+        return pydantic.parse_obj_as(List[Artifact], response.json())
+
     async def __aenter__(self):
         """
         Start the client.

--- a/src/prefect/experimental/cli/artifact.py
+++ b/src/prefect/experimental/cli/artifact.py
@@ -44,7 +44,7 @@ async def list_artifacts():
             table.add_row(
                 str(artifact.id),
                 artifact.key,
-                str(artifact.type),
+                artifact.type,
                 pendulum.instance(artifact.updated).diff_for_humans(),
             )
 

--- a/src/prefect/experimental/cli/artifact.py
+++ b/src/prefect/experimental/cli/artifact.py
@@ -1,0 +1,51 @@
+import pendulum
+from rich.table import Table
+
+from prefect import get_client
+from prefect._internal.compatibility.experimental import experimental
+from prefect.cli._types import PrefectTyper
+from prefect.cli.root import app
+from prefect.client.orchestration import get_client
+from prefect.server import schemas
+
+artifact_app = PrefectTyper(
+    name="artifact", help="Commands for starting and interacting with artifacts."
+)
+app.add_typer(artifact_app)
+
+
+@artifact_app.command("ls")
+@experimental(
+    feature="The Artifact CLI",
+    group="artifacts",
+)
+async def list_artifacts():
+    """
+    List artifacts.
+    """
+    async with get_client() as client:
+        latest_artifact_filter = schemas.filters.ArtifactFilter(
+            is_latest=schemas.filters.ArtifactFilterLatest(is_latest=True)
+        )
+        artifacts = await client.read_artifacts(artifact_filter=latest_artifact_filter)
+
+        table = Table(
+            title="Artifacts",
+            caption="List Artifacts using `prefect artifact ls`",
+            show_header=True,
+        )
+
+        table.add_column("ID", justify="right", style="cyan", no_wrap=True)
+        table.add_column("Key", style="blue", no_wrap=True)
+        table.add_column("Type", style="blue", no_wrap=True)
+        table.add_column("Updated", style="blue", no_wrap=True)
+
+        for artifact in sorted(artifacts, key=lambda x: f"{x.key}"):
+            table.add_row(
+                str(artifact.id),
+                artifact.key,
+                str(artifact.type),
+                pendulum.instance(artifact.updated).diff_for_humans(),
+            )
+
+        app.console.print(table)

--- a/src/prefect/experimental/cli/artifact.py
+++ b/src/prefect/experimental/cli/artifact.py
@@ -1,4 +1,5 @@
 import pendulum
+import typer
 from rich.table import Table
 
 from prefect import get_client
@@ -19,15 +20,28 @@ app.add_typer(artifact_app)
     feature="The Artifact CLI",
     group="artifacts",
 )
-async def list_artifacts():
+async def list_artifacts(
+    limit: int = typer.Option(
+        100,
+        "--limit",
+        help="The maximum number of artifacts to return.",
+    ),
+    latest: bool = typer.Option(
+        False,
+        "--latest",
+        help="Whether or not to only return the latest version of each artifact.",
+    ),
+):
     """
     List artifacts.
     """
     async with get_client() as client:
         latest_artifact_filter = schemas.filters.ArtifactFilter(
-            is_latest=schemas.filters.ArtifactFilterLatest(is_latest=True)
+            is_latest=schemas.filters.ArtifactFilterLatest(is_latest=latest)
         )
-        artifacts = await client.read_artifacts(artifact_filter=latest_artifact_filter)
+        artifacts = await client.read_artifacts(
+            artifact_filter=latest_artifact_filter, limit=limit
+        )
 
         table = Table(
             title="Artifacts",

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1623,20 +1623,86 @@ class TestArtifacts:
         assert PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS.value() is True
 
     @pytest.fixture
-    async def artifact(self):
-        yield ArtifactCreate(
+    async def artifacts(self, orion_client):
+        artifact1_schema = ArtifactCreate(
+            key="voltaic",
+            data=1,
+            type="table",
+            description="# This is a markdown description title",
+        )
+
+        artifact2_schema = ArtifactCreate(
+            key="voltaic",
+            data=2,
+            type="table",
+            description="# This is a markdown description title",
+        )
+
+        artifact3_schema = ArtifactCreate(
+            key="lotus",
+            data=3,
+            type="markdown",
+            description="# This is a markdown description title",
+        )
+
+        artifact1 = await orion_client.create_artifact(artifact=artifact1_schema)
+        artifact2 = await orion_client.create_artifact(artifact=artifact2_schema)
+        artifact3 = await orion_client.create_artifact(artifact=artifact3_schema)
+
+        return [artifact1, artifact2, artifact3]
+
+    async def test_create_then_read_artifact(self, orion_client, client):
+        artifact_schema = ArtifactCreate(
             key="voltaic",
             data=1,
             description="# This is a markdown description title",
             metadata_={"data": "opens many doors"},
         )
+        artifact = await orion_client.create_artifact(artifact=artifact_schema)
 
-    async def test_create_then_read_artifact(self, orion_client, client, artifact):
-        result = await orion_client.create_artifact(artifact=artifact)
-        assert result.key == artifact.key
-        assert result.description == artifact.description
-
-        response = await client.get(f"/experimental/artifacts/{result.id}")
+        response = await client.get(f"/experimental/artifacts/{artifact.id}")
         assert response.status_code == 200
         assert response.json()["key"] == artifact.key
         assert response.json()["description"] == artifact.description
+
+    async def test_read_artifacts(self, orion_client, artifacts):
+        artifact_list = await orion_client.read_artifacts()
+        assert len(artifact_list) == 3
+        keyed_data = {(r.key, r.data) for r in artifact_list}
+        assert keyed_data == {
+            ("voltaic", 1),
+            ("voltaic", 2),
+            ("lotus", 3),
+        }
+
+    async def test_read_artifacts_with_latest_filter(self, orion_client, artifacts):
+        latest_artifact_filter = schemas.filters.ArtifactFilter(
+            is_latest=schemas.filters.ArtifactFilterLatest(is_latest=True)
+        )
+
+        artifact_list = await orion_client.read_artifacts(
+            artifact_filter=latest_artifact_filter
+        )
+
+        assert len(artifact_list) == 2
+        keyed_data = {(r.key, r.data) for r in artifact_list}
+        assert keyed_data == {
+            ("voltaic", 2),
+            ("lotus", 3),
+        }
+
+    async def test_read_artifacts_with_key_filter(self, orion_client, artifacts):
+        key_artifact_filter = schemas.filters.ArtifactFilter(
+            key=schemas.filters.ArtifactFilterKey(any_=["voltaic"])
+        )
+
+        artifact_list = await orion_client.read_artifacts(
+            artifact_filter=key_artifact_filter
+        )
+
+        assert len(artifact_list) == 2
+        keyed_data = {(r.key, r.data) for r in artifact_list}
+        assert keyed_data == {
+            ("voltaic", 1),
+            ("voltaic", 2),
+        }

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1624,30 +1624,30 @@ class TestArtifacts:
 
     @pytest.fixture
     async def artifacts(self, orion_client):
-        artifact1_schema = ArtifactCreate(
-            key="voltaic",
-            data=1,
-            type="table",
-            description="# This is a markdown description title",
+        artifact1 = await orion_client.create_artifact(
+            artifact=ArtifactCreate(
+                key="voltaic",
+                data=1,
+                type="table",
+                description="# This is a markdown description title",
+            )
         )
-
-        artifact2_schema = ArtifactCreate(
-            key="voltaic",
-            data=2,
-            type="table",
-            description="# This is a markdown description title",
+        artifact2 = await orion_client.create_artifact(
+            artifact=ArtifactCreate(
+                key="voltaic",
+                data=2,
+                type="table",
+                description="# This is a markdown description title",
+            )
         )
-
-        artifact3_schema = ArtifactCreate(
-            key="lotus",
-            data=3,
-            type="markdown",
-            description="# This is a markdown description title",
+        artifact3 = await orion_client.create_artifact(
+            artifact=ArtifactCreate(
+                key="lotus",
+                data=3,
+                type="markdown",
+                description="# This is a markdown description title",
+            )
         )
-
-        artifact1 = await orion_client.create_artifact(artifact=artifact1_schema)
-        artifact2 = await orion_client.create_artifact(artifact=artifact2_schema)
-        artifact3 = await orion_client.create_artifact(artifact=artifact3_schema)
 
         return [artifact1, artifact2, artifact3]
 

--- a/tests/experimental/cli/test_artifact.py
+++ b/tests/experimental/cli/test_artifact.py
@@ -19,6 +19,22 @@ def auto_enable_artifacts(enable_artifacts):
 @pytest.fixture
 async def artifact(session):
     artifact_schema = schemas.core.Artifact(
+        key="voltaic", data={"a": 1}, type="table", description="opens many doors"
+    )
+    model = (
+        await models.artifacts.create_artifact(
+            session=session, artifact=artifact_schema
+        ),
+    )
+
+    await session.commit()
+
+    return model[0]
+
+
+@pytest.fixture
+async def artifact_null_field(session):
+    artifact_schema = schemas.core.Artifact(
         key="voltaic", data=1, metadata_={"description": "opens many doors"}
     )
     model = (
@@ -34,24 +50,23 @@ async def artifact(session):
 
 @pytest.fixture
 async def artifacts(session):
-    artifact1_schema = schemas.core.Artifact(
-        key="voltaic", data=1, description="opens many doors", type="table"
-    )
-    artifact2_schema = schemas.core.Artifact(
-        key="voltaic", data=2, description="opens many doors", type="table"
-    )
-    artifact3_schema = schemas.core.Artifact(
-        key="lotus", data=3, description="opens many doors", type="markdown"
-    )
-
     model1 = await models.artifacts.create_artifact(
-        session=session, artifact=artifact1_schema
+        session=session,
+        artifact=schemas.core.Artifact(
+            key="voltaic", data=1, description="opens many doors", type="table"
+        ),
     )
     model2 = await models.artifacts.create_artifact(
-        session=session, artifact=artifact2_schema
+        session=session,
+        artifact=schemas.core.Artifact(
+            key="voltaic", data=2, description="opens many doors", type="table"
+        ),
     )
     model3 = await models.artifacts.create_artifact(
-        session=session, artifact=artifact3_schema
+        session=session,
+        artifact=schemas.core.Artifact(
+            key="lotus", data=3, description="opens many doors", type="markdown"
+        ),
     )
 
     await session.commit()
@@ -75,10 +90,26 @@ def test_listing_artifacts_after_creating_artifacts(artifact):
     invoke_and_assert(
         ["artifact", "ls"],
         expected_output_contains=f"""
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+            ┃                                   ID ┃ Key     ┃ Type  ┃ Updated           ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+            │ {artifact.id} │ {artifact.key} │ {artifact.type} │ {pendulum.instance(artifact.updated).diff_for_humans()} │
+            └──────────────────────────────────────┴─────────┴───────┴───────────────────┘
+            """,
+    )
+
+
+def test_listing_artifacts_after_creating_artifacts_with_null_fields(
+    artifact_null_field,
+):
+    artifact = artifact_null_field
+    invoke_and_assert(
+        ["artifact", "ls"],
+        expected_output_contains=f"""
             ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
             ┃                                   ID ┃ Key     ┃ Type ┃ Updated           ┃
             ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
-            │ {artifact.id} │ {artifact.key} │ {artifact.type} │ {pendulum.instance(artifact.updated).diff_for_humans()} │
+            │ {artifact.id} │ {artifact.key} │      │ {pendulum.instance(artifact.updated).diff_for_humans()} │
             └──────────────────────────────────────┴─────────┴──────┴───────────────────┘
             """,
     )
@@ -93,5 +124,6 @@ def test_listing_artifacts_lists_only_latest_versions(artifacts):
     invoke_and_assert(
         ["artifact", "ls"],
         expected_output_contains=expected_output,
+        expected_output_does_not_contain=f"{artifacts[0].id}",
         expected_code=0,
     )

--- a/tests/experimental/cli/test_artifact.py
+++ b/tests/experimental/cli/test_artifact.py
@@ -1,0 +1,61 @@
+import pendulum
+import pytest
+
+from prefect.server import models, schemas
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS
+from prefect.testing.cli import invoke_and_assert
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_artifacts(enable_artifacts):
+    """
+    Enable workers for testing
+    """
+    assert PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS
+    # Import to register worker CLI
+    import prefect.experimental.cli.artifact  # noqa
+
+
+@pytest.fixture
+async def artifact(session):
+    artifact_schema = schemas.core.Artifact(
+        key="voltaic", data=1, metadata_={"description": "opens many doors"}
+    )
+    model = (
+        await models.artifacts.create_artifact(
+            session=session, artifact=artifact_schema
+        ),
+    )
+
+    await session.commit()
+
+    read_artifact = await models.artifacts.read_artifact(
+        session=session, artifact_id=model[0].id
+    )
+
+    return read_artifact
+
+
+def test_listing_artifacts_when_none_exist():
+    invoke_and_assert(
+        ["artifact", "ls"],
+        expected_output_contains=f"""
+            ┏━━━━┳━━━━━┳━━━━━━┳━━━━━━━━━┓
+            ┃ ID ┃ Key ┃ Type ┃ Updated ┃
+            ┡━━━━╇━━━━━╇━━━━━━╇━━━━━━━━━┩
+            └────┴─────┴──────┴─────────┘
+        """,
+    )
+
+
+def test_listing_artifacts_after_creating_artifacts(artifact):
+    invoke_and_assert(
+        ["artifact", "ls"],
+        expected_output_contains=f"""
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+            ┃                                   ID ┃ Key     ┃ Type ┃ Updated           ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+            │ {artifact.id} │ {artifact.key} │ {artifact.type} │ {pendulum.instance(artifact.updated).diff_for_humans()} │
+            └──────────────────────────────────────┴─────────┴──────┴───────────────────┘
+            """,
+    )

--- a/tests/experimental/cli/test_artifact.py
+++ b/tests/experimental/cli/test_artifact.py
@@ -29,11 +29,7 @@ async def artifact(session):
 
     await session.commit()
 
-    read_artifact = await models.artifacts.read_artifact(
-        session=session, artifact_id=model[0].id
-    )
-
-    return read_artifact
+    return model[0]
 
 
 def test_listing_artifacts_when_none_exist():

--- a/tests/experimental/cli/test_artifact.py
+++ b/tests/experimental/cli/test_artifact.py
@@ -9,10 +9,10 @@ from prefect.testing.cli import invoke_and_assert
 @pytest.fixture(autouse=True)
 def auto_enable_artifacts(enable_artifacts):
     """
-    Enable workers for testing
+    Enable artifacts for testing
     """
     assert PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS
-    # Import to register worker CLI
+    # Import to register artifact CLI
     import prefect.experimental.cli.artifact  # noqa
 
 


### PR DESCRIPTION
### Overview

Adds initial artifact CLI with command `ls`.

### Example

Create an artifact:
```python
from prefect import flow
from prefect.experimental.artifacts import create_markdown_artifact

@flow
def my_flow():
    create_markdown_artifact(
        key="my-first-artifact",
        markdown="## my markdown",
        description="This is my most important artifact",
    )

if __name__ == "__main__":
    my_flow()
```

Then run:
```bash
prefect config set PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS=True
prefect artifact ls
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
