### PR TITLE
Add 30s timeout to shutdown of the log worker thread

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -233,7 +233,10 @@ class APILogWorker:
             if self._started:
                 self._flush_event.set()
                 self._stop_event.set()
-                self._send_thread.join()
+                # TODO: Sometimes the log worker will deadlock and never join during
+                #       an at-exit hook so we will only block for 30 seconds here.
+                #       When logging is refactored, this deadlock should be resolved.
+                self._send_thread.join(30.0)
                 self._started = False
                 self._stopped = True
 


### PR DESCRIPTION
A blunt fix to issues where the worker thread hangs during interpreter shutdown — we will address this in the long run by moving this worker onto the global loop thread.

This flow hangs on exit:

```
import time
from prefect import task, flow, get_run_logger

import faulthandler


@task
def my_task(i):
    logger = get_run_logger()
    logger.info(f"Task start {i}")
    time.sleep(0.5)


@flow
def my_flow():
    for i in range(1000):
        my_task.submit(i)


faulthandler.dump_traceback_later(60)
my_flow()
```

Here's the faulthandler traceback
```
Thread 0x0000000172d8f000 (most recent call first):
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/selectors.py", line 561 in select
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/asyncio/base_events.py", line 1884 in _run_once
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/asyncio/base_events.py", line 607 in run_forever
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/asyncio/base_events.py", line 640 in run_until_complete
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/asyncio/runners.py", line 118 in run
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/asyncio/runners.py", line 190 in run
  File "/Users/mz/.pyenv/versions/prefect-311/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 292 in run
  File "/Users/mz/.pyenv/versions/prefect-311/lib/python3.11/site-packages/anyio/_core/_eventloop.py", line 70 in run
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 92 in _send_logs_loop
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 975 in run
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 1038 in _bootstrap_inner
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 995 in _bootstrap

Thread 0x00000001e6a28140 (most recent call first):
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 1132 in _wait_for_tstate_lock
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 1116 in join
  File "/Users/mz/dev/prefect/src/prefect/logging/handlers.py", line 239 in stop
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/threading.py", line 1553 in _shutdown

```