### PR TITLE
Fix `EXTRA_PIP_PACKAGES` info in Docker guide

### DIFF
--- a/docs/concepts/filesystems.md
+++ b/docs/concepts/filesystems.md
@@ -308,7 +308,7 @@ A Prefect installation and doesn't include filesystem-specific package dependenc
 
 You must ensure that filesystem-specific libraries are installed in an execution environment where they will be used by flow runs.
 
-In Dockerized deployments, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
+In Dockerized deployments using a `prefecthq/prefect` image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
 
 Here is an example from a deployment YAML file showing how to specify the installation of `s3fs` from into your image:
 

--- a/docs/concepts/filesystems.md
+++ b/docs/concepts/filesystems.md
@@ -308,7 +308,7 @@ A Prefect installation and doesn't include filesystem-specific package dependenc
 
 You must ensure that filesystem-specific libraries are installed in an execution environment where they will be used by flow runs.
 
-In Dockerized deployments using a `prefecthq/prefect` image, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
+In Dockerized deployments, you can leverage the `EXTRA_PIP_PACKAGES` environment variable. Those dependencies will be installed at runtime within your Docker container or Kubernetes Job before the flow starts running. 
 
 Here is an example from a deployment YAML file showing how to specify the installation of `s3fs` from into your image:
 

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -58,7 +58,7 @@ Second, we need to make sure the container includes any additional files, librar
 
 In the [Storage and Infrastructure](/tutorials/storage/) tutorial, recall that we needed to `pip install s3fs` the library for an S3 storage block. You'll need to include the same command in the configuration of the Docker Container infrastructure block. When the agent spins up a container for a flow run, it will know to install the `s3fs` package before starting the flow run.
 
-As a convenience, we can use the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
+As a convenience, Prefect base images check the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
 
 In the **Env (Optional)** box, enter the following to specify that the `s3fs` package should be installed. Note that we use JSON formatting to specify the environment variable (key) and packages to install (value).
 

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -58,7 +58,7 @@ Second, we need to make sure the container includes any additional files, librar
 
 In the [Storage and Infrastructure](/tutorials/storage/) tutorial, recall that we needed to `pip install s3fs` the library for an S3 storage block. You'll need to include the same command in the configuration of the Docker Container infrastructure block. When the agent spins up a container for a flow run, it will know to install the `s3fs` package before starting the flow run.
 
-As a convenience, `prefecthq/prefect` images check the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
+As a convenience, we can use the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
 
 In the **Env (Optional)** box, enter the following to specify that the `s3fs` package should be installed. Note that we use JSON formatting to specify the environment variable (key) and packages to install (value).
 

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -58,7 +58,7 @@ Second, we need to make sure the container includes any additional files, librar
 
 In the [Storage and Infrastructure](/tutorials/storage/) tutorial, recall that we needed to `pip install s3fs` the library for an S3 storage block. You'll need to include the same command in the configuration of the Docker Container infrastructure block. When the agent spins up a container for a flow run, it will know to install the `s3fs` package before starting the flow run.
 
-As a convenience, we can use the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
+As a convenience, `prefecthq/prefect` images check the [`EXTRA_PIP_PACKAGES` environment variable](/concepts/infrastructure/#installing-extra-dependencies-at-runtime) to install dependencies at runtime. If defined, `pip install ${EXTRA_PIP_PACKAGES}` is executed before the flow run starts.
 
 In the **Env (Optional)** box, enter the following to specify that the `s3fs` package should be installed. Note that we use JSON formatting to specify the environment variable (key) and packages to install (value).
 


### PR DESCRIPTION
We sometimes get user reports of `EXTRA_PIP_PACKAGES` not working in custom Docker images. This happens because Prefect images use a custom entrypoint script that checks for this environment variable. Since this does not happen in custom images, `EXTRA_PIP_PACKAGES` does not work there. See #8988 for an example.

This PR updates the Docker guide in the docs to clarify that EXTRA_PIP_PACKAGES applies to Prefect base images. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
