### PR TITLE
Add `BatchedQueueService` abstract class

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -228,16 +228,28 @@ class BatchedQueueService(QueueService[T]):
 
                     batch.append(item)
                     batch_size += self._get_size(item)
+                    logger.debug(
+                        "Service %r added item %r to batch (size %s/%s)",
+                        self,
+                        item,
+                        batch_size,
+                        self._max_batch_size,
+                    )
 
             if not batch:
                 continue
 
+            logger.debug(
+                "Service %r processing batch of size %s",
+                self,
+                batch_size,
+            )
             try:
                 await self._handle_batch(batch)
             except Exception:
                 logger.exception(
                     "Service %r failed to process batch of size %s",
-                    type(self).__name__,
+                    self,
                     batch_size,
                 )
 

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -1,6 +1,6 @@
+import asyncio
 import contextlib
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 from unittest.mock import ANY, MagicMock, call
@@ -294,7 +294,8 @@ def test_batched_queue_service_min_interval():
     instance = MockBatchedService.instance()
     instance._min_interval = 0.01
     instance.send(1)
-    time.sleep(1)
+    # Sleep in the loop thread to force a yield
+    from_sync.call_soon_in_loop_thread(create_call(asyncio.sleep, 0.1)).result()
     instance.send(2)
-    time.sleep(1)
+    from_sync.call_soon_in_loop_thread(create_call(asyncio.sleep, 0.1)).result()
     MockBatchedService.mock.assert_has_calls([call(instance, [1]), call(instance, [2])])

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -297,7 +297,7 @@ def test_batched_queue_service_min_interval():
     instance._min_interval = 0.01
     instance.send(1)
     # Wait for the event to be set
-    assert event.wait(2.0), "Item not handled within 2s"
+    assert event.wait(10.0), "Item not handled within 10s"
     instance.send(2)
     instance.drain()
     MockBatchedService.mock.assert_has_calls([call(instance, [1]), call(instance, [2])])

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -115,6 +115,7 @@ def test_instance_returns_new_instance_after_base_exception():
 
     # Wait for the service to actually handle the item
     event.wait()
+    instance.mock.reset_mock(side_effect=True)
 
     new_instance = MockService.instance()
     assert new_instance is not instance

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -44,8 +44,11 @@ class MockBatchedService(BatchedQueueService[int]):
 
 @pytest.fixture(autouse=True)
 def reset_mock_services():
+    yield
     MockService.mock.reset_mock(side_effect=True)
     MockBatchedService.mock.reset_mock(side_effect=True)
+    MockService.drain_all()
+    MockBatchedService.drain_all()
 
 
 def test_instance_returns_instance():

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -294,7 +294,7 @@ def test_batched_queue_service_min_interval():
     instance = MockBatchedService.instance()
     instance._min_interval = 0.1
     instance.send(1)
-    time.sleep(0.1)
+    time.sleep(0.25)
     instance.send(2)
-    time.sleep(0.1)
+    time.sleep(0.25)
     MockBatchedService.mock.assert_has_calls([call(instance, [1]), call(instance, [2])])

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -203,7 +203,7 @@ def test_send_many_instances_many_threads():
 def test_drain_many_instances_many_threads():
     def on_thread(i):
         MockService.instance(i).send(i)
-        MockService.instance(i).drain()
+        MockService.drain_all()
 
     with ThreadPoolExecutor() as executor:
         for i in range(10):

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -44,8 +44,9 @@ class MockBatchedService(BatchedQueueService[int]):
 
 
 @pytest.fixture(autouse=True)
-def reset_mock_service():
+def reset_mock_services():
     MockService.mock.reset_mock()
+    MockBatchedService.mock.reset_mock()
 
 
 def test_instance_returns_instance():

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -292,9 +292,9 @@ def test_batched_queue_service():
 
 def test_batched_queue_service_min_interval():
     instance = MockBatchedService.instance()
-    instance._min_interval = 0.1
+    instance._min_interval = 0.01
     instance.send(1)
-    time.sleep(0.25)
+    time.sleep(1)
     instance.send(2)
-    time.sleep(0.25)
+    time.sleep(1)
     MockBatchedService.mock.assert_has_calls([call(instance, [1]), call(instance, [2])])


### PR DESCRIPTION
In preparation for moving the log worker to run on the global event loop, introduces a batched queue service so we can send logs in batches even when they're emitted one at a time.