### PR TITLE
Adding clarity to Filesystem package dependencies

### DIFF
--- a/docs/concepts/filesystems.md
+++ b/docs/concepts/filesystems.md
@@ -308,7 +308,7 @@ A Prefect installation and doesn't include filesystem-specific package dependenc
 
 You must ensure that filesystem-specific libraries are installed in an execution environment where they will be used by flow runs.
 
-In Dockerized deployments that utilize the Prefect base image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
+In Dockerized deployments using the Prefect base image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
 
 In Dockerized deployments that utilize a custom image, you must include the filesystem-specific package dependency in your image.
 

--- a/docs/concepts/filesystems.md
+++ b/docs/concepts/filesystems.md
@@ -308,7 +308,9 @@ A Prefect installation and doesn't include filesystem-specific package dependenc
 
 You must ensure that filesystem-specific libraries are installed in an execution environment where they will be used by flow runs.
 
-In Dockerized deployments, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
+In Dockerized deployments that utilize the Prefect base image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
+
+In Dockerized deployments that utilize a custom image, you must include the filesystem-specific package dependency in your image.
 
 Here is an example from a deployment YAML file showing how to specify the installation of `s3fs` from into your image:
 

--- a/docs/concepts/filesystems.md
+++ b/docs/concepts/filesystems.md
@@ -310,7 +310,7 @@ You must ensure that filesystem-specific libraries are installed in an execution
 
 In Dockerized deployments using the Prefect base image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
 
-In Dockerized deployments that utilize a custom image, you must include the filesystem-specific package dependency in your image.
+In Dockerized deployments using a custom image, you must include the filesystem-specific package dependency in your image.
 
 Here is an example from a deployment YAML file showing how to specify the installation of `s3fs` from into your image:
 


### PR DESCRIPTION
This PR updates the filesystem docs to clarify when EXTRA_PIP_PACKAGES works and when it does not.
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
