### PR TITLE
local and remote filesystems return path on write

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -223,6 +223,8 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         async with await anyio.open_file(path, mode="wb") as f:
             await f.write(content)
+        # Leave path stringify to the OS
+        return str(path)
 
 
 class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
@@ -393,6 +395,7 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
 
         with self.filesystem.open(path, "wb") as file:
             await run_sync_in_worker_thread(file.write, content)
+        return path
 
     @property
     def filesystem(self) -> fsspec.AbstractFileSystem:

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -46,17 +46,22 @@ def setup_test_directory(tmp_src: str, sub_dir: str = "puppy") -> Tuple[str, str
 class TestLocalFileSystem:
     async def test_read_write_roundtrip(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
-        await fs.write_path("test.txt", content=b"hello")
+        path = await fs.write_path("test.txt", content=b"hello")
+        assert path.endswith("test.txt")
         assert await fs.read_path("test.txt") == b"hello"
 
     def test_read_write_roundtrip_sync(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
-        fs.write_path("test.txt", content=b"hello")
+        path: str = fs.write_path("test.txt", content=b"hello")
+        assert path.endswith("test.txt")
         assert fs.read_path("test.txt") == b"hello"
 
     async def test_write_with_missing_directory_creates(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
-        await fs.write_path(Path("folder") / "test.txt", content=b"hello")
+        dst = Path("folder") / "test.txt"
+        path = await fs.write_path(dst, content=b"hello")
+        # as_posix because of windows delimiter
+        assert Path(path).as_posix().endswith("folder/test.txt")
         assert (tmp_path / "folder").exists()
         assert (tmp_path / "folder" / "test.txt").read_text() == "hello"
 
@@ -220,12 +225,14 @@ class TestRemoteFileSystem:
 
     async def test_read_write_roundtrip(self):
         fs = RemoteFileSystem(basepath="memory://root")
-        await fs.write_path("test.txt", content=b"hello")
+        path = await fs.write_path("test.txt", content=b"hello")
+        assert path.endswith("test.txt")
         assert await fs.read_path("test.txt") == b"hello"
 
     def test_read_write_roundtrip_sync(self):
         fs = RemoteFileSystem(basepath="memory://root")
-        fs.write_path("test.txt", content=b"hello")
+        path: str = fs.write_path("test.txt", content=b"hello")
+        assert path.endswith("test.txt")
         assert fs.read_path("test.txt") == b"hello"
 
     async def test_write_with_missing_directory_succeeds(self):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

`LocalFileSystem.write_path` and `RemoteFileSystem.write_path` return the path written to as a string.

closes https://github.com/PrefectHQ/prefect/issues/8964

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```py
from prefect.filesystems import LocalFileSystem

dst = LocalFileSystem.write_path("./test.txt", b"data")
print(f"Wrote some data to '{dst}'")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ x ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
