### PR TITLE
Variable api routes

### DIFF
--- a/src/prefect/server/api/__init__.py
+++ b/src/prefect/server/api/__init__.py
@@ -20,6 +20,7 @@ from . import (
     block_types,
     block_capabilities,
     collections,
+    variables,
     ui,
     root,
     # Server relies on all of the above routes

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -77,6 +77,7 @@ API_ROUTERS = (
     api.block_schemas.router,
     api.block_capabilities.router,
     api.collections.router,
+    api.variables.router,
     api.ui.flow_runs.router,
     api.admin.router,
     api.root.router,

--- a/src/prefect/server/api/variables.py
+++ b/src/prefect/server/api/variables.py
@@ -1,0 +1,168 @@
+"""
+Routes for interacting with variable objects
+"""
+
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import Body, Depends, HTTPException, Path, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import models
+from prefect.server.api.dependencies import LimitBody
+from prefect.server.database.dependencies import provide_database_interface
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.schemas import actions, core, filters, sorting
+from prefect.server.utilities.server import PrefectRouter
+
+
+async def get_variable_or_404(session: AsyncSession, variable_id: UUID):
+    """Returns a variable or raises 404 HTTPException if it does not exist"""
+
+    variable = await models.variables.read_variable(
+        session=session, variable_id=variable_id
+    )
+    if not variable:
+        raise HTTPException(status_code=404, detail="Variable not found.")
+
+    return variable
+
+
+async def get_variable_by_name_or_404(session: AsyncSession, name: str):
+    """Returns a variable or raises 404 HTTPException if it does not exist"""
+
+    variable = await models.variables.read_variable_by_name(session=session, name=name)
+    if not variable:
+        raise HTTPException(status_code=404, detail="Variable not found.")
+
+    return variable
+
+
+router = PrefectRouter(
+    prefix="/variables",
+    tags=["Variables"],
+)
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_variable(
+    variable: actions.VariableCreate,
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> core.Variable:
+    async with db.session_context(begin_transaction=True) as session:
+        model = await models.variables.create_variable(
+            session=session, variable=variable
+        )
+
+    return core.Variable.from_orm(model)
+
+
+@router.get("/{id:uuid}")
+async def read_variable(
+    variable_id: UUID = Path(..., alias="id"),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> core.Variable:
+    async with db.session_context(begin_transaction=True) as session:
+        model = await get_variable_or_404(session=session, variable_id=variable_id)
+
+    return core.Variable.from_orm(model)
+
+
+@router.get("/name/{name:str}")
+async def read_variable_by_name(
+    name: str = Path(...),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> core.Variable:
+    async with db.session_context(begin_transaction=True) as session:
+        model = await get_variable_by_name_or_404(session=session, name=name)
+
+    return core.Variable.from_orm(model)
+
+
+@router.post("/filter")
+async def read_variables(
+    limit: int = LimitBody(),
+    offset: int = Body(0, ge=0),
+    variables: Optional[filters.VariableFilter] = None,
+    sort: sorting.VariableSort = Body(sorting.VariableSort.NAME_ASC),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> List[core.Variable]:
+    async with db.session_context() as session:
+        return await models.variables.read_variables(
+            session=session,
+            variable_filter=variables,
+            sort=sort,
+            offset=offset,
+            limit=limit,
+        )
+
+
+@router.post("/count")
+async def count_variables(
+    variables: Optional[filters.VariableFilter] = Body(None, embed=True),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> int:
+    async with db.session_context() as session:
+        return await models.variables.count_variables(
+            session=session,
+            variable_filter=variables,
+        )
+
+
+@router.patch("/{id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
+async def update_variable(
+    variable: actions.VariableUpdate,
+    variable_id: UUID = Path(..., alias="id"),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+):
+    async with db.session_context(begin_transaction=True) as session:
+        updated = await models.variables.update_variable(
+            session=session,
+            variable_id=variable_id,
+            variable=variable,
+        )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Variable not found.")
+
+
+@router.patch("/name/{name:str}", status_code=status.HTTP_204_NO_CONTENT)
+async def update_variable_by_name(
+    variable: actions.VariableUpdate,
+    name: str = Path(..., alias="name"),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+):
+    async with db.session_context(begin_transaction=True) as session:
+        updated = await models.variables.update_variable_by_name(
+            session=session,
+            name=name,
+            variable=variable,
+        )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Variable not found.")
+
+
+@router.delete("/{id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_variable(
+    variable_id: UUID = Path(..., alias="id"),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+):
+    async with db.session_context(begin_transaction=True) as session:
+        deleted = await models.variables.delete_variable(
+            session=session, variable_id=variable_id
+        )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Variable not found.")
+
+
+@router.delete("/name/{name:str}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_variable_by_name(
+    name: str = Path(...),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+):
+    async with db.session_context(begin_transaction=True) as session:
+        deleted = await models.variables.delete_variable_by_name(
+            session=session, name=name
+        )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Variable not found.")

--- a/src/prefect/server/models/__init__.py
+++ b/src/prefect/server/models/__init__.py
@@ -18,4 +18,5 @@ from . import (
     work_queues,
     agents,
     artifacts,
+    variables,
 )

--- a/src/prefect/server/models/variables.py
+++ b/src/prefect/server/models/variables.py
@@ -1,0 +1,182 @@
+from typing import Optional
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server.database.dependencies import inject_db
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.schemas import filters, sorting
+from prefect.server.schemas.actions import VariableCreate, VariableUpdate
+
+
+@inject_db
+async def create_variable(
+    session: AsyncSession,
+    variable: VariableCreate,
+    db: PrefectDBInterface,
+):
+    """
+    Create a variable
+
+    Args:
+        session: async database session
+        variable: variable to create
+
+    Returns:
+        db.Variable
+    """
+    model = db.Variable(**variable.dict())
+    session.add(model)
+    await session.flush()
+
+    return model
+
+
+@inject_db
+async def read_variable(
+    session: AsyncSession,
+    variable_id: UUID,
+    db: PrefectDBInterface,
+):
+    """
+    Reads a variable by id.
+    """
+
+    query = sa.select(db.Variable).where(db.Variable.id == variable_id)
+
+    result = await session.execute(query)
+    return result.scalar()
+
+
+@inject_db
+async def read_variable_by_name(
+    session: AsyncSession,
+    name: str,
+    db: PrefectDBInterface,
+):
+    """
+    Reads a variable by name.
+    """
+
+    query = sa.select(db.Variable).where(db.Variable.name == name)
+
+    result = await session.execute(query)
+    return result.scalar()
+
+
+@inject_db
+async def read_variables(
+    session: AsyncSession,
+    db: PrefectDBInterface,
+    variable_filter: Optional[filters.VariableFilter] = None,
+    sort: sorting.VariableSort = sorting.VariableSort.NAME_ASC,
+    offset: int = None,
+    limit: int = None,
+):
+    """
+    Read variables, applying filers.
+    """
+    query = sa.select(db.Variable).order_by(sort.as_sql_sort(db))
+
+    if variable_filter:
+        query = query.where(variable_filter.as_sql_filter(db))
+
+    if offset is not None:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+
+    result = await session.execute(query)
+    return result.scalars().unique().all()
+
+
+@inject_db
+async def count_variables(
+    session: AsyncSession,
+    db: PrefectDBInterface,
+    variable_filter: Optional[filters.VariableFilter] = None,
+) -> int:
+    """
+    Count variables, applying filters.
+    """
+
+    query = sa.select(sa.func.count()).select_from(db.Variable)
+
+    if variable_filter:
+        query = query.where(variable_filter.as_sql_filter(db))
+
+    result = await session.execute(query)
+    return result.scalar()
+
+
+@inject_db
+async def update_variable(
+    session: AsyncSession,
+    variable_id: UUID,
+    variable: VariableUpdate,
+    db: PrefectDBInterface,
+) -> bool:
+    """
+    Updates a variable by id.
+    """
+    query = (
+        sa.update(db.Variable)
+        .where(db.Variable.id == variable_id)
+        .values(**variable.dict(shallow=True, exclude_unset=True))
+    )
+
+    result = await session.execute(query)
+    return result.rowcount > 0
+
+
+@inject_db
+async def update_variable_by_name(
+    session: AsyncSession,
+    name: str,
+    variable: VariableUpdate,
+    db: PrefectDBInterface,
+) -> bool:
+    """
+    Updates a variable by name.
+    """
+    query = (
+        sa.update(db.Variable)
+        .where(db.Variable.name == name)
+        .values(**variable.dict(shallow=True, exclude_unset=True))
+    )
+
+    result = await session.execute(query)
+    return result.rowcount > 0
+
+
+@inject_db
+async def delete_variable(
+    session: AsyncSession,
+    variable_id: UUID,
+    db: PrefectDBInterface,
+) -> bool:
+    """
+    Delete a variable by id.
+    """
+
+    query = sa.delete(db.Variable).where(db.Variable.id == variable_id)
+
+    result = await session.execute(query)
+    return result.rowcount > 0
+
+
+@inject_db
+async def delete_variable_by_name(
+    session: AsyncSession,
+    name: str,
+    db: PrefectDBInterface,
+) -> bool:
+    """
+    Delete a variable by name.
+    """
+
+    query = sa.delete(db.Variable).where(db.Variable.name == name)
+
+    result = await session.execute(query)
+    return result.rowcount > 0

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -22,6 +22,7 @@ from prefect.server.utilities.schemas import (
 from prefect.utilities.pydantic import get_class_fields_only
 
 LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
+LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX = "^[a-z0-9_]*$"
 
 
 def validate_block_type_slug(value):
@@ -53,9 +54,9 @@ def validate_artifact_key(value):
 
 
 def validate_variable_name(value):
-    if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
+    if not bool(re.match(LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX, value)):
         raise ValueError(
-            "name must only contain lowercase letters, numbers, and dashes"
+            "name must only contain lowercase letters, numbers, and underscores"
         )
     return value
 
@@ -612,7 +613,7 @@ class VariableUpdate(ActionBaseModel):
     name: Optional[str] = Field(
         default=None,
         description="The name of the variable",
-        example="my-variable",
+        example="my_variable",
         max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
     )
     value: Optional[str] = Field(

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -52,6 +52,14 @@ def validate_artifact_key(value):
     return value
 
 
+def validate_variable_name(value):
+    if not bool(re.match(LOWERCASE_LETTERS_AND_DASHES_ONLY_REGEX, value)):
+        raise ValueError(
+            "name must only contain lowercase letters, numbers, and dashes"
+        )
+    return value
+
+
 class ActionBaseModel(PrefectBaseModel):
     class Config:
         extra = "forbid"
@@ -583,3 +591,37 @@ class ArtifactUpdate(ActionBaseModel):
     data: Optional[Union[Dict[str, Any], Any]] = FieldFrom(schemas.core.Artifact)
     description: Optional[str] = FieldFrom(schemas.core.Artifact)
     metadata_: Optional[Dict[str, str]] = FieldFrom(schemas.core.Artifact)
+
+
+@copy_model_fields
+class VariableCreate(ActionBaseModel):
+    """Data used by the Prefect REST API to create a Variable."""
+
+    name: str = FieldFrom(schemas.core.Variable)
+    value: str = FieldFrom(schemas.core.Variable)
+    tags: Optional[List[str]] = FieldFrom(schemas.core.Variable)
+
+    # validators
+    _validate_name_format = validator("name", allow_reuse=True)(validate_variable_name)
+
+
+@copy_model_fields
+class VariableUpdate(ActionBaseModel):
+    """Data used by the Prefect REST API to update a Variable."""
+
+    name: Optional[str] = Field(
+        default=None,
+        description="The name of the variable",
+        example="my-variable",
+        max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
+    )
+    value: Optional[str] = Field(
+        default=None,
+        description="The value of the variable",
+        example="my-value",
+        max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
+    )
+    tags: Optional[List[str]] = FieldFrom(schemas.core.Variable)
+
+    # validators
+    _validate_name_format = validator("name", allow_reuse=True)(validate_variable_name)

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1212,7 +1212,7 @@ class Variable(ORMBaseModel):
     name: str = Field(
         default=...,
         description="The name of the variable",
-        example="my-variable",
+        example="my_variable",
         max_length=MAX_VARIABLE_NAME_LENGTH,
     )
     value: str = Field(

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -37,6 +37,9 @@ FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS = [
 
 DEFAULT_BLOCK_SCHEMA_VERSION = "non-versioned"
 
+MAX_VARIABLE_NAME_LENGTH = 255
+MAX_VARIABLE_VALUE_LENGTH = 5000
+
 
 def raise_on_invalid_name(name: str) -> None:
     """
@@ -1203,3 +1206,23 @@ class Artifact(ORMBaseModel):
             if len(str(v[key])) > max_metadata_length:
                 v[key] = str(v[key])[:max_metadata_length] + "..."
         return v
+
+
+class Variable(ORMBaseModel):
+    name: str = Field(
+        default=...,
+        description="The name of the variable",
+        example="my-variable",
+        max_length=MAX_VARIABLE_NAME_LENGTH,
+    )
+    value: str = Field(
+        default=...,
+        description="The value of the variable",
+        example="my-value",
+        max_length=MAX_VARIABLE_VALUE_LENGTH,
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="A list of variable tags",
+        example=["tag-1", "tag-2"],
+    )

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1221,7 +1221,7 @@ class Variable(ORMBaseModel):
         example="my-value",
         max_length=MAX_VARIABLE_VALUE_LENGTH,
     )
-    tags: list[str] = Field(
+    tags: List[str] = Field(
         default_factory=list,
         description="A list of variable tags",
         example=["tag-1", "tag-2"],

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1642,7 +1642,7 @@ class VariableFilterName(PrefectFilterBaseModel):
             "A string to match variable names against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-variable-%",
+        example="my_variable_%",
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1614,3 +1614,123 @@ class ArtifactFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.is_latest.as_sql_filter(db))
 
         return filters
+
+
+class VariableFilterId(PrefectFilterBaseModel):
+    """Filter by `Variable.id`."""
+
+    any_: Optional[List[UUID]] = Field(
+        default=None, description="A list of variable ids to include"
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.Variable.id.in_(self.any_))
+        return filters
+
+
+class VariableFilterName(PrefectFilterBaseModel):
+    """Filter by `Variable.name`."""
+
+    any_: Optional[List[str]] = Field(
+        default=None, description="A list of variables names to include"
+    )
+    like_: Optional[str] = Field(
+        default=None,
+        description=(
+            "A string to match variable names against. This can include "
+            "SQL wildcard characters like `%` and `_`."
+        ),
+        example="my-variable-%",
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.Variable.name.in_(self.any_))
+        if self.like_ is not None:
+            filters.append(db.Variable.name.ilike(f"%{self.like_}%"))
+        return filters
+
+
+class VariableFilterValue(PrefectFilterBaseModel):
+    """Filter by `Variable.value`."""
+
+    any_: Optional[List[str]] = Field(
+        default=None, description="A list of variables value to include"
+    )
+    like_: Optional[str] = Field(
+        default=None,
+        description=(
+            "A string to match variable value against. This can include "
+            "SQL wildcard characters like `%` and `_`."
+        ),
+        example="my-value-%",
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.Variable.value.in_(self.any_))
+        if self.like_ is not None:
+            filters.append(db.Variable.value.ilike(f"%{self.like_}%"))
+        return filters
+
+
+class VariableFilterTags(PrefectOperatorFilterBaseModel):
+    """Filter by `Variable.tags`."""
+
+    all_: Optional[List[str]] = Field(
+        default=None,
+        example=["tag-1", "tag-2"],
+        description=(
+            "A list of tags. Variables will be returned only if their tags are a"
+            " superset of the list"
+        ),
+    )
+    is_null_: Optional[bool] = Field(
+        default=None, description="If true, only include Variables without tags"
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        from prefect.server.utilities.database import json_has_all_keys
+
+        filters = []
+        if self.all_ is not None:
+            filters.append(json_has_all_keys(db.Variable.tags, self.all_))
+        if self.is_null_ is not None:
+            filters.append(
+                db.Variable.tags == [] if self.is_null_ else db.Variable.tags != []
+            )
+        return filters
+
+
+class VariableFilter(PrefectOperatorFilterBaseModel):
+    """Filter variables. Only variables matching all criteria will be returned"""
+
+    id: Optional[VariableFilterId] = Field(
+        default=None, description="Filter criteria for `Variable.id`"
+    )
+    name: Optional[VariableFilterName] = Field(
+        default=None, description="Filter criteria for `Variable.name`"
+    )
+    value: Optional[VariableFilterValue] = Field(
+        default=None, description="Filter criteria for `Variable.value`"
+    )
+    tags: Optional[VariableFilterTags] = Field(
+        default=None, description="Filter criteria for `Variable.tags`"
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+
+        if self.id is not None:
+            filters.append(self.id.as_sql_filter(db))
+        if self.name is not None:
+            filters.append(self.name.as_sql_filter(db))
+        if self.value is not None:
+            filters.append(self.value.as_sql_filter(db))
+        if self.tags is not None:
+            filters.append(self.tags.as_sql_filter(db))
+        return filters

--- a/src/prefect/server/schemas/sorting.py
+++ b/src/prefect/server/schemas/sorting.py
@@ -148,3 +148,22 @@ class ArtifactSort(AutoEnum):
             "KEY_ASC": db.Artifact.key.asc(),
         }
         return sort_mapping[self.value]
+
+
+class VariableSort(AutoEnum):
+    """Defines variables sorting options."""
+
+    CREATED_DESC = "CREATED_DESC"
+    UPDATED_DESC = "UPDATED_DESC"
+    NAME_DESC = "NAME_DESC"
+    NAME_ASC = "NAME_ASC"
+
+    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+        """Return an expression used to sort variables"""
+        sort_mapping = {
+            "CREATED_DESC": db.Variable.created.desc(),
+            "UPDATED_DESC": db.Variable.updated.desc(),
+            "NAME_DESC": db.Variable.name.desc(),
+            "NAME_ASC": db.Variable.name.asc(),
+        }
+        return sort_mapping[self.value]

--- a/tests/server/api/test_variables.py
+++ b/tests/server/api/test_variables.py
@@ -1,0 +1,634 @@
+import uuid
+
+import pydantic
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server.models.variables import create_variable
+from prefect.server.schemas import core, sorting
+from prefect.server.schemas.actions import VariableCreate, VariableUpdate
+from prefect.server.schemas.filters import (
+    VariableFilter,
+    VariableFilterId,
+    VariableFilterName,
+    VariableFilterTags,
+    VariableFilterValue,
+)
+
+
+@pytest.fixture
+async def variable(
+    session: AsyncSession,
+):
+    model = await create_variable(
+        session,
+        VariableCreate(name="my_variable", value="my-value", tags=["123", "456"]),
+    )
+    await session.commit()
+
+    return model
+
+
+@pytest.fixture
+async def variables(
+    session: AsyncSession,
+):
+    variables = [
+        VariableCreate(name="variable1", value="value1", tags=["tag1"]),
+        VariableCreate(name="variable12", value="value12", tags=["tag2"]),
+        VariableCreate(name="variable2", value="value2", tags=["tag1"]),
+        VariableCreate(name="variable21", value="value21", tags=["tag2"]),
+    ]
+    models = []
+    for variable in variables:
+        model = await create_variable(session, variable)
+        models.append(model)
+    await session.commit()
+
+    return models
+
+
+class TestCreateVariable:
+    async def test_create_variable(
+        self,
+        client: AsyncClient,
+    ):
+        variable = VariableCreate(
+            name="my_variable", value="my-value", tags=["123", "456"]
+        )
+        res = await client.post(
+            f"/variables/",
+            json=variable.dict(json_compatible=True),
+        )
+        assert res
+        assert res.status_code == 201
+
+        res = res.json()
+        assert res["id"]
+        assert res["created"]
+        assert res["updated"]
+
+        assert res["name"] == variable.name
+        assert res["value"] == variable.value
+        assert res["tags"] == variable.tags
+
+    @pytest.mark.parametrize(
+        "variable_name", ["MY_VARIABLE", "my variable", "my-variable", "!@#$%"]
+    )
+    async def test_name_constraints(
+        self,
+        client: AsyncClient,
+        variable_name: str,
+    ):
+        res = await client.post(
+            f"/variables/",
+            json={"name": variable_name, "value": "my-value"},
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            res.json()["exception_detail"][0]["msg"]
+            == "name must only contain lowercase letters, numbers, and underscores"
+        )
+
+    async def test_name_unique(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        same_name_variable = VariableCreate(name=variable.name, value="other-value")
+        res = await client.post(
+            f"/variables/",
+            json=same_name_variable.dict(json_compatible=True),
+        )
+        assert res
+        assert res.status_code == 409
+
+    async def test_name_max_length(
+        self,
+        client: AsyncClient,
+    ):
+        max_length = 255
+
+        res = await client.post(
+            f"/variables/",
+            json={"name": "v" * max_length, "value": "value"},
+        )
+        assert res
+        assert res.status_code == 201
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.post(
+            f"/variables/",
+            json={"name": "v" * max_length_plus1, "value": "value"},
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
+
+    async def test_value_max_length(
+        self,
+        client: AsyncClient,
+    ):
+        max_length = 5000
+
+        res = await client.post(
+            f"/variables/",
+            json={"name": "name", "value": "v" * max_length},
+        )
+        assert res
+        assert res.status_code == 201
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.post(
+            f"/variables/",
+            json={"name": "name", "value": "v" * max_length_plus1},
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
+
+
+class TestReadVariable:
+    async def test_read_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        res = await client.get(
+            f"/variables/{variable.id}",
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(core.Variable, res.json())
+        assert res.id == variable.id
+        assert res.name == variable.name
+        assert res.tags == variable.tags
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.get(
+            f"/variables/{uuid.uuid4()}",
+        )
+        assert res.status_code == 404
+
+
+class TestReadVariableByName:
+    async def test_read_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        res = await client.get(
+            f"/variables/name/{variable.name}",
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(core.Variable, res.json())
+        assert res.id == variable.id
+        assert res.name == variable.name
+        assert res.tags == variable.tags
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.get(
+            f"/variables/name/doesntexist",
+        )
+        assert res.status_code == 404
+
+
+class TestReadVariables:
+    async def test_no_results(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.post(
+            f"/variables/filter",
+        )
+        assert res.status_code == 200
+        assert len(res.json()) == 0
+
+    async def test_no_filter(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        res = await client.post(
+            f"/variables/filter",
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == len(variables)
+        assert {v.id for v in res} == {v.id for v in variables}
+
+    async def test_filter_name(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(
+                    name=VariableFilterName(any_=["variable1"])
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 1
+        assert {v.id for v in res} == {v.id for v in variables if v.name == "variable1"}
+
+        # like filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(
+                    name=VariableFilterName(like_="variable1%")
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 2
+        assert {v.id for v in res} == {v.id for v in variables if "variable1" in v.name}
+
+    async def test_filter_value(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(
+                    value=VariableFilterValue(any_=["value1"])
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 1
+        assert {v.id for v in res} == {v.id for v in variables if v.value == "value1"}
+
+        # like filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(
+                    value=VariableFilterValue(like_="value1%")
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 2
+        assert {v.id for v in res} == {v.id for v in variables if "value1" in v.value}
+
+    async def test_filter_id(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        variable = variables[0]
+        # any filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(id=VariableFilterId(any_=[variable.id])).dict(
+                    json_compatible=True
+                )
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 1
+        assert {v.id for v in res} == {variable.id}
+
+    async def test_filter_tags(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/filter",
+            json=dict(
+                variables=VariableFilter(tags=VariableFilterTags(all_=["tag1"])).dict(
+                    json_compatible=True
+                )
+            ),
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == 2
+        assert {v.id for v in res} == {v.id for v in variables if "tag1" in v.tags}
+
+    async def test_name_sorted_forwards(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # name sorted forwards
+        res = await client.post(
+            f"/variables/filter",
+            json={"sort": sorting.VariableSort.NAME_ASC},
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == len(variables)
+        assert [v.name for v in res] == sorted([v.name for v in variables])
+
+    async def test_name_sorted_backwards(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # name sorted backwards
+        res = await client.post(
+            f"/variables/filter",
+            json={"sort": sorting.VariableSort.NAME_DESC},
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(list[core.Variable], res.json())
+        assert len(res) == len(variables)
+        assert [v.name for v in res] == sorted(
+            [v.name for v in variables], reverse=True
+        )
+
+
+class TestCountVariables:
+    async def test_no_results(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.post(
+            f"/variables/count",
+        )
+        assert res.status_code == 200
+        assert res.json() == 0
+
+    async def test_no_filter(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        res = await client.post(
+            f"/variables/count",
+        )
+        assert res.status_code == 200
+        assert res.json() == 4
+
+    async def test_filter_name(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(
+                    name=VariableFilterName(any_=["variable1"])
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        assert res.json() == 1
+
+        # like filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(
+                    name=VariableFilterName(like_="variable1%")
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        assert res.json() == 2
+
+    async def test_filter_value(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(
+                    value=VariableFilterValue(any_=["value1"])
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        assert res.json() == 1
+
+        # like filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(
+                    value=VariableFilterValue(like_="value1%")
+                ).dict(json_compatible=True)
+            ),
+        )
+        assert res.status_code == 200
+        assert res.json() == 2
+
+    async def test_filter_id(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        variable = variables[0]
+        # any filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(id=VariableFilterId(any_=[variable.id])).dict(
+                    json_compatible=True
+                )
+            ),
+        )
+        assert res.json() == 1
+
+    async def test_filter_tags(
+        self,
+        client: AsyncClient,
+        variables,
+    ):
+        # any filter
+        res = await client.post(
+            f"/variables/count",
+            json=dict(
+                variables=VariableFilter(tags=VariableFilterTags(all_=["tag1"])).dict(
+                    json_compatible=True
+                )
+            ),
+        )
+        assert res.status_code == 200
+        assert res.json() == 2
+
+
+class TestUpdateVariable:
+    async def test_update_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        update = VariableUpdate(
+            name="updated_variable", value="updated-value", tags=["updated-tag"]
+        )
+        res = await client.patch(
+            f"/variables/{variable.id}",
+            json=update.dict(json_compatible=True),
+        )
+        assert res.status_code == 204
+        res = await client.get(
+            f"/variables/{variable.id}",
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(core.Variable, res.json())
+        assert res.id == variable.id
+        assert res.name == update.name
+        assert res.value == update.value
+        assert res.tags == update.tags
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        update = VariableUpdate(
+            name="updated_variable", value="updated-value", tags=["updated-tag"]
+        )
+        res = await client.patch(
+            f"/variables/{uuid.uuid4()}",
+            json=update.dict(json_compatible=True),
+        )
+        assert res.status_code == 404
+
+    async def test_name_unique(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        same_name_update = VariableUpdate(name=variable.name)
+        res = await client.patch(
+            f"/variables/{variable.id}",
+            json=same_name_update.dict(json_compatible=True),
+        )
+        assert res
+        assert res.status_code == 409
+
+
+class TestUpdateVariableByName:
+    async def test_update_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        update = VariableUpdate(
+            name="updated_variable", value="updated-value", tags=["updated-tag"]
+        )
+        res = await client.patch(
+            f"/variables/name/{variable.name}",
+            json=update.dict(json_compatible=True),
+        )
+        assert res.status_code == 204
+        res = await client.get(
+            f"/variables/{variable.id}",
+        )
+        assert res.status_code == 200
+        res = pydantic.parse_obj_as(core.Variable, res.json())
+        assert res.id == variable.id
+        assert res.name == update.name
+        assert res.value == update.value
+        assert res.tags == update.tags
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        update = VariableUpdate(
+            name="updated_variable", value="updated-value", tags=["updated-tag"]
+        )
+        res = await client.patch(
+            f"/variables/name/doesnotexist",
+            json=update.dict(json_compatible=True),
+        )
+        assert res.status_code == 404
+
+    async def test_name_unique(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        same_name_update = VariableUpdate(name=variable.name)
+        res = await client.patch(
+            f"/variables/name/{variable.name}",
+            json=same_name_update.dict(json_compatible=True),
+        )
+        assert res.status_code == 409
+
+
+class TestDeleteVariable:
+    async def test_delete_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        res = await client.delete(
+            f"/variables/{variable.id}",
+        )
+        assert res.status_code == 204
+        res = await client.get(
+            f"/variables/{variable.id}",
+        )
+        assert res.status_code == 404
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.delete(
+            f"/variables/{uuid.uuid4()}",
+        )
+        assert res.status_code == 404
+
+
+class TestDeleteVariableByName:
+    async def test_delete_variable(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        res = await client.delete(
+            f"/variables/name/{variable.name}",
+        )
+        assert res.status_code == 204
+        res = await client.get(
+            f"/variables/name/{variable.name}",
+        )
+        assert res.status_code == 404
+
+    async def test_does_not_exist(
+        self,
+        client: AsyncClient,
+    ):
+        res = await client.delete(
+            f"/variables/name/doesntexist",
+        )
+        assert res.status_code == 404

--- a/tests/server/models/test_variables.py
+++ b/tests/server/models/test_variables.py
@@ -32,7 +32,7 @@ async def variable(
 ):
     model = await create_variable(
         session,
-        VariableCreate(name="my-variable", value="my-value", tags=["123", "456"]),
+        VariableCreate(name="my_variable", value="my-value", tags=["123", "456"]),
     )
     await session.commit()
 
@@ -66,7 +66,7 @@ class TestCreateVariable:
         now = pendulum.now("UTC")
 
         variable = VariableCreate(
-            name="my-variable", value="my-value", tags=["123", "456"]
+            name="my_variable", value="my-value", tags=["123", "456"]
         )
         model = await create_variable(session, variable)
         await session.commit()
@@ -88,7 +88,7 @@ class TestCreateVariable:
             await create_variable(
                 session,
                 VariableCreate(
-                    name="my-variable", value="my-value", tags=["123", "456"]
+                    name="my_variable", value="my-value", tags=["123", "456"]
                 ),
             )
 
@@ -258,7 +258,7 @@ class TestUpdateVariable:
         session,
         variable,
     ):
-        new_name = "another-name"
+        new_name = "another_name"
         updated = await update_variable(
             session, variable.id, VariableUpdate(name=new_name)  # type: ignore
         )
@@ -273,7 +273,7 @@ class TestUpdateVariable:
         session,
         variable,
     ):
-        new_value = "another-name"
+        new_value = "another_name"
         updated = await update_variable(
             session, variable.id, VariableUpdate(value=new_value)  # type: ignore
         )
@@ -305,7 +305,7 @@ class TestUpdateVariableByName:
         session,
         variable,
     ):
-        new_name = "another-name"
+        new_name = "another_name"
         updated = await update_variable_by_name(
             session, variable.name, VariableUpdate(name=new_name)
         )
@@ -319,7 +319,7 @@ class TestUpdateVariableByName:
         session,
         variable,
     ):
-        new_value = "another-name"
+        new_value = "another_name"
         updated = await update_variable_by_name(
             session, variable.name, VariableUpdate(value=new_value)
         )

--- a/tests/server/models/test_variables.py
+++ b/tests/server/models/test_variables.py
@@ -1,0 +1,386 @@
+import uuid
+
+import pendulum
+import pytest
+import sqlalchemy as sa
+
+from prefect.server.models.variables import (
+    count_variables,
+    create_variable,
+    delete_variable,
+    delete_variable_by_name,
+    read_variable,
+    read_variable_by_name,
+    read_variables,
+    update_variable,
+    update_variable_by_name,
+)
+from prefect.server.schemas.actions import VariableCreate, VariableUpdate
+from prefect.server.schemas.filters import (
+    VariableFilter,
+    VariableFilterId,
+    VariableFilterName,
+    VariableFilterTags,
+    VariableFilterValue,
+)
+from prefect.server.schemas.sorting import VariableSort
+
+
+@pytest.fixture
+async def variable(
+    session,
+):
+    model = await create_variable(
+        session,
+        VariableCreate(name="my-variable", value="my-value", tags=["123", "456"]),
+    )
+    await session.commit()
+
+    return model
+
+
+@pytest.fixture
+async def variables(
+    session,
+):
+    variables = [
+        VariableCreate(name="variable1", value="value1", tags=["tag1"]),
+        VariableCreate(name="variable12", value="value12", tags=["tag2"]),
+        VariableCreate(name="variable2", value="value2", tags=["tag1"]),
+        VariableCreate(name="variable21", value="value21", tags=["tag2"]),
+    ]
+    models = []
+    for variable in variables:
+        model = await create_variable(session, variable)
+        models.append(model)
+    await session.commit()
+
+    return models
+
+
+class TestCreateVariable:
+    async def test_create_variable(
+        self,
+        session,
+    ):
+        now = pendulum.now("UTC")
+
+        variable = VariableCreate(
+            name="my-variable", value="my-value", tags=["123", "456"]
+        )
+        model = await create_variable(session, variable)
+        await session.commit()
+
+        assert model
+        assert model.id
+        assert model.created and model.created > now
+        assert model.updated and model.updated > now
+        assert model.name == variable.name
+        assert model.value == variable.value
+        assert model.tags == variable.tags
+
+    async def test_create_variable_name_unique(
+        self,
+        session,
+        variable,
+    ):
+        with pytest.raises(sa.exc.IntegrityError):
+            await create_variable(
+                session,
+                VariableCreate(
+                    name="my-variable", value="my-value", tags=["123", "456"]
+                ),
+            )
+
+
+class TestReadVariable:
+    async def test_read_variable(
+        self,
+        session,
+        variable,
+    ):
+        model = await read_variable(session, variable.id)  # type: ignore
+        assert model
+        assert model.id == variable.id
+        assert model.name == variable.name
+        assert model.tags == variable.tags
+
+
+class TestReadVariableByName:
+    async def test_read_variable(
+        self,
+        session,
+        variable,
+    ):
+        model = await read_variable_by_name(session, variable.name)
+        assert model
+        assert model.id == variable.id
+        assert model.name == variable.name
+        assert model.tags == variable.tags
+
+
+class TestReadVariables:
+    async def test_no_filter(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(session)
+        assert len(res) == 4
+        assert {r.id for r in res} == {v.id for v in variables}
+
+    async def test_filter_by_id(
+        self,
+        session,
+        variables,
+    ):
+        variable = variables[0]
+
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(id=VariableFilterId(any_=[variable.id])),
+        )
+        assert len(res) == 1
+        assert res[0].id == variable.id
+
+    async def test_filter_by_any_name(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(name=VariableFilterName(any_=["variable1"])),
+        )
+        assert len(res) == 1
+        assert {r.id for r in res} == {v.id for v in variables if "variable1" == v.name}
+
+    async def test_filter_by_like_name(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(name=VariableFilterName(like_="variable1%")),
+        )
+        assert len(res) == 2
+        assert {r.id for r in res} == {v.id for v in variables if "variable1" in v.name}
+
+    async def test_filter_by_any_value(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(value=VariableFilterValue(any_=["value1"])),
+        )
+        assert len(res) == 1
+        assert {r.id for r in res} == {v.id for v in variables if "value1" == v.value}
+
+    async def test_filter_by_like_value(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(value=VariableFilterValue(like_="value1%")),
+        )
+        assert len(res) == 2
+        assert {r.id for r in res} == {v.id for v in variables if "value1" in v.value}
+
+    async def test_filter_by_tag(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(
+            session,
+            variable_filter=VariableFilter(tags=VariableFilterTags(all_=["tag1"])),
+        )
+        assert len(res) == 2
+        assert {r.id for r in res} == {v.id for v in variables if "tag1" in v.tags}
+
+    async def test_sorted_by_name_asc(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(session, sort=VariableSort.NAME_ASC)
+        assert len(res) == 4
+        assert [r.name for r in res] == sorted([v.name for v in variables])
+
+    async def test_sorted_by_name_desc(
+        self,
+        session,
+        variables,
+    ):
+        res = await read_variables(session, sort=VariableSort.NAME_DESC)
+        assert len(res) == 4
+        assert [r.name for r in res] == sorted(
+            [v.name for v in variables], reverse=True
+        )
+
+
+class TestCountVariables:
+    async def test_count_zero_variables(
+        self,
+        session,
+    ):
+        res = await count_variables(session)
+        assert res == 0
+
+    async def test_count_one_variables(
+        self,
+        session,
+        variable,
+    ):
+        res = await count_variables(session)
+        assert res == 1
+
+    async def test_count_variables_with_filter(
+        self,
+        session,
+        variables,
+    ):
+        res = await count_variables(
+            session,
+            variable_filter=VariableFilter(name=VariableFilterName(like_="variable1%")),
+        )
+        assert res == 2
+
+
+class TestUpdateVariable:
+    async def test_update_name(
+        self,
+        session,
+        variable,
+    ):
+        new_name = "another-name"
+        updated = await update_variable(
+            session, variable.id, VariableUpdate(name=new_name)  # type: ignore
+        )
+        assert updated
+
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.name == new_name
+
+    async def test_update_value(
+        self,
+        session,
+        variable,
+    ):
+        new_value = "another-name"
+        updated = await update_variable(
+            session, variable.id, VariableUpdate(value=new_value)  # type: ignore
+        )
+        assert updated
+
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.value == new_value
+
+    async def test_update_tags(
+        self,
+        session,
+        variable,
+    ):
+        new_tags = ["new-tag-123"]
+        updated = await update_variable(
+            session, variable.id, VariableUpdate(tags=new_tags)  # type: ignore
+        )
+        assert updated
+
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.tags == new_tags
+
+
+class TestUpdateVariableByName:
+    async def test_update_name(
+        self,
+        session,
+        variable,
+    ):
+        new_name = "another-name"
+        updated = await update_variable_by_name(
+            session, variable.name, VariableUpdate(name=new_name)
+        )
+        assert updated
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.name == new_name
+
+    async def test_update_value(
+        self,
+        session,
+        variable,
+    ):
+        new_value = "another-name"
+        updated = await update_variable_by_name(
+            session, variable.name, VariableUpdate(value=new_value)
+        )
+        assert updated
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.value == new_value
+
+    async def test_update_tags(
+        self,
+        session,
+        variable,
+    ):
+        new_tags = ["new-tag-123"]
+        updated = await update_variable_by_name(
+            session, variable.name, VariableUpdate(tags=new_tags)
+        )
+        assert updated
+
+        updated_variable = await read_variable(session, variable.id)  # type: ignore
+        assert updated_variable
+        assert updated_variable.tags == new_tags
+
+
+class TestDeleteVariable:
+    async def test_delete_variable(
+        self,
+        session,
+        variable,
+    ):
+        deleted = await delete_variable(session, variable.id)  # type: ignore
+        assert deleted
+
+        model = await read_variable(session, variable.id)  # type: ignore
+        assert not model
+
+    async def test_variable_doesnt_exist(
+        self,
+        session,
+        variable,
+    ):
+        deleted = await delete_variable(session, uuid.uuid4())
+        assert not deleted
+
+
+class TestDeleteVariableByName:
+    async def test_delete_variable_by_name(
+        self,
+        session,
+        variable,
+    ):
+        deleted = await delete_variable_by_name(session, variable.name)
+        assert deleted
+
+        model = await read_variable(session, variable.id)  # type: ignore
+        assert not model
+
+    async def test_variable_doesnt_exist(
+        self,
+        session,
+        variable,
+    ):
+        deleted = await delete_variable_by_name(session, "doesntexist")
+        assert not deleted


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/9067

OSS implementation of `Variables` API routes:

- create a variable: `POST - /variables/` 
- read a variable: `GET - /variables/{id}`
- read a variable by name: `GET - `/variables/name/{name}`
- read variables: `POST - /variables/filter`
- count variables: `POST - /variables/count`
- update variable: `PATCH - /variables/{id}`
- update variable by name: `PATCH - /variables/name/{name}`
- delete variable: `DELETE - /variables/{id}`
- delete variable by name: `DELETE - /variables/name/{name}`