### PR TITLE
fix(deployments): default state Scheduled for /create_flow_run

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -391,7 +391,7 @@ async def create_flow_run_from_deployment(
     Any parameters not provided will be inferred from the deployment's parameters.
     If tags are not provided, the deployment's tags will be used.
 
-    If no state is provided, the flow run will be created in a PENDING state.
+    If no state is provided, the flow run will be created in a SCHEDULED state.
     """
     async with db.session_context(begin_transaction=True) as session:
         # get relevant info from the deployment
@@ -429,7 +429,7 @@ async def create_flow_run_from_deployment(
         )
 
         if not flow_run.state:
-            flow_run.state = schemas.states.Pending()
+            flow_run.state = schemas.states.Scheduled()
 
         now = pendulum.now("UTC")
         model = await models.flow_runs.create_flow_run(

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -1226,6 +1226,7 @@ class TestCreateFlowRunFromDeployment:
             deployment.infrastructure_document_id
         )
         assert response.json()["work_queue_name"] == deployment.work_queue_name
+        assert response.json()["state_type"] == schemas.states.StateType.SCHEDULED
 
     async def test_create_flow_run_from_deployment_uses_work_queue_name(
         self, deployment, client, session


### PR DESCRIPTION
Fixes #9040. Changes the default state to Scheduled for ad hoc created flow runs. This causes the flow to start immediately.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
