### PR TITLE
Add a 10 minute cache to API healthchecks

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -20,6 +20,7 @@ import logging
 import os
 import signal
 import sys
+import time
 from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
 from functools import partial
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, Set, TypeVar, Union
@@ -35,6 +36,7 @@ import prefect.context
 from prefect._internal.concurrency.api import create_call, from_async, from_sync
 from prefect._internal.concurrency.calls import get_current_call
 from prefect._internal.concurrency.threads import wait_for_global_loop_exit
+from prefect._internal.concurrency.timeouts import get_deadline
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
 from prefect.client.utilities import inject_client
@@ -114,6 +116,7 @@ R = TypeVar("R")
 EngineReturnType = Literal["future", "state", "result"]
 
 
+API_HEALTHCHECKS = {}
 UNTRACKABLE_TYPES = {bool, type(None), type(...), type(NotImplemented)}
 engine_logger = get_logger("engine")
 
@@ -217,11 +220,8 @@ async def create_then_begin_flow_run(
     # TODO: Returns a `State` depending on `return_type` and we can add an overload to
     #       the function signature to clarify this eventually.
 
-    connect_error = await client.api_healthcheck()
-    if connect_error:
-        raise RuntimeError(
-            f"Cannot create flow run. Failed to reach API at {client.api_url}."
-        ) from connect_error
+    await check_api_reachable(client, "Cannot create flow run")
+
     state = Pending()
     if flow.should_validate_parameters:
         try:
@@ -1358,13 +1358,9 @@ async def begin_task_run(
         if log_prints:
             stack.enter_context(patch_print())
 
-        connect_error = await client.api_healthcheck()
-        if connect_error:
-            raise RuntimeError(
-                f"Cannot orchestrate task run '{task_run.id}'. "
-                f"Failed to connect to API at {client.api_url}."
-            ) from connect_error
-
+        await check_api_reachable(
+            client, f"Cannot orchestrate task run '{task_run.id}'"
+        )
         try:
             state = await orchestrate_task_run(
                 task=task,
@@ -2119,6 +2115,23 @@ async def _run_flow_hooks(flow: Flow, flow_run: FlowRun, state: State) -> None:
                 )
             else:
                 logger.info(f"Hook {hook.__name__!r} finished running successfully")
+
+
+async def check_api_reachable(client: PrefectClient, fail_message: str):
+    # Do not perform a healthcheck if it exists and is not expired
+    if client.api_url in API_HEALTHCHECKS:
+        expires = API_HEALTHCHECKS[client.api_url]
+        if expires < time.monotonic():
+            return
+
+    connect_error = await client.api_healthcheck()
+    if connect_error:
+        raise RuntimeError(
+            f"{fail_message}. Failed to reach API at {client.api_url}."
+        ) from connect_error
+
+    # Create a 10 minute cache for the healthy response
+    API_HEALTHCHECKS[client.api_url] = get_deadline(60 * 10)
 
 
 if __name__ == "__main__":

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2119,19 +2119,20 @@ async def _run_flow_hooks(flow: Flow, flow_run: FlowRun, state: State) -> None:
 
 async def check_api_reachable(client: PrefectClient, fail_message: str):
     # Do not perform a healthcheck if it exists and is not expired
-    if client.api_url in API_HEALTHCHECKS:
-        expires = API_HEALTHCHECKS[client.api_url]
-        if expires < time.monotonic():
+    api_url = str(client.api_url)
+    if api_url in API_HEALTHCHECKS:
+        expires = API_HEALTHCHECKS[api_url]
+        if expires > time.monotonic():
             return
 
     connect_error = await client.api_healthcheck()
     if connect_error:
         raise RuntimeError(
-            f"{fail_message}. Failed to reach API at {client.api_url}."
+            f"{fail_message}. Failed to reach API at {api_url}."
         ) from connect_error
 
     # Create a 10 minute cache for the healthy response
-    API_HEALTHCHECKS[client.api_url] = get_deadline(60 * 10)
+    API_HEALTHCHECKS[api_url] = get_deadline(60 * 10)
 
 
 if __name__ == "__main__":

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -74,7 +74,7 @@ async def hosted_api_server(unused_tcp_port_factory):
             with anyio.move_on_after(20):
                 while True:
                     try:
-                        response = await client.get(api_url + "health")
+                        response = await client.get(api_url + "/health")
                     except httpx.ConnectError:
                         pass
                     else:

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -66,7 +66,7 @@ async def hosted_api_server(unused_tcp_port_factory):
         stderr=sys.stderr,
         env={**os.environ, **get_current_settings().to_environment_variables()},
     ) as process:
-        api_url = f"http://localhost:{port}/api"
+        api_url = f"http://localhost:{port}/api/"
 
         # Wait for the server to be ready
         async with httpx.AsyncClient() as client:
@@ -74,7 +74,7 @@ async def hosted_api_server(unused_tcp_port_factory):
             with anyio.move_on_after(20):
                 while True:
                     try:
-                        response = await client.get(api_url + "/health")
+                        response = await client.get(api_url + "health")
                     except httpx.ConnectError:
                         pass
                     else:

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -66,7 +66,7 @@ async def hosted_api_server(unused_tcp_port_factory):
         stderr=sys.stderr,
         env={**os.environ, **get_current_settings().to_environment_variables()},
     ) as process:
-        api_url = f"http://localhost:{port}/api/"
+        api_url = f"http://localhost:{port}/api"
 
         # Wait for the server to be ready
         async with httpx.AsyncClient() as client:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,6 +3,7 @@ import os
 import signal
 import statistics
 import sys
+import time
 from contextlib import contextmanager
 from functools import partial
 from typing import List
@@ -16,10 +17,13 @@ from pydantic import BaseModel
 
 import prefect.flows
 from prefect import engine, flow, task
+from prefect.client.orchestration import get_client
 from prefect.client.schemas import OrchestrationResult
 from prefect.context import FlowRunContext, get_run_context
 from prefect.engine import (
+    API_HEALTHCHECKS,
     begin_flow_run,
+    check_api_reachable,
     create_and_begin_subflow_run,
     create_then_begin_flow_run,
     link_state_to_result,
@@ -2001,3 +2005,67 @@ class TestLinkStateToResult:
         with await get_flow_run_context():
             link_state_to_result(state=state, result=test_input)
             assert state.state_details.untrackable_result == expected_status
+
+
+class TestAPIHealthcheck:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        API_HEALTHCHECKS.clear()
+        yield
+
+    async def test_healthcheck_for_ephemeral_client(self):
+        async with get_client() as client:
+            await check_api_reachable(client, fail_message="test")
+
+        # Check caching
+        assert "http://ephemeral-prefect/api/" in API_HEALTHCHECKS
+        assert isinstance(API_HEALTHCHECKS["http://ephemeral-prefect/api/"], float)
+
+        assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] == pytest.approx(
+            time.monotonic() + 60 * 10, abs=5
+        )
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_healthcheck_for_remote_client(self, hosted_api_server):
+        async with get_client() as client:
+            await check_api_reachable(client, fail_message="test")
+
+        assert hosted_api_server in API_HEALTHCHECKS
+        assert isinstance(API_HEALTHCHECKS[hosted_api_server], float)
+
+        assert API_HEALTHCHECKS[hosted_api_server] == pytest.approx(
+            time.monotonic() + 60 * 10, abs=10
+        )
+
+    async def test_healthcheck_not_reset_within_expiration(self):
+        async with get_client() as client:
+            await check_api_reachable(client, fail_message="test")
+            value = API_HEALTHCHECKS["http://ephemeral-prefect/api/"]
+            for _ in range(2):
+                await check_api_reachable(client, fail_message="test")
+                assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] == value
+
+    async def test_healthcheck_reset_after_expiration(self):
+        async with get_client() as client:
+            await check_api_reachable(client, fail_message="test")
+            value = API_HEALTHCHECKS[
+                "http://ephemeral-prefect/api/"
+            ] = time.monotonic()  # set it to expire now
+            await check_api_reachable(client, fail_message="test")
+            assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] != value
+            assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] == pytest.approx(
+                time.monotonic() + 60 * 10, abs=5
+            )
+
+    async def test_failed_healthcheck(self):
+        async with get_client() as client:
+            client.api_healthcheck = AsyncMock(return_value=ValueError("test"))
+            with pytest.raises(
+                RuntimeError,
+                match="test. Failed to reach API at http://ephemeral-prefect/api/.",
+            ):
+                await check_api_reachable(client, fail_message="test")
+
+            # Not cached
+            assert "http://ephemeral-prefect/api/" not in API_HEALTHCHECKS
+            assert len(API_HEALTHCHECKS.keys()) == 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2030,10 +2030,12 @@ class TestAPIHealthcheck:
         async with get_client() as client:
             await check_api_reachable(client, fail_message="test")
 
-        assert hosted_api_server in API_HEALTHCHECKS
-        assert isinstance(API_HEALTHCHECKS[hosted_api_server], float)
+        expected_url = hosted_api_server + "/"  # httpx client appends trailing /
 
-        assert API_HEALTHCHECKS[hosted_api_server] == pytest.approx(
+        assert expected_url in API_HEALTHCHECKS
+        assert isinstance(API_HEALTHCHECKS[expected_url], float)
+
+        assert API_HEALTHCHECKS[expected_url] == pytest.approx(
             time.monotonic() + 60 * 10, abs=10
         )
 


### PR DESCRIPTION
Caching applies per API URL reducing the number of redundant API healthchecks we make. Only applies to explicit checks in the engine, this is not applied at the client level.