### PR TITLE
Fix bug where iterable defaults were treated as mapped parameters

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1039,6 +1039,11 @@ async def begin_task_map(
         call_parameters = {key: value[i] for key, value in iterable_parameters.items()}
         call_parameters.update({key: value for key, value in static_parameters.items()})
 
+        # Add default values for parameters; these are skipped earlier since they should
+        # not be mapped over
+        for key, value in get_parameter_defaults(task.fn).items():
+            call_parameters.setdefault(key, value)
+
         # Re-apply annotations to each key again
         for key, annotation in annotated_parameters.items():
             call_parameters[key] = annotation.rewrap(call_parameters[key])

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -845,8 +845,9 @@ class Task(Generic[P, R]):
 
         from prefect.engine import enter_task_run_engine
 
-        # Convert the call args/kwargs to a parameter dict
-        parameters = get_call_parameters(self.fn, args, kwargs)
+        # Convert the call args/kwargs to a parameter dict; do not apply defaults
+        # since they should not be mapped over
+        parameters = get_call_parameters(self.fn, args, kwargs, apply_defaults=False)
         return_type = "state" if return_state else "future"
 
         return enter_task_run_engine(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2987,6 +2987,19 @@ class TestTaskMap:
         task_states = my_flow()
         assert [state.result() for state in task_states] == [6, 7, 8]
 
+    def test_with_keyword_with_iterable_default(self):
+        @task
+        def add_some(x, y=[1, 4]):
+            return x + sum(y)
+
+        @flow
+        def my_flow():
+            numbers = [1, 2, 3]
+            return add_some.map(numbers)
+
+        task_states = my_flow()
+        assert [state.result() for state in task_states] == [6, 7, 8]
+
     def test_with_variadic_keywords_and_iterable(self):
         @task
         def add_some(x, **kwargs):


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/9020

Previously we treated iterable defaults as mapped parameters. However, default values should never be mapped over and should always be treated as `unmapped`. 

```python
@task
def add_some(x, y=[1, 4]):
    return x + sum(y)

@flow
def my_flow():
    numbers = [1, 2, 3]
    return add_some.map(numbers)
```

Example previous failure:

```
prefect.exceptions.MappingLengthMismatch: Received iterable parameters with different lengths.
Parameters for map must all be the same length. Got lengths: {'x': 3, 'y': 2}
```



