### PR TITLE
Add internal `QueueService` abstract class

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -67,7 +67,7 @@ class QueueService(abc.ABC, Generic[T]):
 
     def send(self, item: T):
         """
-        Send an item to the instance of the service.
+        Send an item to this instance of the service.
         """
         if self._stopped:
             raise RuntimeError("Cannot put items in a stopped service.")
@@ -94,7 +94,7 @@ class QueueService(abc.ABC, Generic[T]):
         Process an item sent to the service.
         """
 
-    def drain_one(self) -> Union[Awaitable, None]:
+    def drain(self) -> Union[Awaitable, None]:
         """
         Stop this instance of the service and wait for remaining work to be completed.
 
@@ -119,7 +119,7 @@ class QueueService(abc.ABC, Generic[T]):
         instances = tuple(cls._instances.values())
 
         for instance in instances:
-            futures.append(instance.drain_one())
+            futures.append(instance.drain())
 
         if get_running_loop() is not None:
             return asyncio.gather(*futures)

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -1,0 +1,183 @@
+import abc
+import asyncio
+import atexit
+import concurrent.futures
+import contextlib
+import threading
+from collections import deque
+from typing import Generic, Optional, Set, Type, TypeVar
+
+from typing_extensions import Self
+
+from prefect._internal.concurrency.api import create_call, from_sync
+from prefect._internal.concurrency.calls import Call
+from prefect._internal.concurrency.event_loop import call_soon_in_loop, get_running_loop
+from prefect._internal.concurrency.threads import get_global_loop
+
+T = TypeVar("T")
+
+
+class QueueService(abc.ABC, Generic[T]):
+    _instance: Optional[Self] = None
+    _instances: Set[Self] = set()
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._queue: Optional[asyncio.Queue] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._done_event: Optional[asyncio.Event] = None
+        self._task: Optional[asyncio.Task] = None
+        self._early_items = deque()
+        self._lock = threading.Lock()
+        self._stopped: bool = False
+        self._started: bool = False
+
+    def start(self):
+        self._queue = asyncio.Queue()
+        self._loop = asyncio.get_running_loop()
+        self._done_event = asyncio.Event()
+        self._task = self._loop.create_task(self._run())
+        self._started = True
+        self._start_call: Optional[Call] = None
+
+        # Put all early submissions in the queue
+        while self._early_items:
+            self.send(self._early_items.pop())
+
+        # Stop at interpreter exit by default
+        atexit.register(self.drain)
+
+    def _stop(self):
+        """
+        Stop running this instance.
+
+        Does not wait for the instance to finish. See `drain`.
+        """
+        # Stop sending work to this instance
+        self._clear_instance(self)
+
+        if not self._started:
+            # Wait for start to finish before stopping
+            self._start_call.result()
+
+        self._stopped = True
+        call_soon_in_loop(self._loop, self._queue.put_nowait, None)
+
+    def _send(self, item: T):
+        """
+        Send an item to the instance.
+        """
+        if self._stopped:
+            raise RuntimeError("Cannot put items in a stopped service.")
+
+        if not self._started:
+            self._early_items.append(item)
+        else:
+            call_soon_in_loop(self._loop, self._queue.put_nowait, item)
+
+    async def _run(self):
+        while True:
+            item: T = await self._queue.get()
+
+            if item is None:
+                break
+
+            await self._handle(item)
+
+        self._done_event.set()
+
+    @abc.abstractmethod
+    async def _handle(self, item: T):
+        """
+        Process an item sent to the service.
+        """
+
+    @classmethod
+    def send(cls, item: T) -> None:
+        """
+        Send an item to an instance of the service.
+        """
+        cls.get_instance()._send(item)
+
+    @classmethod
+    def drain(cls, wait: bool = True):
+        """
+        Stop all instances of the service and wait for all remaining work to be
+        completed.
+
+        This method is not safe to call from an asynchronous context unless `wait` is
+        set to `False`.
+        """
+        if wait and get_running_loop() is not None:
+            raise RuntimeError(
+                "Queue services cannot be drained from an async context without "
+                "`wait=False`."
+            )
+
+        futures = []
+
+        with cls._instance_lock:
+            instances = tuple(cls._instances)
+
+        for instance in instances:
+            if not instance._stopped:
+                instance._stop()
+
+            futures.append(
+                asyncio.run_coroutine_threadsafe(
+                    instance._done_event.wait(), instance._loop
+                )
+            )
+
+            cls._instances.discard(instance)
+
+        if wait:
+            concurrent.futures.wait(futures)
+
+        return futures
+
+    @classmethod
+    def get_instance(cls: Type[Self]) -> Self:
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls._new_instance()
+
+            return cls._instance
+
+    @classmethod
+    def _clear_instance(cls, instance: Optional[Self] = None):
+        with cls._instance_lock:
+            if instance is None or instance == cls._instance:
+                cls._instance = None
+
+    @classmethod
+    def _new_instance(cls):
+        """
+        Create and start a new instance of the service.
+        """
+        instance = cls()
+
+        # If already on the global loop, just start it here to avoid deadlock
+        if threading.get_ident() == get_global_loop().thread.ident:
+            instance.start()
+
+        # Otherwise, bind the service to the global loop
+        else:
+            from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
+
+        cls._instances.add(instance)
+
+        return instance
+
+
+@contextlib.contextmanager
+def drain_on_exit(service: QueueService):
+    yield
+    service.drain()
+
+
+@contextlib.asynccontextmanager
+async def drain_on_exit_async(service: QueueService):
+    yield
+    futures = [asyncio.wrap_future(fut) for fut in service.drain(wait=False)]
+    await asyncio.gather(*futures)

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -1,11 +1,10 @@
 import abc
 import asyncio
 import atexit
-import concurrent.futures
 import contextlib
 import threading
 from collections import deque
-from typing import Generic, Optional, Set, Type, TypeVar
+from typing import Awaitable, Dict, Generic, Optional, Type, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -18,11 +17,10 @@ T = TypeVar("T")
 
 
 class QueueService(abc.ABC, Generic[T]):
-    _instance: Optional[Self] = None
-    _instances: Set[Self] = set()
+    _instances: Dict[int, Self] = {}
     _instance_lock = threading.Lock()
 
-    def __init__(self) -> None:
+    def __init__(self, *args) -> None:
         self._queue: Optional[asyncio.Queue] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._done_event: Optional[asyncio.Event] = None
@@ -31,6 +29,7 @@ class QueueService(abc.ABC, Generic[T]):
         self._lock = threading.Lock()
         self._stopped: bool = False
         self._started: bool = False
+        self._key = hash(args)
 
     def start(self):
         self._queue = asyncio.Queue()
@@ -45,7 +44,7 @@ class QueueService(abc.ABC, Generic[T]):
             self.send(self._early_items.pop())
 
         # Stop at interpreter exit by default
-        atexit.register(self.drain)
+        atexit.register(self.drain_all)
 
     def _stop(self):
         """
@@ -53,8 +52,11 @@ class QueueService(abc.ABC, Generic[T]):
 
         Does not wait for the instance to finish. See `drain`.
         """
+        if self._stopped:
+            return
+
         # Stop sending work to this instance
-        self._clear_instance(self)
+        self._remove_instance()
 
         if not self._started:
             # Wait for start to finish before stopping
@@ -63,9 +65,9 @@ class QueueService(abc.ABC, Generic[T]):
         self._stopped = True
         call_soon_in_loop(self._loop, self._queue.put_nowait, None)
 
-    def _send(self, item: T):
+    def send(self, item: T):
         """
-        Send an item to the instance.
+        Send an item to the instance of the service.
         """
         if self._stopped:
             raise RuntimeError("Cannot put items in a stopped service.")
@@ -92,70 +94,58 @@ class QueueService(abc.ABC, Generic[T]):
         Process an item sent to the service.
         """
 
-    @classmethod
-    def send(cls, item: T) -> None:
+    def drain_one(self) -> Union[Awaitable, None]:
         """
-        Send an item to an instance of the service.
+        Stop this instance of the service and wait for remaining work to be completed.
+
+        Returns an awaitable if called from an async context.
         """
-        cls.get_instance()._send(item)
+        self._stop()
+        future = asyncio.run_coroutine_threadsafe(self._done_event.wait(), self._loop)
+        if get_running_loop() is not None:
+            return asyncio.wrap_future(future)
+        else:
+            return future.result()
 
     @classmethod
-    def drain(cls, wait: bool = True):
+    def drain_all(cls) -> Union[Awaitable, None]:
         """
         Stop all instances of the service and wait for all remaining work to be
         completed.
 
-        This method is not safe to call from an asynchronous context unless `wait` is
-        set to `False`.
+        Returns an awaitable if called from an async context.
         """
-        if wait and get_running_loop() is not None:
-            raise RuntimeError(
-                "Queue services cannot be drained from an async context without "
-                "`wait=False`."
-            )
-
         futures = []
-
-        with cls._instance_lock:
-            instances = tuple(cls._instances)
+        instances = tuple(cls._instances.values())
 
         for instance in instances:
-            if not instance._stopped:
-                instance._stop()
+            futures.append(instance.drain_one())
 
-            futures.append(
-                asyncio.run_coroutine_threadsafe(
-                    instance._done_event.wait(), instance._loop
-                )
-            )
-
-            cls._instances.discard(instance)
-
-        if wait:
-            concurrent.futures.wait(futures)
-
-        return futures
+        if get_running_loop() is not None:
+            return asyncio.gather(*futures)
 
     @classmethod
-    def get_instance(cls: Type[Self]) -> Self:
-        with cls._instance_lock:
-            if cls._instance is None:
-                cls._instance = cls._new_instance()
+    def instance(cls: Type[Self], *args) -> Self:
+        """
+        Get an instance of the service.
 
-            return cls._instance
+        If an instance already exists with the given arguments, it will be returned.
+        """
+        key = hash(args)
+        if key not in cls._instances:
+            cls._instances[key] = cls._new_instance(*args)
+
+        return cls._instances[key]
+
+    def _remove_instance(self):
+        self._instances.pop(self._key, None)
 
     @classmethod
-    def _clear_instance(cls, instance: Optional[Self] = None):
-        with cls._instance_lock:
-            if instance is None or instance == cls._instance:
-                cls._instance = None
-
-    @classmethod
-    def _new_instance(cls):
+    def _new_instance(cls, *args):
         """
         Create and start a new instance of the service.
         """
-        instance = cls()
+        instance = cls(*args)
 
         # If already on the global loop, just start it here to avoid deadlock
         if threading.get_ident() == get_global_loop().thread.ident:
@@ -165,19 +155,16 @@ class QueueService(abc.ABC, Generic[T]):
         else:
             from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
 
-        cls._instances.add(instance)
-
         return instance
 
 
 @contextlib.contextmanager
 def drain_on_exit(service: QueueService):
     yield
-    service.drain()
+    service.drain_all()
 
 
 @contextlib.asynccontextmanager
 async def drain_on_exit_async(service: QueueService):
     yield
-    futures = [asyncio.wrap_future(fut) for fut in service.drain(wait=False)]
-    await asyncio.gather(*futures)
+    await service.drain_all()

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -64,7 +64,7 @@ class QueueService(abc.ABC, Generic[T]):
             self._start_call.result()
 
         self._stopped = True
-        call_soon_in_loop(self._loop, self._queue.put_nowait, None).result()
+        call_soon_in_loop(self._loop, self._queue.put_nowait, None)
 
     def send(self, item: T):
         """

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
@@ -14,8 +15,11 @@ from prefect._internal.concurrency.services import (
 class MockService(QueueService[int]):
     mock = MagicMock()
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, index: Optional[int] = None) -> None:
+        if index is not None:
+            super().__init__(index)
+        else:
+            super().__init__()
 
     async def _handle(self, item: int):
         self.mock(self, item)
@@ -27,48 +31,53 @@ def reset_mock_service():
 
 
 def test_get_instance_returns_instance():
-    instance = MockService.get_instance()
+    instance = MockService.instance()
     assert isinstance(instance, MockService)
 
 
 def test_get_instance_returns_same_instance():
-    instance = MockService.get_instance()
-    assert MockService.get_instance() is instance
+    instance = MockService.instance()
+    assert MockService.instance() is instance
 
 
 def test_get_instance_returns_new_instance_after_stopping():
-    instance = MockService.get_instance()
+    instance = MockService.instance()
     instance._stop()
-    new_instance = MockService.get_instance()
+    new_instance = MockService.instance()
+    assert new_instance is not instance
+    assert isinstance(new_instance, MockService)
+
+
+def test_get_instance_returns_new_instance_with_unique_key():
+    instance = MockService.instance(1)
+    new_instance = MockService.instance(2)
     assert new_instance is not instance
     assert isinstance(new_instance, MockService)
 
 
 def test_send_one():
-    instance = MockService.get_instance()
-    MockService.send(1)
-    MockService.drain()
+    instance = MockService.instance()
+    instance.send(1)
+    MockService.drain_all()
     MockService.mock.assert_called_once_with(instance, 1)
 
 
 def test_send_many():
-    instance = MockService.get_instance()
+    instance = MockService.instance()
     for i in range(10):
-        MockService.send(i)
-    MockService.drain()
+        instance.send(i)
+    MockService.drain_all()
     MockService.mock.assert_has_calls([call(instance, i) for i in range(10)])
 
 
 def test_send_many_instances():
     instances = []
     for i in range(10):
-        MockService.send(i)
-        instances.append(MockService.get_instance())
+        instance = MockService.instance(i)
+        instance.send(i)
+        instances.append(instance)
 
-        # Clear the current instance so a new one is retrieved per iteration
-        MockService._clear_instance()
-
-    MockService.drain()
+    MockService.drain_all()
     MockService.mock.assert_has_calls(
         [call(instance, i) for instance, i in zip(instances, range(10))]
     )
@@ -77,15 +86,13 @@ def test_send_many_instances():
 def test_drain_safe_to_call_multiple_times():
     instances = []
     for i in range(10):
-        MockService.send(i)
-        instances.append(MockService.get_instance())
+        instance = MockService.instance(i)
+        instance.send(i)
+        instances.append(instance)
 
-        # Clear the current instance so a new one is retrieved per iteration
-        MockService._clear_instance()
-
-    MockService.drain()
-    MockService.drain()
-    MockService.drain()
+    MockService.drain_all()
+    MockService.drain_all()
+    MockService.drain_all()
 
     MockService.mock.assert_has_calls(
         [call(instance, i) for instance, i in zip(instances, range(10))]
@@ -94,28 +101,25 @@ def test_drain_safe_to_call_multiple_times():
 
 def test_send_many_threads():
     def on_thread(i):
-        MockService.send(i)
+        MockService.instance().send(i)
 
     with ThreadPoolExecutor() as executor:
         for i in range(10):
             executor.submit(on_thread, i)
 
-    MockService.drain()
+    MockService.drain_all()
     MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)], any_order=True)
 
 
 def test_send_many_instances_many_threads():
     def on_thread(i):
-        MockService.send(i)
-
-        # Clear the instance so a new one is retrieved ~ per iteration
-        MockService._clear_instance()
+        MockService.instance(i).send(i)
 
     with ThreadPoolExecutor() as executor:
         for i in range(10):
             executor.submit(on_thread, i)
 
-    MockService.drain()
+    MockService.drain_all()
     MockService.mock.assert_has_calls(
         [call(ANY, i) for i in range(10)],
         any_order=True,
@@ -124,8 +128,8 @@ def test_send_many_instances_many_threads():
 
 def test_drain_many_instances_many_threads():
     def on_thread(i):
-        MockService.send(i)
-        MockService.drain()
+        MockService.instance(i).send(i)
+        MockService.drain_all()
 
     with ThreadPoolExecutor() as executor:
         for i in range(10):
@@ -140,14 +144,14 @@ def test_drain_many_instances_many_threads():
 def test_drain_on_exit():
     with drain_on_exit(MockService):
         for i in range(10):
-            MockService.send(i)
+            MockService.instance().send(i)
     MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)])
 
 
 async def test_drain_on_exit_async():
     async with drain_on_exit_async(MockService):
         for i in range(10):
-            MockService.send(i)
+            MockService.instance().send(i)
     MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)])
 
 
@@ -155,7 +159,7 @@ def test_drain_on_exit_async_from_same_loop():
     async def on_global_loop():
         async with drain_on_exit_async(MockService):
             for i in range(10):
-                MockService.send(i)
+                MockService.instance().send(i)
 
     from_sync.call_soon_in_loop_thread(create_call(on_global_loop)).result()
 

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -1,0 +1,162 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import ANY, MagicMock, call
+
+import pytest
+
+from prefect._internal.concurrency.api import create_call, from_sync
+from prefect._internal.concurrency.services import (
+    QueueService,
+    drain_on_exit,
+    drain_on_exit_async,
+)
+
+
+class MockService(QueueService[int]):
+    mock = MagicMock()
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    async def _handle(self, item: int):
+        self.mock(self, item)
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_service():
+    MockService.mock.reset_mock()
+
+
+def test_get_instance_returns_instance():
+    instance = MockService.get_instance()
+    assert isinstance(instance, MockService)
+
+
+def test_get_instance_returns_same_instance():
+    instance = MockService.get_instance()
+    assert MockService.get_instance() is instance
+
+
+def test_get_instance_returns_new_instance_after_stopping():
+    instance = MockService.get_instance()
+    instance._stop()
+    new_instance = MockService.get_instance()
+    assert new_instance is not instance
+    assert isinstance(new_instance, MockService)
+
+
+def test_send_one():
+    instance = MockService.get_instance()
+    MockService.send(1)
+    MockService.drain()
+    MockService.mock.assert_called_once_with(instance, 1)
+
+
+def test_send_many():
+    instance = MockService.get_instance()
+    for i in range(10):
+        MockService.send(i)
+    MockService.drain()
+    MockService.mock.assert_has_calls([call(instance, i) for i in range(10)])
+
+
+def test_send_many_instances():
+    instances = []
+    for i in range(10):
+        MockService.send(i)
+        instances.append(MockService.get_instance())
+
+        # Clear the current instance so a new one is retrieved per iteration
+        MockService._clear_instance()
+
+    MockService.drain()
+    MockService.mock.assert_has_calls(
+        [call(instance, i) for instance, i in zip(instances, range(10))]
+    )
+
+
+def test_drain_safe_to_call_multiple_times():
+    instances = []
+    for i in range(10):
+        MockService.send(i)
+        instances.append(MockService.get_instance())
+
+        # Clear the current instance so a new one is retrieved per iteration
+        MockService._clear_instance()
+
+    MockService.drain()
+    MockService.drain()
+    MockService.drain()
+
+    MockService.mock.assert_has_calls(
+        [call(instance, i) for instance, i in zip(instances, range(10))]
+    )
+
+
+def test_send_many_threads():
+    def on_thread(i):
+        MockService.send(i)
+
+    with ThreadPoolExecutor() as executor:
+        for i in range(10):
+            executor.submit(on_thread, i)
+
+    MockService.drain()
+    MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)], any_order=True)
+
+
+def test_send_many_instances_many_threads():
+    def on_thread(i):
+        MockService.send(i)
+
+        # Clear the instance so a new one is retrieved ~ per iteration
+        MockService._clear_instance()
+
+    with ThreadPoolExecutor() as executor:
+        for i in range(10):
+            executor.submit(on_thread, i)
+
+    MockService.drain()
+    MockService.mock.assert_has_calls(
+        [call(ANY, i) for i in range(10)],
+        any_order=True,
+    )
+
+
+def test_drain_many_instances_many_threads():
+    def on_thread(i):
+        MockService.send(i)
+        MockService.drain()
+
+    with ThreadPoolExecutor() as executor:
+        for i in range(10):
+            executor.submit(on_thread, i)
+
+    MockService.mock.assert_has_calls(
+        [call(ANY, i) for i in range(10)],
+        any_order=True,
+    )
+
+
+def test_drain_on_exit():
+    with drain_on_exit(MockService):
+        for i in range(10):
+            MockService.send(i)
+    MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)])
+
+
+async def test_drain_on_exit_async():
+    async with drain_on_exit_async(MockService):
+        for i in range(10):
+            MockService.send(i)
+    MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)])
+
+
+def test_drain_on_exit_async_from_same_loop():
+    async def on_global_loop():
+        async with drain_on_exit_async(MockService):
+            for i in range(10):
+                MockService.send(i)
+
+    from_sync.call_soon_in_loop_thread(create_call(on_global_loop)).result()
+
+    MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)])


### PR DESCRIPTION
Adds a queue service class that runs on the global event loop. A queue service runs on a loop handling items as they are received. Items can be sent from any thread. The service can be "drained" which will ensure all remaining items are handled.

This will be used for the event and logs workers and we also hope to use this to implement a singleton client instance that runs on the global loop.

```python
from prefect._internal.concurrency.services import QueueService, drain_on_exit


class ExampleService(QueueService[int]):
    async def _handle(self, item: int):
        print(hex(id(self)), item)


with drain_on_exit(ExampleService):
    # These will all be handled by the same instance
    ExampleService.instance().send(1)
    ExampleService.instance().send(2)
    ExampleService.instance().send(3)


# Services are drained on interpreter exit, so 4 will display
# Since the service was already drained, it should be handled by a new instance though

ExampleService.instance().send(4)

```

```
❯ python example.py
0x1004e2610 1
0x1004e2610 2
0x1004e2610 3
0x106516550 4
```