### PR TITLE
Enable stale pull requests and increase ops/hr

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,4 @@ jobs:
           days-before-close: 14
           exempt-issue-labels: "status:in-progress,status:roadmap,status:accepted"
           ascending: true # https://github.com/actions/stale#ascending
-          operations-per-run: 30
+          operations-per-run: 500

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: "Close stale issues and PRs"
 on:
   schedule:
-    - cron: "30 * * * *"
+    - cron: "60 * * * *"
 
 jobs:
   stale:
@@ -13,7 +13,10 @@ jobs:
           stale-issue-label: "status:stale"
           close-issue-message: "This issue was closed because it has been stale for 14 days with no activity. If this issue is important or you have more to add feel free to re-open it."
           days-before-stale: 30
-          days-before-pr-stale: -1 # Disable stale-ing PRs
+          stale-pr-message: "This pull request is stale because it has been open 60 days with no activity. To keep this pull request open remove stale label or comment."
+          stale-pr-label: "status:stale"
+          close-pr-message: "This pull request was closed because it has been stale for 14 days with no activity. If this pull request is important or you have more to add feel free to re-open it."
+          days-before-pr-stale: 60
           days-before-close: 14
           exempt-issue-labels: "status:in-progress,status:roadmap,status:accepted"
           ascending: true # https://github.com/actions/stale#ascending


### PR DESCRIPTION
- Enable stale pull requests after 60 days
- Bump stale bot operations to 500/hr; previously this was 60/hr to avoid reaching our GitHub API request limit but that actually appears to be 15,000/hr so we should be safe with this and I want to work through the backlog