### PR TITLE
Update default agent query interval from 10s to 15s

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -789,23 +789,23 @@ interpreted and lead to incomplete output, e.g.
 
 PREFECT_AGENT_QUERY_INTERVAL = Setting(
     float,
-    default=10,
+    default=15,
 )
 """
 The agent loop interval, in seconds. Agents will check for new runs this often. 
-Defaults to `10`.
+Defaults to `15`.
 """
 
 PREFECT_AGENT_PREFETCH_SECONDS = Setting(
     int,
-    default=10,
+    default=15,
 )
 """
 Agents will look for scheduled runs this many seconds in
 the future and attempt to run them. This accounts for any additional
 infrastructure spin-up time or latency in preparing a flow run. Note
 flow runs will not start before their scheduled time, even if they are
-prefetched. Defaults to `10`.
+prefetched. Defaults to `15`.
 """
 
 PREFECT_ASYNC_FETCH_STATE_RESULT = Setting(bool, default=False)


### PR DESCRIPTION
The current default is a bit aggressive for the cost of the query the agent makes. Increases the default prefetch interval to match.