### PR TITLE
Add `access_token` to `git_clone_project` step for private repository support

### DIFF
--- a/src/prefect/projects/recipes/docker-git/prefect.yaml
+++ b/src/prefect/projects/recipes/docker-git/prefect.yaml
@@ -14,3 +14,4 @@ pull:
   - prefect.projects.steps.git_clone_project:
       repository: "{{ repository }}"
       branch: "{{ branch }}"
+      access_token: null

--- a/src/prefect/projects/recipes/git/prefect.yaml
+++ b/src/prefect/projects/recipes/git/prefect.yaml
@@ -7,3 +7,4 @@ pull:
   - prefect.projects.steps.git_clone_project:
       repository: "{{ repository }}"
       branch: "{{ branch }}"
+      access_token: null

--- a/src/prefect/projects/steps/pull.py
+++ b/src/prefect/projects/steps/pull.py
@@ -4,6 +4,8 @@ Core set of steps for specifying a Prefect project pull step.
 import os
 import subprocess
 import sys
+import urllib.parse
+from typing import Optional
 
 
 def set_working_directory(directory: str) -> dict:
@@ -11,11 +13,22 @@ def set_working_directory(directory: str) -> dict:
     return dict(directory=directory)
 
 
-def git_clone_project(repository: str, branch: str = None) -> dict:
+def git_clone_project(
+    repository: str, branch: Optional[str] = None, access_token: Optional[str] = None
+) -> dict:
     """
     Just a repo name will be assumed GitHub, otherwise provide a full repo_url.
     """
-    cmd = ["git", "clone", repository]
+    url_components = urllib.parse.urlparse(repository)
+    if url_components.scheme == "https" and access_token is not None:
+        updated_components = url_components._replace(
+            netloc=f"{access_token}@{url_components.netloc}"
+        )
+        repository_url = urllib.parse.urlunparse(updated_components)
+    else:
+        repository_url = repository
+
+    cmd = ["git", "clone", repository_url]
     if branch:
         cmd += ["-b", branch]
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Enables pulling a project from private repositories. Should work with the major SCM services.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Usage:
```yaml
pull:
- prefect.projects.steps.git_clone_project:
    repository: https://github.com/PrefectHQ/hello-projects.git
    branch: main
    access_token: "{{ prefect.blocks.secret.github-access-token }}"
```
Note usage of block document placeholders reqiures #9081 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
