### PR TITLE
Enables use of block document placeholders in steps

### DIFF
--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -116,7 +116,7 @@ async def clone(
 
     # TODO: allow for passing values between steps / stacking them
     for step in deployment.pull_steps:
-        output = run_step(step)
+        output = await run_step(step)
 
     app.console.out(output["directory"])
 

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -360,7 +360,7 @@ async def deploy(
     ## RUN BUILD AND PUSH STEPS
     step_outputs = {}
     for step in project["build"] + project["push"]:
-        step_outputs.update(run_step(step))
+        step_outputs.update(await run_step(step))
 
     variable_overrides = {}
     for variable in variables or []:

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -199,7 +199,7 @@ async def load_flow_from_flow_run(
         # TODO: allow for passing values between steps / stacking them
         output = {}
         for step in deployment.pull_steps:
-            output.update(run_step(step))
+            output.update(await run_step(step))
         if output.get("directory"):
             logger.debug(f"Changing working directory to {output['directory']!r}")
             os.chdir(output["directory"])

--- a/src/prefect/projects/steps/core.py
+++ b/src/prefect/projects/steps/core.py
@@ -6,6 +6,7 @@ import sys
 from typing import Optional
 
 from prefect.utilities.importtools import import_object
+from prefect.utilities.templating import resolve_block_document_references
 
 RESERVED_KEYWORDS = {"requires"}
 
@@ -33,7 +34,7 @@ def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = 
     return step_func
 
 
-def run_step(step: dict) -> dict:
+async def run_step(step: dict) -> dict:
     """
     Runs a step, returns the step's output.
 
@@ -57,6 +58,8 @@ def run_step(step: dict) -> dict:
         for keyword in RESERVED_KEYWORDS
         if keyword in inputs
     }
+
+    inputs = await resolve_block_document_references(inputs)
 
     step_func = _get_function_for_step(fqn, requires=keywords.get("requires"))
     return step_func(**inputs)

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -211,7 +211,11 @@ async def resolve_block_document_references(
             block_document = await client.read_block_document_by_name(
                 name=block_document_name, block_type_slug=block_type_slug
             )
-            return block_document.data
+            # Handling for system blocks like Secret that have a value field
+            # These blocks will be replaced by variables in the future and this
+            # logic can be removed at that time.
+            value = block_document.data.get("value", block_document.data)
+            return value
         else:
             raise ValueError(
                 f"Invalid template: {template!r}. Only a single block placeholder is"

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -1,6 +1,7 @@
 import pytest
 
 from prefect import Flow
+from prefect.blocks.system import Secret
 from prefect.projects.steps import run_step
 
 
@@ -13,6 +14,21 @@ class TestRunStep:
 
     async def test_run_step_errors_with_improper_format(self):
         with pytest.raises(ValueError, match="unexpected"):
-            run_step(
+            await run_step(
                 {"prefect.flow": {"__fn": lambda x: 42, "name": "test-name"}, "jedi": 0}
             )
+
+    async def test_run_step_resolves_block_document_references_before_running(self):
+        await Secret(value="secret-name").save(name="test-secret")
+
+        flow = await run_step(
+            {
+                "prefect.flow": {
+                    "__fn": lambda x: 42,
+                    "name": "{{ prefect.blocks.secret.test-secret }}",
+                }
+            }
+        )
+        assert isinstance(flow, Flow)
+        assert flow.name == "secret-name"
+        assert flow.fn(None) == 42

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -7,7 +7,9 @@ from prefect.projects.steps import run_step
 
 class TestRunStep:
     async def test_run_step_runs_importable_functions(self):
-        flow = run_step({"prefect.flow": {"__fn": lambda x: 42, "name": "test-name"}})
+        flow = await run_step(
+            {"prefect.flow": {"__fn": lambda x: 42, "name": "test-name"}}
+        )
         assert isinstance(flow, Flow)
         assert flow.name == "test-name"
         assert flow.fn(None) == 42


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Allows the use of block document placeholders in project steps. For blocks that have a `value` field, `resolve_block_document_references` will unpack and return the value stored in `value` to make `JSON` and `Secret` blocks more readily usable.

I had to make `run_step` an `async` function to add a call to `resolve_block_document_references`, but I don't expect that to cause any issues.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
