### PR TITLE
Adds human-friendly way to reference block documents

### DIFF
--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -191,7 +191,13 @@ async def resolve_block_document_references(
         ]
     elif isinstance(template, str):
         placeholders = find_placeholders(template)
-        if (
+        has_block_document_placeholder = any(
+            placeholder.type is PlaceholderType.BLOCK_DOCUMENT
+            for placeholder in placeholders
+        )
+        if len(placeholders) == 0 or not has_block_document_placeholder:
+            return template
+        elif (
             len(placeholders) == 1
             and list(placeholders)[0].full_match == template
             and list(placeholders)[0].type is PlaceholderType.BLOCK_DOCUMENT
@@ -205,12 +211,10 @@ async def resolve_block_document_references(
                 name=block_document_name, block_type_slug=block_type_slug
             )
             return block_document.data
-        elif len(placeholders) > 1 and any(
-            [p.type == PlaceholderType.BLOCK_DOCUMENT for p in placeholders]
-        ):
+        else:
             raise ValueError(
-                f"Invalid template: {template!r}. Block placeholders must "
-                "be the only placeholder in a string."
+                f"Invalid template: {template!r}. Only a single block placeholder is"
+                " allowed in a string and no surrounding text is allowed."
             )
 
     return template

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -56,8 +56,8 @@ def find_placeholders(template: T) -> Set[Placeholder]:
     if isinstance(template, str):
         result = PLACEHOLDER_CAPTURE_REGEX.findall(template)
         return {
-            Placeholder(match[0], match[1], determine_placeholder_type(match[1]))
-            for match in result
+            Placeholder(full_match, name, determine_placeholder_type(name))
+            for full_match, name in result
         }
     elif isinstance(template, dict):
         return set().union(
@@ -96,11 +96,7 @@ def apply_values(template: T, values: Dict[str, Any]) -> Union[T, Type[NotSet]]:
     Returns:
         The template with the values applied
     """
-    if (
-        isinstance(template, (int, float, bool))
-        or template is NotSet
-        or template is None
-    ):
+    if isinstance(template, (int, float, bool, type(NotSet), type(None))):
         return template
     if isinstance(template, str):
         placeholders = find_placeholders(template)

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -1,8 +1,9 @@
 import pytest
 
 from prefect.blocks.core import Block
+from prefect.utilities.annotations import NotSet
 from prefect.utilities.templating import (
-    UNSET,
+    PlaceholderType,
     apply_values,
     find_placeholders,
     resolve_block_document_references,
@@ -67,6 +68,14 @@ class TestFindPlaceholders:
         names = set(p.name for p in placeholders)
         assert names == {"first_name", "last_name"}
 
+    def test_finds_block_document_placeholders(self):
+        template = "Hello {{prefect.blocks.document.name}}!"
+        placeholders = find_placeholders(template)
+        assert len(placeholders) == 1
+        placeholder = placeholders.pop()
+        assert placeholder.name == "prefect.blocks.document.name"
+        assert placeholder.type is PlaceholderType.BLOCK_DOCUMENT
+
 
 class TestApplyValues:
     def test_apply_values_simple_string_with_one_placeholder(self):
@@ -102,8 +111,8 @@ class TestApplyValues:
             "age": 30,
         }
 
-    def test_apply_values_dictionary_with_UNSET_value_removed(self):
-        template = {"name": UNSET, "age": "{{age}}"}
+    def test_apply_values_dictionary_with_notset_value_removed(self):
+        template = {"name": NotSet, "age": "{{age}}"}
         values = {"age": 30}
         assert apply_values(template, values) == {"age": 30}
 
@@ -126,6 +135,13 @@ class TestApplyValues:
 
     def test_apply_values_boolean_input(self):
         assert apply_values(True, {"flag": False}) is True
+
+    def test_apply_values_none_input(self):
+        assert apply_values(None, {"key": "value"}) is None
+
+    def test_does_not_apply_values_to_block_document_placeholders(self):
+        template = "Hello {{prefect.blocks.document.name}}!"
+        assert apply_values(template, {"name": "Alice"}) == template
 
 
 class TestResolveBlockDocumentReferences:
@@ -163,26 +179,59 @@ class TestResolveBlockDocumentReferences:
                 "other_nested_key": {"$ref": {"block_document_id": block_document_id}},
             }
         }
-        block_document_data = {"a": 1, "b": "hello"}
+        block_document = await orion_client.read_block_document(block_document_id)
 
         result = await resolve_block_document_references(template, client=orion_client)
 
         assert result == {
             "key": {
-                "nested_key": block_document_data,
-                "other_nested_key": block_document_data,
+                "nested_key": block_document.data,
+                "other_nested_key": block_document.data,
             }
         }
 
     async def test_resolve_block_document_references_with_list_of_block_document_references(
         self, orion_client, block_document_id
     ):
-        # given
         template = [{"$ref": {"block_document_id": block_document_id}}]
-        block_document_data = {"a": 1, "b": "hello"}
+        block_document = await orion_client.read_block_document(block_document_id)
 
-        # when
         result = await resolve_block_document_references(template, client=orion_client)
 
-        # then
-        assert result == [block_document_data]
+        assert result == [block_document.data]
+
+    async def test_resolve_block_document_references_with_dot_delimited_syntax(
+        self, orion_client, block_document_id
+    ):
+        template = {"key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }}"}
+
+        block_document = await orion_client.read_block_document(block_document_id)
+
+        result = await resolve_block_document_references(template, client=orion_client)
+
+        assert result == {"key": block_document.data}
+
+    async def test_resolve_block_document_references_raises_on_multiple_placeholders(
+        self, orion_client
+    ):
+        template = {
+            "key": (
+                "{{ prefect.blocks.arbitraryblock.arbitrary-block }} {{"
+                " another_placeholder }}"
+            )
+        }
+
+        with pytest.raises(
+            ValueError,
+            match="Block placeholders must be the only placeholder in a string.",
+        ):
+            await resolve_block_document_references(template, client=orion_client)
+
+    async def test_resolve_block_document_references_does_not_change_standard_placeholders(
+        self,
+    ):
+        template = {"key": "{{ standard_placeholder }}"}
+
+        result = await resolve_block_document_references(template)
+
+        assert result == template

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -223,7 +223,26 @@ class TestResolveBlockDocumentReferences:
 
         with pytest.raises(
             ValueError,
-            match="Block placeholders must be the only placeholder in a string.",
+            match=(
+                "Only a single block placeholder is allowed in a string and no"
+                " surrounding text is allowed."
+            ),
+        ):
+            await resolve_block_document_references(template, client=orion_client)
+
+    async def test_resolve_block_document_references_raises_on_extra_text(
+        self, orion_client
+    ):
+        template = {
+            "key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }} extra text"
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Only a single block placeholder is allowed in a string and no"
+                " surrounding text is allowed."
+            ),
         ):
             await resolve_block_document_references(template, client=orion_client)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the ability to reference block documents in worker base job templates and project config files with a dot-delimited syntax. When templating, the referenced block document will be retrieved, and the placeholder will be replaced by the data contained in the block document and any nested block documents. Block document placeholders must be used by themselves because they perform a full replacement in the template.

Closes #9036 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Use an arbitrary block in a template:

```python
class ArbitraryBlock(Block):
            a: int
            b: str

await ArbitraryBlock(a=1, b="hello").save(name="arbitrary-block")

template = {"key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }}"}

result = await resolve_block_document_references(template)

assert result == {"key": { "a": 1, "b": "hello" }}

```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
