### PR TITLE
Update log worker to run on the global event loop

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -405,7 +405,7 @@ async def begin_flow_run(
                 f" {timeout.to_rfc3339_string()} to finish execution."
             ),
         )
-        APILogHandler.flush(block=True)
+        await APILogHandler.flush()
 
         return terminal_or_paused_state
     else:
@@ -421,7 +421,7 @@ async def begin_flow_run(
 
     # When a "root" flow run finishes, flush logs so we do not have to rely on handling
     # during interpreter shutdown
-    APILogHandler.flush(block=True)
+    await APILogHandler.flush()
 
     return terminal_state
 
@@ -1380,7 +1380,7 @@ async def begin_task_run(
             if not maybe_flow_run_context:
                 # When a a task run finishes on a remote worker flush logs to prevent
                 # loss if the process exits
-                APILogHandler.flush(block=True)
+                await APILogHandler.flush()
 
         except Abort as abort:
             # Task run probably already completed, fetch its state

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -1,30 +1,29 @@
-import atexit
 import json
 import logging
-import queue
 import sys
-import threading
 import time
 import traceback
 import warnings
-from typing import Any, Dict, List, Tuple, Union
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Type, Union
 
-import anyio
 import pendulum
 from rich.console import Console
 from rich.highlighter import Highlighter, NullHighlighter
 from rich.theme import Theme
+from typing_extensions import Self
 
 import prefect.context
 from prefect._internal.compatibility.deprecated import deprecated_callable
+from prefect._internal.concurrency.services import BatchedQueueService
 from prefect.client.orchestration import get_client
 from prefect.exceptions import MissingContextError
 from prefect.logging.highlighters import PrefectConsoleHighlighter
 from prefect.server.schemas.actions import LogCreate
 from prefect.settings import (
+    PREFECT_API_URL,
     PREFECT_LOGGING_COLORS,
     PREFECT_LOGGING_MARKUP,
-    PREFECT_LOGGING_TO_API_BATCH_INTERVAL,
     PREFECT_LOGGING_TO_API_BATCH_SIZE,
     PREFECT_LOGGING_TO_API_ENABLED,
     PREFECT_LOGGING_TO_API_MAX_LOG_SIZE,
@@ -32,217 +31,42 @@ from prefect.settings import (
 )
 
 
-class APILogWorker:
-    """
-    Manages the submission of logs to the API in a background thread.
-    """
-
-    def __init__(self, profile_context: prefect.context.SettingsContext) -> None:
-        self.profile_context = profile_context.copy()
-
-        self._queue: queue.Queue[Tuple[Dict[str, Any], int]] = queue.Queue()
-
-        self._send_thread = threading.Thread(
-            target=self._send_logs_loop,
-            name="orion-log-worker",
-            daemon=True,
-        )
-        self._flush_event = threading.Event()
-        self._stop_event = threading.Event()
-        self._send_logs_finished_event = threading.Event()
-        self._lock = threading.Lock()
-        self._started = False
-        self._stopped = False  # Cannot be started again after stopped
-
-        # Tracks logs that have been pulled from the queue but not sent successfully
-        self._pending_logs: List[dict] = []
-        self._pending_size: int = 0
-        self._retries = 0
-        self._max_retries = 3
-
-        # Ensure stop is called at exit
-        if sys.version_info < (3, 9):
-            atexit.register(self.stop)
-        else:
-            # See related issue at https://bugs.python.org/issue42647
-            # The http client uses a thread pool executor to make requests and in 3.9+
-            # new threads cannot be spawned after the interpreter finalizes threads
-            # which happens _before_ the normal `atexit` hook is called resulting in
-            # the failure to send logs.
-            from threading import _register_atexit
-
-            _register_atexit(self.stop)
-
-    def _send_logs_loop(self):
-        """
-        Should only be the target of the `send_thread` as it creates a new event loop.
-
-        Runs until the `stop_event` is set.
-        """
-        # Initialize prefect in this new thread, but do not reconfigure logging
-        try:
-            with self.profile_context:
-                while not self._stop_event.is_set():
-                    # Wait until flush is called or the batch interval is reached
-                    self._flush_event.wait(
-                        PREFECT_LOGGING_TO_API_BATCH_INTERVAL.value()
-                    )
-                    self._flush_event.clear()
-
-                    anyio.run(self.send_logs)
-
-                    # Notify watchers that logs were sent
-                    self._send_logs_finished_event.set()
-                    self._send_logs_finished_event.clear()
-
-                # After the stop event, we are exiting...
-                # Try to send any remaining logs
-                anyio.run(self.send_logs, True)
-
-        except Exception:
-            if logging.raiseExceptions and sys.stderr:
-                sys.stderr.write("--- Error logging to API ---\n")
-                sys.stderr.write("The log worker encountered a fatal error.\n")
-                traceback.print_exc(file=sys.stderr)
-                sys.stderr.write(self.worker_info())
-
-        finally:
-            # Set the finished event so anyone waiting on worker completion does not
-            # continue to block if an exception is encountered
-            self._send_logs_finished_event.set()
-
-    async def send_logs(self, exiting: bool = False) -> None:
-        """
-        Send all logs in the queue in batches to avoid network limits.
-
-        If a client error is encountered, the logs pulled from the queue are retained
-        and will be sent on the next call.
-
-        Note that if there is a single bad log in the queue, this will repeatedly
-        fail as we do not ever drop logs. We may want to adjust this behavior in the
-        future if there are issues.
-        """
-        done = False
-
-        # Determine the batch size by removing the max size of a single log to avoid
-        # exceeding the max size in normal operation. If the single log size is greater
-        # than this difference, we use that instead so logs will still be sent.
-        max_batch_size = max(
+class APILogWorker(BatchedQueueService[Dict[str, Any]]):
+    @property
+    def _max_batch_size(self):
+        return max(
             PREFECT_LOGGING_TO_API_BATCH_SIZE.value()
             - PREFECT_LOGGING_TO_API_MAX_LOG_SIZE.value(),
             PREFECT_LOGGING_TO_API_MAX_LOG_SIZE.value(),
         )
 
-        # Loop until the queue is empty or we encounter an error
-        while not done:
-            # Pull logs from the queue until it is empty or we reach the batch size
-            try:
-                while self._pending_size < max_batch_size:
-                    log, log_size = self._queue.get_nowait()
-                    self._pending_logs.append(log)
-                    self._pending_size += log_size
+    async def _handle_batch(self, items: List):
+        try:
+            await self._client.create_logs(items)
+        except Exception:
+            # Roughly replicate the behavior of the stdlib logger error handling
+            if logging.raiseExceptions and sys.stderr:
+                sys.stderr.write("--- Error logging to API ---\n")
+                traceback.print_exc(file=sys.stderr)
 
-            except queue.Empty:
-                done = True
+    @asynccontextmanager
+    async def _lifespan(self):
+        async with get_client() as self._client:
+            yield
 
-            if not self._pending_logs:
-                continue
-
-            client = get_client()
-            client.manage_lifespan = False
-            async with client:
-                try:
-                    await client.create_logs(self._pending_logs)
-                    self._pending_logs = []
-                    self._pending_size = 0
-                    self._retries = 0
-                except Exception:
-                    # Attempt to send these logs on the next call instead
-                    done = True
-                    self._retries += 1
-
-                    # Roughly replicate the behavior of the stdlib logger error handling
-                    if logging.raiseExceptions and sys.stderr:
-                        sys.stderr.write("--- Error logging to API ---\n")
-                        traceback.print_exc(file=sys.stderr)
-                        sys.stderr.write(self.worker_info())
-                        if exiting:
-                            sys.stderr.write(
-                                "The log worker is stopping and these logs will not be"
-                                " sent.\n"
-                            )
-                        elif self._retries > self._max_retries:
-                            sys.stderr.write(
-                                "The log worker has tried to send these logs "
-                                f"{self._retries} times and will now drop them."
-                            )
-                        else:
-                            sys.stderr.write(
-                                "The log worker will attempt to send these logs"
-                                " again in "
-                                f"{PREFECT_LOGGING_TO_API_BATCH_INTERVAL.value()}s\n"
-                            )
-
-                    if self._retries > self._max_retries:
-                        # Drop this batch of logs
-                        self._pending_logs = []
-                        self._pending_size = 0
-                        self._retries = 0
-
-    def worker_info(self) -> str:
-        """Returns a debugging string with worker log stats"""
-        return (
-            "Worker information:\n"
-            f"    Approximate queue length: {self._queue.qsize()}\n"
-            f"    Pending log batch length: {len(self._pending_logs)}\n"
-            f"    Pending log batch size: {self._pending_size}\n"
+    @classmethod
+    def instance(cls: Type[Self]) -> Self:
+        settings = (
+            PREFECT_LOGGING_TO_API_BATCH_SIZE.value(),
+            PREFECT_API_URL.value(),
+            PREFECT_LOGGING_TO_API_MAX_LOG_SIZE.value(),
         )
 
-    def enqueue(self, log: Dict[str, Any], log_size: int):
-        if self._stopped:
-            raise RuntimeError(
-                "Logs cannot be enqueued after the API log worker is stopped."
-            )
-        self._queue.put((log, log_size))
+        # Ensure a unique worker is retrieved per relevant logging settings
+        return super().instance(*settings)
 
-    def flush(self, block: bool = False) -> None:
-        with self._lock:
-            if not self._started and not self._stopped:
-                raise RuntimeError("Worker was never started.")
-            self._flush_event.set()
-            if block:
-                # TODO: Sometimes the log worker will deadlock and never finish
-                #       so we will only block for 30 seconds here. When logging is
-                #       refactored, this deadlock should be resolved.
-                self._send_logs_finished_event.wait(30)
-
-    def start(self) -> None:
-        """Start the background thread"""
-        with self._lock:
-            if not self._started and not self._stopped:
-                self._send_thread.start()
-                self._started = True
-            elif self._stopped:
-                raise RuntimeError(
-                    "The API log worker cannot be started after stopping."
-                )
-
-    def stop(self) -> None:
-        """Flush all logs and stop the background thread"""
-        with self._lock:
-            if self._started:
-                self._flush_event.set()
-                self._stop_event.set()
-                # TODO: Sometimes the log worker will deadlock and never join during
-                #       an at-exit hook so we will only block for 30 seconds here.
-                #       When logging is refactored, this deadlock should be resolved.
-                self._send_thread.join(30.0)
-                self._started = False
-                self._stopped = True
-
-    def is_stopped(self) -> bool:
-        with self._lock:
-            return not self._stopped
+    def _get_size(self, item: Dict[str, Any]) -> int:
+        return item.pop("__payload_size__") or len(json.dumps(item).encode())
 
 
 class APILogHandler(logging.Handler):
@@ -253,24 +77,15 @@ class APILogHandler(logging.Handler):
     the background.
     """
 
-    workers: Dict[prefect.context.SettingsContext, APILogWorker] = {}
-
-    def get_worker(self, context: prefect.context.SettingsContext) -> APILogWorker:
-        if context not in self.workers:
-            worker = self.workers[context] = APILogWorker(context)
-            worker.start()
-
-        return self.workers[context]
-
     @classmethod
-    def flush(cls, block: bool = False):
+    def flush(cls):
         """
-        Tell the `APILogWorker` to send any currently enqueued logs.
+        Tell the `APILogWorker` to send any currently enqueued logs and block until
+        completion.
 
-        Blocks until enqueued logs are sent if `block` is set.
+        Returns an awaitable if called from an async context.
         """
-        for worker in cls.workers.values():
-            worker.flush(block)
+        return APILogWorker.drain_all()
 
     def emit(self, record: logging.LogRecord):
         """
@@ -284,8 +99,9 @@ class APILogHandler(logging.Handler):
             if not getattr(record, "send_to_orion", True):
                 return  # Do not send records that have opted out
 
-            log, log_size = self.prepare(record, profile.settings)
-            self.get_worker(profile).enqueue(log, log_size)
+            log = self.prepare(record)
+            APILogWorker.instance().send(log)
+
         except Exception:
             self.handleError(record)
 
@@ -309,9 +125,7 @@ class APILogHandler(logging.Handler):
         # Display a longer traceback for other errors
         return super().handleError(record)
 
-    def prepare(
-        self, record: logging.LogRecord, settings: prefect.settings.Settings
-    ) -> Tuple[Dict[str, Any], int]:
+    def prepare(self, record: logging.LogRecord) -> Dict[str, Any]:
         """
         Convert a `logging.LogRecord` to the API `LogCreate` schema and serialize.
 
@@ -360,27 +174,14 @@ class APILogHandler(logging.Handler):
             message=self.format(record),
         ).dict(json_compatible=True)
 
-        log_size = self.get_log_size(log)
+        log_size = log["__payload_size__"] = len(json.dumps(log).encode())
         if log_size > PREFECT_LOGGING_TO_API_MAX_LOG_SIZE.value():
             raise ValueError(
                 f"Log of size {log_size} is greater than the max size of "
                 f"{PREFECT_LOGGING_TO_API_MAX_LOG_SIZE.value()}"
             )
 
-        return (log, log_size)
-
-    def close(self) -> None:
-        """
-        Shuts down this handler and the flushes the `APILogWorkers`
-        """
-        for worker in self.workers.values():
-            # Flush instead of closing ecause another instance may be using the worker
-            worker.flush()
-
-        return super().close()
-
-    def get_log_size(self, log: Dict[str, Any]) -> int:
-        return len(json.dumps(log).encode())
+        return log
 
 
 class PrefectConsoleHandler(logging.StreamHandler):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,12 +1,8 @@
-import asyncio
 import json
 import logging
-import queue
 import sys
-import threading
 import time
 import uuid
-import warnings
 from contextlib import nullcontext
 from functools import partial
 from unittest.mock import ANY, MagicMock
@@ -269,41 +265,10 @@ class TestAPILogHandler:
         yield logger
         logger.removeHandler(handler)
 
-    def test_handler_instances_share_log_worker(self):
-        first = APILogHandler().get_worker(prefect.context.get_settings_context())
-        second = APILogHandler().get_worker(prefect.context.get_settings_context())
-        assert first is second
-        assert len(APILogHandler.workers) == 1
-
-    def test_log_workers_are_cached_by_profile(self):
-        a = APILogHandler().get_worker(prefect.context.get_settings_context())
-        b = APILogHandler().get_worker(
-            prefect.context.get_settings_context().copy(update={"name": "foo"})
-        )
-        assert a is not b
-        assert len(APILogHandler.workers) == 2
-
-    def test_instantiates_log_worker(self, mock_log_worker):
-        APILogHandler().get_worker(prefect.context.get_settings_context())
-        mock_log_worker.assert_called_once_with(prefect.context.get_settings_context())
-        mock_log_worker().start.assert_called_once_with()
-
-    def test_worker_is_not_started_until_log_is_emitted(self, mock_log_worker, logger):
-        mock_log_worker().start.assert_not_called()
-        logger.setLevel(logging.INFO)
-        logger.debug("test-task", extra={"flow_run_id": uuid.uuid4()})
-        mock_log_worker().start.assert_not_called()
-        logger.info("test-task", extra={"flow_run_id": uuid.uuid4()})
-        mock_log_worker().start.assert_called()
-
     def test_worker_is_flushed_on_handler_close(self, mock_log_worker):
         handler = APILogHandler()
-        handler.get_worker(prefect.context.get_settings_context())
         handler.close()
-        mock_log_worker().flush.assert_called_once()
-        # The worker cannot be stopped because it is a singleton and other handler
-        # instances may be using it
-        mock_log_worker().stop.assert_not_called()
+        mock_log_worker.drain_all.assert_called_once()
 
     @pytest.mark.flaky
     async def test_logs_can_still_be_sent_after_close(
@@ -312,33 +277,10 @@ class TestAPILogHandler:
         logger.info("Test", extra={"flow_run_id": flow_run.id})  # Start the logger
         handler.close()  # Close it
         logger.info("Test", extra={"flow_run_id": flow_run.id})
-        handler.flush(block=True)
+        await handler.flush()
 
         logs = await orion_client.read_logs()
         assert len(logs) == 2
-
-    async def test_logs_cannot_be_sent_after_worker_stop(
-        self, logger, handler, flow_run, orion_client, capsys
-    ):
-        logger.info("Test", extra={"flow_run_id": flow_run.id})
-        for worker in handler.workers.values():
-            worker.stop()
-
-        # Send a log that will not be sent
-        logger.info("Test", extra={"flow_run_id": flow_run.id})
-
-        logs = await orion_client.read_logs()
-        assert len(logs) == 1
-
-        output = capsys.readouterr()
-        assert (
-            "RuntimeError: Logs cannot be enqueued after the API log worker is stopped."
-            in output.err
-        )
-
-    def test_worker_is_not_stopped_if_not_set_on_handler_close(self, mock_log_worker):
-        APILogHandler().close()
-        mock_log_worker().stop.assert_not_called()
 
     def test_sends_task_run_log_to_worker(self, logger, mock_log_worker, task_run):
         with TaskRunContext.construct(task_run=task_run):
@@ -352,9 +294,9 @@ class TestAPILogHandler:
             message="test-task",
         ).dict(json_compatible=True)
         expected["timestamp"] = ANY  # Tested separately
-        log_size = ANY  # Tested separately
+        expected["__payload_size__"] = ANY  # Tested separately
 
-        mock_log_worker().enqueue.assert_called_once_with(expected, log_size)
+        mock_log_worker.instance().send.assert_called_once_with(expected)
 
     def test_sends_flow_run_log_to_worker(self, logger, mock_log_worker, flow_run):
         with FlowRunContext.construct(flow_run=flow_run):
@@ -368,9 +310,9 @@ class TestAPILogHandler:
             message="test-flow",
         ).dict(json_compatible=True)
         expected["timestamp"] = ANY  # Tested separately
-        log_size = ANY  # Tested separately
+        expected["__payload_size__"] = ANY  # Tested separately
 
-        mock_log_worker().enqueue.assert_called_once_with(expected, log_size)
+        mock_log_worker.instance().send.assert_called_once_with(expected)
 
     @pytest.mark.parametrize("with_context", [True, False])
     def test_respects_explicit_flow_run_id(
@@ -393,9 +335,9 @@ class TestAPILogHandler:
             message="test-task",
         ).dict(json_compatible=True)
         expected["timestamp"] = ANY  # Tested separately
-        log_size = ANY  # Tested separately
+        expected["__payload_size__"] = ANY  # Tested separately
 
-        mock_log_worker().enqueue.assert_called_once_with(expected, log_size)
+        mock_log_worker.instance().send.assert_called_once_with(expected)
 
     @pytest.mark.parametrize("with_context", [True, False])
     def test_respects_explicit_task_run_id(
@@ -419,14 +361,14 @@ class TestAPILogHandler:
             message="test-task",
         ).dict(json_compatible=True)
         expected["timestamp"] = ANY  # Tested separately
-        log_size = ANY  # Tested separately
+        expected["__payload_size__"] = ANY  # Tested separately
 
-        mock_log_worker().enqueue.assert_called_once_with(expected, log_size)
+        mock_log_worker.instance().send.assert_called_once_with(expected)
 
     def test_does_not_emit_logs_below_level(self, logger, mock_log_worker):
         logger.setLevel(logging.WARNING)
         logger.info("test-task", extra={"flow_run_id": uuid.uuid4()})
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
     def test_explicit_task_run_id_still_requires_flow_run_id(
         self, logger, mock_log_worker
@@ -437,7 +379,7 @@ class TestAPILogHandler:
         ):
             logger.info("test-task", extra={"task_run_id": task_run_id})
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
     def test_sets_timestamp_from_record_created_time(
         self, logger, mock_log_worker, flow_run, handler
@@ -449,7 +391,7 @@ class TestAPILogHandler:
             logger.info("test-flow")
 
         record = handler.emit.call_args[0][0]
-        log_dict = mock_log_worker().enqueue.call_args[0][0]
+        log_dict = mock_log_worker.instance().send.call_args[0][0]
 
         assert (
             log_dict["timestamp"] == pendulum.from_timestamp(record.created).isoformat()
@@ -472,7 +414,7 @@ class TestAPILogHandler:
         with FlowRunContext.construct(flow_run=flow_run):
             logger.info("test-flow")
 
-        log_dict = mock_log_worker().enqueue.call_args[0][0]
+        log_dict = mock_log_worker.instance().send.call_args[0][0]
 
         assert log_dict["timestamp"] == pendulum.from_timestamp(now).isoformat()
 
@@ -480,7 +422,7 @@ class TestAPILogHandler:
         with TaskRunContext.construct(task_run=task_run):
             logger.info("test", extra={"send_to_orion": False})
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
     def test_does_not_send_logs_when_handler_is_disabled(
         self, logger, mock_log_worker, task_run
@@ -491,7 +433,7 @@ class TestAPILogHandler:
             with TaskRunContext.construct(task_run=task_run):
                 logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
     def test_does_not_send_logs_outside_of_run_context_with_default_setting(
         self, logger, mock_log_worker, capsys
@@ -502,7 +444,7 @@ class TestAPILogHandler:
         ):
             logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
         # No stderr output
         output = capsys.readouterr()
@@ -533,7 +475,7 @@ class TestAPILogHandler:
             ):
                 logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
         # No stderr output
         output = capsys.readouterr()
@@ -563,7 +505,7 @@ class TestAPILogHandler:
         ):
             logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
         # No stderr output
         output = capsys.readouterr()
@@ -590,7 +532,7 @@ class TestAPILogHandler:
             ):
                 logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
         # No stderr output
         output = capsys.readouterr()
@@ -628,7 +570,7 @@ class TestAPILogHandler:
             # The above dynamic collects the line number so that added tests do not
             # break this test
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
         assert warnings.pop().lineno == lineno
 
     def test_writes_logging_errors_to_stderr(
@@ -641,7 +583,7 @@ class TestAPILogHandler:
         # No error raised
         logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
 
         # Error is in stderr
         output = capsys.readouterr()
@@ -652,7 +594,7 @@ class TestAPILogHandler:
     ):
         logger.info("test", extra={"send_to_orion": False})
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
         output = capsys.readouterr()
         assert (
             "RuntimeError: Attempted to send logs to the API without a flow run id."
@@ -666,7 +608,7 @@ class TestAPILogHandler:
             with temporary_settings(updates={PREFECT_LOGGING_TO_API_MAX_LOG_SIZE: "1"}):
                 logger.info("test")
 
-        mock_log_worker().enqueue.assert_not_called()
+        mock_log_worker.instance().send.assert_not_called()
         output = capsys.readouterr()
         assert "ValueError" in output.err
         assert "is greater than the max size of 1" in output.err
@@ -684,10 +626,14 @@ class TestAPILogHandler:
         log_size = len(json.dumps(dict_log))
         assert log_size == 211
         handler = APILogHandler()
-        assert handler.get_log_size(dict_log) == log_size
+        assert handler._get_payload_size(dict_log) == log_size
 
 
 class TestAPILogWorker:
+    @pytest.fixture
+    async def worker(self):
+        return APILogWorker.instance()
+
     @pytest.fixture
     def log_dict(self):
         return LogCreate(
@@ -699,63 +645,9 @@ class TestAPILogWorker:
             message="hello",
         ).dict(json_compatible=True)
 
-    @pytest.fixture
-    def log_size(self, log_dict) -> int:
-        return APILogHandler().get_log_size(log_dict)
-
-    @pytest.fixture
-    def worker(self, get_worker):
-        yield get_worker()
-
-    @pytest.fixture
-    def get_worker(self):
-        # Ensures that a worker is stopped _before_ the test is torn down. Otherwise,
-        # remaining logs could be written by a background thread after all the tests
-        # finish and the database has been reset.
-        worker = None
-
-        def get_worker():
-            nonlocal worker
-            worker = APILogWorker(prefect.context.get_settings_context())
-            return worker
-
-        yield get_worker
-
-        if worker:
-            worker.stop()
-        else:
-            warnings.warn("`get_worker` fixture was specified but not called.")
-
-    def test_start_is_idempotent(self, worker):
-        worker._send_thread = MagicMock()
-        worker.start()
-        worker.start()
-        worker._send_thread.start.assert_called_once()
-
-    def test_stop_is_idempotent(self, worker):
-        worker._send_thread = MagicMock()
-        worker._stop_event = MagicMock()
-        worker._flush_event = MagicMock()
-        worker.stop()
-        worker._stop_event.set.assert_not_called()
-        worker._flush_event.set.assert_not_called()
-        worker._send_thread.join.assert_not_called()
-        worker.start()
-        worker.stop()
-        worker.stop()
-        worker._flush_event.set.assert_called_once()
-        worker._stop_event.set.assert_called_once()
-        worker._send_thread.join.assert_called_once()
-
-    def test_enqueue(self, log_dict, log_size, worker):
-        worker.enqueue(log_dict, log_size)
-        assert worker._queue.get_nowait() == (log_dict, log_size)
-
-    async def test_send_logs_single_record(
-        self, log_dict, log_size, orion_client, worker
-    ):
-        worker.enqueue(log_dict, log_size)
-        await worker.send_logs()
+    async def test_send_logs_single_record(self, log_dict, orion_client, worker):
+        worker.send(log_dict)
+        await worker.drain()
         logs = await orion_client.read_logs()
         assert len(logs) == 1
         assert logs[0].dict(include=log_dict.keys(), json_compatible=True) == log_dict
@@ -768,9 +660,8 @@ class TestAPILogWorker:
         for i in range(count):
             new_log = log_dict.copy()
             new_log["message"] = str(i)
-            new_log_size = APILogHandler().get_log_size(new_log)
-            worker.enqueue(new_log, new_log_size)
-        await worker.send_logs()
+            worker.send(new_log)
+        await worker.drain()
 
         logs = await orion_client.read_logs()
         assert len(logs) == count
@@ -783,60 +674,29 @@ class TestAPILogWorker:
             )
         assert len(set(log.message for log in logs)) == count, "Each log is unique"
 
-    async def test_send_logs_retries_on_next_call_on_exception(
-        self, log_dict, log_size, orion_client, monkeypatch, capsys, worker
-    ):
-        create_logs = orion_client.create_logs
-        monkeypatch.setattr(
-            "prefect.client.PrefectClient.create_logs",
-            MagicMock(side_effect=ValueError("Test")),
-        )
-
-        worker.enqueue(log_dict, log_size)
-        await worker.send_logs()
-
-        # Log moved from queue to pending logs
-        assert worker._pending_logs == [log_dict]
-        with pytest.raises(queue.Empty):
-            worker._queue.get_nowait()
-
-        # Restore client
-        monkeypatch.setattr(
-            "prefect.client.PrefectClient.create_logs",
-            create_logs,
-        )
-        await worker.send_logs()
-
-        logs = await orion_client.read_logs()
-        assert len(logs) == 1
-
     @pytest.mark.parametrize("exiting", [True, False])
     async def test_send_logs_writes_exceptions_to_stderr(
-        self, log_dict, log_size, capsys, monkeypatch, exiting, worker
+        self, log_dict, capsys, monkeypatch, exiting, worker
     ):
         monkeypatch.setattr(
             "prefect.client.PrefectClient.create_logs",
             MagicMock(side_effect=ValueError("Test")),
         )
 
-        worker.enqueue(log_dict, log_size)
-        await worker.send_logs(exiting=exiting)
+        worker.send(log_dict)
+        await worker.drain()
 
         err = capsys.readouterr().err
         assert "--- Error logging to API ---" in err
         assert "ValueError: Test" in err
-        if not exiting:
-            assert "will attempt to send these logs again" in err
-        else:
-            assert "log worker is stopping and these logs will not be sent" in err
 
-    async def test_send_logs_batches_by_size(
-        self, log_dict, log_size, monkeypatch, get_worker
-    ):
+    async def test_send_logs_batches_by_size(self, log_dict, monkeypatch):
         mock_create_logs = AsyncMock()
         monkeypatch.setattr(
             "prefect.client.PrefectClient.create_logs", mock_create_logs
         )
+
+        log_size = APILogHandler()._get_payload_size(log_dict)
 
         with temporary_settings(
             updates={
@@ -844,75 +704,22 @@ class TestAPILogWorker:
                 PREFECT_LOGGING_TO_API_MAX_LOG_SIZE: log_size,
             }
         ):
-            worker = get_worker()
-            worker.enqueue(log_dict, log_size)
-            worker.enqueue(log_dict, log_size)
-            worker.enqueue(log_dict, log_size)
-            await worker.send_logs()
+            worker = APILogWorker.instance()
+            worker.send(log_dict)
+            worker.send(log_dict)
+            worker.send(log_dict)
+            await worker.drain()
 
         assert mock_create_logs.call_count == 3
 
-    @pytest.mark.flaky(max_runs=3)
-    async def test_logs_are_sent_when_started(
-        self, log_dict, log_size, orion_client, get_worker, monkeypatch
-    ):
-        event = threading.Event()
-        unpatched_create_logs = orion_client.create_logs
-
-        async def create_logs(self, *args, **kwargs):
-            result = await unpatched_create_logs(*args, **kwargs)
-            event.set()
-            return result
-
-        monkeypatch.setattr("prefect.client.PrefectClient.create_logs", create_logs)
-
-        with temporary_settings(
-            updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "0.001"}
-        ):
-            worker = get_worker()
-            worker.enqueue(log_dict, log_size)
-            worker.start()
-            worker.enqueue(log_dict, log_size)
-
-        # We want to ensure logs are written without the thread being joined
-        await asyncio.sleep(0.01)
-        event.wait()
-        logs = await orion_client.read_logs()
-        # TODO: CI failures sometimes find one log here instead of two.
-        assert len(logs) == 2
-
-    def test_batch_interval_is_respected(self, get_worker):
-        with temporary_settings(updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "5"}):
-            worker = get_worker()
-            worker._flush_event = MagicMock(return_val=False)
-            worker.start()
-
-            # Wait for the a loop to complete
-            worker._send_logs_finished_event.wait(1)
-
-        worker._flush_event.wait.assert_called_with(5)
-
-    def test_flush_event_is_cleared(self, get_worker):
-        with temporary_settings(updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "5"}):
-            worker = get_worker()
-            worker._flush_event = MagicMock(return_val=False)
-            worker.start()
-            worker.flush(block=True)
-
-        worker._flush_event.wait.assert_called_with(5)
-        worker._flush_event.clear.assert_called()
-
-    async def test_logs_are_sent_immediately_when_stopped(
-        self, log_dict, log_size, orion_client, get_worker
-    ):
+    async def test_logs_are_sent_immediately_when_stopped(self, log_dict, orion_client):
         # Set a long interval
         start_time = time.time()
         with temporary_settings(updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "10"}):
-            worker = get_worker()
-            worker.enqueue(log_dict, log_size)
-            worker.start()
-            worker.enqueue(log_dict, log_size)
-            worker.stop()
+            worker = APILogWorker.instance()
+            worker.send(log_dict)
+            worker.send(log_dict)
+            await worker.drain()
         end_time = time.time()
 
         assert (
@@ -921,32 +728,16 @@ class TestAPILogWorker:
 
         logs = await orion_client.read_logs()
         assert len(logs) == 2
-
-    async def test_raises_on_enqueue_after_stop(self, worker, log_dict, log_size):
-        worker.start()
-        worker.stop()
-        with pytest.raises(
-            RuntimeError, match="Logs cannot be enqueued after .* is stopped"
-        ):
-            worker.enqueue(log_dict, log_size)
-
-    async def test_raises_on_start_after_stop(self, worker):
-        worker.start()
-        worker.stop()
-        with pytest.raises(RuntimeError, match="cannot be started after stopping"):
-            worker.start()
 
     async def test_logs_are_sent_immediately_when_flushed(
-        self, log_dict, log_size, orion_client, get_worker
+        self, log_dict, orion_client, worker
     ):
         # Set a long interval
         start_time = time.time()
         with temporary_settings(updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "10"}):
-            worker = get_worker()
-            worker.enqueue(log_dict, log_size)
-            worker.start()
-            worker.enqueue(log_dict, log_size)
-            worker.flush(block=True)
+            worker.send(log_dict)
+            worker.send(log_dict)
+            await worker.drain()
         end_time = time.time()
 
         assert (
@@ -955,29 +746,6 @@ class TestAPILogWorker:
 
         logs = await orion_client.read_logs()
         assert len(logs) == 2
-
-    async def test_logs_can_be_flushed_repeatedly(
-        self, log_dict, log_size, orion_client, get_worker
-    ):
-        # Set a long interval
-        start_time = time.time()
-        with temporary_settings(updates={PREFECT_LOGGING_TO_API_BATCH_INTERVAL: "10"}):
-            worker = get_worker()
-            worker.enqueue(log_dict, log_size)
-            worker.start()
-            worker.enqueue(log_dict, log_size)
-            worker.flush()
-            worker.flush()
-            worker.enqueue(log_dict, log_size)
-            worker.flush(block=True)
-        end_time = time.time()
-
-        assert (
-            end_time - start_time
-        ) < 5  # An arbitary time less than the 10s interval
-
-        logs = await orion_client.read_logs()
-        assert len(logs) == 3
 
 
 def test_flow_run_logger(flow_run):


### PR DESCRIPTION
Uses the abstraction introduced in #9045 to reimplement the log worker and update it to run on the global event loop.

Drops a great deal of worker management complexity as well as handling of retries (we rely on retries in the client layer instead).