### PR TITLE
docs: adding .yaml template for efficient creation of docs Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
@@ -1,0 +1,46 @@
+name: 📝 Suggest edits or changes to docs
+description: Propose edits or enhancements to Prefect documentation
+labels: ["docs enhancement", "copy edit"]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: First check
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a descriptive title to this issue.
+          required: true
+        - label: I used GitHub search to find a similar request and didn't find it 😇
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Paste the relevant docs section URL here
+      description: If the issue applies to more than one section, please choose a representative example and paste that URL
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the current state
+      description: A clear, concise description of the current docs behavior
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
+      label: Describe the proposed state
+      description: A clear, concise description of what new content or behavior you would like to see
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Provide additional context or relevant examples related to this issue
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "**Happy engineering!**"

--- a/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
@@ -15,14 +15,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Paste the relevant docs section URL here
-      description: If the issue applies to more than one section, please choose a representative example and paste that URL
-    validations:
-      required: true
-
-  - type: textarea
-    attributes:
-      label: Describe the current state
+      label: Paste the relevant docs section URL here and describe the issue
       description: A clear, concise description of the current docs behavior
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
@@ -1,6 +1,6 @@
 name: 📝 Suggest edits or changes to docs
 description: Propose edits or enhancements to Prefect documentation
-labels: ["docs enhancement", "copy edit"]
+labels: ["docs", "status:triage"]
 body:
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/5_docs_ticket.yaml
@@ -22,15 +22,15 @@ body:
       
   - type: textarea
     attributes:
-      label: Describe the proposed state
-      description: A clear, concise description of what new content or behavior you would like to see
+      label: Describe the proposed change
+      description: A clear, concise description of the proposed docs change
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Additional context
-      description: Provide additional context or relevant examples related to this issue
+      description: Provide additional context or relevant examples for this issue
     validations:
       required: false
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Inspired by Ryan P to create a new Issues template specific to docs edits/changes.

### Example
following same .yaml template for the existing 4 templates...
e.g.
- type: textarea
    attributes:
      label: Paste the relevant docs section URL here
      description: If the issue applies to more than one section, please choose a representative example and paste that URL
    validations:
      required: true

 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
