### PR TITLE
Add `--type` option to create work-pool CLI

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -400,6 +400,7 @@ async def get_default_base_job_template_for_type(type: str) -> Optional[Dict[str
                         return worker.get("default_base_job_configuration")
         except Exception:
             return None
+    return None
 
 
 async def get_available_work_pool_types() -> Set[str]:

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -1,14 +1,58 @@
+import httpx
 import pytest
 
 from prefect.exceptions import ObjectNotFound
+from prefect.experimental.workers.process import ProcessWorker
 from prefect.server.schemas.actions import WorkPoolUpdate
 from prefect.server.schemas.core import WorkPool
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
+FAKE_DEFAULT_BASE_JOB_TEMPLATE = {
+    "job_configuration": {
+        "fake": "{{ fake_var }}",
+    },
+    "variables": {
+        "type": "object",
+        "properties": {
+            "fake_var": {
+                "type": "string",
+                "default": "fake",
+            }
+        },
+    },
+}
+
 
 class TestCreate:
-    async def test_create_work_pool(self, orion_client):
+    @pytest.fixture(autouse=True)
+    async def mock_collection_registry(self, respx_mock):
+        respx_mock.get(
+            "https://raw.githubusercontent.com/PrefectHQ/"
+            "prefect-collection-registry/main/views/aggregate-worker-metadata.json"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "prefect": {
+                        "prefect-agent": {
+                            "type": "prefect-agent",
+                            "default_base_job_configuration": {},
+                        }
+                    },
+                    "prefect-fake": {
+                        "fake": {
+                            "type": "fake",
+                            "default_base_job_configuration": (
+                                FAKE_DEFAULT_BASE_JOB_TEMPLATE
+                            ),
+                        }
+                    },
+                },
+            )
+        )
+
+    async def test_create_work_pool(self, orion_client, mock_collection_registry):
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -18,6 +62,7 @@ class TestCreate:
         assert f"Created work pool {pool_name!r}" in res.output
         client_res = await orion_client.read_work_pool(pool_name)
         assert client_res.name == pool_name
+        assert client_res.base_job_template == {}
         assert isinstance(client_res, WorkPool)
 
     async def test_default_template(self, orion_client):
@@ -49,6 +94,50 @@ class TestCreate:
         assert res.exit_code == 0
         client_res = await orion_client.read_work_pool(pool_name)
         assert client_res.is_paused is True
+
+    async def test_create_work_pool_from_registry(self, orion_client):
+        pool_name = "fake-work"
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} --type fake",
+        )
+        assert res.exit_code == 0
+        assert f"Created work pool {pool_name!r}" in res.output
+        client_res = await orion_client.read_work_pool(pool_name)
+        assert client_res.name == pool_name
+        assert client_res.base_job_template == FAKE_DEFAULT_BASE_JOB_TEMPLATE
+        assert client_res.type == "fake"
+        assert isinstance(client_res, WorkPool)
+
+    async def test_create_process_work_pool(self, orion_client):
+        pool_name = "process-work"
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} --type process",
+        )
+        assert res.exit_code == 0
+        assert f"Created work pool {pool_name!r}" in res.output
+        client_res = await orion_client.read_work_pool(pool_name)
+        assert client_res.name == pool_name
+        assert (
+            client_res.base_job_template
+            == ProcessWorker.get_default_base_job_template()
+        )
+        assert client_res.type == "process"
+        assert isinstance(client_res, WorkPool)
+
+    def test_create_with_unsupported_type(self):
+        invoke_and_assert(
+            ["work-pool", "create", "my-pool", "--type", "unsupported"],
+            expected_code=1,
+            expected_output_contains=[
+                "Unknown work pool type 'unsupported'.",
+                "Please choose from",
+                "process",
+                "prefect-agent",
+                "fake",
+            ],
+        )
 
 
 class TestInspect:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the ability to specify a type when creating a work pool via the CLI. A work pool also needs a base job template in order to allow the configuration of flow runs, so we attempt to find a default base job template based on the type provided by the user.

To determine the base job template for the new work pool, first we look for the corresponding worker type in the client-side type registry. If the worker type is not found, then we look in the collection registry worker metadata for the work type. If the worker type still isn't found, then the command exits with an error and we print the available types for the user.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Create a Kubernetes work pool:
```bash
> prefect work-pool create --type kubernetes olympic
Created work pool 'olympic'.
```

Create a work pool with an unknown type:
```bash
> prefect work-pool create --type rancher in-ground
Unknown work pool type 'rancher'. Please choose from kubernetes, prefect-agent, process.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
