### PR TITLE
Avoid using spin locks while waiting for task submission

### DIFF
--- a/src/prefect/_internal/concurrency/event_loop.py
+++ b/src/prefect/_internal/concurrency/event_loop.py
@@ -5,7 +5,7 @@ Thread-safe utilities for working with asynchronous event loops.
 import asyncio
 import concurrent.futures
 import functools
-from typing import Callable, Optional, TypeVar
+from typing import Awaitable, Callable, Coroutine, Optional, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -76,3 +76,19 @@ def call_soon_in_loop(
         __loop.call_soon_threadsafe(wrapper)
 
     return future
+
+
+async def run_coroutine_in_loop_from_async(
+    __loop: asyncio.AbstractEventLoop, __coro: Coroutine
+) -> Awaitable:
+    """
+    Run an asynchronous call in an event loop from an asynchronous context.
+
+    Returns an awaitable that returns the result of the coroutine.
+    """
+    if __loop is get_running_loop():
+        return await __coro
+    else:
+        return await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(__coro, __loop)
+        )

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -23,6 +23,7 @@ from uuid import UUID
 import anyio
 
 from prefect._internal.concurrency.api import create_call, from_sync
+from prefect._internal.concurrency.event_loop import run_coroutine_in_loop_from_async
 from prefect.client.orchestration import PrefectClient
 from prefect.client.utilities import inject_client
 from prefect.states import State
@@ -277,16 +278,7 @@ class PrefectFuture(Generic[R, A]):
         return task_run.state
 
     async def _wait_for_submission(self):
-        import asyncio
-
-        # TODO: This spin lock is not performant but is necessary for cases where a
-        #       future is created in a separate event loop i.e. when a sync task is
-        #       called in an async flow
-        if not asyncio.get_running_loop() == self._loop:
-            while not self._submitted.is_set():
-                await anyio.sleep(0)
-        else:
-            await self._submitted.wait()
+        await run_coroutine_in_loop_from_async(self._loop, self._submitted.wait())
 
     def __hash__(self) -> int:
         return hash(self.key)


### PR DESCRIPTION
Supersedes #9070 
Closes https://github.com/PrefectHQ/prefect/issues/8986
May resolve https://github.com/PrefectHQ/prefect/issues/8982

Removes use of a spin-lock for cross-event loop waits in favor of nice future-based scheduling :) should be a significant performance improvement for some task submission cases and may resolve submission deadlocks.